### PR TITLE
Making many free/release/deinit functions return void.

### DIFF
--- a/bindings/python/pyiree/compiler/compiler.h
+++ b/bindings/python/pyiree/compiler/compiler.h
@@ -65,10 +65,9 @@ class OpaqueBlob {
       std::shared_ptr<OpaqueBlob> blob;
     };
     Holder* holder = new Holder{std::move(blob)};
-    auto free_fn = +([](void* self, void*) -> iree_status_t {
+    auto free_fn = +([](void* self, void*) {
       Holder* self_holder = static_cast<Holder*>(self);
       delete self_holder;
-      return IREE_STATUS_OK;
     });
     return {holder /* self */, nullptr /* alloc */, free_fn /* free */};
   }

--- a/bindings/python/pyiree/rt/vm.cc
+++ b/bindings/python/pyiree/rt/vm.cc
@@ -153,10 +153,9 @@ VmModule VmModule::FromFlatbufferBlob(py::buffer flatbuffer_blob) {
 
   // Bridge to the C-based deallocator API.
   auto* raw_ptr = flatbuffer_blob.ptr();
-  auto free_fn = +([](void* self, void*) -> iree_status_t {
+  auto free_fn = +([](void* self, void*) {
     PyObject* self_ptr = static_cast<PyObject*>(self);
     Py_XDECREF(self_ptr);
-    return IREE_STATUS_OK;
   });
   flatbuffer_blob.inc_ref();
   iree_allocator_t deallocator{raw_ptr /* self */, nullptr /* alloc */,

--- a/bindings/python/pyiree/rt/vm.h
+++ b/bindings/python/pyiree/rt/vm.h
@@ -67,7 +67,7 @@ class VmVariantList {
   VmVariantList() : list_(nullptr) {}
   ~VmVariantList() {
     if (list_) {
-      CheckApiStatus(iree_vm_variant_list_free(list_), "Error freeing list");
+      iree_vm_variant_list_free(list_);
     }
   }
 

--- a/iree/base/api.cc
+++ b/iree/base/api.cc
@@ -101,12 +101,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_allocator_malloc(
                          byte_length, out_ptr);
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_allocator_free(iree_allocator_t allocator, void* ptr) {
   if (ptr && allocator.free) {
     return allocator.free(allocator.self, ptr);
   }
-  return IREE_STATUS_OK;
 }
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL
@@ -139,14 +138,13 @@ iree_allocator_system_allocate(void* self, iree_allocation_mode_t mode,
   return IREE_STATUS_OK;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_allocator_system_free(void* self, void* ptr) {
+IREE_API_EXPORT void IREE_API_CALL iree_allocator_system_free(void* self,
+                                                              void* ptr) {
   IREE_TRACE_SCOPE0("iree_allocator_system_free");
   IREE_TRACE_FREE(ptr);
   if (ptr) {
     std::free(ptr);
   }
-  return IREE_STATUS_OK;
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -379,7 +379,7 @@ typedef struct {
                                      iree_host_size_t byte_length,
                                      void** out_ptr);
   // Frees |ptr| from a previous alloc call.
-  iree_status_t(IREE_API_PTR* free)(void* self, void* ptr);
+  void(IREE_API_PTR* free)(void* self, void* ptr);
 } iree_allocator_t;
 
 // Allocates using the iree_allocator_malloc and iree_allocator_free methods.
@@ -400,7 +400,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_allocator_malloc(
     iree_allocator_t allocator, iree_host_size_t byte_length, void** out_ptr);
 
 // Frees a previously-allocated block of memory to the given allocator.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_allocator_free(iree_allocator_t allocator, void* ptr);
 
 // Allocates a block of |byte_length| bytes from the default system allocator.
@@ -409,8 +409,8 @@ iree_allocator_system_allocate(void* self, iree_allocation_mode_t mode,
                                iree_host_size_t byte_length, void** out_ptr);
 
 // Frees a previously-allocated block of memory to the default system allocator.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_allocator_system_free(void* self, void* ptr);
+IREE_API_EXPORT void IREE_API_CALL iree_allocator_system_free(void* self,
+                                                              void* ptr);
 
 #endif  // IREE_API_NO_PROTOTYPES
 

--- a/iree/hal/api.cc
+++ b/iree/hal/api.cc
@@ -44,20 +44,16 @@ namespace iree {
 namespace hal {
 
 // Defines the iree_hal_<type_name>_retain/_release methods.
-#define IREE_HAL_API_RETAIN_RELEASE(type_name, cc_type)         \
-  IREE_API_EXPORT iree_status_t iree_hal_##type_name##_retain(  \
-      iree_hal_##type_name##_t* type_name) {                    \
-    auto* handle = reinterpret_cast<cc_type*>(type_name);       \
-    if (!handle) return IREE_STATUS_INVALID_ARGUMENT;           \
-    handle->AddReference();                                     \
-    return IREE_STATUS_OK;                                      \
-  }                                                             \
-  IREE_API_EXPORT iree_status_t iree_hal_##type_name##_release( \
-      iree_hal_##type_name##_t* type_name) {                    \
-    auto* handle = reinterpret_cast<cc_type*>(type_name);       \
-    if (!handle) return IREE_STATUS_INVALID_ARGUMENT;           \
-    handle->ReleaseReference();                                 \
-    return IREE_STATUS_OK;                                      \
+#define IREE_HAL_API_RETAIN_RELEASE(type_name, cc_type)   \
+  IREE_API_EXPORT void iree_hal_##type_name##_retain(     \
+      iree_hal_##type_name##_t* type_name) {              \
+    auto* handle = reinterpret_cast<cc_type*>(type_name); \
+    if (handle) handle->AddReference();                   \
+  }                                                       \
+  IREE_API_EXPORT void iree_hal_##type_name##_release(    \
+      iree_hal_##type_name##_t* type_name) {              \
+    auto* handle = reinterpret_cast<cc_type*>(type_name); \
+    if (handle) handle->ReleaseReference();               \
   }
 
 //===----------------------------------------------------------------------===//

--- a/iree/hal/api.h
+++ b/iree/hal/api.h
@@ -607,11 +607,11 @@ iree_hal_allocator_create_host_local(iree_allocator_t allocator,
                                      iree_hal_allocator** out_allocator);
 
 // Retains the given |allocator| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_allocator_retain(iree_hal_allocator_t* allocator);
 
 // Releases the given |allocator| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_allocator_release(iree_hal_allocator_t* allocator);
 
 // Calculates the allocation size of a buffer.
@@ -690,11 +690,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_subspan(
     iree_hal_buffer_t** out_buffer);
 
 // Retains the given |buffer| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_buffer_retain(iree_hal_buffer_t* buffer);
 
 // Releases the given |buffer| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_buffer_release(iree_hal_buffer_t* buffer);
 
 // Returns the allocator this buffer was allocated from.
@@ -810,11 +810,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_view_subview(
     iree_allocator_t allocator, iree_hal_buffer_view_t** out_buffer_view);
 
 // Retains the given |buffer_view| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_buffer_view_retain(iree_hal_buffer_view_t* buffer_view);
 
 // Releases the given |buffer_view| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_buffer_view_release(iree_hal_buffer_view_t* buffer_view);
 
 // Returns the buffer underlying the buffer view.
@@ -910,11 +910,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_command_buffer_create(
     iree_hal_command_buffer_t** out_command_buffer);
 
 // Retains the given |command_buffer| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_command_buffer_retain(iree_hal_command_buffer_t* command_buffer);
 
 // Releases the given |command_buffer| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_command_buffer_release(iree_hal_command_buffer_t* command_buffer);
 
 // Resets and begins recording into the command buffer, clearing all
@@ -1070,11 +1070,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_descriptor_set_create(
     iree_allocator_t allocator, iree_hal_descriptor_set_t** out_descriptor_set);
 
 // Retains the given |set| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_descriptor_set_retain(iree_hal_descriptor_set_t* descriptor_set);
 
 // Releases the given |set| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_descriptor_set_release(iree_hal_descriptor_set_t* descriptor_set);
 
 #endif  // IREE_API_NO_PROTOTYPES
@@ -1096,13 +1096,11 @@ iree_hal_descriptor_set_layout_create(
     iree_hal_descriptor_set_layout_t** out_descriptor_set_layout);
 
 // Retains the given |descriptor_set_layout| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_descriptor_set_layout_retain(
+IREE_API_EXPORT void IREE_API_CALL iree_hal_descriptor_set_layout_retain(
     iree_hal_descriptor_set_layout_t* descriptor_set_layout);
 
 // Releases the given |descriptor_set_layout| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_hal_descriptor_set_layout_release(
+IREE_API_EXPORT void IREE_API_CALL iree_hal_descriptor_set_layout_release(
     iree_hal_descriptor_set_layout_t* descriptor_set_layout);
 
 #endif  // IREE_API_NO_PROTOTYPES
@@ -1114,11 +1112,11 @@ iree_hal_descriptor_set_layout_release(
 #ifndef IREE_API_NO_PROTOTYPES
 
 // Retains the given |device| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_device_retain(iree_hal_device_t* device);
 
 // Releases the given |device| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_device_release(iree_hal_device_t* device);
 
 // Returns a reference to the allocator of the device that can be used for
@@ -1190,11 +1188,11 @@ iree_hal_device_wait_semaphores_with_timeout(
 #ifndef IREE_API_NO_PROTOTYPES
 
 // Retains the given |driver| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_driver_retain(iree_hal_driver_t* driver);
 
 // Releases the given |driver| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_driver_release(iree_hal_driver_t* driver);
 
 // Queries available devices and returns them as a list.
@@ -1257,11 +1255,11 @@ iree_hal_driver_registry_create_driver(iree_string_view_t driver_name,
 #ifndef IREE_API_NO_PROTOTYPES
 
 // Retains the given |executable| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_executable_retain(iree_hal_executable_t* executable);
 
 // Releases the given |executable| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_executable_release(iree_hal_executable_t* executable);
 
 #endif  // IREE_API_NO_PROTOTYPES
@@ -1281,11 +1279,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_cache_create(
     iree_hal_executable_cache_t** out_executable_cache);
 
 // Retains the given |executable_cache| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_executable_cache_retain(iree_hal_executable_cache_t* executable_cache);
 
 // Releases the given |executable_cache| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_cache_release(
+IREE_API_EXPORT void IREE_API_CALL iree_hal_executable_cache_release(
     iree_hal_executable_cache_t* executable_cache);
 
 // Returns true if the executable cache can prepare the given executable input
@@ -1329,11 +1327,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_layout_create(
     iree_hal_executable_layout_t** out_executable_layout);
 
 // Retains the given |executable_layout| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_layout_retain(
+IREE_API_EXPORT void IREE_API_CALL iree_hal_executable_layout_retain(
     iree_hal_executable_layout_t* executable_layout);
 
 // Releases the given |executable_layout| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_executable_layout_release(
+IREE_API_EXPORT void IREE_API_CALL iree_hal_executable_layout_release(
     iree_hal_executable_layout_t* executable_layout);
 
 #endif  // IREE_API_NO_PROTOTYPES
@@ -1352,11 +1350,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_semaphore_create(
     iree_allocator_t allocator, iree_hal_semaphore_t** out_semaphore);
 
 // Retains the given |semaphore| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_semaphore_retain(iree_hal_semaphore_t* semaphore);
 
 // Releases the given |semaphore| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_hal_semaphore_release(iree_hal_semaphore_t* semaphore);
 
 // Queries the current payload of the semaphore and stores the result in

--- a/iree/hal/api_string_util_test.cc
+++ b/iree/hal/api_string_util_test.cc
@@ -300,7 +300,7 @@ StatusOr<std::string> FormatBufferElements(
 
 // C API iree_*_retain/iree_*_release function pointer.
 template <typename T>
-using HandleRefFn = iree_status_t(IREE_API_PTR*)(T*);
+using HandleRefFn = void(IREE_API_PTR*)(T*);
 
 // C++ RAII wrapper for an IREE C reference object.
 // Behaves the same as a thread-safe intrusive pointer.

--- a/iree/hal/vmla/vmla_command_processor.cc
+++ b/iree/hal/vmla/vmla_command_processor.cc
@@ -69,10 +69,8 @@ Status VMLACommandProcessor::DispatchInline(
     }
   }
 
-  RETURN_IF_ERROR(FromApiStatus(
-      iree_vm_stack_init(
-          iree_vm_context_state_resolver(vmla_executable->context()), stack_),
-      IREE_LOC));
+  iree_vm_stack_init(iree_vm_context_state_resolver(vmla_executable->context()),
+                     stack_);
   auto status =
       FromApiStatus(iree_vm_invoke_within(
                         vmla_executable->context(), stack_,

--- a/iree/hal/vmla/vmla_module.cc
+++ b/iree/hal/vmla/vmla_module.cc
@@ -230,9 +230,8 @@ class VMLAModuleState final {
     IREE_TRACE_SCOPE0("VMLAModuleState::BufferConst");
     iree_allocator_t external_allocator = {0};
     external_allocator.self = vm::retain_ref(value).release();
-    external_allocator.free = +[](void* self, void* ptr) -> iree_status_t {
+    external_allocator.free = +[](void* self, void* ptr) {
       vm::assign_ref(reinterpret_cast<iree_vm_ro_byte_buffer_t*>(self)).reset();
-      return IREE_STATUS_OK;
     };
     return Buffer::Wrap(value->data.data, value->data.data_length,
                         external_allocator);
@@ -287,9 +286,8 @@ class VMLAModuleState final {
 
     iree_allocator_t external_allocator = {0};
     external_allocator.self = vm::retain_ref(src).release();
-    external_allocator.free = +[](void* self, void* ptr) -> iree_status_t {
+    external_allocator.free = +[](void* self, void* ptr) {
       vm::assign_ref(reinterpret_cast<Buffer*>(self)).reset();
-      return IREE_STATUS_OK;
     };
     return Buffer::Wrap(data, data_length, external_allocator);
   }

--- a/iree/modules/check/check_module_main.cc
+++ b/iree/modules/check/check_module_main.cc
@@ -64,9 +64,7 @@ class CheckModuleTest : public ::testing::Test {
         instance_, modules_.data(), modules_.size(), IREE_ALLOCATOR_SYSTEM,
         &context_));
   }
-  void TearDown() override {
-    IREE_ASSERT_OK(iree_vm_context_release(context_));
-  }
+  void TearDown() override { iree_vm_context_release(context_); }
 
   void TestBody() override {
     IREE_EXPECT_OK(iree_vm_invoke(context_, function_, /*policy=*/nullptr,
@@ -165,19 +163,11 @@ StatusOr<int> Run(std::string input_file_path) {
   }
   int ret = RUN_ALL_TESTS();
 
-  // TODO(b/146898896): Investigate mechanism for sharing state between tests
-  // that happens before test registration (we need the input module) and has
-  // nice setup/teardown split.
-  // TODO(gcmn): Some nice wrappers to make this pattern shorter with generated
-  // error messages.
-  // Deallocate:
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_module_release(hal_module), IREE_LOC));
-  RETURN_IF_ERROR(
-      FromApiStatus(iree_vm_module_release(check_module), IREE_LOC));
-  RETURN_IF_ERROR(
-      FromApiStatus(iree_vm_module_release(input_module), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_hal_device_release(device), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_instance_release(instance), IREE_LOC));
+  iree_vm_module_release(hal_module);
+  iree_vm_module_release(check_module);
+  iree_vm_module_release(input_module);
+  iree_hal_device_release(device);
+  iree_vm_instance_release(instance);
 
   return ret;
 }

--- a/iree/tools/benchmark_module_main.cc
+++ b/iree/tools/benchmark_module_main.cc
@@ -123,7 +123,7 @@ Status Run(::benchmark::State& state) {
       FromApiStatus(iree_vm_invoke(context, function, /*policy=*/nullptr,
                                    inputs, outputs, IREE_ALLOCATOR_SYSTEM),
                     IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_variant_list_free(outputs), IREE_LOC));
+  iree_vm_variant_list_free(outputs);
 
   for (auto _ : state) {
     // No status conversions and conditional returns in the benchmarked inner
@@ -132,19 +132,15 @@ Status Run(::benchmark::State& state) {
                                              IREE_ALLOCATOR_SYSTEM, &outputs));
     IREE_CHECK_OK(iree_vm_invoke(context, function, /*policy=*/nullptr, inputs,
                                  outputs, IREE_ALLOCATOR_SYSTEM));
-    IREE_CHECK_OK(iree_vm_variant_list_free(outputs));
+    iree_vm_variant_list_free(outputs);
   }
 
-  // TODO(gcmn): Some nice wrappers to make this pattern shorter with generated
-  // error messages.
-  // Deallocate:
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_variant_list_free(inputs), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_module_release(hal_module), IREE_LOC));
-  RETURN_IF_ERROR(
-      FromApiStatus(iree_vm_module_release(input_module), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_hal_device_release(device), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_context_release(context), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_instance_release(instance), IREE_LOC));
+  iree_vm_variant_list_free(inputs);
+  iree_vm_module_release(hal_module);
+  iree_vm_module_release(input_module);
+  iree_hal_device_release(device);
+  iree_vm_context_release(context);
+  iree_vm_instance_release(instance);
   return OkStatus();
 }
 

--- a/iree/tools/run_module_main.cc
+++ b/iree/tools/run_module_main.cc
@@ -127,17 +127,13 @@ Status Run() {
   RETURN_IF_ERROR(PrintVariantList(output_descs, outputs))
       << "printing results";
 
-  // TODO(gcmn): Some nice wrappers to make this pattern shorter with generated
-  // error messages.
-  // Deallocate:
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_variant_list_free(inputs), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_variant_list_free(outputs), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_module_release(hal_module), IREE_LOC));
-  RETURN_IF_ERROR(
-      FromApiStatus(iree_vm_module_release(input_module), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_hal_device_release(device), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_context_release(context), IREE_LOC));
-  RETURN_IF_ERROR(FromApiStatus(iree_vm_instance_release(instance), IREE_LOC));
+  iree_vm_variant_list_free(inputs);
+  iree_vm_variant_list_free(outputs);
+  iree_vm_module_release(hal_module);
+  iree_vm_module_release(input_module);
+  iree_hal_device_release(device);
+  iree_vm_context_release(context);
+  iree_vm_instance_release(instance);
   return OkStatus();
 }
 

--- a/iree/tools/vm_util.cc
+++ b/iree/tools/vm_util.cc
@@ -314,8 +314,7 @@ Status CreateDevice(absl::string_view driver_name,
                                     driver, IREE_ALLOCATOR_SYSTEM, out_device),
                                 IREE_LOC))
       << "Creating default device for driver '" << driver_name << "'";
-  RETURN_IF_ERROR(FromApiStatus(iree_hal_driver_release(driver), IREE_LOC))
-      << "Releasing driver '" << driver_name << "'";
+  iree_hal_driver_release(driver);
   return OkStatus();
 }
 

--- a/iree/tools/vm_util_test.cc
+++ b/iree/tools/vm_util_test.cc
@@ -35,7 +35,7 @@ class VmUtilTest : public ::testing::Test {
     allocator_ = iree_hal_device_allocator(device_);
   }
 
-  virtual void TearDown() { IREE_ASSERT_OK(iree_hal_device_release(device_)); }
+  virtual void TearDown() { iree_hal_device_release(device_); }
 
   iree_hal_device_t* device_ = nullptr;
   iree_hal_allocator_t* allocator_ = nullptr;
@@ -54,7 +54,7 @@ TEST_F(VmUtilTest, ParsePrintBuffer) {
   ASSERT_OK(PrintVariantList({desc}, variant_list, &os));
   EXPECT_EQ(os.str(), absl::StrCat(buf_string, "\n"));
 
-  IREE_ASSERT_OK(iree_vm_variant_list_free(variant_list));
+  iree_vm_variant_list_free(variant_list);
 }
 
 TEST_F(VmUtilTest, ParsePrintScalar) {
@@ -69,7 +69,7 @@ TEST_F(VmUtilTest, ParsePrintScalar) {
   ASSERT_OK(PrintVariantList({desc}, variant_list, &os));
   EXPECT_EQ(os.str(), absl::StrCat(input_string, "\n"));
 
-  IREE_ASSERT_OK(iree_vm_variant_list_free(variant_list));
+  iree_vm_variant_list_free(variant_list);
 }
 
 TEST_F(VmUtilTest, ParsePrintRank0Buffer) {
@@ -84,7 +84,7 @@ TEST_F(VmUtilTest, ParsePrintRank0Buffer) {
   ASSERT_OK(PrintVariantList({desc}, variant_list, &os));
   EXPECT_EQ(os.str(), absl::StrCat(buf_string, "\n"));
 
-  IREE_ASSERT_OK(iree_vm_variant_list_free(variant_list));
+  iree_vm_variant_list_free(variant_list);
 }
 
 TEST_F(VmUtilTest, ParsePrintMultipleBuffers) {
@@ -107,7 +107,7 @@ TEST_F(VmUtilTest, ParsePrintMultipleBuffers) {
   ASSERT_OK(PrintVariantList({desc1, desc2}, variant_list, &os));
   EXPECT_EQ(os.str(), absl::StrCat(buf_string1, "\n", buf_string2, "\n"));
 
-  IREE_ASSERT_OK(iree_vm_variant_list_free(variant_list));
+  iree_vm_variant_list_free(variant_list);
 }
 
 }  // namespace

--- a/iree/vm/bytecode_module.cc
+++ b/iree/vm/bytecode_module.cc
@@ -202,7 +202,7 @@ static iree_status_t iree_vm_bytecode_module_flatbuffer_verify(
   return IREE_STATUS_OK;
 }
 
-static iree_status_t iree_vm_bytecode_module_destroy(void* self) {
+static void iree_vm_bytecode_module_destroy(void* self) {
   iree_vm_bytecode_module_t* module = (iree_vm_bytecode_module_t*)self;
 
   iree_allocator_free(module->flatbuffer_allocator,
@@ -210,7 +210,7 @@ static iree_status_t iree_vm_bytecode_module_destroy(void* self) {
   module->flatbuffer_data = {NULL, 0};
   module->flatbuffer_allocator = IREE_ALLOCATOR_NULL;
 
-  return iree_allocator_free(module->allocator, module);
+  iree_allocator_free(module->allocator, module);
 }
 
 static iree_string_view_t iree_vm_bytecode_module_name(void* self) {
@@ -472,18 +472,19 @@ static iree_status_t iree_vm_bytecode_module_alloc_state(
   return IREE_STATUS_OK;
 }
 
-static iree_status_t iree_vm_bytecode_module_free_state(
+static void iree_vm_bytecode_module_free_state(
     void* self, iree_vm_module_state_t* module_state) {
+  if (!module_state) return;
+
   iree_vm_bytecode_module_state_t* state =
       (iree_vm_bytecode_module_state_t*)module_state;
-  if (!state) return IREE_STATUS_INVALID_ARGUMENT;
 
   // Release remaining global references.
   for (int i = 0; i < state->global_ref_count; ++i) {
     iree_vm_ref_release(&state->global_ref_table[i]);
   }
 
-  return state->allocator.free(state->allocator.self, module_state);
+  iree_allocator_free(state->allocator, module_state);
 }
 
 static iree_status_t iree_vm_bytecode_module_resolve_import(

--- a/iree/vm/context.c
+++ b/iree/vm/context.c
@@ -175,8 +175,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_context_create_with_modules(
       sizeof(iree_vm_module_state_t*) * module_count;
 
   iree_vm_context_t* context = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_allocator_malloc(allocator, context_size, (void**)&context));
+  iree_allocator_malloc(allocator, context_size, (void**)&context);
   iree_atomic_store(&context->ref_count, 1);
   context->instance = instance;
   iree_vm_instance_retain(context->instance);
@@ -213,14 +212,9 @@ static void iree_vm_context_destroy(iree_vm_context_t* context) {
     // If we shrunk the stack (or made it so that it could dynamically grow)
     // then we could stack-allocate it here and not need the allocator at all.
     iree_vm_stack_t* stack = NULL;
-    IREE_RETURN_IF_ERROR(iree_allocator_malloc(
-        context->allocator, sizeof(iree_vm_stack_t), (void**)&stack));
-    iree_status_t status =
-        iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
-    if (!iree_status_is_ok(status)) {
-      iree_allocator_free(context->allocator, stack);
-      return status;
-    }
+    iree_allocator_malloc(context->allocator, sizeof(iree_vm_stack_t),
+                          (void**)&stack);
+    iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
 
     iree_vm_context_release_modules(context, stack, 0, context->list.count - 1);
 
@@ -334,12 +328,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_context_register_modules(
   iree_vm_stack_t* stack = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       context->allocator, sizeof(iree_vm_stack_t), (void**)&stack));
-  iree_status_t status =
-      iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
-  if (!iree_status_is_ok(status)) {
-    iree_allocator_free(context->allocator, stack);
-    return status;
-  }
+  iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
 
   // Retain all modules and allocate their state.
   assert(context->list.capacity >= context->list.count + module_count);

--- a/iree/vm/context.h
+++ b/iree/vm/context.h
@@ -56,11 +56,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_context_create_with_modules(
     iree_vm_context_t** out_context);
 
 // Retains the given |context| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_context_retain(iree_vm_context_t* context);
 
 // Releases the given |context| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_context_release(iree_vm_context_t* context);
 
 // Returns a process-unique ID for the |context|.

--- a/iree/vm/instance.c
+++ b/iree/vm/instance.c
@@ -41,24 +41,20 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_instance_create(
   return IREE_STATUS_OK;
 }
 
-static iree_status_t iree_vm_instance_destroy(iree_vm_instance_t* instance) {
+static void iree_vm_instance_destroy(iree_vm_instance_t* instance) {
   iree_allocator_free(instance->allocator, instance);
-  return IREE_STATUS_OK;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_instance_retain(iree_vm_instance_t* instance) {
-  if (!instance) return IREE_STATUS_INVALID_ARGUMENT;
-  iree_atomic_fetch_add(&instance->ref_count, 1);
-  return IREE_STATUS_OK;
+  if (instance) {
+    iree_atomic_fetch_add(&instance->ref_count, 1);
+  }
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_instance_release(iree_vm_instance_t* instance) {
-  if (instance) {
-    if (iree_atomic_fetch_sub(&instance->ref_count, 1) == 1) {
-      return iree_vm_instance_destroy(instance);
-    }
+  if (instance && iree_atomic_fetch_sub(&instance->ref_count, 1) == 1) {
+    iree_vm_instance_destroy(instance);
   }
-  return IREE_STATUS_OK;
 }

--- a/iree/vm/instance.h
+++ b/iree/vm/instance.h
@@ -44,11 +44,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_instance_create(
     iree_allocator_t allocator, iree_vm_instance_t** out_instance);
 
 // Retains the given |instance| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_instance_retain(iree_vm_instance_t* instance);
 
 // Releases the given |instance| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_instance_release(iree_vm_instance_t* instance);
 
 #endif  // IREE_API_NO_PROTOTYPES

--- a/iree/vm/invocation.c
+++ b/iree/vm/invocation.c
@@ -74,14 +74,9 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke(
   iree_vm_stack_t* stack = NULL;
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(allocator, sizeof(iree_vm_stack_t),
                                              (void**)&stack));
-  iree_status_t status =
-      iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
-  if (!iree_status_is_ok(status)) {
-    iree_allocator_free(allocator, stack);
-    return status;
-  }
+  iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
 
-  status =
+  iree_status_t status =
       iree_vm_invoke_within(context, stack, function, policy, inputs, outputs);
 
   iree_vm_stack_deinit(stack);

--- a/iree/vm/module.c
+++ b/iree/vm/module.c
@@ -26,21 +26,18 @@ iree_vm_module_init(iree_vm_module_t* module, void* self) {
   return IREE_STATUS_OK;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_module_retain(iree_vm_module_t* module) {
-  if (!module) return IREE_STATUS_INVALID_ARGUMENT;
-  iree_atomic_fetch_add(&module->ref_count, 1);
-  return IREE_STATUS_OK;
+  if (module) {
+    iree_atomic_fetch_add(&module->ref_count, 1);
+  }
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_module_release(iree_vm_module_t* module) {
-  if (module) {
-    if (iree_atomic_fetch_sub(&module->ref_count, 1) == 1) {
-      return module->destroy(module->self);
-    }
+  if (module && iree_atomic_fetch_sub(&module->ref_count, 1) == 1) {
+    module->destroy(module->self);
   }
-  return IREE_STATUS_OK;
 }
 
 IREE_API_EXPORT iree_string_view_t IREE_API_CALL

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -97,7 +97,7 @@ typedef struct iree_vm_module {
   iree_atomic_intptr_t ref_count;
 
   // Destroys |self| when all references to the module have been released.
-  iree_status_t(IREE_API_PTR* destroy)(void* self);
+  void(IREE_API_PTR* destroy)(void* self);
 
   // Returns the name of the module (used during resolution).
   iree_string_view_t(IREE_API_PTR* name)(void* self);
@@ -126,8 +126,8 @@ typedef struct iree_vm_module {
       iree_vm_module_state_t** out_module_state);
 
   // Frees module state data.
-  iree_status_t(IREE_API_PTR* free_state)(void* self,
-                                          iree_vm_module_state_t* module_state);
+  void(IREE_API_PTR* free_state)(void* self,
+                                 iree_vm_module_state_t* module_state);
 
   // Resolves the import with the given ordinal to |function|.
   // The function is guaranteed to remain valid for the lifetime of the module
@@ -167,11 +167,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_vm_module_init(iree_vm_module_t* module, void* self);
 
 // Retains the given |module| for the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_module_retain(iree_vm_module_t* module);
 
 // Releases the given |module| from the caller.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_module_release(iree_vm_module_t* module);
 
 // Returns the name of the module (used during resolution).

--- a/iree/vm/module_abi_cc.h
+++ b/iree/vm/module_abi_cc.h
@@ -109,10 +109,7 @@ class NativeModule {
     return reinterpret_cast<State*>(self);
   }
 
-  static iree_status_t ModuleDestroy(void* self) {
-    delete FromModulePointer(self);
-    return IREE_STATUS_OK;
-  }
+  static void ModuleDestroy(void* self) { delete FromModulePointer(self); }
 
   static iree_string_view_t ModuleName(void* self) {
     auto* module = FromModulePointer(self);
@@ -198,11 +195,9 @@ class NativeModule {
     return IREE_STATUS_OK;
   }
 
-  static iree_status_t ModuleFreeState(void* self,
-                                       iree_vm_module_state_t* module_state) {
-    if (!module_state) return IREE_STATUS_INVALID_ARGUMENT;
-    delete FromStatePointer(module_state);
-    return IREE_STATUS_OK;
+  static void ModuleFreeState(void* self,
+                              iree_vm_module_state_t* module_state) {
+    if (module_state) delete FromStatePointer(module_state);
   }
 
   static iree_status_t ModuleResolveImport(void* self,

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -25,12 +25,11 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_init(
   return IREE_STATUS_OK;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_stack_deinit(iree_vm_stack_t* stack) {
   while (stack->depth) {
-    IREE_RETURN_IF_ERROR(iree_vm_stack_function_leave(stack));
+    iree_vm_stack_function_leave(stack);
   }
-  return IREE_STATUS_OK;
 }
 
 IREE_API_EXPORT iree_vm_stack_frame_t* IREE_API_CALL

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -18,11 +18,10 @@
 
 #include "iree/vm/module.h"
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_init(
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_init(
     iree_vm_state_resolver_t state_resolver, iree_vm_stack_t* out_stack) {
   memset(out_stack, 0, sizeof(iree_vm_stack_t));
   out_stack->state_resolver = state_resolver;
-  return IREE_STATUS_OK;
 }
 
 IREE_API_EXPORT void IREE_API_CALL

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -117,8 +117,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_init(
     iree_vm_state_resolver_t state_resolver, iree_vm_stack_t* out_stack);
 
 // Destructs |stack|.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_vm_stack_deinit(iree_vm_stack_t* stack);
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_deinit(iree_vm_stack_t* stack);
 
 // Returns the current stack frame or nullptr if the stack is empty.
 IREE_API_EXPORT iree_vm_stack_frame_t* IREE_API_CALL

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -113,7 +113,7 @@ typedef struct iree_vm_stack {
 } iree_vm_stack_t;
 
 // Constructs a stack in-place in |out_stack|.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_init(
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_init(
     iree_vm_state_resolver_t state_resolver, iree_vm_stack_t* out_stack);
 
 // Destructs |stack|.

--- a/iree/vm/stack_test.cc
+++ b/iree/vm/stack_test.cc
@@ -79,7 +79,7 @@ TEST(VMStackTest, Usage) {
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
 
-  IREE_EXPECT_OK(iree_vm_stack_deinit(stack.get()));
+  iree_vm_stack_deinit(stack.get());
 }
 
 // Tests stack cleanup with unpopped frames (like during failure teardown).
@@ -98,7 +98,7 @@ TEST(VMStackTest, DeinitWithRemainingFrames) {
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
 
   // Don't pop the last frame before deinit; it should handle it.
-  IREE_EXPECT_OK(iree_vm_stack_deinit(stack.get()));
+  iree_vm_stack_deinit(stack.get());
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
 }
 
@@ -130,7 +130,7 @@ TEST(VMStackTest, StackOverflow) {
   // Should still be frame A.
   EXPECT_EQ(0, iree_vm_stack_current_frame(stack.get())->function.ordinal);
 
-  IREE_EXPECT_OK(iree_vm_stack_deinit(stack.get()));
+  iree_vm_stack_deinit(stack.get());
 }
 
 // Tests unbalanced stack popping.
@@ -142,7 +142,7 @@ TEST(VMStackTest, UnbalancedPop) {
   EXPECT_EQ(IREE_STATUS_FAILED_PRECONDITION,
             iree_vm_stack_function_leave(stack.get()));
 
-  IREE_EXPECT_OK(iree_vm_stack_deinit(stack.get()));
+  iree_vm_stack_deinit(stack.get());
 }
 
 // Tests module state reuse and querying.
@@ -185,7 +185,7 @@ TEST(VMStackTest, ModuleStateQueries) {
   IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
   IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
 
-  IREE_EXPECT_OK(iree_vm_stack_deinit(stack.get()));
+  iree_vm_stack_deinit(stack.get());
 }
 
 // Tests that module state query failures propagate to callers correctly.
@@ -207,7 +207,7 @@ TEST(VMStackTest, ModuleStateQueryFailure) {
   EXPECT_EQ(IREE_STATUS_INTERNAL,
             iree_vm_stack_function_enter(stack.get(), function_a, &frame_a));
 
-  IREE_EXPECT_OK(iree_vm_stack_deinit(stack.get()));
+  iree_vm_stack_deinit(stack.get());
 }
 
 static int dummy_object_count = 0;
@@ -254,7 +254,7 @@ TEST(VMStackTest, RefRegisterCleanup) {
   IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
   EXPECT_EQ(0, dummy_object_count);
 
-  IREE_EXPECT_OK(iree_vm_stack_deinit(stack.get()));
+  iree_vm_stack_deinit(stack.get());
 }
 
 }  // namespace

--- a/iree/vm/stack_test.cc
+++ b/iree/vm/stack_test.cc
@@ -49,7 +49,7 @@ static iree_status_t SentinelStateResolver(
 TEST(VMStackTest, Usage) {
   auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_EXPECT_OK(iree_vm_stack_init(state_resolver, stack.get()));
+  iree_vm_stack_init(state_resolver, stack.get());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
@@ -86,7 +86,7 @@ TEST(VMStackTest, Usage) {
 TEST(VMStackTest, DeinitWithRemainingFrames) {
   auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_EXPECT_OK(iree_vm_stack_init(state_resolver, stack.get()));
+  iree_vm_stack_init(state_resolver, stack.get());
 
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
@@ -106,7 +106,7 @@ TEST(VMStackTest, DeinitWithRemainingFrames) {
 TEST(VMStackTest, StackOverflow) {
   auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_EXPECT_OK(iree_vm_stack_init(state_resolver, stack.get()));
+  iree_vm_stack_init(state_resolver, stack.get());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
@@ -137,7 +137,7 @@ TEST(VMStackTest, StackOverflow) {
 TEST(VMStackTest, UnbalancedPop) {
   auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_EXPECT_OK(iree_vm_stack_init(state_resolver, stack.get()));
+  iree_vm_stack_init(state_resolver, stack.get());
 
   EXPECT_EQ(IREE_STATUS_FAILED_PRECONDITION,
             iree_vm_stack_function_leave(stack.get()));
@@ -149,7 +149,7 @@ TEST(VMStackTest, UnbalancedPop) {
 TEST(VMStackTest, ModuleStateQueries) {
   auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_EXPECT_OK(iree_vm_stack_init(state_resolver, stack.get()));
+  iree_vm_stack_init(state_resolver, stack.get());
 
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
@@ -198,7 +198,7 @@ TEST(VMStackTest, ModuleStateQueryFailure) {
         // NOTE: always failing.
         return IREE_STATUS_INTERNAL;
       }};
-  IREE_EXPECT_OK(iree_vm_stack_init(state_resolver, stack.get()));
+  iree_vm_stack_init(state_resolver, stack.get());
 
   // Push should fail if we can't query state, status should propagate.
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
@@ -234,7 +234,7 @@ iree_vm_ref_type_t DummyObject::kTypeID = IREE_VM_REF_TYPE_NULL;
 TEST(VMStackTest, RefRegisterCleanup) {
   auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  IREE_EXPECT_OK(iree_vm_stack_init(state_resolver, stack.get()));
+  iree_vm_stack_init(state_resolver, stack.get());
 
   dummy_object_count = 0;
   DummyObject::RegisterType();

--- a/iree/vm/variant_list.c
+++ b/iree/vm/variant_list.c
@@ -33,7 +33,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_variant_list_alloc(
   iree_vm_variant_list_t* list = NULL;
   IREE_RETURN_IF_ERROR(
       iree_allocator_malloc(allocator, alloc_size, (void**)&list));
-  IREE_RETURN_IF_ERROR(iree_vm_variant_list_init(list, capacity));
+  iree_vm_variant_list_init(list, capacity);
   list->allocator = allocator;
   *out_list = list;
   return IREE_STATUS_OK;
@@ -44,23 +44,22 @@ iree_vm_variant_list_alloc_size(iree_host_size_t capacity) {
   return sizeof(iree_vm_variant_list_t) + sizeof(iree_vm_variant_t) * capacity;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_variant_list_init(
+IREE_API_EXPORT void IREE_API_CALL iree_vm_variant_list_init(
     iree_vm_variant_list_t* list, iree_host_size_t capacity) {
   memset(&list->allocator, 0, sizeof(list->allocator));
   list->capacity = capacity;
   list->count = 0;
   memset(list->values, 0, sizeof(list->values[0]) * capacity);
-  return IREE_STATUS_OK;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_variant_list_free(iree_vm_variant_list_t* list) {
   for (iree_host_size_t i = 0; i < list->count; ++i) {
     if (IREE_VM_VARIANT_IS_REF(&list->values[i])) {
       iree_vm_ref_release(&list->values[i].ref);
     }
   }
-  return iree_allocator_free(list->allocator, list);
+  iree_allocator_free(list->allocator, list);
 }
 
 IREE_API_EXPORT iree_host_size_t IREE_API_CALL

--- a/iree/vm/variant_list.h
+++ b/iree/vm/variant_list.h
@@ -65,11 +65,11 @@ iree_vm_variant_list_alloc_size(iree_host_size_t capacity);
 // iree_vm_variant_list_alloc_size for the same |capacity|.
 // The list must be freed with iree_vm_variant_list_free unless ownership is
 // transferred to code that will perform the free as documented in its API.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_variant_list_init(
+IREE_API_EXPORT void IREE_API_CALL iree_vm_variant_list_init(
     iree_vm_variant_list_t* list, iree_host_size_t capacity);
 
 // Frees the list using the allocator it was originally allocated from.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
+IREE_API_EXPORT void IREE_API_CALL
 iree_vm_variant_list_free(iree_vm_variant_list_t* list);
 
 // Returns the total number of elements added to the list.


### PR DESCRIPTION
It was rare they would be able to return a meaningful error and checking
wasn't worth the complexity. This will make future work on iree_status_t
easier as cleanup code paths will be much simpler.