### PR TITLE
Moving hal.ex.dispatch to the runtime.

### DIFF
--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -103,9 +103,6 @@ static Value allocateOutputBuffer(Value streamValue, Value externalValue,
                                                   bufferUsage, allocationSize)
           .getResult();
 
-  // TODO(benvanik): implement resource sets.
-  rewriter.create<IREE::HAL::ExDeferReleaseOp>(loc, buffer);
-
   return buffer;
 }
 
@@ -159,9 +156,6 @@ static Value allocateTransientBuffer(Value streamValue, Value allocator,
           .create<IREE::HAL::AllocatorAllocateOp>(loc, allocator, memoryTypes,
                                                   bufferUsage, allocationSize)
           .getResult();
-
-  // TODO(benvanik): implement resource sets.
-  rewriter.create<IREE::HAL::ExDeferReleaseOp>(loc, buffer);
 
   return buffer;
 }
@@ -501,14 +495,6 @@ static LogicalResult recordTensorUpdate(Value device, Value commandBuffer,
   rewriter.create<IREE::HAL::CommandBufferCopyBufferOp>(
       updateOp.getLoc(), commandBuffer, update->getBuffer(), zeroOffset,
       result->getBuffer(), targetRange->offset, targetRange->length);
-
-  // TODO(benvanik): implement resource sets.
-  rewriter.create<IREE::HAL::ExDeferReleaseOp>(updateOp.getLoc(),
-                                               target->getBuffer());
-  rewriter.create<IREE::HAL::ExDeferReleaseOp>(updateOp.getLoc(),
-                                               update->getBuffer());
-  rewriter.create<IREE::HAL::ExDeferReleaseOp>(updateOp.getLoc(),
-                                               result->getBuffer());
 
   // Full barriers for now as we aren't scheduling things.
   // TODO(benvanik): don't add at the end of the command buffer (we could

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertTensorOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertTensorOps.cpp
@@ -77,9 +77,6 @@ class ConstantTensorOpConversion
     auto buffer = rewriter.createOrFold<IREE::HAL::AllocatorAllocateConstOp>(
         constantOp.getLoc(), allocator, memoryTypes, bufferUsage, elementsAttr);
 
-    // TODO(benvanik): implement resource sets.
-    rewriter.create<IREE::HAL::ExDeferReleaseOp>(constantOp.getLoc(), buffer);
-
     rewriter.replaceOp(constantOp, {buffer});
     return success();
   }

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/test/stream_ops.mlir
@@ -21,9 +21,7 @@ func @multipleDispatches(%arg0: tensor<128xf32>) -> tensor<128xf32> {
   // CHECK-DAG: %[[C128:.+]] = constant 128
   %cst = constant 128 : index
   // CHECK: %[[RET_BUF:.+]] = hal.allocator.allocate {{.+}}, "HostVisible|DeviceVisible|DeviceLocal", "Constant|Transfer|Mapping|Dispatch"
-  // CHECK-NEXT: hal.ex.defer_release %[[RET_BUF]]
   // CHECK: %[[TMP_BUF:.+]] = hal.allocator.allocate {{.+}}, "DeviceVisible|DeviceLocal", "Transfer|Dispatch"
-  // CHECK-NEXT: hal.ex.defer_release %[[TMP_BUF]]
   // CHECK: %[[CMD:.+]] = hal.command_buffer.create {{.+}}, "OneShot", "Transfer|Dispatch"
   // CHECK-NEXT: hal.command_buffer.begin %[[CMD]]
   %0 = flow.ex.stream.fragment(%arg1 = %cst : index, %arg2 = %arg0 : tensor<128xf32>) -> tensor<128xf32> {

--- a/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExperimentalOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExperimentalOps.cpp
@@ -25,8 +25,6 @@ void populateHALExperimentalToVMPatterns(MLIRContext *context,
                                          OwningRewritePatternList &patterns) {
   patterns.insert<VMImportOpConversion<IREE::HAL::ExSharedDeviceOp>>(
       context, importSymbols, typeConverter, "hal.ex.shared_device");
-  patterns.insert<VMImportOpConversion<IREE::HAL::ExDeferReleaseOp>>(
-      context, importSymbols, typeConverter, "hal.ex.defer_release");
   patterns.insert<VMImportOpConversion<IREE::HAL::ExSubmitAndWaitOp>>(
       context, importSymbols, typeConverter, "hal.ex.submit_and_wait");
 }

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -50,15 +50,6 @@ def HAL_ExSharedDeviceOp : HAL_PureOp<"ex.shared_device", [
   ];
 }
 
-// TODO(benvanik): replace with resource sets.
-def HAL_ExDeferReleaseOp : HAL_Op<"ex.defer_release"> {
-  let arguments = (ins
-    HAL_ObjectType:$operand
-  );
-
-  let assemblyFormat = "$operand `:` type($operand) attr-dict";
-}
-
 def HAL_ExSubmitAndWaitOp : HAL_Op<"ex.submit_and_wait", [YieldPoint]> {
   let arguments = (ins
     HAL_Device:$device,

--- a/iree/compiler/Dialect/HAL/hal.imports.mlir
+++ b/iree/compiler/Dialect/HAL/hal.imports.mlir
@@ -11,10 +11,6 @@ vm.module @hal {
 vm.import @ex.shared_device() -> !vm.ref<!hal.device>
 attributes {nosideeffects}
 
-vm.import @ex.defer_release(
-  %operand : !vm.ref<?>
-)
-
 vm.import @ex.submit_and_wait(
   %device : !vm.ref<!hal.device>,
   %command_buffer : !vm.ref<!hal.command_buffer>


### PR DESCRIPTION
This will eventually be replaced with resource sets as a pure runtime
HAL module bit of tracking, so there's no need to preserve the TODO
reminder op through the compiler. This also has the benefit of
being safer (the reason to do the tracking on the runtime) but also
speeds up/shrinks all compiled modules as now a few thousand ops can
go away.