### PR TITLE
Tracing improvements for the VM, executables, and iree-benchmark-module.

### DIFF
--- a/iree/base/api.h
+++ b/iree/base/api.h
@@ -540,6 +540,13 @@ typedef void* iree_status_t;
   if (IREE_UNLIKELY(var)) {                                                  \
     return IREE_STATUS_IMPL_ANNOTATE_SWITCH_(var, __VA_ARGS__);              \
   }
+#define IREE_STATUS_IMPL_RETURN_AND_EVAL_IF_API_ERROR_(tail_expr, var, ...)  \
+  iree_status_t var = (IREE_STATUS_IMPL_IDENTITY_(                           \
+      IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_GET_EXPR_)(__VA_ARGS__))); \
+  if (IREE_UNLIKELY(var)) {                                                  \
+    (tail_expr);                                                             \
+    return IREE_STATUS_IMPL_ANNOTATE_SWITCH_(var, __VA_ARGS__);              \
+  }
 #define IREE_STATUS_IMPL_IGNORE_ERROR_(var, expr) \
   iree_status_t var = (expr);                     \
   if (IREE_UNLIKELY(var)) iree_status_ignore(var);
@@ -552,6 +559,14 @@ typedef void* iree_status_t;
 #define IREE_STATUS_IMPL_RETURN_IF_API_ERROR_(var, expr, ...) \
   iree_status_t var = (expr);                                 \
   if (IREE_UNLIKELY(var)) return var;
+#undef IREE_STATUS_IMPL_RETURN_AND_EVAL_IF_API_ERROR_
+#define IREE_STATUS_IMPL_RETURN_AND_EVAL_IF_API_ERROR_(tail_expr, var, expr, \
+                                                       ...)                  \
+  iree_status_t var = (expr);                                                \
+  if (IREE_UNLIKELY(var)) {                                                  \
+    (tail_expr);                                                             \
+    return var;                                                              \
+  }
 #undef IREE_STATUS_IMPL_IGNORE_ERROR_
 #define IREE_STATUS_IMPL_IGNORE_ERROR_(var, expr) \
   iree_status_t var = (expr);                     \
@@ -591,6 +606,12 @@ typedef void* iree_status_t;
 #define IREE_RETURN_IF_ERROR(...)                       \
   IREE_STATUS_IMPL_RETURN_IF_API_ERROR_(                \
       IREE_STATUS_IMPL_CONCAT_(__status_, __COUNTER__), \
+      IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_IDENTITY_(__VA_ARGS__)))
+
+// IREE_RETURN_IF_ERROR with a custom expression to evaluate before returning.
+#define IREE_RETURN_AND_EVAL_IF_ERROR(tail_expr, ...)              \
+  IREE_STATUS_IMPL_RETURN_AND_EVAL_IF_API_ERROR_(                  \
+      tail_expr, IREE_STATUS_IMPL_CONCAT_(__status_, __COUNTER__), \
       IREE_STATUS_IMPL_IDENTITY_(IREE_STATUS_IMPL_IDENTITY_(__VA_ARGS__)))
 
 // Ignores the status result of (expr) regardless of its value.

--- a/iree/base/flatbuffer_util.cc
+++ b/iree/base/flatbuffer_util.cc
@@ -66,8 +66,7 @@ Status FlatBufferFileBase::FromBuffer(Identifier identifier,
                                       std::function<void()> deleter,
                                       size_t root_type_size,
                                       VerifierFn verifier_fn) {
-  IREE_TRACE_SCOPE("FlatBufferFileBase::FromBuffer:size", int)
-  (static_cast<int>(buffer_data.size()));
+  IREE_TRACE_SCOPE();
 
   // Sanity check buffer for the minimum size as FlatBuffers doesn't.
   if (buffer_data.size() < 16) {

--- a/iree/hal/device_manager.cc
+++ b/iree/hal/device_manager.cc
@@ -108,8 +108,7 @@ StatusOr<ref_ptr<Buffer>> DeviceManager::TryAllocateDeviceVisibleBuffer(
     MemoryTypeBitfield memory_type, BufferUsageBitfield buffer_usage,
     device_size_t allocation_size,
     absl::Span<const DevicePlacement> device_placements) {
-  IREE_TRACE_SCOPE("DeviceManager::TryAllocateDeviceVisibleBuffer:size", int)
-  (static_cast<int>(allocation_size));
+  IREE_TRACE_SCOPE0("DeviceManager::TryAllocateDeviceVisibleBuffer:size");
   if (!AnyBitSet(memory_type & MemoryType::kHostLocal)) {
     return InvalidArgumentErrorBuilder(IREE_LOC)
            << "Host-local buffers require the kHostLocal bit: "
@@ -138,8 +137,7 @@ StatusOr<ref_ptr<Buffer>> DeviceManager::AllocateDeviceVisibleBuffer(
     MemoryTypeBitfield memory_type, BufferUsageBitfield buffer_usage,
     device_size_t allocation_size,
     absl::Span<const DevicePlacement> device_placements) {
-  IREE_TRACE_SCOPE("DeviceManager::AllocateDeviceVisibleBuffer:size", int)
-  (static_cast<int>(allocation_size));
+  IREE_TRACE_SCOPE0("DeviceManager::AllocateDeviceVisibleBuffer:size");
   if (!AnyBitSet(memory_type & MemoryType::kHostLocal)) {
     return InvalidArgumentErrorBuilder(IREE_LOC)
            << "Host-local buffers require the kHostLocal bit: "
@@ -160,8 +158,7 @@ StatusOr<ref_ptr<Buffer>> DeviceManager::AllocateDeviceLocalBuffer(
     MemoryTypeBitfield memory_type, BufferUsageBitfield buffer_usage,
     device_size_t allocation_size,
     absl::Span<const DevicePlacement> device_placements) {
-  IREE_TRACE_SCOPE("DeviceManager::AllocateDeviceLocalBuffer:size", int)
-  (static_cast<int>(allocation_size));
+  IREE_TRACE_SCOPE0("DeviceManager::AllocateDeviceLocalBuffer:size");
   if (!AnyBitSet(memory_type & MemoryType::kDeviceLocal)) {
     return InvalidArgumentErrorBuilder(IREE_LOC)
            << "Device-local buffers require the kDeviceLocal bit: "

--- a/iree/hal/dylib/dylib_executable.h
+++ b/iree/hal/dylib/dylib_executable.h
@@ -21,6 +21,7 @@
 #include "absl/container/inlined_vector.h"
 #include "iree/base/dynamic_library.h"
 #include "iree/base/status.h"
+#include "iree/base/tracing.h"
 #include "iree/hal/executable_spec.h"
 #include "iree/hal/host/host_executable.h"
 
@@ -50,6 +51,10 @@ class DyLibExecutable final : public HostExecutable {
   std::string executable_library_temp_path_;
   std::unique_ptr<DynamicLibrary> executable_library_;
   absl::InlinedVector<void*, 4> entry_functions_;
+
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+  absl::InlinedVector<const char*, 4> entry_names_;
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 };
 
 }  // namespace dylib

--- a/iree/hal/host/BUILD
+++ b/iree/hal/host/BUILD
@@ -55,6 +55,7 @@ cc_library(
     deps = [
         "//iree/base:logging",
         "//iree/base:status",
+        "//iree/base:tracing",
         "//iree/hal:buffer",
     ],
 )

--- a/iree/hal/host/CMakeLists.txt
+++ b/iree/hal/host/CMakeLists.txt
@@ -55,6 +55,7 @@ iree_cc_library(
   DEPS
     iree::base::logging
     iree::base::status
+    iree::base::tracing
     iree::hal::buffer
   PUBLIC
 )

--- a/iree/hal/host/host_buffer.cc
+++ b/iree/hal/host/host_buffer.cc
@@ -20,6 +20,7 @@
 
 #include "iree/base/logging.h"
 #include "iree/base/status.h"
+#include "iree/base/tracing.h"
 
 namespace iree {
 namespace hal {
@@ -36,6 +37,7 @@ HostBuffer::HostBuffer(Allocator* allocator, MemoryTypeBitfield memory_type,
       owns_data_(owns_data) {}
 
 HostBuffer::~HostBuffer() {
+  IREE_TRACE_SCOPE();
   if (owns_data_ && data_) {
     std::free(data_);
     data_ = nullptr;

--- a/iree/hal/vmla/vmla_executable.cc
+++ b/iree/hal/vmla/vmla_executable.cc
@@ -156,8 +156,9 @@ VMLAExecutable::PrepareDispatch(const DispatchParams& params) {
 
 Status VMLAExecutable::DispatchTile(DispatchState* state,
                                     std::array<uint32_t, 3> workgroup_xyz) {
-  IREE_TRACE_SCOPE0("VMLAExecutable::DispatchTile");
   auto* dispatch_state = static_cast<VMLADispatchState*>(state);
+  IREE_TRACE_SCOPE_DYNAMIC(
+      iree_vm_function_name(&dispatch_state->function).data);
 
   auto* input_list_storage = alloca(dispatch_state->input_list_size);
   iree_vm_list_t* input_list = nullptr;

--- a/iree/modules/hal/hal_module.cc
+++ b/iree/modules/hal/hal_module.cc
@@ -156,10 +156,13 @@ class HALModuleState final {
     IREE_RETURN_IF_ERROR(iree_hal_semaphore_wait_with_deadline(
         semaphore.get(), 1ull, IREE_TIME_INFINITE_FUTURE));
 
-    for (auto& ref : deferred_releases_) {
-      iree_vm_ref_release(&ref);
+    {
+      IREE_TRACE_SCOPE0("HALModuleState::DeferredReleases");
+      for (auto& ref : deferred_releases_) {
+        iree_vm_ref_release(&ref);
+      }
+      deferred_releases_.clear();
     }
-    deferred_releases_.clear();
 
     return OkStatus();
   }

--- a/iree/vm/BUILD
+++ b/iree/vm/BUILD
@@ -170,6 +170,7 @@ cc_library(
         ":builtin_types",
         "//iree/base:api",
         "//iree/base:atomics",
+        "//iree/base:tracing",
     ],
 )
 
@@ -221,6 +222,7 @@ cc_library(
         "//iree/base:alignment",
         "//iree/base:api",
         "//iree/base:atomics",
+        "//iree/base:tracing",
     ],
 )
 

--- a/iree/vm/CMakeLists.txt
+++ b/iree/vm/CMakeLists.txt
@@ -190,6 +190,7 @@ iree_cc_library(
     ::builtin_types
     iree::base::api
     iree::base::atomics
+    iree::base::tracing
   PUBLIC
 )
 
@@ -251,6 +252,7 @@ iree_cc_library(
     iree::base::alignment
     iree::base::api
     iree::base::atomics
+    iree::base::tracing
   PUBLIC
 )
 

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -14,6 +14,7 @@
 
 #include <string.h>
 
+#include "iree/base/tracing.h"
 #include "iree/vm/bytecode_dispatch_util.h"
 #include "iree/vm/list.h"
 

--- a/iree/vm/module.c
+++ b/iree/vm/module.c
@@ -17,6 +17,7 @@
 #include <string.h>
 
 #include "iree/base/atomics.h"
+#include "iree/base/tracing.h"
 #include "iree/vm/ref.h"
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL
@@ -138,9 +139,11 @@ iree_vm_function_call_release(iree_vm_function_call_t* call,
 
 IREE_API_EXPORT iree_status_t IREE_API_CALL
 iree_vm_module_initialize(iree_vm_module_t* module, void* self) {
+  IREE_TRACE_ZONE_BEGIN(z0);
   memset(module, 0, sizeof(iree_vm_module_t));
   module->self = self;
   iree_atomic_ref_count_init(&module->ref_count);
+  IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
 
@@ -225,8 +228,10 @@ iree_vm_function_signature(const iree_vm_function_t* function) {
 IREE_API_EXPORT iree_string_view_t IREE_API_CALL
 iree_vm_function_reflection_attr(const iree_vm_function_t* function,
                                  iree_string_view_t key) {
+  IREE_TRACE_ZONE_BEGIN(z0);
   iree_vm_module_t* module = function->module;
   if (!module->get_function_reflection_attr) {
+    IREE_TRACE_ZONE_END(z0);
     return iree_string_view_empty();
   }
   for (int index = 0;; ++index) {
@@ -239,9 +244,11 @@ iree_vm_function_reflection_attr(const iree_vm_function_t* function,
       break;
     }
     if (iree_string_view_compare(key, index_key) == 0) {
+      IREE_TRACE_ZONE_END(z0);
       return index_value;
     }
   }
+  IREE_TRACE_ZONE_END(z0);
   return iree_string_view_empty();
 }
 

--- a/iree/vm/stack.h
+++ b/iree/vm/stack.h
@@ -20,6 +20,7 @@
 
 #include "iree/base/alignment.h"
 #include "iree/base/api.h"
+#include "iree/base/tracing.h"
 #include "iree/vm/module.h"
 #include "iree/vm/ref.h"
 
@@ -85,6 +86,10 @@ typedef struct iree_vm_stack_frame {
   // offset (such as in the case of VM bytecode), a block identifier (compiled
   // code), etc.
   iree_vm_source_offset_t pc;
+
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+  iree_zone_id_t trace_zone;
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 } iree_vm_stack_frame_t;
 
 // Returns the implementation-defined frame storage associated with |frame|.


### PR DESCRIPTION
* Adds new 'Iterations' counter for easy navigation in iree-benchmark-module traces
* Adds BM_* zones to traces
* Removes warmup run (no longer useful with constant pooling)
![image](https://user-images.githubusercontent.com/75337/96683640-465fb480-132f-11eb-9fae-5d52c236b62a.png)
* Adds a good deal of zones to the VM and bytecode functions
![image](https://user-images.githubusercontent.com/75337/96683732-668f7380-132f-11eb-96db-90976ceb2508.png)
* Adds executable zones for VMLA and dylib, showing the original flow.executable/hal.executable names
![image](https://user-images.githubusercontent.com/75337/96684053-d43b9f80-132f-11eb-8a58-3985d0cc0896.png)

Future changes will improve the bytecode function information to include source locations. Today they cannot show in statistics as they all have the same source location (of our C code). Executables names will show but do not link back to their original source information in mlir; you have to export the flow/hal files to see.