### PR TITLE
Enable 1x1 mhlo.conv -> mhlo.dot rewrite

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HLOToHLOPreprocessing.cpp
@@ -37,7 +37,7 @@ static llvm::cl::opt<bool> extractPadFromConv(
 static llvm::cl::opt<bool> conv1x1toDot(
     "iree-flow-1x1-conv-to-dot",
     llvm::cl::desc("Rewrites mhlo.conv with 1x1 filter into mhlo.dot"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 static bool isAllZero(DenseIntElementsAttr attr) {
   if (!attr.isSplat()) return false;


### PR DESCRIPTION
Enable 1x1 mlhlo convolution rewrites by default, it was disabled due to reshape issues fixed recently #2882
This speeds up all conv models, below LLVM benchmarks on x86
```
Resnet50 Before:
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time       8861 ms         8859 ms            1

Resnet50 After:
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time       7162 ms         7161 ms            1


MobileNetV1 Before:
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time       1076 ms         1075 ms            1

MobileNetV1 After:
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time        385 ms          385 ms            2


MobileNetV1 Before:
MobileNetV2:
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time        356 ms          356 ms            2

MobileNetV1 After:
------------------------------------------------------------------------------
Benchmark                                    Time             CPU   Iterations
------------------------------------------------------------------------------
BM_RunModule/process_time/real_time        252 ms          252 ms            2
```