### PR TITLE
Reworking VM stack ABI to use host stack storage in most cases

### DIFF
--- a/bindings/python/pyiree/rt/vm.cc
+++ b/bindings/python/pyiree/rt/vm.cc
@@ -242,7 +242,7 @@ void SetupVmBindings(pybind11::module m) {
   m.def("create_strings_module", &CreateStringsModule);
   m.def("create_tensorlist_module", &CreateTensorListModule);
 
-  py::enum_<iree_vm_function_linkage_t>(m, "Linkage")
+  py::enum_<enum iree_vm_function_linkage_e>(m, "Linkage")
       .value("INTERNAL", IREE_VM_FUNCTION_LINKAGE_INTERNAL)
       .value("IMPORT", IREE_VM_FUNCTION_LINKAGE_IMPORT)
       .value("EXPORT", IREE_VM_FUNCTION_LINKAGE_EXPORT)

--- a/iree/base/tracing.h
+++ b/iree/base/tracing.h
@@ -86,7 +86,7 @@
 // IREE_TRACING_MODE = 1: instrumentation and basic statistics
 // IREE_TRACING_MODE = 2: same as 1 with added allocation tracking
 // IREE_TRACING_MODE = 3: same as 2 with callstacks for allocations
-// IREE_TRACING_MODE = 3: same as 3 with callstacks for all instrumentation
+// IREE_TRACING_MODE = 4: same as 3 with callstacks for all instrumentation
 #if !defined(IREE_TRACING_FEATURES)
 #if defined(IREE_TRACING_MODE) && IREE_TRACING_MODE == 1
 #define IREE_TRACING_FEATURES (IREE_TRACING_FEATURE_INSTRUMENTATION)

--- a/iree/compiler/Dialect/Shape/Transforms/ConvertHLOToShapeDialectPass.cpp
+++ b/iree/compiler/Dialect/Shape/Transforms/ConvertHLOToShapeDialectPass.cpp
@@ -31,20 +31,6 @@ namespace iree_compiler {
 namespace Shape {
 namespace {
 
-// Returns a 1-d i64 elements attribute populated with numbers from start to
-// end, excluding.
-static DenseIntElementsAttr getI64ElementsAttrForSeq(int start, int end,
-                                                     Builder &builder) {
-  int size = end - start;
-
-  SmallVector<int64_t, 4> vals;
-  vals.resize(size);
-  std::iota(vals.begin(), vals.end(), start);
-
-  TensorType ty = RankedTensorType::get({size}, builder.getIntegerType(64));
-  return DenseIntElementsAttr::get(ty, vals);
-}
-
 class ConvertDynamicBroadcastInDim
     : public OpConversionPattern<xla_hlo::DynamicBroadcastInDimOp> {
   using OpConversionPattern::OpConversionPattern;

--- a/iree/compiler/Dialect/Shape/Transforms/FunctionSignatureExpansionPass.cpp
+++ b/iree/compiler/Dialect/Shape/Transforms/FunctionSignatureExpansionPass.cpp
@@ -30,23 +30,6 @@ namespace iree_compiler {
 namespace Shape {
 namespace {
 
-bool isLegallyShapedSignatureType(Type thisType, Type nextType) {
-  if (!thisType.isa<TensorType>()) return true;  // Legal: Don't care.
-  auto rankedType = thisType.dyn_cast<RankedTensorType>();
-  if (!rankedType) return false;  // Illegal: Non-ranked tensor
-  if (rankedType.getNumDynamicDims() == 0) return true;  // Legal: Static shape
-
-  // At this point, the type is ranked and has dynamic dims. Validate.
-  auto rankedShapeType = nextType.dyn_cast_or_null<Shape::RankedShapeType>();
-  if (!rankedShapeType) return false;  // Illegal: No following shape.
-
-  // Are dims equal.
-  auto thisDims = rankedType.getShape();
-  auto shapeDims = rankedShapeType.getAllDims();
-  if (!thisDims.equals(shapeDims)) return false;  // Illegal: Mismatched shape.
-  return true;  // Legal: dynamic tensor followed by matching shape.
-}
-
 class ExpandFunctionDynamicDimsPass
     : public PassWrapper<ExpandFunctionDynamicDimsPass, FunctionPass> {
   void runOnFunction() override {

--- a/iree/hal/host/inproc_command_buffer.cc
+++ b/iree/hal/host/inproc_command_buffer.cc
@@ -244,6 +244,7 @@ Status InProcCommandBuffer::Process(CommandBuffer* command_processor) const {
       LOG(ERROR) << "DeviceQueue failure while executing command; permanently "
                     "failing all future commands: "
                  << command_status;
+      return command_status;
     }
   }
 

--- a/iree/hal/vmla/vmla_command_processor.h
+++ b/iree/hal/vmla/vmla_command_processor.h
@@ -16,7 +16,6 @@
 #define IREE_HAL_VMLA_VMLA_COMMAND_PROCESSOR_H_
 
 #include "iree/hal/host/host_local_command_processor.h"
-#include "iree/vm/stack.h"
 
 namespace iree {
 namespace hal {
@@ -34,9 +33,6 @@ class VMLACommandProcessor final : public HostLocalCommandProcessor {
       const PushConstantBlock& push_constants,
       absl::Span<const absl::Span<const DescriptorSet::Binding>> set_bindings)
       override;
-
- private:
-  iree_vm_stack_t* stack_ = nullptr;
 };
 
 }  // namespace vmla

--- a/iree/modules/check/check_test.cc
+++ b/iree/modules/check/check_test.cc
@@ -170,6 +170,7 @@ class CheckTest : public ::testing::Test {
             &function),
         IREE_LOC))
         << "Exported function '" << function_name << "' not found";
+    // TODO(#2075): don't directly invoke native functions like this.
     return FromApiStatus(
         iree_vm_invoke(context_, function,
                        /*policy=*/nullptr, inputs_,

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -559,7 +559,7 @@ class HALModuleState final {
       absl::Span<const int32_t> binding_offsets,
       absl::Span<const int32_t> binding_lengths) {
     IREE_TRACE_SCOPE0("HALModuleState::CommandBufferPushDescriptorSet");
-    absl::InlinedVector<iree_hal_descriptor_set_binding_t, 4> binding_structs(
+    absl::InlinedVector<iree_hal_descriptor_set_binding_t, 16> binding_structs(
         binding_ordinals.size());
     for (int i = 0; i < binding_ordinals.size(); ++i) {
       binding_structs[i] = {

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -245,7 +245,7 @@ class HALModuleState final {
         IREE_LOC));
     if (allocation_size < value->data.data_length) {
       return InvalidArgumentErrorBuilder(IREE_LOC)
-             << "Constant data is too larger for the minimum allocation size";
+             << "Constant data is too large for the minimum allocation size";
     }
 
     vm::ref<iree_hal_buffer_t> buffer;

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -95,7 +95,9 @@ iree_check_single_backend_test_suite(
         "tanh.mlir",
         "torch_index_select.mlir",
         "transpose.mlir",
-        "while.mlir",
+
+        # TODO(#2022): fails on real devices.
+        # "while.mlir",
     ],
     driver = "vulkan",
     target_backend = "vulkan-spirv",

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -63,7 +63,6 @@ iree_check_single_backend_test_suite(
     "tanh.mlir"
     "torch_index_select.mlir"
     "transpose.mlir"
-    "while.mlir"
   TARGET_BACKEND
     vulkan-spirv
   DRIVER

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -150,6 +150,7 @@ cc_library(
     srcs = ["module.c"],
     hdrs = ["module.h"],
     deps = [
+        "//iree/base:alignment",
         "//iree/base:api",
         "//iree/base:atomics",
     ],
@@ -215,6 +216,7 @@ cc_library(
     deps = [
         ":module",
         ":ref",
+        ":variant_list",
         "//iree/base:alignment",
         "//iree/base:api",
     ],

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -119,6 +119,7 @@ cc_library(
         ":stack",
         "//iree/base:api",
         "//iree/base:atomics",
+        "//iree/base:tracing",
     ],
 )
 
@@ -142,6 +143,7 @@ cc_library(
         ":module",
         ":variant_list",
         "//iree/base:api",
+        "//iree/base:tracing",
     ],
 )
 
@@ -219,6 +221,7 @@ cc_library(
         ":variant_list",
         "//iree/base:alignment",
         "//iree/base:api",
+        "//iree/base:tracing",
     ],
 )
 

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -172,6 +172,7 @@ iree_cc_library(
   SRCS
     "module.c"
   DEPS
+    iree::base::alignment
     iree::base::api
     iree::base::atomics
   PUBLIC
@@ -246,6 +247,7 @@ iree_cc_library(
   DEPS
     ::module
     ::ref
+    ::variant_list
     iree::base::alignment
     iree::base::api
   PUBLIC

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -132,6 +132,7 @@ iree_cc_library(
     ::stack
     iree::base::api
     iree::base::atomics
+    iree::base::tracing
   PUBLIC
 )
 
@@ -161,6 +162,7 @@ iree_cc_library(
     ::module
     ::variant_list
     iree::base::api
+    iree::base::tracing
   PUBLIC
 )
 
@@ -250,6 +252,7 @@ iree_cc_library(
     ::variant_list
     iree::base::alignment
     iree::base::api
+    iree::base::tracing
   PUBLIC
 )
 

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -47,71 +47,7 @@
 #define VMCHECK(expr)
 #endif  // NDEBUG
 
-// Remaps argument registers from a source list to the 0-N ABI registers.
-static void iree_vm_bytecode_dispatch_remap_argument_registers(
-    iree_vm_registers_t* src_regs, const iree_vm_register_list_t* src_reg_list,
-    iree_vm_registers_t* dst_regs) {
-  // Each bank begins left-aligned at 0 and increments per arg of its type.
-  int i32_reg_offset = 0;
-  int ref_reg_offset = 0;
-  for (int i = 0; i < src_reg_list->size; ++i) {
-    // TODO(benvanik): change encoding to avoid this branching.
-    // Could write two arrays: one for prims and one for refs.
-    uint16_t src_reg = src_reg_list->registers[i];
-    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
-      uint16_t dst_reg = ref_reg_offset++;
-      memset(&dst_regs->ref[dst_reg & IREE_REF_REGISTER_MASK], 0,
-             sizeof(iree_vm_ref_t));
-      iree_vm_ref_retain_or_move(
-          src_reg & IREE_REF_REGISTER_MOVE_BIT,
-          &src_regs->ref[src_reg & IREE_REF_REGISTER_MASK],
-          &dst_regs->ref[dst_reg & IREE_REF_REGISTER_MASK]);
-    } else {
-      uint16_t dst_reg = i32_reg_offset++;
-      dst_regs->i32[dst_reg & IREE_I32_REGISTER_MASK] =
-          src_regs->i32[src_reg & IREE_I32_REGISTER_MASK];
-    }
-  }
-  dst_regs->ref_register_count = ref_reg_offset;
-}
-
-// Remaps registers from source to destination, possibly across frames.
-static void iree_vm_bytecode_dispatch_remap_registers(
-    iree_vm_registers_t* src_regs, const iree_vm_register_list_t* src_reg_list,
-    iree_vm_registers_t* dst_regs,
-    const iree_vm_register_list_t* dst_reg_list) {
-  VMCHECK(src_reg_list->size == dst_reg_list->size);
-  for (int i = 0; i < src_reg_list->size; ++i) {
-    // TODO(benvanik): change encoding to avoid this branching.
-    // Could write two arrays: one for prims and one for refs.
-    uint16_t src_reg = src_reg_list->registers[i];
-    uint16_t dst_reg = dst_reg_list->registers[i];
-    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
-      iree_vm_ref_retain_or_move(
-          src_reg & IREE_REF_REGISTER_MOVE_BIT,
-          &src_regs->ref[src_reg & IREE_REF_REGISTER_MASK],
-          &dst_regs->ref[dst_reg & IREE_REF_REGISTER_MASK]);
-    } else {
-      dst_regs->i32[dst_reg & IREE_I32_REGISTER_MASK] =
-          src_regs->i32[src_reg & IREE_I32_REGISTER_MASK];
-    }
-  }
-}
-
-// Discards ref registers in the list if they are marked move.
-static void iree_vm_bytecode_dispatch_discard_registers(
-    iree_vm_registers_t* regs, const iree_vm_register_list_t* reg_list) {
-  for (int i = 0; i < reg_list->size; ++i) {
-    // TODO(benvanik): change encoding to avoid this branching.
-    uint16_t reg = reg_list->registers[i];
-    if ((reg & (IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT)) ==
-        (IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT)) {
-      iree_vm_ref_release(&regs->ref[reg & IREE_REF_REGISTER_MASK]);
-    }
-  }
-}
-
-// Interleaved src-dst register sets.
+// Interleaved src-dst register sets for branch register remapping.
 // This structure is an overlay for the bytecode that is serialized in a
 // matching format.
 typedef struct {
@@ -126,9 +62,15 @@ static_assert(iree_alignof(iree_vm_register_remap_list_t) == 2,
 static_assert(offsetof(iree_vm_register_remap_list_t, pairs) == 2,
               "Expect no padding in the struct");
 
-// Remaps registers from a source set to a destination set within the frame.
+// Remaps registers from a source set to a destination set within the same stack
+// frame. This is a way to perform a conditional multi-mov sequence instead of
+// requiring the additional bytecode representation of the conditional movs.
+//
+// This assumes that the remapping list is properly ordered such that there are
+// no swapping hazards (such as 0->1,1->0). The register allocator in the
+// compiler should ensure this is the case when it can occur.
 static void iree_vm_bytecode_dispatch_remap_branch_registers(
-    iree_vm_registers_t* regs,
+    const iree_vm_registers_t regs,
     const iree_vm_register_remap_list_t* remap_list) {
   for (int i = 0; i < remap_list->size; ++i) {
     // TODO(benvanik): change encoding to avoid this branching.
@@ -137,11 +79,25 @@ static void iree_vm_bytecode_dispatch_remap_branch_registers(
     uint16_t dst_reg = remap_list->pairs[i].dst_reg;
     if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
       iree_vm_ref_retain_or_move(src_reg & IREE_REF_REGISTER_MOVE_BIT,
-                                 &regs->ref[src_reg & IREE_REF_REGISTER_MASK],
-                                 &regs->ref[dst_reg & IREE_REF_REGISTER_MASK]);
+                                 &regs.ref[src_reg & regs.ref_mask],
+                                 &regs.ref[dst_reg & regs.ref_mask]);
     } else {
-      regs->i32[dst_reg & IREE_I32_REGISTER_MASK] =
-          regs->i32[src_reg & IREE_I32_REGISTER_MASK];
+      regs.i32[dst_reg & regs.i32_mask] = regs.i32[src_reg & regs.i32_mask];
+    }
+  }
+}
+
+// Discards ref registers in the list if they are marked move.
+// This can be used to eagerly release resources we don't need and reduces
+// memory consumption if used effectively prior to yields/waits.
+static void iree_vm_bytecode_dispatch_discard_registers(
+    const iree_vm_registers_t regs, const iree_vm_register_list_t* reg_list) {
+  for (int i = 0; i < reg_list->size; ++i) {
+    // TODO(benvanik): change encoding to avoid this branching.
+    uint16_t reg = reg_list->registers[i];
+    if ((reg & (IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT)) ==
+        (IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT)) {
+      iree_vm_ref_release(&regs.ref[reg & regs.ref_mask]);
     }
   }
 }
@@ -229,8 +185,8 @@ iree_status_t iree_vm_bytecode_dispatch(
       ((uint32_t)bytecode_data[pc + 3 + i] << 24)
 #endif  // IREE_IS_LITTLE_ENDIAN
 
-#define OP_R_I32(i) regs->i32[OP_I16(i) & IREE_I32_REGISTER_MASK]
-#define OP_R_REF(i) regs->ref[OP_I16(i) & IREE_REF_REGISTER_MASK]
+#define OP_R_I32(i) regs.i32[OP_I16(i) & regs.i32_mask]
+#define OP_R_REF(i) regs.ref[OP_I16(i) & regs.ref_mask]
 #define OP_R_REF_IS_MOVE(i) (OP_I16(i) & IREE_REF_REGISTER_MOVE_BIT)
 
   // Primary dispatch state. This is our 'native stack frame' and really
@@ -240,15 +196,14 @@ iree_status_t iree_vm_bytecode_dispatch(
   // The hope is that the compiler decides to keep these in registers (as
   // they are touched for every instruction executed). The frame will change
   // as we call into different functions.
-  const iree_vm_function_descriptor_t* entry_function_descriptor =
-      &module->function_descriptor_table[entry_frame->function.ordinal];
   iree_vm_stack_frame_t* current_frame = entry_frame;
+  iree_vm_registers_t regs = entry_frame->registers;
   const uint8_t* bytecode_data =
-      module->bytecode_data.data + entry_function_descriptor->bytecode_offset;
+      module->bytecode_data.data +
+      module->function_descriptor_table[current_frame->function.ordinal]
+          .bytecode_offset;
   iree_vm_source_offset_t pc = current_frame->pc;
-  iree_vm_registers_t* regs = &current_frame->registers;
-  // TODO(benvanik): hide this register initialization logic in the stack enter.
-  regs->ref_register_count = entry_function_descriptor->ref_register_count;
+  const int32_t entry_frame_depth = entry_frame->depth;
 
   memset(out_result, 0, sizeof(*out_result));
 
@@ -446,6 +401,10 @@ iree_status_t iree_vm_bytecode_dispatch(
       //   VM_EncResult<"value">,
       // ];
       int32_t rodata_ordinal = OP_I32(0);
+      if (rodata_ordinal < 0 ||
+          rodata_ordinal >= module_state->rodata_ref_count) {
+        return IREE_STATUS_OUT_OF_RANGE;
+      }
       // TODO(benvanik): allow decompression callbacks to run now (if needed).
       iree_vm_ref_wrap_retain(&module_state->rodata_ref_table[rodata_ordinal],
                               iree_vm_ro_byte_buffer_type_id(), &OP_R_REF(4));
@@ -511,8 +470,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       pc += kRegSize + 4 + kRegSize + value_reg_list->size * kRegSize;
       int32_t new_value = default_value;
       if (index >= 0 && index < value_reg_list->size) {
-        new_value = regs->i32[value_reg_list->registers[index] &
-                              IREE_I32_REGISTER_MASK];
+        new_value = regs.i32[value_reg_list->registers[index] & regs.i32_mask];
       }
       OP_R_I32(0) = new_value;
       pc += kRegSize;
@@ -538,8 +496,7 @@ iree_status_t iree_vm_bytecode_dispatch(
           kRegSize + 4 + kRegSize + kRegSize + value_reg_list->size * kRegSize;
       iree_vm_ref_t* new_value = default_value;
       if (index >= 0 && index < value_reg_list->size) {
-        new_value = &regs->ref[value_reg_list->registers[index] &
-                               IREE_REF_REGISTER_MASK];
+        new_value = &regs.ref[value_reg_list->registers[index] & regs.ref_mask];
         is_move = value_reg_list->registers[index] & IREE_REF_REGISTER_MOVE_BIT;
       }
       iree_vm_ref_t* result_reg = &OP_R_REF(0);
@@ -754,68 +711,51 @@ iree_status_t iree_vm_bytecode_dispatch(
       pc += 4 + kRegSize + src_reg_list->size * kRegSize;
       const iree_vm_register_list_t* dst_reg_list =
           (const iree_vm_register_list_t*)&bytecode_data[pc];
-      current_frame->return_registers = dst_reg_list;
       pc += kRegSize + dst_reg_list->size * kRegSize;
       current_frame->pc = pc;
 
       // NOTE: we assume validation has ensured these functions exist.
       // TODO(benvanik): something more clever than just a high bit?
-      iree_vm_function_t target_function;
       int is_import = (function_ordinal & 0x80000000u) != 0;
       if (is_import) {
-        // Import that we can fetch from the module state.
-        target_function =
-            module_state->import_table[function_ordinal & 0x7FFFFFFFu];
-      } else {
-        // Internal to the current module.
-        target_function.module = &module->interface;
-        target_function.linkage = IREE_VM_FUNCTION_LINKAGE_INTERNAL;
-        target_function.ordinal = function_ordinal;
-      }
-
-      IREE_DISPATCH_LOG_CALL(target_function);
-
-      // Remap registers from caller to callee.
-      iree_vm_stack_frame_t* callee_frame = NULL;
-      iree_status_t enter_status =
-          iree_vm_stack_function_enter(stack, target_function, &callee_frame);
-      if (!iree_status_is_ok(enter_status)) {
-        // TODO(benvanik): set execution result to stack overflow.
-        return enter_status;
-      }
-      iree_vm_bytecode_dispatch_remap_argument_registers(
-          &current_frame->registers, src_reg_list, &callee_frame->registers);
-
-      if (is_import) {
         // Call external function.
-        iree_status_t call_status = target_function.module->execute(
-            target_function.module->self, stack, callee_frame, out_result);
+        iree_vm_function_call_t call;
+        memset(&call, 0, sizeof(call));
+        call.function =
+            module_state->import_table[function_ordinal & 0x7FFFFFFFu];
+        call.argument_registers = src_reg_list;
+        call.result_registers = dst_reg_list;
+        IREE_DISPATCH_LOG_CALL(call.function);
+        iree_status_t call_status = call.function.module->begin_call(
+            call.function.module->self, stack, &call, out_result);
         if (!iree_status_is_ok(call_status)) {
           // TODO(benvanik): set execution result to failure/capture stack.
           return call_status;
         }
-        if (callee_frame->return_registers) {
-          iree_vm_bytecode_dispatch_remap_registers(
-              &callee_frame->registers, callee_frame->return_registers,
-              &current_frame->registers, current_frame->return_registers);
-        }
-        iree_vm_stack_function_leave(stack);
       } else {
         // Switch execution to the target function and continue running in the
         // bytecode dispatcher.
-        const iree_vm_function_descriptor_t* function_descriptor =
-            &module->function_descriptor_table[callee_frame->function.ordinal];
-        current_frame = callee_frame;
+        iree_vm_function_t target_function;
+        target_function.module = &module->interface;
+        target_function.linkage = IREE_VM_FUNCTION_LINKAGE_INTERNAL;
+        target_function.ordinal = function_ordinal;
+        const iree_vm_function_descriptor_t* target_descriptor =
+            &module->function_descriptor_table[function_ordinal];
+        target_function.i32_register_count =
+            target_descriptor->i32_register_count;
+        target_function.ref_register_count =
+            target_descriptor->ref_register_count;
+        IREE_DISPATCH_LOG_CALL(target_function);
+        iree_status_t enter_status = iree_vm_stack_function_enter(
+            stack, target_function, src_reg_list, dst_reg_list, &current_frame);
+        if (!iree_status_is_ok(enter_status)) {
+          // TODO(benvanik): set execution result to stack overflow.
+          return enter_status;
+        }
+        regs = current_frame->registers;
         bytecode_data =
-            module->bytecode_data.data + function_descriptor->bytecode_offset;
-        regs = &callee_frame->registers;
-        // TODO(benvanik): hide this in the stack.
-        memset(
-            &regs->ref[regs->ref_register_count], 0,
-            sizeof(iree_vm_ref_t) * (function_descriptor->ref_register_count -
-                                     regs->ref_register_count));
-        regs->ref_register_count = function_descriptor->ref_register_count;
-        pc = callee_frame->pc;
+            module->bytecode_data.data + target_descriptor->bytecode_offset;
+        pc = current_frame->pc;
       }
     });
 
@@ -842,13 +782,11 @@ iree_status_t iree_vm_bytecode_dispatch(
       pc += kRegSize + src_reg_list->size * kRegSize;
       const iree_vm_register_list_t* dst_reg_list =
           (const iree_vm_register_list_t*)&bytecode_data[pc];
-      current_frame->return_registers = dst_reg_list;
       pc += kRegSize + dst_reg_list->size * kRegSize;
       current_frame->pc = pc;
 
       // NOTE: we assume validation has ensured these functions exist.
       // TODO(benvanik): something more clever than just a high bit?
-      iree_vm_function_t target_function;
       int is_import = (function_ordinal & 0x80000000u) != 0;
       if (!is_import) {
         // Variadic calls are currently only supported for import functions.
@@ -856,38 +794,22 @@ iree_status_t iree_vm_bytecode_dispatch(
       }
 
       // Import that we can fetch from the module state.
-      target_function =
+      iree_vm_function_call_t call;
+      memset(&call, 0, sizeof(call));
+      call.function =
           module_state->import_table[function_ordinal & 0x7FFFFFFFu];
-
-      IREE_DISPATCH_LOG_CALL(target_function);
-
-      // Remap registers from caller to callee.
-      iree_vm_stack_frame_t* callee_frame = NULL;
-      iree_status_t enter_status =
-          iree_vm_stack_function_enter(stack, target_function, &callee_frame);
-      if (!iree_status_is_ok(enter_status)) {
-        // TODO(benvanik): set execution result to stack overflow.
-        return enter_status;
-      }
-      iree_vm_bytecode_dispatch_remap_argument_registers(
-          &current_frame->registers, src_reg_list, &callee_frame->registers);
-
-      // TODO(benvanik): rename return_registers.
-      callee_frame->return_registers = seg_size_list;
+      call.argument_registers = src_reg_list;
+      call.variadic_segment_size_list = seg_size_list;
+      call.result_registers = dst_reg_list;
+      IREE_DISPATCH_LOG_CALL(call.function);
 
       // Call external function.
-      iree_status_t call_status = target_function.module->execute(
-          target_function.module->self, stack, callee_frame, out_result);
+      iree_status_t call_status = call.function.module->begin_call(
+          call.function.module->self, stack, &call, out_result);
       if (!iree_status_is_ok(call_status)) {
         // TODO(benvanik): set execution result to failure/capture stack.
         return call_status;
       }
-      if (callee_frame->return_registers) {
-        iree_vm_bytecode_dispatch_remap_registers(
-            &callee_frame->registers, callee_frame->return_registers,
-            &current_frame->registers, current_frame->return_registers);
-      }
-      iree_vm_stack_function_leave(stack);
     });
 
     DISPATCH_OP(Return, {
@@ -901,33 +823,22 @@ iree_status_t iree_vm_bytecode_dispatch(
           (const iree_vm_register_list_t*)&bytecode_data[pc];
       current_frame->pc = pc + kRegSize + src_reg_list->size * kRegSize;
 
-      if (current_frame == entry_frame) {
-        // Return from the top-level entry frame - return back to execute().
+      // Leave callee by cleaning up the stack.
+      iree_vm_stack_function_leave(stack, src_reg_list, &current_frame);
+
+      if (!current_frame || current_frame->depth < entry_frame_depth) {
+        // Return from the top-level entry frame - return back to call().
         // TODO(benvanik): clear execution results.
-        current_frame->return_registers = src_reg_list;
         return IREE_STATUS_OK;
       }
 
-      // Copy results back to the caller registers.
-      // The caller pc should be pointing at the head of the return
-      // registers list.
-      iree_vm_stack_frame_t* caller_frame = iree_vm_stack_parent_frame(stack);
-      VMCHECK(caller_frame);
-      iree_vm_bytecode_dispatch_remap_registers(
-          &current_frame->registers, src_reg_list, &caller_frame->registers,
-          caller_frame->return_registers);
-
-      // Leave callee by cleaning up the stack.
-      iree_vm_stack_function_leave(stack);
-
       // Reset dispatch state so we can continue executing in the caller.
-      current_frame = caller_frame;
+      regs = current_frame->registers;
       bytecode_data =
           module->bytecode_data.data +
-          module->function_descriptor_table[caller_frame->function.ordinal]
+          module->function_descriptor_table[current_frame->function.ordinal]
               .bytecode_offset;
-      regs = &caller_frame->registers;
-      pc = caller_frame->pc;
+      pc = current_frame->pc;
     });
 
     DISPATCH_OP(Fail, {

--- a/iree/vm/bytecode_module_benchmark.cc
+++ b/iree/vm/bytecode_module_benchmark.cc
@@ -26,18 +26,23 @@ namespace {
 
 // Example import function that adds 1 to its value.
 static iree_status_t IREE_API_CALL SimpleAddExecute(
-    void* self, iree_vm_stack_t* stack, iree_vm_stack_frame_t* frame,
+    void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call,
     iree_vm_execution_result_t* out_result) {
-  int32_t value = frame->registers.i32[0];
-  frame->registers.i32[0] = value + 1;
+  iree_vm_stack_frame_t* callee_frame;
+  IREE_CHECK_OK(iree_vm_stack_function_enter(
+      stack, call->function, call->argument_registers, call->result_registers,
+      &callee_frame));
+
+  auto& regs = callee_frame->registers;
+  int32_t value = regs.i32[0];
+  regs.i32[0] = value + 1;
 
   // TODO(benvanik): replace with macro? helper for none/i32/etc
   static const union {
     uint16_t reserved[2];
     iree_vm_register_list_t list;
-  } return_registers = {{1, 0}};
-  frame->return_registers = &return_registers.list;
-
+  } result_registers = {{1, 0}};
+  iree_vm_stack_function_leave(stack, &result_registers.list, NULL);
   return IREE_STATUS_OK;
 }
 
@@ -60,8 +65,10 @@ static iree_status_t RunFunction(benchmark::State& state,
   module->alloc_state(module->self, IREE_ALLOCATOR_SYSTEM, &module_state);
 
   iree_vm_module_t import_module;
-  import_module.execute = SimpleAddExecute;
+  memset(&import_module, 0, sizeof(import_module));
+  import_module.begin_call = SimpleAddExecute;
   iree_vm_function_t imported_func;
+  memset(&imported_func, 0, sizeof(imported_func));
   imported_func.module = &import_module;
   imported_func.linkage = IREE_VM_FUNCTION_LINKAGE_INTERNAL;
   imported_func.ordinal = 0;
@@ -76,33 +83,50 @@ static iree_status_t RunFunction(benchmark::State& state,
         return IREE_STATUS_OK;
       }};
 
-  auto stack = std::make_unique<iree_vm_stack_t>();
-  iree_vm_stack_init(state_resolver, stack.get());
-
   iree_vm_function_t function;
-  IREE_CHECK_OK(module->lookup_function(
+  IREE_CHECK_OK(iree_vm_module_lookup_function_by_name(
       module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
       iree_string_view_t{function_name.data(), function_name.size()},
       &function))
       << "Exported function '" << function_name << "' not found";
+  auto signature = iree_vm_function_signature(&function);
 
-  while (state.KeepRunningBatch(batch_size)) {
-    iree_vm_stack_frame_t* entry_frame;
-    iree_vm_stack_function_enter(stack.get(), function, &entry_frame);
-    // TODO(benvanik): replace direct register manipulation with setter:
-    //   iree_vm_stack_frame_set_arguments(entry_frame, 1, i32_args, 0, {});
-    for (int i = 0; i < i32_args.size(); ++i) {
-      entry_frame->registers.i32[i] = i32_args[i];
-    }
-
-    iree_vm_execution_result_t result;
-    IREE_CHECK_OK(
-        module->execute(module->self, stack.get(), entry_frame, &result));
-
-    iree_vm_stack_function_leave(stack.get());
+  auto* argument_registers = (iree_vm_register_list_t*)iree_alloca(
+      sizeof(iree_vm_register_list_t) +
+      signature.argument_count * sizeof(uint16_t));
+  argument_registers->size = signature.argument_count;
+  for (int i = 0; i < argument_registers->size; ++i) {
+    argument_registers->registers[i] = i;
+  }
+  auto* result_registers = (iree_vm_register_list_t*)iree_alloca(
+      sizeof(iree_vm_register_list_t) +
+      signature.result_count * sizeof(uint16_t));
+  result_registers->size = signature.result_count;
+  for (int i = 0; i < result_registers->size; ++i) {
+    result_registers->registers[i] = i;
   }
 
-  iree_vm_stack_deinit(stack.get());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
+  while (state.KeepRunningBatch(batch_size)) {
+    iree_vm_stack_frame_t* external_frame = NULL;
+    IREE_CHECK_OK(iree_vm_stack_external_enter(
+        stack, iree_make_cstring_view("invoke"), 8, &external_frame));
+
+    for (int i = 0; i < argument_registers->size; ++i) {
+      external_frame->registers.i32[i] = i32_args[i];
+    }
+
+    iree_vm_function_call_t call;
+    memset(&call, 0, sizeof(call));
+    call.function = function;
+    call.argument_registers = argument_registers;
+    call.result_registers = result_registers;
+    iree_vm_execution_result_t result;
+    IREE_CHECK_OK(module->begin_call(module->self, stack, &call, &result));
+
+    iree_vm_stack_external_leave(stack);
+  }
+  iree_vm_stack_deinitialize(stack);
 
   module->free_state(module->self, module_state);
   module->destroy(module->self);
@@ -232,36 +256,13 @@ BENCHMARK(BM_CallInternalFuncReference);
 
 static void BM_CallInternalFuncBytecode(benchmark::State& state) {
   IREE_CHECK_OK(RunFunction(state, "call_internal_func", {100},
-                            /*batch_size=*/10));
+                            /*batch_size=*/20));
 }
 BENCHMARK(BM_CallInternalFuncBytecode);
 
-static void BM_CallImportedFuncReference(benchmark::State& state) {
-  iree_vm_module_t import_module;
-  import_module.execute = SimpleAddExecute;
-  iree_vm_module_t* module_ptr = &import_module;
-  benchmark::DoNotOptimize(module_ptr);
-
-  auto stack = std::make_unique<iree_vm_stack_t>();
-  iree_vm_stack_frame_t* frame = &stack->frames[0];
-  iree_vm_execution_result_t result;
-  while (state.KeepRunningBatch(10)) {
-    int value = 100;
-    for (int i = 0; i < 10; ++i) {
-      frame->registers.i32[0] = value;
-      module_ptr->execute(module_ptr->self, stack.get(), frame, &result);
-      value = frame->registers.i32[0];
-      benchmark::DoNotOptimize(value);
-      benchmark::ClobberMemory();
-    }
-    benchmark::ClobberMemory();
-  }
-}
-BENCHMARK(BM_CallImportedFuncReference);
-
 static void BM_CallImportedFuncBytecode(benchmark::State& state) {
   IREE_CHECK_OK(RunFunction(state, "call_imported_func", {100},
-                            /*batch_size=*/10));
+                            /*batch_size=*/20));
 }
 BENCHMARK(BM_CallImportedFuncBytecode);
 

--- a/iree/vm/bytecode_module_benchmark.mlir
+++ b/iree/vm/bytecode_module_benchmark.mlir
@@ -21,7 +21,18 @@ vm.module @bytecode_module_benchmark {
     %7 = vm.call @internal_func(%6) : (i32) -> i32
     %8 = vm.call @internal_func(%7) : (i32) -> i32
     %9 = vm.call @internal_func(%8) : (i32) -> i32
-    vm.return %9 : i32
+    %10 = vm.call @internal_func(%9) : (i32) -> i32
+    %11 = vm.call @internal_func(%10) : (i32) -> i32
+    %12 = vm.call @internal_func(%11) : (i32) -> i32
+    %13 = vm.call @internal_func(%12) : (i32) -> i32
+    %14 = vm.call @internal_func(%13) : (i32) -> i32
+    %15 = vm.call @internal_func(%14) : (i32) -> i32
+    %16 = vm.call @internal_func(%15) : (i32) -> i32
+    %17 = vm.call @internal_func(%16) : (i32) -> i32
+    %18 = vm.call @internal_func(%17) : (i32) -> i32
+    %19 = vm.call @internal_func(%18) : (i32) -> i32
+    %20 = vm.call @internal_func(%19) : (i32) -> i32
+    vm.return %20 : i32
   }
 
   // Measures the cost of a call to an imported function.
@@ -38,7 +49,18 @@ vm.module @bytecode_module_benchmark {
     %7 = vm.call @benchmark.imported_func(%6) : (i32) -> i32
     %8 = vm.call @benchmark.imported_func(%7) : (i32) -> i32
     %9 = vm.call @benchmark.imported_func(%8) : (i32) -> i32
-    vm.return %9 : i32
+    %10 = vm.call @benchmark.imported_func(%9) : (i32) -> i32
+    %11 = vm.call @benchmark.imported_func(%10) : (i32) -> i32
+    %12 = vm.call @benchmark.imported_func(%11) : (i32) -> i32
+    %13 = vm.call @benchmark.imported_func(%12) : (i32) -> i32
+    %14 = vm.call @benchmark.imported_func(%13) : (i32) -> i32
+    %15 = vm.call @benchmark.imported_func(%14) : (i32) -> i32
+    %16 = vm.call @benchmark.imported_func(%15) : (i32) -> i32
+    %17 = vm.call @benchmark.imported_func(%16) : (i32) -> i32
+    %18 = vm.call @benchmark.imported_func(%17) : (i32) -> i32
+    %19 = vm.call @benchmark.imported_func(%18) : (i32) -> i32
+    %20 = vm.call @benchmark.imported_func(%19) : (i32) -> i32
+    vm.return %20 : i32
   }
 
   // Measures the cost of a simple for-loop.

--- a/iree/vm/bytecode_module_impl.h
+++ b/iree/vm/bytecode_module_impl.h
@@ -101,7 +101,7 @@ typedef struct {
   iree_allocator_t allocator;
 } iree_vm_bytecode_module_state_t;
 
-// Begins (or resumes) execution of the given |entry_frame| and continues until
+// Begins (or resumes) execution of the current frame and continues until
 // either a yield or return. |out_result| will contain the result status for
 // continuation, if needed.
 iree_status_t iree_vm_bytecode_dispatch(

--- a/iree/vm/invocation.c
+++ b/iree/vm/invocation.c
@@ -14,54 +14,121 @@
 
 #include "iree/vm/invocation.h"
 
-static iree_status_t iree_vm_validate_function_inputs(
-    iree_vm_function_t function, iree_vm_variant_list_t* inputs) {
-  // TODO(benvanik): validate inputs.
-  return IREE_STATUS_OK;
-}
+#include "iree/base/api.h"
+#include "iree/base/tracing.h"
 
-static iree_status_t iree_vm_marshal_inputs(
-    iree_vm_variant_list_t* inputs, iree_vm_stack_frame_t* callee_frame) {
-  iree_vm_registers_t* registers = &callee_frame->registers;
+#define VMMAX(a, b) (((a) > (b)) ? (a) : (b))
+#define VMMIN(a, b) (((a) < (b)) ? (a) : (b))
+
+// Marshals a variant list of values into callee registers.
+// The |out_dst_reg_list| will be populated with the register ordinals and must
+// be preallocated to store iree_vm_variant_list_size inputs.
+static void iree_vm_stack_frame_marshal_inputs(
+    iree_vm_variant_list_t* inputs, const iree_vm_registers_t dst_regs,
+    iree_vm_register_list_t* out_dst_reg_list) {
   iree_host_size_t count = iree_vm_variant_list_size(inputs);
-  int i32_reg = 0;
-  int ref_reg = 0;
-  for (int i = 0; i < count; ++i) {
+  uint16_t i32_reg = 0;
+  uint16_t ref_reg = 0;
+  out_dst_reg_list->size = (uint16_t)count;
+  for (iree_host_size_t i = 0; i < count; ++i) {
     iree_vm_variant_t* variant = iree_vm_variant_list_get(inputs, i);
     if (IREE_VM_VARIANT_IS_REF(variant)) {
-      iree_vm_ref_t* reg_ref = &registers->ref[ref_reg++];
+      out_dst_reg_list->registers[i] =
+          ref_reg | IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT;
+      iree_vm_ref_t* reg_ref = &dst_regs.ref[ref_reg++];
       memset(reg_ref, 0, sizeof(*reg_ref));
       iree_vm_ref_retain(&variant->ref, reg_ref);
     } else {
-      registers->i32[i32_reg++] = variant->i32;
+      out_dst_reg_list->registers[i] = i32_reg;
+      dst_regs.i32[i32_reg++] = variant->i32;
     }
   }
-  registers->ref_register_count = ref_reg;
-  return IREE_STATUS_OK;
 }
 
-static iree_status_t iree_vm_marshal_outputs(
-    iree_vm_stack_frame_t* callee_frame, iree_vm_variant_list_t* outputs) {
-  iree_vm_registers_t* registers = &callee_frame->registers;
-  const iree_vm_register_list_t* return_registers =
-      callee_frame->return_registers;
-  for (int i = 0; i < return_registers->size; ++i) {
-    uint16_t reg = return_registers->registers[i];
+// Marshals callee return registers into a variant list.
+static iree_status_t iree_vm_stack_frame_marshal_outputs(
+    const iree_vm_registers_t src_regs,
+    const iree_vm_register_list_t* src_reg_list,
+    iree_vm_variant_list_t* outputs) {
+  for (int i = 0; i < src_reg_list->size; ++i) {
+    uint16_t reg = src_reg_list->registers[i];
     if (reg & IREE_REF_REGISTER_TYPE_BIT) {
-      if (reg & IREE_REF_REGISTER_MOVE_BIT) {
-        IREE_RETURN_IF_ERROR(iree_vm_variant_list_append_ref_move(
-            outputs, &registers->ref[reg & IREE_REF_REGISTER_MASK]));
-      } else {
-        IREE_RETURN_IF_ERROR(iree_vm_variant_list_append_ref_retain(
-            outputs, &registers->ref[reg & IREE_REF_REGISTER_MASK]));
-      }
+      iree_vm_ref_t* value = &src_regs.ref[reg & src_regs.ref_mask];
+      IREE_RETURN_IF_ERROR(
+          iree_vm_variant_list_append_ref_move(outputs, value));
     } else {
       iree_vm_value_t value;
       value.type = IREE_VM_VALUE_TYPE_I32;
-      value.i32 = registers->i32[reg & IREE_I32_REGISTER_MASK];
+      value.i32 = src_regs.i32[reg & src_regs.i32_mask];
       IREE_RETURN_IF_ERROR(iree_vm_variant_list_append_value(outputs, value));
     }
   }
+  return IREE_STATUS_OK;
+}
+
+// TODO(benvanik): implement this as an iree_vm_invocation_t sequence.
+static iree_status_t iree_vm_invoke_within(
+    iree_vm_context_t* context, iree_vm_stack_t* stack,
+    iree_vm_function_t function, const iree_vm_invocation_policy_t* policy,
+    iree_vm_variant_list_t* inputs, iree_vm_variant_list_t* outputs) {
+  iree_vm_function_signature_t signature =
+      iree_vm_function_signature(&function);
+  if ((inputs &&
+       iree_vm_variant_list_size(inputs) != signature.argument_count) ||
+      (!inputs && signature.argument_count > 0)) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+  if (!outputs && signature.result_count > 0) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+
+  // Allocate storage for marshaling arguments into the callee stack frame.
+  iree_vm_register_list_t* argument_registers =
+      (iree_vm_register_list_t*)iree_alloca(sizeof(iree_vm_register_list_t) +
+                                            signature.argument_count *
+                                                sizeof(uint16_t));
+  argument_registers->size = signature.argument_count;
+  iree_vm_register_list_t* result_registers =
+      (iree_vm_register_list_t*)iree_alloca(sizeof(iree_vm_register_list_t) +
+                                            signature.result_count *
+                                                sizeof(uint16_t));
+  result_registers->size = signature.result_count;
+
+  // Enter the [external] frame, which will have storage space for the
+  // argument and result registers.
+  int32_t register_count =
+      max(signature.argument_count, signature.result_count);
+  iree_vm_stack_frame_t* external_frame = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_vm_stack_external_enter(stack, iree_make_cstring_view("invoke"),
+                                   register_count, &external_frame));
+
+  // Marshal inputs into the external stack frame registers.
+  if (inputs) {
+    iree_vm_stack_frame_marshal_inputs(inputs, external_frame->registers,
+                                       argument_registers);
+  }
+
+  // Perform execution. Note that for synchronous execution we expect this to
+  // complete without yielding.
+  iree_vm_function_call_t call;
+  memset(&call, 0, sizeof(call));
+  call.function = function;
+  call.argument_registers = argument_registers;
+  call.result_registers = result_registers;
+  iree_vm_execution_result_t result;
+  IREE_RETURN_IF_ERROR(function.module->begin_call(function.module->self, stack,
+                                                   &call, &result));
+
+  // Read back the outputs from the [external] marshaling stack frame.
+  external_frame = iree_vm_stack_current_frame(stack);
+  if (outputs) {
+    IREE_RETURN_IF_ERROR(iree_vm_stack_frame_marshal_outputs(
+        external_frame->registers, result_registers, outputs));
+  }
+
+  iree_vm_stack_external_leave(stack);
+
   return IREE_STATUS_OK;
 }
 
@@ -69,52 +136,15 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke(
     iree_vm_context_t* context, iree_vm_function_t function,
     const iree_vm_invocation_policy_t* policy, iree_vm_variant_list_t* inputs,
     iree_vm_variant_list_t* outputs, iree_allocator_t allocator) {
-  // Allocate a stack on the heap and initialize it.
-  // TODO(#1172): allocate this stack on ... the stack when smaller.
-  iree_vm_stack_t* stack = NULL;
-  IREE_RETURN_IF_ERROR(iree_allocator_malloc(allocator, sizeof(iree_vm_stack_t),
-                                             (void**)&stack));
-  iree_vm_stack_init(iree_vm_context_state_resolver(context), stack);
+  IREE_TRACE_ZONE_BEGIN(z0);
 
+  // Allocate a VM stack on the host stack and initialize it.
+  IREE_VM_INLINE_STACK_INITIALIZE(
+      stack, iree_vm_context_state_resolver(context), allocator);
   iree_status_t status =
       iree_vm_invoke_within(context, stack, function, policy, inputs, outputs);
+  iree_vm_stack_deinitialize(stack);
 
-  iree_vm_stack_deinit(stack);
-  iree_allocator_free(allocator, stack);
+  IREE_TRACE_ZONE_END(z0);
   return status;
-}
-
-// TODO(benvanik): implement this as an iree_vm_invocation_t sequence.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke_within(
-    iree_vm_context_t* context, iree_vm_stack_t* stack,
-    iree_vm_function_t function, const iree_vm_invocation_policy_t* policy,
-    iree_vm_variant_list_t* inputs, iree_vm_variant_list_t* outputs) {
-  // NOTE: it is ok to have no inputs or outputs. If we do have them, though,
-  // they must be valid.
-  // TODO(benvanik): validate outputs capacity.
-  IREE_RETURN_IF_ERROR(iree_vm_validate_function_inputs(function, inputs));
-
-  iree_vm_stack_frame_t* callee_frame = NULL;
-  IREE_RETURN_IF_ERROR(
-      iree_vm_stack_function_enter(stack, function, &callee_frame));
-
-  // Marshal inputs.
-  if (inputs) {
-    IREE_RETURN_IF_ERROR(iree_vm_marshal_inputs(inputs, callee_frame));
-  }
-
-  // Perform execution. Note that for synchronous execution we expect this to
-  // complete without yielding.
-  iree_vm_execution_result_t result;
-  IREE_RETURN_IF_ERROR(function.module->execute(function.module->self, stack,
-                                                callee_frame, &result));
-
-  // Marshal outputs.
-  if (outputs) {
-    IREE_RETURN_IF_ERROR(iree_vm_marshal_outputs(callee_frame, outputs));
-  }
-
-  IREE_RETURN_IF_ERROR(iree_vm_stack_function_leave(stack));
-
-  return IREE_STATUS_OK;
 }

--- a/iree/vm/invocation.c
+++ b/iree/vm/invocation.c
@@ -127,9 +127,7 @@ static iree_status_t iree_vm_invoke_within(
         external_frame->registers, result_registers, outputs));
   }
 
-  iree_vm_stack_external_leave(stack);
-
-  return IREE_STATUS_OK;
+  return iree_vm_stack_external_leave(stack);
 }
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke(

--- a/iree/vm/invocation.h
+++ b/iree/vm/invocation.h
@@ -49,13 +49,6 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke(
     const iree_vm_invocation_policy_t* policy, iree_vm_variant_list_t* inputs,
     iree_vm_variant_list_t* outputs, iree_allocator_t allocator);
 
-// Equivalent to iree_vm_invoke but uses an existing |stack|.
-// If the invocation fails the stack may be left in an indeterminate state.
-IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invoke_within(
-    iree_vm_context_t* context, iree_vm_stack_t* stack,
-    iree_vm_function_t function, const iree_vm_invocation_policy_t* policy,
-    iree_vm_variant_list_t* inputs, iree_vm_variant_list_t* outputs);
-
 // TODO(benvanik): document and implement.
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_invocation_create(
     iree_vm_context_t* context, iree_vm_function_t function,

--- a/iree/vm/module.c
+++ b/iree/vm/module.c
@@ -19,7 +19,7 @@
 #include "iree/base/atomics.h"
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_vm_module_init(iree_vm_module_t* module, void* self) {
+iree_vm_module_initialize(iree_vm_module_t* module, void* self) {
   memset(module, 0, sizeof(iree_vm_module_t));
   module->self = self;
   iree_atomic_store(&module->ref_count, 1);
@@ -88,6 +88,18 @@ iree_vm_function_name(const iree_vm_function_t* function) {
     return iree_make_cstring_view("<error>");
   }
   return name;
+}
+
+IREE_API_EXPORT iree_vm_function_signature_t IREE_API_CALL
+iree_vm_function_signature(const iree_vm_function_t* function) {
+  iree_vm_function_signature_t signature;
+  memset(&signature, 0, sizeof(signature));
+  IREE_IGNORE_ERROR(function->module->get_function(
+      function->module->self, function->linkage, function->ordinal,
+      /*out_function=*/NULL,
+      /*out_name=*/NULL,
+      /*out_signature=*/&signature));
+  return signature;
 }
 
 IREE_API_EXPORT iree_string_view_t IREE_API_CALL

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -651,11 +651,12 @@ static void iree_vm_stack_populate_external_result_list(
   }
 }
 
-IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_function_leave(
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_leave(
     iree_vm_stack_t* stack, const iree_vm_register_list_t* result_registers,
     iree_vm_stack_frame_t** out_caller_frame) {
-  VMCHECK(stack->top != NULL);
-  if (!stack->top) return;
+  if (!stack->top) {
+    return IREE_STATUS_FAILED_PRECONDITION;
+  }
 
   iree_vm_stack_frame_header_t* frame_header = stack->top;
   iree_vm_stack_frame_t* callee_frame = &frame_header->frame;
@@ -691,6 +692,7 @@ IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_function_leave(
   stack->frame_storage_size -= frame_header->frame_size;
 
   if (out_caller_frame) *out_caller_frame = caller_frame;
+  return IREE_STATUS_OK;
 }
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_external_enter(
@@ -708,11 +710,12 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_external_enter(
   return IREE_STATUS_OK;
 }
 
-IREE_API_EXPORT void IREE_API_CALL
+IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_vm_stack_external_leave(iree_vm_stack_t* stack) {
-  VMCHECK(stack->top != NULL);
-  if (!stack->top) return;
-  VMCHECK(stack->top->type == IREE_VM_STACK_FRAME_EXTERNAL);
-  if (stack->top->type != IREE_VM_STACK_FRAME_EXTERNAL) return;
-  iree_vm_stack_function_leave(stack, NULL, NULL);
+  if (!stack->top) {
+    return IREE_STATUS_FAILED_PRECONDITION;
+  } else if (stack->top->type != IREE_VM_STACK_FRAME_EXTERNAL) {
+    return IREE_STATUS_FAILED_PRECONDITION;
+  }
+  return iree_vm_stack_function_leave(stack, NULL, NULL);
 }

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -16,87 +16,703 @@
 
 #include <string.h>
 
+#include "iree/base/api.h"
+#include "iree/base/tracing.h"
 #include "iree/vm/module.h"
 
-IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_init(
-    iree_vm_state_resolver_t state_resolver, iree_vm_stack_t* out_stack) {
-  memset(out_stack, 0, sizeof(iree_vm_stack_t));
-  out_stack->state_resolver = state_resolver;
+#ifndef NDEBUG
+#define VMCHECK(expr) assert(expr)
+#else
+#define VMCHECK(expr)
+#endif  // NDEBUG
+
+#define VMMAX(a, b) (((a) > (b)) ? (a) : (b))
+#define VMMIN(a, b) (((a) < (b)) ? (a) : (b))
+
+//===----------------------------------------------------------------------===//
+// Stack implementation
+//===----------------------------------------------------------------------===//
+//
+// The stack is (currently) designed to contain enough information to allow us
+// to build some nice debugging tools. This means that we try hard to preserve
+// all information needed for complete and precise stack dumps as well as
+// allowing inspection of both current and previous stack frame registers.
+// In the future we may want to toggle these modes such that registers, for
+// example, are hidden by the module implementations to allow for more
+// optimization opportunity but as a whole we tradeoff minimal memory
+// consumption for flexibility and debugging. Given that a single activation
+// tensor will usually dwarf the entire size of the stack used for an invocation
+// it's generally acceptable :)
+//
+// Stack frames and storage
+// ------------------------
+// Frames are stored as a linked list of iree_vm_stack_frame_header_t's
+// containing the API-visible stack frame information (such as which function
+// the frame is in and it's program counter) and the storage for registers used
+// by the frame. As all operations including stack dumps only ever need to
+// enumerate the frames in storage order there's no need to be able to randomly
+// index into them and the linked list combined with dynamic stack growth gives
+// us (practically) unlimited stack depth.
+//
+// [iree_vm_stack_t]
+//   +- top -------> [frame 3 header] [registers] ---+
+//                                                   |
+//              +--- [frame 2 header] [registers] <--+
+//              |
+//              +--> [frame 1 header] [registers] ---+
+//                                                   |
+//         NULL <--- [frame 0 header] [registers] <--+
+//
+// To allow for static stack allocation and make allocating the VM stack on the
+// host stack or within an existing data structure the entire stack, including
+// all frame storage, can be placed into an existing allocation. This is similar
+// to inlined vectors/etc where some storage is available directly in the object
+// and only when exceeded will it switch to a dynamic allocation.
+//
+// Dynamic stack growth
+// --------------------
+// Though most of the stacks we deal with are rather shallow due to aggressive
+// inlining in the compiler it's still possible to spill any reasonably-sized
+// static storage allocation. This can be especially true in modules compiled
+// with optimizations disabled; for example the debug register allocator may
+// expand the required register count for a function from 30 to 3000.
+//
+// To support these cases the stack can optionally be provided an allocator to
+// enable it to grow the stack when the initial storage is exhausted. As we
+// store pointers to the stack storage within the storage itself (such as the
+// iree_vm_registers_t pointers) this means we need to perform a fixup step
+// during reallocation to ensure they are all updated. This also means that the
+// pointers to the stack frames are possibly invalidated on every function
+// entry and that users of the stack cannot rely on pointer stability during
+// execution.
+//
+// Calling convention
+// ------------------
+// Stack frames are managed by callees. A caller will provide a list of argument
+// and result registers in the caller frame that should be passed into and out
+// of the callee. The callee will first push its stack frame and reserve the
+// register storage it requires, copy or move the argument values from the
+// caller frame into the callee frame, and then begin execution. Upon return the
+// callee function will move return registers from its frame out to the caller
+// frame and pop its stack frame.
+//
+// By making the actual stack frame setup and teardown callee-controlled we can
+// have optimized implementations that treat register storage differently across
+// various frames. For example, native modules that store their registers in
+// host-machine specific registers can marshal the caller registers in/out of
+// the host registers (or stack/etc) without exposing the actual implementation
+// to the caller.
+//
+// Calling into the VM
+// -------------------
+// Calls from external code into the VM such as via iree_vm_invoke reuse the
+// same calling convention as internal-to-internal calls: callees load arguments
+// from the caller frame and store results into the caller frame. To enable this
+// a set of iree_vm_stack_external_enter/iree_vm_stack_external_leave functions
+// are provided to setup the special `[external]` stack frame that allows the
+// external code to marshal in the arguments and marshal out the results.
+//
+// Marshaling arguments is easy given that the caller controls these and we can
+// trivially map the ordered set of argument types into the ABI registers.
+//
+// TODO(#1979): know result types ahead of time.
+// Results are more difficult as today we do not know the order or type of the
+// function results upon entry. As such when the callee goes to leave its frame
+// and store the results back to the caller we cannot place directly into
+// registers that then the iree_vm_stack_external_leave can access. To work
+// around this until we can more cleanly provide this information we check for
+// external callers when leaving frames and duplicate the register mapping. This
+// can result in use-after-free if the result register mapping was not in rdata
+// however today both our C++ and bytecode implementations are.
+//
+// A side-effect (beyond code reuse) is that ref types are retained by the VM
+// for the entire lifetime they may be accessible by VM routines. This lets us
+// get rich stack traces without needing to hook into external code and lets us
+// timeshift via coroutines where we may otherwise not know when the external
+// caller will resume a yielded call and actually read back the results.
+//
+// The overhead of this marshaling is minimal as external functions can always
+// use move semantics on the ref objects. Since we are reusing the normal VM
+// code paths which are likely still in I$ the bulk of the work amounts to some
+// small memcpys.
+
+// Multiplier on the capacity of the stack frame storage when growing.
+// Since we never shrink stacks it's nice to keep this relative low. If we
+// measure a lot of growth happening in normal models we should increase this
+// but otherwise leave as small as we can to avoid overallocation.
+#define IREE_VM_STACK_GROWTH_FACTOR 2
+
+enum {
+  // Represents an `[external]` frame that needs to marshal args/results.
+  // These frames have no source location and are tracked so that we know when
+  // transitions occur into/out-of external code.
+  IREE_VM_STACK_FRAME_EXTERNAL = 0,
+  // Normal VM stack frame using the internal register storage.
+  IREE_VM_STACK_FRAME_INTERNAL = 1,
+};
+typedef uint8_t iree_vm_stack_frame_type_t;
+
+// A private stack frame header that allows us to walk the linked list of
+// frames without exposing their exact structure through the API. This makes it
+// easier for us to add/version additional information or hide implementation
+// details.
+typedef struct iree_vm_stack_frame_header {
+  // Size, in bytes, of the frame header and frame payload including registers.
+  // Adding this value to the base header pointer will yield the next available
+  // memory location. Ensure that it does not exceed the total
+  // frame_storage_capacity.
+  iree_host_size_t frame_size;
+
+  // Pointer to the parent stack frame, usually immediately preceding this one
+  // in the frame storage. May be NULL.
+  struct iree_vm_stack_frame_header* parent;
+
+  // Stack frame type used to determine which fields are valid.
+  iree_vm_stack_frame_type_t type;
+
+  // Pointer to a register list within the stack frame where return registers
+  // will be stored by callees upon return.
+  //
+  // TODO(#1979): external frames will have a direct reference to the callee
+  // frame return registers.
+  const iree_vm_register_list_t* return_registers;
+
+  // Actual stack frame as visible through the API.
+  // The registers within the frame will (likely) point to addresses immediately
+  // following this header in memory.
+  iree_vm_stack_frame_t frame;
+} iree_vm_stack_frame_header_t;
+
+// Core stack storage. This will be mapped either into dynamic memory allocated
+// by the member allocator or static memory allocated externally. Static stacks
+// cannot grow when storage runs out while dynamic ones will resize their stack.
+struct iree_vm_stack {
+  // NOTE: to get better cache hit rates we put the most frequently accessed
+  // members first.
+
+  // Pointer to the current top of the stack.
+  // This can be used to walk the stack from top to bottom by following the
+  // |parent| pointers. Note that these pointers are invalidated each time the
+  // stack grows (if dynamic growth is enabled) and all of the frames will need
+  // updating.
+  iree_vm_stack_frame_header_t* top;
+
+  // Base pointer to stack storage.
+  // For statically-allocated stacks this will (likely) point to immediately
+  // after the iree_vm_stack_t in memory. For dynamically-allocated stacks this
+  // will (likely) point to heap memory.
+  iree_host_size_t frame_storage_capacity;
+  iree_host_size_t frame_storage_size;
+  void* frame_storage;
+
+  // True if the stack owns the frame_storage and should free it when it is no
+  // longer required. Host stack-allocated stacks don't own their storage but
+  // may transition to owning it on dynamic growth.
+  bool owns_frame_storage;
+
+  // Resolves a module to a module state within a context.
+  // This will be called on function entry whenever module transitions occur.
+  iree_vm_state_resolver_t state_resolver;
+
+  // Allocator used for dynamic stack allocations. May be the null allocator
+  // if growth is prohibited.
+  iree_allocator_t allocator;
+};
+
+//===----------------------------------------------------------------------===//
+// Math utilities, kept here to limit dependencies
+//===----------------------------------------------------------------------===//
+
+// Haswell or later, gcc compile time option: -mlzcnt
+#if defined(__LZCNT__)
+#include <x86intrin.h>
+#endif  // __LZCNT__
+
+// Clang on Windows has __builtin_clz; otherwise we need to use the
+// Windows intrinsic functions.
+#if defined(_MSC_VER)
+#include <intrin.h>
+#pragma intrinsic(_BitScanReverse)
+#endif  // _MSC_VER
+
+// https://en.wikipedia.org/wiki/Find_first_set
+int iree_math_count_leading_zeros_u32(uint32_t n) {
+#if defined(_MSC_VER)
+  unsigned long result = 0;  // NOLINT(runtime/int)
+  if (_BitScanReverse(&result, n)) {
+    return 31 - result;
+  }
+  return 32;
+#elif defined(__GNUC__)
+  // Use __builtin_clz, which uses the following instructions:
+  //  x86: bsr
+  //  ARM64: clz
+  //  PPC: cntlzd
+  static_assert(sizeof(int) == sizeof(n),
+                "__builtin_clz does not take 32-bit arg");
+
+#if defined(__LCZNT__)
+  // NOTE: LZCNT is a risky instruction; it is not supported on architectures
+  // before Haswell, yet it is encoded as 'rep bsr', which typically ignores
+  // invalid rep prefixes, and interprets it as the 'bsr' instruction, which
+  // returns the index of the value rather than the count, resulting in
+  // incorrect code.
+  return __lzcnt32(n);
+#endif  // defined(__LCZNT__)
+
+  // Handle 0 as a special case because __builtin_clz(0) is undefined.
+  return n ? __builtin_clz(n) : 32;
+#else
+#error No clz for this arch.
+#endif
+}
+
+// Rounds up the value to the nearest power of 2 (if not already a power of 2).
+uint32_t iree_math_round_up_to_pow2_u32(uint32_t n) {
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  n++;
+  return n;
+}
+
+// Aligns |value| up to the given power-of-two |alignment| if required.
+// https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+iree_host_size_t iree_math_align(iree_host_size_t value,
+                                 iree_host_size_t alignment) {
+  return (value + (alignment - 1)) & ~(alignment - 1);
+}
+
+//===----------------------------------------------------------------------===//
+// Stack implementation
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_initialize(
+    iree_byte_span_t storage, iree_vm_state_resolver_t state_resolver,
+    iree_allocator_t allocator, iree_vm_stack_t** out_stack) {
+  *out_stack = NULL;
+  if (storage.data_length < IREE_VM_STACK_MIN_SIZE) {
+    return IREE_STATUS_INVALID_ARGUMENT;
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_vm_stack_t* stack = (iree_vm_stack_t*)storage.data;
+  memset(stack, 0, sizeof(iree_vm_stack_t));
+  stack->owns_frame_storage = false;
+  stack->state_resolver = state_resolver;
+  stack->allocator = allocator;
+
+  iree_host_size_t storage_offset =
+      iree_math_align(sizeof(iree_vm_stack_t), 16);
+  stack->frame_storage_capacity = storage.data_length - storage_offset;
+  stack->frame_storage_size = 0;
+  stack->frame_storage = storage.data + storage_offset;
+
+  stack->top = NULL;
+
+  *out_stack = stack;
+
+  IREE_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
 }
 
 IREE_API_EXPORT void IREE_API_CALL
-iree_vm_stack_deinit(iree_vm_stack_t* stack) {
-  while (stack->depth) {
-    iree_vm_stack_function_leave(stack);
+iree_vm_stack_deinitialize(iree_vm_stack_t* stack) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  while (stack->top) {
+    iree_vm_stack_function_leave(stack, NULL, NULL);
   }
+
+  if (stack->owns_frame_storage) {
+    iree_allocator_free(stack->allocator, stack->frame_storage);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_allocate(
+    iree_vm_state_resolver_t state_resolver, iree_allocator_t allocator,
+    iree_vm_stack_t** out_stack) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  *out_stack = NULL;
+
+  iree_host_size_t storage_size = IREE_VM_STACK_DEFAULT_SIZE;
+  void* storage = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(allocator, storage_size, &storage);
+  iree_vm_stack_t* stack = NULL;
+  if (iree_status_is_ok(status)) {
+    iree_byte_span_t storage_span = iree_make_byte_span(storage, storage_size);
+    status = iree_vm_stack_initialize(storage_span, state_resolver, allocator,
+                                      &stack);
+  }
+
+  *out_stack = stack;
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_free(iree_vm_stack_t* stack) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_allocator_t allocator = stack->allocator;
+  void* storage = (void*)stack;
+  iree_vm_stack_deinitialize(stack);
+  iree_allocator_free(allocator, storage);
+
+  IREE_TRACE_ZONE_END(z0);
 }
 
 IREE_API_EXPORT iree_vm_stack_frame_t* IREE_API_CALL
 iree_vm_stack_current_frame(iree_vm_stack_t* stack) {
-  return stack->depth > 0 ? &stack->frames[stack->depth - 1] : NULL;
+  return stack->top ? &stack->top->frame : NULL;
 }
 
 IREE_API_EXPORT iree_vm_stack_frame_t* IREE_API_CALL
 iree_vm_stack_parent_frame(iree_vm_stack_t* stack) {
-  return stack->depth > 1 ? &stack->frames[stack->depth - 2] : NULL;
+  if (!stack->top) return NULL;
+  iree_vm_stack_frame_header_t* parent_header = stack->top->parent;
+  return parent_header ? &parent_header->frame : NULL;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_query_module_state(
+    iree_vm_stack_t* stack, iree_vm_module_t* module,
+    iree_vm_module_state_t** out_module_state) {
+  return stack->state_resolver.query_module_state(stack->state_resolver.self,
+                                                  module, out_module_state);
+}
+
+// Attempts to grow the stack store to hold at least |minimum_capacity|.
+// Pointers to existing stack frames will be invalidated and any pointers
+// embedded in the stack frame data structures will be updated.
+// Fails if dynamic stack growth is disabled or the allocator is OOM.
+static iree_status_t iree_vm_stack_grow(iree_vm_stack_t* stack,
+                                        iree_host_size_t minimum_capacity) {
+  if (stack->allocator.alloc == NULL) {
+    return IREE_STATUS_RESOURCE_EXHAUSTED;
+  }
+
+  // Ensure we grow at least as much as required.
+  iree_host_size_t new_capacity = stack->frame_storage_capacity;
+  do {
+    new_capacity *= IREE_VM_STACK_GROWTH_FACTOR;
+  } while (new_capacity < minimum_capacity);
+  if (new_capacity > IREE_VM_STACK_MAX_SIZE) {
+    return IREE_STATUS_RESOURCE_EXHAUSTED;
+  }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Reallocate the frame storage. 99.9999% chance the new storage pointer will
+  // differ and we'll need to fix up pointers so we just always do that.
+  void* old_storage = stack->frame_storage;
+  void* new_storage = stack->frame_storage;
+  iree_status_t status;
+  if (stack->owns_frame_storage) {
+    // We own the storage already likely from a previous growth operation.
+    status =
+        iree_allocator_realloc(stack->allocator, new_capacity, &new_storage);
+  } else {
+    // We don't own the original storage so we are going to switch to our own
+    // newly-allocated storage instead. We need to make sure we copy over the
+    // existing stack contents.
+    status =
+        iree_allocator_malloc(stack->allocator, new_capacity, &new_storage);
+    if (iree_status_is_ok(status)) {
+      memcpy(new_storage, old_storage, stack->frame_storage_capacity);
+    }
+  }
+  if (!iree_status_is_ok(status)) {
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+  stack->frame_storage = new_storage;
+  stack->frame_storage_capacity = new_capacity;
+  stack->owns_frame_storage = true;
+
+#define REBASE_POINTER(type, ptr, old_base, new_base)           \
+  if (ptr) {                                                    \
+    (ptr) = (type)(((uintptr_t)(ptr) - (uintptr_t)(old_base)) + \
+                   (uintptr_t)(new_base));                      \
+  }
+
+  // Fixup embedded stack frame pointers.
+  REBASE_POINTER(iree_vm_stack_frame_header_t*, stack->top, old_storage,
+                 new_storage);
+  iree_vm_stack_frame_header_t* frame_header = stack->top;
+  while (frame_header != NULL) {
+    iree_vm_registers_t* registers = &frame_header->frame.registers;
+    REBASE_POINTER(int32_t*, registers->i32, old_storage, new_storage);
+    REBASE_POINTER(iree_vm_ref_t*, registers->ref, old_storage, new_storage);
+    REBASE_POINTER(iree_vm_stack_frame_header_t*, frame_header->parent,
+                   old_storage, new_storage);
+    frame_header = frame_header->parent;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return IREE_STATUS_OK;
+}
+
+// Remaps argument/result registers from a source list in the caller/callee
+// frame to the 0-N ABI registers in the callee/caller frame. This assumes that
+// the destination stack frame registers are unused and ok to overwrite
+// directly.
+static void iree_vm_stack_frame_remap_abi_registers(
+    const iree_vm_registers_t src_regs,
+    const iree_vm_register_list_t* src_reg_list,
+    const iree_vm_registers_t dst_regs) {
+  // Each bank begins left-aligned at 0 and increments per arg of its type.
+  int i32_reg_offset = 0;
+  int ref_reg_offset = 0;
+  for (int i = 0; i < src_reg_list->size; ++i) {
+    // TODO(benvanik): change encoding to avoid this branching.
+    // Could write two arrays: one for prims and one for refs.
+    uint16_t src_reg = src_reg_list->registers[i];
+    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
+      uint16_t dst_reg = ref_reg_offset++;
+      memset(&dst_regs.ref[dst_reg & dst_regs.ref_mask], 0,
+             sizeof(iree_vm_ref_t));
+      iree_vm_ref_retain_or_move(src_reg & IREE_REF_REGISTER_MOVE_BIT,
+                                 &src_regs.ref[src_reg & src_regs.ref_mask],
+                                 &dst_regs.ref[dst_reg & dst_regs.ref_mask]);
+    } else {
+      uint16_t dst_reg = i32_reg_offset++;
+      dst_regs.i32[dst_reg & dst_regs.i32_mask] =
+          src_regs.i32[src_reg & src_regs.i32_mask];
+    }
+  }
+}
+
+// Remaps registers from source to destination, possibly across frames.
+// Registers from the |src_regs| will be copied/moved to |dst_regs| with the
+// mappings provided by |src_reg_list| and |dst_reg_list|. It's assumed that the
+// mappings are matching by type and - in the case that they aren't - things
+// will get weird (but not crash).
+static void iree_vm_stack_frame_remap_registers(
+    const iree_vm_registers_t src_regs,
+    const iree_vm_register_list_t* src_reg_list,
+    const iree_vm_registers_t dst_regs,
+    const iree_vm_register_list_t* dst_reg_list) {
+  VMCHECK(src_reg_list->size == dst_reg_list->size);
+  if (src_reg_list->size != dst_reg_list->size) return;
+  for (int i = 0; i < src_reg_list->size; ++i) {
+    // TODO(benvanik): change encoding to avoid this branching.
+    // Could write two arrays: one for prims and one for refs.
+    uint16_t src_reg = src_reg_list->registers[i];
+    uint16_t dst_reg = dst_reg_list->registers[i];
+    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
+      iree_vm_ref_retain_or_move(src_reg & IREE_REF_REGISTER_MOVE_BIT,
+                                 &src_regs.ref[src_reg & src_regs.ref_mask],
+                                 &dst_regs.ref[dst_reg & dst_regs.ref_mask]);
+    } else {
+      dst_regs.i32[dst_reg & dst_regs.i32_mask] =
+          src_regs.i32[src_reg & src_regs.i32_mask];
+    }
+  }
 }
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_enter(
     iree_vm_stack_t* stack, iree_vm_function_t function,
+    const iree_vm_register_list_t* argument_registers,
+    const iree_vm_register_list_t* result_registers,
     iree_vm_stack_frame_t** out_callee_frame) {
-  *out_callee_frame = NULL;
-  if (stack->depth == IREE_MAX_STACK_DEPTH) {
-    return IREE_STATUS_RESOURCE_EXHAUSTED;
-  }
+  if (out_callee_frame) *out_callee_frame = NULL;
 
   // Try to reuse the same module state if the caller and callee are from the
   // same module. Otherwise, query the state from the registered handler.
-  iree_vm_stack_frame_t* callee_frame = &stack->frames[stack->depth];
-  if (stack->depth > 0) {
-    iree_vm_stack_frame_t* caller_frame = &stack->frames[stack->depth - 1];
-    if (caller_frame->function.module == function.module) {
-      callee_frame->module_state = caller_frame->module_state;
-    }
-  }
-  if (!callee_frame->module_state) {
+  iree_vm_stack_frame_header_t* caller_frame_header = stack->top;
+  iree_vm_stack_frame_t* caller_frame =
+      caller_frame_header ? &caller_frame_header->frame : NULL;
+  iree_vm_module_state_t* module_state = NULL;
+  if (caller_frame && caller_frame->function.module == function.module) {
+    module_state = caller_frame->module_state;
+  } else if (function.module != NULL) {
     IREE_RETURN_IF_ERROR(stack->state_resolver.query_module_state(
-        stack->state_resolver.self, function.module,
-        &callee_frame->module_state));
+        stack->state_resolver.self, function.module, &module_state));
   }
 
-  ++stack->depth;
+  // We first compute the frame size of the callee and the masks we'll use to
+  // bounds check register access. This lets us allocate the entire frame
+  // (header, frame, and register storage) as a single pointer bump below.
+  iree_vm_registers_t registers;
+  memset(&registers, 0, sizeof(registers));
 
-  callee_frame->function = function;
+  // Round up register counts to the nearest power of 2 (if not already).
+  // This let's us use bit masks on register accesses to do bounds checking
+  // instead of more complex logic. The cost of these extra registers is only at
+  // worst 2x the required cost: so not large when thinking about the normal
+  // size of data used in an IREE app for tensors.
+  //
+  // Note that to allow the masking to work as a guard we need to ensure we at
+  // least allocate 1 register; this way an i32[reg & mask] will always point at
+  // valid memory even if mask == 0.
+  uint32_t i32_register_count =
+      iree_math_round_up_to_pow2_u32(VMMAX(1, function.i32_register_count));
+  uint32_t ref_register_count =
+      iree_math_round_up_to_pow2_u32(VMMAX(1, function.ref_register_count));
+  if (i32_register_count > IREE_I32_REGISTER_MASK ||
+      ref_register_count > IREE_REF_REGISTER_MASK) {
+    // Register count overflow. A valid compiler should never produce files that
+    // hit this.
+    return IREE_STATUS_RESOURCE_EXHAUSTED;
+  }
+  // NOTE: >> by the bit width is undefined so we use a 64bit mask here to
+  // ensure we are ok.
+  registers.i32_mask =
+      (uint16_t)(0xFFFFFFFFull >>
+                 (iree_math_count_leading_zeros_u32(i32_register_count) + 1)) &
+      IREE_I32_REGISTER_MASK;
+  registers.ref_mask =
+      (uint16_t)(0xFFFFFFFFull >>
+                 (iree_math_count_leading_zeros_u32(ref_register_count) + 1)) &
+      IREE_REF_REGISTER_MASK;
+
+  // We need to align the ref register start to the natural machine alignment
+  // in case the compiler is expecting that (it makes it easier to debug too).
+  iree_host_size_t i32_register_size =
+      iree_math_align(i32_register_count * sizeof(int32_t), 16);
+  iree_host_size_t ref_register_size =
+      iree_math_align(ref_register_count * sizeof(iree_vm_ref_t), 16);
+  iree_host_size_t header_size =
+      iree_math_align(sizeof(iree_vm_stack_frame_header_t), 16);
+  iree_host_size_t frame_size =
+      header_size + i32_register_size + ref_register_size;
+
+  // Grow stack, if required.
+  iree_host_size_t new_top = stack->frame_storage_size + frame_size;
+  if (new_top > stack->frame_storage_capacity) {
+    IREE_RETURN_IF_ERROR(iree_vm_stack_grow(stack, new_top));
+
+    // NOTE: the caller_frame pointer may have changed if the stack grew.
+    caller_frame = iree_vm_stack_current_frame(stack);
+  }
+
+  // Bump pointer and get real stack pointer offsets.
+  iree_vm_stack_frame_header_t* frame_header =
+      (iree_vm_stack_frame_header_t*)((uintptr_t)stack->frame_storage +
+                                      stack->frame_storage_size);
+  memset(frame_header, 0, frame_size);
+  registers.i32 = (int32_t*)((uintptr_t)frame_header + header_size);
+  registers.ref =
+      (iree_vm_ref_t*)((uintptr_t)registers.i32 + i32_register_size);
+
+  frame_header->frame_size = frame_size;
+  frame_header->parent = stack->top;
+  frame_header->type = IREE_VM_STACK_FRAME_INTERNAL;
+  frame_header->return_registers = result_registers;
+
+  iree_vm_stack_frame_t* callee_frame = &frame_header->frame;
   callee_frame->pc = 0;
-  callee_frame->registers.ref_register_count = 0;
-  callee_frame->return_registers = NULL;
+  callee_frame->registers = registers;
+  callee_frame->function = function;
+  callee_frame->module_state = module_state;
+  callee_frame->depth = caller_frame ? caller_frame->depth + 1 : 0;
 
-#ifndef NDEBUG
-  memset(callee_frame->registers.i32, 0xCD,
-         sizeof(callee_frame->registers.i32));
-  memset(callee_frame->registers.ref, 0xCD,
-         sizeof(callee_frame->registers.ref));
-#endif  // !NDEBUG
+  stack->frame_storage_size = new_top;
+  stack->top = frame_header;
 
-  *out_callee_frame = callee_frame;
+  // Remap arguments from the caller stack frame into the callee stack frame.
+  if (caller_frame && argument_registers) {
+    iree_vm_stack_frame_remap_abi_registers(
+        caller_frame->registers, argument_registers, callee_frame->registers);
+  }
+
+  if (out_callee_frame) *out_callee_frame = callee_frame;
   return IREE_STATUS_OK;
 }
 
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_vm_stack_function_leave(iree_vm_stack_t* stack) {
-  if (stack->depth <= 0) {
-    return IREE_STATUS_FAILED_PRECONDITION;
+// The external caller doesn't know the register types that it's going to be
+// getting back today and as such cannot provide them the way normal calls can.
+// Here we take the callee register list and construct a left-aligned register
+// list (each register type starting from 0-N in each bank).
+static void iree_vm_stack_populate_external_result_list(
+    const iree_vm_register_list_t* callee_registers,
+    const iree_vm_register_list_t* external_registers) {
+  VMCHECK(external_registers->size == callee_registers->size);
+  uint16_t i32_reg_ordinal = 0;
+  uint16_t ref_reg_ordinal = 0;
+  uint16_t* dst_reg_list = (uint16_t*)external_registers->registers;
+  for (int i = 0; i < callee_registers->size; ++i) {
+    uint16_t src_reg = callee_registers->registers[i];
+    uint16_t abi_reg;
+    if (src_reg & IREE_REF_REGISTER_TYPE_BIT) {
+      abi_reg = IREE_REF_REGISTER_TYPE_BIT | IREE_REF_REGISTER_MOVE_BIT |
+                (ref_reg_ordinal++);
+    } else {
+      abi_reg = i32_reg_ordinal++;
+    }
+    dst_reg_list[i] = abi_reg;
+  }
+}
+
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_function_leave(
+    iree_vm_stack_t* stack, const iree_vm_register_list_t* result_registers,
+    iree_vm_stack_frame_t** out_caller_frame) {
+  VMCHECK(stack->top != NULL);
+  if (!stack->top) return;
+
+  iree_vm_stack_frame_header_t* frame_header = stack->top;
+  iree_vm_stack_frame_t* callee_frame = &frame_header->frame;
+  iree_vm_stack_frame_t* caller_frame =
+      frame_header->parent ? &frame_header->parent->frame : NULL;
+
+  // TODO(#1979): avoid this hack to propagate results to external frames.
+  if (frame_header->parent &&
+      frame_header->parent->type == IREE_VM_STACK_FRAME_EXTERNAL &&
+      result_registers) {
+    iree_vm_stack_populate_external_result_list(result_registers,
+                                                frame_header->return_registers);
+    frame_header->parent->return_registers = frame_header->return_registers;
   }
 
-  iree_vm_stack_frame_t* callee_frame = &stack->frames[stack->depth - 1];
-  --stack->depth;
-  memset(&callee_frame->function, 0, sizeof(callee_frame->function));
-  callee_frame->module_state = NULL;
+  // Remap result registers from the callee frame to the caller frame.
+  if (caller_frame && result_registers) {
+    iree_vm_stack_frame_remap_registers(
+        callee_frame->registers, result_registers, caller_frame->registers,
+        frame_header->parent->return_registers);
+  }
 
+  // Release the reserved register storage to restore the frame pointer.
+  // TODO(benvanik): allow the VM to elide this when it's known that there are
+  // no more live registers.
   iree_vm_registers_t* registers = &callee_frame->registers;
-  for (int i = 0; i < registers->ref_register_count; ++i) {
+  for (int i = 0; i <= registers->ref_mask; ++i) {
     iree_vm_ref_release(&registers->ref[i]);
   }
 
+  // Restore the frame pointer to the caller.
+  stack->top = stack->top->parent;
+  stack->frame_storage_size -= frame_header->frame_size;
+
+  if (out_caller_frame) *out_caller_frame = caller_frame;
+}
+
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_external_enter(
+    iree_vm_stack_t* stack, iree_string_view_t name,
+    iree_host_size_t register_count, iree_vm_stack_frame_t** out_callee_frame) {
+  iree_vm_function_t external_function;
+  memset(&external_function, 0, sizeof(external_function));
+  external_function.ref_register_count = (uint16_t)register_count;
+  external_function.i32_register_count = (uint16_t)register_count;
+
+  IREE_RETURN_IF_ERROR(iree_vm_stack_function_enter(
+      stack, external_function, NULL, NULL, out_callee_frame));
+
+  stack->top->type = IREE_VM_STACK_FRAME_EXTERNAL;
   return IREE_STATUS_OK;
+}
+
+IREE_API_EXPORT void IREE_API_CALL
+iree_vm_stack_external_leave(iree_vm_stack_t* stack) {
+  VMCHECK(stack->top != NULL);
+  if (!stack->top) return;
+  VMCHECK(stack->top->type == IREE_VM_STACK_FRAME_EXTERNAL);
+  if (stack->top->type != IREE_VM_STACK_FRAME_EXTERNAL) return;
+  iree_vm_stack_function_leave(stack, NULL, NULL);
 }

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -634,7 +634,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_enter(
 static void iree_vm_stack_populate_external_result_list(
     const iree_vm_register_list_t* callee_registers,
     const iree_vm_register_list_t* external_registers) {
-  VMCHECK(external_registers->size == callee_registers->size);
+  VMCHECK(external_registers->size >= callee_registers->size);
   uint16_t i32_reg_ordinal = 0;
   uint16_t ref_reg_ordinal = 0;
   uint16_t* dst_reg_list = (uint16_t*)external_registers->registers;

--- a/iree/vm/stack.c
+++ b/iree/vm/stack.c
@@ -133,8 +133,8 @@
 //
 // The overhead of this marshaling is minimal as external functions can always
 // use move semantics on the ref objects. Since we are reusing the normal VM
-// code paths which are likely still in I$ the bulk of the work amounts to some
-// small memcpys.
+// code paths which are likely still in instruction cache the bulk of the work
+// amounts to some small memcpys.
 
 // Multiplier on the capacity of the stack frame storage when growing.
 // Since we never shrink stacks it's nice to keep this relative low. If we
@@ -236,7 +236,7 @@ struct iree_vm_stack {
 #endif  // _MSC_VER
 
 // https://en.wikipedia.org/wiki/Find_first_set
-int iree_math_count_leading_zeros_u32(uint32_t n) {
+static inline int iree_math_count_leading_zeros_u32(uint32_t n) {
 #if defined(_MSC_VER)
   unsigned long result = 0;  // NOLINT(runtime/int)
   if (_BitScanReverse(&result, n)) {
@@ -268,7 +268,7 @@ int iree_math_count_leading_zeros_u32(uint32_t n) {
 }
 
 // Rounds up the value to the nearest power of 2 (if not already a power of 2).
-uint32_t iree_math_round_up_to_pow2_u32(uint32_t n) {
+static inline uint32_t iree_math_round_up_to_pow2_u32(uint32_t n) {
   n--;
   n |= n >> 1;
   n |= n >> 2;
@@ -281,8 +281,8 @@ uint32_t iree_math_round_up_to_pow2_u32(uint32_t n) {
 
 // Aligns |value| up to the given power-of-two |alignment| if required.
 // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
-iree_host_size_t iree_math_align(iree_host_size_t value,
-                                 iree_host_size_t alignment) {
+static inline iree_host_size_t iree_math_align(iree_host_size_t value,
+                                               iree_host_size_t alignment) {
   return (value + (alignment - 1)) & ~(alignment - 1);
 }
 

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -213,7 +213,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_enter(
 // Leaves the current stack frame.
 // The provided |result_registers| in the callee frame will be stored back into
 // the caller frame result registers.
-IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_function_leave(
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_leave(
     iree_vm_stack_t* stack, const iree_vm_register_list_t* result_registers,
     iree_vm_stack_frame_t** out_caller_frame);
 
@@ -231,7 +231,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_external_enter(
     iree_host_size_t register_count, iree_vm_stack_frame_t** out_callee_frame);
 
 // Leaves the current external stack frame.
-IREE_API_EXPORT void IREE_API_CALL
+IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_vm_stack_external_leave(iree_vm_stack_t* stack);
 
 #ifdef __cplusplus

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -22,13 +22,30 @@
 #include "iree/base/api.h"
 #include "iree/vm/module.h"
 #include "iree/vm/ref.h"
+#include "iree/vm/variant_list.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
-// Maximum stack depth, in frames.
-#define IREE_MAX_STACK_DEPTH 32
+// A reasonable default stack storage size, in bytes.
+// This will allow most (reasonable) programs to run. If running
+// unverified/untested programs then prefer to use a dynamically growable stack
+// until the expectations of the programs are checked; for example, hopefully
+// in a year or two we have much more complex models with much deeper call
+// stacks and we may want to re-evaluate the host-stack allocation size.
+//
+// The value was chosen to fit quite a few i32 registers and a reasonable amount
+// of ref registers (that are 2 * sizeof(void*)). For many invocations this will
+// be more than enough to perform the work without needing an additional dynamic
+// allocation/resize.
+#define IREE_VM_STACK_DEFAULT_SIZE (8 * 1024)
+
+// The minimum size of VM stack storage.
+#define IREE_VM_STACK_MIN_SIZE (1 * 1024)
+
+// The maximum size of VM stack storage; anything larger is probably a bug.
+#define IREE_VM_STACK_MAX_SIZE (1 * 1024 * 1024)
 
 // Maximum register count per bank.
 // This determines the bits required to reference registers in the VM bytecode.
@@ -41,52 +58,46 @@ extern "C" {
 #define IREE_REF_REGISTER_MOVE_BIT 0x4000
 #define IREE_REF_REGISTER_MASK 0x3FFF
 
-// An opaque offset into a source map that a source resolver can calculate.
-// Do not assume that iree_vm_source_offset_t+1 means the next byte offset as
-// backends are free to treat these as everything from pointers to machine code
-// to hash codes.
-typedef int64_t iree_vm_source_offset_t;
-
-// Register banks for use within a stack frame.
+// Pointers to typed register storage.
 typedef struct {
-  // Integer registers.
-  iree_alignas(16) int32_t i32[IREE_I32_REGISTER_COUNT];
-  // Reference counted registers.
-  iree_vm_ref_t ref[IREE_REF_REGISTER_COUNT];
-  // Total number of valid ref registers used by the function.
-  // TODO(benvanik): make the above dynamic and include i32 count.
-  uint16_t ref_register_count;
+  // Ordinal mask defining which ordinal bits are valid. All i32 indexing must
+  // be ANDed with this mask.
+  uint16_t i32_mask;
+  // Ordinal mask defining which ordinal bits are valid. All ref indexing must
+  // be ANDed with this mask.
+  uint16_t ref_mask;
+  // 16-byte aligned i32 register array.
+  int32_t* i32;
+  // Naturally aligned ref register array.
+  iree_vm_ref_t* ref;
 } iree_vm_registers_t;
-
-// A variable-length list of registers.
-//
-// This structure is an overlay for the bytecode that is serialized in a
-// matching format, though it can be stack allocated as needed.
-typedef struct {
-  uint16_t size;
-  uint16_t registers[];
-} iree_vm_register_list_t;
-static_assert(iree_alignof(iree_vm_register_list_t) == 2,
-              "Expecting byte alignment (to avoid padding)");
-static_assert(offsetof(iree_vm_register_list_t, registers) == 2,
-              "Expect no padding in the struct");
 
 // A single stack frame within the VM.
 typedef struct iree_vm_stack_frame {
-  // Function that the stack frame is within.
-  iree_vm_function_t function;
-  // Cached module state pointer for the module containing |function|.
-  iree_vm_module_state_t* module_state;
-  // Current program counter (byte offset) within the function.
+  // NOTE: to (try to) get better cache hit rates we put the most frequently
+  // accessed members first.
+
+  // Current program counter within the function.
+  // Implementations may treat this offset differently, treating it as a byte
+  // offset (such as in the case of VM bytecode), a block identifier (compiled
+  // code), etc.
   iree_vm_source_offset_t pc;
-  // Registers used within the frame.
-  // TODO(benvanik): pointer to an arena? avoids fixed overheads.
+
+  // Pointers to register arrays into storage.
   iree_vm_registers_t registers;
 
-  // Pointer to a register list where callers can source their return registers.
-  // If omitted then the return values are assumed to be left-aligned in the
-  // register banks.
-  const iree_vm_register_list_t* return_registers;
+  // Function that the stack frame is within.
+  iree_vm_function_t function;
+
+  // Cached module state pointer for the module containing |function|.
+  // This removes the need to lookup the module state when control returns to
+  // the function during continuation or from a return instruction.
+  iree_vm_module_state_t* module_state;
+
+  // Depth of the frame within the stack.
+  // As stack frame pointers are not stable this can be used instead to detect
+  // stack enter/leave balance issues.
+  int32_t depth;
 } iree_vm_stack_frame_t;
 
 // A state resolver that can allocate or lookup module state.
@@ -100,24 +111,75 @@ typedef struct iree_vm_state_resolver {
 // A fiber stack used for storing stack frame state during execution.
 // All required state is stored within the stack and no host thread-local state
 // is used allowing us to execute multiple fibers on the same host thread.
-typedef struct iree_vm_stack {
-  // TODO(benvanik): add globally useful things (instance/device manager?)
-  // Depth of the stack, in frames. 0 indicates an empty stack.
-  int32_t depth;
-  // [0-depth) valid stack frames.
-  iree_vm_stack_frame_t frames[IREE_MAX_STACK_DEPTH];
+typedef struct iree_vm_stack iree_vm_stack_t;
 
-  // Resolves a module to a module state within a context.
-  // This will be called on function entry whenever module transitions occur.
-  iree_vm_state_resolver_t state_resolver;
-} iree_vm_stack_t;
+// Defines and initializes an inline VM stack.
+// The stack will be ready for use and must be deinitialized with
+// iree_vm_stack_deinitialize when no longer required.
+//
+// Example:
+//  IREE_VM_INLINE_STACK_INITIALIZE(
+//      stack,
+//      iree_vm_context_state_resolver(context),
+//      IREE_ALLOCATOR_SYSTEM);
+//  ...
+//  iree_vm_stack_deinitialize(stack);
+#define IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, allocator) \
+  uint8_t __stack_storage[IREE_VM_STACK_DEFAULT_SIZE];                    \
+  iree_byte_span_t __stack_storage_span =                                 \
+      iree_make_byte_span(__stack_storage, sizeof(__stack_storage));      \
+  iree_vm_stack_t* stack = NULL;                                          \
+  IREE_IGNORE_ERROR(iree_vm_stack_initialize(                             \
+      __stack_storage_span, (state_resolver), (allocator), &stack));
 
-// Constructs a stack in-place in |out_stack|.
-IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_init(
-    iree_vm_state_resolver_t state_resolver, iree_vm_stack_t* out_stack);
+// Initializes a statically-allocated stack in |storage|.
+// The contents of the |storage| can be anything upon initialization and the
+// stack must be deinitialized with iree_vm_stack_deinitialize before the
+// storage is freed. The provided |allocator| is only used for stack growth
+// beyond the intial storage capacity and may be IREE_ALLOCATOR_NULL to prevent
+// growth. Use IREE_VM_STACK_DEFAULT_SIZE for a reasonable default or use
+// iree_vm_stack_allocate if the input programs may exceed reason.
+//
+// The provided |state_resolver| will be used to resolve a module to a module
+// state within a context. This will be called on function entry whenever module
+// transitions occur.
+//
+// Example:
+//  uint8_t stack_storage[IREE_VM_STACK_DEFAULT_SIZE];
+//  iree_vm_stack_t* stack = NULL;
+//  iree_vm_stack_initialize(stack_storage, ..., &stack);
+//  ...
+//  iree_vm_stack_deinitialize(stack);
+//  // stack_storage can now be reused/freed/etc
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_initialize(
+    iree_byte_span_t storage, iree_vm_state_resolver_t state_resolver,
+    iree_allocator_t allocator, iree_vm_stack_t** out_stack);
 
-// Destructs |stack|.
-IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_deinit(iree_vm_stack_t* stack);
+// Deinitializes a statically-allocated |stack| previously initialized with
+// iree_vm_stack_initialize.
+IREE_API_EXPORT void IREE_API_CALL
+iree_vm_stack_deinitialize(iree_vm_stack_t* stack);
+
+// Allocates a dynamically-growable stack.
+//
+// The provided |state_resolver| will be used to resolve a module to a module
+// state within a context. This will be called on function entry whenever module
+// transitions occur.
+//
+// The stack will be allocated from |allocator| and returned in |out_stack|.
+// It must be freed with iree_vm_stack_free.
+//
+// Example:
+//  iree_vm_stack_t* stack = NULL;
+//  iree_vm_stack_allocate(..., IREE_ALLOCATOR_SYSTEM, &stack);
+//  ...
+//  iree_vm_stack_free(stack);
+IREE_API_EXPORT iree_status_t IREE_API_CALL
+iree_vm_stack_allocate(iree_vm_state_resolver_t state_resolver,
+                       iree_allocator_t allocator, iree_vm_stack_t** out_stack);
+
+// Frees a dynamically-allocated |stack| from iree_vm_stack_allocate.
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_free(iree_vm_stack_t* stack);
 
 // Returns the current stack frame or nullptr if the stack is empty.
 IREE_API_EXPORT iree_vm_stack_frame_t* IREE_API_CALL
@@ -127,16 +189,50 @@ iree_vm_stack_current_frame(iree_vm_stack_t* stack);
 IREE_API_EXPORT iree_vm_stack_frame_t* IREE_API_CALL
 iree_vm_stack_parent_frame(iree_vm_stack_t* stack);
 
+// Queries the context-specific module state for the given module.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_query_module_state(
+    iree_vm_stack_t* stack, iree_vm_module_t* module,
+    iree_vm_module_state_t** out_module_state);
+
 // Enters into the given |function| and returns the callee stack frame.
-// Callers must populate the argument registers as defined by the VM API.
+// May invalidate any pointers to stack frames and the only pointer that can be
+// assumed valid after return is the one in |out_callee_frame|.
+//
+// |argument_registers| and |result_registers| are lists of registers within the
+// caller frame that will be used to source and store arguments and results with
+// the callee. They must remain live and valid until the callee returns (which
+// may be much later if asynchronous!).
+//
+// TODO(benvanik): copy the result register list to make async easier.
 IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_enter(
     iree_vm_stack_t* stack, iree_vm_function_t function,
+    const iree_vm_register_list_t* argument_registers,
+    const iree_vm_register_list_t* result_registers,
     iree_vm_stack_frame_t** out_callee_frame);
 
 // Leaves the current stack frame.
-// Callers must have retrieved the result registers as defined by the VM API.
-IREE_API_EXPORT iree_status_t IREE_API_CALL
-iree_vm_stack_function_leave(iree_vm_stack_t* stack);
+// The provided |result_registers| in the callee frame will be stored back into
+// the caller frame result registers.
+IREE_API_EXPORT void IREE_API_CALL iree_vm_stack_function_leave(
+    iree_vm_stack_t* stack, const iree_vm_register_list_t* result_registers,
+    iree_vm_stack_frame_t** out_caller_frame);
+
+// Enters into an `[external]` frame and returns the external stack frame.
+// May invalidate any pointers to stack frames and the only pointer that can be
+// assumed valid after return is the one in |out_callee_frame|.
+//
+// The frame will have |register_count| registers of each type reserved and
+// ready for the caller to populate.
+//
+// |name| can be used to provide a debug-visible name to help identify where the
+// transition is occurring.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_external_enter(
+    iree_vm_stack_t* stack, iree_string_view_t name,
+    iree_host_size_t register_count, iree_vm_stack_frame_t** out_callee_frame);
+
+// Leaves the current external stack frame.
+IREE_API_EXPORT void IREE_API_CALL
+iree_vm_stack_external_leave(iree_vm_stack_t* stack);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -218,8 +218,8 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_stack_function_leave(
     iree_vm_stack_frame_t** out_caller_frame);
 
 // Enters into an `[external]` frame and returns the external stack frame.
-// May invalidate any pointers to stack frames and the only pointer that can be
-// assumed valid after return is the one in |out_callee_frame|.
+// May invalidate any existing pointers to stack frames and the only pointer
+// that can be assumed valid after return is the one in |out_callee_frame|.
 //
 // The frame will have |register_count| registers of each type reserved and
 // ready for the caller to populate.

--- a/iree/vm/stack_test.cc
+++ b/iree/vm/stack_test.cc
@@ -71,10 +71,10 @@ TEST(VMStackTest, Usage) {
   EXPECT_EQ(frame_b, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(frame_a, iree_vm_stack_parent_frame(stack));
 
-  iree_vm_stack_function_leave(stack, NULL, NULL);
+  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack, NULL, NULL));
   EXPECT_EQ(frame_a, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
-  iree_vm_stack_function_leave(stack, NULL, NULL);
+  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack, NULL, NULL));
   EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
   EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
 
@@ -120,7 +120,7 @@ TEST(VMStackTest, StackOverflow) {
       did_overflow = true;
       break;
     }
-    EXPECT_TRUE(iree_status_is_ok(status));
+    IREE_EXPECT_OK(status);
   }
   ASSERT_TRUE(did_overflow);
 
@@ -132,7 +132,8 @@ TEST(VMStackTest, UnbalancedPop) {
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
   IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
 
-  iree_vm_stack_function_leave(stack, NULL, NULL);
+  EXPECT_TRUE(iree_status_is_failed_precondition(
+      iree_vm_stack_function_leave(stack, NULL, NULL)));
 
   iree_vm_stack_deinitialize(stack);
 }
@@ -172,9 +173,9 @@ TEST(VMStackTest, ModuleStateQueries) {
   EXPECT_EQ(MODULE_B_STATE_SENTINEL, frame_b->module_state);
   EXPECT_EQ(1, module_b_state_resolve_count);
 
-  iree_vm_stack_function_leave(stack, NULL, NULL);
-  iree_vm_stack_function_leave(stack, NULL, NULL);
-  iree_vm_stack_function_leave(stack, NULL, NULL);
+  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack, NULL, NULL));
+  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack, NULL, NULL));
+  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack, NULL, NULL));
 
   iree_vm_stack_deinitialize(stack);
 }

--- a/iree/vm/stack_test.cc
+++ b/iree/vm/stack_test.cc
@@ -47,112 +47,103 @@ static iree_status_t SentinelStateResolver(
 
 // Tests simple stack usage, mainly just for demonstration.
 TEST(VMStackTest, Usage) {
-  auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  iree_vm_stack_init(state_resolver, stack.get());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
 
-  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
+  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
 
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
   iree_vm_stack_frame_t* frame_a = nullptr;
   IREE_EXPECT_OK(
-      iree_vm_stack_function_enter(stack.get(), function_a, &frame_a));
+      iree_vm_stack_function_enter(stack, function_a, NULL, NULL, &frame_a));
   EXPECT_EQ(0, frame_a->function.ordinal);
-  EXPECT_EQ(frame_a, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
+  EXPECT_EQ(frame_a, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
 
   iree_vm_function_t function_b = {MODULE_B_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 1};
   iree_vm_stack_frame_t* frame_b = nullptr;
   IREE_EXPECT_OK(
-      iree_vm_stack_function_enter(stack.get(), function_b, &frame_b));
+      iree_vm_stack_function_enter(stack, function_b, NULL, NULL, &frame_b));
   EXPECT_EQ(1, frame_b->function.ordinal);
-  EXPECT_EQ(frame_b, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(frame_a, iree_vm_stack_parent_frame(stack.get()));
+  EXPECT_EQ(frame_b, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(frame_a, iree_vm_stack_parent_frame(stack));
 
-  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
-  EXPECT_EQ(frame_a, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
-  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
+  iree_vm_stack_function_leave(stack, NULL, NULL);
+  EXPECT_EQ(frame_a, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
+  iree_vm_stack_function_leave(stack, NULL, NULL);
+  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
 
-  iree_vm_stack_deinit(stack.get());
+  iree_vm_stack_deinitialize(stack);
 }
 
 // Tests stack cleanup with unpopped frames (like during failure teardown).
 TEST(VMStackTest, DeinitWithRemainingFrames) {
-  auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  iree_vm_stack_init(state_resolver, stack.get());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
 
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
   iree_vm_stack_frame_t* frame_a = nullptr;
   IREE_EXPECT_OK(
-      iree_vm_stack_function_enter(stack.get(), function_a, &frame_a));
+      iree_vm_stack_function_enter(stack, function_a, NULL, NULL, &frame_a));
   EXPECT_EQ(0, frame_a->function.ordinal);
-  EXPECT_EQ(frame_a, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
+  EXPECT_EQ(frame_a, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
 
   // Don't pop the last frame before deinit; it should handle it.
-  iree_vm_stack_deinit(stack.get());
-  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
+  iree_vm_stack_deinitialize(stack);
 }
 
 // Tests stack overflow detection.
 TEST(VMStackTest, StackOverflow) {
-  auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  iree_vm_stack_init(state_resolver, stack.get());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
 
-  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
+  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
 
   // Fill the entire stack up to the max.
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
-  for (int i = 0; i < IREE_MAX_STACK_DEPTH; ++i) {
+  bool did_overflow = false;
+  for (int i = 0; i < 99999; ++i) {
     iree_vm_stack_frame_t* frame_a = nullptr;
-    IREE_EXPECT_OK(
-        iree_vm_stack_function_enter(stack.get(), function_a, &frame_a));
+    iree_status_t status =
+        iree_vm_stack_function_enter(stack, function_a, NULL, NULL, &frame_a);
+    if (iree_status_is_resource_exhausted(status)) {
+      // Hit the stack overflow, as expected.
+      did_overflow = true;
+      break;
+    }
+    EXPECT_TRUE(iree_status_is_ok(status));
   }
+  ASSERT_TRUE(did_overflow);
 
-  // Try to push on one more frame.
-  iree_vm_function_t function_b = {MODULE_B_SENTINEL,
-                                   IREE_VM_FUNCTION_LINKAGE_INTERNAL, 1};
-  iree_vm_stack_frame_t* frame_b = nullptr;
-  EXPECT_EQ(IREE_STATUS_RESOURCE_EXHAUSTED,
-            iree_vm_stack_function_enter(stack.get(), function_b, &frame_b));
-
-  // Should still be frame A.
-  EXPECT_EQ(0, iree_vm_stack_current_frame(stack.get())->function.ordinal);
-
-  iree_vm_stack_deinit(stack.get());
+  iree_vm_stack_deinitialize(stack);
 }
 
 // Tests unbalanced stack popping.
 TEST(VMStackTest, UnbalancedPop) {
-  auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  iree_vm_stack_init(state_resolver, stack.get());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
 
-  EXPECT_EQ(IREE_STATUS_FAILED_PRECONDITION,
-            iree_vm_stack_function_leave(stack.get()));
+  iree_vm_stack_function_leave(stack, NULL, NULL);
 
-  iree_vm_stack_deinit(stack.get());
+  iree_vm_stack_deinitialize(stack);
 }
 
 // Tests module state reuse and querying.
 TEST(VMStackTest, ModuleStateQueries) {
-  auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  iree_vm_stack_init(state_resolver, stack.get());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
 
-  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack.get()));
-  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack.get()));
+  EXPECT_EQ(nullptr, iree_vm_stack_current_frame(stack));
+  EXPECT_EQ(nullptr, iree_vm_stack_parent_frame(stack));
 
   module_a_state_resolve_count = 0;
   module_b_state_resolve_count = 0;
@@ -162,7 +153,7 @@ TEST(VMStackTest, ModuleStateQueries) {
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
   iree_vm_stack_frame_t* frame_a = nullptr;
   IREE_EXPECT_OK(
-      iree_vm_stack_function_enter(stack.get(), function_a, &frame_a));
+      iree_vm_stack_function_enter(stack, function_a, NULL, NULL, &frame_a));
   EXPECT_EQ(MODULE_A_STATE_SENTINEL, frame_a->module_state);
   EXPECT_EQ(1, module_a_state_resolve_count);
 
@@ -171,26 +162,25 @@ TEST(VMStackTest, ModuleStateQueries) {
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 1};
   iree_vm_stack_frame_t* frame_b = nullptr;
   IREE_EXPECT_OK(
-      iree_vm_stack_function_enter(stack.get(), function_b, &frame_b));
+      iree_vm_stack_function_enter(stack, function_b, NULL, NULL, &frame_b));
   EXPECT_EQ(MODULE_B_STATE_SENTINEL, frame_b->module_state);
   EXPECT_EQ(1, module_b_state_resolve_count);
 
   // [A, B, B (reuse)]
   IREE_EXPECT_OK(
-      iree_vm_stack_function_enter(stack.get(), function_b, &frame_b));
+      iree_vm_stack_function_enter(stack, function_b, NULL, NULL, &frame_b));
   EXPECT_EQ(MODULE_B_STATE_SENTINEL, frame_b->module_state);
   EXPECT_EQ(1, module_b_state_resolve_count);
 
-  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
-  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
-  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
+  iree_vm_stack_function_leave(stack, NULL, NULL);
+  iree_vm_stack_function_leave(stack, NULL, NULL);
+  iree_vm_stack_function_leave(stack, NULL, NULL);
 
-  iree_vm_stack_deinit(stack.get());
+  iree_vm_stack_deinitialize(stack);
 }
 
 // Tests that module state query failures propagate to callers correctly.
 TEST(VMStackTest, ModuleStateQueryFailure) {
-  auto stack = std::make_unique<iree_vm_stack_t>();
   iree_vm_state_resolver_t state_resolver = {
       nullptr,
       +[](void* state_resolver, iree_vm_module_t* module,
@@ -198,63 +188,16 @@ TEST(VMStackTest, ModuleStateQueryFailure) {
         // NOTE: always failing.
         return IREE_STATUS_INTERNAL;
       }};
-  iree_vm_stack_init(state_resolver, stack.get());
+  IREE_VM_INLINE_STACK_INITIALIZE(stack, state_resolver, IREE_ALLOCATOR_SYSTEM);
 
   // Push should fail if we can't query state, status should propagate.
   iree_vm_function_t function_a = {MODULE_A_SENTINEL,
                                    IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
   iree_vm_stack_frame_t* frame_a = nullptr;
-  EXPECT_EQ(IREE_STATUS_INTERNAL,
-            iree_vm_stack_function_enter(stack.get(), function_a, &frame_a));
+  EXPECT_EQ(IREE_STATUS_INTERNAL, iree_vm_stack_function_enter(
+                                      stack, function_a, NULL, NULL, &frame_a));
 
-  iree_vm_stack_deinit(stack.get());
-}
-
-static int dummy_object_count = 0;
-class DummyObject : public iree::RefObject<DummyObject> {
- public:
-  static iree_vm_ref_type_t kTypeID;
-
-  static void RegisterType() {
-    static iree_vm_ref_type_descriptor_t descriptor;
-    descriptor.type_name = iree_string_view_t{
-        typeid(DummyObject).name(), std::strlen(typeid(DummyObject).name())};
-    descriptor.offsetof_counter = DummyObject::offsetof_counter();
-    descriptor.destroy = DummyObject::DirectDestroy;
-    iree_vm_ref_register_type(&descriptor);
-    kTypeID = descriptor.type;
-  }
-
-  DummyObject() { ++dummy_object_count; }
-  ~DummyObject() { --dummy_object_count; }
-};
-iree_vm_ref_type_t DummyObject::kTypeID = IREE_VM_REF_TYPE_NULL;
-
-// Tests stack frame ref register cleanup.
-TEST(VMStackTest, RefRegisterCleanup) {
-  auto stack = std::make_unique<iree_vm_stack_t>();
-  iree_vm_state_resolver_t state_resolver = {nullptr, SentinelStateResolver};
-  iree_vm_stack_init(state_resolver, stack.get());
-
-  dummy_object_count = 0;
-  DummyObject::RegisterType();
-
-  iree_vm_function_t function_a = {MODULE_A_SENTINEL,
-                                   IREE_VM_FUNCTION_LINKAGE_INTERNAL, 0};
-  iree_vm_stack_frame_t* frame_a = nullptr;
-  IREE_EXPECT_OK(
-      iree_vm_stack_function_enter(stack.get(), function_a, &frame_a));
-  frame_a->registers.ref_register_count = 1;
-  memset(&frame_a->registers.ref[0], 0, sizeof(iree_vm_ref_t));
-  IREE_EXPECT_OK(iree_vm_ref_wrap_assign(
-      new DummyObject(), DummyObject::kTypeID, &frame_a->registers.ref[0]));
-  EXPECT_EQ(1, dummy_object_count);
-
-  // This should release the ref for us. Heap checker will yell if it doesn't.
-  IREE_EXPECT_OK(iree_vm_stack_function_leave(stack.get()));
-  EXPECT_EQ(0, dummy_object_count);
-
-  iree_vm_stack_deinit(stack.get());
+  iree_vm_stack_deinitialize(stack);
 }
 
 }  // namespace

--- a/iree/vm/variant_list.c
+++ b/iree/vm/variant_list.c
@@ -63,6 +63,11 @@ iree_vm_variant_list_free(iree_vm_variant_list_t* list) {
 }
 
 IREE_API_EXPORT iree_host_size_t IREE_API_CALL
+iree_vm_variant_list_capacity(const iree_vm_variant_list_t* list) {
+  return list->capacity;
+}
+
+IREE_API_EXPORT iree_host_size_t IREE_API_CALL
 iree_vm_variant_list_size(const iree_vm_variant_list_t* list) {
   return list->count;
 }

--- a/iree/vm/variant_list.h
+++ b/iree/vm/variant_list.h
@@ -72,6 +72,10 @@ IREE_API_EXPORT void IREE_API_CALL iree_vm_variant_list_init(
 IREE_API_EXPORT void IREE_API_CALL
 iree_vm_variant_list_free(iree_vm_variant_list_t* list);
 
+// Returns the capacity of the list in elements.
+IREE_API_EXPORT iree_host_size_t IREE_API_CALL
+iree_vm_variant_list_capacity(const iree_vm_variant_list_t* list);
+
 // Returns the total number of elements added to the list.
 IREE_API_EXPORT iree_host_size_t IREE_API_CALL
 iree_vm_variant_list_size(const iree_vm_variant_list_t* list);


### PR DESCRIPTION
Reduces the default stack to be small enough to fit on the host stack and
dynamically growable if needed. This dramatically reduces our memory
footprint and speeds up almost everything VM-related (invocation from C
to bytecode, bytecode to C, and bytecode to bytecode). It also has the
effect of properly guarding register array accesses via valid bit masks
that avoids expensive logic in the actual bytecode op implementations.

Fixes #1172.

Before/after (of just one function type):
![image](https://user-images.githubusercontent.com/75337/83363175-2ca3dd80-a34c-11ea-9891-019ae11bd58b.png)
