### PR TITLE
Adding synchronization and threading primitives

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -392,6 +392,39 @@ cc_test(
 )
 
 cc_library(
+    name = "synchronization",
+    srcs = ["synchronization.c"],
+    hdrs = ["synchronization.h"],
+    linkopts = ["-lpthread"],
+    deps = [
+        ":api",
+        ":atomics",
+        ":target_platform",
+        ":tracing",
+    ],
+)
+
+cc_test(
+    name = "synchronization_benchmark",
+    srcs = ["synchronization_benchmark.cc"],
+    deps = [
+        ":synchronization",
+        "//iree/testing:benchmark_main",
+        "@com_google_benchmark//:benchmark",
+    ],
+)
+
+cc_test(
+    name = "synchronization_test",
+    srcs = ["synchronization_test.cc"],
+    deps = [
+        ":synchronization",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
+cc_library(
     name = "target_platform",
     hdrs = ["target_platform.h"],
 )

--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -448,6 +448,56 @@ cc_test(
 )
 
 cc_library(
+    name = "threading",
+    srcs = [
+        "threading.c",
+        "threading_darwin.c",
+        "threading_impl.h",
+        "threading_pthreads.c",
+        "threading_win32.c",
+    ],
+    hdrs = ["threading.h"],
+    copts = [
+        "-D_GNU_SOURCE=1",
+    ],
+    linkopts = [
+        "-ldl",
+        "-lpthread",
+    ],
+    deps = [
+        ":api",
+        ":atomics",
+        ":synchronization",
+        ":target_platform",
+        ":tracing",
+    ],
+)
+
+cc_test(
+    name = "threading_benchmark",
+    srcs = ["threading_benchmark.cc"],
+    deps = [
+        ":threading",
+        "//iree/testing:benchmark_main",
+        "@com_google_benchmark//:benchmark",
+    ],
+)
+
+cc_test(
+    name = "threading_test",
+    srcs = [
+        "threading_impl.h",
+        "threading_test.cc",
+    ],
+    deps = [
+        ":synchronization",
+        ":threading",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
+cc_library(
     name = "tracing",
     hdrs = ["tracing.h"],
     deps = [

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -528,6 +528,60 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_select_compiler_opts(_THREADING_LINKOPTS
+  CLANG_OR_GCC
+    "-ldl"
+    "-lpthread"
+)
+
+iree_cc_library(
+  NAME
+    threading
+  HDRS
+    "threading.h"
+  SRCS
+    "threading.c"
+    "threading_darwin.c"
+    "threading_impl.h"
+    "threading_pthreads.c"
+    "threading_win32.c"
+  COPTS
+    "-D_GNU_SOURCE=1"
+  LINKOPTS
+    ${_THREADING_LINKOPTS}
+  DEPS
+    ::api
+    ::atomics
+    ::synchronization
+    ::target_platform
+    ::tracing
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    threading_benchmark
+  SRCS
+    "threading_benchmark.cc"
+  DEPS
+    ::threading
+    benchmark
+    iree::testing::benchmark_main
+)
+
+iree_cc_test(
+  NAME
+    threading_test
+  SRCS
+    "threading_impl.h"
+    "threading_test.cc"
+  DEPS
+    ::synchronization
+    ::threading
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 if(${IREE_ENABLE_RUNTIME_TRACING})
   iree_cc_library(
     NAME

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -455,6 +455,50 @@ iree_cc_test(
     iree::testing::gtest_main
 )
 
+iree_select_compiler_opts(_SYNCHRONIZATION_LINKOPTS
+  CLANG_OR_GCC
+    "-lpthread"
+)
+
+iree_cc_library(
+  NAME
+    synchronization
+  HDRS
+    "synchronization.h"
+  SRCS
+    "synchronization.c"
+  LINKOPTS
+    ${_SYNCHRONIZATION_LINKOPTS}
+  DEPS
+    ::api
+    ::atomics
+    ::target_platform
+    ::tracing
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    synchronization_benchmark
+  SRCS
+    "synchronization_benchmark.cc"
+  DEPS
+    ::synchronization
+    benchmark
+    iree::testing::benchmark_main
+)
+
+iree_cc_test(
+  NAME
+    synchronization_test
+  SRCS
+    "synchronization_test.cc"
+  DEPS
+    ::synchronization
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 iree_cc_library(
   NAME
     target_platform

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -229,6 +229,9 @@ static inline iree_host_size_t iree_math_align(iree_host_size_t value,
   return (value + (alignment - 1)) & ~(alignment - 1);
 }
 
+#define iree_min(lhs, rhs) ((lhs) <= (rhs) ? (lhs) : (rhs))
+#define iree_max(lhs, rhs) ((lhs) <= (rhs) ? (rhs) : (lhs))
+
 //===----------------------------------------------------------------------===//
 // Byte buffers and memory utilities
 //===----------------------------------------------------------------------===//

--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -200,18 +200,6 @@ extern "C" {
 #define IREE_UNLIKELY(x) (x)
 #endif  // IREE_HAVE_ATTRIBUTE(likely)
 
-#if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
-     __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
-#define IREE_IS_LITTLE_ENDIAN 1
-#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
-    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#define IREE_IS_BIG_ENDIAN 1
-#elif defined(_WIN32)
-#define IREE_IS_LITTLE_ENDIAN 1
-#else
-#error "IREE endian detection needs to be set up for your compiler"
-#endif  // __BYTE_ORDER__
-
 // Size, in bytes, of a buffer on the host.
 typedef size_t iree_host_size_t;
 

--- a/iree/base/ref_ptr.h
+++ b/iree/base/ref_ptr.h
@@ -339,7 +339,7 @@ class RefObject {
   RefObject(const RefObject&) = default;
   RefObject& operator=(const RefObject&) { return *this; }
 
-  std::atomic<intptr_t> counter_{0};
+  std::atomic<int32_t> counter_{0};
 };
 
 // Various comparison operator overloads.

--- a/iree/base/synchronization.c
+++ b/iree/base/synchronization.c
@@ -1,0 +1,599 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/synchronization.h"
+
+#include <assert.h>
+
+#if defined(IREE_PLATFORM_EMSCRIPTEN)
+
+#include <emscripten/threading.h>
+#include <errno.h>
+
+#elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+
+#include <errno.h>
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+// Oh Android...
+#ifndef SYS_futex
+#define SYS_futex __NR_futex
+#endif  // !SYS_futex
+#ifndef FUTEX_PRIVATE_FLAG
+#define FUTEX_PRIVATE_FLAG 128
+#endif  // !FUTEX_PRIVATE_FLAG
+
+#endif  // IREE_PLATFORM_*
+
+#if defined(NDEBUG)
+#define SYNC_ASSERT(x) (void)(x)
+#else
+#define SYNC_ASSERT(x) assert(x)
+#endif  // NDEBUG
+
+// Tag functions in .c files with this to indicate that thread safety analysis
+// warnings should not show. This is useful on our implementation functions as
+// clang cannot reason about lock-free magic.
+#define IREE_DISABLE_THREAD_SAFETY_ANALYSIS \
+  IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis)
+
+//==============================================================================
+// Cross-platform futex mappings (where supported)
+//==============================================================================
+
+#if defined(IREE_PLATFORM_HAS_FUTEX)
+
+// Waits in the OS for the value at the specified |address| to change.
+// If the contents of |address| do not match |expected_value| the wait will
+// fail and return IREE_STATUS_UNAVAILABLE and should be retried.
+//
+// |timeout_ms| can be either IREE_INFINITE_TIMEOUT_MS to wait forever or a
+// relative number of milliseconds to wait prior to returning early with
+// IREE_STATUS_DEADLINE_EXCEEDED.
+static inline iree_status_t iree_futex_wait(void* address,
+                                            uint32_t expected_value,
+                                            uint32_t timeout_ms);
+
+// Wakes at most |count| threads waiting for the |address| to change.
+// Use IREE_ALL_WAITERS to wake all waiters. Which waiters are woken is
+// undefined and it is not guaranteed that higher priority waiters will be woken
+// over lower priority waiters.
+static inline void iree_futex_wake(void* address, int32_t count);
+
+#if defined(IREE_PLATFORM_EMSCRIPTEN)
+
+static inline iree_status_t iree_futex_wait(void* address,
+                                            uint32_t expected_value,
+                                            uint32_t timeout_ms) {
+  int rc = emscripten_futex_wait(address, expected_value, (double)timeout_ms);
+  switch (rc) {
+    default:
+      return iree_ok_status();
+    case -ETIMEDOUT:
+      return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+    case -EWOULDBLOCK:
+      return iree_status_from_code(IREE_STATUS_UNAVAILABLE);
+  }
+}
+
+static inline void iree_futex_wake(void* address, int32_t count) {
+  emscripten_futex_wake(address, count);
+}
+
+#elif defined(IREE_PLATFORM_WINDOWS)
+
+#pragma comment(lib, "synchronization")
+
+static inline iree_status_t iree_futex_wait(void* address,
+                                            uint32_t expected_value,
+                                            uint32_t timeout_ms) {
+  if (IREE_LIKELY(WaitOnAddress(address, &expected_value,
+                                sizeof(expected_value), timeout_ms) == TRUE)) {
+    return iree_ok_status();
+  }
+  if (GetLastError() == ERROR_TIMEOUT) {
+    return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+  }
+  return iree_status_from_code(IREE_STATUS_UNAVAILABLE);
+}
+
+static inline void iree_futex_wake(void* address, int32_t count) {
+  if (count == INT32_MAX) {
+    WakeByAddressAll(address);
+    return;
+  }
+  for (; count > 0; --count) {
+    WakeByAddressSingle(address);
+  }
+}
+
+#elif defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+
+static inline iree_status_t iree_futex_wait(void* address,
+                                            uint32_t expected_value,
+                                            uint32_t timeout_ms) {
+  struct timespec timeout;
+  timeout.tv_sec = timeout_ms / 1000;
+  timeout.tv_nsec = (timeout_ms % 1000) * 1000000;
+  int rc = syscall(
+      SYS_futex, address, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, expected_value,
+      timeout_ms == IREE_INFINITE_TIMEOUT_MS ? NULL : &timeout, NULL, 0);
+  if (IREE_LIKELY(rc == 0)) {
+    return iree_ok_status();
+  } else if (rc == ETIMEDOUT) {
+    return iree_status_from_code(IREE_STATUS_DEADLINE_EXCEEDED);
+  }
+  return iree_status_from_code(IREE_STATUS_UNAVAILABLE);
+}
+
+static inline void iree_futex_wake(void* address, int32_t count) {
+  syscall(SYS_futex, address, FUTEX_WAKE | FUTEX_PRIVATE_FLAG, count, NULL,
+          NULL, 0);
+}
+
+#endif  // IREE_PLATFORM_*
+
+#endif  // IREE_PLATFORM_HAS_FUTEX
+
+//==============================================================================
+// iree_mutex_t
+//==============================================================================
+
+#if defined(IREE_PLATFORM_WINDOWS) && defined(IREE_MUTEX_USE_WIN32_SRW)
+
+// Win32 Slim Reader/Writer (SRW) Lock (same as std::mutex)
+#define iree_mutex_impl_initialize(mutex) InitializeSRWLock(&(mutex)->value)
+#define iree_mutex_impl_deinitialize(mutex)
+#define iree_mutex_impl_lock(mutex) AcquireSRWLockExclusive(&(mutex)->value)
+#define iree_mutex_impl_try_lock(mutex) \
+  (TryAcquireSRWLockExclusive(&(mutex)->value) == TRUE)
+#define iree_mutex_impl_unlock(mutex) ReleaseSRWLockExclusive(&(mutex)->value)
+
+#elif defined(IREE_PLATFORM_WINDOWS)
+
+// Win32 CRITICAL_SECTION
+#define IREE_WIN32_CRITICAL_SECTION_FLAG_DYNAMIC_SPIN 0x02000000
+#define iree_mutex_impl_initialize(mutex)            \
+  InitializeCriticalSectionEx(&(mutex)->value, 4000, \
+                              IREE_WIN32_CRITICAL_SECTION_FLAG_DYNAMIC_SPIN)
+#define iree_mutex_impl_deinitialize(mutex) \
+  DeleteCriticalSection(&(mutex)->value)
+#define iree_mutex_impl_lock(mutex) EnterCriticalSection(&(mutex)->value)
+#define iree_mutex_impl_try_lock(mutex) \
+  (TryEnterCriticalSection(&(mutex)->value) == TRUE)
+#define iree_mutex_impl_unlock(mutex) LeaveCriticalSection(&(mutex)->value)
+
+#else
+
+// pthreads pthread_mutex_t
+#define iree_mutex_impl_initialize(mutex) \
+  pthread_mutex_init(&(mutex)->value, NULL)
+#define iree_mutex_impl_deinitialize(mutex) \
+  pthread_mutex_destroy(&(mutex)->value)
+#define iree_mutex_impl_lock(mutex) pthread_mutex_lock(&(mutex)->value)
+#define iree_mutex_impl_try_lock(mutex) \
+  (pthread_mutex_trylock(&(mutex)->value) == 0)
+#define iree_mutex_impl_unlock(mutex) pthread_mutex_unlock(&(mutex)->value)
+
+#endif  // IREE_PLATFORM_*
+
+#if (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_SLOW_LOCKS)
+
+// NOTE: the tracy mutex tracing code takes locks itself (which makes it slower
+// and may cause deadlocks).
+
+void iree_mutex_initialize_impl(const iree_tracing_location_t* src_loc,
+                                iree_mutex_t* out_mutex) {
+  memset(out_mutex, 0, sizeof(*out_mutex));
+  iree_tracing_mutex_announce(src_loc, &out_mutex->lock_id);
+  iree_mutex_impl_initialize(out_mutex);
+}
+
+void iree_mutex_deinitialize(iree_mutex_t* mutex) {
+  iree_mutex_impl_deinitialize(mutex);
+  iree_tracing_mutex_terminate(mutex->lock_id);
+  memset(mutex, 0, sizeof(*mutex));
+}
+
+void iree_mutex_lock(iree_mutex_t* mutex) IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_tracing_mutex_before_lock(mutex->lock_id);
+  iree_mutex_impl_lock(mutex);
+  iree_tracing_mutex_after_lock(mutex->lock_id);
+}
+
+bool iree_mutex_try_lock(iree_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  bool was_acquired = iree_mutex_impl_try_lock(mutex);
+  iree_tracing_mutex_after_try_lock(mutex->lock_id, was_acquired);
+  return was_acquired;
+}
+
+void iree_mutex_unlock(iree_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_mutex_impl_unlock(mutex);
+  iree_tracing_mutex_after_unlock(mutex->lock_id);
+}
+
+#else
+
+void iree_mutex_initialize(iree_mutex_t* out_mutex) {
+  memset(out_mutex, 0, sizeof(*out_mutex));
+  iree_mutex_impl_initialize(out_mutex);
+}
+
+void iree_mutex_deinitialize(iree_mutex_t* mutex) {
+  iree_mutex_impl_deinitialize(mutex);
+  memset(mutex, 0, sizeof(*mutex));
+}
+
+void iree_mutex_lock(iree_mutex_t* mutex) IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_mutex_impl_lock(mutex);
+}
+
+bool iree_mutex_try_lock(iree_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  return iree_mutex_impl_try_lock(mutex);
+}
+
+void iree_mutex_unlock(iree_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_mutex_impl_unlock(mutex);
+}
+
+#endif  // IREE_TRACING_FEATURE_SLOW_LOCKS
+
+//==============================================================================
+// iree_slim_mutex_t
+//==============================================================================
+
+#if defined(IREE_PLATFORM_APPLE)
+
+void iree_slim_mutex_initialize(iree_slim_mutex_t* out_mutex) {
+  *out_mutex->value = OS_UNFAIR_LOCK_INIT;
+}
+
+void iree_slim_mutex_deinitialize(iree_slim_mutex_t* mutex) {
+  os_unfair_lock_assert_not_owner(&mutex->value);
+}
+
+void iree_slim_mutex_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  os_unfair_lock_lock(&mutex->value);
+}
+
+bool iree_slim_mutex_try_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  return os_unfair_lock_trylock(&mutex->value);
+}
+
+void iree_slim_mutex_unlock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  os_unfair_lock_unlock(&mutex->value);
+}
+
+#elif defined(IREE_PLATFORM_WINDOWS) && defined(IREE_MUTEX_USE_WIN32_SRW)
+
+// The SRW on Windows is pointer-sized and slightly better than what we emulate
+// with the futex so let's just use that.
+
+void iree_slim_mutex_initialize(iree_slim_mutex_t* out_mutex) {
+  iree_mutex_impl_initialize(out_mutex);
+}
+
+void iree_slim_mutex_deinitialize(iree_slim_mutex_t* mutex) {
+  iree_mutex_impl_deinitialize(mutex);
+}
+
+void iree_slim_mutex_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_mutex_impl_lock(mutex);
+}
+
+bool iree_slim_mutex_try_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  return iree_mutex_impl_try_lock(mutex);
+}
+
+void iree_slim_mutex_unlock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_mutex_impl_unlock(mutex);
+}
+
+#elif defined(IREE_PLATFORM_HAS_FUTEX)
+
+// This implementation is a combo of several sources:
+//
+// Basics of Futexes by Eli Bendersky:
+// https://eli.thegreenplace.net/2018/basics-of-futexes/
+//
+// Futex based locks for C11’s generic atomics by Jens Gustedt:
+// https://hal.inria.fr/hal-01236734/document
+//
+// Mutexes and Condition Variables using Futexes:
+// http://locklessinc.com/articles/mutex_cv_futex/
+//
+// The high bit of the atomic value indicates whether the lock is held; each
+// thread tries to transition the bit from 0->1 to acquire the lock and 1->0 to
+// release it. The lower bits of the value are whether there are any interested
+// waiters. We track these waiters so that we know when we can avoid performing
+// the futex wake syscall.
+
+#define iree_slim_mutex_value(value) (0x80000000u | (value))
+#define iree_slim_mutex_is_locked(value) (0x80000000u & (value))
+
+void iree_slim_mutex_initialize(iree_slim_mutex_t* out_mutex) {
+  memset(out_mutex, 0, sizeof(*out_mutex));
+}
+
+void iree_slim_mutex_deinitialize(iree_slim_mutex_t* mutex) {
+  // Assert unlocked (callers must ensure the mutex is no longer in use).
+  SYNC_ASSERT(
+      iree_atomic_load_int32(&mutex->value, iree_memory_order_seq_cst) == 0);
+}
+
+void iree_slim_mutex_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  // Try first to acquire the lock from an unlocked state.
+  // Note that the weak form can fail spuriously. That's fine, as the perf
+  // benefit in the uncontended cases is worth the additional loop below that
+  // will correctly handle any such failures in contended cases.
+  int32_t value = 0;
+  if (iree_atomic_compare_exchange_weak_int32(
+          &mutex->value, &value, iree_slim_mutex_value(1),
+          iree_memory_order_acquire, iree_memory_order_relaxed)) {
+    // Successfully took the lock and there were no other waiters.
+    return;
+  }
+
+  // Increment the count bits to indicate that we want the lock and are willing
+  // to wait for it to be available. Note that between the CAS above and this
+  // the lock could have been made available and we want to ensure we don't
+  // change the lock bit.
+  value =
+      iree_atomic_fetch_add_int32(&mutex->value, 1, iree_memory_order_relaxed) +
+      1;
+
+  while (true) {
+    // While the lock is available: try to acquire it for this thread.
+    while (!iree_slim_mutex_is_locked(value)) {
+      if (iree_atomic_compare_exchange_weak_int32(
+              &mutex->value, &value, iree_slim_mutex_value(value),
+              iree_memory_order_acquire, iree_memory_order_relaxed)) {
+        // Successfully took the lock.
+        return;
+      }
+
+      // Spin a small amount to give us a tiny chance of falling through to the
+      // wait. We can tune this value based on likely contention, however 10-60
+      // is the recommended value and we should keep it in that order of
+      // magnitude. A way to think of this is "how many spins would we have to
+      // do to equal one call to iree_futex_wait" - if it's faster just to do
+      // a futex wait then we shouldn't be spinning!
+      // TODO(benvanik): measure on real workload on ARM; maybe remove entirely.
+      int spin_count = 100;
+      for (int i = 0; i < spin_count && iree_slim_mutex_is_locked(value); ++i) {
+        value =
+            iree_atomic_load_int32(&mutex->value, iree_memory_order_relaxed);
+      }
+    }
+
+    // While the lock is unavailable: wait for it to become available.
+    while (iree_slim_mutex_is_locked(value)) {
+      // NOTE: we don't care about wait failure here as we are going to loop
+      // and check again anyway.
+      iree_status_ignore(
+          iree_futex_wait(&mutex->value, value, IREE_INFINITE_TIMEOUT_MS));
+      value = iree_atomic_load_int32(&mutex->value, iree_memory_order_relaxed);
+    }
+  }
+}
+
+bool iree_slim_mutex_try_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  // Attempt to acquire the lock from an unlocked state.
+  // We don't care if this fails spuriously as that's the whole point of a try.
+  int32_t value = 0;
+  return iree_atomic_compare_exchange_weak_int32(
+      &mutex->value, &value, iree_slim_mutex_value(1),
+      iree_memory_order_acquire, iree_memory_order_relaxed);
+}
+
+void iree_slim_mutex_unlock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  // Transition 1->0 (unlocking with no waiters) or 2->1 (with waiters).
+  if (iree_atomic_fetch_sub_int32(&mutex->value, iree_slim_mutex_value(1),
+                                  iree_memory_order_release) !=
+      iree_slim_mutex_value(1)) {
+    // One (or more) waiters; wake a single one to avoid a thundering herd of
+    // multiple threads all waking and trying to grab the lock (as only one will
+    // win).
+    //
+    // Note that futexes (futeces? futices? futii?) are unfair and what thread
+    // gets woken is undefined (not FIFO on waiters).
+    iree_futex_wake(&mutex->value, 1);
+  }
+}
+
+#else
+
+// Pass-through to iree_mutex_t as a fallback for platforms without a futex we
+// can use to implement a slim lock. Note that since we are reusing iree_mutex_t
+// when tracing all slim mutexes will be traced along with the fat mutexes.
+
+void iree_slim_mutex_initialize(iree_slim_mutex_t* out_mutex) {
+  iree_mutex_initialize(&out_mutex->impl);
+}
+
+void iree_slim_mutex_deinitialize(iree_slim_mutex_t* mutex) {
+  iree_mutex_deinitialize(&mutex->impl);
+}
+
+void iree_slim_mutex_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_mutex_lock(&mutex->impl);
+}
+
+bool iree_slim_mutex_try_lock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  return iree_mutex_try_lock(&mutex->impl);
+}
+
+void iree_slim_mutex_unlock(iree_slim_mutex_t* mutex)
+    IREE_DISABLE_THREAD_SAFETY_ANALYSIS {
+  iree_mutex_unlock(&mutex->impl);
+}
+
+#endif  // IREE_PLATFORM_*
+
+//==============================================================================
+// iree_notification_t
+//==============================================================================
+
+// The 64-bit value used to atomically read-modify-write (RMW) the state is
+// split in two and treated as independent 32-bit ints:
+//
+//  MSB (63)                           32                               LSB (0)
+// +-------------------------------------+-------------------------------------+
+// |            epoch/notification count |                        waiter count |
+// +-------------------------------------+-------------------------------------+
+//
+// We use the epoch to wait/wake the futex (which is 32-bits), and as such when
+// we pass the value address to the futex APIs we need to ensure we are only
+// passing the most significant 32-bit value regardless of endianness.
+//
+// We use signed addition on the full 64-bit value to increment/decrement the
+// waiter count. This means that an add of -1ll will decrement the waiter count
+// and do nothing to the epoch count.
+#if defined(IREE_ENDIANNESS_LITTLE)
+#define IREE_NOTIFICATION_EPOCH_OFFSET (/*words=*/1)
+#else
+#define IREE_NOTIFICATION_EPOCH_OFFSET (/*words=*/0)
+#endif  // IREE_ENDIANNESS_*
+#define iree_notification_epoch_address(notification) \
+  ((iree_atomic_int32_t*)(&(notification)->value) +   \
+   IREE_NOTIFICATION_EPOCH_OFFSET)
+#define IREE_NOTIFICATION_WAITER_INC 0x0000000000000001ull
+#define IREE_NOTIFICATION_WAITER_DEC 0xFFFFFFFFFFFFFFFFull
+#define IREE_NOTIFICATION_WAITER_MASK 0x00000000FFFFFFFFull
+#define IREE_NOTIFICATION_EPOCH_SHIFT 32
+#define IREE_NOTIFICATION_EPOCH_INC \
+  (0x00000001ull << IREE_NOTIFICATION_EPOCH_SHIFT)
+
+void iree_notification_initialize(iree_notification_t* out_notification) {
+  memset(out_notification, 0, sizeof(*out_notification));
+#if !defined(IREE_PLATFORM_HAS_FUTEX)
+  pthread_mutex_init(&out_notification->mutex);
+  pthread_cond_init(&out_notification->cond);
+#endif  // IREE_PLATFORM_HAS_FUTEX
+}
+
+void iree_notification_deinitialize(iree_notification_t* notification) {
+  // Assert no more waiters (callers must tear down waiters first).
+  SYNC_ASSERT(
+      (iree_atomic_load_int64(&notification->value, iree_memory_order_seq_cst) &
+       IREE_NOTIFICATION_WAITER_MASK) == 0);
+#if !defined(IREE_PLATFORM_HAS_FUTEX)
+  pthread_cond_destroy(&notification->cond);
+  pthread_mutex_destroy(&notification->mutex);
+#endif  // IREE_PLATFORM_HAS_FUTEX
+}
+
+void iree_notification_post(iree_notification_t* notification, int32_t count) {
+  uint64_t previous_value = iree_atomic_fetch_add_int64(
+      &notification->value, IREE_NOTIFICATION_EPOCH_INC,
+      iree_memory_order_acq_rel);
+  // Ensure we have at least one waiter; wake up to |count| of them.
+  if (IREE_UNLIKELY(previous_value & IREE_NOTIFICATION_WAITER_MASK)) {
+#if defined(IREE_PLATFORM_HAS_FUTEX)
+    iree_futex_wake(iree_notification_epoch_address(notification), count);
+#else
+    pthread_mutex_lock(&notification->mutex);
+    if (count == IREE_ALL_WAITERS) {
+      pthread_cond_broadcast(&notification->cond);
+    } else {
+      for (int32_t i = 0; i < count; ++i) {
+        pthread_cond_signal(&notification->cond);
+      }
+    }
+    pthread_mutex_unlock(&notification->mutex);
+#endif  // IREE_PLATFORM_HAS_FUTEX
+  }
+}
+
+iree_wait_token_t iree_notification_prepare_wait(
+    iree_notification_t* notification) {
+  uint64_t previous_value = iree_atomic_fetch_add_int64(
+      &notification->value, IREE_NOTIFICATION_WAITER_INC,
+      iree_memory_order_acq_rel);
+  return (iree_wait_token_t)(previous_value >> IREE_NOTIFICATION_EPOCH_SHIFT);
+}
+
+void iree_notification_commit_wait(iree_notification_t* notification,
+                                   iree_wait_token_t wait_token) {
+  // Spin until notified and the epoch increments from what we captured during
+  // iree_notification_prepare_wait.
+  while ((iree_atomic_load_int64(&notification->value,
+                                 iree_memory_order_acquire) >>
+          IREE_NOTIFICATION_EPOCH_SHIFT) == wait_token) {
+#if defined(IREE_PLATFORM_HAS_FUTEX)
+    iree_status_ignore(
+        iree_futex_wait(iree_notification_epoch_address(notification),
+                        wait_token, IREE_INFINITE_TIMEOUT_MS));
+#else
+    pthread_mutex_lock(&notification->mutex);
+    pthread_mutex_wait(&notification->cond, &notification->mutex);
+    pthread_mutex_unlock(&notification->mutex);
+#endif  // IREE_PLATFORM_HAS_FUTEX
+  }
+
+  // TODO(benvanik): benchmark under real workloads.
+  // iree_memory_order_relaxed would suffice for correctness but the faster
+  // the waiter count gets to 0 the less likely we'll wake on the futex.
+  uint64_t previous_value = iree_atomic_fetch_add_int64(
+      &notification->value, IREE_NOTIFICATION_WAITER_DEC,
+      iree_memory_order_seq_cst);
+  SYNC_ASSERT((previous_value & IREE_NOTIFICATION_WAITER_MASK) != 0);
+}
+
+void iree_notification_cancel_wait(iree_notification_t* notification) {
+  // TODO(benvanik): benchmark under real workloads.
+  // iree_memory_order_relaxed would suffice for correctness but the faster
+  // the waiter count gets to 0 the less likely we'll wake on the futex.
+  uint64_t previous_value = iree_atomic_fetch_add_int64(
+      &notification->value, IREE_NOTIFICATION_WAITER_DEC,
+      iree_memory_order_seq_cst);
+  SYNC_ASSERT((previous_value & IREE_NOTIFICATION_WAITER_MASK) != 0);
+}
+
+void iree_notification_await(iree_notification_t* notification,
+                             iree_condition_fn_t condition_fn,
+                             void* condition_arg) {
+  if (IREE_LIKELY(condition_fn(condition_arg))) {
+    // Fast-path with condition already met.
+    return;
+  }
+  // Slow-path: try-wait until the condition is met.
+  while (true) {
+    iree_wait_token_t wait_token = iree_notification_prepare_wait(notification);
+    if (condition_fn(condition_arg)) {
+      // Condition is now met; no need to wait on the futex.
+      iree_notification_cancel_wait(notification);
+      return;
+    } else {
+      iree_notification_commit_wait(notification, wait_token);
+    }
+  }
+}

--- a/iree/base/synchronization.h
+++ b/iree/base/synchronization.h
@@ -1,0 +1,346 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: the best kind of synchronization is no synchronization; always try to
+// design your algorithm so that you don't need anything from this file :)
+// See https://travisdowns.github.io/blog/2020/07/06/concurrency-costs.html
+
+#ifndef IREE_BASE_SYNCHRONIZATION_H_
+#define IREE_BASE_SYNCHRONIZATION_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "iree/base/api.h"
+#include "iree/base/atomics.h"
+#include "iree/base/target_platform.h"
+#include "iree/base/tracing.h"
+
+#if defined(IREE_COMPILER_CLANG)
+#define IREE_THREAD_ANNOTATION_ATTRIBUTE(x) __attribute__((x))
+#else
+#define IREE_THREAD_ANNOTATION_ATTRIBUTE(x)
+#endif  // IREE_COMPILER_CLANG
+
+// Documents if a shared field or global variable needs to be protected by a
+// mutex. IREE_GUARDED_BY() allows the user to specify a particular mutex that
+// should be held when accessing the annotated variable.
+#define IREE_GUARDED_BY(x) IREE_THREAD_ANNOTATION_ATTRIBUTE(guarded_by(x))
+
+// Like IREE_GUARDED_BY but specifies that the contents of a pointer are guarded
+// by a mutex instead of the pointer itself.
+#define IREE_PTR_GUARDED_BY(x) \
+  IREE_THREAD_ANNOTATION_ATTRIBUTE(pt_guarded_by(x))
+
+#define IREE_EXCLUSIVE_LOCK_FUNCTION(...) \
+  IREE_THREAD_ANNOTATION_ATTRIBUTE(exclusive_lock_function(__VA_ARGS__))
+#define IREE_EXCLUSIVE_TRYLOCK_FUNCTION(...) \
+  IREE_THREAD_ANNOTATION_ATTRIBUTE(exclusive_trylock_function(__VA_ARGS__))
+#define IREE_UNLOCK_FUNCTION(...) \
+  IREE_THREAD_ANNOTATION_ATTRIBUTE(unlock_function(__VA_ARGS__))
+
+#if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_EMSCRIPTEN) || \
+    defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_WINDOWS)
+#define IREE_PLATFORM_HAS_FUTEX 1
+#endif  // IREE_PLATFORM_*
+
+#if defined(IREE_PLATFORM_APPLE)
+#include <os/lock.h>
+#endif  // IREE_PLATFORM_APPLE
+
+#if !defined(IREE_PLATFORM_WINDOWS)
+#include <pthread.h>
+#endif  // !IREE_PLATFORM_WINDOWS
+
+// We have the CRITICAL_SECTION path for now but Slim Reader/Writer lock (SRW)
+// is much better (and what std::mutex uses). SRW doesn't spin, though, and has
+// some other implications that don't quite line up with pthread_mutex_t on most
+// platforms. Once we have larger end-to-end benchmarks we should choose based
+// on workloads.
+#define IREE_MUTEX_USE_WIN32_SRW 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define IREE_ALL_WAITERS INT32_MAX
+#define IREE_INFINITE_TIMEOUT_MS UINT32_MAX
+
+//==============================================================================
+// iree_mutex_t
+//==============================================================================
+
+// A normal fat mutex (ala std::mutex).
+// This may be implemented as a slim mutex on certain platforms but in the worst
+// case will be the native platform primitive (like pthread_mutex_t) and as such
+// should not be embedded in structures meant to be kept small.
+//
+// Windows: Slim Reader/Writer (SRW) Locks
+// All others: pthread_mutex_t
+typedef struct IREE_THREAD_ANNOTATION_ATTRIBUTE(capability("mutex")) {
+#if defined(IREE_PLATFORM_WINDOWS) && defined(IREE_MUTEX_USE_WIN32_SRW)
+  SRWLOCK value;
+#elif defined(IREE_PLATFORM_WINDOWS)
+  CRITICAL_SECTION value;
+#else
+  pthread_mutex_t value;
+#endif  // IREE_PLATFORM_*
+#if (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_SLOW_LOCKS)
+  uint32_t lock_id;
+#endif  // IREE_TRACING_FEATURE_SLOW_LOCKS
+} iree_mutex_t;
+
+#if (IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_SLOW_LOCKS)
+// Initializes |out_mutex| to the well-defined unlocked contents.
+// Must be called prior to using any other iree_mutex_* method.
+#define iree_mutex_initialize(out_mutex)                                      \
+  static const iree_tracing_location_t TracyConcat(                           \
+      __tracy_source_location, __LINE__) = {NULL, __FUNCTION__, __FILE__,     \
+                                            (uint32_t)__LINE__, 0};           \
+  iree_mutex_initialize_impl(&TracyConcat(__tracy_source_location, __LINE__), \
+                             out_mutex);
+void iree_mutex_initialize_impl(const iree_tracing_location_t* src_loc,
+                                iree_mutex_t* out_mutex);
+#else
+// Initializes |out_mutex| to the well-defined unlocked contents.
+// Must be called prior to using any other iree_mutex_* method.
+void iree_mutex_initialize(iree_mutex_t* out_mutex);
+#endif  // IREE_TRACING_FEATURE_SLOW_LOCKS
+
+// Deinitializes |mutex| (after a prior call to iree_mutex_initialize).
+// The mutex must not be held by any thread.
+void iree_mutex_deinitialize(iree_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(locks_excluded(mutex));
+
+// Locks the |mutex| and returns when held by the caller.
+void iree_mutex_lock(iree_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(acquire_capability(mutex));
+
+// Tries to lock the |mutex| and returns true if the caller holds the lock.
+bool iree_mutex_try_lock(iree_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(try_acquire_capability(true, mutex));
+
+// Unlocks the |mutex|, which must be held by the caller.
+void iree_mutex_unlock(iree_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(release_capability(mutex));
+
+//==============================================================================
+// iree_slim_mutex_t
+//==============================================================================
+
+// TODO(benvanik): instrument with tracy; need to capture source location on
+// init and add storage for ID.
+
+// A lightweight unfair lock.
+// Depending on platform this is significantly smaller than a mutex (4-8 bytes
+// vs 64+ bytes), can always be statically initialized/requires no allocations,
+// and performs the minimal amount of work possible while still playing nicely
+// with the OS thread scheduler.
+//
+// Unlike a full mutex these don't have the ability to be shared across
+// processes (not something we care about), don't have a way to define timeouts,
+// and have only a binary held/unheld state. They are often an order of
+// magnitude faster in uncontended/lightly-contended code and the same
+// performance in highly-contended code, though, so it's worth it for locks that
+// be guarding small data structures (queue pointers, etc) and touched from many
+// threads. Since they are so lightweight it's possible to embed them per-object
+// instead of per-manager and change from a single highly-contended lock to
+// thousands of almost completely uncontended slim locks.
+//
+// Though these locks support spinning they always have a fallback path that
+// ends up calling into the kernel to properly wait the thread. This is critical
+// to avoid pathological cases under contention and allowing for thread priority
+// inheritence when there are multiple threads competing that may otherwise be
+// scheduled in a potentially livelocking order.
+//
+// The "unfair" here comes from the fact that it's possible on certain platforms
+// for certain threads to never be able to acquire the lock in cases of
+// extremely high contention or widely disparate thread priority levels. This is
+// mitigated by ensuring only very small regions of code are guarded and that
+// there's enough work happening outside of the lock on any particular thread to
+// ensure that there's some chance of other threads being able to acquire it.
+//
+// MacOS/iOS: os_unfair_lock
+//   Spins and after a short backoff drops to a futex-like behavior of waiting
+//   in the kernel. Unfortunately real futexes aren't supported.
+// See:
+//   https://developer.apple.com/documentation/os/synchronization
+//   https://opensource.apple.com/source/libplatform/libplatform-125/src/os/lock.c.auto.html
+//
+// Emscripten: emscripten_futex_wait/emscripten_futex_wake
+//   Spins and after a short backoff drops to a futex-like behavior of waiting
+//   in the kernel.
+// See:
+//   https://github.com/emscripten-core/emscripten/blob/b43474f55aeb49083b9df74fdd0e52ec8decf788/system/include/emscripten/threading.h#L114-L120
+//   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/wait
+//   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify
+//
+// Windows: WaitOnAddress/WakeByAddress*
+//   Spins and after a short backoff drops to a futex and waits in the kernel.
+// See:
+//   https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-waitonaddress
+//   https://devblogs.microsoft.com/oldnewthing/20170601-00/?p=96265
+//
+// Linux/Android/others: futex
+//   Spins and after a short backoff drops to a futex and waits in the kernel.
+// See:
+//   http://locklessinc.com/articles/futex_cheat_sheet/
+//   https://man7.org/linux/man-pages/man2/futex.2.html
+//   https://eli.thegreenplace.net/2018/basics-of-futexes/
+//   https://bartoszmilewski.com/2008/09/01/thin-lock-vs-futex/
+typedef struct IREE_THREAD_ANNOTATION_ATTRIBUTE(capability("mutex")) {
+#if defined(IREE_PLATFORM_APPLE)
+  os_unfair_lock value;
+#elif defined(IREE_PLATFORM_WINDOWS) && defined(IREE_MUTEX_USE_WIN32_SRW)
+  SRWLOCK value;
+#elif defined(IREE_PLATFORM_HAS_FUTEX)
+  iree_atomic_int32_t value;
+#else
+  iree_mutex_t impl;  // fallback
+#endif  // IREE_PLATFORM_*
+} iree_slim_mutex_t;
+
+// Initializes |out_mutex| to the well-defined unlocked contents.
+// Must be called prior to using any other iree_slim_mutex_* method.
+//
+// Though optional (static initialization is fine) this is required to support
+// lock tracing. Assume it's (mostly) free and always call it if possible. This
+// also allows us to swap in a non-slim lock for enhanced debugging if we run
+// into threading issues.
+void iree_slim_mutex_initialize(iree_slim_mutex_t* out_mutex);
+
+// Deinitializes |mutex| (after a prior call to iree_slim_mutex_initialize).
+// The mutex must not be held by any thread.
+void iree_slim_mutex_deinitialize(iree_slim_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(locks_excluded(mutex));
+
+// Locks the |mutex| and returns when held by the caller.
+void iree_slim_mutex_lock(iree_slim_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(acquire_capability(mutex));
+
+// Tries to lock the |mutex| and returns true if the caller holds the lock.
+bool iree_slim_mutex_try_lock(iree_slim_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(try_acquire_capability(true, mutex));
+
+// Unlocks the |mutex|, which must be held by the caller.
+void iree_slim_mutex_unlock(iree_slim_mutex_t* mutex)
+    IREE_THREAD_ANNOTATION_ATTRIBUTE(release_capability(mutex));
+
+//==============================================================================
+// iree_notification_t
+//==============================================================================
+
+// TODO(benvanik): add tracy support for watching the waits.
+
+// A lightweight wait-free cross-thread notification mechanism.
+// Classically called an 'event counter', these replace the use of condvars in
+// lock-free code where you wouldn't want to guard a lock-free data structure
+// with a lock.
+//
+// See:
+// http://www.1024cores.net/home/lock-free-algorithms/eventcounts
+// https://software.intel.com/en-us/forums/intel-threading-building-blocks/topic/299245
+// https://github.com/r10a/Event-Counts
+// https://github.com/facebook/folly/blob/master/folly/experimental/EventCount.h
+// https://github.com/concurrencykit/ck/blob/master/include/ck_ec.h
+typedef struct {
+#if !defined(IREE_PLATFORM_HAS_FUTEX)
+  // No futex on darwin, so use mutex/condvar instead.
+  pthread_mutex_t mutex;
+  pthread_cond_t cond;
+#endif  // IREE_PLATFORM_*
+  iree_atomic_int64_t value;
+} iree_notification_t;
+
+// Initializes a notification to no waiters and an initial epoch of 0.
+void iree_notification_initialize(iree_notification_t* out_notification);
+
+// Deinitializes |notification| (after a prior call to
+// iree_notification_initialize). No threads may be waiting on the notification.
+void iree_notification_deinitialize(iree_notification_t* notification);
+
+// Notifies up to |count| waiters of a change. Each waiter will wake and can
+// check to see if they need to do any additional work.
+// To notify all potential waiters pass IREE_ALL_WAITERS.
+//
+// Acts as (at least) a memory_order_release barrier:
+//   A store operation with this memory order performs the release operation: no
+//   reads or writes in the current thread can be reordered after this store.
+//   All writes in the current thread are visible in other threads that acquire
+//   the same atomic variable and writes that carry a dependency into the atomic
+//   variable become visible in other threads that consume the same atomic.
+void iree_notification_post(iree_notification_t* notification, int32_t count);
+
+typedef uint32_t iree_wait_token_t;  // opaque
+
+// Prepares for a wait operation, returning a token that must be passed to
+// iree_notification_commit_wait to perform the actual wait.
+//
+// Acts as a memory_order_acq_rel barrier:
+//   A read-modify-write operation with this memory order is both an acquire
+//   operation and a release operation. No memory reads or writes in the current
+//   thread can be reordered before or after this store. All writes in other
+//   threads that release the same atomic variable are visible before the
+//   modification and the modification is visible in other threads that acquire
+//   the same atomic variable.
+iree_wait_token_t iree_notification_prepare_wait(
+    iree_notification_t* notification);
+
+// Commits a pending wait operation when the caller has ensured it must wait.
+// Waiting will continue until a notification has been posted.
+//
+// Acts as (at least) a memory_order_acquire barrier:
+//   A load operation with this memory order performs the acquire operation on
+//   the affected memory location: no reads or writes in the current thread can
+//   be reordered before this load. All writes in other threads that release the
+//   same atomic variable are visible in the current thread.
+void iree_notification_commit_wait(iree_notification_t* notification,
+                                   iree_wait_token_t wait_token);
+
+// Cancels a pending wait operation without blocking.
+//
+// Acts as (at least) a memory_order_relaxed barrier:
+//   Relaxed operation: there are no synchronization or ordering constraints
+//   imposed on other reads or writes, only this operation's atomicity is
+//   guaranteed.
+void iree_notification_cancel_wait(iree_notification_t* notification);
+
+// Returns true if the condition is true.
+// |arg| is the |condition_arg| passed to the await function.
+// Implementations must ensure they are coherent with their state values.
+typedef bool (*iree_condition_fn_t)(void* arg);
+
+// Blocks and waits until |condition_fn| returns true. Other threads must modify
+// state checked by the |condition_fn| and post the notification.
+//
+// Example:
+//  thread 1:
+//   bool check_flag_pred(void* arg) {
+//     return iree_atomic_int32_load((iree_atomic_int32_t*)arg,
+//                                   iree_memory_order_acquire) == 1;
+//   }
+//   iree_atomic_int32_t* flag = ...;
+//   iree_notification_await(&notification, check_flag_pred, flag);
+//  thread 2:
+//   iree_atomic_int32_store(flag, 1, iree_memory_order_release);
+//   iree_notification_post(&notification, IREE_ALL_WAITERS);
+void iree_notification_await(iree_notification_t* notification,
+                             iree_condition_fn_t condition_fn,
+                             void* condition_arg);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_BASE_SYNCHRONIZATION_H_

--- a/iree/base/synchronization_benchmark.cc
+++ b/iree/base/synchronization_benchmark.cc
@@ -1,0 +1,263 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mutex>
+
+#include "benchmark/benchmark.h"
+#include "iree/base/synchronization.h"
+
+namespace {
+
+//==============================================================================
+// Inlined timing utils
+//==============================================================================
+
+void SpinDelay(int count, int* data) {
+  // This emulates work we may be doing while holding the lock (like swapping
+  // around some pointers).
+  for (size_t i = 0; i < count * 10; ++i) {
+    ++(*data);
+    benchmark::DoNotOptimize(*data);
+  }
+}
+
+//==============================================================================
+// iree_mutex_t / iree_slim_mutex_t
+//==============================================================================
+
+void BM_Mutex(benchmark::State& state) {
+  static iree_mutex_t* mu = ([]() -> iree_mutex_t* {
+    auto mutex = new iree_mutex_t();
+    iree_mutex_initialize(mutex);
+    return mutex;
+  })();
+  for (auto _ : state) {
+    iree_mutex_lock(mu);
+    benchmark::DoNotOptimize(*mu);
+    iree_mutex_unlock(mu);
+  }
+}
+BENCHMARK(BM_Mutex)->UseRealTime()->Threads(1)->ThreadPerCpu();
+
+template <typename MutexType>
+class RaiiLocker;
+
+template <>
+class RaiiLocker<iree_mutex_t> {
+ public:
+  static void Initialize(iree_mutex_t* out_mu) {
+    iree_mutex_initialize(out_mu);
+  }
+  static void Deinitialize(iree_mutex_t* mu) { iree_mutex_deinitialize(mu); }
+  explicit RaiiLocker(iree_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis)
+      : mu_(mu) {
+    iree_mutex_lock(mu_);
+  }
+  ~RaiiLocker() IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    iree_mutex_unlock(mu_);
+  }
+
+ private:
+  iree_mutex_t* mu_;
+};
+
+template <>
+class RaiiLocker<iree_slim_mutex_t> {
+ public:
+  static void Initialize(iree_slim_mutex_t* out_mu) {
+    iree_slim_mutex_initialize(out_mu);
+  }
+  static void Deinitialize(iree_slim_mutex_t* mu) {
+    iree_slim_mutex_deinitialize(mu);
+  }
+  explicit RaiiLocker(iree_slim_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis)
+      : mu_(mu) {
+    iree_slim_mutex_lock(mu_);
+  }
+  ~RaiiLocker() IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    iree_slim_mutex_unlock(mu_);
+  }
+
+ private:
+  iree_slim_mutex_t* mu_;
+};
+
+template <>
+class RaiiLocker<std::mutex> {
+ public:
+  static void Initialize(std::mutex* out_mu) {}
+  static void Deinitialize(std::mutex* mu) {}
+  explicit RaiiLocker(std::mutex* mu) : mu_(mu) { mu_->lock(); }
+  ~RaiiLocker() { mu_->unlock(); }
+
+ private:
+  std::mutex* mu_;
+};
+
+template <typename MutexType>
+void BM_CreateDelete(benchmark::State& state) {
+  for (auto _ : state) {
+    MutexType mu;
+    RaiiLocker<MutexType>::Initialize(&mu);
+    benchmark::DoNotOptimize(mu);
+    RaiiLocker<MutexType>::Deinitialize(&mu);
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_CreateDelete, iree_mutex_t)->UseRealTime()->Threads(1);
+
+BENCHMARK_TEMPLATE(BM_CreateDelete, iree_slim_mutex_t)
+    ->UseRealTime()
+    ->Threads(1);
+
+BENCHMARK_TEMPLATE(BM_CreateDelete, std::mutex)->UseRealTime()->Threads(1);
+
+template <typename MutexType>
+void BM_Uncontended(benchmark::State& state) {
+  MutexType mu;
+  RaiiLocker<MutexType>::Initialize(&mu);
+  int data = 0;
+  int local = 0;
+  for (auto _ : state) {
+    // Here we model both local work outside of the critical section as well as
+    // some work inside of the critical section. The idea is to capture some
+    // more or less realisitic contention levels.
+    // If contention is too low, the benchmark won't measure anything useful.
+    // If contention is unrealistically high, the benchmark will favor
+    // bad mutex implementations that block and otherwise distract threads
+    // from the mutex and shared state for as much as possible.
+    // To achieve this amount of local work is multiplied by number of threads
+    // to keep ratio between local work and critical section approximately
+    // equal regardless of number of threads.
+    SpinDelay(100 * state.threads, &local);
+    RaiiLocker<MutexType> locker(&mu);
+    SpinDelay(static_cast<int>(state.range(0)), &data);
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_Uncontended, iree_mutex_t)
+    ->UseRealTime()
+    ->Threads(1)
+    ->Arg(50)
+    ->Arg(200);
+
+BENCHMARK_TEMPLATE(BM_Uncontended, iree_slim_mutex_t)
+    ->UseRealTime()
+    ->Threads(1)
+    ->Arg(50)
+    ->Arg(200);
+
+BENCHMARK_TEMPLATE(BM_Uncontended, std::mutex)
+    ->UseRealTime()
+    ->Threads(1)
+    ->Arg(50)
+    ->Arg(200);
+
+template <typename MutexType>
+void BM_Contended(benchmark::State& state) {
+  struct Shared {
+    MutexType mu;
+    int data = 0;
+    Shared() { RaiiLocker<MutexType>::Initialize(&mu); }
+  };
+  static auto* shared = new Shared();
+  int local = 0;
+  for (auto _ : state) {
+    // Here we model both local work outside of the critical section as well as
+    // some work inside of the critical section. The idea is to capture some
+    // more or less realisitic contention levels.
+    // If contention is too low, the benchmark won't measure anything useful.
+    // If contention is unrealistically high, the benchmark will favor
+    // bad mutex implementations that block and otherwise distract threads
+    // from the mutex and shared state for as much as possible.
+    // To achieve this amount of local work is multiplied by number of threads
+    // to keep ratio between local work and critical section approximately
+    // equal regardless of number of threads.
+    SpinDelay(100 * state.threads, &local);
+    RaiiLocker<MutexType> locker(&shared->mu);
+    SpinDelay(static_cast<int>(state.range(0)), &shared->data);
+  }
+}
+
+BENCHMARK_TEMPLATE(BM_Contended, iree_mutex_t)
+    ->UseRealTime()
+    // ThreadPerCpu poorly handles non-power-of-two CPU counts.
+    ->Threads(1)
+    ->Threads(2)
+    ->Threads(4)
+    ->Threads(6)
+    ->Threads(8)
+    ->Threads(12)
+    ->Threads(16)
+    ->Threads(24)
+    ->Threads(32)
+    ->Threads(48)
+    ->Threads(64)
+    ->Threads(96)
+    // Some empirically chosen amounts of work in critical section.
+    // 1 is low contention, 200 is high contention and few values in between.
+    ->Arg(50)
+    ->Arg(200);
+
+BENCHMARK_TEMPLATE(BM_Contended, iree_slim_mutex_t)
+    ->UseRealTime()
+    // ThreadPerCpu poorly handles non-power-of-two CPU counts.
+    ->Threads(1)
+    ->Threads(2)
+    ->Threads(4)
+    ->Threads(6)
+    ->Threads(8)
+    ->Threads(12)
+    ->Threads(16)
+    ->Threads(24)
+    ->Threads(32)
+    ->Threads(48)
+    ->Threads(64)
+    ->Threads(96)
+    // Some empirically chosen amounts of work in critical section.
+    // 1 is low contention, 200 is high contention and few values in between.
+    ->Arg(50)
+    ->Arg(200);
+
+BENCHMARK_TEMPLATE(BM_Contended, std::mutex)
+    ->UseRealTime()
+    // ThreadPerCpu poorly handles non-power-of-two CPU counts.
+    ->Threads(1)
+    ->Threads(2)
+    ->Threads(4)
+    ->Threads(6)
+    ->Threads(8)
+    ->Threads(12)
+    ->Threads(16)
+    ->Threads(24)
+    ->Threads(32)
+    ->Threads(48)
+    ->Threads(64)
+    ->Threads(96)
+    // Some empirically chosen amounts of work in critical section.
+    // 1 is low contention, 200 is high contention and few values in between.
+    ->Arg(50)
+    ->Arg(200);
+
+//==============================================================================
+// iree_notification_t
+//==============================================================================
+
+// TODO(benvanik): benchmark this; it should in the worst case be as bad as
+// mutex/futex (as that's what is used), but at the moment we don't really
+// care beyond that.
+
+}  // namespace

--- a/iree/base/synchronization_test.cc
+++ b/iree/base/synchronization_test.cc
@@ -1,0 +1,187 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/synchronization.h"
+
+#include <chrono>
+#include <thread>
+
+#include "iree/testing/gtest.h"
+
+namespace {
+
+//==============================================================================
+// Test utils
+//==============================================================================
+
+template <typename T>
+class Mutex;
+
+template <>
+class Mutex<iree_mutex_t> {
+ public:
+  static void Initialize(iree_mutex_t* out_mu) {
+    iree_mutex_initialize(out_mu);
+  }
+  static void Deinitialize(iree_mutex_t* mu) { iree_mutex_deinitialize(mu); }
+  static void Lock(iree_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    iree_mutex_lock(mu);
+  }
+  static bool TryLock(iree_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    return iree_mutex_try_lock(mu);
+  }
+  static void Unlock(iree_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    iree_mutex_unlock(mu);
+  }
+};
+
+template <>
+class Mutex<iree_slim_mutex_t> {
+ public:
+  static void Initialize(iree_slim_mutex_t* out_mu) {
+    iree_slim_mutex_initialize(out_mu);
+  }
+  static void Deinitialize(iree_slim_mutex_t* mu) {
+    iree_slim_mutex_deinitialize(mu);
+  }
+  static void Lock(iree_slim_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    iree_slim_mutex_lock(mu);
+  }
+  static bool TryLock(iree_slim_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    return iree_slim_mutex_try_lock(mu);
+  }
+  static void Unlock(iree_slim_mutex_t* mu)
+      IREE_THREAD_ANNOTATION_ATTRIBUTE(no_thread_safety_analysis) {
+    iree_slim_mutex_unlock(mu);
+  }
+};
+
+// Tests that a mutex allows exclusive access to a region by touching it from
+// multiple threads.
+template <typename T>
+void TestMutexExclusiveAccess() {
+  // We'll increment the counter back and forth as we touch it from multiple
+  // threads.
+  int counter = 0;
+
+  T mu;
+  Mutex<T>::Initialize(&mu);
+
+  // Hold the lock at the start. The threads should block waiting for the lock
+  // to be released so they can take it.
+  ASSERT_EQ(0, counter);
+  Mutex<T>::Lock(&mu);
+
+  // Start up a thread to ++counter (it should block since we hold the lock).
+  std::thread th1([&]() {
+    Mutex<T>::Lock(&mu);
+    ++counter;
+    Mutex<T>::Unlock(&mu);
+  });
+
+  // Unlock and wait for the thread to acquire the lock and finish its work.
+  ASSERT_EQ(0, counter);
+  Mutex<T>::Unlock(&mu);
+  th1.join();
+
+  // Thread should have been able to increment the counter.
+  ASSERT_EQ(1, counter);
+
+  Mutex<T>::Deinitialize(&mu);
+}
+
+// Tests that try lock bails when the lock is held by another thread.
+template <typename T>
+void TestMutexExclusiveAccessTryLock() {
+  int counter = 0;
+  T mu;
+  Mutex<T>::Initialize(&mu);
+
+  // Hold the lock at the start. The try lock should fail and the thread should
+  // exit without changing the counter value.
+  ASSERT_EQ(0, counter);
+  Mutex<T>::Lock(&mu);
+  std::thread th1([&]() {
+    if (Mutex<T>::TryLock(&mu)) {
+      ++counter;
+      Mutex<T>::Unlock(&mu);
+    }
+  });
+
+  // Wait for the thread to try (and fail).
+  th1.join();
+  Mutex<T>::Unlock(&mu);
+
+  // The thread should not have been able to change the counter.
+  ASSERT_EQ(0, counter);
+
+  Mutex<T>::Deinitialize(&mu);
+}
+
+//==============================================================================
+// iree_mutex_t
+//==============================================================================
+
+TEST(MutexTest, Lifetime) {
+  iree_mutex_t mutex;
+  iree_mutex_initialize(&mutex);
+  bool did_lock = iree_mutex_try_lock(&mutex);
+  EXPECT_TRUE(did_lock);
+  if (did_lock) iree_mutex_unlock(&mutex);
+  iree_mutex_lock(&mutex);
+  iree_mutex_unlock(&mutex);
+  iree_mutex_deinitialize(&mutex);
+}
+
+TEST(MutexTest, ExclusiveAccess) { TestMutexExclusiveAccess<iree_mutex_t>(); }
+
+TEST(MutexTest, ExclusiveAccessTryLock) {
+  TestMutexExclusiveAccessTryLock<iree_mutex_t>();
+}
+
+//==============================================================================
+// iree_slim_mutex_t
+//==============================================================================
+
+TEST(SlimMutexTest, Lifetime) {
+  iree_slim_mutex_t mutex;
+  iree_slim_mutex_initialize(&mutex);
+  bool did_lock = iree_slim_mutex_try_lock(&mutex);
+  EXPECT_TRUE(did_lock);
+  if (did_lock) iree_slim_mutex_unlock(&mutex);
+  iree_slim_mutex_lock(&mutex);
+  iree_slim_mutex_unlock(&mutex);
+  iree_slim_mutex_deinitialize(&mutex);
+}
+
+TEST(SlimMutexTest, ExclusiveAccess) {
+  TestMutexExclusiveAccess<iree_slim_mutex_t>();
+}
+
+TEST(SlimMutexTest, ExclusiveAccessTryLock) {
+  TestMutexExclusiveAccessTryLock<iree_slim_mutex_t>();
+}
+
+//==============================================================================
+// iree_notification_t
+//==============================================================================
+
+// Tested implicitly in threading_test.cc.
+
+}  // namespace

--- a/iree/base/target_platform.h
+++ b/iree/base/target_platform.h
@@ -18,15 +18,15 @@
 // The Bazel rule defines one of the following top-level platforms and then
 // one platform+architecture pair for that platform.
 //
-// IREE_ARCH_ARM_V7A
-// IREE_ARCH_ARM_V8A
-// IREE_ARCH_ASMJS
+// IREE_ARCH_ARM_32
+// IREE_ARCH_ARM_64
 // IREE_ARCH_WASM_32
 // IREE_ARCH_WASM_64
 // IREE_ARCH_X86_32
 // IREE_ARCH_X86_64
 //
-// TODO(benvanik): endianness
+// IREE_ENDIANNESS_LITTLE
+// IREE_ENDIANNESS_BIG
 //
 // IREE_COMPILER_CLANG
 // IREE_COMPILER_GCC
@@ -64,9 +64,7 @@
 #define IREE_ARCH_WASM_32 1
 #elif defined(__wasm64__)
 #define IREE_ARCH_WASM_64 1
-#elif defined(__asmjs__)
-#define IREE_ARCH_ASMJS 1
-#endif  // wasm/asmjs
+#endif  // WASM
 
 #if defined(__i386__) || defined(__i486__) || defined(__i586__) || \
     defined(__i686__) || defined(__i386) || defined(_M_IX86) || defined(_X86_)
@@ -76,12 +74,28 @@
 #define IREE_ARCH_X86_64 1
 #endif  // X86
 
-#if !defined(IREE_ARCH_ARM_32) && !defined(IREE_ARCH_ARM_64) &&  \
-    !defined(IREE_ARCH_ASMJS) && !defined(IREE_ARCH_WASM_32) &&  \
-    !defined(IREE_ARCH_WASM_64) && !defined(IREE_ARCH_X86_32) && \
-    !defined(IREE_ARCH_X86_64)
+#if !defined(IREE_ARCH_ARM_32) && !defined(IREE_ARCH_ARM_64) &&   \
+    !defined(IREE_ARCH_WASM_32) && !defined(IREE_ARCH_WASM_64) && \
+    !defined(IREE_ARCH_X86_32) && !defined(IREE_ARCH_X86_64)
 #error Unknown architecture.
 #endif  // all archs
+
+//==============================================================================
+// IREE_ENDIANNESS_*
+//==============================================================================
+// https://en.wikipedia.org/wiki/Endianness
+
+#if (defined(__BYTE_ORDER__) && defined(__ORDER_LITTLE_ENDIAN__) && \
+     __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#define IREE_ENDIANNESS_LITTLE 1
+#elif defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && \
+    __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define IREE_ENDIANNESS_BIG 1
+#elif defined(_WIN32)
+#define IREE_ENDIANNESS_LITTLE 1
+#else
+#error IREE endian detection needs to be set up for your compiler
+#endif  // __BYTE_ORDER__
 
 //==============================================================================
 // IREE_COMPILER_*

--- a/iree/base/threading.c
+++ b/iree/base/threading.c
@@ -1,0 +1,257 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/threading.h"
+
+#include "iree/base/threading_impl.h"
+
+#if defined(IREE_ARCH_X86_32) || defined(IREE_ARCH_X86_64)
+#include <xmmintrin.h>
+#endif  // IREE_ARCH_X86_*
+
+#if defined(IREE_COMPILER_MSVC)
+#include <intrin.h>
+#endif  // IREE_COMPILER_MSVC
+
+int iree_strncpy_s(char* restrict dest, size_t destsz, const char* restrict src,
+                   size_t count) {
+#if defined(IREE_COMPILER_MSVC) || defined(__STDC_LIB_EXT1__)
+  return strncpy_s(dest, destsz, src, count);
+#else
+  if (!src || !dest || !destsz) return EINVAL;
+  size_t src_len = strnlen(src, destsz);
+  if (count >= destsz && destsz <= src_len) return ERANGE;
+  if (src_len > count) src_len = count;
+  while (*src != 0 && src_len > 0) {
+    *(dest++) = *(src++);
+    --src_len;
+  }
+  *dest = 0;
+  return 0;
+#endif  // GNU
+}
+
+//==============================================================================
+// iree_thread_override_list_t
+//==============================================================================
+// This is shared by multiple platform implementations and gets stripped in LTO
+// when unused.
+
+struct iree_thread_override_s {
+  iree_thread_override_list_t* list;
+  iree_thread_override_t* next;
+  iree_thread_override_t* prev;
+  iree_thread_t* thread;
+  iree_thread_priority_class_t priority_class;
+};
+
+void iree_thread_override_list_initialize(
+    iree_thread_set_priority_fn_t set_priority_fn,
+    iree_thread_priority_class_t base_priority_class,
+    iree_allocator_t allocator, iree_thread_override_list_t* out_list) {
+  memset(out_list, 0, sizeof(*out_list));
+  out_list->set_priority_fn = set_priority_fn;
+  out_list->base_priority_class = base_priority_class;
+  out_list->allocator = allocator;
+  iree_slim_mutex_initialize(&out_list->mutex);
+  out_list->current_priority_class = base_priority_class;
+}
+
+void iree_thread_override_list_deinitialize(iree_thread_override_list_t* list) {
+#if !defined(NDEBUG)
+  // Assert that all overrides have been removed (and properly freed).
+  iree_slim_mutex_lock(&list->mutex);
+  assert(!list->head);
+  iree_slim_mutex_unlock(&list->mutex);
+#endif  // !NDEBUG
+
+  iree_slim_mutex_deinitialize(&list->mutex);
+}
+
+// Updates the priority class of the thread to the maximum across all overrides
+// and the base thread priority class.
+//
+// NOTE: assumes the lock is held so the list can be safely walked.
+static void iree_thread_override_list_update_priority_class(
+    iree_thread_override_list_t* list, iree_thread_t* thread) {
+  // Compute the new maximum priority class with the override now added.
+  iree_thread_priority_class_t max_priority_class = list->base_priority_class;
+  for (iree_thread_override_t* override = list->head; override != NULL;
+       override = override->next) {
+    max_priority_class = iree_max(max_priority_class, override->priority_class);
+  }
+  bool needs_update = max_priority_class != list->current_priority_class;
+  list->current_priority_class = max_priority_class;
+
+  // Change priority if needed (this way we are avoiding syscalls if we get a
+  // wave of overrides at the same priority class).
+  //
+  // NOTE: we do this inside the lock so that we don't lose priorities. It'd be
+  // nice to do this outside the lock if we could so we aren't holding it during
+  // a syscall. Overrides should (hopefully) be infrequent enough that this is
+  // rarely called.
+  if (needs_update) {
+    list->set_priority_fn(thread, max_priority_class);
+  }
+}
+
+iree_thread_override_t* iree_thread_override_list_add(
+    iree_thread_override_list_t* list, iree_thread_t* thread,
+    iree_thread_priority_class_t priority_class) {
+  // Allocate the override struct we'll pass back to the caller.
+  iree_thread_override_t* override = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      list->allocator, sizeof(*override), (void**)&override);
+  if (IREE_UNLIKELY(!iree_status_is_ok(iree_status_consume_code(status)))) {
+    return NULL;
+  }
+  override->list = list;
+  override->next = NULL;
+  override->prev = NULL;
+  override->thread = thread;
+  override->priority_class = priority_class;
+
+  iree_slim_mutex_lock(&list->mutex);
+
+  // Add the override to the list.
+  override->next = list->head;
+  if (list->head) {
+    list->head->prev = override;
+  }
+  list->head = override;
+
+  // Update and change priority if needed.
+  // NOTE: the lock must be held.
+  iree_thread_override_list_update_priority_class(list, thread);
+
+  iree_slim_mutex_unlock(&list->mutex);
+
+  return override;
+}
+
+void iree_thread_override_remove_self(iree_thread_override_t* override) {
+  iree_thread_override_list_t* list = override->list;
+  iree_slim_mutex_lock(&list->mutex);
+
+  // Remove the override from the list.
+  if (override->prev) {
+    override->prev->next = override->next;
+  }
+  if (override->next) {
+    override->next->prev = override->prev;
+  }
+  if (list->head == override) {
+    list->head = override->next;
+  }
+
+  // Update and change priority if needed.
+  // NOTE: the lock must be held.
+  iree_thread_t* thread = override->thread;
+  iree_thread_override_list_update_priority_class(list, thread);
+
+  iree_slim_mutex_unlock(&list->mutex);
+
+  // Deallocate the override outside of the lock as no one should be using it
+  // anymore.
+  iree_allocator_free(list->allocator, override);
+}
+
+//==============================================================================
+// iree_fpu_state_t
+//==============================================================================
+// https://github.com/petewarden/tensorflow_makefile/blob/master/tensorflow/core/platform/denormal.cc
+// https://chromium.googlesource.com/chromium/blink/+/master/Source/platform/audio/DenormalDisabler.h
+
+static uint64_t iree_fpu_state_set_dtz(uint64_t state, bool denormals_to_zero);
+
+#if defined(IREE_ARCH_ARM_32)
+static uint64_t iree_fpu_state_set_dtz(uint64_t state, bool denormals_to_zero) {
+  return (state & ~0x1000000) | (denormals_to_zero ? 0x1000000 : 0);
+}
+#elif defined(IREE_ARCH_ARM_64)
+static uint64_t iree_fpu_state_set_dtz(uint64_t state, bool denormals_to_zero) {
+  return (state & ~0x1080000) | (denormals_to_zero ? 0x1080000 : 0);
+}
+#elif defined(IREE_ARCH_X86_32) || defined(IREE_ARCH_X86_64)
+static uint64_t iree_fpu_state_set_dtz(uint64_t state, bool denormals_to_zero) {
+  return (state & ~0x8040) | (denormals_to_zero ? 0x8040 : 0);
+}
+#else
+static uint64_t iree_fpu_state_set_dtz(uint64_t state, bool denormals_to_zero) {
+  return state;
+}
+#endif  // IREE_ARCH_*
+
+static uint64_t iree_fpu_load_state();
+static void iree_fpu_store_state(uint64_t state);
+
+#if defined(IREE_ARCH_ARM_32) && defined(IREE_COMPILER_MSVC)
+static uint64_t iree_fpu_load_state() {
+  return (uint64_t)_MoveFromCoprocessor(10, 7, 1, 0, 0);
+}
+static void iree_fpu_store_state(uint64_t state) {
+  _MoveToCoprocessor((int)state, 10, 7, 1, 0, 0);
+}
+#elif defined(IREE_ARCH_ARM_32)
+static uint64_t iree_fpu_load_state() {
+  uint32_t fpscr;
+  __asm__ __volatile__("VMRS %[fpscr], fpscr" : [ fpscr ] "=r"(fpscr));
+  return (uint64_t)fpscr;
+}
+static void iree_fpu_store_state(uint64_t state) {
+  __asm__ __volatile__("VMSR fpscr, %[fpscr]" : : [ fpscr ] "r"(state));
+}
+#elif defined(IREE_ARCH_ARM_64) && defined(IREE_COMPILER_MSVC)
+static uint64_t iree_fpu_load_state() {
+  return (uint64_t)_ReadStatusReg(0x5A20);
+}
+static void iree_fpu_store_state(uint64_t state) {
+  _WriteStatusReg(0x5A20, (__int64)state);
+}
+#elif defined(IREE_ARCH_ARM_64)
+static uint64_t iree_fpu_load_state() {
+  uint64_t fpcr;
+  __asm__ __volatile__("MRS %[fpcr], fpcr" : [ fpcr ] "=r"(fpcr));
+  return fpcr;
+}
+static void iree_fpu_store_state(uint64_t state) {
+  __asm__ __volatile__("MSR fpcr, %[fpcr]" : : [ fpcr ] "r"(state));
+}
+#elif defined(IREE_ARCH_X86_32) || defined(IREE_ARCH_X86_64)
+static uint64_t iree_fpu_load_state() { return (uint64_t)_mm_getcsr(); }
+static void iree_fpu_store_state(uint64_t state) {
+  _mm_setcsr((unsigned int)state);
+}
+#else
+static uint64_t iree_fpu_load_state() { return 0; }
+static void iree_fpu_store_state(uint64_t state) {}
+#endif  // IREE_ARCH_*
+
+iree_fpu_state_t iree_fpu_state_push(iree_fpu_state_flags_t flags) {
+  iree_fpu_state_t state;
+  state.current_value = state.previous_value = iree_fpu_load_state();
+  state.current_value = iree_fpu_state_set_dtz(
+      state.current_value,
+      (flags & IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO) ? true : false);
+  if (state.previous_value != state.current_value) {
+    iree_fpu_store_state(state.current_value);
+  }
+  return state;
+}
+
+void iree_fpu_state_pop(iree_fpu_state_t state) {
+  if (state.previous_value != state.current_value) {
+    iree_fpu_store_state(state.previous_value);
+  }
+}

--- a/iree/base/threading.h
+++ b/iree/base/threading.h
@@ -1,0 +1,165 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BASE_THREADING_H_
+#define IREE_BASE_THREADING_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+
+#include "iree/base/api.h"
+#include "iree/base/target_platform.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//==============================================================================
+// iree_thread_t
+//==============================================================================
+
+typedef struct iree_thread_s iree_thread_t;
+
+// Specifies a thread's priority class.
+// These translate roughly to the same thing across all platforms, though they
+// are just a hint and the schedulers on various platforms may behave very
+// differently. When in doubt prefer to write code that works at the extremes
+// of the classes.
+enum iree_thread_priority_class_e {
+  // Lowest possible priority used for background/idle work.
+  // Maps to QOS_CLASS_BACKGROUND.
+  IREE_THREAD_PRIORITY_CLASS_LOWEST = -2,
+  // Low priority work but still something the user expects to complete soon.
+  // Maps to QOS_CLASS_UTILITY.
+  IREE_THREAD_PRIORITY_CLASS_LOW = -1,
+  // Normal/default priority for the system.
+  // Maps to QOS_CLASS_DEFAULT.
+  IREE_THREAD_PRIORITY_CLASS_NORMAL = 0,
+  // High priority work for operations the user is waiting on.
+  // Maps to QOS_CLASS_USER_INITIATED.
+  IREE_THREAD_PRIORITY_CLASS_HIGH = 1,
+  // Highest possible priority used for interactive work.
+  // Maps to QOS_CLASS_USER_INTERACTIVE.
+  IREE_THREAD_PRIORITY_CLASS_HIGHEST = 2,
+};
+typedef int32_t iree_thread_priority_class_t;
+
+// Thread creation parameters.
+// All are optional and the entire struct can safely be zero-initialized.
+typedef struct {
+  // Developer-visible name for the thread displayed in tooling.
+  // May be omitted for the system-default name (usually thread ID).
+  iree_string_view_t name;
+
+  // Stack size of the new thread, in bytes. If omitted a platform-defined
+  // default system stack size will be used.
+  size_t stack_size;
+
+  // Whether to create the thread in a suspended state. The thread will be
+  // initialized but not call the entry routine until it is resumed with
+  // iree_thread_resume. This can be useful to avoid a thundering herd upon
+  // creation of many threads.
+  bool create_suspended;
+
+  // Initial priority class.
+  // This may be changed later via iree_thread_set_priority_class; see that for
+  // more information.
+  iree_thread_priority_class_t priority_class;
+} iree_thread_create_params_t;
+
+typedef int (*iree_thread_entry_t)(void* entry_arg);
+
+// Creates a new thread and calls |entry| with |entry_arg|.
+// |params| can be used to specify additional thread creation parameters but can
+// also be zero-initialized to use defaults.
+//
+// The thread will be created and configured prior to returning from the
+// function. If the create_suspended parameter is set the thread will be
+// suspended and must be resumed with iree_thread_resume. Otherwise, the thread
+// may already be inside of the |entry| function by the time the function
+// returns.
+//
+// |entry_arg| lifetime is not managed and unless the caller is waiting for the
+// thread to start must not be stack-allocated.
+iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
+                                 iree_thread_create_params_t params,
+                                 iree_allocator_t allocator,
+                                 iree_thread_t** out_thread);
+
+// Retains the given |thread| for the caller.
+void iree_thread_retain(iree_thread_t* thread);
+
+// Releases the given |thread| from the caller.
+void iree_thread_release(iree_thread_t* thread);
+
+// Returns a platform-defined thread ID for the given |thread|.
+uintptr_t iree_thread_id(iree_thread_t* thread);
+
+typedef struct iree_thread_override_s iree_thread_override_t;
+
+// Begins overriding the priority class of the given |thread|.
+// The priority of the thread will be the max of the base priority and the
+// overridden priority. Callers must pass the returned override token to
+// iree_thread_override_end.
+iree_thread_override_t* iree_thread_priority_class_override_begin(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class);
+
+// Ends a priority class override that was began for a thread with
+// iree_thread_priority_class_override_begin.
+void iree_thread_override_end(iree_thread_override_t* override_token);
+
+// Resumes |thread| if it was created suspended.
+// This has no effect if the thread is not suspended.
+void iree_thread_resume(iree_thread_t* thread);
+
+//==============================================================================
+// iree_fpu_state_*
+//==============================================================================
+
+// Flags controlling FPU features.
+enum iree_fpu_state_flags_e {
+  // Platform default.
+  IREE_FPU_STATE_DEFAULT = 0,
+
+  // Denormals can cause some serious slowdowns in certain ISAs where they may
+  // be implemented in microcode. Flushing them to zero instead of letting them
+  // propagate ensures that the slow paths aren't hit. This is a fast-math style
+  // optimization (and is often part of all compiler's fast-math set of flags).
+  //
+  // https://en.wikipedia.org/wiki/Denormal_number
+  // https://carlh.net/plugins/denormals.php
+  // https://www.xspdf.com/resolution/50507310.html
+  IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO = 1 << 0,
+};
+typedef uint32_t iree_fpu_state_flags_t;
+
+// Opaque FPU state vector manipulated with iree_fpu_* functions.
+typedef struct {
+  uint64_t previous_value;
+  uint64_t current_value;
+} iree_fpu_state_t;
+
+// Pushes a new floating-point unit (FPU) state for the current thread.
+// May lead to a pipeline flush; avoid if possible.
+iree_fpu_state_t iree_fpu_state_push(iree_fpu_state_flags_t flags);
+
+// Restores the FPU state of the thread to its original value.
+// May lead to a pipeline flush; avoid if possible.
+void iree_fpu_state_pop(iree_fpu_state_t state);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_BASE_THREADING_H_

--- a/iree/base/threading_benchmark.cc
+++ b/iree/base/threading_benchmark.cc
@@ -1,0 +1,133 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "benchmark/benchmark.h"
+#include "iree/base/threading.h"
+
+namespace {
+
+//==============================================================================
+// iree_fpu_state_*
+//==============================================================================
+
+constexpr size_t kElementBufferSize = 2048;
+
+// Scales a buffer of floats by |scale| and disables autovectorization.
+// Will generally be normal scalar floating point math and indicate whether the
+// FPU has issues with denormals.
+static float UnvectorizedScaleBufferByValue(float scale) {
+  float buffer[kElementBufferSize];
+  for (size_t i = 0; i < IREE_ARRAYSIZE(buffer); ++i) {
+    buffer[i] = 1.0f;
+  }
+  benchmark::DoNotOptimize(*buffer);
+  for (size_t i = 0; i < IREE_ARRAYSIZE(buffer); ++i) {
+    buffer[i] *= scale;
+    benchmark::DoNotOptimize(buffer[i]);
+  }
+  benchmark::DoNotOptimize(*buffer);
+  float sum = 0.0f;
+  for (size_t i = 0; i < IREE_ARRAYSIZE(buffer); ++i) {
+    sum += buffer[i];
+  }
+  return sum;
+}
+
+// Scales a buffer of floats by |scale| and allows autovectorization.
+// Will generally be SIMD floating point math and indicate whether the vector
+// units (NEON, AVX, etc) have issues with denormals.
+static float VectorizedScaleBufferByValue(float scale) {
+  float buffer[kElementBufferSize];
+  for (size_t i = 0; i < IREE_ARRAYSIZE(buffer); ++i) {
+    buffer[i] = 1.0f;
+  }
+  benchmark::DoNotOptimize(*buffer);
+  for (size_t i = 0; i < IREE_ARRAYSIZE(buffer); ++i) {
+    buffer[i] *= scale;
+  }
+  benchmark::DoNotOptimize(*buffer);
+  float sum = 0.0f;
+  for (size_t i = 0; i < IREE_ARRAYSIZE(buffer); ++i) {
+    sum += buffer[i];
+  }
+  return sum;
+}
+
+void BM_UnvectorizedNormals(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(UnvectorizedScaleBufferByValue(1.0f));
+  }
+}
+BENCHMARK(BM_UnvectorizedNormals);
+
+void BM_UnvectorizedDenormals(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(UnvectorizedScaleBufferByValue(1e-39f));
+  }
+}
+BENCHMARK(BM_UnvectorizedDenormals);
+
+void BM_UnvectorizedDenormalsFlushedToZero(benchmark::State& state) {
+  iree_fpu_state_t fpu_state =
+      iree_fpu_state_push(IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(UnvectorizedScaleBufferByValue(1e-39f));
+  }
+  iree_fpu_state_pop(fpu_state);
+}
+BENCHMARK(BM_UnvectorizedDenormalsFlushedToZero);
+
+void BM_UnvectorizedDenormalsNotFlushedToZero(benchmark::State& state) {
+  iree_fpu_state_t fpu_state = iree_fpu_state_push(IREE_FPU_STATE_DEFAULT);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(UnvectorizedScaleBufferByValue(1e-39f));
+  }
+  iree_fpu_state_pop(fpu_state);
+}
+BENCHMARK(BM_UnvectorizedDenormalsNotFlushedToZero);
+
+void BM_VectorizedNormals(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(VectorizedScaleBufferByValue(1.0f));
+  }
+}
+BENCHMARK(BM_VectorizedNormals);
+
+void BM_VectorizedDenormals(benchmark::State& state) {
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(VectorizedScaleBufferByValue(1e-39f));
+  }
+}
+BENCHMARK(BM_VectorizedDenormals);
+
+void BM_VectorizedDenormalsFlushedToZero(benchmark::State& state) {
+  iree_fpu_state_t fpu_state =
+      iree_fpu_state_push(IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(VectorizedScaleBufferByValue(1e-39f));
+  }
+  iree_fpu_state_pop(fpu_state);
+}
+BENCHMARK(BM_VectorizedDenormalsFlushedToZero);
+
+void BM_VectorizedDenormalsNotFlushedToZero(benchmark::State& state) {
+  iree_fpu_state_t fpu_state = iree_fpu_state_push(IREE_FPU_STATE_DEFAULT);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(VectorizedScaleBufferByValue(1e-39f));
+  }
+  iree_fpu_state_pop(fpu_state);
+}
+BENCHMARK(BM_VectorizedDenormalsNotFlushedToZero);
+
+}  // namespace

--- a/iree/base/threading_darwin.c
+++ b/iree/base/threading_darwin.c
@@ -1,0 +1,214 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/atomics.h"
+#include "iree/base/threading.h"
+#include "iree/base/tracing.h"
+
+#if defined(IREE_PLATFORM_APPLE)
+
+#include <errno.h>
+#include <mach/mach.h>
+#include <mach/thread_act.h>
+#include <pthread.h>
+#include <string.h>
+
+// Useful to see how pthreads is implemented on (old) darwin:
+// https://opensource.apple.com/source/Libc/Libc-825.40.1/pthreads/pthread.c.auto.html
+
+struct iree_thread_s {
+  iree_atomic_ref_count_t ref_count;
+  iree_allocator_t allocator;
+
+  char name[16];
+  pthread_t handle;
+  mach_port_t mach_port;
+
+  iree_thread_entry_t entry;
+  void* entry_arg;
+
+  iree_atomic_int32_t is_suspended;
+};
+
+static qos_class_t iree_thread_qos_class_for_priority_class(
+    iree_thread_priority_class_t priority_class);
+
+static void* iree_thread_start_routine(void* param) {
+  // NOTE: we own a reference to the thread handle so that the creation
+  // thread can't delete this out from under us.
+  iree_thread_t* thread = (iree_thread_t*)param;
+
+  // Set the thread name used by debuggers and tracy (which must be called on
+  // the thread).
+  pthread_setname_np(thread->name);
+  IREE_TRACE_SET_THREAD_NAME(thread->name);
+
+  // "Consume" the entry info so that we don't see it again (as we don't own
+  // its lifetime).
+  iree_thread_entry_t entry = thread->entry;
+  void* entry_arg = thread->entry_arg;
+  thread->entry = NULL;
+  thread->entry_arg = NULL;
+
+  // Release our ownership of the thread handle. If the creating thread doesn't
+  // want it this will free the memory and fully detach the thread.
+  iree_thread_release(thread);
+
+  // Call the user thread entry point function.
+  // Note that this can be a tail-call which saves a stack frame in all threads
+  // (which is really just to make call stacks in debuggers much cleaner).
+  return (void*)((uintptr_t)entry(entry_arg));
+}
+
+iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
+                                 iree_thread_create_params_t params,
+                                 iree_allocator_t allocator,
+                                 iree_thread_t** out_thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate our thread struct; we'll use it to shuttle params into the thread
+  // (including the user-specified entry_arg).
+  iree_thread_t* thread = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(allocator, sizeof(iree_thread_t), (void**)&thread);
+  if (!iree_status_is_ok(status)) {
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+  iree_atomic_ref_count_init(&thread->ref_count);
+  thread->allocator = allocator;
+  thread->entry = entry;
+  thread->entry_arg = entry_arg;
+  iree_strncpy_s(thread->name, IREE_ARRAYSIZE(thread->name), params.name.data,
+                 iree_min(params.name.size, IREE_ARRAYSIZE(thread->name) - 1));
+  iree_atomic_store_int32(&thread->is_suspended, 1, iree_memory_order_relaxed);
+
+  pthread_attr_t thread_attr;
+  pthread_attr_init(&thread_attr);
+  pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_DETACHED);
+  if (params.stack_size) {
+    pthread_attr_setstacksize(&thread_attr, params.stack_size);
+  }
+
+  // Ensure we start with the right QoS class.
+  qos_class_t qos_class =
+      iree_thread_qos_class_for_priority_class(priority_class);
+  pthread_attr_set_qos_class_np(&thread_attr, qos_class, 0);
+
+  // Always create the thread suspended.
+  // If we didn't do this it's possible the OS could schedule the thread
+  // immediately inside of CreateThread and we wouldn't be able to prepare
+  // it (and even weirder, it's possible the thread would have exited and
+  // the handle would be closed before we even do anything with it!).
+  int rc = pthread_create_suspended_np(&thread->handle, &thread_attr,
+                                       &iree_thread_start_routine, thread);
+  pthread_attr_destroy(&thread_attr);
+  if (rc != 0) {
+    iree_allocator_free(allocator, thread);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "thread creation failed with %d", rc);
+  }
+
+  thread->mach_port = pthread_mach_thread_np(thread->handle);
+
+  // Retain the thread for the thread itself; this way if the caller immediately
+  // releases the iree_thread_t handle the thread won't explode.
+  iree_thread_retain(thread);
+
+  // If the thread is being created unsuspended then resume now. Otherwise the
+  // caller must resume when they want it spun up.
+  if (!params.create_suspended) {
+    iree_thread_resume(thread);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  *out_thread = thread;
+  return iree_ok_status();
+}
+
+void iree_thread_retain(iree_thread_t* thread) {
+  if (thread) {
+    iree_atomic_ref_count_inc(&thread->ref_count);
+  }
+}
+
+void iree_thread_release(iree_thread_t* thread) {
+  if (thread && iree_atomic_ref_count_dec(&thread->ref_count) == 1) {
+    iree_allocator_free(thread->allocator, thread);
+  }
+}
+
+uintptr_t iree_thread_id(iree_thread_t* thread) {
+  return (uintptr_t)thread->handle;
+}
+
+// Maps an IREE iree_thread_priority_class_t value to a QoS type.
+// https://developer.apple.com/library/archive/documentation/Performance/Conceptual/EnergyGuide-iOS/PrioritizeWorkWithQoS.html
+static qos_class_t iree_thread_qos_class_for_priority_class(
+    iree_thread_priority_class_t priority_class) {
+  switch (priority_class) {
+    case IREE_THREAD_PRIORITY_CLASS_LOWEST:
+      return QOS_CLASS_BACKGROUND;
+    case IREE_THREAD_PRIORITY_CLASS_LOW:
+      return QOS_CLASS_UTILITY;
+    default:
+    case IREE_THREAD_PRIORITY_CLASS_NORMAL:
+      return QOS_CLASS_DEFAULT;
+    case IREE_THREAD_PRIORITY_CLASS_HIGH:
+      return QOS_CLASS_USER_INITIATED;
+    case IREE_THREAD_PRIORITY_CLASS_HIGHEST:
+      return QOS_CLASS_USER_INTERACTIVE;
+  }
+}
+
+iree_thread_override_t* iree_thread_priority_class_override_begin(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  qos_class_t qos_class =
+      iree_thread_qos_class_for_priority_class(priority_class);
+  pthread_override_t override =
+      pthread_override_qos_class_start_np(thread->handle, qos_class, 0);
+
+  IREE_TRACE_ZONE_END(z0);
+  return (iree_thread_override_t*)override;
+}
+
+void iree_thread_override_end(iree_thread_override_t* override) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  pthread_override_qos_class_end_np((pthread_override_t)override);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void iree_thread_resume(iree_thread_t* thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: we don't track the suspend/resume depth here because we don't
+  // expose suspend as an operation (yet). If we did we'd want to make sure we
+  // always balance suspend/resume or else we'll mess with any
+  // debuggers/profilers that may be suspending threads for their own uses.
+  int32_t expected = 1;
+  if (iree_atomic_compare_exchange_strong_int32(
+          &thread->is_suspended, &expected, 0, iree_memory_order_seq_cst,
+          iree_memory_order_seq_cst)) {
+    thread_resume(thread->mach_port);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+#endif  // IREE_PLATFORM_APPLE

--- a/iree/base/threading_impl.h
+++ b/iree/base/threading_impl.h
@@ -1,0 +1,72 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BASE_THREADING_IMPL_H_
+#define IREE_BASE_THREADING_IMPL_H_
+
+#include <assert.h>
+#include <errno.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/base/synchronization.h"
+#include "iree/base/threading.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// strncpy_s shall copy the first N characters of src to dst, where N is the
+// lesser of MaxCount and the length of src.
+//
+// We have this here patching over GNU being stubborn about supporting this.
+// If we start using it other places we can move it into a helper file.
+int iree_strncpy_s(char* dest, size_t destsz, const char* src, size_t count);
+
+typedef void (*iree_thread_set_priority_fn_t)(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class);
+
+typedef struct {
+  iree_thread_set_priority_fn_t set_priority_fn;
+  iree_thread_priority_class_t base_priority_class;
+  iree_allocator_t allocator;
+  iree_slim_mutex_t mutex;
+  iree_thread_priority_class_t current_priority_class;
+  iree_thread_override_t* head;
+} iree_thread_override_list_t;
+
+// Initializes the override list for a thread with |base_priority_class|.
+// |set_priority_fn| will be used to update the thread priority when needed.
+void iree_thread_override_list_initialize(
+    iree_thread_set_priority_fn_t set_priority_fn,
+    iree_thread_priority_class_t base_priority_class,
+    iree_allocator_t allocator, iree_thread_override_list_t* out_list);
+
+// Deinitializes an override list; expects that all overrides have been removed.
+void iree_thread_override_list_deinitialize(iree_thread_override_list_t* list);
+
+// Adds a new override to the list and returns an allocated handle.
+iree_thread_override_t* iree_thread_override_list_add(
+    iree_thread_override_list_t* list, iree_thread_t* thread,
+    iree_thread_priority_class_t priority_class);
+
+// Removes an override from its parent list and deallocates it.
+void iree_thread_override_remove_self(iree_thread_override_t* override);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // IREE_BASE_THREADING_IMPL_H_

--- a/iree/base/threading_pthreads.c
+++ b/iree/base/threading_pthreads.c
@@ -1,0 +1,281 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/atomics.h"
+#include "iree/base/synchronization.h"
+#include "iree/base/threading.h"
+#include "iree/base/threading_impl.h"
+#include "iree/base/tracing.h"
+
+#if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_EMSCRIPTEN) || \
+    defined(IREE_PLATFORM_LINUX)
+
+#include <dlfcn.h>
+#include <errno.h>
+#include <pthread.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/sysctl.h>
+#include <time.h>
+#include <unistd.h>
+
+struct iree_thread_s {
+  iree_atomic_ref_count_t ref_count;
+  iree_allocator_t allocator;
+
+  char name[16];
+  pthread_t handle;
+
+  iree_thread_entry_t entry;
+  void* entry_arg;
+
+  iree_atomic_int32_t suspend_count;
+  iree_notification_t suspend_barrier;
+
+  // Thread-safe (has its own synchronization).
+  iree_thread_override_list_t qos_override_list;
+};
+
+static void iree_thread_set_priority_class(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class);
+
+static bool iree_thread_resumed_predicate(void* arg) {
+  iree_thread_t* thread = (iree_thread_t*)arg;
+  return iree_atomic_load_int32(&thread->suspend_count,
+                                iree_memory_order_seq_cst) == 0;
+}
+
+typedef int (*pthread_setname_np_fn_t)(pthread_t thread, const char* name);
+
+static int iree_thread_set_name(pthread_t handle, const char* name) {
+  static pthread_setname_np_fn_t pthread_setname_np_fn = NULL;
+  if (!pthread_setname_np_fn) {
+    pthread_setname_np_fn =
+        (pthread_setname_np_fn_t)dlsym(RTLD_DEFAULT, "pthread_setname_np");
+  }
+  if (!pthread_setname_np_fn) return EINVAL;
+  return pthread_setname_np_fn(handle, name);
+}
+
+static void* iree_thread_start_routine(void* param) {
+  // NOTE: we own a reference to the thread handle so that the creation
+  // thread can't delete this out from under us.
+  iree_thread_t* thread = (iree_thread_t*)param;
+
+  // Set the thread name used by debuggers and tracy (which must be called on
+  // the thread).
+  iree_thread_set_name(thread->handle, thread->name);
+  IREE_TRACE_SET_THREAD_NAME(thread->name);
+
+  // Wait until we resume if we were created suspended.
+  iree_notification_await(&thread->suspend_barrier,
+                          iree_thread_resumed_predicate, thread);
+
+  // "Consume" the entry info so that we don't see it again (as we don't own
+  // its lifetime).
+  iree_thread_entry_t entry = thread->entry;
+  void* entry_arg = thread->entry_arg;
+  thread->entry = NULL;
+  thread->entry_arg = NULL;
+
+  // Release our ownership of the thread handle. If the creating thread doesn't
+  // want it this will free the memory and fully detach the thread.
+  iree_thread_release(thread);
+
+  // Call the user thread entry point function.
+  // Note that this can be a tail-call which saves a stack frame in all threads
+  // (which is really just to make call stacks in debuggers much cleaner).
+  return (void*)((uintptr_t)entry(entry_arg));
+}
+
+iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
+                                 iree_thread_create_params_t params,
+                                 iree_allocator_t allocator,
+                                 iree_thread_t** out_thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate our thread struct; we'll use it to shuttle params into the thread
+  // (including the user-specified entry_arg).
+  iree_thread_t* thread = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(allocator, sizeof(iree_thread_t), (void**)&thread);
+  if (!iree_status_is_ok(status)) {
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+  iree_atomic_ref_count_init(&thread->ref_count);
+  thread->allocator = allocator;
+  thread->entry = entry;
+  thread->entry_arg = entry_arg;
+  iree_strncpy_s(thread->name, IREE_ARRAYSIZE(thread->name), params.name.data,
+                 iree_min(params.name.size, IREE_ARRAYSIZE(thread->name) - 1));
+  thread->suspend_count = IREE_ATOMIC_VAR_INIT(params.create_suspended ? 1 : 0);
+  iree_notification_initialize(&thread->suspend_barrier);
+  iree_thread_override_list_initialize(iree_thread_set_priority_class,
+                                       params.priority_class, thread->allocator,
+                                       &thread->qos_override_list);
+
+  pthread_attr_t thread_attr;
+  pthread_attr_init(&thread_attr);
+  pthread_attr_setdetachstate(&thread_attr, PTHREAD_CREATE_DETACHED);
+  if (params.stack_size) {
+    pthread_attr_setstacksize(&thread_attr, params.stack_size);
+  }
+
+  // Retain the thread for the thread itself; this way if the caller immediately
+  // releases the iree_thread_t handle the thread won't explode.
+  iree_thread_retain(thread);
+
+  // Unfortunately we can't create the thread suspended (no API). This means
+  // that we are likely to incur some thrashing here as the thread gets spun up
+  // immediately. We emulate the create_suspended behavior by waiting in the
+  // thread until iree_thread_resume is called which at least gives us the same
+  // execution order guarantee across all platforms.
+  int rc = pthread_create(&thread->handle, &thread_attr,
+                          &iree_thread_start_routine, thread);
+  pthread_attr_destroy(&thread_attr);
+  if (rc != 0) {
+    iree_allocator_free(allocator, thread);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "thread creation failed with %d", rc);
+  }
+
+  if (params.priority_class != IREE_THREAD_PRIORITY_CLASS_NORMAL) {
+    iree_thread_set_priority_class(thread, params.priority_class);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  *out_thread = thread;
+  return iree_ok_status();
+}
+
+static void iree_thread_delete(iree_thread_t* thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_thread_resume(thread);
+
+  iree_notification_deinitialize(&thread->suspend_barrier);
+  iree_thread_override_list_deinitialize(&thread->qos_override_list);
+  iree_allocator_free(thread->allocator, thread);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void iree_thread_retain(iree_thread_t* thread) {
+  if (thread) {
+    iree_atomic_ref_count_inc(&thread->ref_count);
+  }
+}
+
+void iree_thread_release(iree_thread_t* thread) {
+  if (thread && iree_atomic_ref_count_dec(&thread->ref_count) == 1) {
+    iree_thread_delete(thread);
+  }
+}
+
+uintptr_t iree_thread_id(iree_thread_t* thread) {
+  return (uintptr_t)thread->handle;
+}
+
+// Maps an IREE iree_thread_priority_class_t value to a pthreads priority param.
+// The min/max ranges of the priority are implementation dependent so we need to
+// do this at runtime.
+static struct sched_param iree_thread_sched_param_for_priority_class(
+    int policy, iree_thread_priority_class_t priority_class) {
+  struct sched_param param;
+  memset(&param, 0, sizeof(param));
+  int min_priority = sched_get_priority_min(policy);
+  int max_priority = sched_get_priority_max(policy);
+  int normal_priority = (max_priority - min_priority) / 2 + min_priority;
+  switch (priority_class) {
+    case IREE_THREAD_PRIORITY_CLASS_LOWEST:
+      param.sched_priority = min_priority;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_LOW:
+      param.sched_priority =
+          (normal_priority - min_priority) / 2 + min_priority;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_NORMAL:
+      param.sched_priority = normal_priority;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_HIGH:
+      param.sched_priority =
+          (max_priority - normal_priority) / 2 + normal_priority;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_HIGHEST:
+      param.sched_priority = max_priority;
+      break;
+  }
+  return param;
+}
+
+// Sets the thread priority to the given |priority_class|, resetting any
+// previous value.
+//
+// NOTE: this probably doesn't work on Android, because Android.
+// They seem to use linux LWPs and setpriority/nice on the tid will actually
+// change the priority. It doesn't seem possible to elevate priority above
+// normal (without root), but it would at least be useful to be able to
+// indicate background threads.
+//
+// See:
+// https://stackoverflow.com/questions/17398075/change-native-thread-priority-on-android-in-c-c
+// https://android.googlesource.com/platform/frameworks/native/+/android-4.2.2_r1/include/utils/ThreadDefs.h
+//
+// TODO(benvanik): try this from filament:
+// https://github.com/google/filament/blob/56682794d398236c4caa5be40d80acdb73a13bc8/libs/utils/src/JobSystem.cpp
+static void iree_thread_set_priority_class(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  int policy = 0;
+  struct sched_param param;
+  pthread_getschedparam(thread->handle, &policy, &param);
+  param = iree_thread_sched_param_for_priority_class(policy, priority_class);
+  pthread_setschedparam(thread->handle, policy, &param);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_thread_override_t* iree_thread_priority_class_override_begin(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_thread_override_t* override = iree_thread_override_list_add(
+      &thread->qos_override_list, thread, priority_class);
+  IREE_TRACE_ZONE_END(z0);
+  return override;
+}
+
+void iree_thread_override_end(iree_thread_override_t* override) {
+  if (!override) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_thread_override_remove_self(override);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void iree_thread_resume(iree_thread_t* thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  if (iree_atomic_exchange_int32(&thread->suspend_count, 0,
+                                 iree_memory_order_seq_cst) == 1) {
+    iree_notification_post(&thread->suspend_barrier, IREE_ALL_WAITERS);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+#endif  // IREE_PLATFORM_*

--- a/iree/base/threading_test.cc
+++ b/iree/base/threading_test.cc
@@ -1,0 +1,246 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/threading.h"
+
+#include <chrono>
+#include <thread>
+
+#include "iree/base/synchronization.h"
+#include "iree/base/threading_impl.h"  // to test the override list
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+using iree::Status;
+
+//==============================================================================
+// iree_thread_t
+//==============================================================================
+
+TEST(ThreadTest, Lifetime) {
+  // Default parameters:
+  iree_thread_create_params_t params;
+  memset(&params, 0, sizeof(params));
+
+  // Our thread: do a bit of math and notify the main test thread when done.
+  struct entry_data_s {
+    iree_atomic_int32_t value;
+    iree_notification_t barrier;
+  } entry_data;
+  iree_atomic_store_int32(&entry_data.value, 123, iree_memory_order_relaxed);
+  iree_notification_initialize(&entry_data.barrier);
+  iree_thread_entry_t entry_fn = +[](void* entry_arg) -> int {
+    auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+    iree_atomic_fetch_add_int32(&entry_data->value, 1,
+                                iree_memory_order_acq_rel);
+    iree_notification_post(&entry_data->barrier, IREE_ALL_WAITERS);
+    return 0;
+  };
+
+  // Create the thread and immediately begin running it.
+  iree_thread_t* thread = nullptr;
+  IREE_ASSERT_OK(Status(iree_thread_create(entry_fn, &entry_data, params,
+                                           iree_allocator_system(), &thread)));
+  EXPECT_NE(0, iree_thread_id(thread));
+
+  // Drop the thread handle; should be safe as the thread should keep itself
+  // retained as long as it needs to.
+  iree_thread_release(thread);
+
+  // Wait for the thread to finish.
+  iree_notification_await(
+      &entry_data.barrier,
+      +[](void* entry_arg) -> bool {
+        auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+        return iree_atomic_load_int32(&entry_data->value,
+                                      iree_memory_order_relaxed) == (123 + 1);
+      },
+      &entry_data);
+  iree_notification_deinitialize(&entry_data.barrier);
+}
+
+TEST(ThreadTest, CreateSuspended) {
+  iree_thread_create_params_t params;
+  memset(&params, 0, sizeof(params));
+  params.create_suspended = true;
+
+  struct entry_data_s {
+    iree_atomic_int32_t value;
+    iree_notification_t barrier;
+  } entry_data;
+  iree_atomic_store_int32(&entry_data.value, 123, iree_memory_order_relaxed);
+  iree_notification_initialize(&entry_data.barrier);
+  iree_thread_entry_t entry_fn = +[](void* entry_arg) -> int {
+    auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+    iree_atomic_fetch_add_int32(&entry_data->value, 1,
+                                iree_memory_order_acq_rel);
+    iree_notification_post(&entry_data->barrier, IREE_ALL_WAITERS);
+    return 0;
+  };
+
+  iree_thread_t* thread = nullptr;
+  IREE_ASSERT_OK(Status(iree_thread_create(entry_fn, &entry_data, params,
+                                           iree_allocator_system(), &thread)));
+  EXPECT_NE(0, iree_thread_id(thread));
+
+  // NOTE: the thread will not be running and we should not expect a change in
+  // the value. I can't think of a good way to test this, though, so we'll just
+  // wait a moment here and assume that if the thread was able to run it would
+  // have during this wait.
+  ASSERT_EQ(123, iree_atomic_load_int32(&entry_data.value,
+                                        iree_memory_order_seq_cst));
+  std::this_thread::sleep_for(std::chrono::milliseconds(150));
+  ASSERT_EQ(123, iree_atomic_load_int32(&entry_data.value,
+                                        iree_memory_order_seq_cst));
+
+  // Resume the thread and wait for it to finish its work.
+  iree_thread_resume(thread);
+  iree_notification_await(
+      &entry_data.barrier,
+      +[](void* entry_arg) -> bool {
+        auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+        return iree_atomic_load_int32(&entry_data->value,
+                                      iree_memory_order_relaxed) == (123 + 1);
+      },
+      &entry_data);
+  iree_notification_deinitialize(&entry_data.barrier);
+  iree_thread_release(thread);
+}
+
+// NOTE: testing whether priority took effect is really hard given that on
+// certain platforms the priority may not be respected or may be clamped by
+// the system. This is here to test the mechanics of the priority override code
+// on our side and assumes that if we tell the OS something it respects it.
+TEST(ThreadTest, PriorityOverride) {
+  iree_thread_create_params_t params;
+  memset(&params, 0, sizeof(params));
+
+  struct entry_data_s {
+    iree_atomic_int32_t value;
+    iree_notification_t barrier;
+  } entry_data;
+  iree_atomic_store_int32(&entry_data.value, 0, iree_memory_order_relaxed);
+  iree_notification_initialize(&entry_data.barrier);
+  iree_thread_entry_t entry_fn = +[](void* entry_arg) -> int {
+    auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+    iree_atomic_fetch_add_int32(&entry_data->value, 1,
+                                iree_memory_order_acq_rel);
+    iree_notification_post(&entry_data->barrier, IREE_ALL_WAITERS);
+    return 0;
+  };
+
+  iree_thread_t* thread = nullptr;
+  IREE_ASSERT_OK(Status(iree_thread_create(entry_fn, &entry_data, params,
+                                           iree_allocator_system(), &thread)));
+  EXPECT_NE(0, iree_thread_id(thread));
+
+  // Push a few overrides.
+  iree_thread_override_t* override0 = iree_thread_priority_class_override_begin(
+      thread, IREE_THREAD_PRIORITY_CLASS_HIGH);
+  EXPECT_NE(nullptr, override0);
+  iree_thread_override_t* override1 = iree_thread_priority_class_override_begin(
+      thread, IREE_THREAD_PRIORITY_CLASS_HIGHEST);
+  EXPECT_NE(nullptr, override1);
+  iree_thread_override_t* override2 = iree_thread_priority_class_override_begin(
+      thread, IREE_THREAD_PRIORITY_CLASS_LOWEST);
+  EXPECT_NE(nullptr, override2);
+
+  // Wait for the thread to finish.
+  iree_notification_await(
+      &entry_data.barrier,
+      +[](void* entry_arg) -> bool {
+        auto* entry_data = reinterpret_cast<struct entry_data_s*>(entry_arg);
+        return iree_atomic_load_int32(&entry_data->value,
+                                      iree_memory_order_relaxed) == 1;
+      },
+      &entry_data);
+  iree_notification_deinitialize(&entry_data.barrier);
+
+  // Pop overrides (in opposite order intentionally).
+  iree_thread_override_end(override0);
+  iree_thread_override_end(override1);
+  iree_thread_override_end(override2);
+
+  iree_thread_release(thread);
+}
+
+//==============================================================================
+// iree_thread_override_list_t
+//==============================================================================
+// This is an implementation detail but useful to test on its own as it's shared
+// across several platform implementations.
+
+TEST(ThreadOverrideListTest, PriorityClass) {
+  static iree_thread_t* kThreadSentinel =
+      reinterpret_cast<iree_thread_t*>(0x123);
+  static iree_thread_priority_class_t current_priority_class =
+      IREE_THREAD_PRIORITY_CLASS_NORMAL;
+  iree_thread_override_list_t list;
+  iree_thread_override_list_initialize(
+      +[](iree_thread_t* thread, iree_thread_priority_class_t priority_class) {
+        EXPECT_EQ(kThreadSentinel, thread);
+        EXPECT_NE(current_priority_class, priority_class);
+        current_priority_class = priority_class;
+      },
+      current_priority_class, iree_allocator_system(), &list);
+
+  // (NORMAL) -> HIGH -> [ignored LOW] -> HIGHEST
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_NORMAL, current_priority_class);
+  iree_thread_override_t* override0 = iree_thread_override_list_add(
+      &list, kThreadSentinel, IREE_THREAD_PRIORITY_CLASS_HIGH);
+  EXPECT_NE(nullptr, override0);
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_HIGH, current_priority_class);
+  iree_thread_override_t* override1 = iree_thread_override_list_add(
+      &list, kThreadSentinel, IREE_THREAD_PRIORITY_CLASS_LOW);
+  EXPECT_NE(nullptr, override1);
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_HIGH, current_priority_class);
+  iree_thread_override_t* override2 = iree_thread_override_list_add(
+      &list, kThreadSentinel, IREE_THREAD_PRIORITY_CLASS_HIGHEST);
+  EXPECT_NE(nullptr, override2);
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_HIGHEST, current_priority_class);
+
+  // Out of order to ensure highest bit sticks:
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_HIGHEST, current_priority_class);
+  iree_thread_override_remove_self(override1);
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_HIGHEST, current_priority_class);
+  iree_thread_override_remove_self(override0);
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_HIGHEST, current_priority_class);
+  iree_thread_override_remove_self(override2);
+  ASSERT_EQ(IREE_THREAD_PRIORITY_CLASS_NORMAL, current_priority_class);
+
+  iree_thread_override_list_deinitialize(&list);
+}
+
+//==============================================================================
+// iree_fpu_state_*
+//==============================================================================
+
+// NOTE: depending on compiler options or architecture denormals may always be
+// flushed to zero. Here we just test that they are flushed when we request them
+// to be.
+TEST(FPUStateTest, FlushDenormalsToZero) {
+  iree_fpu_state_t fpu_state =
+      iree_fpu_state_push(IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO);
+
+  float f = 1.0f;
+  volatile float* fp = &f;
+  *fp = *fp * 1e-39f;
+  EXPECT_EQ(0.0f, f);
+
+  iree_fpu_state_pop(fpu_state);
+}
+
+}  // namespace

--- a/iree/base/threading_win32.c
+++ b/iree/base/threading_win32.c
@@ -1,0 +1,275 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/atomics.h"
+#include "iree/base/threading.h"
+#include "iree/base/threading_impl.h"
+#include "iree/base/tracing.h"
+
+#if defined(IREE_PLATFORM_WINDOWS)
+
+struct iree_thread_s {
+  iree_atomic_ref_count_t ref_count;
+  iree_allocator_t allocator;
+
+  char name[16];
+  HANDLE handle;
+  DWORD id;
+
+  iree_thread_entry_t entry;
+  void* entry_arg;
+
+  iree_atomic_int32_t is_suspended;
+
+  // Thread-safe (has its own synchronization).
+  iree_thread_override_list_t qos_override_list;
+};
+
+static void iree_thread_set_priority_class(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class);
+
+// Sets the thread's name to the given NUL-terminated string.
+//
+// See:
+// https://docs.microsoft.com/en-us/visualstudio/debugger/how-to-set-a-thread-name-in-native-code
+static void iree_thread_set_name(HANDLE handle, const char* name) {
+  // Try first to use the modern SetThreadDescription API.
+  // This will work even if a debugger is not attached meaning that tools that
+  // don't use the debugger API can still query thread names. It's only
+  // available on Win10+.
+  typedef HRESULT(WINAPI * SetThreadDescriptionFn)(HANDLE hThread,
+                                                   PCWSTR lpThreadDescription);
+  SetThreadDescriptionFn pSetThreadDescription =
+      (SetThreadDescriptionFn)GetProcAddress(GetModuleHandleW(L"Kernel32.dll"),
+                                             "SetThreadDescription");
+  if (pSetThreadDescription) {
+    wchar_t name_wide[16] = {0};
+    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, name, -1, name_wide,
+                        IREE_ARRAYSIZE(name_wide) - 1);
+    pSetThreadDescription(handle, name_wide);
+    return;
+  }
+
+  if (!IsDebuggerPresent()) {
+    // The name is only captured if a debugger is attached so we can avoid
+    // doing any of the work if none is present. This means that a debugger
+    // attached to the process after thread creation won't see thread names but
+    // that's a rare case anyway.
+    return;
+  }
+
+#pragma pack(push, 8)
+  struct THREADNAME_INFO {
+    DWORD dwType;      // Must be 0x1000.
+    LPCSTR szName;     // Pointer to name (in user addr space).
+    DWORD dwThreadID;  // Thread ID (-1=caller thread).
+    DWORD dwFlags;     // Reserved for future use, must be zero.
+  };
+#pragma pack(pop)
+
+#pragma warning(push)
+#pragma warning(disable : 6320 6322)
+  struct THREADNAME_INFO info;
+  info.dwType = 0x1000;
+  info.szName = name;
+  info.dwThreadID = GetThreadId(handle);
+  info.dwFlags = 0;
+  __try {
+    RaiseException(0x406D1388u, 0, sizeof(info) / sizeof(ULONG_PTR),
+                   (ULONG_PTR*)(&info));
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+  }
+#pragma warning(pop)
+}
+
+static DWORD WINAPI iree_thread_start_routine(LPVOID param) {
+  // NOTE: we own a reference to the thread handle so that the creation
+  // thread can't delete this out from under us.
+  iree_thread_t* thread = (iree_thread_t*)param;
+
+  // Set the thread name used by tracy (which must be called on the thread).
+  IREE_TRACE_SET_THREAD_NAME(thread->name);
+
+  // "Consume" the entry info so that we don't see it again (as we don't own
+  // its lifetime).
+  iree_thread_entry_t entry = thread->entry;
+  void* entry_arg = thread->entry_arg;
+  thread->entry = NULL;
+  thread->entry_arg = NULL;
+
+  // Release our ownership of the thread handle. If the creating thread doesn't
+  // want it this will free the memory and fully detach the thread.
+  iree_thread_release(thread);
+
+  // Call the user thread entry point function.
+  // Note that this can be a tail-call which saves a stack frame in all threads
+  // (which is really just to make call stacks in debuggers much cleaner).
+  return (DWORD)entry(entry_arg);
+}
+
+iree_status_t iree_thread_create(iree_thread_entry_t entry, void* entry_arg,
+                                 iree_thread_create_params_t params,
+                                 iree_allocator_t allocator,
+                                 iree_thread_t** out_thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Allocate our thread struct; we'll use it to shuttle params into the thread
+  // (including the user-specified entry_arg).
+  iree_thread_t* thread = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(allocator, sizeof(iree_thread_t), (void**)&thread);
+  if (!iree_status_is_ok(status)) {
+    IREE_TRACE_ZONE_END(z0);
+    return status;
+  }
+  iree_atomic_ref_count_init(&thread->ref_count);
+  thread->allocator = allocator;
+  thread->entry = entry;
+  thread->entry_arg = entry_arg;
+  strncpy_s(thread->name, IREE_ARRAYSIZE(thread->name), params.name.data,
+            min(params.name.size, IREE_ARRAYSIZE(thread->name) - 1));
+  iree_atomic_store_int32(&thread->is_suspended, 1, iree_memory_order_relaxed);
+  iree_thread_override_list_initialize(iree_thread_set_priority_class,
+                                       params.priority_class, thread->allocator,
+                                       &thread->qos_override_list);
+
+  // Always create the thread suspended.
+  // If we didn't do this it's possible the OS could schedule the thread
+  // immediately inside of CreateThread and we wouldn't be able to prepare it
+  // (and even weirder, it's possible the thread would have exited and the
+  // handle would be closed before we even do anything with it!).
+  thread->handle =
+      CreateThread(NULL, params.stack_size, iree_thread_start_routine, thread,
+                   CREATE_SUSPENDED, &thread->id);
+  if (thread->handle == INVALID_HANDLE_VALUE) {
+    iree_allocator_free(allocator, thread);
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "thread creation failed with %lu", GetLastError());
+  }
+
+  // Immediately set thread properties before resuming (so that we don't
+  // start on the wrong core/at the wrong priority).
+  if (!iree_string_view_is_empty(params.name)) {
+    iree_thread_set_name(thread->handle, thread->name);
+  }
+  if (params.priority_class != IREE_THREAD_PRIORITY_CLASS_NORMAL) {
+    iree_thread_set_priority_class(thread, params.priority_class);
+  }
+
+  // Retain the thread for the thread itself; this way if the caller immediately
+  // releases the iree_thread_t handle the thread won't explode.
+  iree_thread_retain(thread);
+
+  // If the thread is being created unsuspended then resume now. Otherwise the
+  // caller must resume when they want it spun up.
+  if (!params.create_suspended) {
+    iree_thread_resume(thread);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  *out_thread = thread;
+  return iree_ok_status();
+}
+
+static void iree_thread_delete(iree_thread_t* thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_thread_resume(thread);
+
+  CloseHandle(thread->handle);
+  iree_thread_override_list_deinitialize(&thread->qos_override_list);
+  iree_allocator_free(thread->allocator, thread);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void iree_thread_retain(iree_thread_t* thread) {
+  if (thread) {
+    iree_atomic_ref_count_inc(&thread->ref_count);
+  }
+}
+
+void iree_thread_release(iree_thread_t* thread) {
+  if (thread && iree_atomic_ref_count_dec(&thread->ref_count) == 1) {
+    iree_thread_delete(thread);
+  }
+}
+
+uintptr_t iree_thread_id(iree_thread_t* thread) {
+  return (uintptr_t)thread->id;
+}
+
+// Sets the thread priority to the given |priority_class| immediately.
+static void iree_thread_set_priority_class(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  DWORD priority = THREAD_PRIORITY_NORMAL;
+  switch (priority_class) {
+    case IREE_THREAD_PRIORITY_CLASS_LOWEST:
+      priority = THREAD_PRIORITY_LOWEST;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_LOW:
+      priority = THREAD_PRIORITY_BELOW_NORMAL;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_NORMAL:
+      priority = THREAD_PRIORITY_NORMAL;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_HIGH:
+      priority = THREAD_PRIORITY_ABOVE_NORMAL;
+      break;
+    case IREE_THREAD_PRIORITY_CLASS_HIGHEST:
+      priority = THREAD_PRIORITY_HIGHEST;
+      break;
+  }
+  SetThreadPriority(thread->handle, priority);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+iree_thread_override_t* iree_thread_priority_class_override_begin(
+    iree_thread_t* thread, iree_thread_priority_class_t priority_class) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_thread_override_t* override = iree_thread_override_list_add(
+      &thread->qos_override_list, thread, priority_class);
+  IREE_TRACE_ZONE_END(z0);
+  return override;
+}
+
+void iree_thread_override_end(iree_thread_override_t* override) {
+  if (!override) return;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_thread_override_remove_self(override);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void iree_thread_resume(iree_thread_t* thread) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOTE: we don't track the suspend/resume depth here because we don't
+  // expose suspend as an operation (yet). If we did we'd want to make sure we
+  // always balance suspend/resume or else we'll mess with any
+  // debuggers/profilers that may be suspending threads for their own uses.
+  int32_t expected = 1;
+  if (iree_atomic_compare_exchange_strong_int32(
+          &thread->is_suspended, &expected, 0, iree_memory_order_seq_cst,
+          iree_memory_order_seq_cst)) {
+    ResumeThread(thread->handle);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+#endif  // IREE_PLATFORM_WINDOWS

--- a/iree/base/tracing.cc
+++ b/iree/base/tracing.cc
@@ -32,7 +32,7 @@ void iree_tracing_set_thread_name_impl(const char* name) {
 }
 
 iree_zone_id_t iree_tracing_zone_begin_impl(
-    const struct ___tracy_source_location_data* src_loc, const char* name,
+    const iree_tracing_location_t* src_loc, const char* name,
     size_t name_length) {
   const iree_zone_id_t zone_id = tracy::GetProfiler().GetNextZoneId();
 
@@ -145,6 +145,58 @@ void iree_tracing_plot_value_f32_impl(const char* name_literal, float value) {
 
 void iree_tracing_plot_value_f64_impl(const char* name_literal, double value) {
   tracy::Profiler::PlotData(name_literal, value);
+}
+
+void iree_tracing_mutex_announce(const iree_tracing_location_t* src_loc,
+                                 uint32_t* out_lock_id) {
+  uint32_t lock_id =
+      tracy::GetLockCounter().fetch_add(1, std::memory_order_relaxed);
+  assert(lock_id != std::numeric_limits<uint32_t>::max());
+  *out_lock_id = lock_id;
+
+  auto item = tracy::Profiler::QueueSerial();
+  tracy::MemWrite(&item->hdr.type, tracy::QueueType::LockAnnounce);
+  tracy::MemWrite(&item->lockAnnounce.id, lock_id);
+  tracy::MemWrite(&item->lockAnnounce.time, tracy::Profiler::GetTime());
+  tracy::MemWrite(&item->lockAnnounce.lckloc,
+                  reinterpret_cast<uint64_t>(srcloc));
+  tracy::MemWrite(&item->lockAnnounce.type, tracy::LockType::Lockable);
+  tracy::Profiler::QueueSerialFinish();
+}
+
+void iree_tracing_mutex_terminate(uint32_t lock_id) {
+  auto item = tracy::Profiler::QueueSerial();
+  tracy::MemWrite(&item->hdr.type, tracy::QueueType::LockTerminate);
+  tracy::MemWrite(&item->lockTerminate.id, lock_id);
+  tracy::MemWrite(&item->lockTerminate.time, tracy::Profiler::GetTime());
+  tracy::Profiler::QueueSerialFinish();
+}
+
+void iree_tracing_mutex_before_lock(uint32_t lock_id) {
+  auto item = Profiler::QueueSerial();
+  tracy::MemWrite(&item->hdr.type, tracy::QueueType::LockWait);
+  tracy::MemWrite(&item->lockWait.thread, tracy::GetThreadHandle());
+  tracy::MemWrite(&item->lockWait.id, lock_id);
+  tracy::MemWrite(&item->lockWait.time, tracy::Profiler::GetTime());
+  Profiler::QueueSerialFinish();
+}
+
+void iree_tracing_mutex_after_lock(uint32_t lock_id) {
+  auto item = tracy::Profiler::QueueSerial();
+  tracy::MemWrite(&item->hdr.type, tracy::QueueType::LockObtain);
+  tracy::MemWrite(&item->lockObtain.thread, tracy::GetThreadHandle());
+  tracy::MemWrite(&item->lockObtain.id, lock_id);
+  tracy::MemWrite(&item->lockObtain.time, tracy::Profiler::GetTime());
+  tracy::Profiler::QueueSerialFinish();
+}
+
+void iree_tracing_mutex_after_unlock(uint32_t lock_id) {
+  auto item = tracy::Profiler::QueueSerial();
+  tracy::MemWrite(&item->hdr.type, tracy::QueueType::LockRelease);
+  tracy::MemWrite(&item->lockRelease.thread, tracy::GetThreadHandle());
+  tracy::MemWrite(&item->lockRelease.id, lock_id);
+  tracy::MemWrite(&item->lockRelease.time, tracy::Profiler::GetTime());
+  tracy::Profiler::QueueSerialFinish();
 }
 
 #endif  // IREE_TRACING_FEATURES

--- a/iree/compiler/Conversion/LinalgToSPIRV/Utils.h
+++ b/iree/compiler/Conversion/LinalgToSPIRV/Utils.h
@@ -29,7 +29,7 @@ class Value;
 class SubViewOp;
 class OperationFolder;
 class OpBuilder;
-struct LogicalResult;
+class LogicalResult;
 
 namespace iree_compiler {
 

--- a/iree/vm/bytecode_dispatch_util.h
+++ b/iree/vm/bytecode_dispatch_util.h
@@ -165,7 +165,7 @@ static const int kRegSize = sizeof(uint16_t);
 
 // Bytecode data access macros for reading values of a given type from a byte
 // offset within the current function.
-#if defined(IREE_IS_LITTLE_ENDIAN)
+#if defined(IREE_ENDIANNESS_LITTLE)
 #define OP_I8(i) bytecode_data[pc + (i)]
 #define OP_I16(i) *((uint16_t*)&bytecode_data[pc + (i)])
 #define OP_I32(i) *((uint32_t*)&bytecode_data[pc + (i)])
@@ -189,7 +189,7 @@ static const int kRegSize = sizeof(uint16_t);
       ((uint64_t)bytecode_data[pc + 5 + (i)] << 40) | \
       ((uint64_t)bytecode_data[pc + 6 + (i)] << 48) | \
       ((uint64_t)bytecode_data[pc + 7 + (i)] << 56)
-#endif  // IREE_IS_LITTLE_ENDIAN
+#endif  // IREE_ENDIANNESS_LITTLE
 
 //===----------------------------------------------------------------------===//
 // Utilities matching the tablegen op encoding scheme

--- a/iree/vm/bytecode_module.c
+++ b/iree/vm/bytecode_module.c
@@ -570,7 +570,7 @@ static iree_status_t iree_vm_bytecode_module_alloc_state(
     iree_vm_RodataSegmentDef_table_t segment =
         iree_vm_RodataSegmentDef_vec_at(rodata_segments, i);
     iree_vm_ro_byte_buffer_t* ref = &state->rodata_ref_table[i];
-    iree_atomic_store(&ref->ref_object.counter, 1);
+    iree_atomic_ref_count_init(&ref->ref_object.counter);
     ref->data.data = iree_vm_RodataSegmentDef_data(segment);
     ref->data.data_length =
         flatbuffers_uint8_vec_len(iree_vm_RodataSegmentDef_data(segment));

--- a/iree/vm/instance.c
+++ b/iree/vm/instance.c
@@ -18,7 +18,7 @@
 #include "iree/vm/builtin_types.h"
 
 struct iree_vm_instance {
-  iree_atomic_intptr_t ref_count;
+  iree_atomic_ref_count_t ref_count;
   iree_allocator_t allocator;
 };
 
@@ -33,7 +33,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_instance_create(
   IREE_RETURN_IF_ERROR(iree_allocator_malloc(
       allocator, sizeof(iree_vm_instance_t), (void**)&instance));
   instance->allocator = allocator;
-  iree_atomic_store(&instance->ref_count, 1);
+  iree_atomic_ref_count_init(&instance->ref_count);
 
   *out_instance = instance;
   return iree_ok_status();
@@ -47,13 +47,13 @@ static void iree_vm_instance_destroy(iree_vm_instance_t* instance) {
 IREE_API_EXPORT void IREE_API_CALL
 iree_vm_instance_retain(iree_vm_instance_t* instance) {
   if (instance) {
-    iree_atomic_fetch_add(&instance->ref_count, 1);
+    iree_atomic_ref_count_inc(&instance->ref_count);
   }
 }
 
 IREE_API_EXPORT void IREE_API_CALL
 iree_vm_instance_release(iree_vm_instance_t* instance) {
-  if (instance && iree_atomic_fetch_sub(&instance->ref_count, 1) == 1) {
+  if (instance && iree_atomic_ref_count_dec(&instance->ref_count) == 1) {
     iree_vm_instance_destroy(instance);
   }
 }

--- a/iree/vm/list.c
+++ b/iree/vm/list.c
@@ -138,7 +138,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_list_initialize(
   memset(storage.data, 0, required_storage_size);
 
   iree_vm_list_t* list = (iree_vm_list_t*)storage.data;
-  iree_atomic_store(&list->ref_object.counter, 1);
+  iree_atomic_ref_count_init(&list->ref_object.counter);
   if (element_type) {
     list->element_type = *element_type;
   }
@@ -164,7 +164,7 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_list_create(
   IREE_RETURN_IF_ERROR(
       iree_allocator_malloc(allocator, sizeof(iree_vm_list_t), (void**)&list));
   memset(list, 0, sizeof(*list));
-  iree_atomic_store(&list->ref_object.counter, 1);
+  iree_atomic_ref_count_init(&list->ref_object.counter);
   list->allocator = allocator;
   if (element_type) {
     list->element_type = *element_type;

--- a/iree/vm/module.c
+++ b/iree/vm/module.c
@@ -140,20 +140,20 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_vm_module_initialize(iree_vm_module_t* module, void* self) {
   memset(module, 0, sizeof(iree_vm_module_t));
   module->self = self;
-  iree_atomic_store(&module->ref_count, 1);
+  iree_atomic_ref_count_init(&module->ref_count);
   return iree_ok_status();
 }
 
 IREE_API_EXPORT void IREE_API_CALL
 iree_vm_module_retain(iree_vm_module_t* module) {
   if (module) {
-    iree_atomic_fetch_add(&module->ref_count, 1);
+    iree_atomic_ref_count_inc(&module->ref_count);
   }
 }
 
 IREE_API_EXPORT void IREE_API_CALL
 iree_vm_module_release(iree_vm_module_t* module) {
-  if (module && iree_atomic_fetch_sub(&module->ref_count, 1) == 1) {
+  if (module && iree_atomic_ref_count_dec(&module->ref_count) == 1) {
     module->destroy(module->self);
   }
 }

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -263,7 +263,7 @@ typedef struct {
 // TODO(benvanik): version this interface.
 typedef struct iree_vm_module {
   void* self;
-  iree_atomic_intptr_t ref_count;
+  iree_atomic_ref_count_t ref_count;
 
   // Destroys |self| when all references to the module have been released.
   void(IREE_API_PTR* destroy)(void* self);

--- a/iree/vm/ref.c
+++ b/iree/vm/ref.c
@@ -26,32 +26,32 @@
 // or something more complex).
 #define IREE_VM_MAX_TYPE_ID 64
 
-static inline volatile iree_atomic_intptr_t* iree_vm_get_raw_counter_ptr(
+static inline volatile iree_atomic_ref_count_t* iree_vm_get_raw_counter_ptr(
     void* ptr, const iree_vm_ref_type_descriptor_t* type_descriptor) {
-  return (volatile iree_atomic_intptr_t*)(((uintptr_t)(ptr)) +
-                                          type_descriptor->offsetof_counter);
+  return (volatile iree_atomic_ref_count_t*)(((uintptr_t)(ptr)) +
+                                             type_descriptor->offsetof_counter);
 }
 
-static inline volatile iree_atomic_intptr_t* iree_vm_get_ref_counter_ptr(
+static inline volatile iree_atomic_ref_count_t* iree_vm_get_ref_counter_ptr(
     iree_vm_ref_t* ref) {
-  return (volatile iree_atomic_intptr_t*)(((uintptr_t)ref->ptr) +
-                                          ref->offsetof_counter);
+  return (volatile iree_atomic_ref_count_t*)(((uintptr_t)ref->ptr) +
+                                             ref->offsetof_counter);
 }
 
 IREE_API_EXPORT void IREE_API_CALL iree_vm_ref_object_retain(
     void* ptr, const iree_vm_ref_type_descriptor_t* type_descriptor) {
   if (!ptr) return;
-  volatile iree_atomic_intptr_t* counter =
+  volatile iree_atomic_ref_count_t* counter =
       iree_vm_get_raw_counter_ptr(ptr, type_descriptor);
-  iree_atomic_fetch_add(counter, 1);
+  iree_atomic_ref_count_inc(counter);
 }
 
 IREE_API_EXPORT void IREE_API_CALL iree_vm_ref_object_release(
     void* ptr, const iree_vm_ref_type_descriptor_t* type_descriptor) {
   if (!ptr) return;
-  volatile iree_atomic_intptr_t* counter =
+  volatile iree_atomic_ref_count_t* counter =
       iree_vm_get_raw_counter_ptr(ptr, type_descriptor);
-  if (iree_atomic_fetch_sub(counter, 1) == 1) {
+  if (iree_atomic_ref_count_dec(counter) == 1) {
     if (type_descriptor->destroy) {
       // NOTE: this makes us not re-entrant, but I think that's OK.
       type_descriptor->destroy(ptr);
@@ -142,9 +142,9 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_ref_wrap_retain(
     void* ptr, iree_vm_ref_type_t type, iree_vm_ref_t* out_ref) {
   IREE_RETURN_IF_ERROR(iree_vm_ref_wrap_assign(ptr, type, out_ref));
   if (out_ref->ptr) {
-    volatile iree_atomic_intptr_t* counter =
+    volatile iree_atomic_ref_count_t* counter =
         iree_vm_get_ref_counter_ptr(out_ref);
-    iree_atomic_fetch_add(counter, 1);
+    iree_atomic_ref_count_inc(counter);
   }
   return iree_ok_status();
 }
@@ -167,9 +167,9 @@ IREE_API_EXPORT void IREE_API_CALL iree_vm_ref_retain(iree_vm_ref_t* ref,
   // Assign ref to out_ref and increment the counter.
   memcpy(out_ref, ref, sizeof(*out_ref));
   if (out_ref->ptr) {
-    volatile iree_atomic_intptr_t* counter =
+    volatile iree_atomic_ref_count_t* counter =
         iree_vm_get_ref_counter_ptr(out_ref);
-    iree_atomic_fetch_add(counter, 1);
+    iree_atomic_ref_count_inc(counter);
   }
 }
 
@@ -196,9 +196,9 @@ IREE_API_EXPORT void IREE_API_CALL iree_vm_ref_retain_or_move(
   memcpy(out_ref, ref, sizeof(*out_ref));
   if (out_ref->ptr && !is_move) {
     // Retain by incrementing counter and preserving the source ref.
-    volatile iree_atomic_intptr_t* counter =
+    volatile iree_atomic_ref_count_t* counter =
         iree_vm_get_ref_counter_ptr(out_ref);
-    iree_atomic_fetch_add(counter, 1);
+    iree_atomic_ref_count_inc(counter);
   } else if (ref != out_ref) {
     // Move by not changing counter and clearing the source ref.
     memset(ref, 0, sizeof(*ref));
@@ -220,8 +220,8 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_vm_ref_retain_or_move_checked(
 IREE_API_EXPORT void IREE_API_CALL iree_vm_ref_release(iree_vm_ref_t* ref) {
   if (ref->type == IREE_VM_REF_TYPE_NULL || ref->ptr == NULL) return;
 
-  volatile iree_atomic_intptr_t* counter = iree_vm_get_ref_counter_ptr(ref);
-  if (iree_atomic_fetch_sub(counter, 1) == 1) {
+  volatile iree_atomic_ref_count_t* counter = iree_vm_get_ref_counter_ptr(ref);
+  if (iree_atomic_ref_count_dec(counter) == 1) {
     const iree_vm_ref_type_descriptor_t* type_descriptor =
         iree_vm_ref_get_type_descriptor(ref->type);
     if (type_descriptor->destroy) {

--- a/iree/vm/ref.h
+++ b/iree/vm/ref.h
@@ -65,7 +65,7 @@ typedef enum {
 // Usage (C++):
 //  Prefer using RefObject as a base type.
 typedef struct {
-  iree_atomic_intptr_t counter;
+  iree_atomic_ref_count_t counter;
 } iree_vm_ref_object_t;
 
 // A pointer reference to a reference-counted object.
@@ -82,7 +82,7 @@ typedef struct {
   // Pointer to the object. Type is resolved based on the |type| field.
   // Will be NULL if the reference points to nothing.
   void* ptr;
-  // Offset from ptr, in bytes, to the start of an atomic_intptr_t representing
+  // Offset from ptr, in bytes, to the start of an atomic_int32_t representing
   // the current reference count. We store this here to avoid the need for an
   // indirection in the (extremely common) case of just reference count inc/dec.
   uint32_t offsetof_counter : 8;
@@ -103,7 +103,7 @@ typedef struct {
   // Function called when references of this type reach 0 and should be
   // destroyed.
   iree_vm_ref_destroy_t destroy;
-  // Offset from ptr, in bytes, to the start of an atomic_intptr_t representing
+  // Offset from ptr, in bytes, to the start of an atomic_int32_t representing
   // the current reference count.
   uint32_t offsetof_counter : 8;
   // The type ID assigned to this type from the iree_vm_ref_type_t table (or an

--- a/iree/vm/ref_test.cc
+++ b/iree/vm/ref_test.cc
@@ -69,8 +69,9 @@ static iree_vm_ref_t MakeRef() {
   return ref;
 }
 
-static intptr_t ReadCounter(iree_vm_ref_t* ref) {
-  return *((intptr_t*)(((uintptr_t)ref->ptr) + ref->offsetof_counter));
+static int32_t ReadCounter(iree_vm_ref_t* ref) {
+  return *((iree_atomic_ref_count_t*)(((uintptr_t)ref->ptr) +
+                                      ref->offsetof_counter));
 }
 
 static iree_vm_ref_type_t kCTypeID = IREE_VM_REF_TYPE_NULL;


### PR DESCRIPTION
These will be used to implement the task system used to execute CPU kernels. The mutex benchmarks show we are faster than std::mutex (due to some limitations we can accept) and we now have complete control over any cross-thread blocking behavior we want to introduce (to favor latency vs. power consumption, etc).

This is compatible with Windows, iOS/MacOS (following the Apple performance/power guidelines), Android/Linux, wasm/emscripten, and fallbacks for normal pthreads usage on other platforms. I've only optimized Windows right now but the other platforms shouldn't require much tweaking and when they do we have a benchmark to do it with.

Progress on #49.
Fixes #1482.