### PR TITLE
Relax PadOp to being able to be a leaf op.

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/test/pad.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pad.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-on-buffers -canonicalize %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-codegen-hlo-to-linalg-pipeline -canonicalize %s | IreeFileCheck %s
 
 module {
   func @pad_cst() {
@@ -21,9 +21,9 @@ module {
 // CHECK_LABEL: @pad_cst
 //   CHECK-DAG: %[[CST:.+]] = constant 0.000000e+00 : f32
 //   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
-//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
+//   CHECK-DAG: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
 //       CHECK: linalg.fill(%[[OUT]], %[[CST]])
-//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
+//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
 //       CHECK: linalg.copy(%[[IN]], %[[SUBVIEW]])
 
 // -----
@@ -49,11 +49,11 @@ module {
 }
 // CHECK_LABEL: @pad_memref
 //   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
-//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
 //   CHECK-DAG: %[[PAD_BUF:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<f32>
-//       CHECK: %[[PAD_VAL:.+]] = load %[[PAD_BUF]][] : memref<f32>
+//   CHECK-DAG: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
+//   CHECK-DAG: %[[PAD_VAL:.+]] = load %[[PAD_BUF]][] : memref<f32>
+//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<12x4xf32>
 //       CHECK: linalg.fill(%[[OUT]], %[[PAD_VAL]])
-//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
 //       CHECK: linalg.copy(%[[IN]], %[[SUBVIEW]])
 
 // -----
@@ -84,10 +84,10 @@ module {
 // -----
 
 module {
-  func @cst_pad_cst() {
+  func @cst_pad_memref() {
     %c0 = constant 0 : index
-    %0 = constant dense<1.0> : tensor<12x4xf32>
-    %1 = constant dense<0.0> : tensor<f32>
+    %0 = constant dense<0.0> : tensor<12x4xf32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<f32>
     %2 = "mhlo.pad"(%0, %1) {
       edge_padding_high = dense<[2, 3]> : tensor<2xi64>,
       edge_padding_low = dense<[4, 5]> : tensor<2xi64>,
@@ -97,13 +97,73 @@ module {
     return
   }
   hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
     hal.interface.binding @ret0, set=0, binding=0, type="StorageBuffer", access="Write"
   }
 }
-// CHECK_LABEL: @cst_pad_cst
+// CHECK_LABEL: @cst_pad_memref
 //   CHECK-DAG: %[[ZERO:.+]] = constant 0.000000e+00 : f32
-//   CHECK-DAG: %[[ONE:.+]] = constant 1.000000e+00 : f32
 //   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<18x12xf32>
+//   CHECK-DAG: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
+//   CHECK-DAG: %[[PAD_BUF:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<f32>
+//   CHECK-DAG: %[[PAD_VAL:.+]] = load %[[PAD_BUF]][] : memref<f32>
+//       CHECK: linalg.fill(%[[OUT]], %[[PAD_VAL]])
+//       CHECK: linalg.fill(%[[SUBVIEW]], %[[ZERO]])
+
+// -----
+
+module {
+  func @add_pad_cst() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x3xi32>
+    %cst = constant dense<0> : tensor<i32>
+    %1 = mhlo.add %0, %0 : tensor<2x3xi32>
+    %2 = "mhlo.pad"(%1, %cst) {edge_padding_high = dense<[1, 5]> : tensor<2xi64>, edge_padding_low = dense<[0, 1]> : tensor<2xi64>, interior_padding = dense<0> : tensor<2xi64>} : (tensor<2x3xi32>, tensor<i32>) -> tensor<3x9xi32>
+    hal.interface.store.tensor %2, @legacy_io::@ret0, offset = %c0 : tensor<3x9xi32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=1, type="StorageBuffer", access="Write|Discard"
+  }
+}
+// CHECK-LABEL: @add_pad_cst
+//   CHECK-DAG: %[[ZERO:.+]] = constant 0 : i32
+//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<3x9xi32>
+//   CHECK-DAG: %[[SUBVIEW:.+]] = subview %[[OUT]][0, 1] [2, 3] [1, 1]
 //       CHECK: linalg.fill(%[[OUT]], %[[ZERO]])
-//       CHECK: %[[SUBVIEW:.+]] = subview %[[OUT]][4, 5] [12, 4] [1, 1]
-//       CHECK: linalg.fill(%[[SUBVIEW]], %[[ONE]])
+//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x3xi32>
+//       CHECK: linalg.generic
+//  CHECK-SAME: ins(%[[IN]]
+//  CHECK-SAME: outs(%[[SUBVIEW]]
+//       CHECK:   addi
+
+// -----
+
+module {
+  func @add_pad_memref() {
+    %c0 = constant 0 : index
+    %0 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<2x3xi32>
+    %1 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<i32>
+    %2 = mhlo.add %0, %0 : tensor<2x3xi32>
+    %3 = "mhlo.pad"(%2, %1) {edge_padding_high = dense<[1, 5]> : tensor<2xi64>, edge_padding_low = dense<[0, 1]> : tensor<2xi64>, interior_padding = dense<0> : tensor<2xi64>} : (tensor<2x3xi32>, tensor<i32>) -> tensor<3x9xi32>
+    hal.interface.store.tensor %3, @legacy_io::@ret0, offset = %c0 : tensor<3x9xi32>
+    return
+  }
+  hal.interface @legacy_io attributes {sym_visibility = "private"} {
+    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
+    hal.interface.binding @ret0, set=0, binding=2, type="StorageBuffer", access="Write|Discard"
+  }
+}
+// CHECK-LABEL: @add_pad_memref
+//   CHECK-DAG: %[[IN:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0} : memref<2x3xi32>
+//   CHECK-DAG: %[[OUT:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0} : memref<3x9xi32>
+//   CHECK-DAG: %[[SUBVIEW:.+]] = subview %[[OUT]][0, 1] [2, 3] [1, 1]
+//   CHECK-DAG: %[[PAD_BUF:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg1} : memref<i32>
+//   CHECK-DAG: %[[PAD_VAL:.+]] = load %[[PAD_BUF]][] : memref<i32>
+//       CHECK: linalg.fill(%[[OUT]], %[[PAD_VAL]])
+//       CHECK: linalg.generic
+//  CHECK-SAME: ins(%[[IN]]
+//  CHECK-SAME: outs(%[[SUBVIEW]]
+//       CHECK:   addi

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.cpp
@@ -163,7 +163,7 @@ OpDispatchPolicy::FusionType OpDispatchPolicy::fuseInput(Operation *anchorOp,
   if (inputOp->isKnownTerminator()) return FusionType::DISABLED;
 
   if ((isIdentityMetadata(inputOp) || isViewModificationOp(inputOp)) &&
-      !isRootOnlyOp(anchorOp)) {
+      !isLeafOnlyOp(anchorOp)) {
     // Shape ties must always be duplicated into the region and remain in their
     // original position. This should apply to any such "metadata" ops.
     return FusionType::CLONE_INTO;
@@ -189,7 +189,7 @@ OpDispatchPolicy::FusionType OpDispatchPolicy::fuseOutput(Operation *anchorOp,
     return FusionType::DISABLED;
   }
   if ((isIdentityMetadata(outputOp) || isViewModificationOp(outputOp)) &&
-      !isLeafOnlyOp(anchorOp)) {
+      !isRootOnlyOp(anchorOp)) {
     return FusionType::MOVE_INTO;
   }
 
@@ -232,11 +232,11 @@ bool OpDispatchPolicy::isUnsupportedFusionOp(Operation *op) {
          isRootOnlyOp(op) || isLeafOnlyOp(op);
 }
 
-bool OpDispatchPolicy::isRootOnlyOp(Operation *op) {
+bool OpDispatchPolicy::isLeafOnlyOp(Operation *op) {
   return isa<mhlo::SliceOp>(op);
 }
 
-bool OpDispatchPolicy::isLeafOnlyOp(Operation *op) {
+bool OpDispatchPolicy::isRootOnlyOp(Operation *op) {
   return isa<mhlo::PadOp>(op);
 }
 

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.h
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.h
@@ -59,6 +59,9 @@ class OpDispatchPolicy {
   // Returns true if |op| can only be a root op.
   static bool isRootOnlyOp(Operation *op);
 
+  // Returns true if |op| can only be a root op.
+  static bool isLeafOnlyOp(Operation *op);
+
   // Returns true if the given |op| can be dispatched in all cases.
   // Other passes may handle special cases of these ops but this initial
   // identification is conservative.

--- a/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.h
+++ b/iree/compiler/Dialect/Flow/Transforms/DispatchConfig.h
@@ -56,10 +56,9 @@ class OpDispatchPolicy {
   // Returns true if |op| is not able to fuse with either producer or consumer.
   static bool isUnsupportedFusionOp(Operation *op);
 
-  // Returns true if |op| can only be a root op.
+  // Returns true if |op| can only be a root/leaf op. See #3924 for more
+  // details.
   static bool isRootOnlyOp(Operation *op);
-
-  // Returns true if |op| can only be a root op.
   static bool isLeafOnlyOp(Operation *op);
 
   // Returns true if the given |op| can be dispatched in all cases.

--- a/iree/test/e2e/structural/BUILD
+++ b/iree/test/e2e/structural/BUILD
@@ -32,6 +32,7 @@ iree_check_single_backend_test_suite(
     name = "check_vulkan-spirv_vulkan",
     srcs = [
         "matmul_add.mlir",
+        "pad.mlir",
         "slice_add.mlir",
     ],
     driver = "vulkan",
@@ -44,6 +45,7 @@ iree_check_single_backend_test_suite(
     name = "check_llvm-ir_llvm",
     srcs = [
         "matmul_add.mlir",
+        "pad.mlir",
         "slice_add.mlir",
     ],
     driver = "llvm",

--- a/iree/test/e2e/structural/CMakeLists.txt
+++ b/iree/test/e2e/structural/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_check_single_backend_test_suite(
     check_vulkan-spirv_vulkan
   SRCS
     "matmul_add.mlir"
+    "pad.mlir"
     "slice_add.mlir"
   TARGET_BACKEND
     vulkan-spirv
@@ -43,6 +44,7 @@ iree_check_single_backend_test_suite(
     check_llvm-ir_llvm
   SRCS
     "matmul_add.mlir"
+    "pad.mlir"
     "slice_add.mlir"
   TARGET_BACKEND
     llvm-ir

--- a/iree/test/e2e/structural/pad.mlir
+++ b/iree/test/e2e/structural/pad.mlir
@@ -1,0 +1,63 @@
+func @slice_add_pad_cst() attributes { iree.module.export } {
+  %input0 = iree.unfoldable_constant dense<[
+    [01, 02, 03, 04],
+    [05, 06, 07, 08],
+    [09, 10, 11, 12]]> : tensor<3x4xi32>
+  %input1 = iree.unfoldable_constant dense<10> : tensor<2x4xi32>
+  %workload = constant 8 : index
+  %result = flow.dispatch.region[%workload: index](%arg0 = %input0 : tensor<3x4xi32>, %arg1 = %input1 : tensor<2x4xi32>) -> tensor<5x8xi32> {
+    %0 = "mhlo.slice"(%arg0) {
+      start_indices = dense<[1, 0]> : tensor<2xi64>,
+      limit_indices = dense<[3, 4]> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    } : (tensor<3x4xi32>) -> tensor<2x4xi32>
+    %1 = mhlo.add %0, %arg1 : tensor<2x4xi32>
+    %cst = constant dense<0> : tensor<i32>
+    %2 = "mhlo.pad"(%1, %cst) {
+      edge_padding_high = dense<[2, 3]> : tensor<2xi64>,
+      edge_padding_low = dense<[1, 1]> : tensor<2xi64>,
+      interior_padding = dense<0> : tensor<2xi64>
+    } : (tensor<2x4xi32>, tensor<i32>) -> tensor<5x8xi32>
+    flow.return %2 : tensor<5x8xi32>
+  }
+  check.expect_eq_const(%result, dense<[
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 15, 16, 17, 18, 0, 0, 0],
+    [0, 19, 20, 21, 22, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0]]> : tensor<5x8xi32>) : tensor<5x8xi32>
+  return
+}
+
+func @slice_add_pad_memref() attributes { iree.module.export } {
+  %input0 = iree.unfoldable_constant dense<[
+    [01, 02, 03, 04],
+    [05, 06, 07, 08],
+    [09, 10, 11, 12]]> : tensor<3x4xi32>
+  %input1 = iree.unfoldable_constant dense<10> : tensor<2x4xi32>
+  %input2 = iree.unfoldable_constant dense<42> : tensor<i32>
+  %workload = constant 8 : index
+  %result = flow.dispatch.region[%workload: index](%arg0 = %input0 : tensor<3x4xi32>, %arg1 = %input1 : tensor<2x4xi32>, %arg2 = %input2 : tensor<i32>) -> tensor<5x8xi32> {
+    %0 = "mhlo.slice"(%arg0) {
+      start_indices = dense<[1, 0]> : tensor<2xi64>,
+      limit_indices = dense<[3, 4]> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    } : (tensor<3x4xi32>) -> tensor<2x4xi32>
+    %1 = mhlo.add %0, %arg1 : tensor<2x4xi32>
+    %2 = "mhlo.pad"(%1, %arg2) {
+      edge_padding_high = dense<[2, 3]> : tensor<2xi64>,
+      edge_padding_low = dense<[1, 1]> : tensor<2xi64>,
+      interior_padding = dense<0> : tensor<2xi64>
+    } : (tensor<2x4xi32>, tensor<i32>) -> tensor<5x8xi32>
+    flow.return %2 : tensor<5x8xi32>
+  }
+  check.expect_eq_const(%result, dense<[
+    [42, 42, 42, 42, 42, 42, 42, 42],
+    [42, 15, 16, 17, 18, 42, 42, 42],
+    [42, 19, 20, 21, 22, 42, 42, 42],
+    [42, 42, 42, 42, 42, 42, 42, 42],
+    [42, 42, 42, 42, 42, 42, 42, 42]]> : tensor<5x8xi32>) : tensor<5x8xi32>
+  return
+}
+
+


### PR DESCRIPTION
Add a isLeafOp trait, so we can make pad ops live with other ops in a
dispatch function.

Also, make reshape op not move into a dispatch function that has root
op.