### PR TITLE
Adding support for multiple VM opcode tables.

### DIFF
--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -56,8 +56,8 @@ def VM_Dialect : Dialect {
 // VM opcodes
 //===----------------------------------------------------------------------===//
 // Opcode ranges:
-// 0x00-0x7F: core VM opcodes, reserved for this dialect
-// 0x80-0xFF: unreserved, used by target-specific ops (like SIMD)
+// 0x00-0x9F: core VM opcodes, reserved for this dialect
+// 0xA0-0xFF: unreserved, used to prefix extension op sets
 //
 // Note that changing existing opcode assignments will invalidate all binaries
 // and should only be done when breaking changes are acceptable. We could add a
@@ -67,9 +67,28 @@ def VM_Dialect : Dialect {
 // Some opcodes require an extension prefix to indicate that runtime support
 // is optional. An op with the ExtI64 trait will require VM_OPC_ExtI64, for
 // example. Ops that bridge extension sets have a canonical form that may
-// require multiple prefix codes.
+// require multiple prefix codes (for example, the i64<->f64 extensions).
 
-class VM_OPC<int opcode, string name> : I32EnumAttrCase<name, opcode>;
+class VM_OPC<int opcode, string name> :
+    IntEnumAttrCaseBase<I8, name, name, opcode>;
+
+class VM_OPC_EnumAttr<string name, string enumName, string enumTag,
+                      string description,
+                      VM_OPC prefix = ?,
+                      list<VM_OPC> cases> :
+    IntEnumAttr<I8, name, description, cases> {
+  let cppNamespace = "IREE::VM";
+  let returnType = cppNamespace # "::" # name;
+  let underlyingType = "uint8_t";
+  let convertFromStorage = "static_cast<" # returnType # ">($_self.getInt())";
+  let constBuilderCall =
+          "$_builder.getI8IntegerAttr(static_cast<int8_t>($0))";
+
+  // Used by VMOpTableGen:
+  string opcodeEnumName = enumName;
+  VM_OPC opcodePrefix = prefix;
+  string opcodeEnumTag = enumTag;
+}
 
 // Globals:
 def VM_OPC_GlobalLoadI32         : VM_OPC<0x00, "GlobalLoadI32">;
@@ -169,9 +188,185 @@ def VM_OPC_CondBreak             : VM_OPC<0x7E, "CondBreak">;
 def VM_OPC_Break                 : VM_OPC<0x7F, "Break">;
 
 // Extension prefixes:
-def VM_OPC_ExtI64                : VM_OPC<0x80, "ExtI64">;
-def VM_OPC_ExtF32                : VM_OPC<0x81, "ExtF32">;
-def VM_OPC_ExtF64                : VM_OPC<0x82, "ExtF64">;
+def VM_OPC_PrefixExtI64          : VM_OPC<0xA0, "PrefixExtI64">;
+def VM_OPC_PrefixExtF32          : VM_OPC<0xA1, "PrefixExtF32">;
+def VM_OPC_PrefixExtF64          : VM_OPC<0xA2, "PrefixExtF64">;
+
+// Runtime enum iree_vm_core_op_t:
+def VM_CoreOpcodeAttr :
+    VM_OPC_EnumAttr<"Opcode",
+                    "iree_vm_core_op_t",
+                    "CORE",  // IREE_VM_OP_CORE_*
+                    "valid VM core operation encodings",
+                    ?, [
+    // Core VM opcodes (0x00-0x9F):
+    VM_OPC_GlobalLoadI32,
+    VM_OPC_GlobalStoreI32,
+    VM_OPC_GlobalLoadIndirectI32,
+    VM_OPC_GlobalStoreIndirectI32,
+    VM_OPC_GlobalLoadRef,
+    VM_OPC_GlobalStoreRef,
+    VM_OPC_GlobalLoadIndirectRef,
+    VM_OPC_GlobalStoreIndirectRef,
+    VM_OPC_ConstI32Zero,
+    VM_OPC_ConstI32,
+    VM_OPC_ConstRefZero,
+    VM_OPC_ConstRefRodata,
+    VM_OPC_ListAlloc,
+    VM_OPC_ListReserve,
+    VM_OPC_ListSize,
+    VM_OPC_ListResize,
+    VM_OPC_ListGetI32,
+    VM_OPC_ListSetI32,
+    VM_OPC_ListGetRef,
+    VM_OPC_ListSetRef,
+    VM_OPC_SelectI32,
+    VM_OPC_SelectRef,
+    VM_OPC_SwitchI32,
+    VM_OPC_SwitchRef,
+    VM_OPC_AddI32,
+    VM_OPC_SubI32,
+    VM_OPC_MulI32,
+    VM_OPC_DivI32S,
+    VM_OPC_DivI32U,
+    VM_OPC_RemI32S,
+    VM_OPC_RemI32U,
+    VM_OPC_NotI32,
+    VM_OPC_AndI32,
+    VM_OPC_OrI32,
+    VM_OPC_XorI32,
+    VM_OPC_ShlI32,
+    VM_OPC_ShrI32S,
+    VM_OPC_ShrI32U,
+    VM_OPC_TruncI32I8,
+    VM_OPC_TruncI32I16,
+    VM_OPC_ExtI8I32S,
+    VM_OPC_ExtI16I32S,
+    VM_OPC_CmpEQI32,
+    VM_OPC_CmpNEI32,
+    VM_OPC_CmpLTI32S,
+    VM_OPC_CmpLTI32U,
+    VM_OPC_CmpLTEI32S,
+    VM_OPC_CmpLTEI32U,
+    VM_OPC_CmpGTI32S,
+    VM_OPC_CmpGTI32U,
+    VM_OPC_CmpGTEI32S,
+    VM_OPC_CmpGTEI32U,
+    VM_OPC_CmpNZI32,
+    VM_OPC_CmpEQRef,
+    VM_OPC_CmpNERef,
+    VM_OPC_CmpNZRef,
+    VM_OPC_Branch,
+    VM_OPC_CondBranch,
+    VM_OPC_Call,
+    VM_OPC_CallVariadic,
+    VM_OPC_Return,
+    VM_OPC_Fail,
+    VM_OPC_Yield,
+    VM_OPC_Trace,
+    VM_OPC_Print,
+    VM_OPC_CondBreak,
+    VM_OPC_Break,
+
+    // Extension opcodes (0xA0-0xFF):
+    VM_OPC_PrefixExtI64,  // VM_ExtI64OpcodeAttr
+    VM_OPC_PrefixExtF32,  // VM_ExtF32OpcodeAttr
+    VM_OPC_PrefixExtF64,  // VM_ExtF64OpcodeAttr
+  ]>;
+
+// i64 extension:
+// (ops are encoded as a VM_OPC_ExtI64 + the opcode below)
+def VM_OPC_GlobalLoadI64         : VM_OPC<0x00, "GlobalLoadI64">;
+def VM_OPC_GlobalStoreI64        : VM_OPC<0x01, "GlobalStoreI64">;
+def VM_OPC_GlobalLoadIndirectI64 : VM_OPC<0x02, "GlobalLoadIndirectI64">;
+def VM_OPC_GlobalStoreIndirectI64: VM_OPC<0x03, "GlobalStoreIndirectI64">;
+def VM_OPC_ConstI64Zero          : VM_OPC<0x08, "ConstI64Zero">;
+def VM_OPC_ConstI64              : VM_OPC<0x09, "ConstI64">;
+def VM_OPC_ListGetI64            : VM_OPC<0x14, "ListGetI64">;
+def VM_OPC_ListSetI64            : VM_OPC<0x15, "ListSetI64">;
+def VM_OPC_SelectI64             : VM_OPC<0x1E, "SelectI64">;
+def VM_OPC_SwitchI64             : VM_OPC<0x20, "SwitchI64">;
+def VM_OPC_AddI64                : VM_OPC<0x22, "AddI64">;
+def VM_OPC_SubI64                : VM_OPC<0x23, "SubI64">;
+def VM_OPC_MulI64                : VM_OPC<0x24, "MulI64">;
+def VM_OPC_DivI64S               : VM_OPC<0x25, "DivI64S">;
+def VM_OPC_DivI64U               : VM_OPC<0x26, "DivI64U">;
+def VM_OPC_RemI64S               : VM_OPC<0x27, "RemI64S">;
+def VM_OPC_RemI64U               : VM_OPC<0x28, "RemI64U">;
+def VM_OPC_NotI64                : VM_OPC<0x29, "NotI64">;
+def VM_OPC_AndI64                : VM_OPC<0x2A, "AndI64">;
+def VM_OPC_OrI64                 : VM_OPC<0x2B, "OrI64">;
+def VM_OPC_XorI64                : VM_OPC<0x2C, "XorI64">;
+def VM_OPC_ShlI64                : VM_OPC<0x2D, "ShlI64">;
+def VM_OPC_ShrI64S               : VM_OPC<0x2E, "ShrI64S">;
+def VM_OPC_ShrI64U               : VM_OPC<0x2F, "ShrI64U">;
+def VM_OPC_TruncI64I8            : VM_OPC<0x31, "TruncI64I8">;
+def VM_OPC_TruncI64I16           : VM_OPC<0x32, "TruncI64I16">;
+def VM_OPC_TruncI64I32           : VM_OPC<0x36, "TruncI64I32">;
+def VM_OPC_ExtI8I64S             : VM_OPC<0x33, "ExtI8I64S">;
+def VM_OPC_ExtI16I64S            : VM_OPC<0x34, "ExtI16I64S">;
+def VM_OPC_ExtI32I64S            : VM_OPC<0x35, "ExtI32I64S">;
+def VM_OPC_CmpEQI64              : VM_OPC<0x40, "CmpEQI64">;
+def VM_OPC_CmpNEI64              : VM_OPC<0x41, "CmpNEI64">;
+def VM_OPC_CmpLTI64S             : VM_OPC<0x42, "CmpLTI64S">;
+def VM_OPC_CmpLTI64U             : VM_OPC<0x43, "CmpLTI64U">;
+def VM_OPC_CmpLTEI64S            : VM_OPC<0x44, "CmpLTEI64S">;
+def VM_OPC_CmpLTEI64U            : VM_OPC<0x45, "CmpLTEI64U">;
+def VM_OPC_CmpGTI64S             : VM_OPC<0x46, "CmpGTI64S">;
+def VM_OPC_CmpGTI64U             : VM_OPC<0x47, "CmpGTI64U">;
+def VM_OPC_CmpGTEI64S            : VM_OPC<0x48, "CmpGTEI64S">;
+def VM_OPC_CmpGTEI64U            : VM_OPC<0x49, "CmpGTEI64U">;
+def VM_OPC_CmpNZI64              : VM_OPC<0x4D, "CmpNZI64">;
+
+// Runtime enum iree_vm_ext_i64_op_t:
+def VM_ExtI64OpcodeAttr :
+    VM_OPC_EnumAttr<"ExtI64Opcode",
+                    "iree_vm_ext_i64_op_t",
+                    "EXT_I64",  // IREE_VM_OP_EXT_I64_*
+                    "valid VM operation encodings in the i64 extension",
+                    VM_OPC_PrefixExtI64, [
+    VM_OPC_GlobalLoadI64,
+    VM_OPC_GlobalStoreI64,
+    VM_OPC_GlobalLoadIndirectI64,
+    VM_OPC_GlobalStoreIndirectI64,
+    VM_OPC_ConstI64Zero,
+    VM_OPC_ConstI64,
+    VM_OPC_ListGetI64,
+    VM_OPC_ListSetI64,
+    VM_OPC_SelectI64,
+    VM_OPC_SwitchI64,
+    VM_OPC_AddI64,
+    VM_OPC_SubI64,
+    VM_OPC_MulI64,
+    VM_OPC_DivI64S,
+    VM_OPC_DivI64U,
+    VM_OPC_RemI64S,
+    VM_OPC_RemI64U,
+    VM_OPC_NotI64,
+    VM_OPC_AndI64,
+    VM_OPC_OrI64,
+    VM_OPC_XorI64,
+    VM_OPC_ShlI64,
+    VM_OPC_ShrI64S,
+    VM_OPC_ShrI64U,
+    VM_OPC_TruncI64I8,
+    VM_OPC_TruncI64I16,
+    VM_OPC_TruncI64I32,
+    VM_OPC_ExtI8I64S,
+    VM_OPC_ExtI16I64S,
+    VM_OPC_ExtI32I64S,
+    VM_OPC_CmpEQI64,
+    VM_OPC_CmpNEI64,
+    VM_OPC_CmpLTI64S,
+    VM_OPC_CmpLTI64U,
+    VM_OPC_CmpLTEI64S,
+    VM_OPC_CmpLTEI64U,
+    VM_OPC_CmpGTI64S,
+    VM_OPC_CmpGTI64U,
+    VM_OPC_CmpGTEI64S,
+    VM_OPC_CmpGTEI64U,
+    VM_OPC_CmpNZI64,
+  ]>;
 
 //===----------------------------------------------------------------------===//
 // Declarative encoding framework

--- a/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp
+++ b/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp
@@ -29,47 +29,33 @@ using ::llvm::format_hex;
 using ::llvm::formatv;
 using ::llvm::Record;
 
-// Finds all serializable ops and emits a enum and template table for their
-// opcode and name.
-bool emitOpTableDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
-  llvm::emitSourceFileHeader("IREE VM Operation Tables", os);
-
-  std::vector<const Record *> opRecords(256);
+void emitOpTable(const llvm::RecordKeeper &recordKeeper, const Record &tableDef,
+                 raw_ostream &os) {
   std::vector<const Record *> opEncodings(256);
-  auto defs = recordKeeper.getAllDerivedDefinitions("VM_Op");
-  for (const auto *def : defs) {
-    if (def->isValueUnset("encoding")) continue;
-    auto encodingExprs = def->getValueAsListOfDefs("encoding");
-    for (auto encodingExpr : encodingExprs) {
-      if (encodingExpr->getType()->getAsString() == "VM_EncOpcode") {
-        auto *opcode = encodingExpr->getValueAsDef("opcode");
-        opRecords[opcode->getValueAsInt("value")] = def;
-        opEncodings[opcode->getValueAsInt("value")] = opcode;
-        break;
-      }
-    }
+  for (auto *opcodeDef : tableDef.getValueAsListOfDefs("enumerants")) {
+    opEncodings[opcodeDef->getValueAsInt("value")] = opcodeDef;
   }
 
   os << "typedef enum {\n";
   for (int i = 0; i < 256; ++i) {
-    auto *def = opRecords[i];
-    if (def) {
-      auto *opcode = opEncodings[i];
-      os << formatv("  IREE_VM_OP_{0} = {1}",
+    if (auto *opcode = opEncodings[i]) {
+      os << formatv("  IREE_VM_OP_{0}_{1} = {2}",
+                    tableDef.getValueAsString("opcodeEnumTag"),
                     opcode->getValueAsString("symbol"), format_hex(i, 4, true));
     } else {
-      os << formatv("  IREE_VM_OP_RSV_{0}", format_hex(i, 4, true));
+      os << formatv("  IREE_VM_OP_{0}_RSV_{1}",
+                    tableDef.getValueAsString("opcodeEnumTag"),
+                    format_hex(i, 4, true));
     }
     os << ",\n";
   }
-  os << "} iree_vm_op_t;\n";
+  os << "} " << tableDef.getValueAsString("opcodeEnumName") << ";\n";
   os << "\n";
 
-  os << "#define IREE_VM_OP_TABLE(OPC, RSV) \\\n";
+  os << formatv("#define IREE_VM_OP_{0}_TABLE(OPC, RSV) \\\n",
+                tableDef.getValueAsString("opcodeEnumTag"));
   for (int i = 0; i < 256; ++i) {
-    auto *def = opRecords[i];
-    if (def) {
-      auto *opcode = opEncodings[i];
+    if (auto *opcode = opEncodings[i]) {
       os << formatv("    OPC({0}, {1})", format_hex(i, 4, true),
                     opcode->getValueAsString("symbol"));
     } else {
@@ -80,6 +66,17 @@ bool emitOpTableDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
     }
   }
   os << "\n\n";
+}
+
+// Finds all opcode tables in VMBase.td and emits a enum and template table for
+// their opcode and name.
+bool emitOpTableDefs(const llvm::RecordKeeper &recordKeeper, raw_ostream &os) {
+  llvm::emitSourceFileHeader("IREE VM Operation Tables", os);
+
+  auto defs = recordKeeper.getAllDerivedDefinitions("VM_OPC_EnumAttr");
+  for (const auto *def : defs) {
+    emitOpTable(recordKeeper, *def, os);
+  }
 
   return false;
 }

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -209,7 +209,7 @@ iree_status_t iree_vm_bytecode_dispatch(
 #define DECLARE_DISPATCH_OPC(ordinal, name) &&_dispatch_##name,
 #define DECLARE_DISPATCH_RSV(ordinal) &&_dispatch_unhandled,
   static const void* kDispatchTable[256] = {
-      IREE_VM_OP_TABLE(DECLARE_DISPATCH_OPC, DECLARE_DISPATCH_RSV)};
+      IREE_VM_OP_CORE_TABLE(DECLARE_DISPATCH_OPC, DECLARE_DISPATCH_RSV)};
 
 #define DISPATCH_UNHANDLED() \
   _dispatch_unhandled:       \
@@ -238,7 +238,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     return IREE_STATUS_UNIMPLEMENTED;
 
 #define DISPATCH_OP(op_name, body)      \
-  case IREE_VM_OP_##op_name:            \
+  case IREE_VM_OP_CORE_##op_name:       \
     IREE_DISPATCH_LOG_OPCODE(#op_name); \
     body;                               \
     break;
@@ -890,6 +890,16 @@ iree_status_t iree_vm_bytecode_dispatch(
       iree_vm_bytecode_dispatch_remap_branch_registers(regs, remap_list);
       pc = block_pc;
     });
+
+    //===------------------------------------------------------------------===//
+    // Extension trampolines
+    //===------------------------------------------------------------------===//
+
+    DISPATCH_OP(PrefixExtI64, { return IREE_STATUS_UNIMPLEMENTED; });
+
+    DISPATCH_OP(PrefixExtF32, { return IREE_STATUS_UNIMPLEMENTED; });
+
+    DISPATCH_OP(PrefixExtF64, { return IREE_STATUS_UNIMPLEMENTED; });
 
     // NOLINTNEXTLINE(misc-static-assert)
     DISPATCH_UNHANDLED();


### PR DESCRIPTION
This makes it possible to easily define the extension op tables and keep
them in sync with the runtime dispatch code. The initial ExtI64 opcodes
are here for testing and will be refined in following changes.

Progress on #2574.