### PR TITLE
Fix build with IREE_ENABLE_RUNTIME_TRACING=ON on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,9 +34,6 @@ set(IREE_IDE_FOLDER IREE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 option(IREE_ENABLE_RUNTIME_TRACING "Enables instrumented runtime tracing." OFF)
-if(${IREE_ENABLE_RUNTIME_TRACING})
-  set (CMAKE_EXE_LINKER_FLAGS -ldl )
-endif()
 option(IREE_ENABLE_LLVM "Enables LLVM dependencies." ON)
 option(IREE_ENABLE_EMITC "Enables MLIR EmitC dependencies." OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,9 @@ set(IREE_IDE_FOLDER IREE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 
 option(IREE_ENABLE_RUNTIME_TRACING "Enables instrumented runtime tracing." OFF)
+if(${IREE_ENABLE_RUNTIME_TRACING})
+  set (CMAKE_EXE_LINKER_FLAGS -ldl )
+endif()
 option(IREE_ENABLE_LLVM "Enables LLVM dependencies." ON)
 option(IREE_ENABLE_EMITC "Enables MLIR EmitC dependencies." OFF)
 

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -26,6 +26,10 @@ list(APPEND IREE_COMMON_INCLUDE_DIRS
   ${PROJECT_BINARY_DIR}
 )
 
+if(${IREE_ENABLE_RUNTIME_TRACING})
+  set (CMAKE_EXE_LINKER_FLAGS -ldl)
+endif()
+
 iree_select_compiler_opts(IREE_DEFAULT_COPTS
   CLANG
     "-Wno-strict-prototypes"

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -602,7 +602,7 @@ if(${IREE_ENABLE_RUNTIME_TRACING})
     DEPS
       absl::core_headers
     DEFINES
-      "IREE_TRACING_MODE=2"
+      "IREE_TRACING_MODE=1"
     PUBLIC
   )
 else()

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -602,6 +602,7 @@ if(${IREE_ENABLE_RUNTIME_TRACING})
     DEPS
       absl::core_headers
     DEFINES
+      # TODO(GH-2114): Change the mode to 2.
       "IREE_TRACING_MODE=1"
     PUBLIC
   )


### PR DESCRIPTION
There is a bug in allocation tracking, so changing the tracing
mode to 1 can temporarily fix it. Hence, we can connect and stream data
to Tracy profiler without errors.