### PR TITLE
Adding vm.list type.

### DIFF
--- a/iree/compiler/Dialect/IREE/IR/IREETypes.h
+++ b/iree/compiler/Dialect/IREE/IR/IREETypes.h
@@ -114,6 +114,7 @@ namespace TypeKind {
 enum Kind {
   Ref = IREE::TypeKind::FIRST_VM_TYPE,
   Opaque,
+  List,
 };
 }  // namespace TypeKind
 }  // namespace VM

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -82,8 +82,21 @@ def VM_OPC_ConstI32              : VM_OPC<0x09, "ConstI32">;
 def VM_OPC_ConstRefZero          : VM_OPC<0x0A, "ConstRefZero">;
 def VM_OPC_ConstRefRodata        : VM_OPC<0x0B, "ConstRefRodata">;
 
-// ref_ptr operations:
-// (none yet)
+// List operations:
+def VM_OPC_ListAlloc             : VM_OPC<0x10, "ListAlloc">;
+def VM_OPC_ListReserve           : VM_OPC<0x11, "ListReserve">;
+def VM_OPC_ListSize              : VM_OPC<0x12, "ListSize">;
+def VM_OPC_ListResize            : VM_OPC<0x13, "ListResize">;
+def VM_OPC_ListGetI32            : VM_OPC<0x14, "ListGetI32">;
+def VM_OPC_ListSetI32            : VM_OPC<0x15, "ListSetI32">;
+def VM_OPC_ListGetRef            : VM_OPC<0x16, "ListGetRef">;
+def VM_OPC_ListSetRef            : VM_OPC<0x17, "ListSetRef">;
+// RESERVED: 0x18 push.i32
+// RESERVED: 0x19 pop.i32
+// RESERVED: 0x1A copy to other list
+// RESERVED: 0x1B slice clone into new list
+// RESERVED: 0x1C read byte buffer?
+// RESERVED: 0x1D write byte buffer?
 
 // Conditional assignment:
 def VM_OPC_SelectI32             : VM_OPC<0x1E, "SelectI32">;
@@ -163,6 +176,14 @@ def VM_OpcodeAttr : I32EnumAttr<"Opcode", "valid VM operation encodings", [
     VM_OPC_ConstI32,
     VM_OPC_ConstRefZero,
     VM_OPC_ConstRefRodata,
+    VM_OPC_ListAlloc,
+    VM_OPC_ListReserve,
+    VM_OPC_ListSize,
+    VM_OPC_ListResize,
+    VM_OPC_ListGetI32,
+    VM_OPC_ListSetI32,
+    VM_OPC_ListGetRef,
+    VM_OPC_ListSetRef,
     VM_OPC_SelectI32,
     VM_OPC_SelectRef,
     VM_OPC_SwitchI32,
@@ -259,6 +280,8 @@ class VM_EncGlobalAttr<string name> : VM_EncEncodeExpr<
     "e.encodeSymbolOrdinal(syms, " # name # "())">;
 class VM_EncRodataAttr<string name> : VM_EncEncodeExpr<
     "e.encodeSymbolOrdinal(syms, " # name # "())">;
+class VM_EncType<string expr> : VM_EncEncodeExpr<
+    "e.encodeType(" # expr # ")">;
 class VM_EncTypeOf<string name> : VM_EncEncodeExpr<
     "e.encodeType(" # name # "())">;
 class VM_EncIntAttr<string name, int thisBitwidth> : VM_EncEncodeExpr<
@@ -395,6 +418,34 @@ class VM_RefOf<Type type> :
 }
 
 //===----------------------------------------------------------------------===//
+// List types
+//===----------------------------------------------------------------------===//
+
+def VM_AnyList : DialectType<
+    IREE_Dialect,
+    And<[
+      CPred<"$_self.isa<IREE::VM::RefType>()">,
+      CPred<"$_self.cast<IREE::VM::RefType>().getObjectType().isa<IREE::VM::ListType>()">,
+    ]>,
+    "list"> {
+  let typeDescription = [{
+    An iree_vm_list_t/iree::vm::list<T> of some type.
+  }];
+}
+
+class VM_ListOf<Type type> :
+    Type<And<[
+      CPred<"$_self.cast<IREE::VM::RefType>().getObjectType().isa<IREE::VM::ListType>()">,
+      SubstLeaves<"$_self",
+                  "$_self.cast<IREE::VM::RefType>().getObjectType().cast<IREE::VM::ListType>().getElementType()",
+                  type.predicate>
+    ]>, "list<" # type.description # ">"> {
+  // Set the builder call if the base type has a builder call.
+  string builderCall = !if(!empty(type.builderCall),
+                           "", "IREE::VM::ListType::get(" # type.builderCall # ")");
+}
+
+//===----------------------------------------------------------------------===//
 // VM types
 //===----------------------------------------------------------------------===//
 
@@ -416,6 +467,11 @@ def VM_AnyType : AnyTypeOf<[
   I32,
   VM_CondValue,
   VM_AnyRef,
+]>;
+
+def VM_PrimitiveType : AnyTypeOf<[
+  AnyIntOfWidths<[8, 16, 32]>,
+  FloatOfWidths<[16, 32]>,
 ]>;
 
 class VM_ConstIntValueAttr<I type> : Attr<

--- a/iree/compiler/Dialect/VM/IR/VMFuncEncoder.h
+++ b/iree/compiler/Dialect/VM/IR/VMFuncEncoder.h
@@ -52,6 +52,7 @@ class VMFuncEncoder {
 
   // Encodes a value type as an integer kind.
   virtual LogicalResult encodeType(Value value) = 0;
+  virtual LogicalResult encodeType(Type type) = 0;
 
   // Encodes an integer attribute as a fixed byte length based on bitwidth.
   virtual LogicalResult encodeIntAttr(IntegerAttr value) = 0;

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -696,6 +696,58 @@ void ConstRefRodataOp::build(OpBuilder &builder, OperationState &result,
 }
 
 //===----------------------------------------------------------------------===//
+// Lists
+//===----------------------------------------------------------------------===//
+
+static LogicalResult verifyListGetRefOp(ListGetRefOp &op) {
+  auto listType = op.list()
+                      .getType()
+                      .cast<IREE::VM::RefType>()
+                      .getObjectType()
+                      .cast<IREE::VM::ListType>();
+  auto elementType = listType.getElementType();
+  auto resultType = op.result().getType();
+  if (elementType.isa<IREE::VM::RefType>() !=
+      resultType.isa<IREE::VM::RefType>()) {
+    // Attempting to go between a primitive type and ref type.
+    return op.emitError() << "cannot convert between list type " << elementType
+                          << " and result type " << resultType;
+  } else if (auto refType = elementType.dyn_cast<IREE::VM::RefType>()) {
+    if (!refType.getObjectType().isa<IREE::VM::OpaqueType>() &&
+        elementType != resultType) {
+      // List has a concrete type, verify it matches.
+      return op.emitError() << "list contains " << elementType
+                            << " that cannot be accessed as " << resultType;
+    }
+  }
+  return success();
+}
+
+static LogicalResult verifyListSetRefOp(ListSetRefOp &op) {
+  auto listType = op.list()
+                      .getType()
+                      .cast<IREE::VM::RefType>()
+                      .getObjectType()
+                      .cast<IREE::VM::ListType>();
+  auto elementType = listType.getElementType();
+  auto valueType = op.value().getType();
+  if (elementType.isa<IREE::VM::RefType>() !=
+      valueType.isa<IREE::VM::RefType>()) {
+    // Attempting to go between a primitive type and ref type.
+    return op.emitError() << "cannot convert between list type " << elementType
+                          << " and value type " << valueType;
+  } else if (auto refType = elementType.dyn_cast<IREE::VM::RefType>()) {
+    if (!refType.getObjectType().isa<IREE::VM::OpaqueType>() &&
+        elementType != valueType) {
+      // List has a concrete type, verify it matches.
+      return op.emitError() << "list contains " << elementType
+                            << " that cannot be mutated as " << valueType;
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // Assignment
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -711,10 +711,231 @@ def VM_ConstRefRodataOp : VM_PureOp<"const.ref.rodata", [
 }
 
 //===----------------------------------------------------------------------===//
-// ref_ptr operations
+// Lists
 //===----------------------------------------------------------------------===//
 
-// TODO(benvanik): model retain/release in here?
+// TODO(benvanik): vm.list.push.i32 / vm.list.pop.i32 (variadic)
+// TODO(benvanik): vm.list.copy(src_list, src_index, dst_list, dst_index, length)
+// TODO(benvanik): vm.list.slice(list, index, length) -> list
+// TODO(benvanik): export into a rwdata buffer
+
+def VM_ListAllocOp :
+    VM_PureOp<"list.alloc", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ]> {
+  let summary = [{allocates a new empty list}];
+  let description = [{
+    Allocates a new typed list with a minimum initial_capacity.
+  }];
+
+  let arguments = (ins
+    I32:$initial_capacity
+  );
+  let results = (outs
+    VM_AnyList:$result
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($initial_capacity) `)` `->` type($result)";
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_ListAlloc>,
+    VM_EncType<"result().getType().cast<IREE::VM::RefType>().getObjectType().cast<IREE::VM::ListType>().getElementType()">,
+    VM_EncOperand<"initial_capacity", 0>,
+    VM_EncResult<"result">,
+  ];
+}
+
+def VM_ListReserveOp :
+    VM_Op<"list.reserve", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ]> {
+  let summary = [{reserves capacity for list growth}];
+  let description = [{
+    Reserves storage for at least minimum_capacity elements. If the list already
+    has at least the specified capacity the operation is ignored.
+  }];
+
+  let arguments = (ins
+    VM_AnyList:$list,
+    I32:$minimum_capacity
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($minimum_capacity) `)`";
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_ListReserve>,
+    VM_EncOperand<"list", 0>,
+    VM_EncOperand<"minimum_capacity", 1>,
+  ];
+}
+
+def VM_ListSizeOp :
+    VM_Op<"list.size", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ]> {
+  let summary = [{the size of the list in elements}];
+  let description = [{
+    Returns the current size of the list in elements.
+  }];
+
+  let arguments = (ins
+    VM_AnyList:$list
+  );
+  let results = (outs
+    I32:$result
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($list) `)` `->` type($result)";
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_ListSize>,
+    VM_EncOperand<"list", 0>,
+    VM_EncResult<"result">,
+  ];
+}
+
+def VM_ListResizeOp :
+    VM_Op<"list.resize", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ]> {
+  let summary = [{resizes the list to a new count in elements}];
+  let description = [{
+    Resizes the list to contain new_size elements. This will either truncate
+    the list if the existing size is greater than new_size or extend the list
+    with the default list value of 0 if storing primitives and null if refs.
+  }];
+
+  let arguments = (ins
+    VM_AnyList:$list,
+    I32:$new_size
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($new_size) `)`";
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_ListResize>,
+    VM_EncOperand<"list", 0>,
+    VM_EncOperand<"new_size", 1>,
+  ];
+}
+
+class VM_ListGetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
+                            list<OpTrait> traits = []> :
+    VM_PureOp<mnemonic, !listconcat(traits, [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ])> {
+  let summary = [{primitive type element accessor}];
+  let description = [{
+    Returns the value of the element at the given index.
+  }];
+
+  let arguments = (ins
+    VM_ListOf<VM_PrimitiveType>:$list,
+    I32:$index
+  );
+  let results = (outs
+    type:$result
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($index) `)` `->` type($result)";
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncOperand<"list", 0>,
+    VM_EncOperand<"index", 1>,
+    VM_EncResult<"result">,
+  ];
+}
+
+class VM_ListSetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
+                            list<OpTrait> traits = []> :
+    VM_Op<mnemonic, !listconcat(traits, [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ])> {
+  let summary = [{primitive type element mutator}];
+  let description = [{
+    Sets the element at the given index to the new value.
+  }];
+
+  let arguments = (ins
+    VM_ListOf<VM_PrimitiveType>:$list,
+    I32:$index,
+    type:$value
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($index) `,` type($value) `)`";
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncOperand<"list", 0>,
+    VM_EncOperand<"index", 1>,
+    VM_EncOperand<"value", 2>,
+  ];
+}
+
+def VM_ListGetI32Op :
+    VM_ListGetPrimitiveOp<I32, "list.get.i32", VM_OPC_ListGetI32> {}
+
+def VM_ListSetI32Op :
+    VM_ListSetPrimitiveOp<I32, "list.set.i32", VM_OPC_ListSetI32> {}
+
+def VM_ListGetRefOp :
+    VM_PureOp<"list.get.ref", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ]> {
+  let summary = [{ref type element accessor}];
+  let description = [{
+    Returns the ref value of the element at the given index. Note that the value
+    may be null if the element is null or the type does not match.
+  }];
+
+  let arguments = (ins
+    VM_AnyList:$list,
+    I32:$index
+  );
+  let results = (outs
+    VM_AnyRef:$result
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($index) `)` `->` type($result)";
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_ListGetRef>,
+    VM_EncOperand<"list", 0>,
+    VM_EncOperand<"index", 1>,
+    VM_EncTypeOf<"result">,
+    VM_EncResult<"result">,
+  ];
+
+  let verifier = [{ return verify$cppClass(*this); }];
+}
+
+def VM_ListSetRefOp :
+    VM_Op<"list.set.ref", [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ]> {
+  let summary = [{ref type element mutator}];
+  let description = [{
+    Sets the element at the given index to the new ref value (possibly null).
+  }];
+
+  let arguments = (ins
+    VM_AnyList:$list,
+    I32:$index,
+    VM_AnyRef:$value
+  );
+
+  let assemblyFormat = "operands attr-dict `:` `(` type($list) `,` type($index) `,` type($value) `)`";
+
+  let encoding = [
+    VM_EncOpcode<VM_OPC_ListSetRef>,
+    VM_EncOperand<"list", 0>,
+    VM_EncOperand<"index", 1>,
+    VM_EncOperand<"value", 2>,
+  ];
+
+  let verifier = [{ return verify$cppClass(*this); }];
+}
 
 //===----------------------------------------------------------------------===//
 // Conditional assignment

--- a/iree/compiler/Dialect/VM/IR/VMTypes.h
+++ b/iree/compiler/Dialect/VM/IR/VMTypes.h
@@ -32,8 +32,41 @@ namespace IREE {
 namespace VM {
 
 namespace detail {
+struct ListTypeStorage;
 struct RefTypeStorage;
 }  // namespace detail
+
+/// A list containing an optional element type.
+class ListType
+    : public Type::TypeBase<ListType, Type, detail::ListTypeStorage> {
+ public:
+  using Base::Base;
+
+  /// Returns true if the given type can be wrapped in a list.
+  static bool isCompatible(Type type);
+
+  /// Gets or creates a ListType with the provided element type.
+  static ListType get(Type elementType);
+
+  /// Gets or creates a ListType with the provided element type.
+  /// This emits an error at the specified location and returns null if the
+  /// element type isn't supported.
+  static ListType getChecked(Type elementType, Location location);
+
+  /// Verifies construction of a type with the given object.
+  static LogicalResult verifyConstructionInvariants(Location loc,
+                                                    Type elementType) {
+    if (!isCompatible(elementType)) {
+      return emitError(loc)
+             << "invalid element type for a list: " << elementType;
+    }
+    return success();
+  }
+
+  Type getElementType();
+
+  static bool kindof(unsigned kind) { return kind == TypeKind::List; }
+};
 
 /// An opaque ref object that comes from an external source.
 class OpaqueType : public Type::TypeBase<OpaqueType, Type> {

--- a/iree/compiler/Dialect/VM/IR/test/list_op_verification.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/list_op_verification.mlir
@@ -1,0 +1,34 @@
+// RUN: iree-opt -split-input-file %s -verify-diagnostics
+
+// -----
+
+vm.module @module {
+  vm.func @primitive_ref_list_type_mismatch(%arg0 : !vm.list<!vm.ref<?>>) {
+    %c100 = vm.const.i32 100 : i32
+    // expected-error @+1 {{but got '!vm.list<!vm.ref<?>>}}
+    %1 = vm.list.get.i32 %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.ref<?>
+    vm.return
+  }
+}
+
+// -----
+
+vm.module @module {
+  vm.func @ref_primitive_list_type_mismatch(%arg0 : !vm.list<i32>) {
+    %c100 = vm.const.i32 100 : i32
+    // expected-error @+1 {{cannot convert between list type 'i32' and result type '!vm.ref<?>'}}
+    %1 = vm.list.get.ref %arg0, %c100 : (!vm.list<i32>, i32) -> !vm.ref<?>
+    vm.return
+  }
+}
+
+// -----
+
+vm.module @module {
+  vm.func @strongly_typed_ref_type_mismatch(%arg0 : !vm.list<!vm.ref<!iree.byte_buffer>>) {
+    %c100 = vm.const.i32 100 : i32
+    // expected-error @+1 {{cannot be accessed as '!vm.ref<!iree.mutable_byte_buffer>'}}
+    %1 = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32) -> !vm.ref<!iree.mutable_byte_buffer>
+    vm.return
+  }
+}

--- a/iree/compiler/Dialect/VM/IR/test/list_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/list_ops.mlir
@@ -1,0 +1,92 @@
+// RUN: iree-opt -split-input-file %s | IreeFileCheck %s
+
+// Common operations that don't care what the type of the list is.
+vm.module @module {
+  // CHECK-LABEL: @list_common
+  vm.func @list_common() {
+    %c42 = vm.const.i32 42 : i32
+    // CHECK: %list = vm.list.alloc %c42 : (i32) -> !vm.list<i32>
+    %list = vm.list.alloc %c42 : (i32) -> !vm.list<i32>
+
+    %c43 = vm.const.i32 43 : i32
+    // CHECK: vm.list.reserve %list, %c43 : (!vm.list<i32>, i32)
+    vm.list.reserve %list, %c43 : (!vm.list<i32>, i32)
+
+    // CHECK: = vm.list.size %list : (!vm.list<i32>) -> i32
+    %0 = vm.list.size %list : (!vm.list<i32>) -> i32
+
+    // CHECK: vm.list.resize %list, %c44 : (!vm.list<i32>, i32)
+    %c44 = vm.const.i32 44 : i32
+    vm.list.resize %list, %c44 : (!vm.list<i32>, i32)
+
+    vm.return
+  }
+}
+
+// -----
+
+// Typed accessors for lists with i32 elements.
+vm.module @module {
+  // CHECK: @list_i32
+  vm.func @list_i32(%arg0 : !vm.list<i32>) {
+    %c100 = vm.const.i32 100 : i32
+
+    // CHECK: vm.list.get.i32 %arg0, %c100 : (!vm.list<i32>, i32) -> i32
+    %0 = vm.list.get.i32 %arg0, %c100 : (!vm.list<i32>, i32) -> i32
+
+    // CHECK: vm.list.set.i32 %arg0, %c100, %c123 : (!vm.list<i32>, i32, i32)
+    %c123 = vm.const.i32 123 : i32
+    vm.list.set.i32 %arg0, %c100, %c123 : (!vm.list<i32>, i32, i32)
+
+    vm.return
+  }
+
+  // CHECK: @list_i8_coerce
+  vm.func @list_i8_coerce(%arg0 : !vm.list<i8>) {
+    %c100 = vm.const.i32 100 : i32
+
+    // CHECK: = vm.list.get.i32 %arg0, %c100 : (!vm.list<i8>, i32) -> i32
+    %0 = vm.list.get.i32 %arg0, %c100 : (!vm.list<i8>, i32) -> i32
+
+    // CHECK: vm.list.set.i32 %arg0, %c100, %0 : (!vm.list<i8>, i32, i32)
+    vm.list.set.i32 %arg0, %c100, %0 : (!vm.list<i8>, i32, i32)
+
+    vm.return
+  }
+}
+
+// -----
+
+// Typed accessors for lists with opaque ref<?> elements.
+vm.module @module {
+  // CHECK: @list_ref_any
+  vm.func @list_ref_any(%arg0 : !vm.list<!vm.ref<?>>) {
+    %c100 = vm.const.i32 100 : i32
+
+    // CHECK: %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.ref<!iree.byte_buffer>
+    %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<?>>, i32) -> !vm.ref<!iree.byte_buffer>
+
+    // CHECK: vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<?>>, i32, !vm.ref<!iree.byte_buffer>)
+    vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<?>>, i32, !vm.ref<!iree.byte_buffer>)
+
+    vm.return
+  }
+}
+
+// -----
+
+// Typed accessors for lists with strongly-typed ref elements.
+vm.module @module {
+  // CHECK: @list_ref_typed
+  vm.func @list_ref_typed(%arg0 : !vm.list<!vm.ref<!iree.byte_buffer>>) {
+    %c100 = vm.const.i32 100 : i32
+
+    // CHECK: %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32) -> !vm.ref<!iree.byte_buffer>
+    %ref = vm.list.get.ref %arg0, %c100 : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32) -> !vm.ref<!iree.byte_buffer>
+
+    // CHECK: vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32, !vm.ref<!iree.byte_buffer>)
+    vm.list.set.ref %arg0, %c100, %ref : (!vm.list<!vm.ref<!iree.byte_buffer>>, i32, !vm.ref<!iree.byte_buffer>)
+
+    vm.return
+  }
+}

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -88,7 +88,11 @@ class V0BytecodeEncoder : public BytecodeEncoder {
              << "type " << value.getType()
              << " is not supported as a serialized type kind";
     }
-    int typeOrdinal = typeTable_->lookup(refPtrType.getObjectType());
+    return encodeType(refPtrType.getObjectType());
+  }
+
+  LogicalResult encodeType(Type type) override {
+    int typeOrdinal = typeTable_->lookup(type);
     return writeUint32(typeOrdinal);
   }
 

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -453,6 +453,19 @@ iree_status_t iree_vm_bytecode_dispatch(
     });
 
     //===------------------------------------------------------------------===//
+    // Lists
+    //===------------------------------------------------------------------===//
+
+    DISPATCH_OP(ListAlloc, { return IREE_STATUS_UNIMPLEMENTED; });
+    DISPATCH_OP(ListReserve, { return IREE_STATUS_UNIMPLEMENTED; });
+    DISPATCH_OP(ListSize, { return IREE_STATUS_UNIMPLEMENTED; });
+    DISPATCH_OP(ListResize, { return IREE_STATUS_UNIMPLEMENTED; });
+    DISPATCH_OP(ListGetI32, { return IREE_STATUS_UNIMPLEMENTED; });
+    DISPATCH_OP(ListSetI32, { return IREE_STATUS_UNIMPLEMENTED; });
+    DISPATCH_OP(ListGetRef, { return IREE_STATUS_UNIMPLEMENTED; });
+    DISPATCH_OP(ListSetRef, { return IREE_STATUS_UNIMPLEMENTED; });
+
+    //===------------------------------------------------------------------===//
     // Conditional assignment
     //===------------------------------------------------------------------===//
 


### PR DESCRIPTION
This is implemented as a ref type that will be able to be passed to modules
via the VM ABI. Contents can be any primitive type or ref type (possibly
? for any). If a concrete ref type is given then all accesses will be
checked, and otherwise any ref type is allowed in the list. Primitive types
will be converted from their storage format (for example `!vm.list<i8>`) to
the form they are accessed in (i32).