### PR TITLE
Adding bindings/tflite/ to expose IREE through the tflite C API

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ option(IREE_BUILD_TESTS "Builds IREE unit tests." ON)
 option(IREE_BUILD_DOCS "Builds IREE docs." OFF)
 option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_DEBUGGER "Builds the IREE debugger app." OFF)
+
 option(IREE_BUILD_TENSORFLOW_COMPILER "Builds TensorFlow compiler frontend." OFF)
 option(IREE_BUILD_TFLITE_COMPILER "Builds the TFLite compiler frontend." OFF)
 option(IREE_BUILD_XLA_COMPILER "Builds TensorFlow XLA compiler frontend." OFF)
@@ -65,6 +66,8 @@ if(${IREE_BUILD_TENSORFLOW_COMPILER} OR
    ${IREE_BUILD_XLA_COMPILER})
   set(IREE_ENABLE_TENSORFLOW ON)
 endif()
+
+option(IREE_BUILD_BINDINGS_TFLITE "Builds the IREE TFLite C API compatibility shim" ON)
 
 # Default python bindings to enabled for some features.
 if(${IREE_ENABLE_TENSORFLOW})
@@ -456,6 +459,10 @@ add_subdirectory(iree/tools)
 # and must come after it.
 if(${IREE_BUILD_PYTHON_BINDINGS})
   add_subdirectory(bindings/python)
+endif()
+
+if(${IREE_BUILD_BINDINGS_TFLITE})
+  add_subdirectory(bindings/tflite)
 endif()
 
 if(${IREE_BUILD_SAMPLES})

--- a/bindings/tflite/BUILD
+++ b/bindings/tflite/BUILD
@@ -1,0 +1,78 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+#===------------------------------------------------------------------------===#
+# TFLite C API compatibility shim
+#===------------------------------------------------------------------------===#
+# See README.md for more information.
+# Use this *in place of tflite*; do not link both this and tflite into your
+# binary (you'll get ODR violations at the least, if not worse).
+
+cc_library(
+    name = "shim",
+    srcs = [
+        "interpreter.c",
+        "interpreter.h",
+        "model.c",
+        "model.h",
+        "options.c",
+        "options.h",
+        "shim.c",
+        "shim.h",
+        "tensor.c",
+        "tensor.h",
+    ],
+    hdrs = [
+        "include/tensorflow/lite/c/c_api.h",
+        "include/tensorflow/lite/c/c_api_experimental.h",
+        "include/tensorflow/lite/c/common.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//iree/base:api",
+        "//iree/base:core_headers",
+        "//iree/base:tracing",
+        "//iree/hal:api",
+        "//iree/hal/drivers",
+        "//iree/modules/hal",
+        "//iree/vm",
+        "//iree/vm:bytecode_module",
+    ],
+)
+
+#===------------------------------------------------------------------------===#
+# Tests for our own unique functionality and tflite compatibility
+#===------------------------------------------------------------------------===#
+
+cc_test(
+    name = "smoke_test",
+    srcs = ["smoke_test.cc"],
+    # TODO(benvanik): bazel/cmake to include this generated file.
+    # Checked in right now until I can figure it out.
+    # data = [
+    #     "//bindings/tflite/testdata:add.module",
+    # ],
+    deps = [
+        ":shim",
+        "//bindings/tflite/testdata:add_cc",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)

--- a/bindings/tflite/CMakeLists.txt
+++ b/bindings/tflite/CMakeLists.txt
@@ -1,0 +1,57 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+iree_cc_library(
+  NAME
+    shim
+  HDRS
+    "include/tensorflow/lite/c/c_api.h"
+    "include/tensorflow/lite/c/c_api_experimental.h"
+    "include/tensorflow/lite/c/common.h"
+  SRCS
+    "interpreter.c"
+    "interpreter.h"
+    "model.c"
+    "model.h"
+    "options.c"
+    "options.h"
+    "shim.c"
+    "shim.h"
+    "tensor.c"
+    "tensor.h"
+  DEPS
+    iree::base::api
+    iree::base::core_headers
+    iree::base::tracing
+    iree::hal::api
+    iree::hal::drivers
+    iree::modules::hal
+    iree::vm
+    iree::vm::bytecode_module
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    smoke_test
+  SRCS
+    "smoke_test.cc"
+  DEPS
+    ::shim
+    bindings::tflite::testdata::add_cc
+    iree::testing::gtest
+    iree::testing::gtest_main
+)

--- a/bindings/tflite/README.md
+++ b/bindings/tflite/README.md
@@ -1,0 +1,261 @@
+# IREE TFLite C API Compatibility Shim
+
+**EXPERIMENTAL**: we are working towards making this a stable API but it has a
+ways to go still. Progress is being tracked in https://github.com/google/iree/projects/17.
+
+Provides a (mostly) tflite-compatible API that allows loading compiled IREE
+modules, managing tensors, and invoking functions with the same conventions as
+[TFLite's C API](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/c).
+
+The intent is not to have a faithful reproduction of all tflite features as
+IREE obviates the need for many of them (such as builtin ops). This is meant as
+a way for applications that may currently be using the tflite API to quickly
+onboard with IREE. We still expect applications to later migrate to proper IREE
+APIs to gain the most from IREE as many of the features in IREE are not possible
+to expse from simple single-shot invocation APIs like tflite.
+
+## Quickstart
+
+### Compiling TFLite FlatBuffers to IREE Modules
+
+```sh
+# TODO(#3970): example command line converting the fb (iree-compile-tflite).
+```
+
+**TODO(benvanik)**: tosa flow, iree-compile (whenever ready)
+
+### Retargeting to the IREE TFLite Binding Library
+
+```sh
+# TODO(benvanik): example command line with include path and IREE static lib.
+```
+
+The bindings supply copies of the tflite include files that expose **only the
+public API and portions that IREE supports**. All unsupported features are
+guarded by a `IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS` define which can be
+enabled if compatibility with code that may reference the calls or types is
+required. Needing that is a strong indication, though, that the application is
+not following the public API and will corrupt its memory touching random
+structure fields.
+
+Always **prefer static linkage** when possible: because the IREE runtime is so
+small the overhead of linking it in its own library can double the size.
+Instead, ensure you are linking it into your main application so the use of
+things like the C runtime are amortized across both your code and IREE's. You
+can force static linkage via the `TFL_COMPILE_LIBRARY` define (as with normal
+tflite).
+
+### Loading and Executing Models
+
+```c
+// TODO(benvanik): tflite usage example.
+```
+
+Use `TfLiteModelCreateFromFile` if loading your model from the filesystem so
+that IREE can directly map it into memory. Even if the model is fetched
+dynamically it is still worth it to write it to disk and then map it so that
+the infrequently used mapped pages can be discarded by the OS to reclaim memory.
+Only use `TfLiteModelCreate` if you have the model embedded in your binary or
+are sure you can accept the wired pages for the convenience like in a
+REPL/notebook. When used in conjunction with the IREE C API the compiler
+arranges the module memory to be able to perform things like data prefetching
+(for constants prior to when they are used), page eviction (for initializer
+constants that won't be needed again), and when compiling for native targets the
+ability to directly execute pages from the memory.
+
+**TODO(benvanik)**: stock example
+
+## Support
+
+|   | Glossary
+| - | --------
+| ✔️ | Supported and expected to match tflite semantics
+| ⚠️ | Supported with compatibility caveats (avoid if possible)
+| 🐢 | Supported with performance caveats (prefer the IREE C API)
+| 🚫 | Unimplemented but supportable if needed
+| ⛔ | Unsupported and unlikely to ever be (see notes below)
+| 🔒 | Not part of the tflite public API
+| ❔ | Unknown; not yet studied
+
+### Op Coverage
+
+**TODO(benvanik)**: note about TOSA, link to tflite->tosa documentation
+
+### API
+
+Only the public C API functions are supported. The contents of internal
+structures like `TfLiteTensor` and `TfLiteContext` are undefined.
+
+|   | TFLite API |  Notes |
+| - | -------- | ----- |
+| ✔️ | `TfLiteVersion` | returns an IREE version string
+|  |  |
+| 🔒 | `TfLiteModel struct` | _implementation detail_
+| ✔️ | `TfLiteModelCreate` |
+| ✔️ | `TfLiteModelCreateFromFile` |
+| ✔️ | `TfLiteModelDelete` |
+|  |  |
+| 🔒 | `TfLiteInterpreterOptions struct` | _implementation detail_
+| ✔️ | `TfLiteInterpreterOptionsCreate` |
+| ✔️ | `TfLiteInterpreterOptionsDelete` |
+| 🐢 | `TfLiteInterpreterOptionsSetNumThreads` | interpreters will not share thread pools; see [external contexts](#-external-contexts)
+| ✔️ | `TfLiteInterpreterOptionsSetErrorReporter` |
+| ⛔ | `TfLiteInterpreterOptionsAddBuiltinOp` | IREE's compiler generates code
+| 🚫 | `TfLiteInterpreterOptionsAddCustomOp` | [not yet implemented](#-custom-ops)
+| 🚫 | `TfLiteInterpreterOptionsSetOpResolver` | [not yet implemented](#-custom-ops)
+| ⚠️ | `TfLiteInterpreterOptionsAddDelegate` | available but a no-op; [not needed in IREE](#-delegates)
+| ⚠️ | `TfLiteInterpreterOptionsSetUseNNAPI` | available but a no-op; NNAPI not supported
+|  |  |
+| 🔒 | `TfLiteInterpreter struct` | _implementation detail_
+| ✔️ | `TfLiteInterpreterCreate` |
+| ✔️ | `TfLiteInterpreterCreateWithSelectedOps` | alias to `TfLiteInterpreterCreate`
+| ✔️ | `TfLiteInterpreterDelete` |
+| ✔️ | `TfLiteInterpreterResetVariableTensors` |
+| ✔️ | `TfLiteInterpreterGetInputTensorCount` |
+| ✔️ | `TfLiteInterpreterGetInputTensor` |
+| ✔️ | `TfLiteInterpreterResizeInputTensor` |
+| ✔️ | `TfLiteInterpreterAllocateTensors` |
+| ✔️ | `TfLiteInterpreterInvoke` |
+| ✔️ | `TfLiteInterpreterGetOutputTensorCount` |
+| ✔️ | `TfLiteInterpreterGetOutputTensor` |
+|  |  |
+| 🚫 | `TfLiteTensor struct` | currently opaque; could be exposed with caveats
+| ✔️ | `TfLiteTensorType` |
+| ✔️ | `TfLiteTensorNumDims` |
+| ✔️ | `TfLiteTensorDim` |
+| ✔️ | `TfLiteTensorByteSize` |
+| ✔️ | `TfLiteTensorData` |
+| ✔️ | `TfLiteTensorName` |
+| ✔️ | `TfLiteTensorQuantizationParams` |
+| ✔️ | `TfLiteTensorCopyFromBuffer` |
+| ✔️ | `TfLiteTensorCopyToBuffer` |
+
+### Features
+
+|   | TFLite Feature |  Notes |
+| - | -------- | ----- |
+| 🔒 | Sparsity | **API not public**; likely possible
+| 🔒 | Complex Numbers | **API not public**; likely possible
+| 🔒 | External Contexts | **API not public**; support possible but API inadequate for performance sensitive applications
+| 🚫 | Custom Ops | [not yet implemented](#-custom-ops); can be supported with performance caveats
+| 🚫 | Dynamic Model Creation | [avoid doing this and use a compiler](#-dynamic-model-creation); almost all use cases besides specialized tools like REPLs can compile their models offline
+| ⛔ | Delegates | concept mismatch; [not needed in IREE](#-delegates) due to its hardware abstraction layer (HAL)
+| ⛔ | TFLite Micro | concept mismatch; [compilers are much better at this scale](#-tflite-micro)
+
+#### 🧪 External Contexts
+
+**CURRENTLY UNSUPPORTED**: tflite has
+[experimental support](https://github.com/tensorflow/tensorflow/blob/4827424ac32433075bf1ec885aa4b38b1ede2d65/tensorflow/lite/c/common.h#L735-L743) for
+["external contexts"](https://github.com/tensorflow/tensorflow/blob/4827424ac32433075bf1ec885aa4b38b1ede2d65/tensorflow/lite/c/common.h#L63-L89)
+but they are not exposed via the public API yet.
+
+Though it's possible to use multiple `TfLiteInterpreter` instances in the same
+process in the real tflite it is strongly discouraged: each interpreter will create its own thread and memory pools and device handles to accelerators and
+assume it owns all resources exclusively. The experimental external contexts
+API is present to try to allow for something better than that and IREE would be
+able to make use of it to the extent the feature allows.
+
+But IREE is designed to fully support large constellations of models all running
+concurrently and passing data between both each other and the application
+efficiently pipelined cross-device and cross-process. Though external contexts
+would allow IREE to at least share some resources such as the thread pool it
+would still require applications to cooperatively schedule model execution to
+ensure that predictable latencies and memory consumption would be fixed at the
+sum of all models peak memory use regardless of scheduling.
+
+When using more than one simultaneously loaded and execution model it is much
+better to use the IREE C API instead.
+
+#### 🤷🏿‍♂️ Custom Ops
+
+**CURRENTLY UNSUPPORTED**: possible to implement if needed; it seems as if there
+barely any usage of the custom op C API outside of Google though so we recommend
+avoiding it for now. ([1](https://www.google.com/search?q=%22TfLiteInterpreterOptionsAddCustomOp%22), [2](https://www.google.com/search?q=%22TfLiteInterpreterOptionsSetOpResolver%22)).
+
+Custom ops in tflite map to functions imported into compiled IREE modules.
+The IREE tflite API shim could provide a wrapper implemented as an
+[iree_vm_module_t](https://github.com/google/iree/blob/main/iree/vm/module.h)
+that resolves and executes the functions as they are called by the VM. Having
+real IREE modules, though, provides significant benefits in representation
+such as the ability to have asynchronous custom behavior that interacts well
+with hardware accelerators and IREE's concurrency and pipelining model. It also
+allows for a majority of the kind of operations that previously would have
+necessitated custom ops at runtime to instead be done in the compiler as MLIR
+dialects and lowered right to native code, SPIR-V, or WebAssembly without the
+need for expensive interop and opportunities for the compiler to tightly
+optimize the custom behavior with the rest of the model.
+
+Relevant **unsupported** APIs:
+* [`TfLiteRegistration`](https://github.com/tensorflow/tensorflow/blob/4827424ac32433075bf1ec885aa4b38b1ede2d65/tensorflow/lite/c/common.h#L827-L884)
+* [`TfLiteInterpreterOptionsAddCustomOp`](https://github.com/tensorflow/tensorflow/blob/4827424ac32433075bf1ec885aa4b38b1ede2d65/tensorflow/lite/c/c_api_experimental.h#L51-L68)
+* [`TfLiteInterpreterOptionsSetOpResolver`](https://github.com/tensorflow/tensorflow/blob/4827424ac32433075bf1ec885aa4b38b1ede2d65/tensorflow/lite/c/c_api_experimental.h#L70-L91)
+
+#### 🙅‍♀️ Dynamic Model Creation
+
+**ACTIVELY DISCOURAGED**: IREE separates compilation and execution; for
+nearly all models that are capable of running on tflite there is no benefit (and
+often extreme downsides) to constructing them at runtime. As in any other domain
+if you don't need a JIT you should *never* use a JIT. Dynamic model creation in
+tflite is most frequently used to work around the lack of dynamism that has been
+inherent in the tflite interchange format and interpreter, neither issues of
+which IREE suffers from. Though it's possible to ship MLIR to target devices and
+construct models on-demand there are almost no situations in which one should do
+so beyond tools like REPLs and it is not a supported IREE use case.
+
+Relevant **unsupported** APIs:
+* [`TfLite*Params` structures](https://github.com/tensorflow/tensorflow/blob/2d03c32d6299935ea74083c943c8d727ff50d4c8/tensorflow%2Flite%2Fc%2Fbuiltin_op_data.h)
+
+#### 🙅‍♀️ Delegates
+
+**SUPERFLUOUS**: The concept of delegates - something that dissects a model at
+runtime and attempts to slice off random parts of it to steal for itself - is
+unnecessary in IREE. The extensible hardware abstraction layer (HAL) that IREE
+provides achieves cross-device portability in a way that allows for predictable
+high-performance heterogeneity and efficient co-optimization with the compiler.
+The act of mutating a user's input graph happens in the compiler where
+significantly more metadata and resources are available to optimize the model
+and the the model is deployed as multi-architecture binaries containing one or
+more formats of native machine code or low-level intermediate representations
+like SPIR-V or WebAssembly. It's akin to transmitting JPEGs and WebPs to web
+browsers and allowing for the client to select the appropriate decoder vs.
+shipping source uncompressed PNGs and having to transcode them on the fly. The
+problem of distribution for deployable IREE artifacts matches that of the kind
+apps must already deal with:
+[split APKs](https://developer.android.com/studio/build/configure-apk-splits),
+[universal binaries](https://developer.apple.com/documentation/xcode/porting_your_macos_apps_to_apple_silicon?language=objc), etc
+and it's easy to map anything you can do with IREE artifacts to that mental
+model.
+
+Relevant **unsupported** APIs:
+* [`TfLiteDelegate`](https://github.com/tensorflow/tensorflow/blob/2d03c32d6299935ea74083c943c8d727ff50d4c8/tensorflow/lite/c/common.h#L919-L960)
+* [`TfLiteInterpreterOptionsAddDelegate`](https://github.com/tensorflow/tensorflow/blob/2d03c32d6299935ea74083c943c8d727ff50d4c8/tensorflow/lite/c/c_api.h#L109-L117)
+
+#### 🙅‍♀️ TFLite Micro
+
+**ACTIVELY DISCOURAGED**: in situations where memory and compute are at a
+premium one should always use an ahead-of-time compiler and not waste precious
+resources (memory, power, thermals, etc) on things like
+[memory planning](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/memory_planner/greedy_memory_planner.cc)
+(especially when only static shapes are supported), data conversion like
+[endianness swapping](https://github.com/tensorflow/tensorflow/blob/2cad9d750cadd825910b61351a731eb0e8031608/tensorflow/lite/micro/micro_interpreter.cc#L180-L214), executing
+[unfused elementwise ops](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/kernels/add.cc), including any executable bytes for
+[code-paths that will never be reached](https://github.com/tensorflow/tensorflow/blob/2cad9d750cadd825910b61351a731eb0e8031608/tensorflow/lite/micro/kernels/softmax.cc#L103-L129)
+in your model, or perform a single superfluous
+**[m](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/kernels/split.cc)
+[e](https://github.com/tensorflow/tensorflow/blob/2cad9d750cadd825910b61351a731eb0e8031608/tensorflow/lite/micro/micro_interpreter.cc#L240-L260)
+[m](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/kernels/reshape.cc)
+[c](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/kernels/concatenation.cc)
+[p](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/kernels/pad.cc)
+[y](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/lite/micro/kernels/strided_slice.cc)**.
+
+In it's most size-optimized form the IREE VM bytecode is lowered to C or LLVM IR
+and compiled along with application code. All tensor operations are aggressively
+fused to avoid the need for transient memory, runtime memory planning (even when
+using dynamic shapes), or copies. Just as there's an expectation that compiler
+toolchains perform basic optimizations to application code (dead code removal,
+code deduplication, etc) so too should there be an expectation for ML models and
+even more so in environments where every byte (and joule) matters.
+
+IREE will likely never have a shim for the tflite micro API or the
+tflite `TF_LITE_STATIC_MEMORY` mode; when operating at that scale the entire
+solution needs to change.

--- a/bindings/tflite/include/README.md
+++ b/bindings/tflite/include/README.md
@@ -1,0 +1,11 @@
+# Cloned TFLite C API Headers
+
+These files were captured from the tensorflow repository:
+https://github.com/tensorflow/tensorflow/tree/master/tensorflow/lite/
+
+Slight modifications were required in order to get them compiling in C and
+outside of the tensorflow repository. Features that IREE does not support are
+guarded with `IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS`.
+
+Origin commit: f954b2770d0cfd8244a9cf9d7116fb15bc044118
+https://github.com/tensorflow/tensorflow/tree/f954b2770d0cfd8244a9cf9d7116fb15bc044118

--- a/bindings/tflite/include/tensorflow/lite/c/c_api.h
+++ b/bindings/tflite/include/tensorflow/lite/c/c_api.h
@@ -1,0 +1,255 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_C_C_API_H_
+#define TENSORFLOW_LITE_C_C_API_H_
+
+#include <stdarg.h>
+#include <stdint.h>
+
+#include "common.h"
+
+// --------------------------------------------------------------------------
+/// C API for TensorFlow Lite.
+///
+/// The API leans towards simplicity and uniformity instead of convenience, as
+/// most usage will be by language-specific wrappers. It provides largely the
+/// same set of functionality as that of the C++ TensorFlow Lite `Interpreter`
+/// API, but is useful for shared libraries where having a stable ABI boundary
+/// is important.
+///
+/// Conventions:
+/// * We use the prefix TfLite for everything in the API.
+/// * size_t is used to represent byte sizes of objects that are
+///   materialized in the address space of the calling process.
+/// * int is used as an index into arrays.
+///
+/// Usage:
+/// <pre><code>
+/// // Create the model and interpreter options.
+/// TfLiteModel* model = TfLiteModelCreateFromFile("/path/to/model.tflite");
+/// TfLiteInterpreterOptions* options = TfLiteInterpreterOptionsCreate();
+/// TfLiteInterpreterOptionsSetNumThreads(options, 2);
+///
+/// // Create the interpreter.
+/// TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
+///
+/// // Allocate tensors and populate the input tensor data.
+/// TfLiteInterpreterAllocateTensors(interpreter);
+/// TfLiteTensor* input_tensor =
+///     TfLiteInterpreterGetInputTensor(interpreter, 0);
+/// TfLiteTensorCopyFromBuffer(input_tensor, input.data(),
+///                            input.size() * sizeof(float));
+///
+/// // Execute inference.
+/// TfLiteInterpreterInvoke(interpreter);
+///
+/// // Extract the output tensor data.
+/// const TfLiteTensor* output_tensor =
+//      TfLiteInterpreterGetOutputTensor(interpreter, 0);
+/// TfLiteTensorCopyToBuffer(output_tensor, output.data(),
+///                          output.size() * sizeof(float));
+///
+/// // Dispose of the model and interpreter objects.
+/// TfLiteInterpreterDelete(interpreter);
+/// TfLiteInterpreterOptionsDelete(options);
+/// TfLiteModelDelete(model);
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// --------------------------------------------------------------------------
+// TfLiteVersion returns a string describing version information of the
+// TensorFlow Lite library. TensorFlow Lite uses semantic versioning.
+TFL_CAPI_EXPORT extern const char* TfLiteVersion(void);
+
+// --------------------------------------------------------------------------
+// TfLiteModel wraps a loaded TensorFlow Lite model.
+typedef struct TfLiteModel TfLiteModel;
+
+// Returns a model from the provided buffer, or null on failure.
+TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreate(const void* model_data,
+                                                      size_t model_size);
+
+// Returns a model from the provided file, or null on failure.
+TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreateFromFile(
+    const char* model_path);
+
+// Destroys the model instance.
+TFL_CAPI_EXPORT extern void TfLiteModelDelete(TfLiteModel* model);
+
+// --------------------------------------------------------------------------
+// TfLiteInterpreterOptions allows customized interpreter configuration.
+typedef struct TfLiteInterpreterOptions TfLiteInterpreterOptions;
+
+// Returns a new interpreter options instances.
+TFL_CAPI_EXPORT extern TfLiteInterpreterOptions*
+TfLiteInterpreterOptionsCreate();
+
+// Destroys the interpreter options instance.
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsDelete(
+    TfLiteInterpreterOptions* options);
+
+// Sets the number of CPU threads to use for the interpreter.
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetNumThreads(
+    TfLiteInterpreterOptions* options, int32_t num_threads);
+
+// Adds a delegate to be applied during `TfLiteInterpreter` creation.
+//
+// If delegate application fails, interpreter creation will also fail with an
+// associated error logged.
+//
+// NOTE: The caller retains ownership of the delegate and should ensure that it
+// remains valid for the duration of any created interpreter's lifetime.
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsAddDelegate(
+    TfLiteInterpreterOptions* options, TfLiteDelegate* delegate);
+
+// Sets a custom error reporter for interpreter execution.
+//
+// * `reporter` takes the provided `user_data` object, as well as a C-style
+//   format string and arg list (see also vprintf).
+// * `user_data` is optional. If provided, it is owned by the client and must
+//   remain valid for the duration of the interpreter lifetime.
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetErrorReporter(
+    TfLiteInterpreterOptions* options,
+    void (*reporter)(void* user_data, const char* format, va_list args),
+    void* user_data);
+
+// --------------------------------------------------------------------------
+// TfLiteInterpreter provides inference from a provided model.
+typedef struct TfLiteInterpreter TfLiteInterpreter;
+
+// Returns a new interpreter using the provided model and options, or null on
+// failure.
+//
+// * `model` must be a valid model instance. The caller retains ownership of the
+//   object, and can destroy it immediately after creating the interpreter; the
+//   interpreter will maintain its own reference to the underlying model data.
+// * `optional_options` may be null. The caller retains ownership of the object,
+//   and can safely destroy it immediately after creating the interpreter.
+//
+// NOTE: The client *must* explicitly allocate tensors before attempting to
+// access input tensor data or invoke the interpreter.
+TFL_CAPI_EXPORT extern TfLiteInterpreter* TfLiteInterpreterCreate(
+    const TfLiteModel* model, const TfLiteInterpreterOptions* optional_options);
+
+// Destroys the interpreter.
+TFL_CAPI_EXPORT extern void TfLiteInterpreterDelete(
+    TfLiteInterpreter* interpreter);
+
+// Returns the number of input tensors associated with the model.
+TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetInputTensorCount(
+    const TfLiteInterpreter* interpreter);
+
+// Returns the tensor associated with the input index.
+// REQUIRES: 0 <= input_index < TfLiteInterpreterGetInputTensorCount(tensor)
+TFL_CAPI_EXPORT extern TfLiteTensor* TfLiteInterpreterGetInputTensor(
+    const TfLiteInterpreter* interpreter, int32_t input_index);
+
+// Resizes the specified input tensor.
+//
+// NOTE: After a resize, the client *must* explicitly allocate tensors before
+// attempting to access the resized tensor data or invoke the interpreter.
+// REQUIRES: 0 <= input_index < TfLiteInterpreterGetInputTensorCount(tensor)
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterResizeInputTensor(
+    TfLiteInterpreter* interpreter, int32_t input_index, const int* input_dims,
+    int32_t input_dims_size);
+
+// Updates allocations for all tensors, resizing dependent tensors using the
+// specified input tensor dimensionality.
+//
+// This is a relatively expensive operation, and need only be called after
+// creating the graph and/or resizing any inputs.
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterAllocateTensors(
+    TfLiteInterpreter* interpreter);
+
+// Runs inference for the loaded graph.
+//
+// NOTE: It is possible that the interpreter is not in a ready state to
+// evaluate (e.g., if a ResizeInputTensor() has been performed without a call to
+// AllocateTensors()).
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterInvoke(
+    TfLiteInterpreter* interpreter);
+
+// Returns the number of output tensors associated with the model.
+TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetOutputTensorCount(
+    const TfLiteInterpreter* interpreter);
+
+// Returns the tensor associated with the output index.
+// REQUIRES: 0 <= output_index < TfLiteInterpreterGetOutputTensorCount(tensor)
+//
+// NOTE: The shape and underlying data buffer for output tensors may be not
+// be available until after the output tensor has been both sized and allocated.
+// In general, best practice is to interact with the output tensor *after*
+// calling TfLiteInterpreterInvoke().
+TFL_CAPI_EXPORT extern const TfLiteTensor* TfLiteInterpreterGetOutputTensor(
+    const TfLiteInterpreter* interpreter, int32_t output_index);
+
+// --------------------------------------------------------------------------
+// TfLiteTensor wraps data associated with a graph tensor.
+//
+// Note that, while the TfLiteTensor struct is not currently opaque, and its
+// fields can be accessed directly, these methods are still convenient for
+// language bindings. In the future the tensor struct will likely be made opaque
+// in the public API.
+
+// Returns the type of a tensor element.
+TFL_CAPI_EXPORT extern TfLiteType TfLiteTensorType(const TfLiteTensor* tensor);
+
+// Returns the number of dimensions that the tensor has.
+TFL_CAPI_EXPORT extern int32_t TfLiteTensorNumDims(const TfLiteTensor* tensor);
+
+// Returns the length of the tensor in the "dim_index" dimension.
+// REQUIRES: 0 <= dim_index < TFLiteTensorNumDims(tensor)
+TFL_CAPI_EXPORT extern int32_t TfLiteTensorDim(const TfLiteTensor* tensor,
+                                               int32_t dim_index);
+
+// Returns the size of the underlying data in bytes.
+TFL_CAPI_EXPORT extern size_t TfLiteTensorByteSize(const TfLiteTensor* tensor);
+
+// Returns a pointer to the underlying data buffer.
+//
+// NOTE: The result may be null if tensors have not yet been allocated, e.g.,
+// if the Tensor has just been created or resized and `TfLiteAllocateTensors()`
+// has yet to be called, or if the output tensor is dynamically sized and the
+// interpreter hasn't been invoked.
+TFL_CAPI_EXPORT extern void* TfLiteTensorData(const TfLiteTensor* tensor);
+
+// Returns the (null-terminated) name of the tensor.
+TFL_CAPI_EXPORT extern const char* TfLiteTensorName(const TfLiteTensor* tensor);
+
+// Returns the parameters for asymmetric quantization. The quantization
+// parameters are only valid when the tensor type is `kTfLiteUInt8` and the
+// `scale != 0`. Quantized values can be converted back to float using:
+//    real_value = scale * (quantized_value - zero_point);
+TFL_CAPI_EXPORT extern TfLiteQuantizationParams TfLiteTensorQuantizationParams(
+    const TfLiteTensor* tensor);
+
+// Copies from the provided input buffer into the tensor's buffer.
+// REQUIRES: input_data_size == TfLiteTensorByteSize(tensor)
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteTensorCopyFromBuffer(
+    TfLiteTensor* tensor, const void* input_data, size_t input_data_size);
+
+// Copies to the provided output buffer from the tensor's buffer.
+// REQUIRES: output_data_size == TfLiteTensorByteSize(tensor)
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteTensorCopyToBuffer(
+    const TfLiteTensor* output_tensor, void* output_data,
+    size_t output_data_size);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // TENSORFLOW_LITE_C_C_API_H_

--- a/bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h
+++ b/bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h
@@ -1,0 +1,133 @@
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+#ifndef TENSORFLOW_LITE_C_C_API_EXPERIMENTAL_H_
+#define TENSORFLOW_LITE_C_C_API_EXPERIMENTAL_H_
+
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+#include "tensorflow/lite/builtin_ops.h"
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+
+#include "c_api.h"
+#include "common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/// Resets all variable tensors to zero.
+///
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterResetVariableTensors(
+    TfLiteInterpreter* interpreter);
+
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+
+/// Adds an op registration for a builtin operator.
+///
+/// Op registrations are used to map ops referenced in the flatbuffer model
+/// to executable function pointers (`TfLiteRegistration`s).
+///
+/// NOTE: The interpreter will make a shallow copy of `registration` internally,
+/// so the caller should ensure that its contents (function pointers, etc...)
+/// remain valid for the duration of the interpreter's lifetime. A common
+/// practice is making the provided `TfLiteRegistration` instance static.
+///
+/// Code that uses this function should NOT call
+/// `TfLiteInterpreterOptionsSetOpResolver' on the same options object.
+///
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT void TfLiteInterpreterOptionsAddBuiltinOp(
+    TfLiteInterpreterOptions* options, TfLiteBuiltinOperator op,
+    const TfLiteRegistration* registration, int32_t min_version,
+    int32_t max_version);
+
+/// Adds an op registration for a custom operator.
+///
+/// Op registrations are used to map ops referenced in the flatbuffer model
+/// to executable function pointers (`TfLiteRegistration`s).
+///
+/// NOTE: The interpreter will make a shallow copy of `registration` internally,
+/// so the caller should ensure that its contents (function pointers, etc...)
+/// remain valid for the duration of any created interpreter's lifetime. A
+/// common practice is making the provided `TfLiteRegistration` instance static.
+///
+/// Code that uses this function should NOT call
+/// `TfLiteInterpreterOptionsSetOpResolver' on the same options object.
+///
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT void TfLiteInterpreterOptionsAddCustomOp(
+    TfLiteInterpreterOptions* options, const char* name,
+    const TfLiteRegistration* registration, int32_t min_version,
+    int32_t max_version);
+
+/// Registers callbacks for resolving builtin or custom operators.
+///
+/// The `TfLiteInterpreterOptionsSetOpResolver` function provides an alternative
+/// method for registering builtin ops and/or custom ops, by providing operator
+/// resolver callbacks.  Unlike using `TfLiteInterpreterOptionsAddBuiltinOp`
+/// and/or `TfLiteInterpreterOptionsAddAddCustomOp`, these let you register all
+/// the operators in a single call.
+///
+/// Code that uses this function should NOT call
+/// `TfLiteInterpreterOptionsAddBuiltin' or
+/// `TfLiteInterpreterOptionsAddCustomOp' on the same options object.
+///
+/// WARNING: This is an experimental API and subject to change.
+void TfLiteInterpreterOptionsSetOpResolver(
+    TfLiteInterpreterOptions* options,
+    const TfLiteRegistration* (*find_builtin_op)(void* user_data,
+                                                 TfLiteBuiltinOperator op,
+                                                 int version),
+    const TfLiteRegistration* (*find_custom_op)(void* user_data,
+                                                const char* custom_op,
+                                                int version),
+    void* op_resolver_user_data);
+
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+
+/// Returns a new interpreter using the provided model and options, or null on
+/// failure, where the model uses only the operators explicitly added to the
+/// options.  This is the same as `TFLiteInterpreterCreate` from `c_api.h`,
+/// except that the only operators that are supported are the ones registered
+/// in `options` via calls to `TfLiteInterpreterOptionsSetOpResolver`,
+/// `TfLiteInterpreterOptionsAddBuiltinOp`, and/or
+/// `TfLiteInterpreterOptionsAddCustomOp`.
+///
+/// * `model` must be a valid model instance. The caller retains ownership of
+///   the object, and can destroy it immediately after creating the interpreter;
+///   the interpreter will maintain its own reference to the underlying model
+///   data.
+/// * `options` should not be null. The caller retains ownership of the object,
+///   and can safely destroy it immediately after creating the interpreter.
+///
+/// NOTE: The client *must* explicitly allocate tensors before attempting to
+/// access input tensor data or invoke the interpreter.
+///
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT extern TfLiteInterpreter*
+TfLiteInterpreterCreateWithSelectedOps(const TfLiteModel* model,
+                                       const TfLiteInterpreterOptions* options);
+
+/// Enable or disable the NN API for the interpreter (true to enable).
+///
+/// WARNING: This is an experimental API and subject to change.
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetUseNNAPI(
+    TfLiteInterpreterOptions* options, bool enable);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // TENSORFLOW_LITE_C_C_API_EXPERIMENTAL_H_

--- a/bindings/tflite/include/tensorflow/lite/c/common.h
+++ b/bindings/tflite/include/tensorflow/lite/c/common.h
@@ -1,0 +1,1001 @@
+/* Copyright 2019 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// This file defines common C types and APIs for implementing operations,
+// delegates and other constructs in TensorFlow Lite. The actual operations and
+// delegates can be defined using C++, but the interface between the interpreter
+// and the operations are C.
+//
+// Summary of abstractions
+// TF_LITE_ENSURE - Self-sufficient error checking
+// TfLiteStatus - Status reporting
+// TfLiteIntArray - stores tensor shapes (dims),
+// TfLiteContext - allows an op to access the tensors
+// TfLiteTensor - tensor (a multidimensional array)
+// TfLiteNode - a single node or operation
+// TfLiteRegistration - the implementation of a conceptual operation.
+// TfLiteDelegate - allows delegation of nodes to alternative backends.
+//
+// Some abstractions in this file are created and managed by Interpreter.
+//
+// NOTE: The order of values in these structs are "semi-ABI stable". New values
+// should be added only to the end of structs and never reordered.
+
+#ifndef TENSORFLOW_LITE_C_COMMON_H_
+#define TENSORFLOW_LITE_C_COMMON_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+typedef enum TfLiteStatus {
+  kTfLiteOk = 0,
+
+  // Generally referring to an error in the runtime (i.e. interpreter)
+  kTfLiteError = 1,
+
+  // Generally referring to an error from a TfLiteDelegate itself.
+  kTfLiteDelegateError = 2,
+
+  // Generally referring to an error in applying a delegate due to
+  // incompatibility between runtime and delegate, e.g., this error is returned
+  // when trying to apply a TfLite delegate onto a model graph that's already
+  // immutable.
+  kTfLiteApplicationError = 3
+} TfLiteStatus;
+
+// The list of external context types known to TF Lite. This list exists solely
+// to avoid conflicts and to ensure ops can share the external contexts they
+// need. Access to the external contexts is controlled by one of the
+// corresponding support files.
+typedef enum TfLiteExternalContextType {
+  kTfLiteEigenContext = 0,       // include eigen_support.h to use.
+  kTfLiteGemmLowpContext = 1,    // include gemm_support.h to use.
+  kTfLiteEdgeTpuContext = 2,     // Placeholder for Edge TPU support.
+  kTfLiteCpuBackendContext = 3,  // include cpu_backend_context.h to use.
+  kTfLiteMaxExternalContexts = 4
+} TfLiteExternalContextType;
+
+// Forward declare so dependent structs and methods can reference these types
+// prior to the struct definitions.
+struct TfLiteContext;
+struct TfLiteDelegate;
+struct TfLiteRegistration;
+
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+
+// An external context is a collection of information unrelated to the TF Lite
+// framework, but useful to a subset of the ops. TF Lite knows very little
+// about the actual contexts, but it keeps a list of them, and is able to
+// refresh them if configurations like the number of recommended threads
+// change.
+typedef struct TfLiteExternalContext {
+  TfLiteExternalContextType type;
+  TfLiteStatus (*Refresh)(struct TfLiteContext* context);
+} TfLiteExternalContext;
+
+#define kTfLiteOptionalTensor (-1)
+
+// Fixed size list of integers. Used for dimensions and inputs/outputs tensor
+// indices
+typedef struct TfLiteIntArray {
+  int size;
+// gcc 6.1+ have a bug where flexible members aren't properly handled
+// https://github.com/google/re2/commit/b94b7cd42e9f02673cd748c1ac1d16db4052514c
+#if (!defined(__clang__) && defined(__GNUC__) && __GNUC__ == 6 && \
+     __GNUC_MINOR__ >= 1) ||                                      \
+    defined(HEXAGON) || (__clang_major__ == 7 && __clang_minor__ == 1)
+  int data[0];
+#else
+  int data[];
+#endif
+} TfLiteIntArray;
+
+// Given the size (number of elements) in a TfLiteIntArray, calculate its size
+// in bytes.
+int TfLiteIntArrayGetSizeInBytes(int size);
+
+#ifndef TF_LITE_STATIC_MEMORY
+// Create a array of a given `size` (uninitialized entries).
+// This returns a pointer, that you must free using TfLiteIntArrayFree().
+TfLiteIntArray* TfLiteIntArrayCreate(int size);
+#endif
+
+// Check if two intarrays are equal. Returns 1 if they are equal, 0 otherwise.
+int TfLiteIntArrayEqual(const TfLiteIntArray* a, const TfLiteIntArray* b);
+
+// Check if an intarray equals an array. Returns 1 if equals, 0 otherwise.
+int TfLiteIntArrayEqualsArray(const TfLiteIntArray* a, int b_size,
+                              const int b_data[]);
+
+#ifndef TF_LITE_STATIC_MEMORY
+// Create a copy of an array passed as `src`.
+// You are expected to free memory with TfLiteIntArrayFree
+TfLiteIntArray* TfLiteIntArrayCopy(const TfLiteIntArray* src);
+
+// Free memory of array `a`.
+void TfLiteIntArrayFree(TfLiteIntArray* a);
+#endif  // TF_LITE_STATIC_MEMORY
+
+// Fixed size list of floats. Used for per-channel quantization.
+typedef struct TfLiteFloatArray {
+  int size;
+// gcc 6.1+ have a bug where flexible members aren't properly handled
+// https://github.com/google/re2/commit/b94b7cd42e9f02673cd748c1ac1d16db4052514c
+// This also applies to the toolchain used for Qualcomm Hexagon DSPs.
+#if !defined(__clang__) && defined(__GNUC__) && __GNUC__ == 6 && \
+    __GNUC_MINOR__ >= 1
+  float data[0];
+#else
+  float data[];
+#endif
+} TfLiteFloatArray;
+
+// Given the size (number of elements) in a TfLiteFloatArray, calculate its size
+// in bytes.
+int TfLiteFloatArrayGetSizeInBytes(int size);
+
+#ifndef TF_LITE_STATIC_MEMORY
+// Create a array of a given `size` (uninitialized entries).
+// This returns a pointer, that you must free using TfLiteFloatArrayFree().
+TfLiteFloatArray* TfLiteFloatArrayCreate(int size);
+
+// Free memory of array `a`.
+void TfLiteFloatArrayFree(TfLiteFloatArray* a);
+#endif  // TF_LITE_STATIC_MEMORY
+
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+
+// Since we must not depend on any libraries, define a minimal subset of
+// error macros while avoiding names that have pre-conceived meanings like
+// assert and check.
+
+// Try to make all reporting calls through TF_LITE_KERNEL_LOG rather than
+// calling the context->ReportError function directly, so that message strings
+// can be stripped out if the binary size needs to be severely optimized.
+#ifndef TF_LITE_STRIP_ERROR_STRINGS
+#define TF_LITE_KERNEL_LOG(context, ...)            \
+  do {                                              \
+    (context)->ReportError((context), __VA_ARGS__); \
+  } while (false)
+
+#define TF_LITE_MAYBE_KERNEL_LOG(context, ...)        \
+  do {                                                \
+    if ((context) != nullptr) {                       \
+      (context)->ReportError((context), __VA_ARGS__); \
+    }                                                 \
+  } while (false)
+#else  // TF_LITE_STRIP_ERROR_STRINGS
+#define TF_LITE_KERNEL_LOG(context, ...)
+#define TF_LITE_MAYBE_KERNEL_LOG(context, ...)
+#endif  // TF_LITE_STRIP_ERROR_STRINGS
+
+// Check whether value is true, and if not return kTfLiteError from
+// the current function (and report the error string msg).
+#define TF_LITE_ENSURE_MSG(context, value, msg)        \
+  do {                                                 \
+    if (!(value)) {                                    \
+      TF_LITE_KERNEL_LOG((context), __FILE__ " " msg); \
+      return kTfLiteError;                             \
+    }                                                  \
+  } while (0)
+
+// Check whether the value `a` is true, and if not return kTfLiteError from
+// the current function, while also reporting the location of the error.
+#define TF_LITE_ENSURE(context, a)                                      \
+  do {                                                                  \
+    if (!(a)) {                                                         \
+      TF_LITE_KERNEL_LOG((context), "%s:%d %s was not true.", __FILE__, \
+                         __LINE__, #a);                                 \
+      return kTfLiteError;                                              \
+    }                                                                   \
+  } while (0)
+
+#define TF_LITE_ENSURE_STATUS(a) \
+  do {                           \
+    const TfLiteStatus s = (a);  \
+    if (s != kTfLiteOk) {        \
+      return s;                  \
+    }                            \
+  } while (0)
+
+// Check whether the value `a == b` is true, and if not return kTfLiteError from
+// the current function, while also reporting the location of the error.
+// `a` and `b` may be evaluated more than once, so no side effects or
+// extremely expensive computations should be done.
+// NOTE: Use TF_LITE_ENSURE_TYPES_EQ if comparing TfLiteTypes.
+#define TF_LITE_ENSURE_EQ(context, a, b)                                   \
+  do {                                                                     \
+    if ((a) != (b)) {                                                      \
+      TF_LITE_KERNEL_LOG((context), "%s:%d %s != %s (%d != %d)", __FILE__, \
+                         __LINE__, #a, #b, (a), (b));                      \
+      return kTfLiteError;                                                 \
+    }                                                                      \
+  } while (0)
+
+#define TF_LITE_ENSURE_TYPES_EQ(context, a, b)                             \
+  do {                                                                     \
+    if ((a) != (b)) {                                                      \
+      TF_LITE_KERNEL_LOG((context), "%s:%d %s != %s (%s != %s)", __FILE__, \
+                         __LINE__, #a, #b, TfLiteTypeGetName(a),           \
+                         TfLiteTypeGetName(b));                            \
+      return kTfLiteError;                                                 \
+    }                                                                      \
+  } while (0)
+
+#define TF_LITE_ENSURE_NEAR(context, a, b, epsilon)                          \
+  do {                                                                       \
+    auto delta = ((a) > (b)) ? ((a) - (b)) : ((b) - (a));                    \
+    if (delta > epsilon) {                                                   \
+      TF_LITE_KERNEL_LOG((context), "%s:%d %s not near %s (%f != %f)",       \
+                         __FILE__, __LINE__, #a, #b, static_cast<double>(a), \
+                         static_cast<double>(b));                            \
+      return kTfLiteError;                                                   \
+    }                                                                        \
+  } while (0)
+
+#define TF_LITE_ENSURE_OK(context, status) \
+  do {                                     \
+    const TfLiteStatus s = (status);       \
+    if ((s) != kTfLiteOk) {                \
+      return s;                            \
+    }                                      \
+  } while (0)
+
+// Define TFL_CAPI_EXPORT macro to export a function properly with a shared
+// library.
+#ifdef SWIG
+#define TFL_CAPI_EXPORT
+#else
+#if defined(_WIN32)
+#ifdef TFL_COMPILE_LIBRARY
+#define TFL_CAPI_EXPORT __declspec(dllexport)
+#else
+#define TFL_CAPI_EXPORT __declspec(dllimport)
+#endif  // TFL_COMPILE_LIBRARY
+#else
+#define TFL_CAPI_EXPORT __attribute__((visibility("default")))
+#endif  // _WIN32
+#endif  // SWIG
+
+// Single-precision complex data type compatible with the C99 definition.
+typedef struct TfLiteComplex64 {
+  float re, im;  // real and imaginary parts, respectively.
+} TfLiteComplex64;
+
+// Double-precision complex data type compatible with the C99 definition.
+typedef struct TfLiteComplex128 {
+  double re, im;  // real and imaginary parts, respectively.
+} TfLiteComplex128;
+
+// Half precision data type compatible with the C99 definition.
+typedef struct TfLiteFloat16 {
+  uint16_t data;
+} TfLiteFloat16;
+
+// Types supported by tensor
+typedef enum {
+  kTfLiteNoType = 0,
+  kTfLiteFloat32 = 1,
+  kTfLiteInt32 = 2,
+  kTfLiteUInt8 = 3,
+  kTfLiteInt64 = 4,
+  kTfLiteString = 5,
+  kTfLiteBool = 6,
+  kTfLiteInt16 = 7,
+  kTfLiteComplex64 = 8,
+  kTfLiteInt8 = 9,
+  kTfLiteFloat16 = 10,
+  kTfLiteFloat64 = 11,
+  kTfLiteComplex128 = 12,
+  kTfLiteUInt64 = 13,
+} TfLiteType;
+
+// Return the name of a given type, for error reporting purposes.
+const char* TfLiteTypeGetName(TfLiteType type);
+
+// SupportedQuantizationTypes.
+typedef enum TfLiteQuantizationType {
+  // No quantization.
+  kTfLiteNoQuantization = 0,
+  // Affine quantization (with support for per-channel quantization).
+  // Corresponds to TfLiteAffineQuantization.
+  kTfLiteAffineQuantization = 1,
+} TfLiteQuantizationType;
+
+// Structure specifying the quantization used by the tensor, if-any.
+typedef struct TfLiteQuantization {
+  // The type of quantization held by params.
+  TfLiteQuantizationType type;
+  // Holds a reference to one of the quantization param structures specified
+  // below.
+  void* params;
+} TfLiteQuantization;
+
+// Legacy. Will be deprecated in favor of TfLiteAffineQuantization.
+// If per-layer quantization is specified this field will still be populated in
+// addition to TfLiteAffineQuantization.
+// Parameters for asymmetric quantization. Quantized values can be converted
+// back to float using:
+//     real_value = scale * (quantized_value - zero_point)
+typedef struct TfLiteQuantizationParams {
+  float scale;
+  int32_t zero_point;
+} TfLiteQuantizationParams;
+
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+
+// Parameters for asymmetric quantization across a dimension (i.e per output
+// channel quantization).
+// quantized_dimension specifies which dimension the scales and zero_points
+// correspond to.
+// For a particular value in quantized_dimension, quantized values can be
+// converted back to float using:
+//     real_value = scale * (quantized_value - zero_point)
+typedef struct TfLiteAffineQuantization {
+  TfLiteFloatArray* scale;
+  TfLiteIntArray* zero_point;
+  int32_t quantized_dimension;
+} TfLiteAffineQuantization;
+
+/* A union of pointers that points to memory for a given tensor. */
+typedef union TfLitePtrUnion {
+  /* Do not access these members directly, if possible, use
+   * GetTensorData<TYPE>(tensor) instead, otherwise only access .data, as other
+   * members are deprecated. */
+  int32_t* i32;
+  int64_t* i64;
+  uint64_t* u64;
+  float* f;
+  TfLiteFloat16* f16;
+  double* f64;
+  char* raw;
+  const char* raw_const;
+  uint8_t* uint8;
+  bool* b;
+  int16_t* i16;
+  TfLiteComplex64* c64;
+  TfLiteComplex128* c128;
+  int8_t* int8;
+  /* Only use this member. */
+  void* data;
+} TfLitePtrUnion;
+
+// Memory allocation strategies.
+//  * kTfLiteMmapRo: Read-only memory-mapped data, or data externally allocated.
+//  * kTfLiteArenaRw: Arena allocated with no guarantees about persistence,
+//        and available during eval.
+//  * kTfLiteArenaRwPersistent: Arena allocated but persistent across eval, and
+//        only available during eval.
+//  * kTfLiteDynamic: Allocated during eval, or for string tensors.
+//  * kTfLitePersistentRo: Allocated and populated during prepare. This is
+//        useful for tensors that can be computed during prepare and treated
+//        as constant inputs for downstream ops (also in prepare).
+//  * kTfLiteCustom: Custom memory allocation provided by the user. See
+//        TfLiteCustomAllocation below.
+typedef enum TfLiteAllocationType {
+  kTfLiteMemNone = 0,
+  kTfLiteMmapRo,
+  kTfLiteArenaRw,
+  kTfLiteArenaRwPersistent,
+  kTfLiteDynamic,
+  kTfLitePersistentRo,
+  kTfLiteCustom,
+} TfLiteAllocationType;
+
+// The delegates should use zero or positive integers to represent handles.
+// -1 is reserved from unallocated status.
+typedef int TfLiteBufferHandle;
+enum {
+  kTfLiteNullBufferHandle = -1,
+};
+
+// Storage format of each dimension in a sparse tensor.
+typedef enum TfLiteDimensionType {
+  kTfLiteDimDense = 0,
+  kTfLiteDimSparseCSR,
+} TfLiteDimensionType;
+
+// Metadata to encode each dimension in a sparse tensor.
+typedef struct TfLiteDimensionMetadata {
+  TfLiteDimensionType format;
+  int dense_size;
+  TfLiteIntArray* array_segments;
+  TfLiteIntArray* array_indices;
+} TfLiteDimensionMetadata;
+
+// Parameters used to encode a sparse tensor. For detailed explanation of each
+// field please refer to lite/schema/schema.fbs.
+typedef struct TfLiteSparsity {
+  TfLiteIntArray* traversal_order;
+  TfLiteIntArray* block_map;
+  TfLiteDimensionMetadata* dim_metadata;
+  int dim_metadata_size;
+} TfLiteSparsity;
+
+// Defines a custom memory allocation not owned by the runtime.
+// `data` should be aligned to kDefaultTensorAlignment defined in
+// lite/util.h. (Currently 64 bytes)
+// NOTE: See Interpreter.SetCustomAllocationForTensor for details on usage.
+typedef struct TfLiteCustomAllocation {
+  void* data;
+  size_t bytes;
+} TfLiteCustomAllocation;
+
+#else
+
+typedef struct TfLiteTensor TfLiteTensor;
+
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+
+// A tensor in the interpreter system which is a wrapper around a buffer of
+// data including a dimensionality (or NULL if not currently defined).
+#ifndef TF_LITE_STATIC_MEMORY
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+typedef struct TfLiteTensor {
+  // The data type specification for data stored in `data`. This affects
+  // what member of `data` union should be used.
+  TfLiteType type;
+  // A union of data pointers. The appropriate type should be used for a typed
+  // tensor based on `type`.
+  TfLitePtrUnion data;
+  // A pointer to a structure representing the dimensionality interpretation
+  // that the buffer should have. NOTE: the product of elements of `dims`
+  // and the element datatype size should be equal to `bytes` below.
+  TfLiteIntArray* dims;
+  // Quantization information.
+  TfLiteQuantizationParams params;
+  // How memory is mapped
+  //  kTfLiteMmapRo: Memory mapped read only.
+  //  i.e. weights
+  //  kTfLiteArenaRw: Arena allocated read write memory
+  //  (i.e. temporaries, outputs).
+  TfLiteAllocationType allocation_type;
+  // The number of bytes required to store the data of this Tensor. I.e.
+  // (bytes of each element) * dims[0] * ... * dims[n-1].  For example, if
+  // type is kTfLiteFloat32 and dims = {3, 2} then
+  // bytes = sizeof(float) * 3 * 2 = 4 * 3 * 2 = 24.
+  size_t bytes;
+
+  // An opaque pointer to a tflite::MMapAllocation
+  const void* allocation;
+
+  // Null-terminated name of this tensor.
+  const char* name;
+
+  // The delegate which knows how to handle `buffer_handle`.
+  // WARNING: This is an experimental interface that is subject to change.
+  struct TfLiteDelegate* delegate;
+
+  // An integer buffer handle that can be handled by `delegate`.
+  // The value is valid only when delegate is not null.
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteBufferHandle buffer_handle;
+
+  // If the delegate uses its own buffer (e.g. GPU memory), the delegate is
+  // responsible to set data_is_stale to true.
+  // `delegate->CopyFromBufferHandle` can be called to copy the data from
+  // delegate buffer.
+  // WARNING: This is an // experimental interface that is subject to change.
+  bool data_is_stale;
+
+  // True if the tensor is a variable.
+  bool is_variable;
+
+  // Quantization information. Replaces params field above.
+  TfLiteQuantization quantization;
+
+  // Parameters used to encode a sparse tensor.
+  // This is optional. The field is NULL if a tensor is dense.
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteSparsity* sparsity;
+
+  // Optional. Encodes shapes with unknown dimensions with -1. This field is
+  // only populated when unknown dimensions exist in a read-write tensor (i.e.
+  // an input or output tensor). (e.g.  `dims` contains [1, 1, 1, 3] and
+  // `dims_signature` contains [1, -1, -1, 3]).
+  const TfLiteIntArray* dims_signature;
+} TfLiteTensor;
+
+// A structure representing an instance of a node.
+// This structure only exhibits the inputs, outputs and user defined data, not
+// other features like the type.
+typedef struct TfLiteNode {
+  // Inputs to this node expressed as indices into the simulator's tensors.
+  TfLiteIntArray* inputs;
+
+  // Outputs to this node expressed as indices into the simulator's tensors.
+  TfLiteIntArray* outputs;
+
+  // intermediate tensors to this node expressed as indices into the simulator's
+  // tensors.
+  TfLiteIntArray* intermediates;
+
+  // Temporary tensors uses during the computations. This usually contains no
+  // tensors, but ops are allowed to change that if they need scratch space of
+  // any sort.
+  TfLiteIntArray* temporaries;
+
+  // Opaque data provided by the node implementer through `Registration.init`.
+  void* user_data;
+
+  // Opaque data provided to the node if the node is a builtin. This is usually
+  // a structure defined in builtin_op_data.h
+  void* builtin_data;
+
+  // Custom initial data. This is the opaque data provided in the flatbuffer.
+  // WARNING: This is an experimental interface that is subject to change.
+  const void* custom_initial_data;
+  int custom_initial_data_size;
+
+  // The pointer to the delegate. This is non-null only when the node is
+  // created by calling `interpreter.ModifyGraphWithDelegate`.
+  // WARNING: This is an experimental interface that is subject to change.
+  struct TfLiteDelegate* delegate;
+} TfLiteNode;
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+#else   // defined(TF_LITE_STATIC_MEMORY)?
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+// NOTE: This flag is opt-in only at compile time.
+//
+// Specific reduced TfLiteTensor struct for TF Micro runtime. This struct
+// contains only the minimum fields required to initialize and prepare a micro
+// inference graph. The fields in this struct have been ordered from
+// largest-to-smallest for optimal struct sizeof.
+//
+// This struct does not use:
+// - allocation
+// - buffer_handle
+// - data_is_stale
+// - delegate
+// - dims_signature
+// - name
+// - sparsity
+typedef struct TfLiteTensor {
+  // TODO(b/155784997): Consider consolidating these quantization fields:
+  // Quantization information. Replaces params field above.
+  TfLiteQuantization quantization;
+
+  // Quantization information.
+  TfLiteQuantizationParams params;
+
+  // A union of data pointers. The appropriate type should be used for a typed
+  // tensor based on `type`.
+  TfLitePtrUnion data;
+
+  // A pointer to a structure representing the dimensionality interpretation
+  // that the buffer should have. NOTE: the product of elements of `dims`
+  // and the element datatype size should be equal to `bytes` below.
+  TfLiteIntArray* dims;
+
+  // The number of bytes required to store the data of this Tensor. I.e.
+  // (bytes of each element) * dims[0] * ... * dims[n-1].  For example, if
+  // type is kTfLiteFloat32 and dims = {3, 2} then
+  // bytes = sizeof(float) * 3 * 2 = 4 * 3 * 2 = 24.
+  size_t bytes;
+
+  // The data type specification for data stored in `data`. This affects
+  // what member of `data` union should be used.
+  TfLiteType type;
+
+  // How memory is mapped
+  //  kTfLiteMmapRo: Memory mapped read only.
+  //  i.e. weights
+  //  kTfLiteArenaRw: Arena allocated read write memory
+  //  (i.e. temporaries, outputs).
+  TfLiteAllocationType allocation_type;
+
+  // True if the tensor is a variable.
+  bool is_variable;
+} TfLiteTensor;
+
+// Specific reduced TfLiteNode struct for TF Micro runtime. This struct contains
+// only the minimum fields required to represent a node.
+//
+// This struct does not use:
+// - delegate
+// - intermediates
+// - temporaries
+typedef struct TfLiteNode {
+  // Inputs to this node expressed as indices into the simulator's tensors.
+  TfLiteIntArray* inputs;
+
+  // Outputs to this node expressed as indices into the simulator's tensors.
+  TfLiteIntArray* outputs;
+
+  // Opaque data provided by the node implementer through `Registration.init`.
+  void* user_data;
+
+  // Opaque data provided to the node if the node is a builtin. This is usually
+  // a structure defined in builtin_op_data.h
+  void* builtin_data;
+
+  // Custom initial data. This is the opaque data provided in the flatbuffer.
+  // WARNING: This is an experimental interface that is subject to change.
+  const void* custom_initial_data;
+  int custom_initial_data_size;
+} TfLiteNode;
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+#endif  // TF_LITE_STATIC_MEMORY
+
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+
+// Light-weight tensor struct for TF Micro runtime. Provides the minimal amount
+// of information required for a kernel to run during TfLiteRegistration::Eval.
+// TODO(b/160955687): Move this field into TF_LITE_STATIC_MEMORY when TFLM
+// builds with this flag by default internally.
+typedef struct TfLiteEvalTensor {
+  // A union of data pointers. The appropriate type should be used for a typed
+  // tensor based on `type`.
+  TfLitePtrUnion data;
+
+  // A pointer to a structure representing the dimensionality interpretation
+  // that the buffer should have.
+  TfLiteIntArray* dims;
+
+  // The data type specification for data stored in `data`. This affects
+  // what member of `data` union should be used.
+  TfLiteType type;
+} TfLiteEvalTensor;
+
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+
+#ifndef TF_LITE_STATIC_MEMORY
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+// Free data memory of tensor `t`.
+void TfLiteTensorDataFree(TfLiteTensor* t);
+
+// Free quantization data.
+void TfLiteQuantizationFree(TfLiteQuantization* quantization);
+
+// Free sparsity parameters.
+void TfLiteSparsityFree(TfLiteSparsity* sparsity);
+
+// Free memory of tensor `t`.
+void TfLiteTensorFree(TfLiteTensor* t);
+
+// Set all of a tensor's fields (and free any previously allocated data).
+void TfLiteTensorReset(TfLiteType type, const char* name, TfLiteIntArray* dims,
+                       TfLiteQuantizationParams quantization, char* buffer,
+                       size_t size, TfLiteAllocationType allocation_type,
+                       const void* allocation, bool is_variable,
+                       TfLiteTensor* tensor);
+
+// Resize the allocated data of a (dynamic) tensor. Tensors with allocation
+// types other than kTfLiteDynamic will be ignored.
+void TfLiteTensorRealloc(size_t num_bytes, TfLiteTensor* tensor);
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+#endif  // TF_LITE_STATIC_MEMORY
+
+#if defined(IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS)
+
+// WARNING: This is an experimental interface that is subject to change.
+//
+// Currently, TfLiteDelegateParams has to be allocated in a way that it's
+// trivially destructable. It will be stored as `builtin_data` field in
+// `TfLiteNode` of the delegate node.
+//
+// See also the `CreateDelegateParams` function in `interpreter.cc` details.
+typedef struct TfLiteDelegateParams {
+  struct TfLiteDelegate* delegate;
+  TfLiteIntArray* nodes_to_replace;
+  TfLiteIntArray* input_tensors;
+  TfLiteIntArray* output_tensors;
+} TfLiteDelegateParams;
+
+typedef struct TfLiteContext {
+  // Number of tensors in the context.
+  size_t tensors_size;
+
+  // The execution plan contains a list of the node indices in execution
+  // order. execution_plan->size is the current number of nodes. And,
+  // execution_plan->data[0] is the first node that needs to be run.
+  // TfLiteDelegates can traverse the current execution plan by iterating
+  // through each member of this array and using GetNodeAndRegistration() to
+  // access details about a node. i.e.
+  // TfLiteIntArray* execution_plan;
+  // TF_LITE_ENSURE_STATUS(context->GetExecutionPlan(context, &execution_plan));
+  // for (int exec_index = 0; exec_index < execution_plan->size; exec_index++) {
+  //    int node_index = execution_plan->data[exec_index];
+  //    TfLiteNode* node;
+  //    TfLiteRegistration* reg;
+  //    context->GetNodeAndRegistration(context, node_index, &node, &reg);
+  // }
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteStatus (*GetExecutionPlan)(struct TfLiteContext* context,
+                                   TfLiteIntArray** execution_plan);
+
+  // An array of tensors in the interpreter context (of length `tensors_size`)
+  TfLiteTensor* tensors;
+
+  // opaque full context ptr (an opaque c++ data structure)
+  void* impl_;
+
+  // Request memory pointer be resized. Updates dimensions on the tensor.
+  // NOTE: ResizeTensor takes ownership of newSize.
+  TfLiteStatus (*ResizeTensor)(struct TfLiteContext*, TfLiteTensor* tensor,
+                               TfLiteIntArray* new_size);
+  // Request that an error be reported with format string msg.
+  void (*ReportError)(struct TfLiteContext*, const char* msg, ...);
+
+  // Add `tensors_to_add` tensors, preserving pre-existing Tensor entries.  If
+  // non-null, the value pointed to by `first_new_tensor_index` will be set to
+  // the index of the first new tensor.
+  TfLiteStatus (*AddTensors)(struct TfLiteContext*, int tensors_to_add,
+                             int* first_new_tensor_index);
+
+  // Get a Tensor node by node_index.
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteStatus (*GetNodeAndRegistration)(
+      struct TfLiteContext*, int node_index, TfLiteNode** node,
+      struct TfLiteRegistration** registration);
+
+  // Replace ops with one or more stub delegate operations. This function
+  // does not take ownership of `nodes_to_replace`.
+  TfLiteStatus (*ReplaceNodeSubsetsWithDelegateKernels)(
+      struct TfLiteContext*, struct TfLiteRegistration registration,
+      const TfLiteIntArray* nodes_to_replace, struct TfLiteDelegate* delegate);
+
+  // Number of threads that are recommended to subsystems like gemmlowp and
+  // eigen.
+  int recommended_num_threads;
+
+  // Access external contexts by type.
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteExternalContext* (*GetExternalContext)(struct TfLiteContext*,
+                                               TfLiteExternalContextType);
+  // Set the value of a external context. Does not take ownership of the
+  // pointer.
+  // WARNING: This is an experimental interface that is subject to change.
+  void (*SetExternalContext)(struct TfLiteContext*, TfLiteExternalContextType,
+                             TfLiteExternalContext*);
+
+  // Flag for allowing float16 precision for FP32 calculation.
+  // default: false.
+  // WARNING: This is an experimental API and subject to change.
+  bool allow_fp32_relax_to_fp16;
+
+  // Pointer to the op-level profiler, if set; nullptr otherwise.
+  void* profiler;
+
+  // Allocate persistent buffer which has the same life time as the interpreter.
+  // Returns nullptr on failure.
+  // The memory is allocated from heap for TFL, and from tail in TFLM.
+  // This method is only available in Init or Prepare stage.
+  // WARNING: This is an experimental interface that is subject to change.
+  void* (*AllocatePersistentBuffer)(struct TfLiteContext* ctx, size_t bytes);
+
+  // Allocate a buffer which will be deallocated right after invoke phase.
+  // The memory is allocated from heap in TFL, and from volatile arena in TFLM.
+  // This method is only available in invoke stage.
+  // NOTE: If possible use RequestScratchBufferInArena method to avoid memory
+  // allocation during inference time.
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteStatus (*AllocateBufferForEval)(struct TfLiteContext* ctx, size_t bytes,
+                                        void** ptr);
+
+  // Request a scratch buffer in the arena through static memory planning.
+  // This method is only available in Prepare stage and the buffer is allocated
+  // by the interpreter between Prepare and Eval stage. In Eval stage,
+  // GetScratchBuffer API can be used to fetch the address.
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteStatus (*RequestScratchBufferInArena)(struct TfLiteContext* ctx,
+                                              size_t bytes, int* buffer_idx);
+
+  // Get the scratch buffer pointer.
+  // This method is only available in Eval stage.
+  // WARNING: This is an experimental interface that is subject to change.
+  void* (*GetScratchBuffer)(struct TfLiteContext* ctx, int buffer_idx);
+
+  // Resize the memory pointer of the `tensor`. This method behaves the same as
+  // `ResizeTensor`, except that it makes a copy of the shape array internally
+  // so the shape array could be deallocated right afterwards.
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteStatus (*ResizeTensorExplicit)(struct TfLiteContext* ctx,
+                                       TfLiteTensor* tensor, int dims,
+                                       const int* shape);
+
+  // This method provides a preview of post-delegation partitioning. Each
+  // TfLiteDelegateParams in the referenced array corresponds to one instance of
+  // the delegate kernel.
+  // Example usage:
+  //
+  // TfLiteIntArray* nodes_to_replace = ...;
+  // TfLiteDelegateParams* params_array;
+  // int num_partitions = 0;
+  // TF_LITE_ENSURE_STATUS(context->PreviewDelegatePartitioning(
+  //    context, delegate, nodes_to_replace, &params_array, &num_partitions));
+  // for (int idx = 0; idx < num_partitions; idx++) {
+  //    const auto& partition_params = params_array[idx];
+  //    ...
+  // }
+  //
+  // NOTE: The context owns the memory referenced by partition_params_array. It
+  // will be cleared with another call to PreviewDelegateParitioning, or after
+  // TfLiteDelegateParams::Prepare returns.
+  //
+  // WARNING: This is an experimental interface that is subject to change.
+  TfLiteStatus (*PreviewDelegatePartitioning)(
+      struct TfLiteContext* context, const TfLiteIntArray* nodes_to_replace,
+      TfLiteDelegateParams** partition_params_array, int* num_partitions);
+
+  // Returns a TfLiteTensor struct for a given index.
+  // WARNING: This is an experimental interface that is subject to change.
+  // WARNING: This method may not be available on all platforms.
+  TfLiteTensor* (*GetTensor)(const struct TfLiteContext* context,
+                             int tensor_idx);
+
+  // Returns a TfLiteEvalTensor struct for a given index.
+  // WARNING: This is an experimental interface that is subject to change.
+  // WARNING: This method may not be available on all platforms.
+  TfLiteEvalTensor* (*GetEvalTensor)(const struct TfLiteContext* context,
+                                     int tensor_idx);
+} TfLiteContext;
+
+typedef struct TfLiteRegistration {
+  // Initializes the op from serialized data.
+  // If a built-in op:
+  //   `buffer` is the op's params data (TfLiteLSTMParams*).
+  //   `length` is zero.
+  // If custom op:
+  //   `buffer` is the op's `custom_options`.
+  //   `length` is the size of the buffer.
+  //
+  // Returns a type-punned (i.e. void*) opaque data (e.g. a primitive pointer
+  // or an instance of a struct).
+  //
+  // The returned pointer will be stored with the node in the `user_data` field,
+  // accessible within prepare and invoke functions below.
+  // NOTE: if the data is already in the desired format, simply implement this
+  // function to return `nullptr` and implement the free function to be a no-op.
+  void* (*init)(TfLiteContext* context, const char* buffer, size_t length);
+
+  // The pointer `buffer` is the data previously returned by an init invocation.
+  void (*free)(TfLiteContext* context, void* buffer);
+
+  // prepare is called when the inputs this node depends on have been resized.
+  // context->ResizeTensor() can be called to request output tensors to be
+  // resized.
+  //
+  // Returns kTfLiteOk on success.
+  TfLiteStatus (*prepare)(TfLiteContext* context, TfLiteNode* node);
+
+  // Execute the node (should read node->inputs and output to node->outputs).
+  // Returns kTfLiteOk on success.
+  TfLiteStatus (*invoke)(TfLiteContext* context, TfLiteNode* node);
+
+  // profiling_string is called during summarization of profiling information
+  // in order to group executions together. Providing a value here will cause a
+  // given op to appear multiple times is the profiling report. This is
+  // particularly useful for custom ops that can perform significantly
+  // different calculations depending on their `user-data`.
+  const char* (*profiling_string)(const TfLiteContext* context,
+                                  const TfLiteNode* node);
+
+  // Builtin codes. If this kernel refers to a builtin this is the code
+  // of the builtin. This is so we can do marshaling to other frameworks like
+  // NN API.
+  // Note: It is the responsibility of the registration binder to set this
+  // properly.
+  int32_t builtin_code;
+
+  // Custom op name. If the op is a builtin, this will be null.
+  // Note: It is the responsibility of the registration binder to set this
+  // properly.
+  // WARNING: This is an experimental interface that is subject to change.
+  const char* custom_name;
+
+  // The version of the op.
+  // Note: It is the responsibility of the registration binder to set this
+  // properly.
+  int version;
+} TfLiteRegistration;
+
+// The flags used in `TfLiteDelegate`. Note that this is a bitmask, so the
+// values should be 1, 2, 4, 8, ...etc.
+typedef enum TfLiteDelegateFlags {
+  kTfLiteDelegateFlagsNone = 0,
+  // The flag is set if the delegate can handle dynamic sized tensors.
+  // For example, the output shape of a `Resize` op with non-constant shape
+  // can only be inferred when the op is invoked.
+  // In this case, the Delegate is responsible for calling
+  // `SetTensorToDynamic` to mark the tensor as a dynamic tensor, and calling
+  // `ResizeTensor` when invoking the op.
+  //
+  // If the delegate isn't capable to handle dynamic tensors, this flag need
+  // to be set to false.
+  kTfLiteDelegateFlagsAllowDynamicTensors = 1,
+
+  // This flag can be used by delegates (that allow dynamic tensors) to ensure
+  // applicable tensor shapes are automatically propagated in the case of tensor
+  // resizing.
+  // This means that non-dynamic (allocation_type != kTfLiteDynamic) I/O tensors
+  // of a delegate kernel will have correct shapes before its Prepare() method
+  // is called. The runtime leverages TFLite builtin ops in the original
+  // execution plan to propagate shapes.
+  //
+  // A few points to note:
+  // 1. This requires kTfLiteDelegateFlagsAllowDynamicTensors. If that flag is
+  // false, this one is redundant since the delegate kernels are re-initialized
+  // every time tensors are resized.
+  // 2. Enabling this flag adds some overhead to AllocateTensors(), since extra
+  // work is required to prepare the original execution plan.
+  // 3. This flag requires that the original execution plan only have ops with
+  // valid registrations (and not 'dummy' custom ops like with Flex).
+  // WARNING: This feature is experimental and subject to change.
+  kTfLiteDelegateFlagsRequirePropagatedShapes = 2
+} TfLiteDelegateFlags;
+
+// WARNING: This is an experimental interface that is subject to change.
+typedef struct TfLiteDelegate {
+  // Data that delegate needs to identify itself. This data is owned by the
+  // delegate. The delegate is owned in the user code, so the delegate is
+  // responsible for doing this when it is destroyed.
+  void* data_;
+
+  // Invoked by ModifyGraphWithDelegate. This prepare is called, giving the
+  // delegate a view of the current graph through TfLiteContext*. It typically
+  // will look at the nodes and call ReplaceNodeSubsetsWithDelegateKernels()
+  // to ask the TensorFlow lite runtime to create macro-nodes to represent
+  // delegated subgraphs of the original graph.
+  TfLiteStatus (*Prepare)(TfLiteContext* context,
+                          struct TfLiteDelegate* delegate);
+
+  // Copy the data from delegate buffer handle into raw memory of the given
+  // 'tensor'. Note that the delegate is allowed to allocate the raw bytes as
+  // long as it follows the rules for kTfLiteDynamic tensors, in which case this
+  // cannot be null.
+  TfLiteStatus (*CopyFromBufferHandle)(TfLiteContext* context,
+                                       struct TfLiteDelegate* delegate,
+                                       TfLiteBufferHandle buffer_handle,
+                                       TfLiteTensor* tensor);
+
+  // Copy the data from raw memory of the given 'tensor' to delegate buffer
+  // handle. This can be null if the delegate doesn't use its own buffer.
+  TfLiteStatus (*CopyToBufferHandle)(TfLiteContext* context,
+                                     struct TfLiteDelegate* delegate,
+                                     TfLiteBufferHandle buffer_handle,
+                                     TfLiteTensor* tensor);
+
+  // Free the Delegate Buffer Handle. Note: This only frees the handle, but
+  // this doesn't release the underlying resource (e.g. textures). The
+  // resources are either owned by application layer or the delegate.
+  // This can be null if the delegate doesn't use its own buffer.
+  void (*FreeBufferHandle)(TfLiteContext* context,
+                           struct TfLiteDelegate* delegate,
+                           TfLiteBufferHandle* handle);
+
+  // Bitmask flags. See the comments in `TfLiteDelegateFlags`.
+  int64_t flags;
+} TfLiteDelegate;
+
+// Build a 'null' delegate, with all the fields properly set to their default
+// values.
+TfLiteDelegate TfLiteDelegateCreate();
+
+#else
+
+typedef struct TfLiteDelegate TfLiteDelegate;
+
+#endif  // IREE_BINDINGS_TFLITE_INCLUDE_UNSUPPORTED_APIS
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+#endif  // TENSORFLOW_LITE_C_COMMON_H_

--- a/bindings/tflite/interpreter.c
+++ b/bindings/tflite/interpreter.c
@@ -1,0 +1,612 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/interpreter.h"
+
+#include "bindings/tflite/model.h"
+#include "bindings/tflite/shim.h"
+#include "bindings/tflite/tensor.h"
+#include "iree/base/threading.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/drivers/init.h"
+#include "iree/modules/hal/hal_module.h"
+
+//===----------------------------------------------------------------------===//
+// HAL / driver support
+//===----------------------------------------------------------------------===//
+
+static iree_once_flag _TfLiteInterpreterRegisterDriverFlag =
+    IREE_ONCE_FLAG_INIT;
+static void _TfLiteInterpreterRegisterDrivers(void) {
+  IREE_IGNORE_ERROR(iree_hal_register_all_available_drivers(
+      iree_hal_driver_registry_default()));
+}
+
+// TODO(#3977): if already provided a HAL device in the options use that.
+static iree_status_t _TfLiteInterpreterPrepareHAL(
+    TfLiteInterpreter* interpreter) {
+  iree_call_once(&_TfLiteInterpreterRegisterDriverFlag,
+                 _TfLiteInterpreterRegisterDrivers);
+
+  iree_hal_driver_registry_t* driver_registry =
+      iree_hal_driver_registry_default();
+
+  iree_hal_driver_info_t* driver_infos = NULL;
+  iree_host_size_t driver_info_count = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_driver_registry_enumerate(
+      driver_registry, interpreter->allocator, &driver_infos,
+      &driver_info_count));
+
+  // TODO(benvanik): figure out how we want to emulate device selection; may
+  // just say "whatever is first" on a query.
+  // iree_string_view_t driver_name = driver_infos[0].driver_name;
+  // NOTE: currently the sample file is compiled only with vmla.
+  iree_string_view_t driver_name = iree_make_cstring_view("vmla");
+
+  // TODO(benvanik): switch to iree_hal_driver_registry_try_create when
+  // implemented.
+  iree_status_t status = iree_hal_driver_registry_try_create_by_name(
+      driver_registry, driver_name, interpreter->allocator,
+      &interpreter->driver);
+  iree_allocator_free(interpreter->allocator, driver_infos);
+  IREE_RETURN_IF_ERROR(status, "failed to create driver '%.*s'",
+                       (int)driver_name.size, driver_name.data);
+
+  IREE_RETURN_IF_ERROR(
+      iree_hal_driver_create_default_device(
+          interpreter->driver, interpreter->allocator, &interpreter->device),
+      "failed creating the default device for driver '%.*s'",
+      (int)driver_name.size, driver_name.data);
+
+  IREE_RETURN_IF_ERROR(iree_hal_module_create(
+      interpreter->device, interpreter->allocator, &interpreter->hal_module));
+
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Model shape function query/mutation utilities
+//===----------------------------------------------------------------------===//
+
+// On-stack storage for shape function invocations.
+// Avoids all allocations and allows for reuse when running down lists of
+// inputs and outputs calling shape functions.
+typedef struct {
+  // Inlined list for the !vm.list in the shape function arguments.
+  uint8_t
+      shape_list_storage[128 + sizeof(int32_t) * IREE_BINDINGS_TFLITE_MAX_RANK];
+  iree_vm_list_t* shape_list;
+
+  // Inlined list for the shape function arguments.
+  uint8_t arg_list_storage[128 + sizeof(uintptr_t) * 2];
+  iree_vm_list_t* arg_list;
+} _TfLiteInterpreterShapeFrame;
+
+// Initializes an on-stack shape frame. Existing contents are discarded.
+static iree_status_t _TfLiteInterpreterShapeFrameInitialize(
+    _TfLiteInterpreterShapeFrame* frame) {
+  // [int32...] storage for the shape dimension inputs/outputs.
+  iree_vm_type_def_t dim_type =
+      iree_vm_type_def_make_value_type(IREE_VM_VALUE_TYPE_I32);
+  IREE_RETURN_IF_ERROR(iree_vm_list_initialize(
+      iree_make_byte_span(frame->shape_list_storage,
+                          IREE_ARRAYSIZE(frame->shape_list_storage)),
+      &dim_type, IREE_BINDINGS_TFLITE_MAX_RANK, &frame->shape_list));
+
+  // (%index : i32, %shape : !vm.list<i32>)
+  IREE_RETURN_IF_ERROR(iree_vm_list_initialize(
+      iree_make_byte_span(frame->arg_list_storage,
+                          IREE_ARRAYSIZE(frame->arg_list_storage)),
+      /*element_type=*/NULL, /*index*/ 1 + /*shape*/ 1, &frame->arg_list));
+  IREE_RETURN_IF_ERROR(iree_vm_list_resize(frame->arg_list, 2));
+
+  // Arg 1 is always the shape list for all I/O, so do that once here.
+  iree_vm_ref_t shape_list_ref = {0};
+  IREE_RETURN_IF_ERROR(iree_vm_ref_wrap_assign(
+      frame->shape_list, iree_vm_list_type_id(), &shape_list_ref));
+  IREE_RETURN_IF_ERROR(
+      iree_vm_list_set_ref_retain(frame->arg_list, 1, &shape_list_ref));
+
+  return iree_ok_status();
+}
+
+// Deinitializes an on-stack shape frame.
+// Though this does not free the frame memory (it's on the stack, afterall) it
+// will release any resources that may be retained and is required.
+static void _TfLiteInterpreterShapeFrameDeinitialize(
+    _TfLiteInterpreterShapeFrame* frame) {
+  iree_vm_list_deinitialize(frame->shape_list);
+  iree_vm_list_deinitialize(frame->arg_list);
+}
+
+// Reads the shape value in the frame storage from the prior application.
+static iree_status_t _TfLiteInterpreterShapeFrameReadValue(
+    _TfLiteInterpreterShapeFrame* frame, int32_t* out_shape_rank,
+    int32_t* out_shape_dims) {
+  *out_shape_rank = (int32_t)iree_vm_list_size(frame->shape_list);
+  for (int32_t i = 0; i < *out_shape_rank; ++i) {
+    iree_vm_value_t dim;
+    IREE_RETURN_IF_ERROR(iree_vm_list_get_value_as(
+        frame->shape_list, i, IREE_VM_VALUE_TYPE_I32, &dim));
+    out_shape_dims[i] = dim.i32;
+  }
+  return iree_ok_status();
+}
+
+// Writes the shape value to the current frame storage for future applications.
+static iree_status_t _TfLiteInterpreterShapeFrameWriteValue(
+    _TfLiteInterpreterShapeFrame* frame, int32_t shape_rank,
+    const int32_t* shape_dims) {
+  IREE_RETURN_IF_ERROR(iree_vm_list_resize(frame->shape_list, shape_rank));
+  for (int32_t i = 0; i < shape_rank; ++i) {
+    iree_vm_value_t dim = iree_vm_value_make_i32(shape_dims[i]);
+    IREE_RETURN_IF_ERROR(iree_vm_list_set_value(frame->shape_list, i, &dim));
+  }
+  return iree_ok_status();
+}
+
+// Calls the |apply_fn| with the current shape frame state.
+static iree_status_t _TfLiteInterpreterShapeFrameApply(
+    _TfLiteInterpreterShapeFrame* frame, TfLiteInterpreter* interpreter,
+    iree_vm_function_t apply_fn, int32_t index) {
+  // Populate shape_list with the shape dimensions for this particular output.
+  iree_vm_value_t index_value = iree_vm_value_make_i32(index);
+  IREE_IGNORE_ERROR(iree_vm_list_set_value(frame->arg_list, 0, &index_value));
+  return iree_vm_invoke(interpreter->context, apply_fn,
+                        /*policy=*/NULL, frame->arg_list, /*outputs=*/NULL,
+                        interpreter->allocator);
+}
+
+//===----------------------------------------------------------------------===//
+// Shape I/O queries
+//===----------------------------------------------------------------------===//
+
+// Queries all input shapes from the module; some may still be dynamic (-1).
+static iree_status_t _TfLiteInterpreterRefreshInputShapes(
+    TfLiteInterpreter* interpreter, _TfLiteInterpreterShapeFrame* frame) {
+  // NOTE: we could optimize this more by using iree_vm_invoke_within, but that
+  // shouldn't be needed (it's just stack pointer manipulation).
+  for (int32_t i = 0; i < interpreter->model->input_count; ++i) {
+    TfLiteTensor* tensor = &interpreter->input_tensors[i];
+    IREE_RETURN_IF_ERROR(_TfLiteInterpreterShapeFrameApply(
+        frame, interpreter, interpreter->model->exports._query_input_shape, i));
+    IREE_RETURN_IF_ERROR(_TfLiteInterpreterShapeFrameReadValue(
+        frame, &tensor->shape_rank, tensor->shape_dims));
+  }
+  return iree_ok_status();
+}
+
+// Queries all output shapes from the module allowing it use the current input
+// shapes to compute the possibly dynamic values.
+static iree_status_t _TfLiteInterpreterRefreshOutputShapes(
+    TfLiteInterpreter* interpreter, _TfLiteInterpreterShapeFrame* frame) {
+  // NOTE: we could optimize this more by using iree_vm_invoke_within, but that
+  // shouldn't be needed (it's just stack pointer manipulation).
+  for (int32_t i = 0; i < interpreter->model->output_count; ++i) {
+    TfLiteTensor* tensor = &interpreter->output_tensors[i];
+    IREE_RETURN_IF_ERROR(_TfLiteInterpreterShapeFrameApply(
+        frame, interpreter, interpreter->model->exports._query_output_shape,
+        i));
+    IREE_RETURN_IF_ERROR(_TfLiteInterpreterShapeFrameReadValue(
+        frame, &tensor->shape_rank, tensor->shape_dims));
+  }
+  return iree_ok_status();
+}
+
+// Refreshes both input and output tensor shapes by querying the module.
+// This should be called after each shape change so that we can let the module
+// run "shape propagation" and compute the new output shapes.
+static iree_status_t _TfLiteInterpreterRefreshIOShapes(
+    TfLiteInterpreter* interpreter) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  _TfLiteInterpreterShapeFrame frame;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, _TfLiteInterpreterShapeFrameInitialize(&frame));
+
+  // Query all shapes.
+  iree_status_t status = iree_ok_status();
+  if (iree_status_is_ok(status)) {
+    status = _TfLiteInterpreterRefreshInputShapes(interpreter, &frame);
+  }
+  if (iree_status_is_ok(status)) {
+    status = _TfLiteInterpreterRefreshOutputShapes(interpreter, &frame);
+  }
+
+  _TfLiteInterpreterShapeFrameDeinitialize(&frame);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// Creation and static initialization
+//===----------------------------------------------------------------------===//
+
+// Computes the storage requirement for the TfLiteInterpreter struct.
+static iree_host_size_t _TfLiteInterpreterCalculateSize(
+    const TfLiteModel* model) {
+  iree_host_size_t total_size =
+      iree_math_align(sizeof(TfLiteInterpreter), iree_max_align_t);
+
+  iree_vm_type_def_t buffer_view_type_def =
+      iree_vm_type_def_make_ref_type(iree_hal_buffer_type_id());
+  total_size +=
+      iree_vm_list_storage_size(&buffer_view_type_def, model->input_count);
+  total_size +=
+      iree_vm_list_storage_size(&buffer_view_type_def, model->output_count);
+  total_size += sizeof(TfLiteTensor) * model->input_count;
+  total_size += sizeof(TfLiteTensor) * model->output_count;
+
+  return total_size;
+}
+
+// Allocates the interpreter slab and populates all internal pointers to the
+// appropriate offsets.
+static iree_status_t _TfLiteInterpreterAllocate(
+    const TfLiteModel* model, TfLiteInterpreter** out_interpreter) {
+  iree_host_size_t interpreter_size = _TfLiteInterpreterCalculateSize(model);
+  TfLiteInterpreter* interpreter = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(model->allocator, interpreter_size,
+                                             (void**)&interpreter));
+  memset(interpreter, 0, interpreter_size);
+  interpreter->allocator = model->allocator;
+  _TfLiteInterpreterOptionsSetDefaults(&interpreter->options);
+  *out_interpreter = interpreter;
+
+  interpreter->model = (TfLiteModel*)model;
+  _TfLiteModelRetain(interpreter->model);
+
+  uint8_t* p = (uint8_t*)interpreter +
+               iree_math_align(sizeof(*interpreter), iree_max_align_t);
+
+  iree_vm_type_def_t buffer_view_type_def =
+      iree_vm_type_def_make_ref_type(iree_hal_buffer_type_id());
+
+  iree_byte_span_t input_list_storage = iree_make_byte_span(
+      p, iree_vm_list_storage_size(&buffer_view_type_def, model->input_count));
+  IREE_RETURN_IF_ERROR(
+      iree_vm_list_initialize(input_list_storage, &buffer_view_type_def,
+                              model->input_count, &interpreter->input_list));
+  p += input_list_storage.data_length;
+
+  iree_byte_span_t output_list_storage = iree_make_byte_span(
+      p, iree_vm_list_storage_size(&buffer_view_type_def, model->output_count));
+  IREE_RETURN_IF_ERROR(
+      iree_vm_list_initialize(output_list_storage, &buffer_view_type_def,
+                              model->output_count, &interpreter->output_list));
+  p += output_list_storage.data_length;
+
+  interpreter->input_tensors = (TfLiteTensor*)p;
+  p += sizeof(TfLiteTensor) * model->input_count;
+  interpreter->output_tensors = (TfLiteTensor*)p;
+  // p += sizeof(TfLiteTensor) * model->output_count;
+
+  return iree_ok_status();
+}
+
+// Populates the input and output tensor lists with static metadata from the
+// model and prepares for allocation/invocation.
+static iree_status_t _TfLiteInterpreterPopulateIO(
+    TfLiteInterpreter* interpreter) {
+  // TODO(#3978): actually read out io_attr attribute values and initialize.
+  // iree_vm_function_t main_fn = interpreter->model->exports._main;
+  // iree_string_view_t io_attr = iree_vm_function_reflection_attr(
+  //     &main_fn, iree_make_cstring_view("tflite_io"));
+
+  // Setup static tensor metadata.
+  for (iree_host_size_t i = 0; i < interpreter->model->input_count; ++i) {
+    iree_string_view_t attr = iree_make_cstring_view("UNIMPLEMENTED");
+    IREE_RETURN_IF_ERROR(
+        _TfLiteTensorParseAttr(attr, &interpreter->input_tensors[i]));
+  }
+  for (iree_host_size_t i = 0; i < interpreter->model->output_count; ++i) {
+    iree_string_view_t attr = iree_make_cstring_view("UNIMPLEMENTED");
+    IREE_RETURN_IF_ERROR(
+        _TfLiteTensorParseAttr(attr, &interpreter->output_tensors[i]));
+  }
+
+  // Prepare the IO lists we use when calling into the model.
+  // The actual contents of these cannot be set until
+  // TfLiteInterpreterAllocateTensors has been called.
+  IREE_RETURN_IF_ERROR(iree_vm_list_reserve(interpreter->input_list,
+                                            interpreter->model->input_count));
+  IREE_RETURN_IF_ERROR(iree_vm_list_reserve(interpreter->output_list,
+                                            interpreter->model->output_count));
+
+  return iree_ok_status();
+}
+
+static iree_status_t _TfLiteInterpreterCreate(
+    const TfLiteModel* model, const TfLiteInterpreterOptions* optional_options,
+    TfLiteInterpreter** out_interpreter) {
+  *out_interpreter = NULL;
+
+  // We allocate a large majority of the interpreter structures as a single
+  // slab. There's still some allocations that we could prevent (like internal
+  // VM stuff) but this at least covers half of it.
+  IREE_RETURN_IF_ERROR(_TfLiteInterpreterAllocate(model, out_interpreter));
+  TfLiteInterpreter* interpreter = *out_interpreter;
+
+  if (optional_options) {
+    memcpy(&interpreter->options, optional_options,
+           sizeof(interpreter->options));
+  }
+
+  interpreter->user_module = model->module;
+  iree_vm_module_retain(interpreter->user_module);
+
+  // External contexts could possibly used to emulate sharing this, but really
+  // if a user is running with multiple models the tflite API is insufficient.
+  IREE_RETURN_IF_ERROR(
+      iree_vm_instance_create(interpreter->allocator, &interpreter->instance));
+  IREE_RETURN_IF_ERROR(_TfLiteInterpreterPrepareHAL(interpreter));
+
+  // Context will contain both the user-provided bytecode and the HAL module.
+  // If we were to support custom ops we would also have a
+  // tflite_resolver_module that we would register to resolve tflite ops into
+  // IREE functions that will call custom ops through TfLiteRegistrations.
+  IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
+      interpreter->instance, interpreter->all_modules,
+      IREE_ARRAYSIZE(interpreter->all_modules), interpreter->allocator,
+      &interpreter->context));
+
+  // Setup all I/O tensors and buffer views.
+  IREE_RETURN_IF_ERROR(_TfLiteInterpreterPopulateIO(interpreter));
+
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// Core API
+//===----------------------------------------------------------------------===//
+
+TFL_CAPI_EXPORT extern TfLiteInterpreter* TfLiteInterpreterCreate(
+    const TfLiteModel* model,
+    const TfLiteInterpreterOptions* optional_options) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  TfLiteInterpreter* interpreter = NULL;
+  iree_status_t status =
+      _TfLiteInterpreterCreate(model, optional_options, &interpreter);
+  if (iree_status_is_ok(iree_status_consume_code(status))) {
+    IREE_TRACE_ZONE_APPEND_TEXT(z0, "num_threads=", strlen("num_threads="));
+    IREE_TRACE_ZONE_APPEND_VALUE(z0, interpreter->options.num_threads);
+  } else {
+    IREE_TRACE_MESSAGE(ERROR, "failed interpreter creation");
+    TfLiteInterpreterDelete(interpreter);
+    interpreter = NULL;
+  }
+  IREE_TRACE_ZONE_END(z0);
+  return interpreter;
+}
+
+TFL_CAPI_EXPORT extern TfLiteInterpreter*
+TfLiteInterpreterCreateWithSelectedOps(
+    const TfLiteModel* model, const TfLiteInterpreterOptions* options) {
+  // No different from TfLiteInterpreterCreate: we don't have "ops" :)
+  return TfLiteInterpreterCreate(model, options);
+}
+
+TFL_CAPI_EXPORT extern void TfLiteInterpreterDelete(
+    TfLiteInterpreter* interpreter) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  for (iree_host_size_t i = 0; i < interpreter->model->input_count; ++i) {
+    _TfLiteTensorReset(&interpreter->input_tensors[i]);
+  }
+  for (iree_host_size_t i = 0; i < interpreter->model->output_count; ++i) {
+    _TfLiteTensorReset(&interpreter->output_tensors[i]);
+  }
+  iree_vm_list_deinitialize(interpreter->input_list);
+  iree_vm_list_deinitialize(interpreter->output_list);
+
+  iree_vm_context_release(interpreter->context);
+  iree_vm_module_release(interpreter->hal_module);
+  iree_vm_module_release(interpreter->user_module);
+  iree_vm_instance_release(interpreter->instance);
+
+  _TfLiteModelRelease(interpreter->model);
+  iree_allocator_free(interpreter->allocator, interpreter);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterResetVariableTensors(
+    TfLiteInterpreter* interpreter) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // The compiler emits a special function we can use to reset just variables.
+  // NOTE: the function is optional if the model had no variables.
+  iree_status_t status = iree_ok_status();
+  iree_vm_function_t reset_variables_fn =
+      interpreter->model->exports._reset_variables;
+  if (!iree_vm_function_is_null(reset_variables_fn)) {
+    status = iree_vm_invoke(interpreter->context, reset_variables_fn,
+                            /*policy=*/NULL, /*inputs=*/NULL, /*outputs=*/NULL,
+                            interpreter->allocator);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return _TfLiteStatusFromIREEStatus(status);
+}
+
+TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetInputTensorCount(
+    const TfLiteInterpreter* interpreter) {
+  return interpreter->model->input_count;
+}
+
+TFL_CAPI_EXPORT extern TfLiteTensor* TfLiteInterpreterGetInputTensor(
+    const TfLiteInterpreter* interpreter, int32_t input_index) {
+  if (input_index < 0 || input_index >= interpreter->model->input_count) {
+    return NULL;
+  }
+  return &interpreter->input_tensors[input_index];
+}
+
+static iree_status_t _TfLiteInterpreterResizeInputTensor(
+    TfLiteInterpreter* interpreter, int32_t input_index, const int* input_dims,
+    int32_t input_dims_size) {
+  if (input_index < 0 || input_index >= interpreter->model->input_count) {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "input_index out of range (0 <= %d < %d)",
+                            input_index, interpreter->model->input_count);
+  }
+  if (iree_vm_function_is_null(
+          interpreter->model->exports._resize_input_shape)) {
+    // TODO(#3975): check if this is a no-op success in tflite.
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "model has no dynamic shapes");
+  }
+
+  _TfLiteInterpreterShapeFrame frame;
+  IREE_RETURN_IF_ERROR(_TfLiteInterpreterShapeFrameInitialize(&frame));
+
+  // Poke the model and let it update its internal shape.
+  // TODO(#3975): return bool to allow model to say it failed.
+  TfLiteTensor* tensor = &interpreter->input_tensors[input_index];
+  iree_status_t status = _TfLiteInterpreterShapeFrameWriteValue(
+      &frame, tensor->shape_rank, tensor->shape_dims);
+  if (iree_status_is_ok(status)) {
+    status = _TfLiteInterpreterShapeFrameApply(
+        &frame, interpreter, interpreter->model->exports._resize_input_shape,
+        input_index);
+  }
+
+  // NOTE: the allocation may now not match the requested shape. This is just
+  // how the tflite API works unfortunately; until
+  // TfLiteInterpreterAllocateTensors it will remain in an indeterminate state.
+
+  _TfLiteInterpreterShapeFrameDeinitialize(&frame);
+  return status;
+}
+
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterResizeInputTensor(
+    TfLiteInterpreter* interpreter, int32_t input_index, const int* input_dims,
+    int32_t input_dims_size) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _TfLiteInterpreterResizeInputTensor(
+      interpreter, input_index, input_dims, input_dims_size);
+  IREE_TRACE_ZONE_END(z0);
+  return _TfLiteStatusFromIREEStatus(status);
+}
+
+static iree_status_t _TfLiteInterpreterAllocateTensors(
+    TfLiteInterpreter* interpreter) {
+  // NOTE: we could slab allocate like tflite does, but then if any single
+  // tensor has any single dimension that is resized the whole thing gets
+  // reallocated upon resize. That's no good. Instead, we realloc each tensor
+  // if their size has changed.
+
+  // Refresh all shapes from the model. It should have all of the
+  // non-data-dependent output shapes.
+  IREE_RETURN_IF_ERROR(_TfLiteInterpreterRefreshIOShapes(interpreter));
+
+  // Drop all input tensors we hang on to in the input list. This way we aren't
+  // double-allocating during the resize.
+  IREE_RETURN_IF_ERROR(iree_vm_list_resize(interpreter->input_list, 0));
+
+  // Reallocate input tensors (if needed).
+  for (iree_host_size_t i = 0; i < interpreter->model->input_count; ++i) {
+    TfLiteTensor* tensor = &interpreter->input_tensors[i];
+    IREE_RETURN_IF_ERROR(_TfLiteTensorReallocateIfNeeded(
+        tensor, iree_hal_device_allocator(interpreter->device),
+        interpreter->allocator));
+    iree_vm_ref_t buffer_ref = iree_hal_buffer_retain_ref(tensor->buffer);
+    IREE_RETURN_IF_ERROR(
+        iree_vm_list_push_ref_move(interpreter->input_list, &buffer_ref));
+  }
+
+  // TODO(benvanik): preallocate outputs when we support using them.
+  // We could stash the buffer views in interpreter->output_list.
+  // For now we just drop them all.
+  for (iree_host_size_t i = 0; i < interpreter->model->output_count; ++i) {
+    _TfLiteTensorDiscardBuffer(&interpreter->output_tensors[i]);
+  }
+
+  return iree_ok_status();
+}
+
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterAllocateTensors(
+    TfLiteInterpreter* interpreter) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = _TfLiteInterpreterAllocateTensors(interpreter);
+
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+  iree_device_size_t total_input_size = 0;
+  for (iree_host_size_t i = 0; i < interpreter->model->input_count; ++i) {
+    total_input_size +=
+        iree_hal_buffer_byte_length(interpreter->input_tensors[i].buffer);
+  }
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, total_input_size);
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+
+  IREE_TRACE_ZONE_END(z0);
+  return _TfLiteStatusFromIREEStatus(status);
+}
+
+static iree_status_t _TfLiteInterpreterInvoke(TfLiteInterpreter* interpreter) {
+  // tflite models only have a single entry point and the IREE converter
+  // emits it as '_main'.
+  IREE_RETURN_IF_ERROR(
+      iree_vm_invoke(interpreter->context, interpreter->model->exports._main,
+                     /*policy=*/NULL, interpreter->input_list,
+                     interpreter->output_list, interpreter->allocator));
+
+  // Refresh output shapes.
+  // TODO(#3975): just use buffer view results or at least just refresh outputs.
+  IREE_RETURN_IF_ERROR(_TfLiteInterpreterRefreshIOShapes(interpreter));
+
+  // Map the output buffers.
+  // NOTE: we could defer the mapping unless requested and ensure state buffers
+  // remain where they currently are for the next invocation.
+  for (iree_host_size_t i = 0; i < interpreter->model->output_count; ++i) {
+    iree_hal_buffer_t* buffer = (iree_hal_buffer_t*)iree_vm_list_get_ref_deref(
+        interpreter->output_list, i, iree_hal_buffer_get_descriptor());
+    TfLiteTensor* tensor = &interpreter->output_tensors[i];
+    IREE_RETURN_IF_ERROR(_TfLiteTensorBind(tensor, buffer));
+  }
+
+  return iree_ok_status();
+}
+
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteInterpreterInvoke(
+    TfLiteInterpreter* interpreter) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = _TfLiteInterpreterInvoke(interpreter);
+
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+  iree_device_size_t total_output_size = 0;
+  for (iree_host_size_t i = 0; i < interpreter->model->output_count; ++i) {
+    total_output_size +=
+        iree_hal_buffer_byte_length(interpreter->output_tensors[i].buffer);
+  }
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, total_output_size);
+#endif  // IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
+
+  IREE_TRACE_ZONE_END(z0);
+  return _TfLiteStatusFromIREEStatus(status);
+}
+
+TFL_CAPI_EXPORT extern int32_t TfLiteInterpreterGetOutputTensorCount(
+    const TfLiteInterpreter* interpreter) {
+  return interpreter->model->output_count;
+}
+
+TFL_CAPI_EXPORT extern const TfLiteTensor* TfLiteInterpreterGetOutputTensor(
+    const TfLiteInterpreter* interpreter, int32_t output_index) {
+  if (output_index < 0 || output_index >= interpreter->model->output_count) {
+    return NULL;
+  }
+  return &interpreter->output_tensors[output_index];
+}

--- a/bindings/tflite/interpreter.h
+++ b/bindings/tflite/interpreter.h
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BINDINGS_TFLITE_INTERPRETER_H_
+#define IREE_BINDINGS_TFLITE_INTERPRETER_H_
+
+#include "bindings/tflite/model.h"
+#include "bindings/tflite/options.h"
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/vm/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+#include "bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h"
+
+struct TfLiteInterpreter {
+  iree_allocator_t allocator;
+
+  TfLiteModel* model;  // retained
+  TfLiteInterpreterOptions options;
+
+  iree_vm_instance_t* instance;
+  iree_hal_driver_t* driver;
+  iree_hal_device_t* device;
+
+  union {
+    // NOTE: order matters; later modules in the list resolve symbols using the
+    // earlier modules (like system/custom modules).
+    struct {
+      iree_vm_module_t* hal_module;
+      iree_vm_module_t* user_module;
+    };
+    iree_vm_module_t* all_modules[2];
+  };
+  iree_vm_context_t* context;
+
+  iree_vm_list_t* input_list;
+  iree_vm_list_t* output_list;
+  TfLiteTensor* input_tensors;
+  TfLiteTensor* output_tensors;
+};
+
+#endif  // IREE_BINDINGS_TFLITE_INTERPRETER_H_

--- a/bindings/tflite/model.c
+++ b/bindings/tflite/model.c
@@ -1,0 +1,203 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/model.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "iree/base/tracing.h"
+#include "iree/modules/hal/hal_module.h"
+#include "iree/vm/bytecode_module.h"
+
+static iree_status_t _TfLiteModelPrepareRuntime() {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, iree_vm_register_builtin_types());
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, iree_hal_module_register_types());
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+static iree_status_t _TfLiteModelCalculateFunctionIOCounts(
+    const iree_vm_function_signature_t* signature, int32_t* out_input_count,
+    int32_t* out_output_count) {
+  iree_string_view_t arguments, results;
+  IREE_RETURN_IF_ERROR(iree_vm_function_call_get_cconv_fragments(
+      signature, &arguments, &results));
+  // NOTE: today we only pass 1:1 buffer views with what tflite does.
+  // That means that both these should be one `r` per buffer view and our counts
+  // are just the number of chars in the cconv.
+  *out_input_count = (int32_t)arguments.size;
+  *out_output_count = (int32_t)results.size;
+  return iree_ok_status();
+}
+
+static iree_status_t _TfLiteModelInitializeModule(const void* flatbuffer_data,
+                                                  size_t flatbuffer_size,
+                                                  iree_allocator_t allocator,
+                                                  TfLiteModel* model) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(z0, _TfLiteModelPrepareRuntime());
+
+  iree_const_byte_span_t flatbuffer_span =
+      iree_make_const_byte_span(flatbuffer_data, flatbuffer_size);
+  iree_allocator_t flatbuffer_allocator = iree_allocator_null();
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_vm_bytecode_module_create(flatbuffer_span, flatbuffer_allocator,
+                                     allocator, &model->module),
+      "error creating bytecode module");
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_vm_module_lookup_function_by_name(
+          model->module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+          iree_make_cstring_view("_main"), &model->exports._main),
+      "unable to find '_main' export in module");
+
+  // Get the input and output counts of the function; this is useful for being
+  // able to preallocate storage when creating interpreters.
+  iree_vm_function_signature_t main_signature =
+      iree_vm_function_signature(&model->exports._main);
+  IREE_RETURN_IF_ERROR(_TfLiteModelCalculateFunctionIOCounts(
+      &main_signature, &model->input_count, &model->output_count));
+
+  // NOTE: the input shape query is not required as it's possible (though
+  // silly) for a model to have no inputs. In testing this can happen a lot
+  // but in the wild it's rare ... says someone who previously filed bugs
+  // against tflite because they didn't support models with no inputs when I
+  // was being silly and needed them ;)
+  IREE_IGNORE_ERROR(iree_vm_module_lookup_function_by_name(
+      model->module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      iree_make_cstring_view("_query_input_shape"),
+      &model->exports._query_input_shape));
+
+  // NOTE: the input shape resizing function is only required if the model has
+  // dynamic shapes.
+  IREE_IGNORE_ERROR(iree_vm_module_lookup_function_by_name(
+      model->module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      iree_make_cstring_view("_resize_input_shape"),
+      &model->exports._resize_input_shape));
+
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_vm_module_lookup_function_by_name(
+          model->module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+          iree_make_cstring_view("_query_output_shape"),
+          &model->exports._query_output_shape),
+      "unable to find '_query_output_shape' export in module");
+
+  // It's OK for this to fail; the model may not have variables.
+  IREE_IGNORE_ERROR(iree_vm_module_lookup_function_by_name(
+      model->module, IREE_VM_FUNCTION_LINKAGE_EXPORT,
+      iree_make_cstring_view("_reset_variables"),
+      &model->exports._reset_variables));
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreate(const void* model_data,
+                                                      size_t model_size) {
+  iree_allocator_t allocator = iree_allocator_system();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  TfLiteModel* model = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(allocator, sizeof(*model), (void**)&model);
+  if (!iree_status_is_ok(iree_status_consume_code(status))) {
+    IREE_TRACE_MESSAGE(ERROR, "failed model allocation");
+    IREE_TRACE_ZONE_END(z0);
+    return NULL;
+  }
+  memset(model, 0, sizeof(*model));
+  iree_atomic_ref_count_init(&model->ref_count);
+  model->allocator = allocator;
+
+  status =
+      _TfLiteModelInitializeModule(model_data, model_size, allocator, model);
+  if (!iree_status_is_ok(iree_status_consume_code(status))) {
+    IREE_TRACE_ZONE_END(z0);
+    return NULL;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return model;
+}
+
+TFL_CAPI_EXPORT extern TfLiteModel* TfLiteModelCreateFromFile(
+    const char* model_path) {
+  iree_allocator_t allocator = iree_allocator_system();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // TODO(#3909): use file mapping C API.
+  FILE* file = fopen(model_path, "r");
+  if (!file) {
+    IREE_TRACE_MESSAGE(ERROR, "failed to open model file");
+    IREE_TRACE_MESSAGE_DYNAMIC(ERROR, model_path, strlen(model_path));
+    IREE_TRACE_ZONE_END(z0);
+    return NULL;
+  }
+  fseek(file, 0, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0, SEEK_SET);
+  TfLiteModel* model = NULL;
+  iree_status_t status = iree_allocator_malloc(
+      allocator, sizeof(TfLiteModel) + file_size, (void**)&model);
+  if (!iree_status_is_ok(iree_status_consume_code(status))) {
+    IREE_TRACE_MESSAGE(ERROR, "failed model+data allocation");
+    IREE_TRACE_ZONE_END(z0);
+    return NULL;
+  }
+  memset(model, 0, sizeof(*model));
+  iree_atomic_ref_count_init(&model->ref_count);
+  model->allocator = allocator;
+  model->owned_model_data = (uint8_t*)model + file_size;
+  (void)fread(model->owned_model_data, 1, file_size, file);
+  fclose(file);
+
+  status = _TfLiteModelInitializeModule(model->owned_model_data, file_size,
+                                        allocator, model);
+  if (!iree_status_is_ok(iree_status_consume_code(status))) {
+    IREE_TRACE_ZONE_END(z0);
+    return NULL;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return model;
+}
+
+void _TfLiteModelRetain(TfLiteModel* model) {
+  if (model) {
+    iree_atomic_ref_count_inc(&model->ref_count);
+  }
+}
+
+void _TfLiteModelRelease(TfLiteModel* model) {
+  if (model && iree_atomic_ref_count_dec(&model->ref_count) == 1) {
+    IREE_TRACE_ZONE_BEGIN(z0);
+    iree_vm_module_release(model->module);
+    iree_allocator_free(model->allocator, model);
+    IREE_TRACE_ZONE_END(z0);
+  }
+}
+
+TFL_CAPI_EXPORT extern void TfLiteModelDelete(TfLiteModel* model) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  _TfLiteModelRelease(model);
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/bindings/tflite/model.h
+++ b/bindings/tflite/model.h
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BINDINGS_TFLITE_MODEL_H_
+#define IREE_BINDINGS_TFLITE_MODEL_H_
+
+#include "iree/base/api.h"
+#include "iree/base/atomics.h"
+#include "iree/vm/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+#include "bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h"
+
+typedef struct _TfLiteModelExports {
+  iree_vm_function_t _reset_variables;
+  iree_vm_function_t _query_input_shape;
+  iree_vm_function_t _resize_input_shape;
+  iree_vm_function_t _query_output_shape;
+  iree_vm_function_t _main;
+} _TfLiteModelExports;
+
+struct TfLiteModel {
+  iree_atomic_ref_count_t ref_count;
+  iree_allocator_t allocator;
+  void* owned_model_data;
+
+  iree_vm_module_t* module;
+  _TfLiteModelExports exports;
+  int32_t input_count;
+  int32_t output_count;
+};
+
+void _TfLiteModelRetain(TfLiteModel* model);
+void _TfLiteModelRelease(TfLiteModel* model);
+
+#endif  // IREE_BINDINGS_TFLITE_MODEL_H_

--- a/bindings/tflite/options.c
+++ b/bindings/tflite/options.c
@@ -1,0 +1,97 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/options.h"
+
+#include "bindings/tflite/shim.h"
+#include "iree/base/tracing.h"
+
+void _TfLiteInterpreterOptionsSetDefaults(TfLiteInterpreterOptions* options) {
+  options->num_threads = -1;
+}
+
+TFL_CAPI_EXPORT extern TfLiteInterpreterOptions*
+TfLiteInterpreterOptionsCreate() {
+  iree_allocator_t allocator = iree_allocator_system();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  TfLiteInterpreterOptions* options = NULL;
+  iree_status_t status =
+      iree_allocator_malloc(allocator, sizeof(*options), (void**)&options);
+  if (!iree_status_is_ok(iree_status_consume_code(status))) {
+    IREE_TRACE_MESSAGE(ERROR, "failed options allocation");
+    IREE_TRACE_ZONE_END(z0);
+    return NULL;
+  }
+  memset(options, 0, sizeof(*options));
+  options->allocator = allocator;
+  _TfLiteInterpreterOptionsSetDefaults(options);
+
+  IREE_TRACE_ZONE_END(z0);
+  return options;
+}
+
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsDelete(
+    TfLiteInterpreterOptions* options) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_allocator_free(options->allocator, options);
+  IREE_TRACE_ZONE_END(z0);
+}
+
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetNumThreads(
+    TfLiteInterpreterOptions* options, int32_t num_threads) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, num_threads);
+  options->num_threads = num_threads;
+  IREE_TRACE_ZONE_END(z0);
+}
+
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsAddDelegate(
+    TfLiteInterpreterOptions* options, TfLiteDelegate* delegate) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Silently ignored as if it never tried to take an ops for itself.
+  IREE_TRACE_MESSAGE(WARNING,
+                     "TfLiteInterpreterOptionsAddDelegate: delegates are "
+                     "unsupported and ignored in the IREE tflite shim");
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetErrorReporter(
+    TfLiteInterpreterOptions* options,
+    void (*reporter)(void* user_data, const char* format, va_list args),
+    void* user_data) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  options->reporter = reporter;
+  options->reporter_user_data = user_data;
+  IREE_TRACE_ZONE_END(z0);
+}
+
+TFL_CAPI_EXPORT extern void TfLiteInterpreterOptionsSetUseNNAPI(
+    TfLiteInterpreterOptions* options, bool enable) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Silently ignored as if it wasn't present.
+  if (enable) {
+    IREE_TRACE_ZONE_APPEND_TEXT(z0, "enabled", strlen("enabled"));
+    IREE_TRACE_MESSAGE(WARNING,
+                       "TfLiteInterpreterOptionsSetUseNNAPI: the NNAPI is "
+                       "unsupported and ignored in the IREE tflite shim");
+  } else {
+    IREE_TRACE_ZONE_APPEND_TEXT(z0, "enabled", strlen("disabled"));
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+}

--- a/bindings/tflite/options.h
+++ b/bindings/tflite/options.h
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BINDINGS_TFLITE_OPTIONS_H_
+#define IREE_BINDINGS_TFLITE_OPTIONS_H_
+
+#include "iree/base/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+#include "bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h"
+
+struct TfLiteInterpreterOptions {
+  iree_allocator_t allocator;
+  int32_t num_threads;
+  void (*reporter)(void* user_data, const char* format, va_list args);
+  void* reporter_user_data;
+
+  // TODO(#3977): an existing iree_hal_device_t to use for the HAL.
+};
+
+void _TfLiteInterpreterOptionsSetDefaults(TfLiteInterpreterOptions* options);
+
+#endif  // IREE_BINDINGS_TFLITE_OPTIONS_H_

--- a/bindings/tflite/shim.c
+++ b/bindings/tflite/shim.c
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/shim.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+#include "bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h"
+
+TFL_CAPI_EXPORT extern const char* TfLiteVersion(void) { return "👻"; }
+
+TfLiteStatus _TfLiteStatusFromIREEStatus(iree_status_t status) {
+  switch (iree_status_consume_code(status)) {
+    case IREE_STATUS_OK:
+      return kTfLiteOk;
+    default:
+      return kTfLiteError;
+  }
+}

--- a/bindings/tflite/shim.h
+++ b/bindings/tflite/shim.h
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BINDINGS_TFLITE_SHIM_H_
+#define IREE_BINDINGS_TFLITE_SHIM_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/vm/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+#include "bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h"
+
+TfLiteStatus _TfLiteStatusFromIREEStatus(iree_status_t status);
+
+#endif  // IREE_BINDINGS_TFLITE_SHIM_H_

--- a/bindings/tflite/smoke_test.cc
+++ b/bindings/tflite/smoke_test.cc
@@ -1,0 +1,338 @@
+// NOTE: file is forked from tensorflow/lite/c/c_api_test.cc with tests that
+// we don't support in the shim removed. It is as unmodified as possible such
+// that if a user of the tflite API does what this test does they should be able
+// to use our shim too.
+
+/* Copyright 2018 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include <stdarg.h>
+#include <stdint.h>
+
+#include <array>
+#include <fstream>
+#include <vector>
+
+#include "iree/testing/gtest.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+
+// Test model is available both on the filesystem and here for embedding testing
+// embedding the module directly in a binary.
+#include "bindings/tflite/testdata/add.h"
+#define IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_DATA \
+  iree::bindings::tflite::testdata::add_create()->data
+#define IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_SIZE \
+  iree::bindings::tflite::testdata::add_create()->size
+
+// TODO(#3971): currently can't nicely load these due to cmake issues.
+#define IREE_BINDINGS_TFLITE_TESTDATA_ADD_PATH \
+  "tensorflow/lite/testdata/add.bin"
+
+namespace {
+
+TEST(CAPI, Version) { EXPECT_STRNE("", TfLiteVersion()); }
+
+// This is the original test, which is silly, because it uses dynamic shapes
+// even though the model has static shapes defined 🤦.
+TEST(CApiSimple, DISABLED_Smoke) {
+  // TODO(#3971): currently can't nicely load these due to cmake issues.
+  // TfLiteModel* model =
+  //     TfLiteModelCreateFromFile(IREE_BINDINGS_TFLITE_TESTDATA_ADD_PATH);
+  TfLiteModel* model =
+      TfLiteModelCreate(IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_DATA,
+                        IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_SIZE);
+  ASSERT_NE(model, nullptr);
+
+  TfLiteInterpreterOptions* options = TfLiteInterpreterOptionsCreate();
+  ASSERT_NE(options, nullptr);
+  TfLiteInterpreterOptionsSetNumThreads(options, 2);
+
+  TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
+  ASSERT_NE(interpreter, nullptr);
+
+  // The options/model can be deleted immediately after interpreter creation.
+  TfLiteInterpreterOptionsDelete(options);
+  TfLiteModelDelete(model);
+
+  ASSERT_EQ(TfLiteInterpreterAllocateTensors(interpreter), kTfLiteOk);
+  ASSERT_EQ(TfLiteInterpreterGetInputTensorCount(interpreter), 1);
+  ASSERT_EQ(TfLiteInterpreterGetOutputTensorCount(interpreter), 1);
+
+  std::array<int, 1> input_dims = {2};
+  ASSERT_EQ(TfLiteInterpreterResizeInputTensor(
+                interpreter, 0, input_dims.data(), input_dims.size()),
+            kTfLiteOk);
+  ASSERT_EQ(TfLiteInterpreterAllocateTensors(interpreter), kTfLiteOk);
+
+  TfLiteTensor* input_tensor = TfLiteInterpreterGetInputTensor(interpreter, 0);
+  ASSERT_NE(input_tensor, nullptr);
+  EXPECT_EQ(TfLiteTensorType(input_tensor), kTfLiteFloat32);
+  EXPECT_EQ(TfLiteTensorNumDims(input_tensor), 1);
+  EXPECT_EQ(TfLiteTensorDim(input_tensor, 0), 2);
+  EXPECT_EQ(TfLiteTensorByteSize(input_tensor), sizeof(float) * 2);
+  EXPECT_NE(TfLiteTensorData(input_tensor), nullptr);
+  EXPECT_STREQ(TfLiteTensorName(input_tensor), "input");
+
+  TfLiteQuantizationParams input_params =
+      TfLiteTensorQuantizationParams(input_tensor);
+  EXPECT_EQ(input_params.scale, 0.f);
+  EXPECT_EQ(input_params.zero_point, 0);
+
+  std::array<float, 2> input = {1.f, 3.f};
+  ASSERT_EQ(TfLiteTensorCopyFromBuffer(input_tensor, input.data(),
+                                       input.size() * sizeof(float)),
+            kTfLiteOk);
+
+  ASSERT_EQ(TfLiteInterpreterInvoke(interpreter), kTfLiteOk);
+
+  const TfLiteTensor* output_tensor =
+      TfLiteInterpreterGetOutputTensor(interpreter, 0);
+  ASSERT_NE(output_tensor, nullptr);
+  EXPECT_EQ(TfLiteTensorType(output_tensor), kTfLiteFloat32);
+  EXPECT_EQ(TfLiteTensorNumDims(output_tensor), 1);
+  EXPECT_EQ(TfLiteTensorDim(output_tensor, 0), 2);
+  EXPECT_EQ(TfLiteTensorByteSize(output_tensor), sizeof(float) * 2);
+  EXPECT_NE(TfLiteTensorData(output_tensor), nullptr);
+  EXPECT_STREQ(TfLiteTensorName(output_tensor), "output");
+
+  TfLiteQuantizationParams output_params =
+      TfLiteTensorQuantizationParams(output_tensor);
+  EXPECT_EQ(output_params.scale, 0.f);
+  EXPECT_EQ(output_params.zero_point, 0);
+
+  std::array<float, 2> output;
+  ASSERT_EQ(TfLiteTensorCopyToBuffer(output_tensor, output.data(),
+                                     output.size() * sizeof(float)),
+            kTfLiteOk);
+  EXPECT_EQ(output[0], 3.f);
+  EXPECT_EQ(output[1], 9.f);
+
+  TfLiteInterpreterDelete(interpreter);
+}
+
+// As with above but without the static->dynamic override junk.
+TEST(CApiSimple, StaticSmoke) {
+  // TODO(#3971): currently can't nicely load these due to cmake issues.
+  // TfLiteModel* model =
+  //     TfLiteModelCreateFromFile(IREE_BINDINGS_TFLITE_TESTDATA_ADD_PATH);
+  TfLiteModel* model =
+      TfLiteModelCreate(IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_DATA,
+                        IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_SIZE);
+  ASSERT_NE(model, nullptr);
+
+  TfLiteInterpreterOptions* options = TfLiteInterpreterOptionsCreate();
+  ASSERT_NE(options, nullptr);
+  TfLiteInterpreterOptionsSetNumThreads(options, 2);
+
+  TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
+  ASSERT_NE(interpreter, nullptr);
+
+  // The options/model can be deleted immediately after interpreter creation.
+  TfLiteInterpreterOptionsDelete(options);
+  TfLiteModelDelete(model);
+
+  ASSERT_EQ(TfLiteInterpreterAllocateTensors(interpreter), kTfLiteOk);
+  ASSERT_EQ(TfLiteInterpreterGetInputTensorCount(interpreter), 1);
+  ASSERT_EQ(TfLiteInterpreterGetOutputTensorCount(interpreter), 1);
+
+  TfLiteTensor* input_tensor = TfLiteInterpreterGetInputTensor(interpreter, 0);
+  ASSERT_NE(input_tensor, nullptr);
+  EXPECT_EQ(TfLiteTensorType(input_tensor), kTfLiteFloat32);
+  EXPECT_EQ(TfLiteTensorNumDims(input_tensor), 4);
+  EXPECT_EQ(TfLiteTensorDim(input_tensor, 0), 1);
+  EXPECT_EQ(TfLiteTensorDim(input_tensor, 1), 8);
+  EXPECT_EQ(TfLiteTensorDim(input_tensor, 2), 8);
+  EXPECT_EQ(TfLiteTensorDim(input_tensor, 3), 3);
+  EXPECT_EQ(TfLiteTensorByteSize(input_tensor), sizeof(float) * 1 * 8 * 8 * 3);
+  EXPECT_NE(TfLiteTensorData(input_tensor), nullptr);
+  // TODO(#3974): plumb through original tensor names.
+  // EXPECT_STREQ(TfLiteTensorName(input_tensor), "input");
+
+  TfLiteQuantizationParams input_params =
+      TfLiteTensorQuantizationParams(input_tensor);
+  EXPECT_EQ(input_params.scale, 0.f);
+  EXPECT_EQ(input_params.zero_point, 0);
+
+  std::array<float, 1 * 8 * 8 * 3> input = {
+      1.f,
+      3.f,
+  };
+  ASSERT_EQ(TfLiteTensorCopyFromBuffer(input_tensor, input.data(),
+                                       input.size() * sizeof(float)),
+            kTfLiteOk);
+
+  ASSERT_EQ(TfLiteInterpreterInvoke(interpreter), kTfLiteOk);
+
+  const TfLiteTensor* output_tensor =
+      TfLiteInterpreterGetOutputTensor(interpreter, 0);
+  ASSERT_NE(output_tensor, nullptr);
+  EXPECT_EQ(TfLiteTensorType(output_tensor), kTfLiteFloat32);
+  EXPECT_EQ(TfLiteTensorNumDims(output_tensor), 4);
+  EXPECT_EQ(TfLiteTensorDim(output_tensor, 0), 1);
+  EXPECT_EQ(TfLiteTensorDim(output_tensor, 1), 8);
+  EXPECT_EQ(TfLiteTensorDim(output_tensor, 2), 8);
+  EXPECT_EQ(TfLiteTensorDim(output_tensor, 3), 3);
+  EXPECT_EQ(TfLiteTensorByteSize(output_tensor), sizeof(float) * 1 * 8 * 8 * 3);
+  EXPECT_NE(TfLiteTensorData(output_tensor), nullptr);
+  // TODO(#3974): plumb through original tensor names.
+  // EXPECT_STREQ(TfLiteTensorName(output_tensor), "output");
+
+  TfLiteQuantizationParams output_params =
+      TfLiteTensorQuantizationParams(output_tensor);
+  EXPECT_EQ(output_params.scale, 0.f);
+  EXPECT_EQ(output_params.zero_point, 0);
+
+  std::array<float, 1 * 8 * 8 * 3> output;
+  ASSERT_EQ(TfLiteTensorCopyToBuffer(output_tensor, output.data(),
+                                     output.size() * sizeof(float)),
+            kTfLiteOk);
+  EXPECT_EQ(output[0], 2.f);
+  EXPECT_EQ(output[1], 6.f);
+
+  TfLiteInterpreterDelete(interpreter);
+}
+
+// TODO(#3971): fix cmake data deps.
+// TODO(#3972): plumb through quantization params.
+TEST(CApiSimple, DISABLED_QuantizationParams) {
+  TfLiteModel* model =
+      TfLiteModelCreateFromFile("tensorflow/lite/testdata/add_quantized.bin");
+  ASSERT_NE(model, nullptr);
+
+  TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, nullptr);
+  ASSERT_NE(interpreter, nullptr);
+
+  TfLiteModelDelete(model);
+
+  const std::array<int, 1> input_dims = {2};
+  ASSERT_EQ(TfLiteInterpreterResizeInputTensor(
+                interpreter, 0, input_dims.data(), input_dims.size()),
+            kTfLiteOk);
+  ASSERT_EQ(TfLiteInterpreterAllocateTensors(interpreter), kTfLiteOk);
+
+  TfLiteTensor* input_tensor = TfLiteInterpreterGetInputTensor(interpreter, 0);
+  ASSERT_NE(input_tensor, nullptr);
+  EXPECT_EQ(TfLiteTensorType(input_tensor), kTfLiteUInt8);
+  EXPECT_EQ(TfLiteTensorNumDims(input_tensor), 1);
+  EXPECT_EQ(TfLiteTensorDim(input_tensor, 0), 2);
+
+  TfLiteQuantizationParams input_params =
+      TfLiteTensorQuantizationParams(input_tensor);
+  EXPECT_EQ(input_params.scale, 0.003922f);
+  EXPECT_EQ(input_params.zero_point, 0);
+
+  const std::array<uint8_t, 2> input = {1, 3};
+  ASSERT_EQ(TfLiteTensorCopyFromBuffer(input_tensor, input.data(),
+                                       input.size() * sizeof(uint8_t)),
+            kTfLiteOk);
+
+  ASSERT_EQ(TfLiteInterpreterInvoke(interpreter), kTfLiteOk);
+
+  const TfLiteTensor* output_tensor =
+      TfLiteInterpreterGetOutputTensor(interpreter, 0);
+  ASSERT_NE(output_tensor, nullptr);
+
+  TfLiteQuantizationParams output_params =
+      TfLiteTensorQuantizationParams(output_tensor);
+  EXPECT_EQ(output_params.scale, 0.003922f);
+  EXPECT_EQ(output_params.zero_point, 0);
+
+  std::array<uint8_t, 2> output;
+  ASSERT_EQ(TfLiteTensorCopyToBuffer(output_tensor, output.data(),
+                                     output.size() * sizeof(uint8_t)),
+            kTfLiteOk);
+  EXPECT_EQ(output[0], 3);
+  EXPECT_EQ(output[1], 9);
+
+  const float dequantizedOutput0 =
+      output_params.scale * (output[0] - output_params.zero_point);
+  const float dequantizedOutput1 =
+      output_params.scale * (output[1] - output_params.zero_point);
+  EXPECT_EQ(dequantizedOutput0, 0.011766f);
+  EXPECT_EQ(dequantizedOutput1, 0.035298f);
+
+  TfLiteInterpreterDelete(interpreter);
+}
+
+// TODO(#3972): extract !quant.uniform and plumb through iree.reflection.
+#if 0
+
+// TODO(#3971): fix cmake data deps.
+TEST(CApiSimple, DISABLED_ErrorReporter) {
+  TfLiteModel* model =
+      TfLiteModelCreateFromFile(IREE_BINDINGS_TFLITE_TESTDATA_ADD_PATH);
+  TfLiteInterpreterOptions* options = TfLiteInterpreterOptionsCreate();
+
+  // Install a custom error reporter into the interpreter by way of options.
+  tflite::TestErrorReporter reporter;
+  TfLiteInterpreterOptionsSetErrorReporter(
+      options,
+      [](void* user_data, const char* format, va_list args) {
+        reinterpret_cast<tflite::TestErrorReporter*>(user_data)->Report(format,
+                                                                        args);
+      },
+      &reporter);
+  TfLiteInterpreter* interpreter = TfLiteInterpreterCreate(model, options);
+
+  // The options/model can be deleted immediately after interpreter creation.
+  TfLiteInterpreterOptionsDelete(options);
+  TfLiteModelDelete(model);
+
+  // Invoke the interpreter before tensor allocation.
+  EXPECT_EQ(TfLiteInterpreterInvoke(interpreter), kTfLiteError);
+
+  // The error should propagate to the custom error reporter.
+  EXPECT_EQ(reporter.error_messages(),
+            "Invoke called on model that is not ready.");
+  EXPECT_EQ(reporter.num_calls(), 1);
+
+  TfLiteInterpreterDelete(interpreter);
+}
+
+#endif  // 0
+
+TEST(CApiSimple, ValidModel) {
+  TfLiteModel* model =
+      TfLiteModelCreate(IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_DATA,
+                        IREE_BINDINGS_TFLITE_TESTDATA_ADD_EMBEDDED_SIZE);
+  ASSERT_NE(model, nullptr);
+  TfLiteModelDelete(model);
+}
+
+// TODO(#3971): fix cmake data deps.
+TEST(CApiSimple, DISABLED_ValidModelFromFile) {
+  TfLiteModel* model =
+      TfLiteModelCreateFromFile(IREE_BINDINGS_TFLITE_TESTDATA_ADD_PATH);
+  ASSERT_NE(model, nullptr);
+  TfLiteModelDelete(model);
+}
+
+TEST(CApiSimple, InvalidModel) {
+  std::vector<char> invalid_model(20, 'c');
+  TfLiteModel* model =
+      TfLiteModelCreate(invalid_model.data(), invalid_model.size());
+  ASSERT_EQ(model, nullptr);
+}
+
+// TODO(#3971): fix cmake data deps.
+TEST(CApiSimple, DISABLED_InvalidModelFromFile) {
+  TfLiteModel* model = TfLiteModelCreateFromFile("invalid/path/foo.vmfb");
+  ASSERT_EQ(model, nullptr);
+}
+
+}  // namespace

--- a/bindings/tflite/tensor.c
+++ b/bindings/tflite/tensor.c
@@ -1,0 +1,267 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "bindings/tflite/tensor.h"
+
+#include "bindings/tflite/shim.h"
+#include "iree/base/tracing.h"
+
+iree_status_t _TfLiteTensorParseAttr(iree_string_view_t attr,
+                                     TfLiteTensor* out_tensor) {
+  memset(out_tensor, 0, sizeof(*out_tensor));
+
+  // TODO(#3978): extract tensor type and plumb through iree.reflection.
+  out_tensor->type = kTfLiteFloat32;
+
+  // TODO(#3972): extract !quant.uniform and plumb through iree.reflection.
+  out_tensor->quantization_params.scale = 0.0f;
+  out_tensor->quantization_params.zero_point = 0;
+
+  // TODO(#3974): extract tensor names from tf.entry_function.
+  out_tensor->name = iree_make_cstring_view("UNIMPLEMENTED");
+
+  return iree_ok_status();
+}
+
+// Who the hell uses sizeof(bool) - an **implementation-defined value** -
+// as a wire format? https://stackoverflow.com/a/4897859
+static_assert(sizeof(bool) == 1, "bool must be 1 byte to match tf/tflite");
+
+// Converts a tflite type to the HAL storage type.
+// If the is a composite of multiple primitive types (such as a complex number)
+// then |out_storage_scalar| is set to >1.
+static iree_status_t _TfLiteTypeToElementType(
+    TfLiteType type, iree_hal_element_type_t* out_element_type,
+    iree_host_size_t* out_storage_scalar) {
+  *out_element_type = IREE_HAL_ELEMENT_TYPE_NONE;
+  *out_storage_scalar = 1;
+  switch (type) {
+    default:
+    case kTfLiteNoType:
+      // Hopefully only used as a sentinel.
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_NONE;
+      break;
+    case kTfLiteInt8:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_SINT_8;
+      break;
+    case kTfLiteUInt8:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_UINT_8;
+      break;
+    case kTfLiteInt16:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_SINT_16;
+      break;
+    case kTfLiteInt32:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_SINT_32;
+      break;
+    case kTfLiteInt64:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_SINT_64;
+      break;
+    case kTfLiteUInt64:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_UINT_64;
+      break;
+    case kTfLiteFloat16:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_FLOAT_16;
+      break;
+    case kTfLiteFloat32:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_FLOAT_32;
+      break;
+    case kTfLiteFloat64:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_FLOAT_64;
+      break;
+    case kTfLiteBool:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_UINT_8;
+      break;
+    case kTfLiteComplex64:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_FLOAT_32;
+      *out_storage_scalar = 2;  // real + imag
+      break;
+    case kTfLiteComplex128:
+      *out_element_type = IREE_HAL_ELEMENT_TYPE_FLOAT_64;
+      *out_storage_scalar = 2;  // real + imag
+      break;
+    case kTfLiteString:
+      // This isn't a tensor, it's an std::vector<std::string>. Don't use this
+      // type and instead use the IREE C API which has such amazing modern
+      // programming concepts like ... lists.
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "kTfLiteString is not implemented (and won't "
+                              "be); use the IREE C API");
+  }
+  return iree_ok_status();
+}
+
+iree_status_t _TfLiteTensorReallocateIfNeeded(
+    TfLiteTensor* tensor, iree_hal_allocator_t* buffer_allocator,
+    iree_allocator_t heap_allocator) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Format conversion; ensure we can support the type.
+  iree_hal_element_type_t element_type = IREE_HAL_ELEMENT_TYPE_NONE;
+  iree_host_size_t storage_scalar = 1;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      _TfLiteTypeToElementType(tensor->type, &element_type, &storage_scalar));
+
+  // Compute the total allocation size required, possibly with padding.
+  iree_hal_dim_t shape_dims[IREE_BINDINGS_TFLITE_MAX_RANK];
+  for (int32_t i = 0; i < tensor->shape_rank; ++i) {
+    shape_dims[i] = (iree_hal_dim_t)tensor->shape_dims[i];
+  }
+  iree_device_size_t allocation_size = 0;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0, iree_hal_buffer_compute_view_size(shape_dims, tensor->shape_rank,
+                                            element_type, &allocation_size));
+  allocation_size *= storage_scalar;
+
+  // If the old buffer is the same size then no need to realloc.
+  if (tensor->buffer &&
+      iree_hal_buffer_byte_length(tensor->buffer) == allocation_size) {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
+
+  // Allocate the underlying buffer for the tensor.
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hal_allocator_allocate_buffer(
+          buffer_allocator,
+          IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+          IREE_HAL_BUFFER_USAGE_ALL, allocation_size, &tensor->buffer));
+
+  // Map the buffer memory immediately. The tflite API doesn't let us know if
+  // this is a buffer the user will actually touch or some state buffer that is
+  // just going to be passed to future invocations. We could move this to an
+  // on-demand mapping when the user calls TfLiteTensorData but this at least
+  // puts potential errors in the same easy to find place.
+  iree_device_size_t byte_offset = 0;
+  iree_device_size_t byte_length = IREE_WHOLE_BUFFER;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hal_buffer_map_range(tensor->buffer, IREE_HAL_MEMORY_ACCESS_ALL, 0,
+                                IREE_WHOLE_BUFFER, &tensor->buffer_mapping));
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+iree_status_t _TfLiteTensorBind(TfLiteTensor* tensor,
+                                iree_hal_buffer_t* buffer) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  _TfLiteTensorDiscardBuffer(tensor);
+  if (!buffer) {
+    // Just a discard (invalid output/etc).
+    IREE_TRACE_ZONE_END(z0);
+    return iree_ok_status();
+  }
+
+  // Attempt to map the buffer. The tflite API doesn't let us know if this
+  // should be read or read/write - or if we even need to map at all. We could
+  // move this to an on-demand mapping when the user calls TfLiteTensorData but
+  // this at least puts potential errors in the same easy to find place.
+  iree_device_size_t byte_offset = 0;
+  iree_device_size_t byte_length = IREE_WHOLE_BUFFER;
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+      z0,
+      iree_hal_buffer_map_range(
+          buffer, IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE,
+          byte_offset, byte_length, &tensor->buffer_mapping));
+
+  // Retain the buffer view until discarded/reset.
+  tensor->buffer = buffer;
+  iree_hal_buffer_retain(tensor->buffer);
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+void _TfLiteTensorDiscardBuffer(TfLiteTensor* tensor) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  if (tensor->buffer_mapping.contents.data != NULL) {
+    iree_hal_buffer_unmap_range(&tensor->buffer_mapping);
+  }
+  iree_hal_buffer_release(tensor->buffer);
+  tensor->buffer = NULL;
+  IREE_TRACE_ZONE_END(z0);
+}
+
+void _TfLiteTensorReset(TfLiteTensor* tensor) {
+  _TfLiteTensorDiscardBuffer(tensor);
+}
+
+TFL_CAPI_EXPORT extern TfLiteType TfLiteTensorType(const TfLiteTensor* tensor) {
+  return tensor->type;
+}
+
+TFL_CAPI_EXPORT extern int32_t TfLiteTensorNumDims(const TfLiteTensor* tensor) {
+  return tensor->shape_rank;
+}
+
+TFL_CAPI_EXPORT extern int32_t TfLiteTensorDim(const TfLiteTensor* tensor,
+                                               int32_t dim_index) {
+  return tensor->shape_dims[dim_index];
+}
+
+TFL_CAPI_EXPORT extern size_t TfLiteTensorByteSize(const TfLiteTensor* tensor) {
+  return (size_t)iree_hal_buffer_byte_length(tensor->buffer);
+}
+
+TFL_CAPI_EXPORT extern void* TfLiteTensorData(const TfLiteTensor* tensor) {
+  return tensor->buffer_mapping.contents.data;
+}
+
+TFL_CAPI_EXPORT extern const char* TfLiteTensorName(
+    const TfLiteTensor* tensor) {
+  return tensor->name.data;
+}
+
+TFL_CAPI_EXPORT extern TfLiteQuantizationParams TfLiteTensorQuantizationParams(
+    const TfLiteTensor* tensor) {
+  return tensor->quantization_params;
+}
+
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteTensorCopyFromBuffer(
+    TfLiteTensor* tensor, const void* input_data, size_t input_data_size) {
+  if (input_data_size != tensor->buffer_mapping.contents.data_length) {
+    return kTfLiteApplicationError;
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, tensor->buffer_mapping.contents.data_length);
+
+  // NOTE: we could use a iree_hal_buffer_write_data here but we already have
+  // the buffer mapped. If we knew the user would never use TfLiteTensorData and
+  // could avoid mapping the buffer it would be more efficient and portable to
+  // do the iree_hal_buffer_copy_data.
+  memcpy(tensor->buffer_mapping.contents.data, input_data, input_data_size);
+
+  IREE_TRACE_ZONE_END(z0);
+  return kTfLiteOk;
+}
+
+TFL_CAPI_EXPORT extern TfLiteStatus TfLiteTensorCopyToBuffer(
+    const TfLiteTensor* output_tensor, void* output_data,
+    size_t output_data_size) {
+  if (output_data_size != output_tensor->buffer_mapping.contents.data_length) {
+    return kTfLiteApplicationError;
+  }
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(
+      z0, output_tensor->buffer_mapping.contents.data_length);
+
+  // NOTE: as with above we should use an iree_hal_buffer_read_data here.
+  memcpy(output_data, output_tensor->buffer_mapping.contents.data,
+         output_data_size);
+
+  IREE_TRACE_ZONE_END(z0);
+  return kTfLiteOk;
+}

--- a/bindings/tflite/tensor.h
+++ b/bindings/tflite/tensor.h
@@ -1,0 +1,74 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_BINDINGS_TFLITE_TENSOR_H_
+#define IREE_BINDINGS_TFLITE_TENSOR_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/vm/api.h"
+
+// NOTE: we pull in our own copy here in case the tflite API changes upstream.
+#define TFL_COMPILE_LIBRARY 1  // force dllexport
+#include "bindings/tflite/include/tensorflow/lite/c/c_api.h"
+#include "bindings/tflite/include/tensorflow/lite/c/c_api_experimental.h"
+
+// This is the same value as TFLITE_RESHAPE_PARAMS_MAX_DIMENSION_COUNT.
+// Since that's all tflite supports internally we are fairly safe to use that
+// as our max for the I/O tensors; internal tensors inside of IREE generated
+// modules may of course have arbitrary shape ranks.
+#define IREE_BINDINGS_TFLITE_MAX_RANK 8
+
+struct TfLiteTensor {
+  // Static metadata about the tensor as it was embedded in the module.
+  TfLiteType type;
+  TfLiteQuantizationParams quantization_params;
+  iree_string_view_t name;
+
+  // Queried shape information from the module; in the case of outputs this is
+  // the expected output shape based on the current input shapes and will be
+  // available even if we haven't yet run and allocated the buffer view.
+  int32_t shape_rank;
+  int32_t shape_dims[IREE_BINDINGS_TFLITE_MAX_RANK];
+
+  // Allocated buffer view referencing the backing tensor memory.
+  iree_hal_buffer_t* buffer;
+  // Persistently mapped buffer; invalidated when buffer is resized.
+  iree_hal_buffer_mapping_t buffer_mapping;
+};
+
+// Initializes the static tensor fields from the given reflection attribute
+// value emitted by the compiler.
+iree_status_t _TfLiteTensorParseAttr(iree_string_view_t attr,
+                                     TfLiteTensor* out_tensor);
+
+// Reallocates and remaps the tensor buffer view if needed.
+// No-op if the buffer view is already allocated and its shape matches the
+// current tensor shape.
+iree_status_t _TfLiteTensorReallocateIfNeeded(
+    TfLiteTensor* tensor, iree_hal_allocator_t* buffer_allocator,
+    iree_allocator_t heap_allocator);
+
+// Binds the given |buffer| to the tensor and maps it.
+// The tensor shape will be overwritten with the buffer view shape.
+iree_status_t _TfLiteTensorBind(TfLiteTensor* tensor,
+                                iree_hal_buffer_t* buffer);
+
+// Discards the current buffer view, if any, resetting it to NULL.
+void _TfLiteTensorDiscardBuffer(TfLiteTensor* tensor);
+
+// Resets the tensor back to its initial state (no buffers, etc).
+void _TfLiteTensorReset(TfLiteTensor* tensor);
+
+#endif  // IREE_BINDINGS_TFLITE_TENSOR_H_

--- a/bindings/tflite/testdata/BUILD
+++ b/bindings/tflite/testdata/BUILD
@@ -1,0 +1,33 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//iree/tools:compilation.bzl", "iree_bytecode_module")
+
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
+
+# TODO(#3970): add.bin/json and import via the tflite importer path.
+
+iree_bytecode_module(
+    name = "add",
+    src = "add.mlir",
+    cc_namespace = "iree::bindings::tflite::testdata",
+    flags = [
+        "-iree-mlir-to-vm-bytecode-module",
+        "-iree-hal-target-backends=vmla",
+    ],
+)

--- a/bindings/tflite/testdata/CMakeLists.txt
+++ b/bindings/tflite/testdata/CMakeLists.txt
@@ -1,0 +1,28 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_add_all_subdirs()
+
+iree_bytecode_module(
+  NAME
+    add
+  SRC
+    "add.mlir"
+  CC_NAMESPACE
+    "iree::bindings::tflite::testdata"
+  FLAGS
+    "-iree-mlir-to-vm-bytecode-module"
+    "-iree-hal-target-backends=vmla"
+  PUBLIC
+)

--- a/bindings/tflite/testdata/add.mlir
+++ b/bindings/tflite/testdata/add.mlir
@@ -1,0 +1,96 @@
+
+//===----------------------------------------------------------------------===//
+// b = add(a, a)
+//===----------------------------------------------------------------------===//
+
+// NOTE: this represents what our tflite import flow should produce; the _
+// prefixed functions are all synthesized by us. We use the VM dialect in here
+// now because std has no list and other stuff. In a real flow we may have a
+// iree_tflite dialect that has pseudo ops for these things that then plug into
+// the VM conversion interface, or maybe we just emit them as-is at input
+// because we know where they are going to end up.
+
+//===----------------------------------------------------------------------===//
+// Global variable initialization
+//===----------------------------------------------------------------------===//
+// Optional generated function to reset any globals we may have in response to a
+// TfLiteInterpreterResetVariableTensors call.
+
+func @_reset_variables() {
+  return
+}
+vm.export @_reset_variables
+
+//===----------------------------------------------------------------------===//
+// Shape I/O queries
+//===----------------------------------------------------------------------===//
+// Generated shape query functions so that we can preallocate (when possible).
+// Note that if there are dynamic shapes some dimensions may be -1. By having
+// these as functions we simplify the frontend (no need for signature parsing
+// stuff) and allow all of this to be compiler-controlled even after deployment.
+// For example, if we wanted to have these shapes based on the variable shapes
+// or even previously computed results we could. The whole resizing operation
+// becomes something we control in the compiler and not something we need the
+// runtime to do for us (shape propagation/etc).
+
+// TODO(#3973): allow index in vm.list so we can just convert based on
+// the supported VM extension mode (i32 or i64).
+func @_query_input_shape(%index : i32, %shape : !vm.list<i32>) {
+  // NOTE: we could switch on %index but we only have one input.
+
+  // TODO(#3973): improved ergonomics here; should have a variadic set.
+  %rank = constant 4 : i32
+  vm.list.resize %shape, %rank : (!vm.list<i32>, i32)
+  %i0 = constant 0 : i32
+  %i1 = constant 1 : i32
+  %i2 = constant 2 : i32
+  %i3 = constant 3 : i32
+  %c1 = constant 1 : i32
+  %c3 = constant 3 : i32
+  %c8 = constant 8 : i32
+  vm.list.set.i32 %shape, %i0, %c1 : (!vm.list<i32>, i32, i32)
+  vm.list.set.i32 %shape, %i1, %c8 : (!vm.list<i32>, i32, i32)
+  vm.list.set.i32 %shape, %i2, %c8 : (!vm.list<i32>, i32, i32)
+  vm.list.set.i32 %shape, %i3, %c3 : (!vm.list<i32>, i32, i32)
+
+  return
+}
+vm.export @_query_input_shape
+
+// Handles TfLiteInterpreterResizeInputTensor calls.
+// It could set vm.global.i32s for the relevant output shapes such that queries
+// there pick up the propagated values. Since this is all just code that's
+// likely to end up as just a handful of muls/divs after CSE (in what would
+// normally be a full "shape propagation" pass).
+func @_resize_input_shape(%index : i32, %shape : !vm.list<i32>) {
+  // Unused here (but also not yet implemented #3975 :).
+  return
+}
+vm.export @_resize_input_shape
+
+func @_query_output_shape(%index : i32, %shape : !vm.list<i32>) {
+  // Same input/output in this particular example. If we weren't writing this by
+  // hand and instead generated this then symbol deduping would help turn them
+  // both into the same thing.
+  call @_query_input_shape(%index, %shape) : (i32, !vm.list<i32>) -> ()
+  return
+}
+vm.export @_query_output_shape
+
+//===----------------------------------------------------------------------===//
+// Entry point
+//===----------------------------------------------------------------------===//
+// Only one entry point today, but multiple are supported in IREE. It's also
+// possible to call functions, so a single _main could fork out based on input
+// arguments to other functions if we wanted to preserve the tflite API while
+// allowing more complex models.
+
+// TODO(#3972): handle tagging !quant.uniform as attributes.
+// TODO(#3974): handle propagating tf.entry_function tensor name attrs .
+func @_main(
+    %input : tensor<1x8x8x3xf32>
+  ) -> tensor<1x8x8x3xf32> {
+  %result = mhlo.add %input, %input : tensor<1x8x8x3xf32>
+  return %result : tensor<1x8x8x3xf32>
+}
+vm.export @_main

--- a/iree/base/api.c
+++ b/iree/base/api.c
@@ -740,7 +740,9 @@ iree_status_annotate(iree_status_t base_status, iree_string_view_t message) {
   // Annotations are disabled so we ignore this entirely.
   return base_status;
 #else
-  if (iree_string_view_is_empty(message)) return base_status;
+  if (iree_status_is_ok(base_status) || iree_string_view_is_empty(message)) {
+    return base_status;
+  }
   // If there's no storage yet we can just reuse normal allocation. Both that
   // and this do not copy |message|.
   iree_status_storage_t* storage = iree_status_storage(base_status);
@@ -784,6 +786,8 @@ iree_status_annotate_vf(iree_status_t base_status, const char* format,
 #if (IREE_STATUS_FEATURES & IREE_STATUS_FEATURE_ANNOTATIONS) == 0
   return base_status;
 #else
+  if (iree_status_is_ok(base_status)) return base_status;
+
   // If there's no storage yet we can just reuse normal allocation. Both that
   // and this do not copy |message|.
   iree_status_storage_t* storage = iree_status_storage(base_status);

--- a/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -141,7 +141,8 @@ def VM_FuncOp : VM_Op<"func", [
 }
 
 def VM_ExportOp : VM_Op<"export", [
-    HasParent<"IREE::VM::ModuleOp">,
+    // TODO(#3968): working around iree.module.export hackability woes.
+    // HasParent<"IREE::VM::ModuleOp">,
   ]> {
   let summary = [{exports a function from the module}];
   let description = [{

--- a/iree/hal/buffer_view.h
+++ b/iree/hal/buffer_view.h
@@ -172,6 +172,14 @@ IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_view_shape(
     const iree_hal_buffer_view_t* buffer_view, iree_host_size_t rank_capacity,
     iree_hal_dim_t* out_shape, iree_host_size_t* out_shape_rank);
 
+// Performs a **metadata update-only** reshape.
+// The new rank and element count must match the existing values. The buffer
+// contents are left untouched; if the buffer is not dense this may make the
+// contents undefined.
+IREE_API_EXPORT iree_status_t IREE_API_CALL iree_hal_buffer_view_reshape(
+    iree_hal_buffer_view_t* buffer_view, const iree_hal_dim_t* shape,
+    iree_host_size_t shape_rank);
+
 // Returns the total number of elements stored in the view.
 IREE_API_EXPORT iree_host_size_t
 iree_hal_buffer_view_element_count(const iree_hal_buffer_view_t* buffer_view);

--- a/iree/vm/bytecode_module.c
+++ b/iree/vm/bytecode_module.c
@@ -454,7 +454,7 @@ static iree_status_t iree_vm_bytecode_module_lookup_function(
     iree_vm_ExportFunctionDef_vec_t exported_functions =
         iree_vm_BytecodeModuleDef_exported_functions(module->def);
     for (size_t ordinal = 0;
-         ordinal < iree_vm_InternalFunctionDef_vec_len(exported_functions);
+         ordinal < iree_vm_ExportFunctionDef_vec_len(exported_functions);
          ++ordinal) {
       iree_vm_ExportFunctionDef_table_t export_def =
           iree_vm_ExportFunctionDef_vec_at(exported_functions, ordinal);

--- a/iree/vm/module.h
+++ b/iree/vm/module.h
@@ -91,6 +91,11 @@ typedef struct {
 static_assert(sizeof(iree_vm_function_t) <= 2 * sizeof(void*),
               "Must remain small as stored on the stack");
 
+// Returns true if the |function| is null (didn't exist, etc).
+static inline bool iree_vm_function_is_null(iree_vm_function_t function) {
+  return function.module == NULL;
+}
+
 // Describes the expected calling convention and arguments/results of a
 // function.
 typedef struct {


### PR DESCRIPTION
Somewhat surprisingly, this seems to work. Some gotchas and TODOs
remaining as tracked in https://github.com/google/iree/projects/17,
but it can run a hello-world add module hand-lowered from a tflite
flatbuffer to an IREE input module. Future work in #3974/#3978/#3972
will automate this lowering.

Fixes #3952.