### PR TITLE
Slash and burn to get the dynamic shaped MLP working on Vulkan.

### DIFF
--- a/integrations/tensorflow/e2e/dynamic_mlp_test.py
+++ b/integrations/tensorflow/e2e/dynamic_mlp_test.py
@@ -61,7 +61,7 @@ class Mlp(tf.Module):
 
 
 @tf_test_utils.compile_modules(
-    backends=["tf", "iree_vmla"], mlp=(Mlp, ["predict"]))
+    backends=["tf", "iree_vmla", "iree_vulkan"], mlp=(Mlp, ["predict"]))
 class DynamicMlpTest(tf_test_utils.SavedModelTestCase):
 
   def test_dynamic_batch(self):

--- a/iree/compiler/Dialect/Flow/IR/FlowOpUtils.h
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpUtils.h
@@ -60,6 +60,8 @@ class ClosureOpDce {
   unsigned variadicOffset;
   llvm::SmallVector<llvm::Optional<BlockArgument>, 8> blockArgReplacements;
   llvm::SmallMapVector<Value, BlockArgument, 8> argToBlockMap;
+  llvm::SmallVector<int, 4> returnIndexMap;
+  llvm::SmallVector<std::pair<int, int>, 4> resultIndexMap;
   bool needsOperandElision = false;
   bool needsResultElision = false;
 };

--- a/iree/compiler/Dialect/Flow/IR/test/dispatch_region_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/dispatch_region_folding.mlir
@@ -8,11 +8,11 @@ func @dceOperandsAndResults(%arg0 : tensor<?xf32>) -> (tensor<?xf32>) {
   // CHECK-SAME: (%[[CA1:.+]] = %arg0 : tensor<?xf32>) -> tensor<?xf32>
   // CHECK: %[[DR0:.+]] = addf %[[CA1]], %[[CA1]]
   // CHECK: flow.return %[[DR0]] : tensor<?xf32>
-  %ret0, %ret1 = flow.dispatch.region[%workload : index](
+  %ret0, %ret1, %ret2 = flow.dispatch.region[%workload : index](
       %i0 = %arg0 : tensor<?xf32>, %i1 = %arg0 : tensor<?xf32>, %i2 = %arg0 : tensor<?xf32>) 
-      -> (tensor<?xf32>, tensor<?xf32>) {
+      -> (tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) {
     %1 = addf %i0, %i1 : tensor<?xf32>
-    flow.return %1, %i2 : tensor<?xf32>, tensor<?xf32>
+    flow.return %1, %i2, %1 : tensor<?xf32>, tensor<?xf32>, tensor<?xf32>
   }
   // CHECK: return %[[R0]] : tensor<?xf32>
   return %ret0 : tensor<?xf32>

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -145,8 +145,13 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager) {
 
   // Create all of the dispatch regions, CSE their workloads, and fold.
   passManager.addPass(IREE::Flow::createIdentifyDispatchRegions2Pass());
+  // TODO(laurenzo): BAD BAD BAD. For some reason, tie_shapes are being
+  // duplicated, requiring multiple hits with the hammer to filter down.
+  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
   passManager.addNestedPass<FuncOp>(createCSEPass());
-  passManager.addPass(IREE::Flow::createFoldCompatibleDispatchRegionsPass());
+  passManager.addNestedPass<FuncOp>(createCanonicalizerPass());
+  // TODO(laurenzo): Make compatible with dynamic shapes.
+  // passManager.addPass(IREE::Flow::createFoldCompatibleDispatchRegionsPass());
 
   // Note that as we are rematerializing things here it's critical we do not run
   // the canonicalizer/CSE between now and when we outline - otherwise it'll


### PR DESCRIPTION
Roughly, several changes:
* Legalize RankedBroadcastInDim back to BroadcastInDim once shapes have been re-ified on the backend.
* Disable all dispatch region fusion for dynamic shapes. I have notes on what the issues are here, but I decided to focus on "O0" functionality first as a baseline.
* Fix to the DR folder to dedup result (it was previously only deduping operands). This came from a limitation in the backends when trying to run completely unfused (the backend does not like producing multiple results that alias from the same thing -- needs to insert explicit copies for generality).
* Enable the vulkan backend for the MLP test.
* A really bad canonicalize->cse->canonicalize thing to workaround an issue with tie_shapes being duplicated in/around dispatch regions, resulting in difficulty determining duplication.

Also requires a one line change to the HLO BroadcastInDim folder to disable folding with dynamic dimensions (this is not legal to do in general):
  if (!type.hasStaticShape()) return nullptr;

Progress on #2057, #2073