### PR TITLE
Working around lack of mlir symbol side effects for variable loads.

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -192,6 +192,18 @@ void VariableOp::build(OpBuilder &builder, OperationState &result,
 // flow.variable.load
 //===----------------------------------------------------------------------===//
 
+void VariableLoadOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  // HACK: works around the lack of symbol side effects in mlir by only saying
+  // we have a side-effect if the variable we are loading is mutable.
+  auto *symbolOp = SymbolTable::lookupNearestSymbolFrom(*this, variable());
+  assert(symbolOp);
+  auto variableOp = dyn_cast<VariableOp>(symbolOp);
+  if (variableOp.is_mutable()) {
+    effects.emplace_back(MemoryEffects::Read::get());
+  }
+}
+
 static LogicalResult verifyVariableLoadOp(VariableLoadOp &op) {
   auto *symbolOp = SymbolTable::lookupNearestSymbolFrom(op, op.variable());
   if (!symbolOp) {

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -84,7 +84,10 @@ def FLOW_VariableAddressOp : FLOW_PureOp<"variable.address"> {
   let assemblyFormat = "$variable attr-dict `:` type($result)";
 }
 
-def FLOW_VariableLoadOp : FLOW_Op<"variable.load", [MemoryEffects<[MemRead]>]> {
+def FLOW_VariableLoadOp : FLOW_Op<"variable.load", [
+    // HACK: works around the lack of symbol side effects in C++.
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  ]> {
   let summary = [{loads a value from a global variable}];
   let description = [{
     Returns a copy of the variable value.
@@ -200,8 +203,8 @@ def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
     /// the new DispatchRegionOp and anchor operation within the region.
     /// Returns llvm::None on failure.
     /// The insertion point of the OpBuilder will be modified.
-    static llvm::Optional<std::pair<DispatchRegionOp, Operation *>> 
-        formFromAnchorOp(Value workload, Operation *anchorOp, 
+    static llvm::Optional<std::pair<DispatchRegionOp, Operation *>>
+        formFromAnchorOp(Value workload, Operation *anchorOp,
                          OpBuilder &builder);
 
     /// Performs an in-place DCE optimization on unused operands and results.
@@ -227,7 +230,7 @@ def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
     /// into an adjacent dispatch region.
     /// Note that the original op is cloned but not erased. It is up to the
     /// caller to cleanup the original op as needed.
-    Operation *inlineOp(Operation *origOp, OpBuilder &builder, 
+    Operation *inlineOp(Operation *origOp, OpBuilder &builder,
         bool positionAtEnd=false);
   }];
 
@@ -240,7 +243,7 @@ def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
     }]>,
   ];
 
-  let hasCanonicalizer = 1;  
+  let hasCanonicalizer = 1;
 }
 
 def FLOW_ReturnOp : FLOW_Op<"return", [Terminator]> {

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -200,7 +200,10 @@ def HAL_VariableAddressOp : HAL_PureOp<"variable.address"> {
   let assemblyFormat = "$variable attr-dict `:` type($result)";
 }
 
-def HAL_VariableLoadOp : HAL_Op<"variable.load", [MemoryEffects<[MemRead]>]> {
+def HAL_VariableLoadOp : HAL_Op<"variable.load", [
+    // HACK: works around the lack of symbol side effects in C++.
+    DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+  ]> {
   let summary = [{loads a value from a global variable}];
   let description = [{
     Returns a copy of the variable value.

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -382,6 +382,8 @@ def VM_GlobalAddressOp : VM_PureOp<"global.address"> {
 class VM_GlobalLoadOp<Type type, string mnemonic, list<OpTrait> traits = []> :
     VM_Op<mnemonic, !listconcat(traits, [
       DeclareOpInterfaceMethods<VM_SerializableOpInterface>,
+      // HACK: works around the lack of symbol side effects in C++.
+      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
     ])> {
   let arguments = (ins
     VM_GlobalRefAttr:$global


### PR DESCRIPTION
This turns flow/hal/vm variable loads into pure ops when the variable they
reference is immutable. This allows CSE and DCE to work its magic.

Partially helps with #1145, though only in specific cases of CSE-able
values. Thankfully the mix of CSE-able to non-CSE-able is about 1000:1 in
BERT, so this is worth doing (and can be easily replaced with symbol-based
side-effects when MLIR gains them).