### PR TITLE
Avoid doing a full VM invoke to access a pointer in VMLA executables.

### DIFF
--- a/iree/hal/vmla/BUILD
+++ b/iree/hal/vmla/BUILD
@@ -162,7 +162,6 @@ cc_library(
         "//iree/vm:bytecode_module",
         "//iree/vm:context",
         "//iree/vm:instance",
-        "//iree/vm:invocation",
         "//iree/vm:module",
         "//iree/vm:variant_list",
         "@com_google_absl//absl/container:inlined_vector",

--- a/iree/hal/vmla/CMakeLists.txt
+++ b/iree/hal/vmla/CMakeLists.txt
@@ -176,7 +176,6 @@ iree_cc_library(
     iree::vm::bytecode_module
     iree::vm::context
     iree::vm::instance
-    iree::vm::invocation
     iree::vm::module
     iree::vm::variant_list
   PUBLIC

--- a/iree/hal/vmla/vmla_module.cc
+++ b/iree/hal/vmla/vmla_module.cc
@@ -198,6 +198,8 @@ class VMLAModuleState final {
 
   ~VMLAModuleState() = default;
 
+  Interface* interface() const { return interface_.get(); }
+
   //===--------------------------------------------------------------------===//
   // vmla.interface.*
   //===--------------------------------------------------------------------===//
@@ -1016,6 +1018,10 @@ Status ModuleCreate(iree_allocator_t allocator, iree_vm_module_t** out_module) {
   RETURN_IF_ERROR(module->Initialize());
   *out_module = module.release()->interface();
   return OkStatus();
+}
+
+Interface* ModuleStateInterface(iree_vm_module_state_t* module_state) {
+  return reinterpret_cast<VMLAModuleState*>(module_state)->interface();
 }
 
 }  // namespace vmla

--- a/iree/hal/vmla/vmla_module.h
+++ b/iree/hal/vmla/vmla_module.h
@@ -130,6 +130,8 @@ Status ModuleRegisterTypes();
 
 Status ModuleCreate(iree_allocator_t allocator, iree_vm_module_t** out_module);
 
+Interface* ModuleStateInterface(iree_vm_module_state_t* module_state);
+
 }  // namespace vmla
 }  // namespace hal
 }  // namespace iree

--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -279,6 +279,13 @@ iree_vm_context_state_resolver(const iree_vm_context_t* context) {
   return state_resolver;
 }
 
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_vm_context_resolve_module_state(
+    const iree_vm_context_t* context, iree_vm_module_t* module,
+    iree_vm_module_state_t** out_module_state) {
+  return iree_vm_context_query_module_state(context, module, out_module_state);
+}
+
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_context_register_modules(
     iree_vm_context_t* context, iree_vm_module_t** modules,
     iree_host_size_t module_count) {

--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -283,7 +283,8 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_vm_context_resolve_module_state(
     const iree_vm_context_t* context, iree_vm_module_t* module,
     iree_vm_module_state_t** out_module_state) {
-  return iree_vm_context_query_module_state(context, module, out_module_state);
+  return iree_vm_context_query_module_state((void*)context, module,
+                                            out_module_state);
 }
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_context_register_modules(

--- a/iree/vm/context.h
+++ b/iree/vm/context.h
@@ -72,6 +72,14 @@ iree_vm_context_id(const iree_vm_context_t* context);
 IREE_API_EXPORT iree_vm_state_resolver_t IREE_API_CALL
 iree_vm_context_state_resolver(const iree_vm_context_t* context);
 
+// Sets |out_module_state| to the context-specific state for the given |module|.
+// The state is owned by the context and will only be live for as long as the
+// context is.
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_vm_context_resolve_module_state(const iree_vm_context_t* context,
+                                     iree_vm_module_t* module,
+                                     iree_vm_module_state_t** out_module_state);
+
 // Registers a list of modules with the context and resolves imports in the
 // order provided.
 // The modules will be retained by the context until destruction.


### PR DESCRIPTION
Fixes #1899.