### PR TITLE
Enables reuse of an existing stack when invoking VM functions.

### DIFF
--- a/iree/hal/host/host_local_command_processor.cc
+++ b/iree/hal/host/host_local_command_processor.cc
@@ -24,9 +24,9 @@ namespace iree {
 namespace hal {
 
 HostLocalCommandProcessor::HostLocalCommandProcessor(
-    Allocator* allocator, CommandBufferModeBitfield mode,
-    CommandCategoryBitfield command_categories)
-    : CommandBuffer(allocator, mode, command_categories) {}
+    Allocator* allocator, CommandCategoryBitfield command_categories)
+    : CommandBuffer(allocator, CommandBufferMode::kOneShot,
+                    command_categories) {}
 
 HostLocalCommandProcessor::~HostLocalCommandProcessor() = default;
 

--- a/iree/hal/host/host_local_command_processor.h
+++ b/iree/hal/host/host_local_command_processor.h
@@ -40,7 +40,6 @@ struct PushConstantBlock {
 class HostLocalCommandProcessor : public CommandBuffer {
  public:
   HostLocalCommandProcessor(Allocator* allocator,
-                            CommandBufferModeBitfield mode,
                             CommandCategoryBitfield command_categories);
   ~HostLocalCommandProcessor() override;
 

--- a/iree/hal/llvmjit/llvmjit_command_processor.cc
+++ b/iree/hal/llvmjit/llvmjit_command_processor.cc
@@ -27,9 +27,8 @@ namespace hal {
 namespace llvmjit {
 
 LLVMJITCommandProcessor::LLVMJITCommandProcessor(
-    Allocator* allocator, CommandBufferModeBitfield mode,
-    CommandCategoryBitfield command_categories)
-    : HostLocalCommandProcessor(allocator, mode, command_categories) {}
+    Allocator* allocator, CommandCategoryBitfield command_categories)
+    : HostLocalCommandProcessor(allocator, command_categories) {}
 
 LLVMJITCommandProcessor::~LLVMJITCommandProcessor() = default;
 

--- a/iree/hal/llvmjit/llvmjit_command_processor.h
+++ b/iree/hal/llvmjit/llvmjit_command_processor.h
@@ -22,7 +22,7 @@ namespace llvmjit {
 
 class LLVMJITCommandProcessor final : public HostLocalCommandProcessor {
  public:
-  LLVMJITCommandProcessor(Allocator* allocator, CommandBufferModeBitfield mode,
+  LLVMJITCommandProcessor(Allocator* allocator,
                           CommandCategoryBitfield command_categories);
   ~LLVMJITCommandProcessor() override;
 

--- a/iree/hal/llvmjit/llvmjit_device.cc
+++ b/iree/hal/llvmjit/llvmjit_device.cc
@@ -84,8 +84,8 @@ class UnsynchronizedCommandQueue final : public CommandQueue {
     for (auto* command_buffer : command_buffers) {
       auto* inproc_command_buffer =
           static_cast<InProcCommandBuffer*>(command_buffer->impl());
-      LLVMJITCommandProcessor command_processor(
-          allocator_, command_buffer->mode(), supported_categories());
+      LLVMJITCommandProcessor command_processor(allocator_,
+                                                supported_categories());
       RETURN_IF_ERROR(inproc_command_buffer->Process(&command_processor));
     }
     return OkStatus();

--- a/iree/hal/vmla/vmla_cache.cc
+++ b/iree/hal/vmla/vmla_cache.cc
@@ -47,9 +47,9 @@ StatusOr<ref_ptr<Executable>> VMLACache::PrepareExecutable(
   // Wrap the data (or copy it).
   bool allow_aliasing_data =
       AllBitsSet(mode, ExecutableCachingMode::kAliasProvidedData);
-  ASSIGN_OR_RETURN(auto executable,
-                   VMLAExecutable::Load(instance_, vmla_module_, spec,
-                                        !allow_aliasing_data));
+  ASSIGN_OR_RETURN(
+      auto executable,
+      VMLAExecutable::Load(instance_, vmla_module_, spec, allow_aliasing_data));
 
   return executable;
 }

--- a/iree/hal/vmla/vmla_command_processor.h
+++ b/iree/hal/vmla/vmla_command_processor.h
@@ -16,6 +16,7 @@
 #define IREE_HAL_VMLA_VMLA_COMMAND_PROCESSOR_H_
 
 #include "iree/hal/host/host_local_command_processor.h"
+#include "iree/vm/stack.h"
 
 namespace iree {
 namespace hal {
@@ -23,7 +24,7 @@ namespace vmla {
 
 class VMLACommandProcessor final : public HostLocalCommandProcessor {
  public:
-  VMLACommandProcessor(Allocator* allocator, CommandBufferModeBitfield mode,
+  VMLACommandProcessor(Allocator* allocator,
                        CommandCategoryBitfield command_categories);
   ~VMLACommandProcessor() override;
 
@@ -33,6 +34,9 @@ class VMLACommandProcessor final : public HostLocalCommandProcessor {
       const PushConstantBlock& push_constants,
       absl::Span<const absl::Span<const DescriptorSet::Binding>> set_bindings)
       override;
+
+ private:
+  iree_vm_stack_t* stack_ = nullptr;
 };
 
 }  // namespace vmla

--- a/iree/vm/invocation.h
+++ b/iree/vm/invocation.h
@@ -49,6 +49,13 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke(
     const iree_vm_invocation_policy_t* policy, iree_vm_variant_list_t* inputs,
     iree_vm_variant_list_t* outputs, iree_allocator_t allocator);
 
+// Equivalent to iree_vm_invoke but uses an existing |stack|.
+// If the invocation fails the stack may be left in an indeterminate state.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke_within(
+    iree_vm_context_t* context, iree_vm_stack_t* stack,
+    iree_vm_function_t function, const iree_vm_invocation_policy_t* policy,
+    iree_vm_variant_list_t* inputs, iree_vm_variant_list_t* outputs);
+
 // TODO(benvanik): document and implement.
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invocation_create(
     iree_vm_context_t* context, iree_vm_function_t function,


### PR DESCRIPTION
This avoids extraneous allocations in the VMLA command processor that were
causing very noisy traces. Future work on #1172 may make this redundant
but it's a good test of the Tracy integration.
Fixes #1942.

![image](https://user-images.githubusercontent.com/75337/82018094-6204b780-9639-11ea-95f4-ba7c88a286f1.png)
