### PR TITLE
Cleaning up vm.cmp and vm.ext/vm.trunc ops in prep for i64.

### DIFF
--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -150,7 +150,9 @@ def VM_OPC_ShrI32U               : VM_OPC<0x2F, "ShrI32U">;
 def VM_OPC_TruncI32I8            : VM_OPC<0x31, "TruncI32I8">;
 def VM_OPC_TruncI32I16           : VM_OPC<0x32, "TruncI32I16">;
 def VM_OPC_ExtI8I32S             : VM_OPC<0x33, "ExtI8I32S">;
-def VM_OPC_ExtI16I32S            : VM_OPC<0x34, "ExtI16I32S">;
+def VM_OPC_ExtI8I32U             : VM_OPC<0x34, "ExtI8I32U">;
+def VM_OPC_ExtI16I32S            : VM_OPC<0x35, "ExtI16I32S">;
+def VM_OPC_ExtI16I32U            : VM_OPC<0x36, "ExtI16I32U">;
 
 // Reduction arithmetic:
 
@@ -241,7 +243,9 @@ def VM_CoreOpcodeAttr :
     VM_OPC_TruncI32I8,
     VM_OPC_TruncI32I16,
     VM_OPC_ExtI8I32S,
+    VM_OPC_ExtI8I32U,
     VM_OPC_ExtI16I32S,
+    VM_OPC_ExtI16I32U,
     VM_OPC_CmpEQI32,
     VM_OPC_CmpNEI32,
     VM_OPC_CmpLTI32S,
@@ -300,12 +304,15 @@ def VM_OPC_XorI64                : VM_OPC<0x2C, "XorI64">;
 def VM_OPC_ShlI64                : VM_OPC<0x2D, "ShlI64">;
 def VM_OPC_ShrI64S               : VM_OPC<0x2E, "ShrI64S">;
 def VM_OPC_ShrI64U               : VM_OPC<0x2F, "ShrI64U">;
-def VM_OPC_TruncI64I8            : VM_OPC<0x31, "TruncI64I8">;
-def VM_OPC_TruncI64I16           : VM_OPC<0x32, "TruncI64I16">;
-def VM_OPC_TruncI64I32           : VM_OPC<0x36, "TruncI64I32">;
+def VM_OPC_TruncI64I8            : VM_OPC<0x30, "TruncI64I8">;
+def VM_OPC_TruncI64I16           : VM_OPC<0x31, "TruncI64I16">;
+def VM_OPC_TruncI64I32           : VM_OPC<0x32, "TruncI64I32">;
 def VM_OPC_ExtI8I64S             : VM_OPC<0x33, "ExtI8I64S">;
-def VM_OPC_ExtI16I64S            : VM_OPC<0x34, "ExtI16I64S">;
-def VM_OPC_ExtI32I64S            : VM_OPC<0x35, "ExtI32I64S">;
+def VM_OPC_ExtI8I64U             : VM_OPC<0x34, "ExtI8I64U">;
+def VM_OPC_ExtI16I64S            : VM_OPC<0x35, "ExtI16I64S">;
+def VM_OPC_ExtI16I64U            : VM_OPC<0x36, "ExtI16I64U">;
+def VM_OPC_ExtI32I64S            : VM_OPC<0x37, "ExtI32I64S">;
+def VM_OPC_ExtI32I64U            : VM_OPC<0x38, "ExtI32I64U">;
 def VM_OPC_CmpEQI64              : VM_OPC<0x40, "CmpEQI64">;
 def VM_OPC_CmpNEI64              : VM_OPC<0x41, "CmpNEI64">;
 def VM_OPC_CmpLTI64S             : VM_OPC<0x42, "CmpLTI64S">;
@@ -353,8 +360,11 @@ def VM_ExtI64OpcodeAttr :
     VM_OPC_TruncI64I16,
     VM_OPC_TruncI64I32,
     VM_OPC_ExtI8I64S,
+    VM_OPC_ExtI8I64U,
     VM_OPC_ExtI16I64S,
+    VM_OPC_ExtI16I64U,
     VM_OPC_ExtI32I64S,
+    VM_OPC_ExtI32I64U,
     VM_OPC_CmpEQI64,
     VM_OPC_CmpNEI64,
     VM_OPC_CmpLTI64S,

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -161,12 +161,6 @@ def VM_OPC_CmpEQI32              : VM_OPC<0x40, "CmpEQI32">;
 def VM_OPC_CmpNEI32              : VM_OPC<0x41, "CmpNEI32">;
 def VM_OPC_CmpLTI32S             : VM_OPC<0x42, "CmpLTI32S">;
 def VM_OPC_CmpLTI32U             : VM_OPC<0x43, "CmpLTI32U">;
-def VM_OPC_CmpLTEI32S            : VM_OPC<0x44, "CmpLTEI32S">;
-def VM_OPC_CmpLTEI32U            : VM_OPC<0x45, "CmpLTEI32U">;
-def VM_OPC_CmpGTI32S             : VM_OPC<0x46, "CmpGTI32S">;
-def VM_OPC_CmpGTI32U             : VM_OPC<0x47, "CmpGTI32U">;
-def VM_OPC_CmpGTEI32S            : VM_OPC<0x48, "CmpGTEI32S">;
-def VM_OPC_CmpGTEI32U            : VM_OPC<0x49, "CmpGTEI32U">;
 def VM_OPC_CmpNZI32              : VM_OPC<0x4D, "CmpNZI32">;
 def VM_OPC_CmpEQRef              : VM_OPC<0x4A, "CmpEQRef">;
 def VM_OPC_CmpNERef              : VM_OPC<0x4B, "CmpNERef">;
@@ -250,12 +244,6 @@ def VM_CoreOpcodeAttr :
     VM_OPC_CmpNEI32,
     VM_OPC_CmpLTI32S,
     VM_OPC_CmpLTI32U,
-    VM_OPC_CmpLTEI32S,
-    VM_OPC_CmpLTEI32U,
-    VM_OPC_CmpGTI32S,
-    VM_OPC_CmpGTI32U,
-    VM_OPC_CmpGTEI32S,
-    VM_OPC_CmpGTEI32U,
     VM_OPC_CmpNZI32,
     VM_OPC_CmpEQRef,
     VM_OPC_CmpNERef,
@@ -317,12 +305,6 @@ def VM_OPC_CmpEQI64              : VM_OPC<0x40, "CmpEQI64">;
 def VM_OPC_CmpNEI64              : VM_OPC<0x41, "CmpNEI64">;
 def VM_OPC_CmpLTI64S             : VM_OPC<0x42, "CmpLTI64S">;
 def VM_OPC_CmpLTI64U             : VM_OPC<0x43, "CmpLTI64U">;
-def VM_OPC_CmpLTEI64S            : VM_OPC<0x44, "CmpLTEI64S">;
-def VM_OPC_CmpLTEI64U            : VM_OPC<0x45, "CmpLTEI64U">;
-def VM_OPC_CmpGTI64S             : VM_OPC<0x46, "CmpGTI64S">;
-def VM_OPC_CmpGTI64U             : VM_OPC<0x47, "CmpGTI64U">;
-def VM_OPC_CmpGTEI64S            : VM_OPC<0x48, "CmpGTEI64S">;
-def VM_OPC_CmpGTEI64U            : VM_OPC<0x49, "CmpGTEI64U">;
 def VM_OPC_CmpNZI64              : VM_OPC<0x4D, "CmpNZI64">;
 
 // Runtime enum iree_vm_ext_i64_op_t:
@@ -369,12 +351,6 @@ def VM_ExtI64OpcodeAttr :
     VM_OPC_CmpNEI64,
     VM_OPC_CmpLTI64S,
     VM_OPC_CmpLTI64U,
-    VM_OPC_CmpLTEI64S,
-    VM_OPC_CmpLTEI64U,
-    VM_OPC_CmpGTI64S,
-    VM_OPC_CmpGTI64U,
-    VM_OPC_CmpGTEI64S,
-    VM_OPC_CmpGTEI64U,
     VM_OPC_CmpNZI64,
   ]>;
 

--- a/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -734,6 +734,26 @@ void CmpLTI32UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
   results.insert<SwapInvertedCmpOps<CmpLTI32UOp, CmpGTEI32UOp>>(context);
 }
 
+namespace {
+
+/// Rewrites a vm.cmp.lte.* pseudo op to a vm.cmp.lt.* op.
+template <typename T, typename U>
+struct RewritePseudoCmpLTEToLT : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+  LogicalResult matchAndRewrite(T op,
+                                PatternRewriter &rewriter) const override {
+    // !(lhs > rhs)
+    auto condValue =
+        rewriter.createOrFold<U>(op.getLoc(), op.getType(), op.rhs(), op.lhs());
+    rewriter.replaceOpWithNewOp<XorI32Op>(
+        op, op.getType(), condValue,
+        rewriter.createOrFold<IREE::VM::ConstI32Op>(op.getLoc(), 1));
+    return success();
+  }
+};
+
+}  // namespace
+
 OpFoldResult CmpLTEI32SOp::fold(ArrayRef<Attribute> operands) {
   if (lhs() == rhs()) {
     // x <= x = true
@@ -746,6 +766,7 @@ OpFoldResult CmpLTEI32SOp::fold(ArrayRef<Attribute> operands) {
 void CmpLTEI32SOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpLTEI32SOp, CmpGTI32SOp>>(context);
+  results.insert<RewritePseudoCmpLTEToLT<CmpLTEI32SOp, CmpLTI32SOp>>(context);
 }
 
 OpFoldResult CmpLTEI32UOp::fold(ArrayRef<Attribute> operands) {
@@ -760,7 +781,24 @@ OpFoldResult CmpLTEI32UOp::fold(ArrayRef<Attribute> operands) {
 void CmpLTEI32UOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpLTEI32UOp, CmpGTI32UOp>>(context);
+  results.insert<RewritePseudoCmpLTEToLT<CmpLTEI32UOp, CmpLTI32UOp>>(context);
 }
+
+namespace {
+
+/// Rewrites a vm.cmp.gt.* pseudo op to a vm.cmp.lt.* op.
+template <typename T, typename U>
+struct RewritePseudoCmpGTToLT : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+  LogicalResult matchAndRewrite(T op,
+                                PatternRewriter &rewriter) const override {
+    // rhs < lhs
+    rewriter.replaceOpWithNewOp<U>(op, op.getType(), op.rhs(), op.lhs());
+    return success();
+  }
+};
+
+}  // namespace
 
 OpFoldResult CmpGTI32SOp::fold(ArrayRef<Attribute> operands) {
   if (lhs() == rhs()) {
@@ -774,6 +812,7 @@ OpFoldResult CmpGTI32SOp::fold(ArrayRef<Attribute> operands) {
 void CmpGTI32SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                               MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpGTI32SOp, CmpLTEI32SOp>>(context);
+  results.insert<RewritePseudoCmpGTToLT<CmpGTI32SOp, CmpLTI32SOp>>(context);
 }
 
 OpFoldResult CmpGTI32UOp::fold(ArrayRef<Attribute> operands) {
@@ -788,7 +827,28 @@ OpFoldResult CmpGTI32UOp::fold(ArrayRef<Attribute> operands) {
 void CmpGTI32UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                               MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpGTI32UOp, CmpLTEI32UOp>>(context);
+  results.insert<RewritePseudoCmpGTToLT<CmpGTI32UOp, CmpLTI32UOp>>(context);
 }
+
+namespace {
+
+/// Rewrites a vm.cmp.gte.* pseudo op to a vm.cmp.lt.* op.
+template <typename T, typename U>
+struct RewritePseudoCmpGTEToLT : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+  LogicalResult matchAndRewrite(T op,
+                                PatternRewriter &rewriter) const override {
+    // !(lhs < rhs)
+    auto condValue =
+        rewriter.createOrFold<U>(op.getLoc(), op.getType(), op.lhs(), op.rhs());
+    rewriter.replaceOpWithNewOp<XorI32Op>(
+        op, op.getType(), condValue,
+        rewriter.createOrFold<IREE::VM::ConstI32Op>(op.getLoc(), 1));
+    return success();
+  }
+};
+
+}  // namespace
 
 OpFoldResult CmpGTEI32SOp::fold(ArrayRef<Attribute> operands) {
   if (lhs() == rhs()) {
@@ -802,6 +862,7 @@ OpFoldResult CmpGTEI32SOp::fold(ArrayRef<Attribute> operands) {
 void CmpGTEI32SOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpGTEI32SOp, CmpLTI32SOp>>(context);
+  results.insert<RewritePseudoCmpGTEToLT<CmpGTEI32SOp, CmpLTI32SOp>>(context);
 }
 
 OpFoldResult CmpGTEI32UOp::fold(ArrayRef<Attribute> operands) {
@@ -816,6 +877,7 @@ OpFoldResult CmpGTEI32UOp::fold(ArrayRef<Attribute> operands) {
 void CmpGTEI32UOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpGTEI32UOp, CmpLTI32UOp>>(context);
+  results.insert<RewritePseudoCmpGTEToLT<CmpGTEI32UOp, CmpLTI32UOp>>(context);
 }
 
 OpFoldResult CmpNZI32Op::fold(ArrayRef<Attribute> operands) {

--- a/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -605,9 +605,19 @@ OpFoldResult ExtI8I32SOp::fold(ArrayRef<Attribute> operands) {
       operands, [&](APInt a) { return a.trunc(8).sext(32); });
 }
 
+OpFoldResult ExtI8I32UOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldUnaryOp<IntegerAttr>(
+      operands, [&](APInt a) { return a.trunc(8).zext(32); });
+}
+
 OpFoldResult ExtI16I32SOp::fold(ArrayRef<Attribute> operands) {
   return constFoldUnaryOp<IntegerAttr>(
       operands, [&](APInt a) { return a.trunc(16).sext(32); });
+}
+
+OpFoldResult ExtI16I32UOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldUnaryOp<IntegerAttr>(
+      operands, [&](APInt a) { return a.trunc(16).zext(32); });
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -716,9 +716,7 @@ OpFoldResult CmpLTI32SOp::fold(ArrayRef<Attribute> operands) {
 }
 
 void CmpLTI32SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
-                                              MLIRContext *context) {
-  results.insert<SwapInvertedCmpOps<CmpLTI32SOp, CmpGTEI32SOp>>(context);
-}
+                                              MLIRContext *context) {}
 
 OpFoldResult CmpLTI32UOp::fold(ArrayRef<Attribute> operands) {
   if (lhs() == rhs()) {
@@ -730,9 +728,7 @@ OpFoldResult CmpLTI32UOp::fold(ArrayRef<Attribute> operands) {
 }
 
 void CmpLTI32UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
-                                              MLIRContext *context) {
-  results.insert<SwapInvertedCmpOps<CmpLTI32UOp, CmpGTEI32UOp>>(context);
-}
+                                              MLIRContext *context) {}
 
 namespace {
 

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1372,6 +1372,27 @@ class VM_BinaryComparisonOp<Type type, string mnemonic, VM_OPC opcode,
   ];
 }
 
+class VM_BinaryComparisonPseudoOp<Type type, string mnemonic,
+                                  list<OpTrait> traits = []> :
+    VM_PureOp<mnemonic, !listconcat(traits, [
+      AllTypesMatch<["lhs", "rhs"]>,
+      VM_PseudoOp,
+    ])> {
+  let description = [{
+    Compares two operands with the specified predicate.
+  }];
+
+  let arguments = (ins
+    type:$lhs,
+    type:$rhs
+  );
+  let results = (outs
+    I32:$result
+  );
+
+  let assemblyFormat = "operands attr-dict `:` type($lhs)";
+}
+
 def VM_CmpEQI32Op :
     VM_BinaryComparisonOp<I32, "cmp.eq.i32", VM_OPC_CmpEQI32, [Commutative]> {
   let summary = [{integer equality comparison operation}];
@@ -1401,43 +1422,42 @@ def VM_CmpLTI32UOp :
 }
 
 def VM_CmpLTEI32SOp :
-    VM_BinaryComparisonOp<I32, "cmp.lte.i32.s", VM_OPC_CmpLTEI32S> {
+    VM_BinaryComparisonPseudoOp<I32, "cmp.lte.i32.s"> {
   let summary = [{signed integer less-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
 
 def VM_CmpLTEI32UOp :
-    VM_BinaryComparisonOp<I32, "cmp.lte.i32.u", VM_OPC_CmpLTEI32U> {
+    VM_BinaryComparisonPseudoOp<I32, "cmp.lte.i32.u"> {
   let summary = [{unsigned integer less-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
 
-// TODO(benvanik): drop these and rely on lt/lte only?
 def VM_CmpGTI32SOp :
-    VM_BinaryComparisonOp<I32, "cmp.gt.i32.s", VM_OPC_CmpGTI32S> {
+    VM_BinaryComparisonPseudoOp<I32, "cmp.gt.i32.s"> {
   let summary = [{signed integer greater-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
 
 def VM_CmpGTI32UOp :
-    VM_BinaryComparisonOp<I32, "cmp.gt.i32.u", VM_OPC_CmpGTI32U> {
+    VM_BinaryComparisonPseudoOp<I32, "cmp.gt.i32.u"> {
   let summary = [{unsigned integer greater-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
 
 def VM_CmpGTEI32SOp :
-    VM_BinaryComparisonOp<I32, "cmp.gte.i32.s", VM_OPC_CmpGTEI32S> {
+    VM_BinaryComparisonPseudoOp<I32, "cmp.gte.i32.s"> {
   let summary = [{signed integer greater-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
 
 def VM_CmpGTEI32UOp :
-    VM_BinaryComparisonOp<I32, "cmp.gte.i32.u", VM_OPC_CmpGTEI32U> {
+    VM_BinaryComparisonPseudoOp<I32, "cmp.gte.i32.u"> {
   let summary = [{unsigned integer greater-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1294,8 +1294,18 @@ def VM_ExtI8I32SOp : VM_UnaryArithmeticOp<I32, "ext.i8.i32.s", VM_OPC_ExtI8I32S>
   let hasFolder = 1;
 }
 
+def VM_ExtI8I32UOp : VM_UnaryArithmeticOp<I32, "ext.i8.i32.u", VM_OPC_ExtI8I32U> {
+  let summary = [{integer zero extend 8 bits to 32 bits}];
+  let hasFolder = 1;
+}
+
 def VM_ExtI16I32SOp : VM_UnaryArithmeticOp<I32, "ext.i16.i32.s", VM_OPC_ExtI16I32S> {
   let summary = [{integer sign extend 16 bits to 32 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI16I32UOp : VM_UnaryArithmeticOp<I32, "ext.i16.i32.u", VM_OPC_ExtI16I32U> {
+  let summary = [{integer zero extend 16 bits to 32 bits}];
   let hasFolder = 1;
 }
 

--- a/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
@@ -33,11 +33,27 @@ vm.module @ext_folds {
     vm.return %0 : i32
   }
 
+  // CHECK-LABEL: @ext_i8_i32_u_const
+  vm.func @ext_i8_i32_u_const() -> i32 {
+    // CHECK: vm.const.i32 255 : i32
+    %c = vm.const.i32 0x000000FF : i32
+    %0 = vm.ext.i8.i32.u %c : i32
+    vm.return %0 : i32
+  }
+
   // CHECK-LABEL: @ext_i16_i32_s_const
   vm.func @ext_i16_i32_s_const() -> i32 {
     // CHECK: vm.const.i32 -1 : i32
     %c = vm.const.i32 0x0000FFFF : i32
     %0 = vm.ext.i16.i32.s %c : i32
+    vm.return %0 : i32
+  }
+
+  // CHECK-LABEL: @ext_i16_i32_u_const
+  vm.func @ext_i16_i32_u_const() -> i32 {
+    // CHECK: vm.const.i32 65535 : i32
+    %c = vm.const.i32 0x0000FFFF : i32
+    %0 = vm.ext.i16.i32.u %c : i32
     vm.return %0 : i32
   }
 }

--- a/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
@@ -20,8 +20,12 @@ vm.module @my_module {
   vm.func @ext(%arg0 : i32) -> i32 {
     // CHECK-NEXT: %0 = vm.ext.i8.i32.s %arg0 : i32
     %0 = vm.ext.i8.i32.s %arg0 : i32
-    // CHECK-NEXT: %1 = vm.ext.i16.i32.s %0 : i32
-    %1 = vm.ext.i16.i32.s %0 : i32
-    vm.return %1 : i32
+    // CHECK-NEXT: %1 = vm.ext.i8.i32.u %0 : i32
+    %1 = vm.ext.i8.i32.u %0 : i32
+    // CHECK-NEXT: %2 = vm.ext.i16.i32.s %1 : i32
+    %2 = vm.ext.i16.i32.s %1 : i32
+    // CHECK-NEXT: %3 = vm.ext.i16.i32.u %2 : i32
+    %3 = vm.ext.i16.i32.u %2 : i32
+    vm.return %3 : i32
   }
 }

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -608,7 +608,9 @@ iree_status_t iree_vm_bytecode_dispatch(
     DISPATCH_OP_CAST_I32(TruncI32I8, uint8_t, uint32_t);
     DISPATCH_OP_CAST_I32(TruncI32I16, uint16_t, uint32_t);
     DISPATCH_OP_CAST_I32(ExtI8I32S, int8_t, int32_t);
+    DISPATCH_OP_CAST_I32(ExtI8I32U, uint8_t, uint32_t);
     DISPATCH_OP_CAST_I32(ExtI16I32S, int16_t, int32_t);
+    DISPATCH_OP_CAST_I32(ExtI16I32U, uint16_t, uint32_t);
 
     //===------------------------------------------------------------------===//
     // Native bitwise shifts and rotates

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -644,12 +644,6 @@ iree_status_t iree_vm_bytecode_dispatch(
     DISPATCH_OP_CMP_I32(CmpNEI32, int32_t, !=);
     DISPATCH_OP_CMP_I32(CmpLTI32S, int32_t, <);
     DISPATCH_OP_CMP_I32(CmpLTI32U, uint32_t, <);
-    DISPATCH_OP_CMP_I32(CmpLTEI32S, int32_t, <=);
-    DISPATCH_OP_CMP_I32(CmpLTEI32U, uint32_t, <=);
-    DISPATCH_OP_CMP_I32(CmpGTI32S, int32_t, >);
-    DISPATCH_OP_CMP_I32(CmpGTI32U, uint32_t, >);
-    DISPATCH_OP_CMP_I32(CmpGTEI32S, int32_t, >=);
-    DISPATCH_OP_CMP_I32(CmpGTEI32U, uint32_t, >=);
     DISPATCH_OP(CmpNZI32, {
       int32_t operand = VM_DecOperandRegI32("operand");
       int32_t* result = VM_DecResultRegI32("result");

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -25,6 +25,7 @@ cc_embed_data(
     name = "all_bytecode_modules_cc",
     srcs = [
         ":arithmetic_ops.module",
+        ":comparison_ops.module",
         ":control_flow_ops.module",
         ":list_ops.module",
     ],
@@ -37,6 +38,12 @@ cc_embed_data(
 iree_bytecode_module(
     name = "arithmetic_ops",
     src = "arithmetic_ops.mlir",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+iree_bytecode_module(
+    name = "comparison_ops",
+    src = "comparison_ops.mlir",
     flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 

--- a/iree/vm/test/CMakeLists.txt
+++ b/iree/vm/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_embed_data(
     all_bytecode_modules_cc
   GENERATED_SRCS
     "arithmetic_ops.module"
+    "comparison_ops.module"
     "control_flow_ops.module"
     "list_ops.module"
   CC_FILE_OUTPUT
@@ -36,6 +37,16 @@ iree_bytecode_module(
     arithmetic_ops
   SRC
     "arithmetic_ops.mlir"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    comparison_ops
+  SRC
+    "comparison_ops.mlir"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC

--- a/iree/vm/test/comparison_ops.mlir
+++ b/iree/vm/test/comparison_ops.mlir
@@ -1,0 +1,172 @@
+vm.module @comparison_ops {
+
+  //===--------------------------------------------------------------------===//
+  // vm.cmp.lt.i32.s
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_cmp_lt_s_0
+  vm.func @test_cmp_lt_s_0() {
+    %lhs = vm.const.i32 2 : i32
+    %lhs_dno = iree.do_not_optimize(%lhs) : i32
+    %rhs = vm.const.i32 -2 : i32
+    %rhs_dno = iree.do_not_optimize(%rhs) : i32
+    %actual = vm.cmp.lt.i32.s %lhs_dno, %rhs_dno : i32
+    %expected = vm.const.i32 0 : i32
+    vm.check.eq %actual, %expected, "2 < -2" : i32
+    vm.return
+  }
+
+  vm.export @test_cmp_lt_s_1
+  vm.func @test_cmp_lt_s_1() {
+    %lhs = vm.const.i32 -2 : i32
+    %lhs_dno = iree.do_not_optimize(%lhs) : i32
+    %rhs = vm.const.i32 2 : i32
+    %rhs_dno = iree.do_not_optimize(%rhs) : i32
+    %actual = vm.cmp.lt.i32.s %lhs_dno, %rhs_dno : i32
+    %expected = vm.const.i32 1 : i32
+    vm.check.eq %actual, %expected, "-2 < 2" : i32
+    vm.return
+  }
+
+  // Expect UINT_MAX to be interpreted as -1 when doing a signed compare.
+  vm.export @test_cmp_lt_s_2
+  vm.func @test_cmp_lt_s_2() {
+    %lhs = vm.const.i32 4294967295 : i32
+    %lhs_dno = iree.do_not_optimize(%lhs) : i32
+    %rhs = vm.const.i32 2 : i32
+    %rhs_dno = iree.do_not_optimize(%rhs) : i32
+    %actual = vm.cmp.lt.i32.s %lhs_dno, %rhs_dno : i32
+    %expected = vm.const.i32 1 : i32
+    vm.check.eq %actual, %expected, "4294967295 (UINT_MAX) < 2" : i32
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // vm.cmp.lt.i32.u
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_cmp_lt_u_0
+  vm.func @test_cmp_lt_u_0() {
+    %lhs = vm.const.i32 2 : i32
+    %lhs_dno = iree.do_not_optimize(%lhs) : i32
+    %rhs = vm.const.i32 -2 : i32
+    %rhs_dno = iree.do_not_optimize(%rhs) : i32
+    %actual = vm.cmp.lt.i32.u %lhs_dno, %rhs_dno : i32
+    %expected = vm.const.i32 1 : i32
+    vm.check.eq %actual, %expected, "2 < -2 (as unsigned)" : i32
+    vm.return
+  }
+
+  vm.export @test_cmp_lt_u_1
+  vm.func @test_cmp_lt_u_1() {
+    %lhs = vm.const.i32 -2 : i32
+    %lhs_dno = iree.do_not_optimize(%lhs) : i32
+    %rhs = vm.const.i32 2 : i32
+    %rhs_dno = iree.do_not_optimize(%rhs) : i32
+    %actual = vm.cmp.lt.i32.u %lhs_dno, %rhs_dno : i32
+    %expected = vm.const.i32 0 : i32
+    vm.check.eq %actual, %expected, "-2 < 2 (as unsigned)" : i32
+    vm.return
+  }
+
+  vm.export @test_cmp_lt_u_2
+  vm.func @test_cmp_lt_u_2() {
+    %lhs = vm.const.i32 4294967295 : i32
+    %lhs_dno = iree.do_not_optimize(%lhs) : i32
+    %rhs = vm.const.i32 2 : i32
+    %rhs_dno = iree.do_not_optimize(%rhs) : i32
+    %actual = vm.cmp.lt.i32.u %lhs_dno, %rhs_dno : i32
+    %expected = vm.const.i32 0 : i32
+    vm.check.eq %actual, %expected, "4294967295 (UINT_MAX) < 2 (as unsigned)" : i32
+    vm.return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // vm.cmp.*.i32.* pseudo-ops
+  //===--------------------------------------------------------------------===//
+  // NOTE: all of these are turned in to some variants of vm.cmp.lt by the
+  // compiler and are here as a way to test the runtime behavior of the
+  // pseudo-op expansions.
+
+  vm.export @test_cmp_lte
+  vm.func @test_cmp_lte() {
+    %true = vm.const.i32 1 : i32
+    %false = vm.const.i32 0 : i32
+
+    %cn2 = vm.const.i32 -2 : i32
+    %cn2_dno = iree.do_not_optimize(%cn2) : i32
+    %c2 = vm.const.i32 2 : i32
+    %c2_dno = iree.do_not_optimize(%c2) : i32
+
+    %cmp_0 = vm.cmp.lte.i32.s %cn2_dno, %c2_dno : i32
+    vm.check.eq %cmp_0, %true, "-2 <= 2" : i32
+    %cmp_1 = vm.cmp.lte.i32.s %c2_dno, %cn2_dno : i32
+    vm.check.eq %cmp_1, %false, "2 <= -2" : i32
+    %cmp_2 = vm.cmp.lte.i32.s %c2_dno, %c2_dno : i32
+    vm.check.eq %cmp_2, %true, "2 <= 2" : i32
+
+    %cmp_3 = vm.cmp.lte.i32.u %cn2_dno, %c2_dno : i32
+    vm.check.eq %cmp_3, %false, "-2 <= 2 (unsigned)" : i32
+    %cmp_4 = vm.cmp.lte.i32.u %c2_dno, %cn2_dno : i32
+    vm.check.eq %cmp_4, %true, "2 <= -2 (unsigned)" : i32
+    %cmp_5 = vm.cmp.lte.i32.u %c2_dno, %c2_dno : i32
+    vm.check.eq %cmp_5, %true, "2 <= 2 (unsigned)" : i32
+
+    vm.return
+  }
+
+  vm.export @test_cmp_gt
+  vm.func @test_cmp_gt() {
+    %true = vm.const.i32 1 : i32
+    %false = vm.const.i32 0 : i32
+
+    %cn2 = vm.const.i32 -2 : i32
+    %cn2_dno = iree.do_not_optimize(%cn2) : i32
+    %c2 = vm.const.i32 2 : i32
+    %c2_dno = iree.do_not_optimize(%c2) : i32
+
+    %cmp_0 = vm.cmp.gt.i32.s %cn2_dno, %c2_dno : i32
+    vm.check.eq %cmp_0, %false, "-2 > 2" : i32
+    %cmp_1 = vm.cmp.gt.i32.s %c2_dno, %cn2_dno : i32
+    vm.check.eq %cmp_1, %true, "2 > -2" : i32
+    %cmp_2 = vm.cmp.gt.i32.s %c2_dno, %c2_dno : i32
+    vm.check.eq %cmp_2, %false, "2 > 2" : i32
+
+    %cmp_3 = vm.cmp.gt.i32.u %cn2_dno, %c2_dno : i32
+    vm.check.eq %cmp_3, %true, "-2 > 2 (unsigned)" : i32
+    %cmp_4 = vm.cmp.gt.i32.u %c2_dno, %cn2_dno : i32
+    vm.check.eq %cmp_4, %false, "2 > -2 (unsigned)" : i32
+    %cmp_5 = vm.cmp.gt.i32.u %c2_dno, %c2_dno : i32
+    vm.check.eq %cmp_5, %false, "2 > 2 (unsigned)" : i32
+
+    vm.return
+  }
+
+  vm.export @test_cmp_gte
+  vm.func @test_cmp_gte() {
+    %true = vm.const.i32 1 : i32
+    %false = vm.const.i32 0 : i32
+
+    %cn2 = vm.const.i32 -2 : i32
+    %cn2_dno = iree.do_not_optimize(%cn2) : i32
+    %c2 = vm.const.i32 2 : i32
+    %c2_dno = iree.do_not_optimize(%c2) : i32
+
+    %cmp_0 = vm.cmp.gte.i32.s %cn2_dno, %c2_dno : i32
+    vm.check.eq %cmp_0, %false, "-2 >= 2" : i32
+    %cmp_1 = vm.cmp.gte.i32.s %c2_dno, %cn2_dno : i32
+    vm.check.eq %cmp_1, %true, "2 >= -2" : i32
+    %cmp_2 = vm.cmp.gte.i32.s %c2_dno, %c2_dno : i32
+    vm.check.eq %cmp_2, %true, "2 >= 2" : i32
+
+    %cmp_3 = vm.cmp.gte.i32.u %cn2_dno, %c2_dno : i32
+    vm.check.eq %cmp_3, %true, "-2 >= 2 (unsigned)" : i32
+    %cmp_4 = vm.cmp.gte.i32.u %c2_dno, %cn2_dno : i32
+    vm.check.eq %cmp_4, %false, "2 >= -2 (unsigned)" : i32
+    %cmp_5 = vm.cmp.gte.i32.u %c2_dno, %c2_dno : i32
+    vm.check.eq %cmp_5, %true, "2 >= 2 (unsigned)" : i32
+
+    vm.return
+  }
+
+}


### PR DESCRIPTION
Fewer ops keeps things simpler in the runtime and zero extension (in addition to the existing sign extension) allows for register transfer.

Progress on #2574.