### PR TITLE
Adding a demonstration of using the flow dialect post-partitioning.

### DIFF
--- a/iree/test/e2e/hackability/BUILD
+++ b/iree/test/e2e/hackability/BUILD
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tests for end-to-end IREE support of specific features to prevent regression.
+# These should focus on support by IREE itself, not for issues with specific runner tools. Place
+# those tests in https://github.com/google/iree/tree/main/iree/tools/test/
+
+load("//iree:lit_test.bzl", "iree_lit_test_suite")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+iree_lit_test_suite(
+    name = "lit",
+    srcs = glob(["*.mlir"]),
+    data = [
+        "//iree/tools:IreeFileCheck",
+        "//iree/tools:iree-run-mlir",
+    ],
+    tags = ["hostonly"],
+)

--- a/iree/test/e2e/hackability/CMakeLists.txt
+++ b/iree/test/e2e/hackability/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+file(GLOB _GLOB_X_MLIR LIST_DIRECTORIES false RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} CONFIGURE_DEPENDS *.mlir)
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "${_GLOB_X_MLIR}"
+  DATA
+    iree::tools::IreeFileCheck
+    iree::tools::iree-run-mlir
+  LABELS
+    "hostonly"
+)

--- a/iree/test/e2e/hackability/flow_partitioned.mlir
+++ b/iree/test/e2e/hackability/flow_partitioned.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-run-mlir -export-all -iree-hal-target-backends=vmla %s | IreeFileCheck %s
+// RUN: [[ $IREE_LLVMJIT_DISABLE == 1 ]] || (iree-run-mlir -export-all -iree-hal-target-backends=llvm-ir %s | IreeFileCheck %s)
+
+flow.executable @ex0 {
+  flow.dispatch.entry @dispatch0 attributes {workload = 4 : index}
+  module {
+    func @dispatch0(%arg0: tensor<4xf32>) -> tensor<4xf32> {
+      %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
+      return %0 : tensor<4xf32>
+    }
+  }
+}
+
+// CHECK-LABEL: EXEC @staticShapedFn
+func @staticShapedFn() -> tensor<4xf32> {
+  %input = iree.unfoldable_constant dense<[-1.0, 2.0, -3.0, 4.0]> : tensor<4xf32>
+  %workload = constant 4 : index
+  %0 = flow.dispatch @ex0::@dispatch0[%workload : index](%input) : (tensor<4xf32>) -> tensor<4xf32>
+  return %0 : tensor<4xf32>
+}
+// CHECK: 4xf32=-2 4 -6 8


### PR DESCRIPTION
Demonstration of adding arbitrary tensor ops to a flow.executable and how to call them.

Viewing the LLVM-IR output can be done with the following:
```
iree-opt -split-input-file -pass-pipeline=iree-flow-transformation-pipeline,iree-hal-transformation-pipeline{serialize-executables=false},canonicalize -iree-hal-target-backends=llvm-ir iree/test/e2e/hackability/flow_partitioned.mlir
```

Example output:
```mlir
module {
  hal.variable @_device_match_id_0 init(@_device_match_id_0_initializer) : i1 attributes {sym_visibility = "private"}
  func @_device_match_id_0_initializer() -> i1 attributes {sym_visibility = "private"} {
    %dev = hal.ex.shared_device : !hal.device
    %0 = hal.device.match.id %dev, pattern = ["llvm-ir*"] : (!hal.device) -> i1
    return %0 : i1
  }
  hal.variable @"_executable_flow_partitioned-linked-llvm_ir" mutable : !hal.executable attributes {sym_visibility = "private"}
  hal.variable @_descriptor_set_layout_0 init(@_descriptor_set_layout_0_initializer) : !hal.descriptor_set_layout attributes {sym_visibility = "private"}
  func @_descriptor_set_layout_0_initializer() -> !hal.descriptor_set_layout attributes {sym_visibility = "private"} {
    %dev = hal.ex.shared_device : !hal.device
    %descriptor_set_layout = hal.descriptor_set_layout.create %dev, "PushOnly", bindings = [#hal.descriptor_set_layout_binding<0, "StorageBuffer", "Read">, #hal.descriptor_set_layout_binding<1, "StorageBuffer", "Write|Discard">] : !hal.descriptor_set_layout
    return %descriptor_set_layout : !hal.descriptor_set_layout
  }
  hal.variable @_executable_layout_0 init(@_executable_layout_0_initializer) : !hal.executable_layout attributes {sym_visibility = "private"}
  func @_executable_layout_0_initializer() -> !hal.executable_layout attributes {sym_visibility = "private"} {
    %0 = hal.variable.load @_descriptor_set_layout_0 : !hal.descriptor_set_layout
    %dev = hal.ex.shared_device : !hal.device
    %executable_layout = hal.executable_layout.create %dev, set_layouts = [%0], push_constants = 0 : !hal.executable_layout
    return %executable_layout : !hal.executable_layout
  }
  hal.variable @_executable_cache init(@_executable_cache_initializer) : !hal.executable_cache
  func @_executable_cache_initializer() -> !hal.executable_cache attributes {sym_visibility = "private"} {
    %dev = hal.ex.shared_device : !hal.device
    %executable_cache_default = hal.executable_cache.create %dev, identifier = "default" : !hal.executable_cache
    %0 = hal.variable.load @_device_match_id_0 : i1
    cond_br %0, ^bb1, ^bb2
  ^bb1:  // pred: ^bb0
    %1 = hal.variable.load @_executable_layout_0 : !hal.executable_layout
    %executable_flow_partitioned-linked-llvm_ir = hal.executable_cache.prepare %executable_cache_default, layout = %1, caching_mode = "AliasProvidedData|AllowPersistentCaching|AllowOptimization", @"flow_partitioned-linked-llvm_ir" : !hal.executable
    hal.variable.store %executable_flow_partitioned-linked-llvm_ir, @"_executable_flow_partitioned-linked-llvm_ir" : !hal.executable
    return %executable_cache_default : !hal.executable_cache
  ^bb2:  // pred: ^bb0
    iree.unreachable
  }
  hal.executable @"flow_partitioned-linked-llvm_ir" attributes {sym_visibility = "private"} {
    hal.interface @legacy_io_0 {
      hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
      hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
    }
    hal.executable.target @llvm_ir, filter="llvm-ir*" {
      hal.executable.entry_point @dispatch0 attributes {interface = @legacy_io_0, ordinal = 0 : i32, signature = (tensor<4xf32>) -> tensor<4xf32>}
      module {
        llvm.func @dispatch0(%arg0: !llvm.ptr<ptr<i8>>, %arg1: !llvm.ptr<i32>) {
          %0 = llvm.bitcast %arg0 : !llvm.ptr<ptr<i8>> to !llvm.ptr<struct<(ptr<float>, ptr<float>)>>
          %1 = llvm.load %0 : !llvm.ptr<struct<(ptr<float>, ptr<float>)>>
          %2 = llvm.extractvalue %1[0] : !llvm.struct<(ptr<float>, ptr<float>)>
          %3 = llvm.mlir.undef : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %4 = llvm.insertvalue %2, %3[0] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %5 = llvm.insertvalue %2, %4[1] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %6 = llvm.mlir.constant(0 : index) : !llvm.i64
          %7 = llvm.insertvalue %6, %5[2] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %8 = llvm.mlir.constant(4 : index) : !llvm.i64
          %9 = llvm.insertvalue %8, %7[3, 0] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %10 = llvm.mlir.constant(1 : index) : !llvm.i64
          %11 = llvm.insertvalue %10, %9[4, 0] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %12 = llvm.extractvalue %1[1] : !llvm.struct<(ptr<float>, ptr<float>)>
          %13 = llvm.insertvalue %12, %3[0] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %14 = llvm.insertvalue %12, %13[1] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %15 = llvm.insertvalue %6, %14[2] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %16 = llvm.insertvalue %8, %15[3, 0] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %17 = llvm.insertvalue %10, %16[4, 0] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          llvm.br ^bb1(%6 : !llvm.i64)
        ^bb1(%18: !llvm.i64):  // 2 preds: ^bb0, ^bb2
          %19 = llvm.icmp "slt" %18, %8 : !llvm.i64
          llvm.cond_br %19, ^bb2, ^bb3
        ^bb2:  // pred: ^bb1
          %20 = llvm.extractvalue %11[1] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %21 = llvm.mul %18, %10 : !llvm.i64
          %22 = llvm.add %6, %21 : !llvm.i64
          %23 = llvm.getelementptr %20[%22] : (!llvm.ptr<float>, !llvm.i64) -> !llvm.ptr<float>
          %24 = llvm.load %23 : !llvm.ptr<float>
          %25 = llvm.load %23 : !llvm.ptr<float>
          %26 = llvm.fadd %24, %25 : !llvm.float
          %27 = llvm.extractvalue %17[1] : !llvm.struct<(ptr<float>, ptr<float>, i64, array<1 x i64>, array<1 x i64>)>
          %28 = llvm.getelementptr %27[%22] : (!llvm.ptr<float>, !llvm.i64) -> !llvm.ptr<float>
          llvm.store %26, %28 : !llvm.ptr<float>
          %29 = llvm.add %18, %10 : !llvm.i64
          llvm.br ^bb1(%29 : !llvm.i64)
        ^bb3:  // pred: ^bb1
          llvm.return
        }
      }
    }
  }
  func @staticShapedFn() -> !hal.buffer {
    %c-1 = constant -1 : index
    %c0 = constant 0 : index
    %c16 = constant 16 : index
    %c1 = constant 1 : index
    %dev = hal.ex.shared_device : !hal.device
    %allocator = hal.device.allocator %dev : !hal.allocator
    %0 = iree.byte_buffer.constant : !iree.byte_buffer = dense<[-1.000000e+00, 2.000000e+00, -3.000000e+00, 4.000000e+00]> : tensor<4xf32>
    %mapped = hal.allocator.map %allocator, "HostVisible|DeviceVisible|DeviceLocal", "Constant|Transfer|Mapping|Dispatch", %0[%c0, %c-1] : !iree.byte_buffer -> !hal.buffer
    %1 = iree.do_not_optimize(%mapped) : !hal.buffer
    %buffer = hal.allocator.allocate %allocator, "HostVisible|DeviceVisible|DeviceLocal", "Constant|Transfer|Mapping|Dispatch", %c16 : !hal.buffer
    %cmd = hal.command_buffer.create %dev, "OneShot", "Transfer|Dispatch" : !hal.command_buffer
    hal.command_buffer.begin %cmd
    %2 = hal.variable.load @_executable_layout_0 : !hal.executable_layout
    hal.command_buffer.push_descriptor_set %cmd, %2, set=0, bindings=[0 = (%1, %c0, %c16), 1 = (%buffer, %c0, %c16)]
    %3 = hal.variable.load @_device_match_id_0 : i1
    cond_br %3, ^bb1, ^bb2
  ^bb1:  // pred: ^bb0
    %4 = hal.variable.load @"_executable_flow_partitioned-linked-llvm_ir" : !hal.executable
    hal.command_buffer.dispatch %cmd, %4, entry_point = 0, workgroup_xyz = [%c1, %c1, %c1]
    %memory_barrier = hal.make_memory_barrier "DispatchWrite", "DispatchRead" : tuple<i32, i32>
    hal.command_buffer.execution_barrier %cmd, "Dispatch|CommandRetire", "CommandIssue|Dispatch", memory_barriers=[%memory_barrier]
    hal.command_buffer.end %cmd
    hal.ex.submit_and_wait %dev, %cmd
    return %buffer : !hal.buffer
  ^bb2:  // pred: ^bb0
    iree.unreachable
  }
}
```

To compile and run in one step:
```
iree-run-mlir -export-all -iree-hal-target-backends=llvm-ir iree/test/e2e/hackability/flow_partitioned.mlir
```

