### PR TITLE
Use proper register masks during register allocation.

### DIFF
--- a/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
+++ b/iree/compiler/Dialect/VM/Analysis/RegisterAllocation.cpp
@@ -149,9 +149,9 @@ struct RegisterUsage {
 
   void releaseRegister(uint16_t reg) {
     if (isRefRegister(reg)) {
-      refRegisters.reset(reg & 0x3F);
+      refRegisters.reset(reg & kRefRegisterCount);
     } else {
-      intRegisters.reset(reg & 0x7F);
+      intRegisters.reset(reg & kIntRegisterCount);
     }
   }
 };


### PR DESCRIPTION
This was missed during the uint8->uint16 register space expansion. I blame beer. By masking incorrectly the allocator was releasing the wrong registers and allowing for their reuse even while the value they were backing was still alive. This issue would only kick in with functions with more than 3F live ref values (though int registers would suffer the same issues, just much harder to track down because we don't have a nice type checker error like we do with refs).

Fixes #1620.
Fixes #1660.