### PR TITLE
Adding hal.interface.workgroup.* ops.

### DIFF
--- a/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
+++ b/iree/compiler/Conversion/LinalgToLLVM/LinalgTileAndDistributePass.cpp
@@ -19,8 +19,8 @@
 #include "iree/compiler/Conversion/Common/Attributes.h"
 #include "iree/compiler/Conversion/Common/Transforms.h"
 #include "iree/compiler/Conversion/LinalgToLLVM/KernelDispatch.h"
-#include "iree/compiler/Dialect/IREE/IR/IREEDialect.h"
-#include "iree/compiler/Dialect/IREE/IR/IREEOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Matchers.h"
@@ -37,7 +37,7 @@ namespace {
 struct LinalgTileAndDistributePass
     : public PassWrapper<LinalgTileAndDistributePass, OperationPass<ModuleOp>> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<linalg::LinalgDialect, IREEDialect, AffineDialect,
+    registry.insert<linalg::LinalgDialect, IREE::HAL::HALDialect, AffineDialect,
                     scf::SCFDialect>();
   }
   LinalgTileAndDistributePass() = default;
@@ -155,16 +155,16 @@ void LinalgTileAndDistributePass::runOnOperation() {
 
   static linalg::LinalgLoopDistributionOptions workgroupDistributionOptions = {
       [](OpBuilder &builder, Location loc, ArrayRef<Range> parallelLoopRanges) {
-        Type indexType = builder.getIndexType();
         auto numParallelDims = parallelLoopRanges.size();
-        SmallVector<linalg::ProcInfo, 2> procInfo(numParallelDims);
-        for (int dim = 0; dim < numParallelDims; ++dim) {
-          std::array<StringRef, 3> dimAttr{"x", "y", "z"};
-          StringAttr attr =
-              builder.getStringAttr(dimAttr[std::min<unsigned>(dim, 3)]);
+        SmallVector<linalg::ProcInfo, 3> procInfo(numParallelDims);
+        for (size_t dim = 0;
+             dim < std::min(numParallelDims, static_cast<size_t>(3)); ++dim) {
           procInfo[numParallelDims - dim - 1] = {
-              builder.create<IREE::WorkgroupIdOp>(loc, indexType, attr),
-              builder.create<IREE::WorkgroupSizeOp>(loc, indexType, attr)};
+              builder.createOrFold<IREE::HAL::InterfaceWorkgroupIDOp>(
+                  loc, builder.getIndexType(), APInt(64, dim)),
+              builder.createOrFold<IREE::HAL::InterfaceWorkgroupCountOp>(
+                  loc, builder.getIndexType(), APInt(64, dim)),
+          };
         }
         return procInfo;
       },

--- a/iree/compiler/Conversion/LinalgToLLVM/Passes.h
+++ b/iree/compiler/Conversion/LinalgToLLVM/Passes.h
@@ -28,10 +28,10 @@ std::unique_ptr<FunctionPass> createConvImg2ColMatmulConversionPass();
 /// order.
 std::unique_ptr<FunctionPass> createPlanConvLoopOrderPass();
 
-/// Distributes linalg ops among iree.workgroup logical threads.
+/// Distributes linalg ops among hal.interface.workgroup logical threads.
 std::unique_ptr<OperationPass<ModuleOp>> createLinalgTileAndDistributePass();
 
-/// Vectorizes linalg ops executed in the same iree.workgroup.
+/// Vectorizes linalg ops executed in the same hal.interface.workgroup.
 std::unique_ptr<FunctionPass> createLinalgTileAndVectorizeWorkgroupsPass();
 
 std::unique_ptr<OperationPass<ModuleOp>>

--- a/iree/compiler/Conversion/LinalgToLLVM/test/convert_to_llvm.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/convert_to_llvm.mlir
@@ -14,7 +14,7 @@ func @convert_dynamic_shape() -> f32 {
 hal.interface @legacy_io attributes {push_constants = 2 : i32, sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 }
-// CHECK: llvm.func @convert_dynamic_shape(%[[ARG0:.+]]: !llvm.ptr<ptr<i8>>, %[[ARG1:.+]]: !llvm.ptr<i32>, %[[THREAD_X_ID:.+]]: !llvm.i32, %[[THREAD_Y_ID:.+]]: !llvm.i32, %[[THREAD_Z_ID:.+]]: !llvm.i32)
+// CHECK: llvm.func @convert_dynamic_shape(%[[ARG0:.+]]: !llvm.ptr<ptr<i8>>, %[[ARG1:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_ID:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_COUNT:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_SIZE:.+]]: !llvm.ptr<i32>)
 // CHECK: %[[PACKED_ARGS_PTR:.+]] = llvm.bitcast %[[ARG0]] : !llvm.ptr<ptr<i8>> to !llvm.ptr<struct<(ptr<float>)>>
 // CHECK: %[[PACKED_ARGS:.+]] = llvm.load %[[PACKED_ARGS_PTR]] : !llvm.ptr<struct<(ptr<float>)>>
 // CHECK: %[[MEMREF0_DATA_PTR:.+]] = llvm.extractvalue %[[PACKED_ARGS]][0] : !llvm.struct<(ptr<float>)>
@@ -53,7 +53,7 @@ func @convert_dynamic_shape2() -> f32 {
 hal.interface @legacy_io2 attributes {push_constants = 1 : i32, sym_visibility = "private"} {
     hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
 }
-// CHECK: llvm.func @convert_dynamic_shape2(%[[ARG0:.+]]: !llvm.ptr<ptr<i8>>, %[[ARG1:.+]]: !llvm.ptr<i32>, %[[THREAD_X_ID:.+]]: !llvm.i32, %[[THREAD_Y_ID:.+]]: !llvm.i32, %[[THREAD_Z_ID:.+]]: !llvm.i32)
+// CHECK: llvm.func @convert_dynamic_shape2(%[[ARG0:.+]]: !llvm.ptr<ptr<i8>>, %[[ARG1:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_ID:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_COUNT:.+]]: !llvm.ptr<i32>, %[[WORKGROUP_SIZE:.+]]: !llvm.ptr<i32>)
 // CHECK: %[[PACKED_ARGS_PTR:.+]] = llvm.bitcast %[[ARG0]] : !llvm.ptr<ptr<i8>> to !llvm.ptr<struct<(ptr<float>)>>
 // CHECK: %[[PACKED_ARGS:.+]] = llvm.load %[[PACKED_ARGS_PTR]] : !llvm.ptr<struct<(ptr<float>)>>
 // CHECK: %[[MEMREF0_DATA_PTR:.+]] = llvm.extractvalue %[[PACKED_ARGS]][0] : !llvm.struct<(ptr<float>)>
@@ -86,9 +86,9 @@ hal.interface @legacy_io2 attributes {push_constants = 1 : i32, sym_visibility =
 // CHECK_LABEL: @distribute_lookup
 func @distribute_lookup() -> f32 {
   %0 = iree.placeholder for "interface buffer" {binding = @legacy_io3::@arg0} : memref<2x2x2xf32>
-  %1 = iree.workgroup_id {dimension = "x"} : index
-  %2 = iree.workgroup_id {dimension = "y"} : index
-  %3 = iree.workgroup_id {dimension = "z"} : index
+  %1 = hal.interface.workgroup.id[0] : index
+  %2 = hal.interface.workgroup.id[1] : index
+  %3 = hal.interface.workgroup.id[2] : index
   %4 = load %0[%1, %2, %3] : memref<2x2x2xf32>
   return %4 : f32
 }

--- a/iree/compiler/Conversion/LinalgToLLVM/test/linalg_rewrite_destructive_updates.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/linalg_rewrite_destructive_updates.mlir
@@ -13,8 +13,8 @@ func @tile_from_tensor_load() {
   %2 = hal.interface.load.tensor @legacy_io::@TENSOR_INIT, offset = %c0
     {operand_result_index = 2 : i32} : tensor<2x4xf32>
 
-  %3 = iree.workgroup_id {dimension = "x"} : index
-  %4 = iree.workgroup_id {dimension = "y"} : index
+  %3 = hal.interface.workgroup.id[0] : index
+  %4 = hal.interface.workgroup.id[1] : index
   // Test step %{{[0-9a-z]}} { to ensure yield has been folded away.
   //      CHECK: scf.for %[[I:.*]] = {{.*}} step %{{[0-9a-z]+}} {
   //      CHECK:   scf.for %[[J:.*]] = {{.*}} step %{{[0-9a-z]+}} {
@@ -83,8 +83,8 @@ func @tile_from_pointwise_lhs() {
   %2 = hal.interface.load.tensor @legacy_io::@TENSOR_RHS, offset = %c0
     {operand_result_index = 2 : i32} : tensor<3x4xf32>
 
-  %4 = iree.workgroup_id {dimension = "x"} : index
-  %5 = iree.workgroup_id {dimension = "y"} : index
+  %4 = hal.interface.workgroup.id[0] : index
+  %5 = hal.interface.workgroup.id[1] : index
   // Test step %{{[0-9a-z]}} { to ensure yield has been folded away.
   //      CHECK: scf.for %[[I:.*]] = {{.*}} step %{{[0-9a-z]+}} {
   //      CHECK:   scf.for %[[J:.*]] = {{.*}} step %{{[0-9a-z]+}} {
@@ -168,8 +168,8 @@ func @tile_from_pointwise_init() {
     linalg.yield %arg0 : f32
   } -> tensor<2x4xf32>
 
-  %4 = iree.workgroup_id {dimension = "x"} : index
-  %5 = iree.workgroup_id {dimension = "y"} : index
+  %4 = hal.interface.workgroup.id[0] : index
+  %5 = hal.interface.workgroup.id[1] : index
 
   // Test step %{{[0-9a-z]}} { to ensure yield has been folded away.
   //      CHECK: scf.for %[[I:.*]] = {{.*}} step %{{[0-9a-z]+}} {

--- a/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/matmul_vectorization.mlir
@@ -7,8 +7,8 @@ func @matmul_128x128x128(%arg0 : memref<128x128xf32>, %arg1: memref<128x128xf32>
 // CHECK: #[[MAP0:map.*]] =  affine_map<()[s0] -> (s0 * 64)>
 // CHECK-LABEL: func @matmul_128x128x128
 // CHECK-SAME: (%[[ARG0:.+]]: memref<128x128xf32>, %[[ARG1:.+]]: memref<128x128xf32>, %[[ARG2:.+]]: memref<128x128xf32>)
-// CHECK-DaG: %[[WORKGROUP_TILE_X:.+]] = iree.workgroup_id {dimension = "x"} : index
-// CHECK-DAG: %[[WORKGROUP_TILE_Y:.+]] = iree.workgroup_id {dimension = "y"} : index
+// CHECK-DaG: %[[WORKGROUP_TILE_X:.+]] = hal.interface.workgroup.id[0] : index
+// CHECK-DAG: %[[WORKGROUP_TILE_Y:.+]] = hal.interface.workgroup.id[1] : index
 // CHECK-DAG: %[[START:.+]] = constant 0
 // CHECK-DAG: %[[WORGKROUP_SIZE:.+]] = constant 64
 // CHECK-DAG: %[[VECTOR_SIZE:.+]] = constant 4

--- a/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute.mlir
@@ -13,17 +13,17 @@ func @dynamic_matmul(%lhs: memref<?x?xf32>, %rhs: memref<?x?xf32>, %result: memr
 // CHECK-DAG: %[[CONST_0:.+]] = constant 0 : index
 // CHECK-DAG: %[[CONST_1:.+]] = constant 1 : index
 // CHECK-DAG: %[[DIM_K:.+]] = dim %[[LHS]], %[[CONST_1]]
-// CHECK-DAG: %[[THREAD_X_ID:.+]] = iree.workgroup_id  {dimension = "x"} : index
-// CHECK-DAG: %[[THREAD_Y_ID:.+]] = iree.workgroup_id  {dimension = "y"} : index
+// CHECK-DAG: %[[THREAD_X_ID:.+]] = hal.interface.workgroup.id[0] : index
+// CHECK-DAG: %[[THREAD_Y_ID:.+]] = hal.interface.workgroup.id[1] : index
 //     CHECK:  scf.for %[[K:.+]] = %[[CONST_0]] to %[[DIM_K]]
 //     CHECK:     %[[I:.+]] = affine.apply #[[MAP0]]()[%[[THREAD_Y_ID]]]
 //     CHECK:     %[[DIM_I:.+]] = dim %[[LHS]], %[[CONST_0]]
 //     CHECK:     %[[I_OFFSET:.+]] = affine.min #[[MAP1]]()[%[[THREAD_Y_ID]], %[[DIM_I]]]
-//     CHECK:     %[[LHS_SUBVIEW:.+]] = subview %[[LHS]][%[[I]], %[[K]]] [%[[I_OFFSET]], 1] [1, 1] 
+//     CHECK:     %[[LHS_SUBVIEW:.+]] = subview %[[LHS]][%[[I]], %[[K]]] [%[[I_OFFSET]], 1] [1, 1]
 //     CHECK:     %[[J:.+]] = affine.apply #[[MAP3]]()[%[[THREAD_X_ID]]]
-//     CHECK:     %[[DIM_J:.+]] = dim %[[RHS]], %[[CONST_1]] 
+//     CHECK:     %[[DIM_J:.+]] = dim %[[RHS]], %[[CONST_1]]
 //     CHECK:     %[[J_OFFSET:.+]] = affine.min #[[MAP4]]()[%[[THREAD_X_ID]], %[[DIM_J]]]
-//     CHECK:     %[[RHS_SUBVIEW:.+]] = subview %[[RHS]][%[[K]], %[[J]]] [1, %[[J_OFFSET]]] [1, 1]  
+//     CHECK:     %[[RHS_SUBVIEW:.+]] = subview %[[RHS]][%[[K]], %[[J]]] [1, %[[J_OFFSET]]] [1, 1]
 //     CHECK:     %[[DIM_I:.+]] = dim %[[RESULT]], %[[CONST_0]]
 //     CHECK:     %[[DIM_I_OFFSET:.+]] = affine.min #[[MAP1]]()[%[[THREAD_Y_ID]], %[[DIM_I]]]
 //     CHECK:     %[[DIM_J:.+]] = dim %[[RESULT]], %[[CONST_1]]
@@ -45,12 +45,12 @@ func @static_matmul(%lhs: memref<16x4xf32>, %rhs: memref<4x8xf32>, %result: memr
 // CHECK-DAG: %[[CONST_0:.+]] = constant 0 : index
 // CHECK-DAG: %[[CONST_4:.+]] = constant 4 : index
 // CHECK-DAG: %[[CONST_1:.+]] = constant 1 : index
-// CHECK-DAG: %[[THREAD_X_ID:.+]] = iree.workgroup_id  {dimension = "x"} : index
-// CHECK-DAG: %[[THREAD_Y_ID:.+]] = iree.workgroup_id  {dimension = "y"} : index
-//     CHECK:  scf.for %[[K:.+]] = %[[CONST_0]] to %[[CONST_4]] step %[[CONST_1]] 
+// CHECK-DAG: %[[THREAD_X_ID:.+]] = hal.interface.workgroup.id[0] : index
+// CHECK-DAG: %[[THREAD_Y_ID:.+]] = hal.interface.workgroup.id[1] : index
+//     CHECK:  scf.for %[[K:.+]] = %[[CONST_0]] to %[[CONST_4]] step %[[CONST_1]]
 //     CHECK:    %[[I:.+]] = affine.apply #[[MAP0]]()[%[[THREAD_Y_ID]]]
 //     CHECK:    %[[LHS_SUBVIEW:.+]] = subview %[[LHS]][%[[I]], %[[K]]] [2, 1] [1, 1]  : memref<16x4xf32> to memref<2x1xf32, #[[MAP1]]>
 //     CHECK:    %[[J:.+]] = affine.apply #[[MAP2]]()[%[[THREAD_X_ID]]]
 //     CHECK:    %[[RHS_SUBVIEW:.+]] = subview %[[RHS]][%[[K]], %[[J]]] [1, 4] [1, 1]  : memref<4x8xf32> to memref<1x4xf32, #[[MAP3]]>
 //     CHECK:    %[[RESULT_SUBVIEW:.+]] = subview %[[RESULT]][%[[I]], %[[J]]] [2, 4] [1, 1]  : memref<16x8xf32> to memref<2x4xf32, #[[MAP3]]>
-//     CHECK:    linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%[[LHS_SUBVIEW]], %[[RHS_SUBVIEW]] : memref<2x1xf32, #[[MAP1]]>, memref<1x4xf32, #[[MAP3]]>) outs(%6 : memref<2x4xf32, #[[MAP3]]>)
+//     CHECK:    linalg.matmul {__internal_linalg_transform__ = "workgroup"} ins(%[[LHS_SUBVIEW]], %[[RHS_SUBVIEW]] : memref<2x1xf32, #[[MAP1]]>, memref<1x4xf32, #[[MAP3]]>) outs(%4 : memref<2x4xf32, #[[MAP3]]>)

--- a/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute_on_tensors.mlir
+++ b/iree/compiler/Conversion/LinalgToLLVM/test/tile_and_distribute_on_tensors.mlir
@@ -13,14 +13,14 @@ func @tensor() -> tensor<2x4xf32> {
   //  CHECK-DAG: %[[C1:.*]] = constant 1 : index
   //  CHECK-DAG: %[[C2:.*]] = constant 2 : index
   //  CHECK-DAG: %[[C4:.*]] = constant 4 : index
-  //  CHECK-DAG: %[[bix:.*]] = iree.workgroup_id {dimension = "x"} : index
-  //  CHECK-DAG: %[[bdx:.*]] = iree.workgoup_size {dimension = "x"} : index
-  //  CHECK-DAG: %[[biy:.*]] = iree.workgroup_id {dimension = "y"} : index
-  //  CHECK-DAG: %[[bdy:.*]] = iree.workgoup_size {dimension = "y"} : index
-  //      CHECK: %{{.*}} = scf.for %[[I:.*]] = %[[bix]] to %[[C2]] step %[[bdx]] iter_args(%arg1 = %2) -> (tensor<2x4xf32>) {
-  // CHECK-NEXT:   %[[biy_scaled:.*]] = muli %[[biy]], %[[C2]] : index
-  // CHECK-NEXT:   %[[bdy_scaled:.*]] = muli %[[bdy]], %[[C2]] : index
-  // CHECK-NEXT:   %{{.*}} = scf.for %[[J:.*]] = %[[biy_scaled]] to %[[C4]] step %[[bdy_scaled]] iter_args(%arg3 = %arg1) -> (tensor<2x4xf32>) {
+  //  CHECK-DAG: %[[bix:.*]] = hal.interface.workgroup.id[0] : index
+  //  CHECK-DAG: %[[bdx:.*]] = hal.interface.workgroup.count[0] : index
+  //  CHECK-DAG: %[[biy:.*]] = hal.interface.workgroup.id[1] : index
+  //  CHECK-DAG: %[[bdy:.*]] = hal.interface.workgroup.count[1] : index
+  //      CHECK: %{{.*}} = scf.for %[[I:.*]] = %[[biy]] to %[[C2]] step %[[bdy]] iter_args(%arg1 = %2) -> (tensor<2x4xf32>) {
+  // CHECK-NEXT:   %[[bix_scaled:.*]] = muli %[[bix]], %[[C2]] : index
+  // CHECK-NEXT:   %[[bdx_scaled:.*]] = muli %[[bdx]], %[[C2]] : index
+  // CHECK-NEXT:   %{{.*}} = scf.for %[[J:.*]] = %[[bix_scaled]] to %[[C4]] step %[[bdx_scaled]] iter_args(%arg3 = %arg1) -> (tensor<2x4xf32>) {
   // CHECK-NEXT:     subtensor %{{.*}}[%[[I]], 0] [1, 3] [1, 1] : tensor<2x3xf32> to tensor<1x3xf32>
   //
   // Canonicalizations not yet powerful enough here.

--- a/iree/compiler/Conversion/LinalgToSPIRV/FoldGPUProcessorIDUses.cpp
+++ b/iree/compiler/Conversion/LinalgToSPIRV/FoldGPUProcessorIDUses.cpp
@@ -73,6 +73,8 @@ bool isLinearExpr(AffineExpr expr) {
     case mlir::AffineExprKind::DimId:
     case mlir::AffineExprKind::SymbolId:
       return true;
+    default:
+      llvm_unreachable("unhandled affine expr kind");
   }
 }
 

--- a/iree/compiler/Dialect/HAL/Conversion/IREEToHAL/ConvertIREEToHAL.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/IREEToHAL/ConvertIREEToHAL.cpp
@@ -24,6 +24,7 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
+
 class DynamicShapeConstantOpConversion
     : public OpConversionPattern<IREE::DynamicShapeConstantOp> {
  public:

--- a/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -464,9 +464,6 @@ def HAL_Dim : TypeAlias<Index>;
 def HAL_Dims : Variadic<HAL_Dim>;
 def HAL_Shape : Variadic<HAL_Dim>;
 
-// Ideally this would be a vector<3xindex> but you can't put indices in vectors.
-def HAL_WorkgroupXYZ : TupleOf<[HAL_Dim, HAL_Dim, HAL_Dim]>;
-
 // TODO(benvanik): assert rank 3
 def HAL_WorkgroupSizeAttr : TypedArrayAttrBase<
     IREE_IndexAttrBase<"size_t">,

--- a/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -464,6 +464,9 @@ def HAL_Dim : TypeAlias<Index>;
 def HAL_Dims : Variadic<HAL_Dim>;
 def HAL_Shape : Variadic<HAL_Dim>;
 
+// Ideally this would be a vector<3xindex> but you can't put indices in vectors.
+def HAL_WorkgroupXYZ : TupleOf<[HAL_Dim, HAL_Dim, HAL_Dim]>;
+
 // TODO(benvanik): assert rank 3
 def HAL_WorkgroupSizeAttr : TypedArrayAttrBase<
     IREE_IndexAttrBase<"size_t">,

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1580,6 +1580,25 @@ static void printInterfaceBindingOp(OpAsmPrinter &p, InterfaceBindingOp op) {
 }
 
 //===----------------------------------------------------------------------===//
+// hal.interface.workgroup.*
+//===----------------------------------------------------------------------===//
+
+void InterfaceWorkgroupIDOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(result(), "workgroup_id");
+}
+
+void InterfaceWorkgroupCountOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(result(), "workgroup_count");
+}
+
+void InterfaceWorkgroupSizeOp::getAsmResultNames(
+    function_ref<void(Value, StringRef)> setNameFn) {
+  setNameFn(result(), "workgroup_size");
+}
+
+//===----------------------------------------------------------------------===//
 // hal.interface.load.tensor
 //===----------------------------------------------------------------------===//
 

--- a/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -18,6 +18,7 @@
 #include "iree/compiler/Dialect/IREE/IR/IREETypes.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/SMLoc.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/OpImplementation.h"
@@ -1583,19 +1584,38 @@ static void printInterfaceBindingOp(OpAsmPrinter &p, InterfaceBindingOp op) {
 // hal.interface.workgroup.*
 //===----------------------------------------------------------------------===//
 
+static void getAsmResultNamesForInterfaceWorkgroupOp(
+    StringRef prefix, const APInt &dimension, Value result,
+    function_ref<void(Value, StringRef)> setNameFn) {
+  switch (dimension.getZExtValue()) {
+    case 0:
+      setNameFn(result, (prefix + "x").str());
+      return;
+    case 1:
+      setNameFn(result, (prefix + "y").str());
+      return;
+    case 2:
+      setNameFn(result, (prefix + "z").str());
+      return;
+  }
+}
+
 void InterfaceWorkgroupIDOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
-  setNameFn(result(), "workgroup_id");
+  getAsmResultNamesForInterfaceWorkgroupOp("workgroup_id_", dimension(),
+                                           result(), setNameFn);
 }
 
 void InterfaceWorkgroupCountOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
-  setNameFn(result(), "workgroup_count");
+  getAsmResultNamesForInterfaceWorkgroupOp("workgroup_count_", dimension(),
+                                           result(), setNameFn);
 }
 
 void InterfaceWorkgroupSizeOp::getAsmResultNames(
     function_ref<void(Value, StringRef)> setNameFn) {
-  setNameFn(result(), "workgroup_size");
+  getAsmResultNamesForInterfaceWorkgroupOp("workgroup_size_", dimension(),
+                                           result(), setNameFn);
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2083,6 +2083,77 @@ def HAL_InterfaceBindingOp : HAL_Op<"interface.binding", [
   );
 }
 
+def HAL_InterfaceWorkgroupIDOp : HAL_PureOp<"interface.workgroup.id", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface>,
+  ]> {
+  let summary = [{returns the index of the current workgroup in the grid}];
+  let description = [{
+    The global workgroup ID of the current tile in the range of
+    `[0, hal.interface.workgroup.count)` along each XYZ dimension.
+
+    Corresponds to the `WorkgroupId` SPIR-V built-in and the `blockIdx` CUDA
+    built-in variable.
+
+    ```mlir
+    %xyz = hal.interface.workgroup.id : tuple<index, index, index>
+    %x = extract_element %xyz[0] : tuple<index, index, index>
+    ```
+  }];
+
+  let arguments = (ins);
+  let results = (outs HAL_WorkgroupXYZ:$result);
+
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+def HAL_InterfaceWorkgroupCountOp : HAL_PureOp<"interface.workgroup.count", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface>,
+  ]> {
+  let summary = [{returns the total workgroup count of the grid}];
+  let description = [{
+    The total number of workgroups along each dimension in the dispatch grid.
+    Matches what was passed to the `hal.command_buffer.dispatch` command (or
+    what was indirectly specified).
+
+    Corresponds to the `NumWorkgroups` SPIR-V built-in and the `gridDim` CUDA
+    built-in variable.
+
+    ```mlir
+    %xyz = hal.interface.workgroup.count : tuple<index, index, index>
+    %x = extract_element %xyz[0] : tuple<index, index, index>
+    ```
+  }];
+
+  let arguments = (ins);
+  let results = (outs HAL_WorkgroupXYZ:$result);
+
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
+def HAL_InterfaceWorkgroupSizeOp : HAL_PureOp<"interface.workgroup.size", [
+    DeclareOpInterfaceMethods<OpAsmOpInterface>,
+  ]> {
+  let summary = [{returns the size of each workgroup in invocations}];
+  let description = [{
+    The number of local invocations within the current workgroup along each
+    dimension. Depending on backend this may map to the SIMT thread count or
+    inner loop nest parameters.
+
+    Corresponds to the `WorkgroupSize` SPIR-V built-in and the `blockDim` CUDA
+    built-in variable.
+
+    ```mlir
+    %xyz = hal.interface.workgroup.size : tuple<index, index, index>
+    %x = extract_element %xyz[0] : tuple<index, index, index>
+    ```
+  }];
+
+  let arguments = (ins);
+  let results = (outs HAL_WorkgroupXYZ:$result);
+
+  let assemblyFormat = "attr-dict `:` type($result)";
+}
+
 def HAL_InterfaceLoadConstantOp : HAL_PureOp<"interface.load.constant"> {
   let summary = [{loads a constant value from the interface constant block}];
   let description = [{

--- a/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1856,7 +1856,8 @@ def HAL_ExecutableEntryPointOp : HAL_Op<"executable.entry_point", [
     StrAttr:$sym_name,
     HAL_OrdinalAttr:$ordinal,
     FlatSymbolRefAttr:$interface,
-    TypeAttr:$signature
+    TypeAttr:$signature,
+    OptionalAttr<HAL_WorkgroupSizeAttr>:$workgroup_size
   );
 }
 
@@ -2095,15 +2096,16 @@ def HAL_InterfaceWorkgroupIDOp : HAL_PureOp<"interface.workgroup.id", [
     built-in variable.
 
     ```mlir
-    %xyz = hal.interface.workgroup.id : tuple<index, index, index>
-    %x = extract_element %xyz[0] : tuple<index, index, index>
+    %x = hal.interface.workgroup.id[0] : index
+    %y = hal.interface.workgroup.id[1] : index
+    %z = hal.interface.workgroup.id[2] : index
     ```
   }];
 
-  let arguments = (ins);
-  let results = (outs HAL_WorkgroupXYZ:$result);
+  let arguments = (ins IndexAttr:$dimension);
+  let results = (outs HAL_Dim:$result);
 
-  let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat = "`[` $dimension `]` attr-dict `:` type($result)";
 }
 
 def HAL_InterfaceWorkgroupCountOp : HAL_PureOp<"interface.workgroup.count", [
@@ -2119,15 +2121,16 @@ def HAL_InterfaceWorkgroupCountOp : HAL_PureOp<"interface.workgroup.count", [
     built-in variable.
 
     ```mlir
-    %xyz = hal.interface.workgroup.count : tuple<index, index, index>
-    %x = extract_element %xyz[0] : tuple<index, index, index>
+    %x = hal.interface.workgroup.count[0] : index
+    %y = hal.interface.workgroup.count[1] : index
+    %z = hal.interface.workgroup.count[2] : index
     ```
   }];
 
-  let arguments = (ins);
-  let results = (outs HAL_WorkgroupXYZ:$result);
+  let arguments = (ins IndexAttr:$dimension);
+  let results = (outs HAL_Dim:$result);
 
-  let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat = "`[` $dimension `]` attr-dict `:` type($result)";
 }
 
 def HAL_InterfaceWorkgroupSizeOp : HAL_PureOp<"interface.workgroup.size", [
@@ -2143,15 +2146,16 @@ def HAL_InterfaceWorkgroupSizeOp : HAL_PureOp<"interface.workgroup.size", [
     built-in variable.
 
     ```mlir
-    %xyz = hal.interface.workgroup.size : tuple<index, index, index>
-    %x = extract_element %xyz[0] : tuple<index, index, index>
+    %x = hal.interface.workgroup.size[0] : index
+    %y = hal.interface.workgroup.size[1] : index
+    %z = hal.interface.workgroup.size[2] : index
     ```
   }];
 
-  let arguments = (ins);
-  let results = (outs HAL_WorkgroupXYZ:$result);
+  let arguments = (ins IndexAttr:$dimension);
+  let results = (outs HAL_Dim:$result);
 
-  let assemblyFormat = "attr-dict `:` type($result)";
+  let assemblyFormat = "`[` $dimension `]` attr-dict `:` type($result)";
 }
 
 def HAL_InterfaceLoadConstantOp : HAL_PureOp<"interface.load.constant"> {

--- a/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -2,21 +2,6 @@
 
 // RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
 
-// CHECK-LABEL: @interface_io
-func @interface_io() {
-  %c16 = constant 16 : index
-  // CHECK: %[[ARG0:.+]] = hal.interface.load.tensor @interface::@s0b0, offset = %c16 : tensor<4xf32>
-  %arg0 = hal.interface.load.tensor @interface::@s0b0, offset=%c16 : tensor<4xf32>
-  // CHECK-NEXT: %[[TEMP:.+]] = mhlo.add %[[ARG0]], %[[ARG0]]
-  %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
-  %c32 = constant 32 : index
-  // CHECK: hal.interface.store.tensor %[[TEMP]], @interface::@s0b1, offset = %c32 : tensor<4xf32>
-  hal.interface.store.tensor %0, @interface::@s0b1, offset=%c32 : tensor<4xf32>
-  return
-}
-
-// -----
-
 // CHECK-LABEL: @ex
 hal.executable @ex {
   // CHECK: hal.executable.target @backend, filter="backend"
@@ -92,24 +77,5 @@ func @executable_cache(%arg0 : !hal.executable_cache, %arg1 : !hal.executable_la
 func @executable_layout_create(%arg0 : !hal.device, %arg1 : !hal.descriptor_set_layout) {
   // CHECK: hal.executable_layout.create %arg0, set_layouts = [%arg1], push_constants = 1 : !hal.executable_layout
   %executable_layout = hal.executable_layout.create %arg0, set_layouts = [%arg1], push_constants = 1 : !hal.executable_layout
-  return
-}
-
-// -----
-
-// CHECK-LABEL: @interface_io
-func @interface_io() {
-  %c16 = constant 16 : index
-  //      CHECK: %[[ARG0:.+]] = hal.interface.load.tensor.tile @interface::@s0b0, base_offset = %c16
-  // CHECK-SAME:   offsets = [0], sizes = [4], strides = [1] : tensor<4xf32>
-  %arg0 = hal.interface.load.tensor.tile @interface::@s0b0, base_offset = %c16,
-    offsets = [0], sizes = [4], strides = [1]: tensor<4xf32>
-  // CHECK-NEXT: %[[TEMP:.+]] = mhlo.add %[[ARG0]], %[[ARG0]]
-  %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
-  %c32 = constant 32 : index
-  //      CHECK: hal.interface.store.tensor.tile %[[TEMP]], @interface::@s0b1, base_offset = %c32
-  // CHECK-SAME:   offsets = [4], sizes = [7], strides = [1] : tensor<4xf32>
-  hal.interface.store.tensor.tile %0, @interface::@s0b1, base_offset = %c32,
-    offsets = [4], sizes = [7], strides = [1]: tensor<4xf32>
   return
 }

--- a/iree/compiler/Dialect/HAL/IR/test/interface_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/interface_ops.mlir
@@ -2,12 +2,12 @@
 
 // CHECK-LABEL: @interface_workgroup_info
 func @interface_workgroup_info() {
-  // CHECK: %workgroup_id = hal.interface.workgroup.id : tuple<index, index, index>
-  %0 = hal.interface.workgroup.id : tuple<index, index, index>
-  // CHECK: %workgroup_count = hal.interface.workgroup.count : tuple<index, index, index>
-  %1 = hal.interface.workgroup.count : tuple<index, index, index>
-  // CHECK: %workgroup_size = hal.interface.workgroup.size : tuple<index, index, index>
-  %2 = hal.interface.workgroup.size : tuple<index, index, index>
+  // CHECK: %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %0 = hal.interface.workgroup.id[0] : index
+  // CHECK: %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %1 = hal.interface.workgroup.count[1] : index
+  // CHECK: %workgroup_size_z = hal.interface.workgroup.size[2] : index
+  %2 = hal.interface.workgroup.size[2] : index
   return
 }
 

--- a/iree/compiler/Dialect/HAL/IR/test/interface_ops.mlir
+++ b/iree/compiler/Dialect/HAL/IR/test/interface_ops.mlir
@@ -1,0 +1,46 @@
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file %s | iree-opt -allow-unregistered-dialect -split-input-file | IreeFileCheck %s
+
+// CHECK-LABEL: @interface_workgroup_info
+func @interface_workgroup_info() {
+  // CHECK: %workgroup_id = hal.interface.workgroup.id : tuple<index, index, index>
+  %0 = hal.interface.workgroup.id : tuple<index, index, index>
+  // CHECK: %workgroup_count = hal.interface.workgroup.count : tuple<index, index, index>
+  %1 = hal.interface.workgroup.count : tuple<index, index, index>
+  // CHECK: %workgroup_size = hal.interface.workgroup.size : tuple<index, index, index>
+  %2 = hal.interface.workgroup.size : tuple<index, index, index>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @interface_io_tensors
+func @interface_io_tensors() {
+  %c16 = constant 16 : index
+  // CHECK: %[[ARG0:.+]] = hal.interface.load.tensor @interface::@s0b0, offset = %c16 : tensor<4xf32>
+  %arg0 = hal.interface.load.tensor @interface::@s0b0, offset=%c16 : tensor<4xf32>
+  // CHECK-NEXT: %[[TEMP:.+]] = mhlo.add %[[ARG0]], %[[ARG0]]
+  %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
+  %c32 = constant 32 : index
+  // CHECK: hal.interface.store.tensor %[[TEMP]], @interface::@s0b1, offset = %c32 : tensor<4xf32>
+  hal.interface.store.tensor %0, @interface::@s0b1, offset=%c32 : tensor<4xf32>
+  return
+}
+
+// -----
+
+// CHECK-LABEL: @interface_io_tiles
+func @interface_io_tiles() {
+  %c16 = constant 16 : index
+  //      CHECK: %[[ARG0:.+]] = hal.interface.load.tensor.tile @interface::@s0b0, base_offset = %c16
+  // CHECK-SAME:   offsets = [0], sizes = [4], strides = [1] : tensor<4xf32>
+  %arg0 = hal.interface.load.tensor.tile @interface::@s0b0, base_offset = %c16,
+    offsets = [0], sizes = [4], strides = [1]: tensor<4xf32>
+  // CHECK-NEXT: %[[TEMP:.+]] = mhlo.add %[[ARG0]], %[[ARG0]]
+  %0 = mhlo.add %arg0, %arg0 : tensor<4xf32>
+  %c32 = constant 32 : index
+  //      CHECK: hal.interface.store.tensor.tile %[[TEMP]], @interface::@s0b1, base_offset = %c32
+  // CHECK-SAME:   offsets = [4], sizes = [7], strides = [1] : tensor<4xf32>
+  hal.interface.store.tensor.tile %0, @interface::@s0b1, base_offset = %c32,
+    offsets = [4], sizes = [7], strides = [1]: tensor<4xf32>
+  return
+}

--- a/iree/compiler/Dialect/HAL/Target/LLVM/LLVMBaseTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/LLVMBaseTarget.cpp
@@ -161,7 +161,7 @@ LogicalResult LLVMBaseTargetBackend::linkExecutables(mlir::ModuleOp moduleOp) {
                 entryPointOp.getLoc(), entryPointOp.sym_nameAttr(),
                 builder.getI32IntegerAttr(nextEntryPointOrdinal++),
                 builder.getSymbolRefAttr(interfaceOpForExecutable.getName()),
-                entryPointOp.signatureAttr());
+                entryPointOp.signatureAttr(), ArrayAttr{});
 
         // Add to replacement table for fixing up dispatch calls referencing
         // this entry point.

--- a/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VMLA/VMLATarget.cpp
@@ -169,7 +169,7 @@ class VMLATargetBackend final : public TargetBackend {
                   entryPointOp.getLoc(), entryPointOp.sym_nameAttr(),
                   builder.getI32IntegerAttr(nextEntryPointOrdinal++),
                   builder.getSymbolRefAttr(interfaceOpForExecutable.getName()),
-                  entryPointOp.signatureAttr());
+                  entryPointOp.signatureAttr(), ArrayAttr{});
 
           // Add to replacement table for fixing up dispatch calls referencing
           // this entry point.

--- a/iree/compiler/Dialect/HAL/Transforms/BUILD
+++ b/iree/compiler/Dialect/HAL/Transforms/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "MemoizeDeviceQueries.cpp",
         "PackConstantPoolStorage.cpp",
         "Passes.cpp",
+        "PropagateConstantWorkgroupInfo.cpp",
         "PublicAbiGeneration.cpp",
         "ResolveEntryPointOrdinals.cpp",
         "SerializeExecutables.cpp",

--- a/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Transforms/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_cc_library(
     "MemoizeDeviceQueries.cpp"
     "PackConstantPoolStorage.cpp"
     "Passes.cpp"
+    "PropagateConstantWorkgroupInfo.cpp"
     "PublicAbiGeneration.cpp"
     "ResolveEntryPointOrdinals.cpp"
     "SerializeExecutables.cpp"

--- a/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -277,7 +277,7 @@ static LogicalResult declareEntryPointOps(
             builder.getStringAttr(thunkFuncOp->getName()),
             builder.getI32IntegerAttr(nextOrdinal++),
             builder.getSymbolRefAttr(interfaceOp),
-            TypeAttr::get(sourceFuncOp.getType()));
+            TypeAttr::get(sourceFuncOp.getType()), ArrayAttr{});
       }
     }
 

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -62,6 +62,8 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(createMaterializeInterfacesPass(targetOptions));
 
   passManager.nest<ExecutableOp>().addNestedPass<ExecutableTargetOp>(
+      createPropagateConstantWorkgroupInfoPass());
+  passManager.nest<ExecutableOp>().addNestedPass<ExecutableTargetOp>(
       createTranslateExecutablesPass(targetOptions));
 
   // Convert supported input dialects (std, flow, etc) into the HAL dialect.

--- a/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -75,6 +75,10 @@ std::unique_ptr<OperationPass<ModuleOp>> createMemoizeDeviceQueriesPass();
 std::unique_ptr<OperationPass<ModuleOp>> createMaterializeInterfacesPass(
     TargetOptions executableOptions);
 
+// Propagates hal.interface.workload.* information when constant.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createPropagateConstantWorkgroupInfoPass();
+
 // Translates hal.executable.target ops via a nested translation pipeline.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
 createTranslateExecutablesPass(TargetOptions executableOptions);

--- a/iree/compiler/Dialect/HAL/Transforms/PropagateConstantWorkgroupInfo.cpp
+++ b/iree/compiler/Dialect/HAL/Transforms/PropagateConstantWorkgroupInfo.cpp
@@ -1,0 +1,68 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/Transforms/Passes.h"
+#include "mlir/IR/SymbolTable.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace HAL {
+
+class PropagateConstantWorkgroupInfoPass
+    : public PassWrapper<PropagateConstantWorkgroupInfoPass,
+                         OperationPass<IREE::HAL::ExecutableTargetOp>> {
+ public:
+  void runOnOperation() override {
+    auto targetOp = getOperation();
+
+    SymbolTable targetSymbolTable(targetOp);
+    for (auto funcOp : targetOp.getInnerModule().getOps<FuncOp>()) {
+      auto entryPointOp =
+          targetSymbolTable.lookup<IREE::HAL::ExecutableEntryPointOp>(
+              funcOp.getName());
+      if (!entryPointOp) continue;
+      if (!entryPointOp.workgroup_size().hasValue()) continue;
+      auto workgroupSizeAttr = entryPointOp.workgroup_sizeAttr();
+      auto workgroupSizeOps = llvm::to_vector<4>(
+          funcOp.getOps<IREE::HAL::InterfaceWorkgroupSizeOp>());
+      for (auto workgroupSizeOp : workgroupSizeOps) {
+        OpBuilder builder(workgroupSizeOp);
+        auto dimValue = builder.createOrFold<ConstantIndexOp>(
+            workgroupSizeOp.getLoc(),
+            workgroupSizeAttr[workgroupSizeOp.dimension().getZExtValue()]
+                .cast<IntegerAttr>()
+                .getInt());
+        workgroupSizeOp.replaceAllUsesWith(dimValue);
+        workgroupSizeOp.erase();
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableTargetOp>>
+createPropagateConstantWorkgroupInfoPass() {
+  return std::make_unique<PropagateConstantWorkgroupInfoPass>();
+}
+
+static PassRegistration<PropagateConstantWorkgroupInfoPass> pass(
+    "iree-hal-propagate-constant-workgroup-info",
+    "Propagates constant hal.interface.workgroup.* queries when known");
+
+}  // namespace HAL
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/HAL/Transforms/test/propagate_constant_workgroup_info.mlir
+++ b/iree/compiler/Dialect/HAL/Transforms/test/propagate_constant_workgroup_info.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt -allow-unregistered-dialect -split-input-file -pass-pipeline='hal.executable(hal.executable.target(iree-hal-propagate-constant-workgroup-info))' %s | IreeFileCheck %s
+
+hal.executable @exe {
+  hal.interface @interface {
+    hal.interface.binding @s0b0, set=0, binding=0, type="StorageBuffer", access="Read"
+    hal.interface.binding @s0b1, set=0, binding=1, type="StorageBuffer", access="Read|Write"
+  }
+  hal.executable.target @target, filter="target" {
+    hal.executable.entry_point @entry attributes {
+      interface = @interface,
+      ordinal = 0 : i32,
+      signature = (tensor<4xf32>) -> tensor<4xf32>,
+      workgroup_size = [32 : index, 4 : index, 8 : index]
+    }
+    module {
+      // CHECK: func @entry()
+      func @entry() {
+        // CHECK-DAG: constant 32 : index
+        %workgroup_size_x = hal.interface.workgroup.size[0] : index
+        // CHECK-DAG: constant 4 : index
+        %workgroup_size_y = hal.interface.workgroup.size[1] : index
+        return
+      }
+    }
+  }
+}

--- a/iree/compiler/Dialect/IREE/IR/IREEOps.td
+++ b/iree/compiler/Dialect/IREE/IR/IREEOps.td
@@ -56,9 +56,12 @@ def IREE_ByteBufferConstantOp : IREE_PureOp<"byte_buffer.constant"> {
 }
 
 //===----------------------------------------------------------------------===//
-// Executable ABI
+// Executable ABI DO NOT ADD THINGS HERE
 //===----------------------------------------------------------------------===//
 
+// ***WARNING***: this is going away soon - please don't extend or add more
+// things like this to this file. Ops should go to the dialect they relate to
+// (HAL, in this case).
 def IREE_PlaceholderOp : IREE_Op<"placeholder", [MemoryEffects<[MemAlloc]>]> {
   let summary = "A placeholder op to feed a value/buffer into computation";
   let description = [{
@@ -74,38 +77,6 @@ def IREE_PlaceholderOp : IREE_Op<"placeholder", [MemoryEffects<[MemAlloc]>]> {
 
   let assemblyFormat = [{ `for` $purpose attr-dict `:` type($output) }];
 }
-
-def IREE_WorkgroupIdOp : IREE_PureOp<"workgroup_id"> {
-  let summary = "Get grid index of an iree workgoup among a specific dimension.";
-  let description = [{
-    IREE workgroups are logically distributed among a hypergrid, each point sampled 
-    from the grid corresponds to a logical thread. For example in a 3d grid case 
-    the op quries (x, y, z) dimensions:
-
-    ```mlir
-     %0 = iree.workgroup_id {dimension = "x"} : index
-     %1 = iree.workgroup_id {dimension = "y"} : index
-     %2 = iree.workgroup_id {dimension = "z"} : index
-    ```
-  }];
-  
-  let arguments = (ins StrAttr:$dimension);
-  let results = (outs Index:$result);
-
-  let assemblyFormat = "attr-dict `:` type($result)";
-}
-
-def IREE_WorkgroupSizeOp: IREE_PureOp<"workgoup_size"> {
-  let summary = "Get grid size of an iree thread among a specific dimension";
-  let description = [{
-    Get grid size of an iree workgroups among a specific dimension
-  }];
-  let arguments = (ins StrAttr:$dimension);
- let results = (outs Index:$result);
-
- let assemblyFormat = "attr-dict `:` type($result)";
-}
-
 
 //===----------------------------------------------------------------------===//
 // Compiler hints

--- a/iree/hal/dylib/dylib_executable.cc
+++ b/iree/hal/dylib/dylib_executable.cc
@@ -185,6 +185,8 @@ struct DyLibDispatchState : public HostExecutable::DispatchState {
 
   IREE_TRACE(const char* entry_name = nullptr);
 
+  std::array<uint32_t, 3> workgroup_count;
+  std::array<uint32_t, 3> workgroup_size;
   void* entry_function = nullptr;
   std::array<void*, 32> args;
   std::array<uint32_t, 32> push_constants;
@@ -200,6 +202,8 @@ DyLibExecutable::PrepareDispatch(const DispatchParams& params) {
   }
 
   auto dispatch_state = make_ref<DyLibDispatchState>();
+  dispatch_state->workgroup_count = params.workgroup_count;
+  dispatch_state->workgroup_size = params.workgroup_size;
   IREE_TRACE(dispatch_state->entry_name = entry_names_[params.entry_point]);
   dispatch_state->entry_function = entry_functions_[params.entry_point];
 
@@ -226,11 +230,12 @@ Status DyLibExecutable::DispatchTile(DispatchState* state,
   auto* dispatch_state = static_cast<DyLibDispatchState*>(state);
   IREE_TRACE_SCOPE_DYNAMIC(dispatch_state->entry_name);
 
-  auto entry_function = (void (*)(void**, uint32_t*, int32_t, int32_t,
-                                  int32_t))dispatch_state->entry_function;
+  auto entry_function = (void (*)(void**, uint32_t*, uint32_t*, uint32_t*,
+                                  uint32_t*))dispatch_state->entry_function;
   entry_function(dispatch_state->args.data(),
-                 dispatch_state->push_constants.data(), workgroup_xyz[0],
-                 workgroup_xyz[1], workgroup_xyz[2]);
+                 dispatch_state->push_constants.data(), workgroup_xyz.data(),
+                 dispatch_state->workgroup_count.data(),
+                 dispatch_state->workgroup_size.data());
 
   return OkStatus();
 }

--- a/iree/hal/host/host_executable.h
+++ b/iree/hal/host/host_executable.h
@@ -46,6 +46,9 @@ class HostExecutable : public Executable {
     // Total workgroup XYZ count for the grid.
     std::array<uint32_t, 3> workgroup_count;
 
+    // Size of each tile in the grid in local space.
+    std::array<uint32_t, 3> workgroup_size;
+
     // Push constants populated by the command buffer.
     const PushConstantBlock* push_constants = nullptr;
 


### PR DESCRIPTION
hal.interface.workgroup.size will always return 1,1,1 at runtime today (until that is available) but a pass is added to propagate it as constant data when present on entry points.