### PR TITLE
Adding i64 VM instructions and runtime support

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertVariableOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertVariableOps.cpp
@@ -37,14 +37,18 @@ class VariableOpConversion : public OpConversionPattern<IREE::HAL::VariableOp> {
           op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
           op.initial_value(), llvm::to_vector<4>(op.getDialectAttrs()));
       return success();
-    } else if (convertedType.isSignlessIntOrIndex()) {
-      // TODO(benvanik): support other types.
+    } else if (convertedType.isInteger(32)) {
       rewriter.replaceOpWithNewOp<IREE::VM::GlobalI32Op>(
           op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
           op.initial_value(), llvm::to_vector<4>(op.getDialectAttrs()));
       return success();
+    } else if (convertedType.isInteger(64)) {
+      rewriter.replaceOpWithNewOp<IREE::VM::GlobalI64Op>(
+          op, op.sym_name(), op.is_mutable(), convertedType, op.initializer(),
+          op.initial_value(), llvm::to_vector<4>(op.getDialectAttrs()));
+      return success();
     }
-    return failure();
+    return op.emitOpError("unsupported variable type");
   }
 
  private:

--- a/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
+++ b/iree/compiler/Dialect/VM/Analysis/test/register_allocation.mlir
@@ -5,11 +5,11 @@ vm.module @module {
   // CHECK-LABEL: @single_block
   vm.func @single_block(%arg0 : i32) -> i32 {
     // CHECK: vm.add.i32
-    // CHECK-SAME: block_registers = ["0"]
-    // CHECK-SAME: result_registers = ["1"]
+    // CHECK-SAME: block_registers = ["i0"]
+    // CHECK-SAME: result_registers = ["i1"]
     %0 = vm.add.i32 %arg0, %arg0 : i32
     // CHECK: vm.sub.i32
-    // CHECK-SAME: result_registers = ["0"]
+    // CHECK-SAME: result_registers = ["i0"]
     %1 = vm.sub.i32 %arg0, %0 : i32
     vm.return %1 : i32
   }
@@ -17,8 +17,8 @@ vm.module @module {
   // CHECK-LABEL: @unused_arg
   vm.func @unused_arg(%arg0 : i32, %arg1 : i32) -> i32 {
     // CHECK: vm.const.i32.zero
-    // CHECK-SAME: block_registers = ["0", "1"]
-    // CHECK-SAME: result_registers = ["0"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
+    // CHECK-SAME: result_registers = ["i0"]
     %zero = vm.const.i32.zero : i32
     vm.return %zero : i32
   }
@@ -26,31 +26,31 @@ vm.module @module {
   // CHECK-LABEL: @dominating_values
   vm.func @dominating_values(%arg0 : i32, %arg1 : i32) -> (i32, i32) {
     // CHECK: vm.const.i32 5
-    // CHECK-SAME: block_registers = ["0", "1"]
-    // CHECK-SAME: result_registers = ["2"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
+    // CHECK-SAME: result_registers = ["i2"]
     %c5 = vm.const.i32 5 : i32
     // CHECK: vm.cond_br
     // CHECK-SAME: remap_registers = [
-    // CHECK-SAME:   [], ["1->3"]
+    // CHECK-SAME:   [], ["i1->i3"]
     // CHECK-SAME: ]
     vm.cond_br %arg0, ^bb1(%arg0 : i32), ^bb2(%arg1 : i32)
   ^bb1(%0 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0"]
+    // CHECK-SAME: block_registers = ["i0"]
     vm.return %0, %arg1 : i32, i32
   ^bb2(%1 : i32):
     // CHECK: vm.add.i32
-    // CHECK-SAME: block_registers = ["3"]
-    // CHECK-SAME: result_registers = ["0"]
+    // CHECK-SAME: block_registers = ["i3"]
+    // CHECK-SAME: result_registers = ["i0"]
     %2 = vm.add.i32 %1, %arg0 : i32
     // CHECK: vm.add.i32
-    // CHECK-SAME: result_registers = ["1"]
+    // CHECK-SAME: result_registers = ["i1"]
     %3 = vm.add.i32 %2, %arg1 : i32
     // CHECK: vm.mul.i32
-    // CHECK-SAME: result_registers = ["0"]
+    // CHECK-SAME: result_registers = ["i0"]
     %4 = vm.mul.i32 %2, %1 : i32
     // CHECK: vm.mul.i32
-    // CHECK-SAME: result_registers = ["0"]
+    // CHECK-SAME: result_registers = ["i0"]
     %5 = vm.mul.i32 %4, %c5 : i32
     vm.return %5, %3 : i32, i32
   }
@@ -58,108 +58,141 @@ vm.module @module {
   // CHECK-LABEL: @branch_args
   vm.func @branch_args(%arg0 : i32, %arg1 : i32) -> i32 {
     // CHECK: vm.br
-    // CHECK-SAME: block_registers = ["0", "1"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
     // CHECK-SAME: remap_registers = [
     // CHECK-SAME:   []
     // CHECK-SAME: ]
     vm.br ^bb1(%arg0, %arg1 : i32, i32)
   ^bb1(%0 : i32, %1 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0", "1"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
     vm.return %0 : i32
   }
 
   // CHECK-LABEL: @branch_args_cycle
   vm.func @branch_args_cycle(%arg0 : i32, %arg1 : i32) -> i32 {
     // CHECK: vm.br
-    // CHECK-SAME: block_registers = ["0", "1"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
     // CHECK-SAME: remap_registers = [
-    // CHECK-SAME:   ["1->2", "0->1", "2->0"]
+    // CHECK-SAME:   ["i0->i2", "i1->i0", "i2->i1"]
     // CHECK-SAME: ]
     vm.br ^bb1(%arg1, %arg0 : i32, i32)
   ^bb1(%0 : i32, %1 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0", "1"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
     vm.return %0 : i32
+  }
+
+  // CHECK-LABEL: @branch_args_cycle_64
+  vm.func @branch_args_cycle_64(%arg0 : i64, %arg1 : i64) -> i64 {
+    // CHECK: vm.br
+    // CHECK-SAME: block_registers = ["i0+1", "i2+3"]
+    // CHECK-SAME: remap_registers = [
+    // CHECK-SAME:   ["i0+1->i4+5", "i2+3->i0+1", "i4+5->i2+3"]
+    // CHECK-SAME: ]
+    vm.br ^bb1(%arg1, %arg0 : i64, i64)
+  ^bb1(%0 : i64, %1 : i64):
+    // CHECK: vm.return
+    // CHECK-SAME: block_registers = ["i0+1", "i2+3"]
+    vm.return %0 : i64
   }
 
   // CHECK-LABEL: @branch_args_swizzled
   vm.func @branch_args_swizzled(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
     // CHECK: vm.br
-    // CHECK-SAME: block_registers = ["0", "1", "2"]
+    // CHECK-SAME: block_registers = ["i0", "i1", "i2"]
     // CHECK-SAME: remap_registers = [
-    // CHECK-SAME:   ["1->3", "2->1", "0->2", "3->0"]
+    // CHECK-SAME:   ["i2->i3", "i0->i2", "i1->i0", "i3->i1"]
     // CHECK-SAME: ]
     vm.br ^bb1(%arg1, %arg2, %arg0 : i32, i32, i32)
   ^bb1(%0 : i32, %1 : i32, %2 : i32):
     // CHECK: vm.br
-    // CHECK-SAME: block_registers = ["0", "1", "2"]
+    // CHECK-SAME: block_registers = ["i0", "i1", "i2"]
     // CHECK-SAME: remap_registers = [
-    // CHECK-SAME:   ["2->3", "0->2", "3->0"]
+    // CHECK-SAME:   ["i0->i3", "i2->i0", "i3->i2"]
     // CHECK-SAME: ]
     vm.br ^bb2(%2, %1, %0 : i32, i32, i32)
   ^bb2(%3 : i32, %4 : i32, %5 : i32):
     // CHECK: vm.br
-    // CHECK-SAME: block_registers = ["0", "1", "2"]
+    // CHECK-SAME: block_registers = ["i0", "i1", "i2"]
     // CHECK-SAME: remap_registers = [
-    // CHECK-SAME:   ["0->2", "1->0"]
+    // CHECK-SAME:   ["i0->i2", "i1->i0"]
     // CHECK-SAME: ]
     vm.br ^bb3(%4, %4, %3 : i32, i32, i32)
   ^bb3(%6 : i32, %7 : i32, %8 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0", "1", "2"]
+    // CHECK-SAME: block_registers = ["i0", "i1", "i2"]
     vm.return %6 : i32
   }
 
   // CHECK-LABEL: @cond_branch_args
   vm.func @cond_branch_args(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
     // CHECK: vm.cond_br
-    // CHECK-SAME: block_registers = ["0", "1", "2"]
+    // CHECK-SAME: block_registers = ["i0", "i1", "i2"]
     // CHECK-SAME: remap_registers = [
-    // CHECK-SAME:   ["1->0"],
-    // CHECK-SAME:   ["2->0"]
+    // CHECK-SAME:   ["i1->i0"],
+    // CHECK-SAME:   ["i2->i0"]
     // CHECK-SAME: ]
     vm.cond_br %arg0, ^bb1(%arg1 : i32), ^bb2(%arg2 : i32)
   ^bb1(%0 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0"]
+    // CHECK-SAME: block_registers = ["i0"]
     vm.return %0 : i32
   ^bb2(%1 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0"]
+    // CHECK-SAME: block_registers = ["i0"]
     vm.return %1 : i32
   }
 
   // CHECK-LABEL: @cond_branch_args_swizzled
   vm.func @cond_branch_args_swizzled(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
     // CHECK: vm.cond_br
-    // CHECK-SAME: block_registers = ["0", "1", "2"]
+    // CHECK-SAME: block_registers = ["i0", "i1", "i2"]
     // CHECK-SAME: remap_registers = [
-    // CHECK-SAME:   ["1->0", "2->1"],
-    // CHECK-SAME:   ["1->3", "0->1", "3->0"]
+    // CHECK-SAME:   ["i1->i0", "i2->i1"],
+    // CHECK-SAME:   ["i0->i3", "i1->i0", "i3->i1"]
     // CHECK-SAME: ]
     vm.cond_br %arg0, ^bb1(%arg1, %arg2 : i32, i32), ^bb2(%arg1, %arg0 : i32, i32)
   ^bb1(%0 : i32, %1 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0", "1"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
     vm.return %0 : i32
   ^bb2(%2 : i32, %3 : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0", "1"]
+    // CHECK-SAME: block_registers = ["i0", "i1"]
     vm.return %3 : i32
+  }
+
+  // CHECK-LABEL: @cond_branch_args_swizzled_64
+  vm.func @cond_branch_args_swizzled_64(%arg0 : i32, %arg1 : i64, %arg2 : i64) -> i64 {
+    // CHECK: vm.cond_br
+    // CHECK-SAME: block_registers = ["i0", "i2+3", "i4+5"]
+    // CHECK-SAME: remap_registers = [
+    // CHECK-SAME:   ["i2+3->i0+1", "i4+5->i2+3"],
+    // CHECK-SAME:   ["i2+3->i0+1"]
+    // CHECK-SAME: ]
+    vm.cond_br %arg0, ^bb1(%arg1, %arg2 : i64, i64), ^bb2(%arg1, %arg1 : i64, i64)
+  ^bb1(%0 : i64, %1 : i64):
+    // CHECK: vm.return
+    // CHECK-SAME: block_registers = ["i0+1", "i2+3"]
+    vm.return %0 : i64
+  ^bb2(%2 : i64, %3 : i64):
+    // CHECK: vm.return
+    // CHECK-SAME: block_registers = ["i0+1", "i2+3"]
+    vm.return %3 : i64
   }
 
   // CHECK-LABEL: @loop
   vm.func @loop() -> i32 {
     // CHECK: vm.const.i32
     // CHECK-SAME: block_registers = []
-    // CHECK-SAME: result_registers = ["0"]
+    // CHECK-SAME: result_registers = ["i0"]
     %c1 = vm.const.i32 1 : i32
     // CHECK: vm.const.i32
-    // CHECK-SAME: result_registers = ["1"]
+    // CHECK-SAME: result_registers = ["i1"]
     %c5 = vm.const.i32 5 : i32
     // CHECK: vm.const.i32.zero
-    // CHECK-SAME: result_registers = ["2"]
+    // CHECK-SAME: result_registers = ["i2"]
     %i0 = vm.const.i32.zero : i32
     // CHECK: vm.br
     // CHECK-SAME: remap_registers = [
@@ -168,21 +201,21 @@ vm.module @module {
     vm.br ^loop(%i0 : i32)
   ^loop(%i : i32):
     // CHECK: vm.add.i32
-    // CHECK-SAME: block_registers = ["2"]
-    // CHECK-SAME: result_registers = ["2"]
+    // CHECK-SAME: block_registers = ["i2"]
+    // CHECK-SAME: result_registers = ["i2"]
     %in = vm.add.i32 %i, %c1 : i32
     // CHECK: vm.cmp.lt.i32.s
-    // CHECK-SAME: result_registers = ["3"]
+    // CHECK-SAME: result_registers = ["i3"]
     %cmp = vm.cmp.lt.i32.s %in, %c5 : i32
     // CHECK: vm.cond_br
     // CHECK-SAME: remap_registers = [
     // CHECK-SAME:   [],
-    // CHECK-SAME:   ["2->0"]
+    // CHECK-SAME:   ["i2->i0"]
     // CHECK-SAME: ]
     vm.cond_br %cmp, ^loop(%in : i32), ^loop_exit(%in : i32)
   ^loop_exit(%ie : i32):
     // CHECK: vm.return
-    // CHECK-SAME: block_registers = ["0"]
+    // CHECK-SAME: block_registers = ["i0"]
     vm.return %ie : i32
   }
 }

--- a/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -292,13 +292,7 @@ def VM_OPC_XorI64                : VM_OPC<0x2C, "XorI64">;
 def VM_OPC_ShlI64                : VM_OPC<0x2D, "ShlI64">;
 def VM_OPC_ShrI64S               : VM_OPC<0x2E, "ShrI64S">;
 def VM_OPC_ShrI64U               : VM_OPC<0x2F, "ShrI64U">;
-def VM_OPC_TruncI64I8            : VM_OPC<0x30, "TruncI64I8">;
-def VM_OPC_TruncI64I16           : VM_OPC<0x31, "TruncI64I16">;
 def VM_OPC_TruncI64I32           : VM_OPC<0x32, "TruncI64I32">;
-def VM_OPC_ExtI8I64S             : VM_OPC<0x33, "ExtI8I64S">;
-def VM_OPC_ExtI8I64U             : VM_OPC<0x34, "ExtI8I64U">;
-def VM_OPC_ExtI16I64S            : VM_OPC<0x35, "ExtI16I64S">;
-def VM_OPC_ExtI16I64U            : VM_OPC<0x36, "ExtI16I64U">;
 def VM_OPC_ExtI32I64S            : VM_OPC<0x37, "ExtI32I64S">;
 def VM_OPC_ExtI32I64U            : VM_OPC<0x38, "ExtI32I64U">;
 def VM_OPC_CmpEQI64              : VM_OPC<0x40, "CmpEQI64">;
@@ -338,13 +332,7 @@ def VM_ExtI64OpcodeAttr :
     VM_OPC_ShlI64,
     VM_OPC_ShrI64S,
     VM_OPC_ShrI64U,
-    VM_OPC_TruncI64I8,
-    VM_OPC_TruncI64I16,
     VM_OPC_TruncI64I32,
-    VM_OPC_ExtI8I64S,
-    VM_OPC_ExtI8I64U,
-    VM_OPC_ExtI16I64S,
-    VM_OPC_ExtI16I64U,
     VM_OPC_ExtI32I64S,
     VM_OPC_ExtI32I64U,
     VM_OPC_CmpEQI64,

--- a/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -111,17 +111,17 @@ struct InlineConstGlobalOpInitializer : public OpRewritePattern<T> {
 
 /// Drops initial_values from globals where the value is 0, as by default all
 /// globals are zero-initialized upon module load.
-struct DropDefaultConstGlobalOpInitializer
-    : public OpRewritePattern<GlobalI32Op> {
-  using OpRewritePattern<GlobalI32Op>::OpRewritePattern;
-  LogicalResult matchAndRewrite(GlobalI32Op op,
+template <typename T>
+struct DropDefaultConstGlobalOpInitializer : public OpRewritePattern<T> {
+  using OpRewritePattern<T>::OpRewritePattern;
+  LogicalResult matchAndRewrite(T op,
                                 PatternRewriter &rewriter) const override {
     if (!op.initial_value().hasValue()) return failure();
-    auto value = op.initial_valueAttr().cast<IntegerAttr>();
+    auto value = op.initial_valueAttr().template cast<IntegerAttr>();
     if (value.getValue() != 0) return failure();
-    rewriter.replaceOpWithNewOp<GlobalI32Op>(
-        op, op.sym_name(), op.is_mutable(), op.type(),
-        llvm::to_vector<4>(op.getDialectAttrs()));
+    rewriter.replaceOpWithNewOp<T>(op, op.sym_name(), op.is_mutable(),
+                                   op.type(),
+                                   llvm::to_vector<4>(op.getDialectAttrs()));
     return success();
   }
 };
@@ -131,7 +131,13 @@ struct DropDefaultConstGlobalOpInitializer
 void GlobalI32Op::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                               MLIRContext *context) {
   results.insert<InlineConstGlobalOpInitializer<GlobalI32Op>,
-                 DropDefaultConstGlobalOpInitializer>(context);
+                 DropDefaultConstGlobalOpInitializer<GlobalI32Op>>(context);
+}
+
+void GlobalI64Op::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {
+  results.insert<InlineConstGlobalOpInitializer<GlobalI64Op>,
+                 DropDefaultConstGlobalOpInitializer<GlobalI64Op>>(context);
 }
 
 void GlobalRefOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
@@ -142,21 +148,23 @@ void GlobalRefOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
 namespace {
 
 /// Inlines immutable global constants into their loads.
-struct InlineConstGlobalLoadI32Op : public OpRewritePattern<GlobalLoadI32Op> {
-  using OpRewritePattern<GlobalLoadI32Op>::OpRewritePattern;
-  LogicalResult matchAndRewrite(GlobalLoadI32Op op,
+template <typename LOAD_OP, typename GLOBAL_OP, typename CONST_OP,
+          typename CONST_ZERO_OP>
+struct InlineConstGlobalLoadIntegerOp : public OpRewritePattern<LOAD_OP> {
+  using OpRewritePattern<LOAD_OP>::OpRewritePattern;
+  LogicalResult matchAndRewrite(LOAD_OP op,
                                 PatternRewriter &rewriter) const override {
-    auto globalAttr = op.getAttrOfType<FlatSymbolRefAttr>("global");
+    auto globalAttr = op.template getAttrOfType<FlatSymbolRefAttr>("global");
     auto globalOp =
-        op.getParentOfType<VM::ModuleOp>().lookupSymbol<GlobalI32Op>(
-            globalAttr.getValue());
+        op.template getParentOfType<VM::ModuleOp>()
+            .template lookupSymbol<GLOBAL_OP>(globalAttr.getValue());
     if (!globalOp) return failure();
     if (globalOp.is_mutable()) return failure();
     if (globalOp.initial_value()) {
-      rewriter.replaceOpWithNewOp<ConstI32Op>(
+      rewriter.replaceOpWithNewOp<CONST_OP>(
           op, globalOp.initial_value().getValue());
     } else {
-      rewriter.replaceOpWithNewOp<ConstI32ZeroOp>(op);
+      rewriter.replaceOpWithNewOp<CONST_ZERO_OP>(op);
     }
     return success();
   }
@@ -166,7 +174,16 @@ struct InlineConstGlobalLoadI32Op : public OpRewritePattern<GlobalLoadI32Op> {
 
 void GlobalLoadI32Op::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
-  results.insert<InlineConstGlobalLoadI32Op>(context);
+  results.insert<InlineConstGlobalLoadIntegerOp<GlobalLoadI32Op, GlobalI32Op,
+                                                ConstI32Op, ConstI32ZeroOp>>(
+      context);
+}
+
+void GlobalLoadI64Op::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<InlineConstGlobalLoadIntegerOp<GlobalLoadI64Op, GlobalI64Op,
+                                                ConstI64Op, ConstI64ZeroOp>>(
+      context);
 }
 
 namespace {
@@ -222,6 +239,13 @@ void GlobalLoadIndirectI32Op::getCanonicalizationPatterns(
       context);
 }
 
+void GlobalLoadIndirectI64Op::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<
+      PropagateGlobalLoadAddress<GlobalLoadIndirectI64Op, GlobalLoadI64Op>>(
+      context);
+}
+
 void GlobalLoadIndirectRefOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<
@@ -256,6 +280,13 @@ void GlobalStoreIndirectI32Op::getCanonicalizationPatterns(
       context);
 }
 
+void GlobalStoreIndirectI64Op::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<
+      PropagateGlobalStoreAddress<GlobalStoreIndirectI64Op, GlobalStoreI64Op>>(
+      context);
+}
+
 void GlobalStoreIndirectRefOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<
@@ -269,7 +300,13 @@ void GlobalStoreIndirectRefOp::getCanonicalizationPatterns(
 
 OpFoldResult ConstI32Op::fold(ArrayRef<Attribute> operands) { return value(); }
 
+OpFoldResult ConstI64Op::fold(ArrayRef<Attribute> operands) { return value(); }
+
 OpFoldResult ConstI32ZeroOp::fold(ArrayRef<Attribute> operands) {
+  return IntegerAttr::get(getResult().getType(), 0);
+}
+
+OpFoldResult ConstI64ZeroOp::fold(ArrayRef<Attribute> operands) {
   return IntegerAttr::get(getResult().getType(), 0);
 }
 
@@ -302,6 +339,10 @@ static OpFoldResult foldSelectOp(T op) {
 }
 
 OpFoldResult SelectI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldSelectOp(*this);
+}
+
+OpFoldResult SelectI64Op::fold(ArrayRef<Attribute> operands) {
   return foldSelectOp(*this);
 }
 
@@ -338,6 +379,10 @@ static OpFoldResult foldSwitchOp(T op) {
 }
 
 OpFoldResult SwitchI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldSwitchOp(*this);
+}
+
+OpFoldResult SwitchI64Op::fold(ArrayRef<Attribute> operands) {
   return foldSwitchOp(*this);
 }
 
@@ -417,207 +462,463 @@ Attribute constFoldBinaryOp(ArrayRef<Attribute> operands,
 
 }  // namespace
 
-OpFoldResult AddI32Op::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+template <typename T>
+static OpFoldResult foldAddOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x + 0 = x or 0 + y = y (commutative)
-    return lhs();
+    return op.lhs();
   }
   return constFoldBinaryOp<IntegerAttr>(operands,
                                         [](APInt a, APInt b) { return a + b; });
 }
 
-OpFoldResult SubI32Op::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult AddI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldAddOp(*this, operands);
+}
+
+OpFoldResult AddI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldAddOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldSubOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x - 0 = x
-    return lhs();
+    return op.lhs();
   }
   return constFoldBinaryOp<IntegerAttr>(operands,
                                         [](APInt a, APInt b) { return a - b; });
 }
 
-OpFoldResult MulI32Op::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult SubI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldSubOp(*this, operands);
+}
+
+OpFoldResult SubI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldSubOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldMulOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x * 0 = 0 or 0 * y = 0 (commutative)
-    return zeroOfType(getType());
-  } else if (matchPattern(rhs(), m_One())) {
+    return zeroOfType(op.getType());
+  } else if (matchPattern(op.rhs(), m_One())) {
     // x * 1 = x or 1 * y = y (commutative)
-    return lhs();
+    return op.lhs();
   }
   return constFoldBinaryOp<IntegerAttr>(operands,
                                         [](APInt a, APInt b) { return a * b; });
 }
 
-OpFoldResult DivI32SOp::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult MulI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldMulOp(*this, operands);
+}
+
+OpFoldResult MulI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldMulOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldDivSOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x / 0 = death
-    emitOpError() << "is a divide by constant zero";
+    op.emitOpError() << "is a divide by constant zero";
     return {};
-  } else if (matchPattern(lhs(), m_Zero())) {
+  } else if (matchPattern(op.lhs(), m_Zero())) {
     // 0 / y = 0
-    return zeroOfType(getType());
-  } else if (matchPattern(rhs(), m_One())) {
+    return zeroOfType(op.getType());
+  } else if (matchPattern(op.rhs(), m_One())) {
     // x / 1 = x
-    return lhs();
+    return op.lhs();
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [](APInt a, APInt b) { return a.sdiv(b); });
 }
 
-OpFoldResult DivI32UOp::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult DivI32SOp::fold(ArrayRef<Attribute> operands) {
+  return foldDivSOp(*this, operands);
+}
+
+OpFoldResult DivI64SOp::fold(ArrayRef<Attribute> operands) {
+  return foldDivSOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldDivUOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x / 0 = death
-    emitOpError() << "is a divide by constant zero";
+    op.emitOpError() << "is a divide by constant zero";
     return {};
-  } else if (matchPattern(lhs(), m_Zero())) {
+  } else if (matchPattern(op.lhs(), m_Zero())) {
     // 0 / y = 0
-    return zeroOfType(getType());
-  } else if (matchPattern(rhs(), m_One())) {
+    return zeroOfType(op.getType());
+  } else if (matchPattern(op.rhs(), m_One())) {
     // x / 1 = x
-    return lhs();
+    return op.lhs();
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [](APInt a, APInt b) { return a.udiv(b); });
 }
 
-OpFoldResult RemI32SOp::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult DivI32UOp::fold(ArrayRef<Attribute> operands) {
+  return foldDivUOp(*this, operands);
+}
+
+OpFoldResult DivI64UOp::fold(ArrayRef<Attribute> operands) {
+  return foldDivUOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldRemSOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x % 0 = death
-    emitOpError() << "is a remainder by constant zero";
+    op.emitOpError() << "is a remainder by constant zero";
     return {};
-  } else if (matchPattern(lhs(), m_Zero()) || matchPattern(rhs(), m_One())) {
+  } else if (matchPattern(op.lhs(), m_Zero()) ||
+             matchPattern(op.rhs(), m_One())) {
     // x % 1 = 0
     // 0 % y = 0
-    return zeroOfType(getType());
+    return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [](APInt a, APInt b) { return a.srem(b); });
 }
 
-OpFoldResult RemI32UOp::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(lhs(), m_Zero()) || matchPattern(rhs(), m_One())) {
+OpFoldResult RemI32SOp::fold(ArrayRef<Attribute> operands) {
+  return foldRemSOp(*this, operands);
+}
+
+OpFoldResult RemI64SOp::fold(ArrayRef<Attribute> operands) {
+  return foldRemSOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldRemUOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.lhs(), m_Zero()) || matchPattern(op.rhs(), m_One())) {
     // x % 1 = 0
     // 0 % y = 0
-    return zeroOfType(getType());
+    return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [](APInt a, APInt b) { return a.urem(b); });
 }
 
-OpFoldResult NotI32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult RemI32UOp::fold(ArrayRef<Attribute> operands) {
+  return foldRemUOp(*this, operands);
+}
+
+OpFoldResult RemI64UOp::fold(ArrayRef<Attribute> operands) {
+  return foldRemUOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldNotOp(T op, ArrayRef<Attribute> operands) {
   return constFoldUnaryOp<IntegerAttr>(operands, [](APInt a) {
     a.flipAllBits();
     return a;
   });
 }
 
-OpFoldResult AndI32Op::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult NotI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldNotOp(*this, operands);
+}
+
+OpFoldResult NotI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldNotOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldAndOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x & 0 = 0 or 0 & y = 0 (commutative)
-    return zeroOfType(getType());
-  } else if (lhs() == rhs()) {
+    return zeroOfType(op.getType());
+  } else if (op.lhs() == op.rhs()) {
     // x & x = x
-    return lhs();
+    return op.lhs();
   }
   return constFoldBinaryOp<IntegerAttr>(operands,
                                         [](APInt a, APInt b) { return a & b; });
 }
 
-OpFoldResult OrI32Op::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult AndI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldAndOp(*this, operands);
+}
+
+OpFoldResult AndI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldAndOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldOrOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x | 0 = x or 0 | y = y (commutative)
-    return lhs();
-  } else if (lhs() == rhs()) {
+    return op.lhs();
+  } else if (op.lhs() == op.rhs()) {
     // x | x = x
-    return lhs();
+    return op.lhs();
   }
   return constFoldBinaryOp<IntegerAttr>(operands,
                                         [](APInt a, APInt b) { return a | b; });
 }
 
-OpFoldResult XorI32Op::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(rhs(), m_Zero())) {
+OpFoldResult OrI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldOrOp(*this, operands);
+}
+
+OpFoldResult OrI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldOrOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldXorOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.rhs(), m_Zero())) {
     // x ^ 0 = x or 0 ^ y = y (commutative)
-    return lhs();
-  } else if (lhs() == rhs()) {
+    return op.lhs();
+  } else if (op.lhs() == op.rhs()) {
     // x ^ x = 0
-    return zeroOfType(getType());
+    return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(operands,
                                         [](APInt a, APInt b) { return a ^ b; });
+}
+
+OpFoldResult XorI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldXorOp(*this, operands);
+}
+
+OpFoldResult XorI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldXorOp(*this, operands);
 }
 
 //===----------------------------------------------------------------------===//
 // Native bitwise shifts and rotates
 //===----------------------------------------------------------------------===//
 
-OpFoldResult ShlI32Op::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(operand(), m_Zero())) {
+template <typename T>
+static OpFoldResult foldShlOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.operand(), m_Zero())) {
     // 0 << y = 0
-    return zeroOfType(getType());
-  } else if (amount() == 0) {
+    return zeroOfType(op.getType());
+  } else if (op.amount() == 0) {
     // x << 0 = x
-    return operand();
+    return op.operand();
   }
   return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.shl(amount()); });
+      operands, [&](APInt a) { return a.shl(op.amount()); });
+}
+
+OpFoldResult ShlI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldShlOp(*this, operands);
+}
+
+OpFoldResult ShlI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldShlOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldShrSOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.operand(), m_Zero())) {
+    // 0 >> y = 0
+    return zeroOfType(op.getType());
+  } else if (op.amount() == 0) {
+    // x >> 0 = x
+    return op.operand();
+  }
+  return constFoldUnaryOp<IntegerAttr>(
+      operands, [&](APInt a) { return a.ashr(op.amount()); });
 }
 
 OpFoldResult ShrI32SOp::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(operand(), m_Zero())) {
+  return foldShrSOp(*this, operands);
+}
+
+OpFoldResult ShrI64SOp::fold(ArrayRef<Attribute> operands) {
+  return foldShrSOp(*this, operands);
+}
+
+template <typename T>
+static OpFoldResult foldShrUOp(T op, ArrayRef<Attribute> operands) {
+  if (matchPattern(op.operand(), m_Zero())) {
     // 0 >> y = 0
-    return zeroOfType(getType());
-  } else if (amount() == 0) {
+    return zeroOfType(op.getType());
+  } else if (op.amount() == 0) {
     // x >> 0 = x
-    return operand();
+    return op.operand();
   }
   return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.ashr(amount()); });
+      operands, [&](APInt a) { return a.lshr(op.amount()); });
 }
 
 OpFoldResult ShrI32UOp::fold(ArrayRef<Attribute> operands) {
-  if (matchPattern(operand(), m_Zero())) {
-    // 0 >> y = 0
-    return zeroOfType(getType());
-  } else if (amount() == 0) {
-    // x >> 0 = x
-    return operand();
-  }
-  return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.lshr(amount()); });
+  return foldShrUOp(*this, operands);
+}
+
+OpFoldResult ShrI64UOp::fold(ArrayRef<Attribute> operands) {
+  return foldShrUOp(*this, operands);
 }
 
 //===----------------------------------------------------------------------===//
 // Casting and type conversion/emulation
 //===----------------------------------------------------------------------===//
 
+/// Performs const folding `calculate` with element-wise behavior on the given
+/// attribute in `operands` and returns the result if possible.
+template <class AttrElementT,
+          class ElementValueT = typename AttrElementT::ValueType,
+          class CalculationT = std::function<ElementValueT(ElementValueT)>>
+Attribute constFoldConversionOp(Type resultType, ArrayRef<Attribute> operands,
+                                const CalculationT &calculate) {
+  assert(operands.size() == 1 && "unary op takes one operand");
+  if (auto operand = operands[0].dyn_cast_or_null<AttrElementT>()) {
+    return AttrElementT::get(resultType, calculate(operand.getValue()));
+  }
+  return {};
+}
+
 OpFoldResult TruncI32I8Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.trunc(8).zext(32); });
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(8).zext(32); });
 }
 
 OpFoldResult TruncI32I16Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.trunc(16).zext(32); });
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(16).zext(32); });
+}
+
+OpFoldResult TruncI64I8Op::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(8).zext(32); });
+}
+
+OpFoldResult TruncI64I16Op::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(16).zext(32); });
+}
+
+OpFoldResult TruncI64I32Op::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(32); });
 }
 
 OpFoldResult ExtI8I32SOp::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.trunc(8).sext(32); });
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(8).sext(32); });
 }
 
 OpFoldResult ExtI8I32UOp::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.trunc(8).zext(32); });
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(8).zext(32); });
 }
 
 OpFoldResult ExtI16I32SOp::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.trunc(16).sext(32); });
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(16).sext(32); });
 }
 
 OpFoldResult ExtI16I32UOp::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](APInt a) { return a.trunc(16).zext(32); });
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(32, getContext()), operands,
+      [&](APInt a) { return a.trunc(16).zext(32); });
+}
+
+OpFoldResult ExtI8I64SOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(64, getContext()), operands,
+      [&](APInt a) { return a.trunc(8).sext(64); });
+}
+
+OpFoldResult ExtI8I64UOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(64, getContext()), operands,
+      [&](APInt a) { return a.trunc(8).zext(64); });
+}
+
+OpFoldResult ExtI16I64SOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(64, getContext()), operands,
+      [&](APInt a) { return a.trunc(16).sext(64); });
+}
+
+OpFoldResult ExtI16I64UOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(64, getContext()), operands,
+      [&](APInt a) { return a.trunc(16).zext(64); });
+}
+
+OpFoldResult ExtI32I64SOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(64, getContext()), operands,
+      [&](APInt a) { return a.sext(64); });
+}
+
+OpFoldResult ExtI32I64UOp::fold(ArrayRef<Attribute> operands) {
+  return constFoldConversionOp<IntegerAttr>(
+      IntegerType::get(64, getContext()), operands,
+      [&](APInt a) { return a.zext(64); });
+}
+
+namespace {
+
+template <typename SRC_OP, typename OP_A, int SZ_T, typename OP_B>
+class PseudoIntegerConversionToSplitConversionOp
+    : public OpRewritePattern<SRC_OP> {
+  using OpRewritePattern<SRC_OP>::OpRewritePattern;
+
+ public:
+  LogicalResult matchAndRewrite(SRC_OP op,
+                                PatternRewriter &rewriter) const override {
+    auto tmp = rewriter.createOrFold<OP_A>(
+        op.getLoc(), rewriter.getIntegerType(SZ_T), op.operand());
+    rewriter.replaceOpWithNewOp<OP_B>(op, op.result().getType(), tmp);
+    return success();
+  }
+};
+
+}  // namespace
+
+void TruncI64I8Op::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<PseudoIntegerConversionToSplitConversionOp<
+      TruncI64I8Op, TruncI64I32Op, 32, TruncI32I8Op>>(context);
+}
+
+void TruncI64I16Op::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<PseudoIntegerConversionToSplitConversionOp<
+      TruncI64I16Op, TruncI64I32Op, 32, TruncI32I16Op>>(context);
+}
+
+void ExtI8I64SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {
+  results.insert<PseudoIntegerConversionToSplitConversionOp<
+      ExtI8I64SOp, ExtI8I32SOp, 32, ExtI32I64SOp>>(context);
+}
+
+void ExtI8I64UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {
+  results.insert<PseudoIntegerConversionToSplitConversionOp<
+      ExtI8I64UOp, ExtI8I32UOp, 32, ExtI32I64UOp>>(context);
+}
+
+void ExtI16I64SOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<PseudoIntegerConversionToSplitConversionOp<
+      ExtI16I64SOp, ExtI16I32SOp, 32, ExtI32I64SOp>>(context);
+}
+
+void ExtI16I64UOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<PseudoIntegerConversionToSplitConversionOp<
+      ExtI16I64UOp, ExtI16I32UOp, 32, ExtI32I64UOp>>(context);
 }
 
 //===----------------------------------------------------------------------===//
@@ -660,13 +961,18 @@ struct SwapInvertedCmpOps : public OpRewritePattern<OP> {
 
 }  // namespace
 
-OpFoldResult CmpEQI32Op::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+template <typename T>
+static OpFoldResult foldCmpEQOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x == x = true
-    return oneOfType(getType());
+    return oneOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.eq(b); });
+}
+
+OpFoldResult CmpEQI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldCmpEQOp(*this, operands);
 }
 
 void CmpEQI32Op::getCanonicalizationPatterns(OwningRewritePatternList &results,
@@ -674,15 +980,43 @@ void CmpEQI32Op::getCanonicalizationPatterns(OwningRewritePatternList &results,
   results.insert<SwapInvertedCmpOps<CmpEQI32Op, CmpNEI32Op>>(context);
 }
 
+OpFoldResult CmpEQI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldCmpEQOp(*this, operands);
+}
+
+void CmpEQI64Op::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                             MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpEQI64Op, CmpNEI64Op>>(context);
+}
+
+template <typename T>
+static OpFoldResult foldCmpNEOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
+    // x != x = false
+    return zeroOfType(op.getType());
+  }
+  return constFoldBinaryOp<IntegerAttr>(
+      operands, [&](APInt a, APInt b) { return a.ne(b); });
+}
+
+OpFoldResult CmpNEI32Op::fold(ArrayRef<Attribute> operands) {
+  return foldCmpNEOp(*this, operands);
+}
+
+OpFoldResult CmpNEI64Op::fold(ArrayRef<Attribute> operands) {
+  return foldCmpNEOp(*this, operands);
+}
+
 namespace {
 
 /// Changes a cmp.ne.i32 check against 0 to a cmp.nz.i32.
-struct CmpNEI32ZeroToCmpNZI32 : public OpRewritePattern<CmpNEI32Op> {
-  using OpRewritePattern<CmpNEI32Op>::OpRewritePattern;
-  LogicalResult matchAndRewrite(CmpNEI32Op op,
+template <typename NE_OP, typename NZ_OP>
+struct CmpNEZeroToCmpNZ : public OpRewritePattern<NE_OP> {
+  using OpRewritePattern<NE_OP>::OpRewritePattern;
+  LogicalResult matchAndRewrite(NE_OP op,
                                 PatternRewriter &rewriter) const override {
     if (matchPattern(op.rhs(), m_Zero())) {
-      rewriter.replaceOpWithNewOp<CmpNZI32Op>(op, op.getType(), op.lhs());
+      rewriter.replaceOpWithNewOp<NZ_OP>(op, op.getType(), op.lhs());
       return success();
     }
     return failure();
@@ -694,40 +1028,61 @@ struct CmpNEI32ZeroToCmpNZI32 : public OpRewritePattern<CmpNEI32Op> {
 void CmpNEI32Op::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                              MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpNEI32Op, CmpEQI32Op>,
-                 CmpNEI32ZeroToCmpNZI32>(context);
+                 CmpNEZeroToCmpNZ<CmpNEI32Op, CmpNZI32Op>>(context);
 }
 
-OpFoldResult CmpNEI32Op::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
-    // x != x = false
-    return zeroOfType(getType());
-  }
-  return constFoldBinaryOp<IntegerAttr>(
-      operands, [&](APInt a, APInt b) { return a.ne(b); });
+void CmpNEI64Op::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                             MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpNEI64Op, CmpEQI64Op>,
+                 CmpNEZeroToCmpNZ<CmpNEI64Op, CmpNZI64Op>>(context);
 }
 
-OpFoldResult CmpLTI32SOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+template <typename T>
+static OpFoldResult foldCmpLTSOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x < x = false
-    return zeroOfType(getType());
+    return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.slt(b); });
 }
 
+OpFoldResult CmpLTI32SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTSOp(*this, operands);
+}
+
+OpFoldResult CmpLTI64SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTSOp(*this, operands);
+}
+
 void CmpLTI32SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                               MLIRContext *context) {}
 
-OpFoldResult CmpLTI32UOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+void CmpLTI64SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {}
+
+template <typename T>
+static OpFoldResult foldCmpLTUOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x < x = false
-    return zeroOfType(getType());
+    return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.ult(b); });
 }
 
+OpFoldResult CmpLTI32UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTUOp(*this, operands);
+}
+
+OpFoldResult CmpLTI64UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTUOp(*this, operands);
+}
+
 void CmpLTI32UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {}
+
+void CmpLTI64UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                               MLIRContext *context) {}
 
 namespace {
@@ -750,13 +1105,22 @@ struct RewritePseudoCmpLTEToLT : public OpRewritePattern<T> {
 
 }  // namespace
 
-OpFoldResult CmpLTEI32SOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+template <typename T>
+static OpFoldResult foldCmpLTESOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x <= x = true
-    return oneOfType(getType());
+    return oneOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.sle(b); });
+}
+
+OpFoldResult CmpLTEI32SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTESOp(*this, operands);
+}
+
+OpFoldResult CmpLTEI64SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTESOp(*this, operands);
 }
 
 void CmpLTEI32SOp::getCanonicalizationPatterns(
@@ -765,19 +1129,40 @@ void CmpLTEI32SOp::getCanonicalizationPatterns(
   results.insert<RewritePseudoCmpLTEToLT<CmpLTEI32SOp, CmpLTI32SOp>>(context);
 }
 
-OpFoldResult CmpLTEI32UOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+void CmpLTEI64SOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpLTEI64SOp, CmpGTI64SOp>>(context);
+  results.insert<RewritePseudoCmpLTEToLT<CmpLTEI64SOp, CmpLTI64SOp>>(context);
+}
+
+template <typename T>
+static OpFoldResult foldCmpLTEUOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x <= x = true
-    return oneOfType(getType());
+    return oneOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.ule(b); });
+}
+
+OpFoldResult CmpLTEI32UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTEUOp(*this, operands);
+}
+
+OpFoldResult CmpLTEI64UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpLTEUOp(*this, operands);
 }
 
 void CmpLTEI32UOp::getCanonicalizationPatterns(
     OwningRewritePatternList &results, MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpLTEI32UOp, CmpGTI32UOp>>(context);
   results.insert<RewritePseudoCmpLTEToLT<CmpLTEI32UOp, CmpLTI32UOp>>(context);
+}
+
+void CmpLTEI64UOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpLTEI64UOp, CmpGTI64UOp>>(context);
+  results.insert<RewritePseudoCmpLTEToLT<CmpLTEI64UOp, CmpLTI64UOp>>(context);
 }
 
 namespace {
@@ -796,13 +1181,22 @@ struct RewritePseudoCmpGTToLT : public OpRewritePattern<T> {
 
 }  // namespace
 
-OpFoldResult CmpGTI32SOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+template <typename T>
+static OpFoldResult foldCmpGTSOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x > x = false
-    return zeroOfType(getType());
+    return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.sgt(b); });
+}
+
+OpFoldResult CmpGTI32SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTSOp(*this, operands);
+}
+
+OpFoldResult CmpGTI64SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTSOp(*this, operands);
 }
 
 void CmpGTI32SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
@@ -811,19 +1205,40 @@ void CmpGTI32SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
   results.insert<RewritePseudoCmpGTToLT<CmpGTI32SOp, CmpLTI32SOp>>(context);
 }
 
-OpFoldResult CmpGTI32UOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+void CmpGTI64SOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpGTI64SOp, CmpLTEI64SOp>>(context);
+  results.insert<RewritePseudoCmpGTToLT<CmpGTI64SOp, CmpLTI64SOp>>(context);
+}
+
+template <typename T>
+static OpFoldResult foldCmpGTUOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x > x = false
-    return zeroOfType(getType());
+    return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.ugt(b); });
+}
+
+OpFoldResult CmpGTI32UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTUOp(*this, operands);
+}
+
+OpFoldResult CmpGTI64UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTUOp(*this, operands);
 }
 
 void CmpGTI32UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
                                               MLIRContext *context) {
   results.insert<SwapInvertedCmpOps<CmpGTI32UOp, CmpLTEI32UOp>>(context);
   results.insert<RewritePseudoCmpGTToLT<CmpGTI32UOp, CmpLTI32UOp>>(context);
+}
+
+void CmpGTI64UOp::getCanonicalizationPatterns(OwningRewritePatternList &results,
+                                              MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpGTI64UOp, CmpLTEI64UOp>>(context);
+  results.insert<RewritePseudoCmpGTToLT<CmpGTI64UOp, CmpLTI64UOp>>(context);
 }
 
 namespace {
@@ -846,13 +1261,22 @@ struct RewritePseudoCmpGTEToLT : public OpRewritePattern<T> {
 
 }  // namespace
 
-OpFoldResult CmpGTEI32SOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+template <typename T>
+static OpFoldResult foldCmpGTESOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x >= x = true
-    return oneOfType(getType());
+    return oneOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.sge(b); });
+}
+
+OpFoldResult CmpGTEI32SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTESOp(*this, operands);
+}
+
+OpFoldResult CmpGTEI64SOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTESOp(*this, operands);
 }
 
 void CmpGTEI32SOp::getCanonicalizationPatterns(
@@ -861,13 +1285,28 @@ void CmpGTEI32SOp::getCanonicalizationPatterns(
   results.insert<RewritePseudoCmpGTEToLT<CmpGTEI32SOp, CmpLTI32SOp>>(context);
 }
 
-OpFoldResult CmpGTEI32UOp::fold(ArrayRef<Attribute> operands) {
-  if (lhs() == rhs()) {
+void CmpGTEI64SOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpGTEI64SOp, CmpLTI64SOp>>(context);
+  results.insert<RewritePseudoCmpGTEToLT<CmpGTEI64SOp, CmpLTI64SOp>>(context);
+}
+
+template <typename T>
+static OpFoldResult foldCmpGTEUOp(T op, ArrayRef<Attribute> operands) {
+  if (op.lhs() == op.rhs()) {
     // x >= x = true
-    return oneOfType(getType());
+    return oneOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
       operands, [&](APInt a, APInt b) { return a.uge(b); });
+}
+
+OpFoldResult CmpGTEI32UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTEUOp(*this, operands);
+}
+
+OpFoldResult CmpGTEI64UOp::fold(ArrayRef<Attribute> operands) {
+  return foldCmpGTEUOp(*this, operands);
 }
 
 void CmpGTEI32UOp::getCanonicalizationPatterns(
@@ -876,9 +1315,20 @@ void CmpGTEI32UOp::getCanonicalizationPatterns(
   results.insert<RewritePseudoCmpGTEToLT<CmpGTEI32UOp, CmpLTI32UOp>>(context);
 }
 
+void CmpGTEI64UOp::getCanonicalizationPatterns(
+    OwningRewritePatternList &results, MLIRContext *context) {
+  results.insert<SwapInvertedCmpOps<CmpGTEI64UOp, CmpLTI64UOp>>(context);
+  results.insert<RewritePseudoCmpGTEToLT<CmpGTEI64UOp, CmpLTI64UOp>>(context);
+}
+
 OpFoldResult CmpNZI32Op::fold(ArrayRef<Attribute> operands) {
   return constFoldUnaryOp<IntegerAttr>(
       operands, [&](APInt a) { return APInt(32, a.getBoolValue()); });
+}
+
+OpFoldResult CmpNZI64Op::fold(ArrayRef<Attribute> operands) {
+  return constFoldUnaryOp<IntegerAttr>(
+      operands, [&](APInt a) { return APInt(64, a.getBoolValue()); });
 }
 
 OpFoldResult CmpEQRefOp::fold(ArrayRef<Attribute> operands) {

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -510,12 +510,14 @@ static bool isConstIntegerBuildableWith(Attribute value, Type type) {
   if (value.getType() != type) {
     return false;
   }
-  // Finally, check that the attribute kind is handled.
-  return value.isa<UnitAttr>() || value.isa<IntegerAttr>() ||
-         (value.isa<ElementsAttr>() && value.cast<ElementsAttr>()
-                                           .getType()
-                                           .getElementType()
-                                           .isSignlessInteger());
+  if (value.isa<UnitAttr>()) {
+    return SZ == 32;  // Conditions/bools are always i32
+  } else if (auto intAttr = value.dyn_cast<IntegerAttr>()) {
+    return intAttr.getType().isInteger(SZ);
+  } else if (auto elementsAttr = value.dyn_cast<ElementsAttr>()) {
+    return elementsAttr.getType().getElementType().isInteger(SZ);
+  }
+  return false;
 }
 
 template <int SZ>

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -274,20 +274,45 @@ class VM_GlobalOp<string mnemonic, Attr attr_type, list<OpTrait> traits = []> :
       bool isMutable, Type type,
       Optional<StringRef> initializer, Optional<Attribute> initialValue,
       ArrayRef<NamedAttribute> attrs = {}
+    }], [{
+      result.addAttribute(SymbolTable::getSymbolAttrName(),
+                          builder.getStringAttr(name));
+      if (isMutable) {
+        result.addAttribute("is_mutable", builder.getUnitAttr());
+      }
+      if (initializer.hasValue()) {
+        result.addAttribute("initializer",
+                            builder.getSymbolRefAttr(initializer.getValue()));
+      } else if (initialValue.hasValue() &&
+                 initialValue.getValue().isa<IntegerAttr>()) {
+        result.addAttribute("initial_value", initialValue.getValue());
+      }
+      result.addAttribute("type", TypeAttr::get(type));
+      result.attributes.append(attrs.begin(), attrs.end());
     }]>,
     OpBuilder<[{
       OpBuilder &builder, OperationState &result, StringRef name,
       bool isMutable, IREE::VM::FuncOp initializer,
       ArrayRef<NamedAttribute> attrs = {}
+    }], [{
+      build(builder, result, name, isMutable,
+            initializer.getType().getResult(0), initializer.getName(),
+            llvm::None, attrs);
     }]>,
     OpBuilder<[{
       OpBuilder &builder, OperationState &result, StringRef name,
       bool isMutable, Type type, Attribute initialValue,
       ArrayRef<NamedAttribute> attrs = {}
+    }], [{
+      build(builder, result, name, isMutable, type, llvm::None, initialValue,
+            attrs);
     }]>,
     OpBuilder<[{
       OpBuilder &builder, OperationState &result, StringRef name,
       bool isMutable, Type type, ArrayRef<NamedAttribute> attrs = {}
+    }], [{
+      build(builder, result, name, isMutable, type, llvm::None, llvm::None,
+            attrs);
     }]>,
   ];
 
@@ -310,6 +335,17 @@ class VM_GlobalOp<string mnemonic, Attr attr_type, list<OpTrait> traits = []> :
 
 def VM_GlobalI32Op : VM_GlobalOp<"global.i32", VM_ConstIntValueAttr<I32>> {
   let summary = [{32-bit integer global declaration}];
+  let description = [{
+    Defines a global value that is treated as a scalar literal at runtime.
+    Initialized to zero unless a custom initializer function is specified.
+  }];
+
+  let hasCanonicalizer = 1;
+}
+
+def VM_GlobalI64Op : VM_GlobalOp<"global.i64", VM_ConstIntValueAttr<I64>,
+                                 [VM_ExtI64]> {
+  let summary = [{64-bit integer global declaration}];
   let description = [{
     Defines a global value that is treated as a scalar literal at runtime.
     Initialized to zero unless a custom initializer function is specified.
@@ -365,6 +401,20 @@ class VM_GlobalLoadOp<Type type, string mnemonic, list<OpTrait> traits = []> :
   let verifier = [{ return verifyGlobalLoadOp(*this); }];
 }
 
+class VM_GlobalLoadPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
+                               list<OpTrait> traits = []> :
+    VM_GlobalLoadOp<type, mnemonic, traits> {
+  let description = [{
+    Loads the value of a global containing an primitive value.
+  }];
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncGlobalAttr<"global">,
+    VM_EncResult<"value">,
+  ];
+}
+
 class VM_GlobalStoreOp<Type type, string mnemonic, list<OpTrait> traits = []> :
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
@@ -379,7 +429,22 @@ class VM_GlobalStoreOp<Type type, string mnemonic, list<OpTrait> traits = []> :
   let verifier = [{ return verifyGlobalStoreOp(*this); }];
 }
 
-class VM_GlobalLoadIndirectOp<Type type, string mnemonic, list<OpTrait> traits = []> :
+class VM_GlobalStorePrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
+                                list<OpTrait> traits = []> :
+    VM_GlobalStoreOp<type, mnemonic, traits> {
+  let description = [{
+    Stores a primitive value value to a global.
+  }];
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncGlobalAttr<"global">,
+    VM_EncOperand<"value", 0>,
+  ];
+}
+
+class VM_GlobalLoadIndirectOp<Type type, string mnemonic,
+                              list<OpTrait> traits = []> :
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     ])> {
@@ -393,7 +458,23 @@ class VM_GlobalLoadIndirectOp<Type type, string mnemonic, list<OpTrait> traits =
   let assemblyFormat = "$global attr-dict `:` type($global) `->` type($value)";
 }
 
-class VM_GlobalStoreIndirectOp<Type type, string mnemonic, list<OpTrait> traits = []> :
+class VM_GlobalLoadIndirectPrimitiveOp<Type type, string mnemonic,
+                                       VM_OPC opcode,
+                                       list<OpTrait> traits = []> :
+    VM_GlobalLoadIndirectOp<type, mnemonic, traits> {
+  let description = [{
+    Loads the value of a global containing a primitive value.
+  }];
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncOperand<"global", 0>,
+    VM_EncResult<"value">,
+  ];
+}
+
+class VM_GlobalStoreIndirectOp<Type type, string mnemonic,
+                               list<OpTrait> traits = []> :
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     ])> {
@@ -405,63 +486,72 @@ class VM_GlobalStoreIndirectOp<Type type, string mnemonic, list<OpTrait> traits 
   let assemblyFormat = "$value `,` $global attr-dict `:` type($value) `->` type($global)";
 }
 
-def VM_GlobalLoadI32Op : VM_GlobalLoadOp<I32, "global.load.i32"> {
-  let summary = [{global 32-bit integer load operation}];
+class VM_GlobalStoreIndirectPrimitiveOp<Type type, string mnemonic,
+                                        VM_OPC opcode,
+                                        list<OpTrait> traits = []> :
+    VM_GlobalStoreIndirectOp<type, mnemonic, traits> {
   let description = [{
-    Loads the value of a global containing a 32-bit integer.
+    Stores a primitive value to a global.
   }];
 
   let encoding = [
-    VM_EncOpcode<VM_OPC_GlobalLoadI32>,
-    VM_EncGlobalAttr<"global">,
-    VM_EncResult<"value">,
+    VM_EncOpcode<VM_OPC_GlobalStoreIndirectI64>,
+    VM_EncOperand<"global", 0>,
+    VM_EncOperand<"value", 1>,
   ];
+}
 
+def VM_GlobalLoadI32Op :
+    VM_GlobalLoadPrimitiveOp<I32, "global.load.i32", VM_OPC_GlobalLoadI32> {
+  let summary = [{global 32-bit integer load operation}];
   let hasCanonicalizer = 1;
 }
 
-def VM_GlobalStoreI32Op : VM_GlobalStoreOp<I32, "global.store.i32"> {
-  let summary = [{global 32-bit integer store operation}];
-  let description = [{
-    Stores the 32-bit integer value to a global.
-  }];
+def VM_GlobalLoadI64Op :
+    VM_GlobalLoadPrimitiveOp<I64, "global.load.i64", VM_OPC_GlobalLoadI64,
+                             [VM_ExtI64]> {
+  let summary = [{global 64-bit integer load operation}];
+  let hasCanonicalizer = 1;
+}
 
-  let encoding = [
-    VM_EncOpcode<VM_OPC_GlobalStoreI32>,
-    VM_EncGlobalAttr<"global">,
-    VM_EncOperand<"value", 0>,
-  ];
+def VM_GlobalStoreI32Op :
+    VM_GlobalStorePrimitiveOp<I32, "global.store.i32", VM_OPC_GlobalStoreI32> {
+  let summary = [{global 32-bit integer store operation}];
+}
+
+def VM_GlobalStoreI64Op :
+    VM_GlobalStorePrimitiveOp<I64, "global.store.i64", VM_OPC_GlobalStoreI64,
+                              [VM_ExtI64]> {
+  let summary = [{global 64-bit integer store operation}];
 }
 
 def VM_GlobalLoadIndirectI32Op :
-    VM_GlobalLoadIndirectOp<I32, "global.load.indirect.i32"> {
+    VM_GlobalLoadIndirectPrimitiveOp<I32, "global.load.indirect.i32",
+                                     VM_OPC_GlobalLoadIndirectI32> {
   let summary = [{global 32-bit integer load operation}];
-  let description = [{
-    Loads the value of a global containing a 32-bit integer.
-  }];
+  let hasCanonicalizer = 1;
+}
 
-  let encoding = [
-    VM_EncOpcode<VM_OPC_GlobalLoadIndirectI32>,
-    VM_EncOperand<"global", 0>,
-    VM_EncResult<"value">,
-  ];
-
+def VM_GlobalLoadIndirectI64Op :
+    VM_GlobalLoadIndirectPrimitiveOp<I64, "global.load.indirect.i64",
+                                     VM_OPC_GlobalLoadIndirectI64,
+                                     [VM_ExtI64]> {
+  let summary = [{global 64-bit integer load operation}];
   let hasCanonicalizer = 1;
 }
 
 def VM_GlobalStoreIndirectI32Op :
-    VM_GlobalStoreIndirectOp<I32, "global.store.indirect.i32"> {
+    VM_GlobalStoreIndirectPrimitiveOp<I32, "global.store.indirect.i32",
+                                      VM_OPC_GlobalStoreIndirectI32> {
   let summary = [{global 32-bit integer store operation}];
-  let description = [{
-    Stores the 32-bit integer value to a global.
-  }];
+  let hasCanonicalizer = 1;
+}
 
-  let encoding = [
-    VM_EncOpcode<VM_OPC_GlobalStoreIndirectI32>,
-    VM_EncOperand<"global", 0>,
-    VM_EncOperand<"value", 1>,
-  ];
-
+def VM_GlobalStoreIndirectI64Op :
+    VM_GlobalStoreIndirectPrimitiveOp<I64, "global.store.indirect.i64",
+                                      VM_OPC_GlobalStoreIndirectI64,
+                                      [VM_ExtI64]> {
+  let summary = [{global 64-bit integer store operation}];
   let hasCanonicalizer = 1;
 }
 
@@ -577,6 +667,9 @@ class VM_ConstIntegerOp<I type, string mnemonic, VM_OPC opcode, string ctype,
     VM_EncIntAttr<"value", type.bitwidth>,
     VM_EncResult<"result">,
   ];
+
+  let parser = [{ return parseConstIntegerOp<$cppClass>(parser, &result); }];
+  let printer = [{ return printConstIntegerOp<$cppClass>(p, *this); }];
 }
 
 def VM_ConstI32Op :
@@ -585,23 +678,28 @@ def VM_ConstI32Op :
   let hasFolder = 1;
 }
 
-def VM_ConstI32ZeroOp : VM_PureOp<"const.i32.zero", [
-    ConstantLike,
-    DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
-  ]> {
-  let summary = [{32-bit integer constant zero operation}];
+def VM_ConstI64Op :
+    VM_ConstIntegerOp<I64, "const.i64", VM_OPC_ConstI64, "int64_t",
+                      [VM_ExtI64]> {
+  let summary = [{64-bit integer constant operation}];
+  let hasFolder = 1;
+}
+
+class VM_ConstIntegerZeroOp<I type, string mnemonic, VM_OPC opcode,
+                            string ctype, list<OpTrait> traits = []> :
+    VM_ConstOp<mnemonic, ctype, traits> {
   let description = [{
-    Defines a constant zero 32-bit integer.
+    Defines a constant zero integer.
   }];
 
   let results = (outs
-    I32:$result
+    type:$result
   );
 
   let assemblyFormat = "`:` type($result) attr-dict";
 
   let encoding = [
-    VM_EncOpcode<VM_OPC_ConstI32Zero>,
+    VM_EncOpcode<opcode>,
     VM_EncResult<"result">,
   ];
 
@@ -611,7 +709,19 @@ def VM_ConstI32ZeroOp : VM_PureOp<"const.i32.zero", [
       OpBuilder &builder, OperationState &result
     }]>,
   ];
+}
 
+def VM_ConstI32ZeroOp :
+    VM_ConstIntegerZeroOp<I32, "const.i32.zero", VM_OPC_ConstI32Zero,
+                          "int32_t"> {
+  let summary = [{32-bit integer constant zero operation}];
+  let hasFolder = 1;
+}
+
+def VM_ConstI64ZeroOp :
+    VM_ConstIntegerZeroOp<I64, "const.i64.zero", VM_OPC_ConstI64Zero,
+                          "int64_t", [VM_ExtI64]> {
+  let summary = [{64-bit integer constant zero operation}];
   let hasFolder = 1;
 }
 
@@ -881,10 +991,16 @@ class VM_ListSetPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
 }
 
 def VM_ListGetI32Op :
-    VM_ListGetPrimitiveOp<I32, "list.get.i32", VM_OPC_ListGetI32> {}
+    VM_ListGetPrimitiveOp<I32, "list.get.i32", VM_OPC_ListGetI32>;
+
+def VM_ListGetI64Op :
+    VM_ListGetPrimitiveOp<I64, "list.get.i64", VM_OPC_ListGetI64, [VM_ExtI64]>;
 
 def VM_ListSetI32Op :
-    VM_ListSetPrimitiveOp<I32, "list.set.i32", VM_OPC_ListSetI32> {}
+    VM_ListSetPrimitiveOp<I32, "list.set.i32", VM_OPC_ListSetI32>;
+
+def VM_ListSetI64Op :
+    VM_ListSetPrimitiveOp<I64, "list.set.i64", VM_OPC_ListSetI64, [VM_ExtI64]>;
 
 def VM_ListGetRefOp :
     VM_PureOp<"list.get.ref", [
@@ -992,6 +1108,12 @@ def VM_SelectI32Op : VM_SelectPrimitiveOp<I32, "select.i32", VM_OPC_SelectI32> {
   let hasFolder = 1;
 }
 
+def VM_SelectI64Op : VM_SelectPrimitiveOp<I64, "select.i64", VM_OPC_SelectI64,
+                                          [VM_ExtI64]> {
+  let summary = [{integer select operation}];
+  let hasFolder = 1;
+}
+
 def VM_SelectRefOp : VM_PureOp<"select.ref", [
     DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
     AllTypesMatch<["true_value", "false_value", "result"]>,
@@ -1026,7 +1148,7 @@ def VM_SelectRefOp : VM_PureOp<"select.ref", [
   let hasFolder = 1;
 }
 
-class VM_SwitchPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
+class VM_SwitchPrimitiveOp<I type, string mnemonic, VM_OPC opcode,
                            list<OpTrait> traits = []> :
     VM_PureOp<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
@@ -1045,7 +1167,7 @@ class VM_SwitchPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
 
   let arguments = (ins
     I32:$index,
-    I32:$default_value,
+    type:$default_value,
     Variadic<type>:$values
   );
   let results = (outs
@@ -1059,13 +1181,19 @@ class VM_SwitchPrimitiveOp<Type type, string mnemonic, VM_OPC opcode,
   let encoding = [
     VM_EncOpcode<opcode>,
     VM_EncOperand<"index", 0>,
-    VM_EncIntAttr<"default_value", 32>,
+    VM_EncIntAttr<"default_value", type.bitwidth>,
     VM_EncVariadicOperands<"values">,
     VM_EncResult<"result">,
   ];
 }
 
 def VM_SwitchI32Op : VM_SwitchPrimitiveOp<I32, "switch.i32", VM_OPC_SwitchI32> {
+  let summary = [{integer switch operation}];
+  let hasFolder = 1;
+}
+
+def VM_SwitchI64Op : VM_SwitchPrimitiveOp<I64, "switch.i64", VM_OPC_SwitchI64,
+                                          [VM_ExtI64]> {
   let summary = [{integer switch operation}];
   let hasFolder = 1;
 }
@@ -1168,8 +1296,21 @@ def VM_AddI32Op :
   let hasFolder = 1;
 }
 
+def VM_AddI64Op :
+    VM_BinaryArithmeticOp<I64, "add.i64", VM_OPC_AddI64,
+                          [VM_ExtI64, Commutative]> {
+  let summary = [{integer add operation}];
+  let hasFolder = 1;
+}
+
 def VM_SubI32Op :
     VM_BinaryArithmeticOp<I32, "sub.i32", VM_OPC_SubI32> {
+  let summary = [{integer subtract operation}];
+  let hasFolder = 1;
+}
+
+def VM_SubI64Op :
+    VM_BinaryArithmeticOp<I64, "sub.i64", VM_OPC_SubI64, [VM_ExtI64]> {
   let summary = [{integer subtract operation}];
   let hasFolder = 1;
 }
@@ -1180,8 +1321,21 @@ def VM_MulI32Op :
   let hasFolder = 1;
 }
 
+def VM_MulI64Op :
+    VM_BinaryArithmeticOp<I64, "mul.i64", VM_OPC_MulI64,
+                          [VM_ExtI64, Commutative]> {
+  let summary = [{integer multiplication operation}];
+  let hasFolder = 1;
+}
+
 def VM_DivI32SOp :
     VM_BinaryArithmeticOp<I32, "div.i32.s", VM_OPC_DivI32S> {
+  let summary = [{signed integer division operation}];
+  let hasFolder = 1;
+}
+
+def VM_DivI64SOp :
+    VM_BinaryArithmeticOp<I64, "div.i64.s", VM_OPC_DivI64S, [VM_ExtI64]> {
   let summary = [{signed integer division operation}];
   let hasFolder = 1;
 }
@@ -1192,8 +1346,20 @@ def VM_DivI32UOp :
   let hasFolder = 1;
 }
 
+def VM_DivI64UOp :
+    VM_BinaryArithmeticOp<I64, "div.i64.u", VM_OPC_DivI64U, [VM_ExtI64]> {
+  let summary = [{unsigned integer division operation}];
+  let hasFolder = 1;
+}
+
 def VM_RemI32SOp :
     VM_BinaryArithmeticOp<I32, "rem.i32.s", VM_OPC_RemI32S> {
+  let summary = [{signed integer division remainder operation}];
+  let hasFolder = 1;
+}
+
+def VM_RemI64SOp :
+    VM_BinaryArithmeticOp<I64, "rem.i64.s", VM_OPC_RemI64S, [VM_ExtI64]> {
   let summary = [{signed integer division remainder operation}];
   let hasFolder = 1;
 }
@@ -1204,8 +1370,20 @@ def VM_RemI32UOp :
   let hasFolder = 1;
 }
 
+def VM_RemI64UOp :
+    VM_BinaryArithmeticOp<I64, "rem.i64.u", VM_OPC_RemI64U, [VM_ExtI64]> {
+  let summary = [{unsigned integer division remainder operation}];
+  let hasFolder = 1;
+}
+
 def VM_NotI32Op :
     VM_UnaryArithmeticOp<I32, "not.i32", VM_OPC_NotI32> {
+  let summary = [{integer binary not operation}];
+  let hasFolder = 1;
+}
+
+def VM_NotI64Op :
+    VM_UnaryArithmeticOp<I64, "not.i64", VM_OPC_NotI64, [VM_ExtI64]> {
   let summary = [{integer binary not operation}];
   let hasFolder = 1;
 }
@@ -1216,14 +1394,35 @@ def VM_AndI32Op :
   let hasFolder = 1;
 }
 
+def VM_AndI64Op :
+    VM_BinaryArithmeticOp<I64, "and.i64", VM_OPC_AndI64,
+                          [VM_ExtI64, Commutative]> {
+  let summary = [{integer binary and operation}];
+  let hasFolder = 1;
+}
+
 def VM_OrI32Op :
     VM_BinaryArithmeticOp<I32, "or.i32", VM_OPC_OrI32, [Commutative]> {
   let summary = [{integer binary or operation}];
   let hasFolder = 1;
 }
 
+def VM_OrI64Op :
+    VM_BinaryArithmeticOp<I64, "or.i64", VM_OPC_OrI64,
+                          [VM_ExtI64, Commutative]> {
+  let summary = [{integer binary or operation}];
+  let hasFolder = 1;
+}
+
 def VM_XorI32Op :
     VM_BinaryArithmeticOp<I32, "xor.i32", VM_OPC_XorI32, [Commutative]> {
+  let summary = [{integer binary exclusive-or operation}];
+  let hasFolder = 1;
+}
+
+def VM_XorI64Op :
+    VM_BinaryArithmeticOp<I64, "xor.i64", VM_OPC_XorI64,
+                          [VM_ExtI64, Commutative]> {
   let summary = [{integer binary exclusive-or operation}];
   let hasFolder = 1;
 }
@@ -1265,7 +1464,19 @@ def VM_ShlI32Op : VM_ShiftArithmeticOp<I32, "shl.i32", VM_OPC_ShlI32> {
   let hasFolder = 1;
 }
 
+def VM_ShlI64Op : VM_ShiftArithmeticOp<I64, "shl.i64", VM_OPC_ShlI64,
+                                       [VM_ExtI64]> {
+  let summary = [{integer shift left operation}];
+  let hasFolder = 1;
+}
+
 def VM_ShrI32SOp : VM_ShiftArithmeticOp<I32, "shr.i32.s", VM_OPC_ShrI32S> {
+  let summary = [{signed integer (arithmetic) shift right operation}];
+  let hasFolder = 1;
+}
+
+def VM_ShrI64SOp : VM_ShiftArithmeticOp<I64, "shr.i64.s", VM_OPC_ShrI64S,
+                                        [VM_ExtI64]> {
   let summary = [{signed integer (arithmetic) shift right operation}];
   let hasFolder = 1;
 }
@@ -1275,37 +1486,140 @@ def VM_ShrI32UOp : VM_ShiftArithmeticOp<I32, "shr.i32.u", VM_OPC_ShrI32U> {
   let hasFolder = 1;
 }
 
+def VM_ShrI64UOp : VM_ShiftArithmeticOp<I64, "shr.i64.u", VM_OPC_ShrI64U,
+                                        [VM_ExtI64]> {
+  let summary = [{unsigned integer (logical) shift right operation}];
+  let hasFolder = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Casting and type conversion/emulation
 //===----------------------------------------------------------------------===//
 
-def VM_TruncI32I8Op : VM_UnaryArithmeticOp<I32, "trunc.i32.i8", VM_OPC_TruncI32I8> {
+class VM_ConversionOp<Type src_type, Type dst_type, string mnemonic,
+                      VM_OPC opcode, list<OpTrait> traits = []> :
+    VM_PureOp<mnemonic, !listconcat(traits, [
+      DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+    ])> {
+  let arguments = (ins
+    src_type:$operand
+  );
+  let results = (outs
+    dst_type:$result
+  );
+
+  let assemblyFormat = "$operand attr-dict `:` type($operand) `->` type($result)";
+
+  let encoding = [
+    VM_EncOpcode<opcode>,
+    VM_EncOperand<"operand", 0>,
+    VM_EncResult<"result">,
+  ];
+}
+
+class VM_ConversionPseudoOp<Type src_type, Type dst_type, string mnemonic,
+                            list<OpTrait> traits = []> :
+    VM_PureOp<mnemonic, traits> {
+  let arguments = (ins
+    src_type:$operand
+  );
+  let results = (outs
+    dst_type:$result
+  );
+
+  let assemblyFormat = "$operand attr-dict `:` type($operand) `->` type($result)";
+
+  let hasCanonicalizer = 1;
+}
+
+def VM_TruncI32I8Op :
+    VM_ConversionOp<I32, I32, "trunc.i32.i8", VM_OPC_TruncI32I8> {
   let summary = [{integer truncate to 8 bits}];
   let hasFolder = 1;
 }
 
-def VM_TruncI32I16Op : VM_UnaryArithmeticOp<I32, "trunc.i32.i16", VM_OPC_TruncI32I16> {
+def VM_TruncI32I16Op :
+    VM_ConversionOp<I32, I32, "trunc.i32.i16", VM_OPC_TruncI32I16> {
   let summary = [{integer truncate to 16 bits}];
   let hasFolder = 1;
 }
 
-def VM_ExtI8I32SOp : VM_UnaryArithmeticOp<I32, "ext.i8.i32.s", VM_OPC_ExtI8I32S> {
+def VM_TruncI64I8Op :
+    VM_ConversionPseudoOp<I64, I32, "trunc.i64.i8", [VM_ExtI64]> {
+  let summary = [{integer truncate to 8 bits}];
+  let hasFolder = 1;
+}
+
+def VM_TruncI64I16Op :
+    VM_ConversionPseudoOp<I64, I32, "trunc.i64.i16", [VM_ExtI64]> {
+  let summary = [{integer truncate to 16 bits}];
+  let hasFolder = 1;
+}
+
+def VM_TruncI64I32Op :
+    VM_ConversionOp<I64, I32, "trunc.i64.i32", VM_OPC_TruncI64I32,
+                    [VM_ExtI64]> {
+  let summary = [{integer truncate to 32 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI8I32SOp :
+    VM_ConversionOp<I32, I32, "ext.i8.i32.s", VM_OPC_ExtI8I32S> {
   let summary = [{integer sign extend 8 bits to 32 bits}];
   let hasFolder = 1;
 }
 
-def VM_ExtI8I32UOp : VM_UnaryArithmeticOp<I32, "ext.i8.i32.u", VM_OPC_ExtI8I32U> {
+def VM_ExtI8I32UOp :
+    VM_ConversionOp<I32, I32, "ext.i8.i32.u", VM_OPC_ExtI8I32U> {
   let summary = [{integer zero extend 8 bits to 32 bits}];
   let hasFolder = 1;
 }
 
-def VM_ExtI16I32SOp : VM_UnaryArithmeticOp<I32, "ext.i16.i32.s", VM_OPC_ExtI16I32S> {
+def VM_ExtI16I32SOp :
+    VM_ConversionOp<I32, I32, "ext.i16.i32.s", VM_OPC_ExtI16I32S> {
   let summary = [{integer sign extend 16 bits to 32 bits}];
   let hasFolder = 1;
 }
 
-def VM_ExtI16I32UOp : VM_UnaryArithmeticOp<I32, "ext.i16.i32.u", VM_OPC_ExtI16I32U> {
+def VM_ExtI16I32UOp :
+    VM_ConversionOp<I32, I32, "ext.i16.i32.u", VM_OPC_ExtI16I32U> {
   let summary = [{integer zero extend 16 bits to 32 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI8I64SOp :
+    VM_ConversionPseudoOp<I32, I64, "ext.i8.i64.s", [VM_ExtI64]> {
+  let summary = [{integer sign extend 8 bits to 64 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI8I64UOp :
+    VM_ConversionPseudoOp<I32, I64, "ext.i8.i64.u", [VM_ExtI64]> {
+  let summary = [{integer zero extend 8 bits to 64 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI16I64SOp :
+    VM_ConversionPseudoOp<I32, I64, "ext.i16.i64.s", [VM_ExtI64]> {
+  let summary = [{integer sign extend 16 bits to 64 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI16I64UOp :
+    VM_ConversionPseudoOp<I32, I64, "ext.i16.i64.u", [VM_ExtI64]> {
+  let summary = [{integer zero extend 16 bits to 64 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI32I64SOp :
+    VM_ConversionOp<I32, I64, "ext.i32.i64.s", VM_OPC_ExtI32I64S, [VM_ExtI64]> {
+  let summary = [{integer sign extend 32 bits to 64 bits}];
+  let hasFolder = 1;
+}
+
+def VM_ExtI32I64UOp :
+    VM_ConversionOp<I32, I64, "ext.i32.i64.u", VM_OPC_ExtI32I64U, [VM_ExtI64]> {
+  let summary = [{integer zero extend 32 bits to 64 bits}];
   let hasFolder = 1;
 }
 
@@ -1400,8 +1714,24 @@ def VM_CmpEQI32Op :
   let hasFolder = 1;
 }
 
+def VM_CmpEQI64Op :
+    VM_BinaryComparisonOp<I64, "cmp.eq.i64", VM_OPC_CmpEQI64,
+                          [VM_ExtI64, Commutative]> {
+  let summary = [{integer equality comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 def VM_CmpNEI32Op :
     VM_BinaryComparisonOp<I32, "cmp.ne.i32", VM_OPC_CmpNEI32, [Commutative]> {
+  let summary = [{integer inequality comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
+def VM_CmpNEI64Op :
+    VM_BinaryComparisonOp<I64, "cmp.ne.i64", VM_OPC_CmpNEI64,
+                          [VM_ExtI64, Commutative]> {
   let summary = [{integer inequality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
@@ -1414,8 +1744,22 @@ def VM_CmpLTI32SOp :
   let hasFolder = 1;
 }
 
+def VM_CmpLTI64SOp :
+    VM_BinaryComparisonOp<I64, "cmp.lt.i64.s", VM_OPC_CmpLTI64S, [VM_ExtI64]> {
+  let summary = [{signed integer less-than comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 def VM_CmpLTI32UOp :
     VM_BinaryComparisonOp<I32, "cmp.lt.i32.u", VM_OPC_CmpLTI32U> {
+  let summary = [{unsigned integer less-than comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
+def VM_CmpLTI64UOp :
+    VM_BinaryComparisonOp<I64, "cmp.lt.i64.u", VM_OPC_CmpLTI64U, [VM_ExtI64]> {
   let summary = [{unsigned integer less-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
@@ -1428,8 +1772,22 @@ def VM_CmpLTEI32SOp :
   let hasFolder = 1;
 }
 
+def VM_CmpLTEI64SOp :
+    VM_BinaryComparisonPseudoOp<I64, "cmp.lte.i64.s", [VM_ExtI64]> {
+  let summary = [{signed integer less-than-or-equal comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 def VM_CmpLTEI32UOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.lte.i32.u"> {
+  let summary = [{unsigned integer less-than-or-equal comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
+def VM_CmpLTEI64UOp :
+    VM_BinaryComparisonPseudoOp<I64, "cmp.lte.i64.u", [VM_ExtI64]> {
   let summary = [{unsigned integer less-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
@@ -1442,8 +1800,22 @@ def VM_CmpGTI32SOp :
   let hasFolder = 1;
 }
 
+def VM_CmpGTI64SOp :
+    VM_BinaryComparisonPseudoOp<I64, "cmp.gt.i64.s", [VM_ExtI64]> {
+  let summary = [{signed integer greater-than comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 def VM_CmpGTI32UOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.gt.i32.u"> {
+  let summary = [{unsigned integer greater-than comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
+def VM_CmpGTI64UOp :
+    VM_BinaryComparisonPseudoOp<I64, "cmp.gt.i64.u", [VM_ExtI64]> {
   let summary = [{unsigned integer greater-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
@@ -1456,6 +1828,13 @@ def VM_CmpGTEI32SOp :
   let hasFolder = 1;
 }
 
+def VM_CmpGTEI64SOp :
+    VM_BinaryComparisonPseudoOp<I64, "cmp.gte.i64.s", [VM_ExtI64]> {
+  let summary = [{signed integer greater-than-or-equal comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 def VM_CmpGTEI32UOp :
     VM_BinaryComparisonPseudoOp<I32, "cmp.gte.i32.u"> {
   let summary = [{unsigned integer greater-than-or-equal comparison operation}];
@@ -1463,8 +1842,24 @@ def VM_CmpGTEI32UOp :
   let hasFolder = 1;
 }
 
+def VM_CmpGTEI64UOp :
+    VM_BinaryComparisonPseudoOp<I64, "cmp.gte.i64.u", [VM_ExtI64]> {
+  let summary = [{unsigned integer greater-than-or-equal comparison operation}];
+  let hasCanonicalizer = 1;
+  let hasFolder = 1;
+}
+
 def VM_CmpNZI32Op :
     VM_UnaryComparisonOp<I32, "cmp.nz.i32", VM_OPC_CmpNZI32> {
+  let summary = [{integer non-zero comparison operation}];
+  let description = [{
+    Compares the given integer operand for a non-zero value.
+  }];
+  let hasFolder = 1;
+}
+
+def VM_CmpNZI64Op :
+    VM_UnaryComparisonOp<I64, "cmp.nz.i64", VM_OPC_CmpNZI64, [VM_ExtI64]> {
   let summary = [{integer non-zero comparison operation}];
   let description = [{
     Compares the given integer operand for a non-zero value.

--- a/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/conversion_folding.mlir
@@ -8,7 +8,7 @@ vm.module @trunc_folds {
   vm.func @trunc_i8_const() -> i32 {
     // CHECK: vm.const.i32 255 : i32
     %c = vm.const.i32 0xFFFFFFFF : i32
-    %0 = vm.trunc.i32.i8 %c : i32
+    %0 = vm.trunc.i32.i8 %c : i32 -> i32
     vm.return %0 : i32
   }
 
@@ -16,7 +16,36 @@ vm.module @trunc_folds {
   vm.func @trunc_i16_const() -> i32 {
     // CHECK: vm.const.i32 65535 : i32
     %c = vm.const.i32 0xFFFFFFFF : i32
-    %0 = vm.trunc.i32.i16 %c : i32
+    %0 = vm.trunc.i32.i16 %c : i32 -> i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @trunc_folds_i64
+vm.module @trunc_folds_i64 {
+  // CHECK-LABEL: @trunc_i8_const
+  vm.func @trunc_i8_const() -> i32 {
+    // CHECK: vm.const.i32 255 : i32
+    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF : i64
+    %0 = vm.trunc.i64.i8 %c : i64 -> i32
+    vm.return %0 : i32
+  }
+
+  // CHECK-LABEL: @trunc_i16_const
+  vm.func @trunc_i16_const() -> i32 {
+    // CHECK: vm.const.i32 65535 : i32
+    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF : i64
+    %0 = vm.trunc.i64.i16 %c : i64 -> i32
+    vm.return %0 : i32
+  }
+
+  // CHECK-LABEL: @trunc_i32_const
+  vm.func @trunc_i32_const() -> i32 {
+    // CHECK: vm.const.i32 -1 : i32
+    %c = vm.const.i64 0xFFFFFFFFFFFFFFFF : i64
+    %0 = vm.trunc.i64.i32 %c : i64 -> i32
     vm.return %0 : i32
   }
 }
@@ -29,7 +58,7 @@ vm.module @ext_folds {
   vm.func @ext_i8_i32_s_const() -> i32 {
     // CHECK: vm.const.i32 -1 : i32
     %c = vm.const.i32 0x000000FF : i32
-    %0 = vm.ext.i8.i32.s %c : i32
+    %0 = vm.ext.i8.i32.s %c : i32 -> i32
     vm.return %0 : i32
   }
 
@@ -37,7 +66,7 @@ vm.module @ext_folds {
   vm.func @ext_i8_i32_u_const() -> i32 {
     // CHECK: vm.const.i32 255 : i32
     %c = vm.const.i32 0x000000FF : i32
-    %0 = vm.ext.i8.i32.u %c : i32
+    %0 = vm.ext.i8.i32.u %c : i32 -> i32
     vm.return %0 : i32
   }
 
@@ -45,7 +74,7 @@ vm.module @ext_folds {
   vm.func @ext_i16_i32_s_const() -> i32 {
     // CHECK: vm.const.i32 -1 : i32
     %c = vm.const.i32 0x0000FFFF : i32
-    %0 = vm.ext.i16.i32.s %c : i32
+    %0 = vm.ext.i16.i32.s %c : i32 -> i32
     vm.return %0 : i32
   }
 
@@ -53,7 +82,60 @@ vm.module @ext_folds {
   vm.func @ext_i16_i32_u_const() -> i32 {
     // CHECK: vm.const.i32 65535 : i32
     %c = vm.const.i32 0x0000FFFF : i32
-    %0 = vm.ext.i16.i32.u %c : i32
+    %0 = vm.ext.i16.i32.u %c : i32 -> i32
     vm.return %0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @ext_folds_i64
+vm.module @ext_folds_i64 {
+  // CHECK-LABEL: @ext_i8_i64_s_const
+  vm.func @ext_i8_i64_s_const() -> i64 {
+    // CHECK: vm.const.i64 -1 : i64
+    %c = vm.const.i32 0x000000FF : i32
+    %0 = vm.ext.i8.i64.s %c : i32 -> i64
+    vm.return %0 : i64
+  }
+
+  // CHECK-LABEL: @ext_i8_i64_u_const
+  vm.func @ext_i8_i64_u_const() -> i64 {
+    // CHECK: vm.const.i64 255 : i64
+    %c = vm.const.i32 0x000000FF : i32
+    %0 = vm.ext.i8.i64.u %c : i32 -> i64
+    vm.return %0 : i64
+  }
+
+  // CHECK-LABEL: @ext_i16_i64_s_const
+  vm.func @ext_i16_i64_s_const() -> i64 {
+    // CHECK: vm.const.i64 -1 : i64
+    %c = vm.const.i32 0x0000FFFF : i32
+    %0 = vm.ext.i16.i64.s %c : i32 -> i64
+    vm.return %0 : i64
+  }
+
+  // CHECK-LABEL: @ext_i16_i64_u_const
+  vm.func @ext_i16_i64_u_const() -> i64 {
+    // CHECK: vm.const.i64 65535 : i64
+    %c = vm.const.i32 0x0000FFFF : i32
+    %0 = vm.ext.i16.i64.u %c : i32 -> i64
+    vm.return %0 : i64
+  }
+
+  // CHECK-LABEL: @ext_i32_i64_s_const
+  vm.func @ext_i32_i64_s_const() -> i64 {
+    // CHECK: vm.const.i64 -1 : i64
+    %c = vm.const.i32 0xFFFFFFFF : i32
+    %0 = vm.ext.i32.i64.s %c : i32 -> i64
+    vm.return %0 : i64
+  }
+
+  // CHECK-LABEL: @ext_i32_i64_u_const
+  vm.func @ext_i32_i64_u_const() -> i64 {
+    // CHECK: vm.const.i64 4294967295 : i64
+    %c = vm.const.i32 0xFFFFFFFF : i32
+    %0 = vm.ext.i32.i64.u %c : i32 -> i64
+    vm.return %0 : i64
   }
 }

--- a/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
+++ b/iree/compiler/Dialect/VM/IR/test/conversion_ops.mlir
@@ -5,11 +5,26 @@
 // CHECK-LABEL: @trunc
 vm.module @my_module {
   vm.func @trunc(%arg0 : i32) -> i32 {
-    // CHECK: %0 = vm.trunc.i32.i8 %arg0 : i32
-    %0 = vm.trunc.i32.i8 %arg0 : i32
-    // CHECK-NEXT: %1 = vm.trunc.i32.i16 %0 : i32
-    %1 = vm.trunc.i32.i16 %0 : i32
+    // CHECK: %0 = vm.trunc.i32.i8 %arg0 : i32 -> i32
+    %0 = vm.trunc.i32.i8 %arg0 : i32 -> i32
+    // CHECK-NEXT: %1 = vm.trunc.i32.i16 %0 : i32 -> i32
+    %1 = vm.trunc.i32.i16 %0 : i32 -> i32
     vm.return %1 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @trunc_i64
+vm.module @my_module {
+  vm.func @trunc_i64(%arg0 : i64) -> (i32, i32 ,i32) {
+    // CHECK: %0 = vm.trunc.i64.i8 %arg0 : i64 -> i32
+    %0 = vm.trunc.i64.i8 %arg0 : i64 -> i32
+    // CHECK-NEXT: %1 = vm.trunc.i64.i16 %arg0 : i64 -> i32
+    %1 = vm.trunc.i64.i16 %arg0 : i64 -> i32
+    // CHECK-NEXT: %2 = vm.trunc.i64.i32 %arg0 : i64 -> i32
+    %2 = vm.trunc.i64.i32 %arg0 : i64 -> i32
+    vm.return %0, %1, %2 : i32, i32, i32
   }
 }
 
@@ -18,14 +33,35 @@ vm.module @my_module {
 // CHECK-LABEL: @ext
 vm.module @my_module {
   vm.func @ext(%arg0 : i32) -> i32 {
-    // CHECK-NEXT: %0 = vm.ext.i8.i32.s %arg0 : i32
-    %0 = vm.ext.i8.i32.s %arg0 : i32
-    // CHECK-NEXT: %1 = vm.ext.i8.i32.u %0 : i32
-    %1 = vm.ext.i8.i32.u %0 : i32
-    // CHECK-NEXT: %2 = vm.ext.i16.i32.s %1 : i32
-    %2 = vm.ext.i16.i32.s %1 : i32
-    // CHECK-NEXT: %3 = vm.ext.i16.i32.u %2 : i32
-    %3 = vm.ext.i16.i32.u %2 : i32
+    // CHECK-NEXT: %0 = vm.ext.i8.i32.s %arg0 : i32 -> i32
+    %0 = vm.ext.i8.i32.s %arg0 : i32 -> i32
+    // CHECK-NEXT: %1 = vm.ext.i8.i32.u %0 : i32 -> i32
+    %1 = vm.ext.i8.i32.u %0 : i32 -> i32
+    // CHECK-NEXT: %2 = vm.ext.i16.i32.s %1 : i32 -> i32
+    %2 = vm.ext.i16.i32.s %1 : i32 -> i32
+    // CHECK-NEXT: %3 = vm.ext.i16.i32.u %2 : i32 -> i32
+    %3 = vm.ext.i16.i32.u %2 : i32 -> i32
     vm.return %3 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @ext_i64
+vm.module @my_module {
+  vm.func @ext_i64(%arg0 : i32) -> i64 {
+    // CHECK-NEXT: %0 = vm.ext.i8.i64.s %arg0 : i32 -> i64
+    %0 = vm.ext.i8.i64.s %arg0 : i32 -> i64
+    // CHECK-NEXT: %1 = vm.ext.i8.i64.u %arg0 : i32 -> i64
+    %1 = vm.ext.i8.i64.u %arg0 : i32 -> i64
+    // CHECK-NEXT: %2 = vm.ext.i16.i64.s %arg0 : i32 -> i64
+    %2 = vm.ext.i16.i64.s %arg0 : i32 -> i64
+    // CHECK-NEXT: %3 = vm.ext.i16.i64.u %arg0 : i32 -> i64
+    %3 = vm.ext.i16.i64.u %arg0 : i32 -> i64
+    // CHECK-NEXT: %4 = vm.ext.i32.i64.s %arg0 : i32 -> i64
+    %4 = vm.ext.i32.i64.s %arg0 : i32 -> i64
+    // CHECK-NEXT: %5 = vm.ext.i32.i64.u %arg0 : i32 -> i64
+    %5 = vm.ext.i32.i64.u %arg0 : i32 -> i64
+    vm.return %5 : i64
   }
 }

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.cpp
@@ -107,6 +107,8 @@ class V0BytecodeEncoder : public BytecodeEncoder {
         return writeUint16(static_cast<uint16_t>(limitedValue));
       case 32:
         return writeUint32(static_cast<uint32_t>(limitedValue));
+      case 64:
+        return writeUint64(static_cast<uint64_t>(limitedValue));
       default:
         return currentOp_->emitOpError()
                << "attribute of bitwidth " << bitWidth << " not supported";
@@ -238,6 +240,10 @@ class V0BytecodeEncoder : public BytecodeEncoder {
   }
 
   LogicalResult writeUint32(uint32_t value) {
+    return writeBytes(&value, sizeof(value));
+  }
+
+  LogicalResult writeUint64(uint64_t value) {
     return writeBytes(&value, sizeof(value));
   }
 

--- a/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
+++ b/iree/compiler/Dialect/VM/Transforms/GlobalInitialization.cpp
@@ -138,6 +138,8 @@ class GlobalInitializationPass
       switch (intValue.getValue().getBitWidth()) {
         case 32:
           return {success(), builder.createOrFold<ConstI32Op>(loc, intValue)};
+        case 64:
+          return {success(), builder.createOrFold<ConstI64Op>(loc, intValue)};
         default:
           return {failure(), {}};
       }
@@ -152,6 +154,9 @@ class GlobalInitializationPass
       switch (intType.getIntOrFloatBitWidth()) {
         case 32:
           builder.create<GlobalStoreI32Op>(loc, value, symName);
+          return success();
+        case 64:
+          builder.create<GlobalStoreI64Op>(loc, value, symName);
           return success();
         default:
           return failure();

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -41,6 +41,7 @@ cc_library(
     name = "bytecode_module",
     srcs = [
         "bytecode_dispatch.c",
+        "bytecode_dispatch_util.h",
         "bytecode_module.cc",
         "bytecode_module_impl.h",
         "bytecode_op_table.h",

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -53,6 +53,7 @@ iree_cc_library(
     "bytecode_module.h"
   SRCS
     "bytecode_dispatch.c"
+    "bytecode_dispatch_util.h"
     "bytecode_module.cc"
     "bytecode_module_impl.h"
     "bytecode_op_table.h"

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -12,63 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
 #include <string.h>
 
-#include "iree/base/alignment.h"
-#include "iree/base/target_platform.h"
-#include "iree/vm/bytecode_module_impl.h"
-#include "iree/vm/bytecode_op_table.h"
+#include "iree/vm/bytecode_dispatch_util.h"
 #include "iree/vm/list.h"
-
-// Enable to get some verbose logging; better than nothing until we have some
-// better tooling.
-#define IREE_DISPATCH_LOGGING 0
-
-#if IREE_DISPATCH_LOGGING
-#include <stdio.h>
-#define IREE_DISPATCH_LOG_OPCODE(op_name) \
-  fprintf(stderr, "DISPATCH %d %s\n", (int)pc, op_name)
-#define IREE_DISPATCH_LOG_CALL(target_function) \
-  fprintf(stderr, "CALL -> %s\n", iree_vm_function_name(&target_function).data);
-#else
-#define IREE_DISPATCH_LOG_OPCODE(...)
-#define IREE_DISPATCH_LOG_CALL(...)
-#endif  // IREE_DISPATCH_LOGGING
-
-#if defined(IREE_COMPILER_MSVC) && !defined(IREE_COMPILER_CLANG)
-#define IREE_DISPATCH_MODE_SWITCH 1
-#else
-#define IREE_DISPATCH_MODE_COMPUTED_GOTO 1
-#endif  // MSVC
-
-#ifndef NDEBUG
-#define VMCHECK(expr) assert(expr)
-#else
-#define VMCHECK(expr)
-#endif  // NDEBUG
-
-// Interleaved src-dst register sets for branch register remapping.
-// This structure is an overlay for the bytecode that is serialized in a
-// matching format.
-typedef struct {
-  uint16_t size;
-  struct pair {
-    uint16_t src_reg;
-    uint16_t dst_reg;
-  } pairs[];
-} iree_vm_register_remap_list_t;
-static_assert(iree_alignof(iree_vm_register_remap_list_t) == 2,
-              "Expecting byte alignment (to avoid padding)");
-static_assert(offsetof(iree_vm_register_remap_list_t, pairs) == 2,
-              "Expect no padding in the struct");
-
-// Maps a type ID to a type def with clamping for out of bounds values.
-static inline const iree_vm_type_def_t* iree_vm_map_type(
-    iree_vm_bytecode_module_t* module, int32_t type_id) {
-  type_id = type_id >= module->type_count ? 0 : type_id;
-  return &module->type_table[type_id];
-}
 
 // Remaps registers from a source set to a destination set within the same stack
 // frame. This is a way to perform a conditional multi-mov sequence instead of
@@ -110,140 +57,14 @@ static void iree_vm_bytecode_dispatch_discard_registers(
   }
 }
 
-static const int kRegSize = sizeof(uint16_t);
-
-// Bytecode data access macros for reading values of a given type from a byte
-// offset within the current function.
-#if defined(IREE_IS_LITTLE_ENDIAN)
-#define OP_I8(i) bytecode_data[pc + i]
-#define OP_I16(i) *((uint16_t*)&bytecode_data[pc + i])
-#define OP_I32(i) *((uint32_t*)&bytecode_data[pc + i])
-#else
-#define OP_I8(i) bytecode_data[pc + i]
-#define OP_I16(i)                         \
-  ((uint16_t)bytecode_data[pc + 0 + i]) | \
-      ((uint16_t)bytecode_data[pc + 1 + i] << 8)
-#define OP_I32(i)                                   \
-  ((uint32_t)bytecode_data[pc + 0 + i]) |           \
-      ((uint32_t)bytecode_data[pc + 1 + i] << 8) |  \
-      ((uint32_t)bytecode_data[pc + 2 + i] << 16) | \
-      ((uint32_t)bytecode_data[pc + 3 + i] << 24)
-#endif  // IREE_IS_LITTLE_ENDIAN
-
-// These utilities match the VM_Enc* statements in VMBase.td 1:1, allowing us
-// to have the inverse of the encoding which make things easier to read.
-//
-// Each macro will increment the pc by the number of bytes read and as such must
-// be called in the same order the values are encoded.
-#define VM_DecConstI8(name) \
-  OP_I8(0);                 \
-  ++pc;
-#define VM_DecConstI32(name) \
-  OP_I32(0);                 \
-  pc += 4;
-#define VM_DecOpcode(opcode) VM_DecConstI8(#opcode)
-#define VM_DecFuncAttr(name) VM_DecConstI32(name)
-#define VM_DecGlobalAttr(name) VM_DecConstI32(name)
-#define VM_DecRodataAttr(name) VM_DecConstI32(name)
-#define VM_DecType(name)               \
-  iree_vm_map_type(module, OP_I32(0)); \
-  pc += 4;
-#define VM_DecTypeOf(name) VM_DecType(name)
-#define VM_DecIntAttr32(name) VM_DecConstI32(name)
-#define VM_DecStrAttr(name, out_str)                     \
-  (out_str)->size = (iree_host_size_t)OP_I16(0);         \
-  (out_str)->data = (const char*)&bytecode_data[pc + 2]; \
-  pc += 2 + (out_str)->size;
-#define VM_DecBranchTarget(block_name) VM_DecConstI32(name)
-#define VM_DecBranchOperands(operands_name)                                   \
-  (const iree_vm_register_remap_list_t*)&bytecode_data[pc];                   \
-  pc +=                                                                       \
-      kRegSize + ((const iree_vm_register_list_t*)&bytecode_data[pc])->size * \
-                     2 * kRegSize;
-#define VM_DecOperandRegI32(name)      \
-  regs.i32[OP_I16(0) & regs.i32_mask]; \
-  pc += kRegSize;
-#define VM_DecOperandRegRef(name, out_is_move)             \
-  &regs.ref[OP_I16(0) & regs.ref_mask];                    \
-  *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT; \
-  pc += kRegSize;
-#define VM_DecVariadicOperands(name)                  \
-  (const iree_vm_register_list_t*)&bytecode_data[pc]; \
-  pc += kRegSize +                                    \
-        ((const iree_vm_register_list_t*)&bytecode_data[pc])->size * kRegSize;
-#define VM_DecResultRegI32(name)        \
-  &regs.i32[OP_I16(0) & regs.i32_mask]; \
-  pc += kRegSize;
-#define VM_DecResultRegRef(name, out_is_move)              \
-  &regs.ref[OP_I16(0) & regs.ref_mask];                    \
-  *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT; \
-  pc += kRegSize;
-#define VM_DecVariadicResults(name) VM_DecVariadicOperands(name)
-
 iree_status_t iree_vm_bytecode_dispatch(
     iree_vm_bytecode_module_t* module,
     iree_vm_bytecode_module_state_t* module_state, iree_vm_stack_t* stack,
     iree_vm_stack_frame_t* entry_frame,
     iree_vm_execution_result_t* out_result) {
-#if defined(IREE_DISPATCH_MODE_COMPUTED_GOTO)
-
-// Dispatch table mapping 1:1 with bytecode ops.
-// Each entry is a label within this function that can be used for computed
-// goto. You can find more information on computed goto here:
-// https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables
-//
-// Note that we ensure the table is 256 elements long exactly to make sure
-// that unused opcodes are handled gracefully.
-//
-// Computed gotos are pretty much the best way to dispatch interpreters but are
-// not part of the C standard; GCC and clang support them but MSVC does not.
-// Because the performance difference is significant we support both here but
-// prefer the computed goto path where available. Empirical data shows them to
-// still be a win in 2019 on x64 desktops and arm32/arm64 mobile devices.
-#define BEGIN_DISPATCH()                     \
-  goto* kDispatchTable[bytecode_data[pc++]]; \
-  while (1)
-
-#define END_DISPATCH()
-
-#define DECLARE_DISPATCH_OPC(ordinal, name) &&_dispatch_##name,
-#define DECLARE_DISPATCH_RSV(ordinal) &&_dispatch_unhandled,
-  static const void* kDispatchTable[256] = {
-      IREE_VM_OP_CORE_TABLE(DECLARE_DISPATCH_OPC, DECLARE_DISPATCH_RSV)};
-
-#define DISPATCH_UNHANDLED() \
-  _dispatch_unhandled:       \
-  VMCHECK(0);                \
-  return IREE_STATUS_UNIMPLEMENTED;
-
-#define DISPATCH_OP(op_name, body)                          \
-  _dispatch_##op_name : IREE_DISPATCH_LOG_OPCODE(#op_name); \
-  body;                                                     \
-  goto* kDispatchTable[bytecode_data[pc++]];
-
-#else
-
-  // Switch-based dispatch. This is strictly less efficient than the computed
-  // goto approach above but is universally supported.
-
-#define BEGIN_DISPATCH() \
-  while (1) {            \
-    switch (bytecode_data[pc++])
-
-#define END_DISPATCH() }
-
-#define DISPATCH_UNHANDLED() \
-  default:                   \
-    VMCHECK(0);              \
-    return IREE_STATUS_UNIMPLEMENTED;
-
-#define DISPATCH_OP(op_name, body)      \
-  case IREE_VM_OP_CORE_##op_name:       \
-    IREE_DISPATCH_LOG_OPCODE(#op_name); \
-    body;                               \
-    break;
-
-#endif  // IREE_DISPATCH_MODE_COMPUTED_GOTO
+  // When required emit the dispatch tables here referencing the labels we are
+  // defining below.
+  DEFINE_DISPATCH_TABLES();
 
   // Primary dispatch state. This is our 'native stack frame' and really
   // just enough to make dereferencing common addresses (like the current
@@ -263,12 +84,12 @@ iree_status_t iree_vm_bytecode_dispatch(
 
   memset(out_result, 0, sizeof(*out_result));
 
-  BEGIN_DISPATCH() {
+  BEGIN_DISPATCH_CORE() {
     //===------------------------------------------------------------------===//
     // Globals
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(GlobalLoadI32, {
+    DISPATCH_OP(CORE, GlobalLoadI32, {
       int32_t byte_offset = VM_DecGlobalAttr("global");
       if (byte_offset < 0 ||
           byte_offset >= module_state->rwdata_storage.data_length) {
@@ -280,7 +101,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       *value = *global_ptr;
     });
 
-    DISPATCH_OP(GlobalStoreI32, {
+    DISPATCH_OP(CORE, GlobalStoreI32, {
       int32_t byte_offset = VM_DecGlobalAttr("global");
       if (byte_offset < 0 ||
           byte_offset >= module_state->rwdata_storage.data_length) {
@@ -292,7 +113,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       *global_ptr = value;
     });
 
-    DISPATCH_OP(GlobalLoadIndirectI32, {
+    DISPATCH_OP(CORE, GlobalLoadIndirectI32, {
       int32_t byte_offset = VM_DecOperandRegI32("global");
       if (byte_offset < 0 ||
           byte_offset >= module_state->rwdata_storage.data_length) {
@@ -304,7 +125,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       *value = *global_ptr;
     });
 
-    DISPATCH_OP(GlobalStoreIndirectI32, {
+    DISPATCH_OP(CORE, GlobalStoreIndirectI32, {
       int32_t byte_offset = VM_DecOperandRegI32("global");
       if (byte_offset < 0 ||
           byte_offset >= module_state->rwdata_storage.data_length) {
@@ -316,7 +137,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       *global_ptr = value;
     });
 
-    DISPATCH_OP(GlobalLoadRef, {
+    DISPATCH_OP(CORE, GlobalLoadRef, {
       int32_t global = VM_DecGlobalAttr("global");
       if (global < 0 || global >= module_state->global_ref_count) {
         return IREE_STATUS_OUT_OF_RANGE;
@@ -329,7 +150,7 @@ iree_status_t iree_vm_bytecode_dispatch(
                                          type_def->ref_type, result);
     });
 
-    DISPATCH_OP(GlobalStoreRef, {
+    DISPATCH_OP(CORE, GlobalStoreRef, {
       int32_t global = VM_DecGlobalAttr("global");
       if (global < 0 || global >= module_state->global_ref_count) {
         return IREE_STATUS_OUT_OF_RANGE;
@@ -342,7 +163,7 @@ iree_status_t iree_vm_bytecode_dispatch(
                                          type_def->ref_type, global_ref);
     });
 
-    DISPATCH_OP(GlobalLoadIndirectRef, {
+    DISPATCH_OP(CORE, GlobalLoadIndirectRef, {
       int32_t global = VM_DecGlobalAttr("global");
       if (global < 0 || global >= module_state->global_ref_count) {
         return IREE_STATUS_OUT_OF_RANGE;
@@ -355,7 +176,7 @@ iree_status_t iree_vm_bytecode_dispatch(
                                          type_def->ref_type, result);
     });
 
-    DISPATCH_OP(GlobalStoreIndirectRef, {
+    DISPATCH_OP(CORE, GlobalStoreIndirectRef, {
       int32_t global = VM_DecGlobalAttr("global");
       if (global < 0 || global >= module_state->global_ref_count) {
         return IREE_STATUS_OUT_OF_RANGE;
@@ -372,24 +193,24 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Constants
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(ConstI32, {
+    DISPATCH_OP(CORE, ConstI32, {
       int32_t value = VM_DecIntAttr32("value");
       int32_t* result = VM_DecResultRegI32("result");
       *result = value;
     });
 
-    DISPATCH_OP(ConstI32Zero, {
+    DISPATCH_OP(CORE, ConstI32Zero, {
       int32_t* result = VM_DecResultRegI32("result");
       *result = 0;
     });
 
-    DISPATCH_OP(ConstRefZero, {
+    DISPATCH_OP(CORE, ConstRefZero, {
       bool result_is_move;
       iree_vm_ref_t* result = VM_DecResultRegRef("result", &result_is_move);
       iree_vm_ref_release(result);
     });
 
-    DISPATCH_OP(ConstRefRodata, {
+    DISPATCH_OP(CORE, ConstRefRodata, {
       int32_t rodata_ordinal = VM_DecRodataAttr("rodata");
       if (rodata_ordinal < 0 ||
           rodata_ordinal >= module_state->rodata_ref_count) {
@@ -405,7 +226,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Lists
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(ListAlloc, {
+    DISPATCH_OP(CORE, ListAlloc, {
       const iree_vm_type_def_t* element_type_def = VM_DecTypeOf("element_type");
       iree_host_size_t initial_capacity =
           VM_DecOperandRegI32("initial_capacity");
@@ -417,7 +238,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       iree_vm_ref_wrap_assign(list, iree_vm_list_type_id(), result);
     });
 
-    DISPATCH_OP(ListReserve, {
+    DISPATCH_OP(CORE, ListReserve, {
       bool list_is_move;
       iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
       iree_vm_list_t* list = iree_vm_list_deref(list_ref);
@@ -426,7 +247,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       IREE_RETURN_IF_ERROR(iree_vm_list_reserve(list, minimum_capacity));
     });
 
-    DISPATCH_OP(ListSize, {
+    DISPATCH_OP(CORE, ListSize, {
       bool list_is_move;
       iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
       iree_vm_list_t* list = iree_vm_list_deref(list_ref);
@@ -435,7 +256,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       *result = (int32_t)iree_vm_list_size(list);
     });
 
-    DISPATCH_OP(ListResize, {
+    DISPATCH_OP(CORE, ListResize, {
       bool list_is_move;
       iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
       iree_vm_list_t* list = iree_vm_list_deref(list_ref);
@@ -444,7 +265,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       IREE_RETURN_IF_ERROR(iree_vm_list_resize(list, new_size));
     });
 
-    DISPATCH_OP(ListGetI32, {
+    DISPATCH_OP(CORE, ListGetI32, {
       bool list_is_move;
       iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
       iree_vm_list_t* list = iree_vm_list_deref(list_ref);
@@ -457,7 +278,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       *result = value.i32;
     });
 
-    DISPATCH_OP(ListSetI32, {
+    DISPATCH_OP(CORE, ListSetI32, {
       bool list_is_move;
       iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
       iree_vm_list_t* list = iree_vm_list_deref(list_ref);
@@ -468,7 +289,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       IREE_RETURN_IF_ERROR(iree_vm_list_set_value(list, index, &value));
     });
 
-    DISPATCH_OP(ListGetRef, {
+    DISPATCH_OP(CORE, ListGetRef, {
       // bool list_is_move;
       // iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
       // iree_vm_list_t* list = iree_vm_list_deref(list_ref);
@@ -478,7 +299,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       return IREE_STATUS_UNIMPLEMENTED;
     });
 
-    DISPATCH_OP(ListSetRef, {
+    DISPATCH_OP(CORE, ListSetRef, {
       // bool list_is_move;
       // iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
       // iree_vm_list_t* list = iree_vm_list_deref(list_ref);
@@ -493,7 +314,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Conditional assignment
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(SelectI32, {
+    DISPATCH_OP(CORE, SelectI32, {
       int32_t condition = VM_DecOperandRegI32("condition");
       int32_t true_value = VM_DecOperandRegI32("true_value");
       int32_t false_value = VM_DecOperandRegI32("false_value");
@@ -501,7 +322,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       *result = condition ? true_value : false_value;
     });
 
-    DISPATCH_OP(SelectRef, {
+    DISPATCH_OP(CORE, SelectRef, {
       int32_t condition = VM_DecOperandRegI32("condition");
       // TODO(benvanik): remove the type_id and use either LHS/RHS (if both are
       // null then output is always null so no need to know the type).
@@ -527,7 +348,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(SwitchI32, {
+    DISPATCH_OP(CORE, SwitchI32, {
       int32_t index = VM_DecOperandRegI32("index");
       int32_t default_value = VM_DecIntAttr32("default_value");
       const iree_vm_register_list_t* value_reg_list =
@@ -540,7 +361,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(SwitchRef, {
+    DISPATCH_OP(CORE, SwitchRef, {
       int32_t index = VM_DecOperandRegI32("index");
       const iree_vm_type_def_t* type_def = VM_DecTypeOf("result");
       bool default_is_move;
@@ -567,90 +388,90 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Native integer arithmetic
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_UNARY_ALU_I32(op_name, type, op)  \
-  DISPATCH_OP(op_name, {                              \
-    int32_t operand = VM_DecOperandRegI32("operand"); \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = (int32_t)(op((type)operand));           \
+#define DISPATCH_OP_CORE_UNARY_ALU_I32(op_name, type, op) \
+  DISPATCH_OP(CORE, op_name, {                            \
+    int32_t operand = VM_DecOperandRegI32("operand");     \
+    int32_t* result = VM_DecResultRegI32("result");       \
+    *result = (int32_t)(op((type)operand));               \
   });
 
-#define DISPATCH_OP_BINARY_ALU_I32(op_name, type, op) \
-  DISPATCH_OP(op_name, {                              \
-    int32_t lhs = VM_DecOperandRegI32("lhs");         \
-    int32_t rhs = VM_DecOperandRegI32("rhs");         \
-    int32_t* result = VM_DecResultRegI32("result");   \
-    *result = (int32_t)(((type)lhs)op((type)rhs));    \
+#define DISPATCH_OP_CORE_BINARY_ALU_I32(op_name, type, op) \
+  DISPATCH_OP(CORE, op_name, {                             \
+    int32_t lhs = VM_DecOperandRegI32("lhs");              \
+    int32_t rhs = VM_DecOperandRegI32("rhs");              \
+    int32_t* result = VM_DecResultRegI32("result");        \
+    *result = (int32_t)(((type)lhs)op((type)rhs));         \
   });
 
-    DISPATCH_OP_BINARY_ALU_I32(AddI32, int32_t, +);
-    DISPATCH_OP_BINARY_ALU_I32(SubI32, int32_t, -);
-    DISPATCH_OP_BINARY_ALU_I32(MulI32, int32_t, *);
-    DISPATCH_OP_BINARY_ALU_I32(DivI32S, int32_t, /);
-    DISPATCH_OP_BINARY_ALU_I32(DivI32U, uint32_t, /);
-    DISPATCH_OP_BINARY_ALU_I32(RemI32S, int32_t, %);
-    DISPATCH_OP_BINARY_ALU_I32(RemI32U, uint32_t, %);
-    DISPATCH_OP_UNARY_ALU_I32(NotI32, uint32_t, ~);
-    DISPATCH_OP_BINARY_ALU_I32(AndI32, uint32_t, &);
-    DISPATCH_OP_BINARY_ALU_I32(OrI32, uint32_t, |);
-    DISPATCH_OP_BINARY_ALU_I32(XorI32, uint32_t, ^);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(AddI32, int32_t, +);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(SubI32, int32_t, -);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(MulI32, int32_t, *);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(DivI32S, int32_t, /);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(DivI32U, uint32_t, /);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(RemI32S, int32_t, %);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(RemI32U, uint32_t, %);
+    DISPATCH_OP_CORE_UNARY_ALU_I32(NotI32, uint32_t, ~);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(AndI32, uint32_t, &);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(OrI32, uint32_t, |);
+    DISPATCH_OP_CORE_BINARY_ALU_I32(XorI32, uint32_t, ^);
 
     //===------------------------------------------------------------------===//
     // Casting and type conversion/emulation
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_CAST_I32(op_name, src_type, dst_type) \
-  DISPATCH_OP(op_name, {                                  \
-    int32_t operand = VM_DecOperandRegI32("operand");     \
-    int32_t* result = VM_DecResultRegI32("result");       \
-    *result = (dst_type)((src_type)operand);              \
+#define DISPATCH_OP_CORE_CAST_I32(op_name, src_type, dst_type) \
+  DISPATCH_OP(CORE, op_name, {                                 \
+    int32_t operand = VM_DecOperandRegI32("operand");          \
+    int32_t* result = VM_DecResultRegI32("result");            \
+    *result = (dst_type)((src_type)operand);                   \
   });
 
-    DISPATCH_OP_CAST_I32(TruncI32I8, uint8_t, uint32_t);
-    DISPATCH_OP_CAST_I32(TruncI32I16, uint16_t, uint32_t);
-    DISPATCH_OP_CAST_I32(ExtI8I32S, int8_t, int32_t);
-    DISPATCH_OP_CAST_I32(ExtI8I32U, uint8_t, uint32_t);
-    DISPATCH_OP_CAST_I32(ExtI16I32S, int16_t, int32_t);
-    DISPATCH_OP_CAST_I32(ExtI16I32U, uint16_t, uint32_t);
+    DISPATCH_OP_CORE_CAST_I32(TruncI32I8, uint32_t, uint8_t);
+    DISPATCH_OP_CORE_CAST_I32(TruncI32I16, uint32_t, uint16_t);
+    DISPATCH_OP_CORE_CAST_I32(ExtI8I32S, int8_t, int32_t);
+    DISPATCH_OP_CORE_CAST_I32(ExtI8I32U, uint8_t, uint32_t);
+    DISPATCH_OP_CORE_CAST_I32(ExtI16I32S, int16_t, int32_t);
+    DISPATCH_OP_CORE_CAST_I32(ExtI16I32U, uint16_t, uint32_t);
 
     //===------------------------------------------------------------------===//
     // Native bitwise shifts and rotates
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_SHIFT_I32(op_name, type, op)      \
-  DISPATCH_OP(op_name, {                              \
+#define DISPATCH_OP_CORE_SHIFT_I32(op_name, type, op) \
+  DISPATCH_OP(CORE, op_name, {                        \
     int32_t operand = VM_DecOperandRegI32("operand"); \
-    int32_t amount = VM_DecConstI8("amount");         \
+    int8_t amount = VM_DecConstI8("amount");          \
     int32_t* result = VM_DecResultRegI32("result");   \
     *result = (int32_t)(((type)operand)op amount);    \
   });
 
-    DISPATCH_OP_SHIFT_I32(ShlI32, int32_t, <<);
-    DISPATCH_OP_SHIFT_I32(ShrI32S, int32_t, >>);
-    DISPATCH_OP_SHIFT_I32(ShrI32U, uint32_t, >>);
+    DISPATCH_OP_CORE_SHIFT_I32(ShlI32, int32_t, <<);
+    DISPATCH_OP_CORE_SHIFT_I32(ShrI32S, int32_t, >>);
+    DISPATCH_OP_CORE_SHIFT_I32(ShrI32U, uint32_t, >>);
 
     //===------------------------------------------------------------------===//
     // Comparison ops
     //===------------------------------------------------------------------===//
 
-#define DISPATCH_OP_CMP_I32(op_name, type, op)      \
-  DISPATCH_OP(op_name, {                            \
+#define DISPATCH_OP_CORE_CMP_I32(op_name, type, op) \
+  DISPATCH_OP(CORE, op_name, {                      \
     int32_t lhs = VM_DecOperandRegI32("lhs");       \
     int32_t rhs = VM_DecOperandRegI32("rhs");       \
     int32_t* result = VM_DecResultRegI32("result"); \
     *result = (((type)lhs)op((type)rhs)) ? 1 : 0;   \
   });
 
-    DISPATCH_OP_CMP_I32(CmpEQI32, int32_t, ==);
-    DISPATCH_OP_CMP_I32(CmpNEI32, int32_t, !=);
-    DISPATCH_OP_CMP_I32(CmpLTI32S, int32_t, <);
-    DISPATCH_OP_CMP_I32(CmpLTI32U, uint32_t, <);
-    DISPATCH_OP(CmpNZI32, {
+    DISPATCH_OP_CORE_CMP_I32(CmpEQI32, int32_t, ==);
+    DISPATCH_OP_CORE_CMP_I32(CmpNEI32, int32_t, !=);
+    DISPATCH_OP_CORE_CMP_I32(CmpLTI32S, int32_t, <);
+    DISPATCH_OP_CORE_CMP_I32(CmpLTI32U, uint32_t, <);
+    DISPATCH_OP(CORE, CmpNZI32, {
       int32_t operand = VM_DecOperandRegI32("operand");
       int32_t* result = VM_DecResultRegI32("result");
       *result = (operand != 0) ? 1 : 0;
     });
 
-    DISPATCH_OP(CmpEQRef, {
+    DISPATCH_OP(CORE, CmpEQRef, {
       bool lhs_is_move;
       iree_vm_ref_t* lhs = VM_DecOperandRegRef("lhs", &lhs_is_move);
       bool rhs_is_move;
@@ -660,7 +481,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       if (lhs_is_move) iree_vm_ref_release(lhs);
       if (rhs_is_move) iree_vm_ref_release(rhs);
     });
-    DISPATCH_OP(CmpNERef, {
+    DISPATCH_OP(CORE, CmpNERef, {
       bool lhs_is_move;
       iree_vm_ref_t* lhs = VM_DecOperandRegRef("lhs", &lhs_is_move);
       bool rhs_is_move;
@@ -670,7 +491,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       if (lhs_is_move) iree_vm_ref_release(lhs);
       if (rhs_is_move) iree_vm_ref_release(rhs);
     });
-    DISPATCH_OP(CmpNZRef, {
+    DISPATCH_OP(CORE, CmpNZRef, {
       bool operand_is_move;
       iree_vm_ref_t* operand = VM_DecOperandRegRef("operand", &operand_is_move);
       int32_t* result = VM_DecResultRegI32("result");
@@ -682,7 +503,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Control flow
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(Branch, {
+    DISPATCH_OP(CORE, Branch, {
       int32_t block_pc = VM_DecBranchTarget("dest");
       const iree_vm_register_remap_list_t* remap_list =
           VM_DecBranchOperands("operands");
@@ -690,7 +511,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       iree_vm_bytecode_dispatch_remap_branch_registers(regs, remap_list);
     });
 
-    DISPATCH_OP(CondBranch, {
+    DISPATCH_OP(CORE, CondBranch, {
       int32_t condition = VM_DecOperandRegI32("condition");
       int32_t true_block_pc = VM_DecBranchTarget("true_dest");
       const iree_vm_register_remap_list_t* true_remap_list =
@@ -708,7 +529,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(Call, {
+    DISPATCH_OP(CORE, Call, {
       int32_t function_ordinal = VM_DecFuncAttr("callee");
       const iree_vm_register_list_t* src_reg_list =
           VM_DecVariadicOperands("operands");
@@ -761,7 +582,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(CallVariadic, {
+    DISPATCH_OP(CORE, CallVariadic, {
       // TODO(benvanik): dedupe with above or merge and always have the seg size
       // list be present (but empty) for non-variadic calls.
       int32_t function_ordinal = VM_DecFuncAttr("callee");
@@ -800,7 +621,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       }
     });
 
-    DISPATCH_OP(Return, {
+    DISPATCH_OP(CORE, Return, {
       const iree_vm_register_list_t* src_reg_list =
           VM_DecVariadicOperands("operands");
       current_frame->pc = pc;
@@ -823,7 +644,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       pc = current_frame->pc;
     });
 
-    DISPATCH_OP(Fail, {
+    DISPATCH_OP(CORE, Fail, {
       uint32_t status_code = VM_DecOperandRegI32("status");
       iree_string_view_t message;
       VM_DecStrAttr("message", &message);
@@ -839,7 +660,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Async/fiber ops
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(Yield, {
+    DISPATCH_OP(CORE, Yield, {
       // TODO(benvanik): yield with execution results.
       return IREE_STATUS_OK;
     });
@@ -848,7 +669,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Debugging
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(Trace, {
+    DISPATCH_OP(CORE, Trace, {
       iree_string_view_t event_name;
       VM_DecStrAttr("event_name", &event_name);
       const iree_vm_register_list_t* src_reg_list =
@@ -857,7 +678,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       iree_vm_bytecode_dispatch_discard_registers(regs, src_reg_list);
     });
 
-    DISPATCH_OP(Print, {
+    DISPATCH_OP(CORE, Print, {
       iree_string_view_t event_name;
       VM_DecStrAttr("event_name", &event_name);
       const iree_vm_register_list_t* src_reg_list =
@@ -866,7 +687,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       iree_vm_bytecode_dispatch_discard_registers(regs, src_reg_list);
     });
 
-    DISPATCH_OP(Break, {
+    DISPATCH_OP(CORE, Break, {
       // TODO(benvanik): break unconditionally.
       int32_t block_pc = VM_DecBranchTarget("dest");
       const iree_vm_register_remap_list_t* remap_list =
@@ -875,7 +696,7 @@ iree_status_t iree_vm_bytecode_dispatch(
       pc = block_pc;
     });
 
-    DISPATCH_OP(CondBreak, {
+    DISPATCH_OP(CORE, CondBreak, {
       int32_t condition = VM_DecOperandRegI32("condition");
       if (condition) {
         // TODO(benvanik): cond break.
@@ -891,14 +712,230 @@ iree_status_t iree_vm_bytecode_dispatch(
     // Extension trampolines
     //===------------------------------------------------------------------===//
 
-    DISPATCH_OP(PrefixExtI64, { return IREE_STATUS_UNIMPLEMENTED; });
+    BEGIN_DISPATCH_PREFIX(PrefixExtI64, EXT_I64) {
+#if IREE_VM_EXT_I64_ENABLE
+      //===----------------------------------------------------------------===//
+      // ExtI64: Globals
+      //===----------------------------------------------------------------===//
 
-    DISPATCH_OP(PrefixExtF32, { return IREE_STATUS_UNIMPLEMENTED; });
+      DISPATCH_OP(EXT_I64, GlobalLoadI64, {
+        int32_t byte_offset = VM_DecGlobalAttr("global");
+        if (byte_offset < 0 ||
+            byte_offset >= module_state->rwdata_storage.data_length) {
+          return IREE_STATUS_OUT_OF_RANGE;
+        }
+        int64_t* value = VM_DecResultRegI64("value");
+        const int64_t* global_ptr =
+            (const int64_t*)(module_state->rwdata_storage.data + byte_offset);
+        *value = *global_ptr;
+      });
 
-    DISPATCH_OP(PrefixExtF64, { return IREE_STATUS_UNIMPLEMENTED; });
+      DISPATCH_OP(EXT_I64, GlobalStoreI64, {
+        int32_t byte_offset = VM_DecGlobalAttr("global");
+        if (byte_offset < 0 ||
+            byte_offset >= module_state->rwdata_storage.data_length) {
+          return IREE_STATUS_OUT_OF_RANGE;
+        }
+        int64_t value = VM_DecOperandRegI64("value");
+        int64_t* global_ptr =
+            (int64_t*)(module_state->rwdata_storage.data + byte_offset);
+        *global_ptr = value;
+      });
+
+      DISPATCH_OP(EXT_I64, GlobalLoadIndirectI64, {
+        int32_t byte_offset = VM_DecOperandRegI32("global");
+        if (byte_offset < 0 ||
+            byte_offset >= module_state->rwdata_storage.data_length) {
+          return IREE_STATUS_OUT_OF_RANGE;
+        }
+        int64_t* value = VM_DecResultRegI64("value");
+        const int64_t* global_ptr =
+            (const int64_t*)(module_state->rwdata_storage.data + byte_offset);
+        *value = *global_ptr;
+      });
+
+      DISPATCH_OP(EXT_I64, GlobalStoreIndirectI64, {
+        int32_t byte_offset = VM_DecOperandRegI32("global");
+        if (byte_offset < 0 ||
+            byte_offset >= module_state->rwdata_storage.data_length) {
+          return IREE_STATUS_OUT_OF_RANGE;
+        }
+        int64_t value = VM_DecOperandRegI64("value");
+        int64_t* global_ptr =
+            (int64_t*)(module_state->rwdata_storage.data + byte_offset);
+        *global_ptr = value;
+      });
+
+      //===----------------------------------------------------------------===//
+      // ExtI64: Constants
+      //===----------------------------------------------------------------===//
+
+      DISPATCH_OP(EXT_I64, ConstI64, {
+        int64_t value = VM_DecIntAttr64("value");
+        int64_t* result = VM_DecResultRegI64("result");
+        *result = value;
+      });
+
+      DISPATCH_OP(EXT_I64, ConstI64Zero, {
+        int64_t* result = VM_DecResultRegI64("result");
+        *result = 0;
+      });
+
+      //===----------------------------------------------------------------===//
+      // ExtI64: Lists
+      //===----------------------------------------------------------------===//
+
+      DISPATCH_OP(EXT_I64, ListGetI64, {
+        bool list_is_move;
+        iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
+        iree_vm_list_t* list = iree_vm_list_deref(list_ref);
+        if (!list) return IREE_STATUS_INVALID_ARGUMENT;
+        int32_t index = VM_DecOperandRegI32("index");
+        int64_t* result = VM_DecResultRegI64("result");
+        iree_vm_value_t value;
+        IREE_RETURN_IF_ERROR(iree_vm_list_get_value_as(
+            list, index, IREE_VM_VALUE_TYPE_I64, &value));
+        *result = value.i32;
+      });
+
+      DISPATCH_OP(EXT_I64, ListSetI64, {
+        bool list_is_move;
+        iree_vm_ref_t* list_ref = VM_DecOperandRegRef("list", &list_is_move);
+        iree_vm_list_t* list = iree_vm_list_deref(list_ref);
+        if (!list) return IREE_STATUS_INVALID_ARGUMENT;
+        int32_t index = VM_DecOperandRegI32("index");
+        int64_t raw_value = VM_DecOperandRegI64("value");
+        iree_vm_value_t value = iree_vm_value_make_i64(raw_value);
+        IREE_RETURN_IF_ERROR(iree_vm_list_set_value(list, index, &value));
+      });
+
+      //===----------------------------------------------------------------===//
+      // ExtI64: Conditional assignment
+      //===----------------------------------------------------------------===//
+
+      DISPATCH_OP(EXT_I64, SelectI64, {
+        int32_t condition = VM_DecOperandRegI32("condition");
+        int64_t true_value = VM_DecOperandRegI64("true_value");
+        int64_t false_value = VM_DecOperandRegI64("false_value");
+        int64_t* result = VM_DecResultRegI64("result");
+        *result = condition ? true_value : false_value;
+      });
+
+      DISPATCH_OP(EXT_I64, SwitchI64, {
+        int32_t index = VM_DecOperandRegI32("index");
+        int64_t default_value = VM_DecIntAttr64("default_value");
+        const iree_vm_register_list_t* value_reg_list =
+            VM_DecVariadicOperands("values");
+        int64_t* result = VM_DecResultRegI64("result");
+        if (index >= 0 && index < value_reg_list->size) {
+          *result =
+              regs.i32[value_reg_list->registers[index] & (regs.i32_mask & ~1)];
+        } else {
+          *result = default_value;
+        }
+      });
+
+      //===----------------------------------------------------------------===//
+      // ExtI64: Native integer arithmetic
+      //===----------------------------------------------------------------===//
+
+#define DISPATCH_OP_EXT_I64_UNARY_ALU_I64(op_name, type, op) \
+  DISPATCH_OP(EXT_I64, op_name, {                            \
+    int64_t operand = VM_DecOperandRegI64("operand");        \
+    int64_t* result = VM_DecResultRegI64("result");          \
+    *result = (int64_t)(op((type)operand));                  \
+  });
+
+#define DISPATCH_OP_EXT_I64_BINARY_ALU_I64(op_name, type, op) \
+  DISPATCH_OP(EXT_I64, op_name, {                             \
+    int64_t lhs = VM_DecOperandRegI64("lhs");                 \
+    int64_t rhs = VM_DecOperandRegI64("rhs");                 \
+    int64_t* result = VM_DecResultRegI64("result");           \
+    *result = (int64_t)(((type)lhs)op((type)rhs));            \
+  });
+
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(AddI64, int64_t, +);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(SubI64, int64_t, -);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(MulI64, int64_t, *);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(DivI64S, int64_t, /);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(DivI64U, uint64_t, /);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(RemI64S, int64_t, %);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(RemI64U, uint64_t, %);
+      DISPATCH_OP_EXT_I64_UNARY_ALU_I64(NotI64, uint64_t, ~);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(AndI64, uint64_t, &);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(OrI64, uint64_t, |);
+      DISPATCH_OP_EXT_I64_BINARY_ALU_I64(XorI64, uint64_t, ^);
+
+      //===----------------------------------------------------------------===//
+      // ExtI64: Casting and type conversion/emulation
+      //===----------------------------------------------------------------===//
+
+#define DISPATCH_OP_EXT_I64_CAST_I64(op_name, src_type, dst_type) \
+  DISPATCH_OP(EXT_I64, op_name, {                                 \
+    int64_t operand = VM_DecOperandRegI64("operand");             \
+    int64_t* result = VM_DecResultRegI64("result");               \
+    *result = (dst_type)((src_type)operand);                      \
+  });
+
+      DISPATCH_OP_EXT_I64_CAST_I64(TruncI64I8, uint64_t, uint8_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(TruncI64I16, uint64_t, uint16_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(TruncI64I32, uint64_t, uint32_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(ExtI8I64S, int8_t, int64_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(ExtI8I64U, uint8_t, uint64_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(ExtI16I64S, int16_t, int64_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(ExtI16I64U, uint16_t, uint64_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(ExtI32I64S, int32_t, int64_t);
+      DISPATCH_OP_EXT_I64_CAST_I64(ExtI32I64U, uint32_t, uint64_t);
+
+      //===----------------------------------------------------------------===//
+      // ExtI64: Native bitwise shifts and rotates
+      //===----------------------------------------------------------------===//
+
+#define DISPATCH_OP_EXT_I64_SHIFT_I64(op_name, type, op) \
+  DISPATCH_OP(EXT_I64, op_name, {                        \
+    int64_t operand = VM_DecOperandRegI64("operand");    \
+    int8_t amount = VM_DecConstI8("amount");             \
+    int64_t* result = VM_DecResultRegI64("result");      \
+    *result = (int64_t)(((type)operand)op amount);       \
+  });
+
+      DISPATCH_OP_EXT_I64_SHIFT_I64(ShlI64, int64_t, <<);
+      DISPATCH_OP_EXT_I64_SHIFT_I64(ShrI64S, int64_t, >>);
+      DISPATCH_OP_EXT_I64_SHIFT_I64(ShrI64U, uint64_t, >>);
+
+      //===----------------------------------------------------------------===//
+      // ExtI64: Comparison ops
+      //===----------------------------------------------------------------===//
+
+#define DISPATCH_OP_EXT_I64_CMP_I64(op_name, type, op) \
+  DISPATCH_OP(EXT_I64, op_name, {                      \
+    int64_t lhs = VM_DecOperandRegI64("lhs");          \
+    int64_t rhs = VM_DecOperandRegI64("rhs");          \
+    int32_t* result = VM_DecResultRegI32("result");    \
+    *result = (((type)lhs)op((type)rhs)) ? 1 : 0;      \
+  });
+
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpEQI64, int64_t, ==);
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpNEI64, int64_t, !=);
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpLTI64S, int64_t, <);
+      DISPATCH_OP_EXT_I64_CMP_I64(CmpLTI64U, uint64_t, <);
+      DISPATCH_OP(EXT_I64, CmpNZI64, {
+        int64_t operand = VM_DecOperandRegI64("operand");
+        int32_t* result = VM_DecResultRegI32("result");
+        *result = (operand != 0) ? 1 : 0;
+      });
+#else
+      return IREE_STATUS_UNIMPLEMENTED;
+#endif  // IREE_VM_EXT_I64_ENABLE
+    }
+    END_DISPATCH_PREFIX();
+
+    DISPATCH_OP(CORE, PrefixExtF32, { return IREE_STATUS_UNIMPLEMENTED; });
+
+    DISPATCH_OP(CORE, PrefixExtF64, { return IREE_STATUS_UNIMPLEMENTED; });
 
     // NOLINTNEXTLINE(misc-static-assert)
-    DISPATCH_UNHANDLED();
+    DISPATCH_UNHANDLED_CORE();
   }
-  END_DISPATCH();
+  END_DISPATCH_CORE();
 }

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -877,13 +877,7 @@ iree_status_t iree_vm_bytecode_dispatch(
     *result = (dst_type)((src_type)operand);                      \
   });
 
-      DISPATCH_OP_EXT_I64_CAST_I64(TruncI64I8, uint64_t, uint8_t);
-      DISPATCH_OP_EXT_I64_CAST_I64(TruncI64I16, uint64_t, uint16_t);
       DISPATCH_OP_EXT_I64_CAST_I64(TruncI64I32, uint64_t, uint32_t);
-      DISPATCH_OP_EXT_I64_CAST_I64(ExtI8I64S, int8_t, int64_t);
-      DISPATCH_OP_EXT_I64_CAST_I64(ExtI8I64U, uint8_t, uint64_t);
-      DISPATCH_OP_EXT_I64_CAST_I64(ExtI16I64S, int16_t, int64_t);
-      DISPATCH_OP_EXT_I64_CAST_I64(ExtI16I64U, uint16_t, uint64_t);
       DISPATCH_OP_EXT_I64_CAST_I64(ExtI32I64S, int32_t, int64_t);
       DISPATCH_OP_EXT_I64_CAST_I64(ExtI32I64U, uint32_t, uint64_t);
 

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -272,9 +272,11 @@ static const int kRegSize = sizeof(uint16_t);
     break;
 
 #define BEGIN_DISPATCH_PREFIX(op_name, ext) \
-  case IREE_VM_OP_CORE_##op_name:           \
+  case IREE_VM_OP_CORE_##op_name: {         \
     switch (bytecode_data[pc++])
-#define END_DISPATCH_PREFIX() break;
+#define END_DISPATCH_PREFIX() \
+  break;                      \
+  }
 
 #endif  // IREE_DISPATCH_MODE_COMPUTED_GOTO
 

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -1,0 +1,281 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_VM_BYTECODE_DISPATCH_UTIL_H_
+#define IREE_VM_BYTECODE_DISPATCH_UTIL_H_
+
+#include <assert.h>
+#include <string.h>
+
+#include "iree/base/alignment.h"
+#include "iree/base/target_platform.h"
+#include "iree/vm/bytecode_module_impl.h"
+#include "iree/vm/bytecode_op_table.h"
+
+// TODO(benvanik): make a compiler setting.
+#define IREE_VM_EXT_I64_ENABLE 1
+#define IREE_VM_EXT_F32_ENABLE 0
+#define IREE_VM_EXT_F64_ENABLE 0
+
+//===----------------------------------------------------------------------===//
+// Shared data structures
+//===----------------------------------------------------------------------===//
+
+// Interleaved src-dst register sets for branch register remapping.
+// This structure is an overlay for the bytecode that is serialized in a
+// matching format.
+typedef struct {
+  uint16_t size;
+  struct pair {
+    uint16_t src_reg;
+    uint16_t dst_reg;
+  } pairs[];
+} iree_vm_register_remap_list_t;
+static_assert(iree_alignof(iree_vm_register_remap_list_t) == 2,
+              "Expecting byte alignment (to avoid padding)");
+static_assert(offsetof(iree_vm_register_remap_list_t, pairs) == 2,
+              "Expect no padding in the struct");
+
+// Maps a type ID to a type def with clamping for out of bounds values.
+static inline const iree_vm_type_def_t* iree_vm_map_type(
+    iree_vm_bytecode_module_t* module, int32_t type_id) {
+  type_id = type_id >= module->type_count ? 0 : type_id;
+  return &module->type_table[type_id];
+}
+
+//===----------------------------------------------------------------------===//
+// Debugging utilities
+//===----------------------------------------------------------------------===//
+
+// Enable to get some verbose logging; better than nothing until we have some
+// better tooling.
+#define IREE_DISPATCH_LOGGING 0
+
+#if IREE_DISPATCH_LOGGING
+#include <stdio.h>
+#define IREE_DISPATCH_LOG_OPCODE(op_name) \
+  fprintf(stderr, "DISPATCH %d %s\n", (int)pc, op_name)
+#define IREE_DISPATCH_LOG_CALL(target_function) \
+  fprintf(stderr, "CALL -> %s\n", iree_vm_function_name(&target_function).data);
+#else
+#define IREE_DISPATCH_LOG_OPCODE(...)
+#define IREE_DISPATCH_LOG_CALL(...)
+#endif  // IREE_DISPATCH_LOGGING
+
+#if defined(IREE_COMPILER_MSVC) && !defined(IREE_COMPILER_CLANG)
+#define IREE_DISPATCH_MODE_SWITCH 1
+#else
+#define IREE_DISPATCH_MODE_COMPUTED_GOTO 1
+#endif  // MSVC
+
+#ifndef NDEBUG
+#define VMCHECK(expr) assert(expr)
+#else
+#define VMCHECK(expr)
+#endif  // NDEBUG
+
+//===----------------------------------------------------------------------===//
+// Bytecode data reading with little-/big-endian support
+//===----------------------------------------------------------------------===//
+
+static const int kRegSize = sizeof(uint16_t);
+
+// Bytecode data access macros for reading values of a given type from a byte
+// offset within the current function.
+#if defined(IREE_IS_LITTLE_ENDIAN)
+#define OP_I8(i) bytecode_data[pc + i]
+#define OP_I16(i) *((uint16_t*)&bytecode_data[pc + i])
+#define OP_I32(i) *((uint32_t*)&bytecode_data[pc + i])
+#define OP_I64(i) *((uint64_t*)&bytecode_data[pc + i])
+#else
+#define OP_I8(i) bytecode_data[pc + i]
+#define OP_I16(i)                         \
+  ((uint16_t)bytecode_data[pc + 0 + i]) | \
+      ((uint16_t)bytecode_data[pc + 1 + i] << 8)
+#define OP_I32(i)                                   \
+  ((uint32_t)bytecode_data[pc + 0 + i]) |           \
+      ((uint32_t)bytecode_data[pc + 1 + i] << 8) |  \
+      ((uint32_t)bytecode_data[pc + 2 + i] << 16) | \
+      ((uint32_t)bytecode_data[pc + 3 + i] << 24)
+#define OP_I64(i)                                   \
+  ((uint64_t)bytecode_data[pc + 0 + i]) |           \
+      ((uint64_t)bytecode_data[pc + 1 + i] << 8) |  \
+      ((uint64_t)bytecode_data[pc + 2 + i] << 16) | \
+      ((uint64_t)bytecode_data[pc + 3 + i] << 24) | \
+      ((uint64_t)bytecode_data[pc + 4 + i] << 32) | \
+      ((uint64_t)bytecode_data[pc + 5 + i] << 40) | \
+      ((uint64_t)bytecode_data[pc + 6 + i] << 48) | \
+      ((uint64_t)bytecode_data[pc + 7 + i] << 56)
+#endif  // IREE_IS_LITTLE_ENDIAN
+
+//===----------------------------------------------------------------------===//
+// Utilities matching the tablegen op encoding scheme
+//===----------------------------------------------------------------------===//
+// These utilities match the VM_Enc* statements in VMBase.td 1:1, allowing us
+// to have the inverse of the encoding which make things easier to read.
+//
+// Each macro will increment the pc by the number of bytes read and as such must
+// be called in the same order the values are encoded.
+
+#define VM_DecConstI8(name) \
+  OP_I8(0);                 \
+  ++pc;
+#define VM_DecConstI32(name) \
+  OP_I32(0);                 \
+  pc += 4;
+#define VM_DecConstI64(name) \
+  OP_I64(0);                 \
+  pc += 8;
+#define VM_DecOpcode(opcode) VM_DecConstI8(#opcode)
+#define VM_DecFuncAttr(name) VM_DecConstI32(name)
+#define VM_DecGlobalAttr(name) VM_DecConstI32(name)
+#define VM_DecRodataAttr(name) VM_DecConstI32(name)
+#define VM_DecType(name)               \
+  iree_vm_map_type(module, OP_I32(0)); \
+  pc += 4;
+#define VM_DecTypeOf(name) VM_DecType(name)
+#define VM_DecIntAttr32(name) VM_DecConstI32(name)
+#define VM_DecIntAttr64(name) VM_DecConstI64(name)
+#define VM_DecStrAttr(name, out_str)                     \
+  (out_str)->size = (iree_host_size_t)OP_I16(0);         \
+  (out_str)->data = (const char*)&bytecode_data[pc + 2]; \
+  pc += 2 + (out_str)->size;
+#define VM_DecBranchTarget(block_name) VM_DecConstI32(name)
+#define VM_DecBranchOperands(operands_name)                                   \
+  (const iree_vm_register_remap_list_t*)&bytecode_data[pc];                   \
+  pc +=                                                                       \
+      kRegSize + ((const iree_vm_register_list_t*)&bytecode_data[pc])->size * \
+                     2 * kRegSize;
+#define VM_DecOperandRegI32(name)      \
+  regs.i32[OP_I16(0) & regs.i32_mask]; \
+  pc += kRegSize;
+#define VM_DecOperandRegI64(name)                           \
+  *((int64_t*)&regs.i32[OP_I16(0) & (regs.i32_mask & ~1)]); \
+  pc += kRegSize;
+#define VM_DecOperandRegRef(name, out_is_move)             \
+  &regs.ref[OP_I16(0) & regs.ref_mask];                    \
+  *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT; \
+  pc += kRegSize;
+#define VM_DecVariadicOperands(name)                  \
+  (const iree_vm_register_list_t*)&bytecode_data[pc]; \
+  pc += kRegSize +                                    \
+        ((const iree_vm_register_list_t*)&bytecode_data[pc])->size * kRegSize;
+#define VM_DecResultRegI32(name)        \
+  &regs.i32[OP_I16(0) & regs.i32_mask]; \
+  pc += kRegSize;
+#define VM_DecResultRegI64(name)                           \
+  ((int64_t*)&regs.i32[OP_I16(0) & (regs.i32_mask & ~1)]); \
+  pc += kRegSize;
+#define VM_DecResultRegRef(name, out_is_move)              \
+  &regs.ref[OP_I16(0) & regs.ref_mask];                    \
+  *(out_is_move) = OP_I16(0) & IREE_REF_REGISTER_MOVE_BIT; \
+  pc += kRegSize;
+#define VM_DecVariadicResults(name) VM_DecVariadicOperands(name)
+
+//===----------------------------------------------------------------------===//
+// Dispatch table structure
+//===----------------------------------------------------------------------===//
+// We support both computed goto (gcc/clang) and switch-based dispatch. Computed
+// goto is preferred when available as it has the most efficient codegen. MSVC
+// doesn't support it, though, and there may be other targets (like wasm) that
+// can only handle the switch-based approach.
+
+#if defined(IREE_DISPATCH_MODE_COMPUTED_GOTO)
+
+// Dispatch table mapping 1:1 with bytecode ops.
+// Each entry is a label within this function that can be used for computed
+// goto. You can find more information on computed goto here:
+// https://eli.thegreenplace.net/2012/07/12/computed-goto-for-efficient-dispatch-tables
+//
+// Note that we ensure the table is 256 elements long exactly to make sure
+// that unused opcodes are handled gracefully.
+//
+// Computed gotos are pretty much the best way to dispatch interpreters but are
+// not part of the C standard; GCC and clang support them but MSVC does not.
+// Because the performance difference is significant we support both here but
+// prefer the computed goto path where available. Empirical data shows them to
+// still be a win in 2019 on x64 desktops and arm32/arm64 mobile devices.
+#define BEGIN_DISPATCH_CORE()                     \
+  goto* kDispatchTable_CORE[bytecode_data[pc++]]; \
+  while (1)
+#define END_DISPATCH_CORE()
+
+#define DECLARE_DISPATCH_CORE_OPC(ordinal, name) &&_dispatch_CORE_##name,
+#define DECLARE_DISPATCH_CORE_RSV(ordinal) &&_dispatch_unhandled,
+#define DEFINE_DISPATCH_TABLE_CORE()                                    \
+  static const void* kDispatchTable_CORE[256] = {IREE_VM_OP_CORE_TABLE( \
+      DECLARE_DISPATCH_CORE_OPC, DECLARE_DISPATCH_CORE_RSV)};
+
+#define DECLARE_DISPATCH_EXT_RSV(ordinal) &&_dispatch_unhandled,
+#if IREE_VM_EXT_I64_ENABLE
+#define DECLARE_DISPATCH_EXT_I64_OPC(ordinal, name) &&_dispatch_EXT_I64_##name,
+#define DEFINE_DISPATCH_TABLE_EXT_I64()                                       \
+  static const void* kDispatchTable_EXT_I64[256] = {IREE_VM_OP_EXT_I64_TABLE( \
+      DECLARE_DISPATCH_EXT_I64_OPC, DECLARE_DISPATCH_EXT_RSV)};
+#else
+#define DEFINE_DISPATCH_TABLE_EXT_I64()
+#endif  // IREE_VM_EXT_I64_ENABLE
+
+#define DEFINE_DISPATCH_TABLES() \
+  DEFINE_DISPATCH_TABLE_CORE();  \
+  DEFINE_DISPATCH_TABLE_EXT_I64();
+
+#define DISPATCH_UNHANDLED_CORE() \
+  _dispatch_unhandled:            \
+  VMCHECK(0);                     \
+  return IREE_STATUS_UNIMPLEMENTED;
+#define DISPATCH_UNHANDLED_EXT()
+
+#define DISPATCH_OP(ext, op_name, body)                             \
+  _dispatch_##ext##_##op_name : IREE_DISPATCH_LOG_OPCODE(#op_name); \
+  body;                                                             \
+  goto* kDispatchTable_CORE[bytecode_data[pc++]];
+
+#define BEGIN_DISPATCH_PREFIX(op_name, ext)                                   \
+  _dispatch_CORE_##op_name : goto* kDispatchTable_##ext[bytecode_data[pc++]]; \
+  while (1)
+#define END_DISPATCH_PREFIX() goto* kDispatchTable_CORE[bytecode_data[pc++]];
+
+#else
+
+// Switch-based dispatch. This is strictly less efficient than the computed
+// goto approach above but is universally supported.
+
+#define BEGIN_DISPATCH_CORE() \
+  while (1) {                 \
+    switch (bytecode_data[pc++])
+#define END_DISPATCH_CORE() }
+
+#define DEFINE_DISPATCH_TABLES()
+
+#define DISPATCH_UNHANDLED_CORE() \
+  default:                        \
+    VMCHECK(0);                   \
+    return IREE_STATUS_UNIMPLEMENTED;
+#define DISPATCH_UNHANDLED_EXT DISPATCH_UNHANDLED_CORE
+
+#define DISPATCH_OP(ext, op_name, body) \
+  case IREE_VM_OP_##ext##_##op_name:    \
+    IREE_DISPATCH_LOG_OPCODE(#op_name); \
+    body;                               \
+    break;
+
+#define BEGIN_DISPATCH_PREFIX(op_name, ext) \
+  case IREE_VM_OP_CORE_##op_name:           \
+    switch (bytecode_data[pc++])
+#define END_DISPATCH_PREFIX() break;
+
+#endif  // IREE_DISPATCH_MODE_COMPUTED_GOTO
+
+#endif  // IREE_VM_BYTECODE_DISPATCH_UTIL_H_

--- a/iree/vm/module_abi_packing.h
+++ b/iree/vm/module_abi_packing.h
@@ -159,6 +159,30 @@ struct ParamUnpack {
 };
 
 template <>
+struct ParamUnpack<int64_t> {
+  using storage_type = int64_t;
+  static void Load(Unpacker* unpacker, storage_type& out_param) {
+    ++unpacker->segment_ordinal;
+    uint16_t reg =
+        unpacker->argument_list->registers[unpacker->argument_ordinal++];
+    out_param = static_cast<int64_t>(
+        unpacker->registers->i32[reg & (unpacker->registers->i32_mask & ~1)]);
+  }
+};
+
+template <>
+struct ParamUnpack<uint64_t> {
+  using storage_type = uint64_t;
+  static void Load(Unpacker* unpacker, storage_type& out_param) {
+    ++unpacker->segment_ordinal;
+    uint16_t reg =
+        unpacker->argument_list->registers[unpacker->argument_ordinal++];
+    out_param = static_cast<uint64_t>(
+        unpacker->registers->i32[reg & (unpacker->registers->i32_mask & ~1)]);
+  }
+};
+
+template <>
 struct ParamUnpack<opaque_ref> {
   using storage_type = opaque_ref;
   static void Load(Unpacker* unpacker, storage_type& out_param) {
@@ -391,6 +415,24 @@ struct ResultPack {
     uint16_t reg = packer->result_list->registers[packer->result_ordinal++];
     packer->registers->i32[reg & packer->registers->i32_mask] =
         static_cast<int32_t>(value);
+  }
+};
+
+template <>
+struct ResultPack<int64_t> {
+  static void Store(Packer* packer, int64_t value) {
+    uint16_t reg = packer->result_list->registers[packer->result_ordinal++];
+    packer->registers->i32[reg & (packer->registers->i32_mask & ~1)] =
+        static_cast<int64_t>(value);
+  }
+};
+
+template <>
+struct ResultPack<uint64_t> {
+  static void Store(Packer* packer, uint64_t value) {
+    uint16_t reg = packer->result_list->registers[packer->result_ordinal++];
+    packer->registers->i32[reg & (packer->registers->i32_mask & ~1)] =
+        static_cast<uint64_t>(value);
   }
 };
 

--- a/iree/vm/test/BUILD
+++ b/iree/vm/test/BUILD
@@ -25,6 +25,7 @@ cc_embed_data(
     name = "all_bytecode_modules_cc",
     srcs = [
         ":arithmetic_ops.module",
+        ":arithmetic_ops_i64.module",
         ":comparison_ops.module",
         ":control_flow_ops.module",
         ":list_ops.module",
@@ -38,6 +39,12 @@ cc_embed_data(
 iree_bytecode_module(
     name = "arithmetic_ops",
     src = "arithmetic_ops.mlir",
+    flags = ["-iree-vm-ir-to-bytecode-module"],
+)
+
+iree_bytecode_module(
+    name = "arithmetic_ops_i64",
+    src = "arithmetic_ops_i64.mlir",
     flags = ["-iree-vm-ir-to-bytecode-module"],
 )
 

--- a/iree/vm/test/CMakeLists.txt
+++ b/iree/vm/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_embed_data(
     all_bytecode_modules_cc
   GENERATED_SRCS
     "arithmetic_ops.module"
+    "arithmetic_ops_i64.module"
     "comparison_ops.module"
     "control_flow_ops.module"
     "list_ops.module"
@@ -37,6 +38,16 @@ iree_bytecode_module(
     arithmetic_ops
   SRC
     "arithmetic_ops.mlir"
+  FLAGS
+    "-iree-vm-ir-to-bytecode-module"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    arithmetic_ops_i64
+  SRC
+    "arithmetic_ops_i64.mlir"
   FLAGS
     "-iree-vm-ir-to-bytecode-module"
   PUBLIC

--- a/iree/vm/test/arithmetic_ops_i64.mlir
+++ b/iree/vm/test/arithmetic_ops_i64.mlir
@@ -1,0 +1,17 @@
+vm.module @arithmetic_ops_i64 {
+
+  //===--------------------------------------------------------------------===//
+  // I64 Arithmetic
+  //===--------------------------------------------------------------------===//
+
+  vm.export @test_add_i64
+  vm.func @test_add_i64() {
+    %c1 = vm.const.i64 1 : i64
+    %c1dno = iree.do_not_optimize(%c1) : i64
+    %v = vm.add.i64 %c1dno, %c1dno : i64
+    %c2 = vm.const.i64 2 : i64
+    vm.check.eq %v, %c2, "1+1=2" : i64
+    vm.return
+  }
+
+}

--- a/iree/vm/value.h
+++ b/iree/vm/value.h
@@ -55,19 +55,19 @@ typedef struct iree_vm_value {
   };
 } iree_vm_value_t;
 
-#ifdef __cplusplus
-inline iree_vm_value_t iree_vm_value_make_i32(int32_t value) {
+static inline iree_vm_value_t iree_vm_value_make_i32(int32_t value) {
   iree_vm_value_t result;
   result.type = IREE_VM_VALUE_TYPE_I32;
   result.i32 = value;
   return result;
 }
-#else
-#define iree_vm_value_make_i32(value)                   \
-  {                                                     \
-    IREE_VM_VALUE_TYPE_I32, { .i32 = (int32_t)(value) } \
-  }
-#endif  // __cplusplus
+
+static inline iree_vm_value_t iree_vm_value_make_i64(int64_t value) {
+  iree_vm_value_t result;
+  result.type = IREE_VM_VALUE_TYPE_I64;
+  result.i64 = value;
+  return result;
+}
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
This completes i64 support in the VM, including both compiler and runtime support. Conversion from other higher-level dialects (like std) is not included and can be done independently in the future.

Progress on #2574.