### PR TITLE
Adding a size benchmark exe for measuring the total size of iree/vm.

### DIFF
--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -92,6 +92,24 @@ iree_bytecode_module(
 )
 
 cc_test(
+    name = "bytecode_module_size_benchmark",
+    srcs = ["bytecode_module_size_benchmark.cc"],
+    deps = [
+        ":bytecode_module",
+        ":bytecode_module_size_benchmark_module_cc",
+        ":vm",
+        "//iree/base:api",
+    ],
+)
+
+iree_bytecode_module(
+    name = "bytecode_module_size_benchmark_module",
+    src = "bytecode_module_size_benchmark.mlir",
+    cc_namespace = "iree::vm",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+cc_test(
     name = "bytecode_module_test",
     srcs = ["bytecode_module_test.cc"],
     deps = [

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -106,6 +106,30 @@ iree_bytecode_module(
 
 iree_cc_test(
   NAME
+    bytecode_module_size_benchmark
+  SRCS
+    "bytecode_module_size_benchmark.cc"
+  DEPS
+    ::bytecode_module
+    ::bytecode_module_size_benchmark_module_cc
+    ::vm
+    iree::base::api
+)
+
+iree_bytecode_module(
+  NAME
+    bytecode_module_size_benchmark_module
+  SRC
+    "bytecode_module_size_benchmark.mlir"
+  CC_NAMESPACE
+    "iree::vm"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
     bytecode_module_test
   SRCS
     "bytecode_module_test.cc"

--- a/iree/vm/bytecode_module_size_benchmark.cc
+++ b/iree/vm/bytecode_module_size_benchmark.cc
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/api.h"
+#include "iree/vm/api.h"
+#include "iree/vm/bytecode_module.h"
+#include "iree/vm/bytecode_module_size_benchmark_module.h"
+
+extern "C" int main(int argc, char** argv) {
+  iree_vm_instance_t* instance = nullptr;
+  iree_vm_instance_create(IREE_ALLOCATOR_SYSTEM, &instance);
+
+  const auto* module_file_toc =
+      iree::vm::bytecode_module_size_benchmark_module_create();
+  iree_vm_module_t* module = nullptr;
+  iree_vm_bytecode_module_create(
+      iree_const_byte_span_t{
+          reinterpret_cast<const uint8_t*>(module_file_toc->data),
+          module_file_toc->size},
+      IREE_ALLOCATOR_NULL, IREE_ALLOCATOR_SYSTEM, &module);
+
+  iree_vm_context_t* context = nullptr;
+  iree_vm_context_create_with_modules(instance, &module, 1,
+                                      IREE_ALLOCATOR_SYSTEM, &context);
+
+  iree_vm_function_t function;
+  iree_vm_module_lookup_function_by_name(
+      module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      iree_make_cstring_view("empty_func"), &function);
+
+  iree_vm_invoke(context, function, /*policy=*/nullptr, /*inputs=*/nullptr,
+                 /*outputs=*/nullptr, IREE_ALLOCATOR_SYSTEM);
+
+  iree_vm_module_release(module);
+  iree_vm_context_release(context);
+  iree_vm_instance_release(instance);
+
+  return 0;
+}

--- a/iree/vm/bytecode_module_size_benchmark.cc
+++ b/iree/vm/bytecode_module_size_benchmark.cc
@@ -31,7 +31,7 @@ extern "C" int main(int argc, char** argv) {
       IREE_ALLOCATOR_NULL, IREE_ALLOCATOR_SYSTEM, &module);
 
   iree_vm_context_t* context = nullptr;
-  iree_vm_context_create_with_modules(instance, &module, 1,
+  iree_vm_context_create_with_modules(instance, &module, /*module_count=*/1,
                                       IREE_ALLOCATOR_SYSTEM, &context);
 
   iree_vm_function_t function;

--- a/iree/vm/bytecode_module_size_benchmark.mlir
+++ b/iree/vm/bytecode_module_size_benchmark.mlir
@@ -1,0 +1,6 @@
+vm.module @bytecode_module_size_benchmark {
+  vm.export @empty_func
+  vm.func @empty_func() {
+    vm.return
+  }
+}


### PR DESCRIPTION
When properly trimmed this should only pull in the parts of the CRT that
we use and nothing else. Today it's about ~30KB for the VM, ~30KB for
iree/base logging/status, and 400KB for random abseil/STL junk.

See issue #898 for details.