### PR TITLE
Changing iree/base/math.h to C and adding some PRNG routines.

### DIFF
--- a/iree/base/BUILD
+++ b/iree/base/BUILD
@@ -67,6 +67,16 @@ cc_test(
     ],
 )
 
+cc_test(
+    name = "math_test",
+    srcs = ["math_test.cc"],
+    deps = [
+        ":core_headers",
+        "//iree/testing:gtest",
+        "//iree/testing:gtest_main",
+    ],
+)
+
 #===------------------------------------------------------------------------===#
 # Internal IREE C++ wrappers and utilities
 #===------------------------------------------------------------------------===#

--- a/iree/base/CMakeLists.txt
+++ b/iree/base/CMakeLists.txt
@@ -309,6 +309,17 @@ iree_cc_library(
   PUBLIC
 )
 
+iree_cc_test(
+  NAME
+    math_test
+  SRCS
+    "math_test.cc"
+  DEPS
+    ::core_headers
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
 iree_cc_library(
   NAME
     ref_ptr

--- a/iree/base/math.h
+++ b/iree/base/math.h
@@ -15,9 +15,11 @@
 #ifndef IREE_BASE_MATH_H_
 #define IREE_BASE_MATH_H_
 
-#include <cstdint>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
 
-#include "absl/base/attributes.h"
+#include "iree/base/target_platform.h"
 
 // Haswell or later, gcc compile time option: -mlzcnt
 #if defined(__LZCNT__)
@@ -26,88 +28,98 @@
 
 // Clang on Windows has __builtin_clzll; otherwise we need to use the
 // windows intrinsic functions.
-#if defined(_MSC_VER)
+#if defined(IREE_COMPILER_MSVC)
 #include <intrin.h>
-#if defined(_M_X64)
+#if defined(IREE_ARCH_ARM_64) || defined(IREE_ARCH_X86_64)
 #pragma intrinsic(_BitScanReverse64)
 #pragma intrinsic(_BitScanForward64)
 #endif
 #pragma intrinsic(_BitScanReverse)
 #pragma intrinsic(_BitScanForward)
-#endif
+#endif  // IREE_COMPILER_MSVC
 
-#if defined(_MSC_VER)
-// We can achieve something similar to attribute((always_inline)) with MSVC by
-// using the __forceinline keyword, however this is not perfect. MSVC is
-// much less aggressive about inlining, and even with the __forceinline keyword.
-#define IREE_FORCEINLINE __forceinline
-#else
-// Use default attribute inline.
-#define IREE_FORCEINLINE inline ABSL_ATTRIBUTE_ALWAYS_INLINE
-#endif
+//==============================================================================
+// Bitwise rotation (aka circular shifts)
+//==============================================================================
 
-namespace iree {
+// Unsigned rotate-left a 64-bit integer.
+// https://en.cppreference.com/w/cpp/numeric/rotl
+//
+//
+// NOTE: this exact form is confirmed to be recognized by the compilers we care
+// about; do not modify: https://godbolt.org/z/xzof9d
+static inline uint64_t iree_math_rotl_u64(const uint64_t n, uint32_t c) {
+  if (!c) return n;
+  const uint32_t mask = 8 * sizeof(n) - 1;
+  c &= mask;
+  return (n << c) | (n >> (64 - c));
+}
 
-IREE_FORCEINLINE int CountLeadingZeros32(uint32_t n) {
-#if defined(_MSC_VER)
+// Unsigned rotate-right a 64-bit integer.
+// https://en.cppreference.com/w/cpp/numeric/rotr
+//
+// NOTE: this exact form is confirmed to be recognized by the compilers we care
+// about **except MSVC**; do not modify: https://godbolt.org/z/xzof9d
+static inline uint64_t iree_math_rotr_u64(const uint64_t n, uint32_t c) {
+  if (!c) return n;
+  const uint32_t mask = 8 * sizeof(n) - 1;
+  c &= mask;
+  return (n >> c) | (n << ((-c) & mask));
+}
+
+//==============================================================================
+// Bit scanning/counting
+//==============================================================================
+
+static inline int iree_math_count_leading_zeros_u32(const uint32_t n) {
+#if defined(IREE_COMPILER_MSVC)
   unsigned long result = 0;  // NOLINT(runtime/int)
   if (_BitScanReverse(&result, n)) {
-    return 31 - result;
+    return (int)(31 - result);
   }
   return 32;
-#elif defined(__GNUC__)
-  // Use __builtin_clz, which uses the following instructions:
-  //  x86: bsr
-  //  ARM64: clz
-  //  PPC: cntlzd
-  static_assert(sizeof(int) == sizeof(n),
-                "__builtin_clz does not take 32-bit arg");
-
+#elif defined(IREE_COMPILER_GCC_COMPAT)
 #if defined(__LCZNT__)
   // NOTE: LZCNT is a risky instruction; it is not supported on architectures
   // before Haswell, yet it is encoded as 'rep bsr', which typically ignores
   // invalid rep prefixes, and interprets it as the 'bsr' instruction, which
   // returns the index of the value rather than the count, resulting in
   // incorrect code.
-  return __lzcnt32(n);
+  return (int)__lzcnt32(n);
 #endif  // defined(__LCZNT__)
 
   // Handle 0 as a special case because __builtin_clz(0) is undefined.
-  if (n == 0) {
-    return 32;
-  }
-  return __builtin_clz(n);
-#else
-#error No clz for this arch.
-#endif
-}
-
-IREE_FORCEINLINE int CountLeadingZeros64(uint64_t n) {
-#if defined(_MSC_VER) && defined(_M_X64)
-  // MSVC does not have __buitin_clzll. Use _BitScanReverse64.
-  unsigned long result = 0;  // NOLINT(runtime/int)
-  if (_BitScanReverse64(&result, n)) {
-    return 63 - result;
-  }
-  return 64;
-#elif defined(_MSC_VER)
-  // MSVC does not have __buitin_clzll. Compose two calls to _BitScanReverse
-  unsigned long result = 0;  // NOLINT(runtime/int)
-  if ((n >> 32) && _BitScanReverse(&result, n >> 32)) {
-    return 31 - result;
-  }
-  if (_BitScanReverse(&result, n)) {
-    return 63 - result;
-  }
-  return 64;
-#elif defined(__GNUC__)
-  // Use __builtin_clzll, which uses the following instructions:
+  if (n == 0) return 32;
+  // Use __builtin_clz, which uses the following instructions:
   //  x86: bsr
   //  ARM64: clz
   //  PPC: cntlzd
-  static_assert(sizeof(unsigned long long) == sizeof(n),  // NOLINT(runtime/int)
-                "__builtin_clzll does not take 64-bit arg");
+  return (int)__builtin_clz(n);
+#else
+#error No clz for this arch.
+#endif  // IREE_COMPILER_MSVC / IREE_COMPILER_GCC_COMPAT
+}
 
+static inline int iree_math_count_leading_zeros_u64(uint64_t n) {
+#if defined(IREE_COMPILER_MSVC) && \
+    (defined(IREE_ARCH_ARM_64) || defined(IREE_ARCH_X86_64))
+  // MSVC does not have __buitin_clzll. Use _BitScanReverse64.
+  unsigned long result = 0;  // NOLINT(runtime/int)
+  if (_BitScanReverse64(&result, n)) {
+    return (int)(63 - result);
+  }
+  return 64;
+#elif defined(IREE_COMPILER_MSVC)
+  // MSVC does not have __buitin_clzll. Compose two calls to _BitScanReverse
+  unsigned long result = 0;  // NOLINT(runtime/int)
+  if ((n >> 32) && _BitScanReverse(&result, n >> 32)) {
+    return (int)(31 - result);
+  }
+  if (_BitScanReverse(&result, n)) {
+    return (int)(63 - result);
+  }
+  return 64;
+#elif defined(IREE_COMPILER_GCC_COMPAT)
 #if defined(__LCZNT__)
   // NOTE: LZCNT is a risky instruction; it is not supported on architectures
   // before Haswell, yet it is encoded as 'rep bsr', which typically ignores
@@ -117,99 +129,267 @@ IREE_FORCEINLINE int CountLeadingZeros64(uint64_t n) {
   return __lzcnt64(n);
 #elif defined(__aarch64__) || defined(__powerpc64__)
   // Empirically verified that __builtin_clzll(0) works as expected.
-  return __builtin_clzll(n);
+  return (int)__builtin_clzll(n);
 #endif
-
   // Handle 0 as a special case because __builtin_clzll(0) is undefined.
-  if (n == 0) {
-    return 64;
-  }
-  return __builtin_clzll(n);
+  if (!n) return 64;
+  // Use __builtin_clzll, which uses the following instructions:
+  //    x86: bsr
+  //    PPC: cntlzd
+  //   WASM: i32.clz
+  // RISC-V: __clzsi2 in GCC, splat out in clang
+  return (int)__builtin_clzll(n);
 #else
 #error No clz for this arch.
-#endif
+#endif  // IREE_COMPILER_MSVC / IREE_COMPILER_GCC_COMPAT
 }
 
-IREE_FORCEINLINE int CountTrailingZerosNonZero32(uint32_t n) {
-#if defined(_MSC_VER)
+static inline int iree_math_count_trailing_zeros_u32(uint32_t n) {
+#if defined(IREE_COMPILER_MSVC)
   unsigned long result = 0;  // NOLINT(runtime/int)
   _BitScanForward(&result, n);
-  return result;
-#elif defined(__GNUC__)
-  static_assert(sizeof(int) == sizeof(n),
-                "__builtin_ctz does not take 32-bit arg");
-  return __builtin_ctz(n);
+  return (int)result;
+#elif defined(IREE_COMPILER_GCC_COMPAT)
+  return (int)__builtin_ctz(n);
 #else
   int c = 31;
   n &= ~n + 1;
-  if (n & 0x0000FFFF) c -= 16;
-  if (n & 0x00FF00FF) c -= 8;
-  if (n & 0x0F0F0F0F) c -= 4;
-  if (n & 0x33333333) c -= 2;
-  if (n & 0x55555555) c -= 1;
+  if (n & 0x0000FFFFu) c -= 16;
+  if (n & 0x00FF00FFu) c -= 8;
+  if (n & 0x0F0F0F0Fu) c -= 4;
+  if (n & 0x33333333u) c -= 2;
+  if (n & 0x55555555u) c -= 1;
   return c;
-#endif
+#endif  // IREE_COMPILER_MSVC / IREE_COMPILER_GCC_COMPAT
 }
 
-IREE_FORCEINLINE int CountTrailingZerosNonZero64(uint64_t n) {
-#if defined(_MSC_VER) && defined(_M_X64)
+static inline int iree_math_count_trailing_zeros_u64(uint64_t n) {
+#if defined(IREE_COMPILER_MSVC) && defined(IREE_PTR_SIZE_64)
   unsigned long result = 0;  // NOLINT(runtime/int)
   _BitScanForward64(&result, n);
-  return result;
-#elif defined(_MSC_VER)
+  return (int)result;
+#elif defined(IREE_COMPILER_MSVC) && defined(IREE_PTR_SIZE_32)
   unsigned long result = 0;  // NOLINT(runtime/int)
-  if (static_cast<uint32_t>(n) == 0) {
+  if ((uint32_t)(n) == 0) {
     _BitScanForward(&result, n >> 32);
     return result + 32;
   }
   _BitScanForward(&result, n);
-  return result;
-#elif defined(__GNUC__)
-  static_assert(sizeof(unsigned long long) == sizeof(n),  // NOLINT(runtime/int)
-                "__builtin_ctzll does not take 64-bit arg");
+  return (int)result;
+#elif defined(IREE_COMPILER_GCC_COMPAT)
+  // Use __builtin_clzll, which uses the following instructions:
+  //    x86: bsr
+  //    PPC: cntlzd
+  //   WASM: i64.clz
+  // RISC-V: __clzdi2 in GCC, splat out in clang
   return __builtin_ctzll(n);
 #else
   int c = 63;
   n &= ~n + 1;
-  if (n & 0x00000000FFFFFFFF) c -= 32;
-  if (n & 0x0000FFFF0000FFFF) c -= 16;
-  if (n & 0x00FF00FF00FF00FF) c -= 8;
-  if (n & 0x0F0F0F0F0F0F0F0F) c -= 4;
-  if (n & 0x3333333333333333) c -= 2;
-  if (n & 0x5555555555555555) c -= 1;
+  if (n & 0x00000000FFFFFFFFull) c -= 32;
+  if (n & 0x0000FFFF0000FFFFull) c -= 16;
+  if (n & 0x00FF00FF00FF00FFull) c -= 8;
+  if (n & 0x0F0F0F0F0F0F0F0Full) c -= 4;
+  if (n & 0x3333333333333333ull) c -= 2;
+  if (n & 0x5555555555555555ull) c -= 1;
   return c;
-#endif
+#endif  // IREE_COMPILER_MSVC / IREE_COMPILER_GCC_COMPAT
 }
 
-template <typename T>
-IREE_FORCEINLINE int TrailingZeros(T x) {
-  return sizeof(T) == 8 ? CountTrailingZerosNonZero64(static_cast<uint64_t>(x))
-                        : CountTrailingZerosNonZero32(static_cast<uint32_t>(x));
-}
-
-template <typename T>
-IREE_FORCEINLINE int LeadingZeros(T x) {
-  return sizeof(T) == 8 ? CountLeadingZeros64(static_cast<uint64_t>(x))
-                        : CountLeadingZeros32(static_cast<uint32_t>(x));
-}
+//==============================================================================
+// Population count
+//==============================================================================
 
 // Returns the number of 1 bits in a 32 bit value.
-IREE_FORCEINLINE int CountOnes32(uint32_t n) {
-  n -= ((n >> 1) & 0x55555555);
-  n = ((n >> 2) & 0x33333333) + (n & 0x33333333);
-  return static_cast<int>((((n + (n >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24);
+static inline int iree_math_count_ones_u32(uint32_t n) {
+  n -= ((n >> 1) & 0x55555555u);
+  n = ((n >> 2) & 0x33333333u) + (n & 0x33333333u);
+  return (int)((((n + (n >> 4)) & 0x0F0F0F0Fu) * 0x01010101u) >> 24);
 }
 
 // Returns the number of 1 bits in a 64 bit value.
-IREE_FORCEINLINE int CountOnes64(uint64_t n) {
-  return CountOnes32(n >> 32) + CountOnes32(n & 0xffffffff);
+static inline int iree_math_count_ones_u64(uint64_t n) {
+  return iree_math_count_ones_u32(n >> 32) +
+         iree_math_count_ones_u32(n & 0xFFFFFFFFu);
+}
+
+//==============================================================================
+// Rounding and alignment
+//==============================================================================
+// There are certain platforms - mostly those with poorer quality compilers or
+// more restricted instruction sets - where we want to avoid the clz path as
+// it is emulated and instead we use some bit-twiddling hacks. On other
+// platforms it's the opposite - they may emulate clz but doing so saves
+// dozens of bytes that otherwise would have been the shift/or tree.
+//
+// Which to choose is entirely determined by fiddling on godbolt for the
+// target platform: https://godbolt.org/z/h4vPzo
+
+// Rounds up the value to the nearest power of 2 (if not already a power of 2).
+// For 32-bit numbers this only supports values <= 2^31; higher will wrap.
+static inline uint32_t iree_math_round_up_to_pow2_u32(uint32_t n) {
+#if 0    // golf required; can be bloated
+  const uint32_t i = (n != 1);
+  return (1 + i) << ((iree_math_count_leading_zeros_u32(n - i) ^ 31));
+#elif 0  // golf required; can be bloated
+  return n == 1 ? 1u : 2u << ((iree_math_count_leading_zeros_u32(n - 1) ^ 31));
+#else
+  // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  return n + 1;
+#endif  // 1
 }
 
 // Rounds up the value to the nearest power of 2 (if not already a power of 2).
-IREE_FORCEINLINE int RoundUpToNearestPow2(int n) {
-  return n ? ~0u >> LeadingZeros(n) : 1;
+// For 64-bit numbers this only supports values <= 2^63; higher will wrap.
+static inline uint64_t iree_math_round_up_to_pow2_u64(uint64_t n) {
+#if 0    // golf required; can be bloated
+  const uint64_t i = (n != 1);
+  return (1 + i) << ((iree_math_count_leading_zeros_u64(n - i) ^ 63));
+#elif 0  // golf required; can be bloated
+  return n == 1 ? 1ull
+                : 2ull << ((iree_math_count_leading_zeros_u64(n - 1) ^ 63));
+#else
+  // https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+  n--;
+  n |= n >> 1;
+  n |= n >> 2;
+  n |= n >> 4;
+  n |= n >> 8;
+  n |= n >> 16;
+  n |= n >> 32;
+  return n + 1;
+#endif  // 1
 }
 
-}  // namespace iree
+//==============================================================================
+// Pseudo-random number generators (PRNGs): **NOT CRYPTOGRAPHICALLY SECURE*
+//==============================================================================
+
+// A fixed-increment version of Java 8's SplittableRandom generator
+// See http://dx.doi.org/10.1145/2714064.2660195 and
+// http://docs.oracle.com/javase/8/docs/api/java/util/SplittableRandom.html
+//
+// SplitMix64 as recommended for use with xoroshiro by the authors:
+// http://prng.di.unimi.it/splitmix64.c
+// http://rosettacode.org/wiki/Pseudo-random_numbers/Splitmix64
+typedef uint64_t iree_prng_splitmix64_state_t;
+
+// Initializes a SplitMix64 PRNG state vector; |out_state| is overwritten.
+// |seed| may be any 64-bit value.
+static inline void iree_prng_splitmix64_initialize(
+    uint64_t seed, iree_prng_splitmix64_state_t* out_state) {
+  *out_state = seed;
+}
+
+// Steps a SplitMix64 PRNG state vector and yields a value for use.
+static inline uint64_t iree_prng_splitmix64_next(
+    iree_prng_splitmix64_state_t* state) {
+  uint64_t z = (*state += 0x9E3779B97F4A7C15ull);
+  z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+  z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+  return z ^ (z >> 31);
+}
+
+// A small **pseudorandom** number generator (named after the operations used).
+// http://prng.di.unimi.it/
+typedef struct {
+  uint64_t value[2];
+} iree_prng_xoroshiro128_state_t;
+
+// Initializes a xoroshiro128+ PRNG state vector; |out_state| is overwritten.
+// |seed| may be any 64-bit value.
+static inline void iree_prng_xoroshiro128_initialize(
+    uint64_t seed, iree_prng_xoroshiro128_state_t* out_state) {
+  // The authors recommend using SplitMix64 to go from a single int seed
+  // into the two state values we need. It's critical that we don't use a
+  // xoroshiro128 for this as seeding a PRNG with the results of itself is...
+  // unsound.
+  iree_prng_splitmix64_state_t init_state;
+  iree_prng_splitmix64_initialize(seed, &init_state);
+  out_state->value[0] = iree_prng_splitmix64_next(&seed);
+  out_state->value[1] = iree_prng_splitmix64_next(&seed);
+
+  // A state of 0 will never produce anything but zeros so ensure that doesn't
+  // happen; of course, after running splitmix that should be closer to the
+  // side of never than not.
+  if (!out_state->value[0] && !out_state->value[1]) {
+    out_state->value[0] = 1;
+  }
+}
+
+// Steps a xoroshiro128 state vector and yields a value for use.
+// xoroshiro128+ variant: produces a single value with 32-bit bits of entropy.
+// This is the fastest variant but the lower 4 bits of the returned value may
+// not be sufficiently well-distributed. This is fine if the usage requires
+// fewer than 60 bits such as when sampling bools or array indices.
+// Note also that this works great for floating-point numbers where only 23 or
+// 53 bits are required to populate a mantissa and an additional step can be
+// used to generate the sign/exponent when required.
+//
+//   footprint: 128-bits
+//      period: 2^128 - 1
+//  ns/64-bits: 0.72
+// cycles/byte: 0.29
+//
+// http://prng.di.unimi.it/xoroshiro128plus.c
+static inline uint64_t iree_prng_xoroshiro128plus_next_uint60(
+    iree_prng_xoroshiro128_state_t* state) {
+  uint64_t s0 = state->value[0];
+  uint64_t s1 = state->value[1];
+  const uint64_t result = s0 + s1;
+  s1 ^= s0;
+  state->value[0] = iree_math_rotl_u64(s0, 24) ^ s1 ^ (s1 << 16);  // a, b
+  state->value[1] = iree_math_rotl_u64(s1, 37);                    // c
+  return result;
+}
+
+// Steps a xoroshiro128 state vector and yields a single boolean value for use.
+// See iree_prng_xoroshiro128plus_next_uint60 for details.
+static inline bool iree_prng_xoroshiro128plus_next_bool(
+    iree_prng_xoroshiro128_state_t* state) {
+  return (bool)(iree_prng_xoroshiro128plus_next_uint60(state) >> (64 - 1));
+}
+
+// Steps a xoroshiro128 state vector and yields a single uint8_t value for use.
+// See iree_prng_xoroshiro128plus_next_uint60 for details.
+static inline uint8_t iree_prng_xoroshiro128plus_next_uint8(
+    iree_prng_xoroshiro128_state_t* state) {
+  return (uint8_t)(iree_prng_xoroshiro128plus_next_uint60(state) >> (64 - 8));
+}
+
+// Steps a xoroshiro128 state vector and yields a single uint32_t value for use.
+// See iree_prng_xoroshiro128plus_next_uint60 for details.
+static inline uint32_t iree_prng_xoroshiro128plus_next_uint32(
+    iree_prng_xoroshiro128_state_t* state) {
+  return (uint32_t)(iree_prng_xoroshiro128plus_next_uint60(state) >> (64 - 32));
+}
+
+// Steps a xoroshiro128 state vector and yields a value for use.
+// xoroshiro128** variant: produces a single value with 32-bit bits of entropy.
+// Prefer this to xoroshiro128+ when good distribution over the integer range
+// is required; see xoroshiro128+ for details of its issues.
+//
+//   footprint: 128-bits
+//      period: 2^128 - 1
+//  ns/64-bits: 0.93
+// cycles/byte: 0.42
+//
+// http://prng.di.unimi.it/xoroshiro128starstar.c
+static inline uint64_t iree_prng_xoroshiro128starstar_next_uint64(
+    iree_prng_xoroshiro128_state_t* state) {
+  uint64_t s0 = state->value[0];
+  uint64_t s1 = state->value[1];
+  const uint64_t result = iree_math_rotl_u64(s0 * 5, 7) * 9;
+  s1 ^= s0;
+  state->value[0] = iree_math_rotl_u64(s0, 24) ^ s1 ^ (s1 << 16);  // a, b
+  state->value[1] = iree_math_rotl_u64(s1, 37);                    // c
+  return result;
+}
 
 #endif  // IREE_BASE_MATH_H_

--- a/iree/base/math_test.cc
+++ b/iree/base/math_test.cc
@@ -1,0 +1,227 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/base/math.h"
+
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace {
+
+//==============================================================================
+// Bitwise rotation (aka circular shifts)
+//==============================================================================
+
+TEST(BitwiseRotationTest, ROTL64) {
+  EXPECT_EQ(0ull, iree_math_rotl_u64(0ull, 0u));
+  EXPECT_EQ(0ull, iree_math_rotl_u64(0ull, 0u));
+  EXPECT_EQ(1ull, iree_math_rotl_u64(1ull, 0u));
+  EXPECT_EQ(1ull, iree_math_rotl_u64(1ull, 0u));
+
+  EXPECT_EQ(2ull, iree_math_rotl_u64(1ull, 1u));
+  EXPECT_EQ(2ull, iree_math_rotl_u64(1ull, 1u));
+  EXPECT_EQ(UINT64_MAX, iree_math_rotl_u64(UINT64_MAX, 63u));
+  EXPECT_EQ(UINT64_MAX, iree_math_rotl_u64(UINT64_MAX, 64u));
+}
+
+TEST(BitwiseRotationTest, ROTR64) {
+  EXPECT_EQ(0ull, iree_math_rotr_u64(0ull, 0u));
+  EXPECT_EQ(0ull, iree_math_rotr_u64(0ull, 0u));
+  EXPECT_EQ(1ull, iree_math_rotr_u64(1ull, 0u));
+  EXPECT_EQ(1ull, iree_math_rotr_u64(1ull, 0u));
+
+  EXPECT_EQ(1ull, iree_math_rotr_u64(2ull, 1u));
+  EXPECT_EQ(0x8000000000000000ull, iree_math_rotr_u64(2ull, 2u));
+  EXPECT_EQ(0x8000000000000000ull, iree_math_rotr_u64(1ull, 1u));
+  EXPECT_EQ(0x4000000000000000ull, iree_math_rotr_u64(1ull, 2u));
+}
+
+//==============================================================================
+// Bit scanning/counting
+//==============================================================================
+
+TEST(BitwiseScansTest, CLZ32) {
+  EXPECT_EQ(32, iree_math_count_leading_zeros_u32(uint32_t{}));
+  EXPECT_EQ(0, iree_math_count_leading_zeros_u32(~uint32_t{}));
+  for (int index = 0; index < 32; index++) {
+    uint32_t x = 1u << index;
+    const int cnt = 31 - index;
+    ASSERT_EQ(cnt, iree_math_count_leading_zeros_u32(x)) << index;
+    ASSERT_EQ(cnt, iree_math_count_leading_zeros_u32(x + x - 1)) << index;
+  }
+}
+
+TEST(BitwiseScansTest, CLZ64) {
+  EXPECT_EQ(64, iree_math_count_leading_zeros_u64(uint64_t{}));
+  EXPECT_EQ(0, iree_math_count_leading_zeros_u64(~uint64_t{}));
+  for (int index = 0; index < 64; index++) {
+    uint64_t x = 1ull << index;
+    const int cnt = 63 - index;
+    ASSERT_EQ(cnt, iree_math_count_leading_zeros_u64(x)) << index;
+    ASSERT_EQ(cnt, iree_math_count_leading_zeros_u64(x + x - 1)) << index;
+  }
+}
+
+TEST(BitwiseScansTest, CTZ32) {
+  EXPECT_EQ(0, iree_math_count_trailing_zeros_u32(~uint32_t{}));
+  for (int index = 0; index < 32; index++) {
+    uint32_t x = static_cast<uint32_t>(1) << index;
+    const int cnt = index;
+    ASSERT_EQ(cnt, iree_math_count_trailing_zeros_u32(x)) << index;
+    ASSERT_EQ(cnt, iree_math_count_trailing_zeros_u32(~(x - 1))) << index;
+  }
+}
+
+TEST(BitwiseScansTest, CTZ64) {
+  // iree_math_count_trailing_zeros_u32
+  EXPECT_EQ(0, iree_math_count_trailing_zeros_u64(~uint64_t{}));
+  for (int index = 0; index < 64; index++) {
+    uint64_t x = static_cast<uint64_t>(1) << index;
+    const int cnt = index;
+    ASSERT_EQ(cnt, iree_math_count_trailing_zeros_u64(x)) << index;
+    ASSERT_EQ(cnt, iree_math_count_trailing_zeros_u64(~(x - 1))) << index;
+  }
+}
+
+//==============================================================================
+// Population count
+//==============================================================================
+
+TEST(PopulationCountTest, Ones32) {
+  EXPECT_EQ(0, iree_math_count_ones_u32(0u));
+  EXPECT_EQ(1, iree_math_count_ones_u32(1u));
+  EXPECT_EQ(29, iree_math_count_ones_u32(-15u));
+  EXPECT_EQ(5, iree_math_count_ones_u32(341u));
+  EXPECT_EQ(32, iree_math_count_ones_u32(UINT32_MAX));
+  EXPECT_EQ(31, iree_math_count_ones_u32(UINT32_MAX - 1));
+}
+
+TEST(PopulationCountTest, Ones64) {
+  EXPECT_EQ(0, iree_math_count_ones_u64(0ull));
+  EXPECT_EQ(1, iree_math_count_ones_u64(1ull));
+  EXPECT_EQ(61, iree_math_count_ones_u64(-15ull));
+  EXPECT_EQ(5, iree_math_count_ones_u64(341ull));
+  EXPECT_EQ(64, iree_math_count_ones_u64(UINT64_MAX));
+  EXPECT_EQ(63, iree_math_count_ones_u64(UINT64_MAX - 1ull));
+}
+
+//==============================================================================
+// Rounding and alignment
+//==============================================================================
+
+TEST(RoundingTest, UpToNextPow232) {
+  constexpr uint32_t kUint16Max = UINT16_MAX;
+  constexpr uint32_t kUint32Max = UINT32_MAX;
+  EXPECT_EQ(0u, iree_math_round_up_to_pow2_u32(0u));
+  EXPECT_EQ(1u, iree_math_round_up_to_pow2_u32(1u));
+  EXPECT_EQ(2u, iree_math_round_up_to_pow2_u32(2u));
+  EXPECT_EQ(4u, iree_math_round_up_to_pow2_u32(3u));
+  EXPECT_EQ(8u, iree_math_round_up_to_pow2_u32(8u));
+  EXPECT_EQ(16u, iree_math_round_up_to_pow2_u32(9u));
+  EXPECT_EQ(kUint16Max + 1u, iree_math_round_up_to_pow2_u32(kUint16Max - 1u));
+  EXPECT_EQ(kUint16Max + 1u, iree_math_round_up_to_pow2_u32(kUint16Max));
+  EXPECT_EQ(kUint16Max + 1u, iree_math_round_up_to_pow2_u32(kUint16Max + 1u));
+  EXPECT_EQ(131072u, iree_math_round_up_to_pow2_u32(kUint16Max + 2u));
+  EXPECT_EQ(262144u, iree_math_round_up_to_pow2_u32(262144u - 1u));
+  EXPECT_EQ(0x80000000u, iree_math_round_up_to_pow2_u32(0x7FFFFFFFu));
+  EXPECT_EQ(0x80000000u, iree_math_round_up_to_pow2_u32(0x80000000u));
+
+  // NOTE: wrap to 0.
+  EXPECT_EQ(0u, iree_math_round_up_to_pow2_u32(0x80000001u));
+  EXPECT_EQ(0u, iree_math_round_up_to_pow2_u32(kUint32Max - 1u));
+  EXPECT_EQ(0u, iree_math_round_up_to_pow2_u32(kUint32Max));
+}
+
+TEST(RoundingTest, UpToNextPow264) {
+  constexpr uint64_t kUint16Max = UINT16_MAX;
+  constexpr uint64_t kUint32Max = UINT32_MAX;
+  constexpr uint64_t kUint64Max = UINT64_MAX;
+  EXPECT_EQ(0ull, iree_math_round_up_to_pow2_u64(0ull));
+  EXPECT_EQ(1ull, iree_math_round_up_to_pow2_u64(1ull));
+  EXPECT_EQ(2ull, iree_math_round_up_to_pow2_u64(2ull));
+  EXPECT_EQ(4ull, iree_math_round_up_to_pow2_u64(3ull));
+  EXPECT_EQ(8ull, iree_math_round_up_to_pow2_u64(8ull));
+  EXPECT_EQ(16ull, iree_math_round_up_to_pow2_u64(9ull));
+  EXPECT_EQ(kUint16Max + 1ull,
+            iree_math_round_up_to_pow2_u64(kUint16Max - 1ull));
+  EXPECT_EQ(kUint16Max + 1ull, iree_math_round_up_to_pow2_u64(kUint16Max));
+  EXPECT_EQ(kUint16Max + 1ull,
+            iree_math_round_up_to_pow2_u64(kUint16Max + 1ull));
+  EXPECT_EQ(131072ull, iree_math_round_up_to_pow2_u64(kUint16Max + 2ull));
+  EXPECT_EQ(0x100000000ull, iree_math_round_up_to_pow2_u64(0xFFFFFFFEull));
+  EXPECT_EQ(0x100000000ull, iree_math_round_up_to_pow2_u64(0xFFFFFFFFull));
+  EXPECT_EQ(0x80000000ull, iree_math_round_up_to_pow2_u64(0x7FFFFFFFull));
+  EXPECT_EQ(0x80000000ull, iree_math_round_up_to_pow2_u64(0x80000000ull));
+  EXPECT_EQ(0x100000000ull, iree_math_round_up_to_pow2_u64(0x80000001ull));
+
+  // NOTE: wrap to 0.
+  EXPECT_EQ(0ull, iree_math_round_up_to_pow2_u64(0x8000000000000001ull));
+  EXPECT_EQ(0ull, iree_math_round_up_to_pow2_u64(kUint64Max - 1ull));
+  EXPECT_EQ(0ull, iree_math_round_up_to_pow2_u64(kUint64Max));
+}
+
+//==============================================================================
+// Pseudo-random number generators (PRNGs): **NOT CRYPTOGRAPHICALLY SECURE*
+//==============================================================================
+// NOTE: we leave the real testing to the authors; this just ensures we aren't
+// `return 4;`ing it or ignoring the seed.
+
+TEST(PRNG, SplitMix64) {
+  iree_prng_splitmix64_state_t state;
+
+  iree_prng_splitmix64_initialize(/*seed=*/0ull, &state);
+  EXPECT_EQ(16294208416658607535ull, iree_prng_splitmix64_next(&state));
+  EXPECT_EQ(7960286522194355700ull, iree_prng_splitmix64_next(&state));
+
+  iree_prng_splitmix64_initialize(/*seed=*/1ull, &state);
+  EXPECT_EQ(10451216379200822465ull, iree_prng_splitmix64_next(&state));
+  EXPECT_EQ(13757245211066428519ull, iree_prng_splitmix64_next(&state));
+
+  iree_prng_splitmix64_initialize(/*seed=*/UINT64_MAX, &state);
+  EXPECT_EQ(16490336266968443936ull, iree_prng_splitmix64_next(&state));
+  EXPECT_EQ(16834447057089888969ull, iree_prng_splitmix64_next(&state));
+}
+
+TEST(PRNG, Xoroshiro128) {
+  iree_prng_xoroshiro128_state_t state;
+
+  iree_prng_xoroshiro128_initialize(/*seed=*/0ull, &state);
+  EXPECT_EQ(5807750865143411619ull,
+            iree_prng_xoroshiro128plus_next_uint60(&state));
+  EXPECT_TRUE(iree_prng_xoroshiro128plus_next_bool(&state));
+  EXPECT_EQ(218u, iree_prng_xoroshiro128plus_next_uint8(&state));
+  EXPECT_EQ(1647201753u, iree_prng_xoroshiro128plus_next_uint32(&state));
+  EXPECT_EQ(7260361800523965311ull,
+            iree_prng_xoroshiro128starstar_next_uint64(&state));
+
+  iree_prng_xoroshiro128_initialize(/*seed=*/1ull, &state);
+  EXPECT_EQ(5761717516557699368ull,
+            iree_prng_xoroshiro128plus_next_uint60(&state));
+  EXPECT_TRUE(iree_prng_xoroshiro128plus_next_bool(&state));
+  EXPECT_EQ(103u, iree_prng_xoroshiro128plus_next_uint8(&state));
+  EXPECT_EQ(2242241045u, iree_prng_xoroshiro128plus_next_uint32(&state));
+  EXPECT_EQ(661144386810419178ull,
+            iree_prng_xoroshiro128starstar_next_uint64(&state));
+
+  iree_prng_xoroshiro128_initialize(/*seed=*/UINT64_MAX, &state);
+  EXPECT_EQ(14878039250348781289ull,
+            iree_prng_xoroshiro128plus_next_uint60(&state));
+  EXPECT_FALSE(iree_prng_xoroshiro128plus_next_bool(&state));
+  EXPECT_EQ(137u, iree_prng_xoroshiro128plus_next_uint8(&state));
+  EXPECT_EQ(2111322015u, iree_prng_xoroshiro128plus_next_uint32(&state));
+  EXPECT_EQ(138107609852220106ull,
+            iree_prng_xoroshiro128starstar_next_uint64(&state));
+}
+
+}  // namespace

--- a/iree/hal/vulkan/descriptor_set_arena.cc
+++ b/iree/hal/vulkan/descriptor_set_arena.cc
@@ -131,10 +131,11 @@ Status DescriptorSetArena::BindDescriptorSet(
 
   // Pick a bucket based on the number of descriptors required.
   // NOTE: right now we are 1:1 with bindings.
-  int required_descriptor_count = static_cast<int>(bindings.size() * 1);
-  int max_descriptor_count =
-      std::max(8, RoundUpToNearestPow2(required_descriptor_count));
-  int bucket = TrailingZeros(max_descriptor_count >> 3);
+  uint32_t required_descriptor_count = static_cast<int>(bindings.size() * 1);
+  uint32_t max_descriptor_count =
+      std::max(8u, iree_math_round_up_to_pow2_u32(required_descriptor_count));
+  uint32_t bucket =
+      iree_math_count_trailing_zeros_u32(max_descriptor_count >> 3);
   if (bucket >= descriptor_pool_buckets_.size()) {
     return OutOfRangeErrorBuilder(IREE_LOC)
            << "Too many descriptors required: " << required_descriptor_count

--- a/iree/hal/vulkan/vulkan_device.cc
+++ b/iree/hal/vulkan/vulkan_device.cc
@@ -171,7 +171,8 @@ absl::InlinedVector<std::unique_ptr<CommandQueue>, 4> CreateCommandQueues(
     const ref_ptr<DynamicSymbols>& syms) {
   absl::InlinedVector<std::unique_ptr<CommandQueue>, 4> command_queues;
 
-  uint64_t compute_queue_count = CountOnes64(compute_queue_set.queue_indices);
+  uint64_t compute_queue_count =
+      iree_math_count_ones_u64(compute_queue_set.queue_indices);
   for (uint32_t i = 0; i < compute_queue_count; ++i) {
     if (!(compute_queue_set.queue_indices & (1ull << i))) continue;
 
@@ -193,7 +194,8 @@ absl::InlinedVector<std::unique_ptr<CommandQueue>, 4> CreateCommandQueues(
     }
   }
 
-  uint64_t transfer_queue_count = CountOnes64(transfer_queue_set.queue_indices);
+  uint64_t transfer_queue_count =
+      iree_math_count_ones_u64(transfer_queue_set.queue_indices);
   for (uint32_t i = 0; i < transfer_queue_count; ++i) {
     if (!(transfer_queue_set.queue_indices & (1ull << i))) continue;
 
@@ -411,8 +413,10 @@ StatusOr<ref_ptr<VulkanDevice>> VulkanDevice::Wrap(
     const ref_ptr<DynamicSymbols>& syms) {
   IREE_TRACE_SCOPE0("VulkanDevice::Wrap");
 
-  uint64_t compute_queue_count = CountOnes64(compute_queue_set.queue_indices);
-  uint64_t transfer_queue_count = CountOnes64(transfer_queue_set.queue_indices);
+  uint64_t compute_queue_count =
+      iree_math_count_ones_u64(compute_queue_set.queue_indices);
+  uint64_t transfer_queue_count =
+      iree_math_count_ones_u64(transfer_queue_set.queue_indices);
 
   if (compute_queue_count == 0) {
     return InvalidArgumentErrorBuilder(IREE_LOC)

--- a/iree/vm/bytecode_dispatch.c
+++ b/iree/vm/bytecode_dispatch.c
@@ -14,25 +14,10 @@
 
 #include <string.h>
 
+#include "iree/base/math.h"
 #include "iree/base/tracing.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_dispatch_util.h"
-
-//===----------------------------------------------------------------------===//
-// Math utilities, kept here to limit dependencies
-//===----------------------------------------------------------------------===//
-
-// Rounds up the value to the nearest power of 2 (if not already a power of 2).
-static inline uint32_t iree_math_round_up_to_pow2_u32(uint32_t n) {
-  n--;
-  n |= n >> 1;
-  n |= n >> 2;
-  n |= n >> 4;
-  n |= n >> 8;
-  n |= n >> 16;
-  n++;
-  return n;
-}
 
 //===----------------------------------------------------------------------===//
 // Register remapping utilities


### PR DESCRIPTION
These routines will be used for threadpool worker theft distribution where it's important that they are relatively fast.

I used this opportunity to clean up the file and finish some of the TODOs for when C happened.