### PR TITLE
Initial poc of IREE remoting.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,8 +545,10 @@ if(${IREE_BUILD_EXPERIMENTAL_REMOTING})
   # NOTE: Currently liburing is only used by the experimental remoting
   # support, so keeping it scoped here. If this broadens, then include along
   # with other dependencies as normal.
+  set(IREE_HAVE_IO_URING 0)
   if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
     message(STATUS "Enabling liburing")
+    set(IREE_HAVE_IO_URING 1)
     add_subdirectory(build_tools/third_party/liburing EXCLUDE_FROM_ALL)
   endif()
   add_subdirectory(experimental/remoting)

--- a/experimental/remoting/iree/remoting/CMakeLists.txt
+++ b/experimental/remoting/iree/remoting/CMakeLists.txt
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(iree/remoting)
+add_subdirectory(protocol_v1)
+add_subdirectory(schemas)
+add_subdirectory(simple)
+add_subdirectory(support)

--- a/experimental/remoting/iree/remoting/protocol_v1/CMakeLists.txt
+++ b/experimental/remoting/iree/remoting/protocol_v1/CMakeLists.txt
@@ -12,4 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(iree/remoting)
+iree_cc_library(
+  NAME
+    protocol_v1
+  HDRS
+    "common.h"
+    "hal_stub.h"
+    "handler.h"
+  SRCS
+    "common.cc"
+    "hal_stub.cc"
+    "handler.cc"
+  DEPS
+    iree::base::logging
+    iree::base::flatcc
+    experimental::remoting::iree::remoting::support
+    experimental::remoting::iree::remoting::schemas::protocol_v1_c_fbs
+)

--- a/experimental/remoting/iree/remoting/protocol_v1/README.md
+++ b/experimental/remoting/iree/remoting/protocol_v1/README.md
@@ -1,0 +1,12 @@
+# IREE Remoting Protocol
+
+## Version 1
+
+The IREE remoting protocol is a binary, packet based, bi-directional, stream
+based protocol.
+
+When a new communication channel is established, both sides send a *handshake*
+message, which is a fixed-length binary struct (see
+`iree_remoting_handshake_v1_wire_t`) with parameters for setting up the transport
+(note that this phase can be optional in certain embedded situations where both
+ends can be configured with a pre-set handshake).

--- a/experimental/remoting/iree/remoting/protocol_v1/common.cc
+++ b/experimental/remoting/iree/remoting/protocol_v1/common.cc
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "experimental/remoting/iree/remoting/protocol_v1/common.h"
+
+#include <string.h>
+
+#include <algorithm>
+
+#include "iree/base/logging.h"
+
+// Now that we are in C++, do some sanity asserts about the structures.
+static_assert(sizeof(iree_remoting_v1_handshake_wire_t) ==
+                  IREE_REMOTING_HANDSHAKE_PADDED_SIZE,
+              "iree_remoting_handshake_v1_t is too large");
+
+namespace {
+
+uint32_t SwapUint32(uint32_t v) {
+  return ((v >> 24) & 0xff) | ((v << 8) & 0xff0000) | ((v >> 8) & 0xff00) |
+         ((v << 24) & 0xff000000);
+}
+
+}  // namespace
+
+void iree_remoting_v1_init_handshake(iree_remoting_v1_handshake_wire_t *packet,
+                                     uint32_t max_stream_packet_size) {
+  memset(packet, 0, sizeof(*packet));
+  packet->handshake.magic_number = IREE_REMOTING_HANDSHAKE_MAGIC_NUMBER;
+  packet->handshake.version = (1 << 16) | (1);  // 1.1
+  packet->handshake.max_stream_packet_size = max_stream_packet_size;
+}
+
+bool iree_remoting_v1_merge_handshake(
+    iree_remoting_transport_config_t *config,
+    iree_remoting_v1_handshake_t *ours,
+    const iree_remoting_v1_handshake_t *theirs) {
+  config->byte_swapped = false;
+
+  // Detect magic number.
+  if (theirs->magic_number != ours->magic_number) {
+    // Is it byte swapped?
+    if (theirs->magic_number != SwapUint32(ours->magic_number)) {
+      IREE_DVLOG(1) << "Mismatched magic number: 0x" << std::hex
+                    << theirs->magic_number;
+      return false;
+    }
+    config->byte_swapped = true;
+  }
+
+  // Version.
+  uint32_t theirs_version =
+      config->byte_swapped ? SwapUint32(theirs->version) : theirs->version;
+  if (theirs_version != ours->version) {
+    // TODO: Implement the version negotiation when there is more than one.
+    IREE_DVLOG(1) << "Version mismatch: theirs=" << std::hex << theirs_version
+                  << ", ours=" << ours->version;
+    return false;
+  }
+
+  // Packet sizes.
+  uint32_t theirs_max_stream_packet_size =
+      config->byte_swapped ? SwapUint32(theirs->max_stream_packet_size)
+                           : theirs->max_stream_packet_size;
+  ours->max_stream_packet_size =
+      std::min(ours->max_stream_packet_size, theirs_max_stream_packet_size);
+
+  return true;
+}

--- a/experimental/remoting/iree/remoting/protocol_v1/common.h
+++ b/experimental/remoting/iree/remoting/protocol_v1/common.h
@@ -1,0 +1,116 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Common structures and support functions for the V1 protocol.
+
+#ifndef IREE_REMOTING_PROTOCOL_V1_COMMON_H_
+#define IREE_REMOTING_PROTOCOL_V1_COMMON_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// "IREe" in big-endian. This is expected to be the magic number invariant
+// of the protocol major version.
+#define IREE_REMOTING_HANDSHAKE_MAGIC_NUMBER \
+  (0x49 << 24) | (0x52 << 16) | (0x45 << 8) | (0x65)
+
+// The size that an iree_remoting_handshake_v1_t should be padded to for
+// transmission over the wire. This is expected to remain constant for all
+// major versions of the protocol.
+#define IREE_REMOTING_HANDSHAKE_PADDED_SIZE 64
+
+// Upon initiating a protocol exchange, each side sends one of these
+// handshake messages, padded to 64 bytes, establishing the transport
+// parameters.
+// Each multi-byte integer is represented in the byte order of the sender.
+// Receivers should note the ordering of the magic number and decode
+// appropriately.
+typedef struct {
+  // Magic number equal to IREE_REMOTING_HANDSHAKE_MAGIC_NUMBER in the
+  // byte order of the sender.
+  uint32_t magic_number;
+
+  // The highest protocol version that the sender supports, represented as two
+  // 16 bit quantities, representing major (high order) and minor (low order).
+  // If two ends of the transport support different versions, they should
+  // negotiate to the mutually supported minimum.
+  uint32_t version;
+
+  // Size in bytes of the maximum packet size for stream chunks. Both sides
+  // should negotiate the actual maximum.
+  uint32_t max_stream_packet_size;
+} iree_remoting_v1_handshake_t;
+
+// Handshake union, padded as it is over the wire.
+typedef union {
+  iree_remoting_v1_handshake_t handshake;
+  char fill[IREE_REMOTING_HANDSHAKE_PADDED_SIZE];
+} iree_remoting_v1_handshake_wire_t;
+
+// Additional transport configuration decided during handshake.
+// This is not part of the wire protocol.
+typedef struct {
+  bool byte_swapped;
+} iree_remoting_transport_config_t;
+
+// Fills a v1 handshake packet to be sent to a remote.
+void iree_remoting_v1_init_handshake(iree_remoting_v1_handshake_wire_t *packet,
+                                     uint32_t max_stream_packet_size);
+
+// Merges a handshake packet that we sent with a handshake packet that a remote
+// sent, updating `ours` to represent negotiated parameters.
+// Returns false if the handshakes are incompatible.
+bool iree_remoting_v1_merge_handshake(
+    iree_remoting_transport_config_t *config,
+    iree_remoting_v1_handshake_t *ours,
+    const iree_remoting_v1_handshake_t *theirs);
+
+// Packet header which precedes all data packets.
+typedef struct {
+  // Size of the packet, including this header, but excluding payload data.
+  uint32_t packet_size;
+
+  // Size of arbitrary payload data that follows this packet.
+  uint32_t payload_size;
+
+  // Type of the packet payload and flags:
+  //   [31..16] : Bit-masked |iree_remoting_v1_flag_t| flags.
+  //   [15..0]  : Packet type |iree_remoting_v1_packet_type_t| constant.
+  uint32_t packet_type;
+} iree_remoting_v1_packet_header_t;
+
+// Message types that the protocol supports.
+typedef enum {
+  // Packet is a control message whose payload is an embedded flatbuffer.
+  IREE_REMOTING_V1_PT_CONTROL = 0,
+  // Packet is a stream message. An additional header
+  // (|iree_remoting_v1_stream_header_t|) is present after the packet header,
+  // followed by a chunk of stream data.
+  IREE_REMOTING_V1_PT_STREAM = 1,
+  // Packet is a no-op and should be ignored.
+  IREE_REMOTING_V1_PT_NOP = 2,
+} iree_remoting_v1_packet_type_t;
+
+// Bit-mask enum for the iree_remoting_packet_v1_header_t.flags field.
+typedef enum {} iree_remoting_v1_flag_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // IREE_REMOTING_PROTOCOL_V1_COMMON_H_

--- a/experimental/remoting/iree/remoting/protocol_v1/hal_stub.cc
+++ b/experimental/remoting/iree/remoting/protocol_v1/hal_stub.cc
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "experimental/remoting/iree/remoting/protocol_v1/hal_stub.h"
+
+#include "experimental/remoting/iree/remoting/schemas/protocol_v1_builder.h"
+
+namespace iree {
+namespace remoting {
+namespace protocol_v1 {
+
+#undef ns
+#define ns(x) FLATBUFFERS_WRAP_NAMESPACE(iree_remoting_protocol_v1, x)
+
+HalClientStub::remote_device_id_t HalClientStub::OpenDevice() {
+  remote_device_id_t remote_device_id = 1;  // TODO
+  flatcc_builder_t *B = protocol_.StartPacket();
+  uint32_t correlation_id = 1;  // TODO
+
+  // Create HalDeviceOpenRequest.
+  ns(HalDeviceOpenRequest_ref_t) request =
+      ns(HalDeviceOpenRequest_create(B, remote_device_id));
+  ns(AnyRequest_union_ref_t) request_union =
+      ns(AnyRequest_as_HalDeviceOpenRequest(request));
+
+  ns(Envelope_start_as_root(B));
+  ns(Envelope_request_add(B, request_union));
+  ns(Envelope_correlation_id_add(B, correlation_id));
+  ns(Envelope_end_as_root(B));
+
+  protocol_.SendPacket();
+  return remote_device_id;
+}
+
+}  // namespace protocol_v1
+}  // namespace remoting
+}  // namespace iree

--- a/experimental/remoting/iree/remoting/protocol_v1/hal_stub.h
+++ b/experimental/remoting/iree/remoting/protocol_v1/hal_stub.h
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_REMOTING_PROTOCOL_V1_HAL_STUB_H_
+#define IREE_REMOTING_PROTOCOL_V1_HAL_STUB_H_
+
+#include "experimental/remoting/iree/remoting/protocol_v1/handler.h"
+
+namespace iree {
+namespace remoting {
+namespace protocol_v1 {
+
+// Stub for marshalling HAL client invocations over the remoting layer.
+class HalClientStub {
+ public:
+  HalClientStub(ProtocolHandler &protocol) : protocol_(protocol) {}
+
+  // Opens a device, returning an opaque id with which to refer to it in
+  // subsequent calls.
+  using remote_device_id_t = uintptr_t;
+  remote_device_id_t OpenDevice();
+
+ private:
+  ProtocolHandler &protocol_;
+};
+
+}  // namespace protocol_v1
+}  // namespace remoting
+}  // namespace iree
+
+#endif  // IREE_REMOTING_PROTOCOL_V1_HAL_STUB_H_

--- a/experimental/remoting/iree/remoting/protocol_v1/handler.cc
+++ b/experimental/remoting/iree/remoting/protocol_v1/handler.cc
@@ -1,0 +1,303 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "experimental/remoting/iree/remoting/protocol_v1/handler.h"
+
+#include "iree/base/logging.h"
+
+using namespace std::placeholders;
+
+namespace iree {
+namespace remoting {
+namespace protocol_v1 {
+
+namespace {
+
+void ConsumeStatus(const char *message, iree_status_t status) {
+  char *buffer;
+  iree_host_size_t len;
+  bool alloced = iree_status_to_string(status, &buffer, &len);
+  IREE_DVLOG(1) << message << ": " << (alloced ? buffer : "<no information>");
+  if (alloced) free(buffer);
+  iree_status_ignore(status);
+}
+
+}  // namespace
+
+constexpr size_t ProtocolHandler::kMaxControlPacketSize;
+constexpr size_t ProtocolHandler::kMinControlPacketAllocSize;
+
+ProtocolHandler::ProtocolHandler(IoBufferPool &buffer_pool,
+                                 IoBufferVec::Pool &iovec_pool)
+    : buffer_pool_(buffer_pool), iovec_pool_(iovec_pool) {
+  IREE_CHECK_EQ(flatcc_builder_init(&outgoing_packet_builder_), 0);
+}
+
+ProtocolHandler::~ProtocolHandler() {
+  iree_allocator_free(allocator_, incoming_control_packet_);
+  flatcc_builder_clear(&outgoing_packet_builder_);
+}
+
+void ProtocolHandler::SetState(State new_state) {
+  IREE_DVLOG(1) << "ProtocolHandler::SetState(" << static_cast<int>(state_)
+                << " -> " << static_cast<int>(new_state) << ")";
+  state_ = new_state;
+}
+
+void ProtocolHandler::Initiate() {
+  assert(state_ == State::kNone);
+  SetState(State::kHandshake);
+  iree_remoting_v1_init_handshake(&handshake_, transport_buffer_size());
+
+  auto write_iov = iovec_pool_.Get();
+  write_iov->add(static_cast<void *>(&handshake_), sizeof(handshake_));
+  TransportWrite(std::move(write_iov));
+  TransportRead(sizeof(their_handshake_));
+}
+
+void ProtocolHandler::Abort() {
+  if (state_ == State::kAbort) return;
+  SetState(State::kAbort);
+  TransportClose();
+}
+
+void ProtocolHandler::InitiateRecvPacketHeader() {
+  SetState(State::kRecvPacketHeader);
+  TransportRead(sizeof(incoming_packet_header_));
+}
+
+void ProtocolHandler::InitiateRecvControlPacketPayload() {
+  SetState(State::kRecvControlPacketPayload);
+  size_t size = incoming_packet_header_.packet_size;
+  if (size < sizeof(incoming_packet_header_) || size > kMaxControlPacketSize) {
+    IREE_DVLOG(1) << "ProtocolHandler: Illegal packet size";
+    return Abort();
+  }
+  size -= sizeof(incoming_packet_header_);
+
+  // Ensure the incoming_control_packet memory is sufficient.
+  if (size > incoming_control_packet_capacity_) {
+    size_t new_capacity = std::min(size, kMinControlPacketAllocSize);
+    iree_status_t status = iree_allocator_realloc(allocator_, new_capacity,
+                                                  &incoming_control_packet_);
+    if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
+      iree_status_ignore(status);
+      IREE_DVLOG(1) << "SocketProtocolHandler: Alloc failed (" << size << ")";
+      return Abort();
+    }
+    incoming_control_packet_capacity_ = new_capacity;
+  }
+  // Read payload.
+  incoming_control_packet_size_ = size;
+  TransportRead(incoming_control_packet_size_);
+}
+
+flatcc_builder_t *ProtocolHandler::StartPacket() {
+  flatcc_builder_reset(&outgoing_packet_builder_);
+  return &outgoing_packet_builder_;
+}
+
+void ProtocolHandler::TransportReceived(IoBufferVec::Ptr iovec) {
+  switch (state_) {
+    case State::kHandshake:
+      iovec->FlattenTo(&their_handshake_, sizeof(their_handshake_));
+      if (IREE_UNLIKELY(!iree_remoting_v1_merge_handshake(
+              &config_, &handshake_.handshake, &their_handshake_.handshake))) {
+        IREE_DVLOG(1) << "SocketProtocolHandler: Bad handshake";
+        return Abort();
+      }
+      InitiateRecvPacketHeader();
+      break;
+    case State::kRecvPacketHeader: {
+      iovec->FlattenTo(&incoming_packet_header_,
+                       sizeof(incoming_packet_header_));
+      uint32_t pt = incoming_packet_header_.packet_type & 0xffff;
+      switch (pt) {
+        case IREE_REMOTING_V1_PT_CONTROL:
+          InitiateRecvControlPacketPayload();
+          break;
+
+        default:
+          IREE_DVLOG(1) << "SocketProtocolHandler: Illegal packet type " << pt;
+          return Abort();
+      }
+      break;
+    }
+    case State::kRecvControlPacketPayload: {
+      IREE_DVLOG(1) << " ** TODO: Implement kRecvControlPacketPayload (size="
+                    << iovec->total_iov_len() << ")";
+      InitiateRecvPacketHeader();
+      break;
+    }
+    default:
+      IREE_DVLOG(1) << "SocketProtocolHandler illegal state: "
+                    << static_cast<int>(state_);
+      return Abort();
+  }
+}
+
+// Sends a control packet as constructed into the builder most recently
+// returned from |StartControlPacket|. Must not use the builder again
+// following this call.
+void ProtocolHandler::SendPacket() {
+  flatcc_builder_t *B = &outgoing_packet_builder_;
+  size_t payload_size =
+      outgoing_payload_ ? outgoing_payload_->total_iov_len() : 0;
+
+  // There are various, advanced ways to integrate with flatcc, possibly
+  // emitting directly to our buffer/iov lists. However, for now, these
+  // messages are small, and we accept a worst-case alloc/copy, leaving
+  // optimization to posterity.
+  size_t fb_size;
+  uint8_t *fb_data;
+  bool fb_alloced = false;
+  fb_data =
+      static_cast<uint8_t *>(flatcc_builder_get_direct_buffer(B, &fb_size));
+  if (!fb_data) {
+    fb_alloced = true;
+    fb_data =
+        static_cast<uint8_t *>(flatcc_builder_finalize_buffer(B, &fb_size));
+  }
+  IREE_CHECK_NE(fb_size, 0);
+
+  auto iovec = iovec_pool_.Get();
+  auto buffer = buffer_pool_.Get();
+
+  // Ensure that a single buffer is at least large enough for the packet
+  // header and the message.
+  iree_remoting_v1_packet_header_t packet_header;
+  size_t header_message_len = sizeof(packet_header) + fb_size;
+  if (IREE_UNLIKELY(header_message_len > buffer->size())) {
+    if (fb_alloced) flatcc_builder_free(fb_data);
+    IREE_LOG(ERROR) << "Buffer size too small for message";
+    return Abort();
+  }
+
+  // Populate header.
+  packet_header.packet_type = IREE_REMOTING_V1_PT_CONTROL;
+  packet_header.packet_size = header_message_len;
+  packet_header.payload_size = payload_size;
+  std::memcpy(buffer->data(), &packet_header, sizeof(packet_header));
+  iovec->add(buffer->data(), header_message_len, std::move(buffer));
+
+  // Append payload.
+  if (outgoing_payload_) {
+    iovec->append(*outgoing_payload_);
+  }
+
+  // Send it off.
+  TransportWrite(std::move(iovec));
+
+  if (fb_alloced) flatcc_builder_free(fb_data);
+}
+
+//===-----------------------------------------------------------------------===/
+// SocketProtocolHandler
+//===-----------------------------------------------------------------------===/
+
+namespace {
+// TODO: Once the shape of this is known, move it to a facility on IoLoop
+// (and guard proper usage there).
+template <typename RequestTy>
+IoRequestPtr<RequestTy> SubmitBlocking(IoLoop &io_loop,
+                                       IoRequestPtr<RequestTy> request) {
+  IoRequest *done_request = nullptr;
+  request->SetCompletionHandler(
+      &done_request, +[](IoRequest *completed_request, void *completion_data) {
+        IoRequest **inner_done_request =
+            static_cast<IoRequest **>(completion_data);
+        *inner_done_request = completed_request;
+      });
+  io_loop.Submit(std::move(request));
+  io_loop.Run([&done_request]() { return done_request == nullptr; });
+  return IoRequestPtr<RequestTy>(static_cast<RequestTy *>(done_request));
+}
+}  // namespace
+
+SocketProtocolHandler::SocketProtocolHandler(IoLoop &io_loop,
+                                             IoBufferPool &buffer_pool,
+                                             IoBufferVec::Pool &iovec_pool,
+                                             socket_t fd)
+    : ProtocolHandler(buffer_pool, iovec_pool),
+      channel_(io_loop, buffer_pool, iovec_pool, fd) {
+  channel_.OnRead(std::bind(&SocketProtocolHandler::OnRead, this, _1, _2));
+  channel_.OnWrite(std::bind(&SocketProtocolHandler::OnWrite, this, _1));
+}
+
+SocketProtocolHandler::~SocketProtocolHandler() {}
+
+void SocketProtocolHandler::OnWrite(iree_status_t status) {
+  if (!iree_status_is_ok(status)) {
+    ConsumeStatus("SocketProtocolHandler::OnWrite() error", status);
+    return Abort();
+  }
+}
+
+void SocketProtocolHandler::OnRead(iree_status_t status,
+                                   IoBufferVec::Ptr iovec) {
+  if (iree_status_is_resource_exhausted(status)) {
+    // EOF. Silently ignore and shutdown.
+    iree_status_ignore(status);
+    return Abort();
+  }
+
+  if (!iree_status_is_ok(status)) {
+    ConsumeStatus("SocketProtocolHandler::OnWrite() error", status);
+    return Abort();
+  }
+
+  TransportReceived(std::move(iovec));
+}
+
+size_t SocketProtocolHandler::transport_buffer_size() {
+  return channel_.buffer_size();
+}
+
+void SocketProtocolHandler::TransportRead(size_t chunk_size) {
+  channel_.Read(chunk_size, /*read_fully=*/true);
+}
+
+void SocketProtocolHandler::TransportWrite(IoBufferVec::Ptr iovec) {
+  channel_.Write(std::move(iovec), /*flush=*/true);
+}
+
+void SocketProtocolHandler::TransportClose() { channel_.Close(); }
+
+iree_status_t SocketProtocolHandler::ConnectAndWait(SocketAddress &dest_addr) {
+  // Connect socket.
+  IREE_DVLOG(1) << "SocketProtocolHandler::Connect() : Connecting socket";
+  auto request = SubmitBlocking(
+      io_loop(),
+      io_loop().NewRequest<IoConnectSocketRequest>(channel_.fd(), dest_addr));
+  IREE_RETURN_IF_ERROR(request->ConsumeStatus());
+
+  // Initiate protocol and wait for ready.
+  IREE_DVLOG(1) << "SocketProtocolHandler::Connect() : Initiating protocol";
+  Initiate();
+  io_loop().Run([this]() { return is_state_initializing(); });
+  IREE_DVLOG(1) << "SocketProtocolHandler::Connect() : Protocol initiated";
+  return CheckProtocolError();
+}
+
+void SocketProtocolHandler::CloseAndWait() {
+  IREE_DVLOG(1) << "SocketProtocolHandler: CloseAndWait()";
+  Close();
+  SocketChannel *local_channel = &channel_;
+  io_loop().Run([local_channel]() { return !local_channel->is_quiescent(); });
+  IREE_DVLOG(1) << "SocketClient: is_quiescent";
+}
+
+}  // namespace protocol_v1
+}  // namespace remoting
+}  // namespace iree

--- a/experimental/remoting/iree/remoting/protocol_v1/handler.h
+++ b/experimental/remoting/iree/remoting/protocol_v1/handler.h
@@ -1,0 +1,166 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_REMOTING_PROTOCOL_V1_HANDLER_H_
+#define IREE_REMOTING_PROTOCOL_V1_HANDLER_H_
+
+#include "experimental/remoting/iree/remoting/protocol_v1/common.h"
+#include "experimental/remoting/iree/remoting/support/channel.h"
+#include "iree/base/api.h"
+#include "iree/base/flatcc.h"
+
+namespace iree {
+namespace remoting {
+namespace protocol_v1 {
+
+// Transport agnostic protocol handler state machine.
+class ProtocolHandler {
+ public:
+  // A ceiling on the size of a control packet we will receive. Intended to
+  // be generous but prevent abuse.
+  static constexpr size_t kMaxControlPacketSize = 4096;
+  static constexpr size_t kMinControlPacketAllocSize = 128;
+
+  ProtocolHandler(IoBufferPool &buffer_pool, IoBufferVec::Pool &iovec_pool);
+  virtual ~ProtocolHandler();
+
+  //===---------------------------------------------------------------------===/
+  // Protocol state.
+  //===---------------------------------------------------------------------===/
+
+  // Whether the protocol is in an initializing state, which is entered on a
+  // call to Initiate and ends in either ready or abort.
+  bool is_state_initializing() { return state_ == State::kHandshake; }
+
+  // Whether the protocol is in an abort state, which is the terminal state
+  // resulting from any end to the protocol (error or otherwise).
+  bool is_state_abort() { return state_ == State::kAbort; }
+
+  //===---------------------------------------------------------------------===/
+  // Initiate and teardown.
+  //===---------------------------------------------------------------------===/
+
+  // Initiate IO interactions with peer.
+  void Initiate();
+  // Requests close of the protocol and backing channel. Complete when the
+  // backing channel reports that it is quiescent.
+  void Close() { Abort(); }
+
+  //===---------------------------------------------------------------------===/
+  // High level message handling.
+  //===---------------------------------------------------------------------===/
+
+  // Starts building a control packet for transmission.
+  flatcc_builder_t *StartPacket();
+  // Sends a control packet as constructed into the builder most recently
+  // returned from |StartControlPacket|. Must not use the builder again
+  // following this call.
+  void SendPacket();
+
+ protected:
+  enum class State {
+    kRecvPacketHeader,
+    kRecvControlPacketPayload,
+    kHandshake,
+    kAbort,
+    kNone,
+  };
+
+  IoBufferPool &buffer_pool() { return buffer_pool_; }
+  IoBufferVec::Pool &iovec_pool() { return iovec_pool_; }
+
+  // Tranport hooks.
+  virtual size_t transport_buffer_size() = 0;
+  virtual void TransportRead(size_t chunk_size) = 0;
+  void TransportReceived(IoBufferVec::Ptr iovec);
+  virtual void TransportWrite(IoBufferVec::Ptr iovec) = 0;
+  virtual void TransportClose() = 0;
+
+  void SetState(State state);
+  void Abort();
+  void InitiateRecvPacketHeader();
+  void InitiateRecvControlPacketPayload();
+
+ private:
+  State state_ = State::kNone;
+  iree_allocator_t allocator_ = iree_allocator_system();
+  IoBufferPool &buffer_pool_;
+  IoBufferVec::Pool &iovec_pool_;
+
+  // Handshake.
+  iree_remoting_v1_handshake_wire_t handshake_;
+  iree_remoting_v1_handshake_wire_t their_handshake_;
+  iree_remoting_transport_config_t config_;
+
+  // Incoming packet.
+  iree_remoting_v1_packet_header_t incoming_packet_header_;
+  size_t incoming_control_packet_capacity_ = 0;
+  size_t incoming_control_packet_size_ = 0;
+  void *incoming_control_packet_ = nullptr;
+
+  // Outgoing packet.
+  flatcc_builder_t outgoing_packet_builder_;
+  IoBufferVec::Ptr outgoing_payload_;
+};
+
+// Handler state machine for the V1 protocol.
+// This class operates at the level of control packets and streams, allowing
+// higher level code to build behavior on top of it and lower level code to
+// bind it to a physical medium (such as a byte stream/socket).
+class SocketProtocolHandler : public ProtocolHandler {
+ public:
+  SocketProtocolHandler(IoLoop &io_loop, IoBufferPool &buffer_pool,
+                        IoBufferVec::Pool &iovec_pool, socket_t fd);
+  ~SocketProtocolHandler();
+
+  // Hooks the underlying channel's OnQuiescent callback. This will be called
+  // after an Abort() is triggered once activity has ceased.
+  void OnQuiescent(Channel::QuiescentCallback on_quiescent) {
+    channel_.OnQuiescent(std::move(on_quiescent));
+  }
+
+  // Blocking convenience methods for client handlers.
+  // Connects the socket and waits, returning the status.
+  iree_status_t ConnectAndWait(SocketAddress &dest_addr);
+  // Closes the socket and waits.
+  void CloseAndWait();
+
+ private:
+  IoLoop &io_loop() { return channel_.io_loop(); }
+
+  // Callbacks.
+  void OnWrite(iree_status_t status);
+  void OnRead(iree_status_t status, IoBufferVec::Ptr iovec);
+
+  size_t transport_buffer_size() override;
+  void TransportRead(size_t chunk_size) override;
+  void TransportWrite(IoBufferVec::Ptr iovec) override;
+  void TransportClose() override;
+
+  iree_status_t CheckProtocolError() {
+    if (is_state_abort()) {
+      return iree_make_status(IREE_STATUS_UNKNOWN,
+                              "A protocol error caused an abort");
+    }
+    return iree_ok_status();
+  }
+
+  SocketChannel channel_;
+};
+
+}  // namespace protocol_v1
+}  // namespace remoting
+}  // namespace iree
+
+#endif  // IREE_REMOTING_PROTOCOL_V1_HANDLER_H_

--- a/experimental/remoting/iree/remoting/schemas/CMakeLists.txt
+++ b/experimental/remoting/iree/remoting/schemas/CMakeLists.txt
@@ -12,4 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(iree/remoting)
+flatbuffer_c_library(
+  NAME
+    protocol_v1_c_fbs
+  SRCS
+    "protocol_v1.fbs"
+  FLATCC_ARGS
+    "--reader"
+    "--builder"
+    "--verifier"
+    "--json"
+  PUBLIC
+)

--- a/experimental/remoting/iree/remoting/schemas/protocol_v1.fbs
+++ b/experimental/remoting/iree/remoting/schemas/protocol_v1.fbs
@@ -1,0 +1,84 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace iree.remoting.protocol_v1;
+
+file_identifier "IRV1";
+file_extension "irv1";
+
+// Opens a device, establishing a protocol-local device_id for the device.
+// TODO: This is just a stub and needs to be adapted to match the real API.
+table HalDeviceOpenRequest {
+  // Protocol local id to assign to the opened device.
+  // Device ids are assigned by the client and must be unique for the duration
+  // of the connection.
+  device_id:uint32;
+  // TODO: Fields for selecting a device.
+}
+table HalDeviceOpenResponse {
+  // An identifier describing the device based.
+  // See: iree_hal_device_id()
+  device_identifier:string;
+}
+
+// Union of all request types (client->server).
+union AnyRequest {
+  // HAL Device Requests.
+  HalDeviceOpenRequest,
+}
+
+// Failing status information. A NULL ErrorStatus == OK.
+table ErrorStatusResponse {
+  // Non-zero status code corresponding to IREE_STATUS_* define values in the
+  // API.
+  code:uint8;
+  // An error message as a string (if available).
+  message:string;
+}
+
+// Union of all response types (server->client).
+union AnyResponse {
+  ErrorStatusResponse,
+  // HAL Device Response.
+  HalDeviceOpenResponse,
+}
+
+// A request from client->server in the protocol.
+table RequestEnvelope {
+  request:AnyRequest;
+  // If the request includes arbitrary payload data following this envelope,
+  // its size is noted here.
+  payload_size:uint32 = 0;
+  correlation_id:uint32 = 0xffffffff;
+}
+
+// Root type for messages.
+table Envelope {
+  // Specific request (client->server) in the protocol.
+  request:AnyRequest;
+  // Specific response (server->client) in the protocol. NULL indicates
+  // successful completion with no further data.
+  response:AnyResponse;
+
+  // A client assigned, opaque identifier which will be echoed in the
+  // ResponseEnvelope for related responses. Typical use is for clients to
+  // assign a monotonically increasing number that can be used to identify
+  // specific responses and/or set fences at response points in the stream
+  // (being mindful of wrap-around).
+  // The value of 0xffffffff is reserved and is used for server responses that
+  // do not correspond with a request.
+  correlation_id:uint32;
+}
+
+root_type Envelope;

--- a/experimental/remoting/iree/remoting/simple/CMakeLists.txt
+++ b/experimental/remoting/iree/remoting/simple/CMakeLists.txt
@@ -1,0 +1,53 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+iree_cc_binary(
+  NAME
+    iree-simple-socket-server
+  OUT
+    iree-simple-socket-server
+  SRCS
+    "iree-simple-socket-server-main.cc"
+  DEPS
+    iree::base::logging
+    experimental::remoting::iree::remoting::protocol_v1
+    experimental::remoting::iree::remoting::schemas::protocol_v1_c_fbs
+    experimental::remoting::iree::remoting::support
+)
+
+iree_cc_binary(
+  NAME
+    iree-test-client
+  OUT
+    iree-test-client
+  SRCS
+    "iree-test-client-main.cc"
+  DEPS
+    iree::base::logging
+    experimental::remoting::iree::remoting::protocol_v1
+    experimental::remoting::iree::remoting::schemas::protocol_v1_c_fbs
+    experimental::remoting::iree::remoting::support
+)
+
+iree_cc_binary(
+  NAME
+    sample-echo-server
+  OUT
+    sample-echo-server
+  SRCS
+    "sample-echo-server-main.cc"
+  DEPS
+    iree::base::logging
+    experimental::remoting::iree::remoting::support
+)

--- a/experimental/remoting/iree/remoting/simple/iree-simple-socket-server-main.cc
+++ b/experimental/remoting/iree/remoting/simple/iree-simple-socket-server-main.cc
@@ -1,0 +1,107 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "experimental/remoting/iree/remoting/protocol_v1/handler.h"
+#include "experimental/remoting/iree/remoting/support/channel.h"
+#include "experimental/remoting/iree/remoting/support/io_loop.h"
+#include "experimental/remoting/iree/remoting/support/socket.h"
+#include "iree/base/api.h"
+#include "iree/base/logging.h"  // TODO: Needed for IREE_CHECK_OK
+
+using namespace iree::remoting;
+using namespace std::placeholders;
+
+namespace {
+
+class Session;
+class Server;
+
+class Server {
+ public:
+  static constexpr size_t kSharedBufferSize = 4096;
+
+  Server(IoLoop &io_loop)
+      : io_loop_(io_loop), shared_buffers_(kSharedBufferSize) {}
+
+  IoLoop &io_loop() { return io_loop_; }
+  IoBufferPool &shared_buffers() { return shared_buffers_; }
+
+  void StartSession(socket_t fd);
+
+ private:
+  IoLoop &io_loop_;
+  IoBufferPool shared_buffers_;
+};
+
+class Session {
+ public:
+  Session(Server &server, socket_t fd)
+      : server_(server),
+        handler_(server.io_loop(), server.shared_buffers(), iovec_pool_, fd) {
+    handler_.OnQuiescent(std::bind(&Session::HandleShutdown, this));
+  }
+
+  void Initiate() { handler_.Initiate(); }
+
+ private:
+  void HandleShutdown() {
+    IREE_DVLOG(1) << "Session: HandleShutdown";
+    delete this;
+  }
+  Server &server_;
+  IoBufferVec::Pool iovec_pool_;
+  protocol_v1::SocketProtocolHandler handler_;
+};
+
+constexpr size_t Server::kSharedBufferSize;
+
+inline void Server::StartSession(socket_t fd) {
+  Session *session = new Session(*this, fd);
+  session->Initiate();
+}
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  int port = 3951;
+
+  // Create socket.
+  SocketAddress listen_addr = SocketAddress::AnyInet(3951);
+  Socket socket;
+  IREE_CHECK_OK(socket.Initialize(listen_addr.family(), SOCK_STREAM, 0));
+  IREE_LOG(INFO) << "Listen on [" << listen_addr.inet_addr_str()
+                 << "]:" << listen_addr.inet_port();
+  IREE_CHECK_OK(socket.BindAndListen(listen_addr));
+
+  // Start IoLoop.
+  std::unique_ptr<IoLoop> io_loop;
+  IREE_CHECK_OK(IoLoop::Create(io_loop));
+  Server server(*io_loop);
+
+  io_loop->SubmitNew<IoAcceptRequest>(
+      socket.fd(), [&](IoAcceptRequest::Ptr request) {
+        IREE_LOG(INFO) << "Accepted connection: " << request->client_fd();
+        if (request->ok()) {
+          server.StartSession(request->client_fd());
+        }
+
+        // Submit again to accept the next connection.
+        request->io_loop()->Submit(std::move(request));
+      });
+
+  io_loop->Run();
+  return 0;
+}

--- a/experimental/remoting/iree/remoting/simple/iree-test-client-main.cc
+++ b/experimental/remoting/iree/remoting/simple/iree-test-client-main.cc
@@ -1,0 +1,85 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "experimental/remoting/iree/remoting/protocol_v1/hal_stub.h"
+#include "experimental/remoting/iree/remoting/protocol_v1/handler.h"
+#include "experimental/remoting/iree/remoting/support/channel.h"
+#include "experimental/remoting/iree/remoting/support/io_loop.h"
+#include "experimental/remoting/iree/remoting/support/socket.h"
+#include "iree/base/api.h"
+#include "iree/base/logging.h"  // TODO: Needed for IREE_CHECK_OK
+
+using namespace iree::remoting;
+
+namespace {
+
+class SocketClient {
+ public:
+  static constexpr size_t kBufferSize = 4096;
+  SocketClient(IoLoop &io_loop, Socket socket)
+      : buffer_pool_(kBufferSize),
+        protocol_(io_loop, buffer_pool_, iovec_pool_, socket.release_fd()),
+        hal_stub_(protocol_) {}
+
+  iree_status_t ConnectAndWait(SocketAddress &sa) {
+    return protocol_.ConnectAndWait(sa);
+  }
+
+  void CloseAndWait() { protocol_.CloseAndWait(); }
+
+  protocol_v1::HalClientStub &hal_stub() { return hal_stub_; }
+
+ private:
+  IoBufferPool buffer_pool_;
+  IoBufferVec::Pool iovec_pool_;
+  protocol_v1::SocketProtocolHandler protocol_;
+  protocol_v1::HalClientStub hal_stub_;
+};
+
+constexpr size_t SocketClient::kBufferSize;
+
+}  // namespace
+
+int main(int argc, char **argv) {
+  SocketAddress sa = SocketAddress::ParseInet("::", 3951);
+  IREE_CHECK(sa.is_valid()) << "Failed to parse local address";
+  IREE_LOG(INFO) << "Connecting to [" << sa.inet_addr_str()
+                 << "]:" << sa.inet_port();
+
+  // Create socket.
+  Socket socket;
+  IREE_CHECK_OK(socket.Initialize(sa.family(), SOCK_STREAM, 0));
+
+  // Start IoLoop.
+  std::unique_ptr<IoLoop> io_loop;
+  IREE_CHECK_OK(IoLoop::Create(io_loop));
+
+  SocketClient client(*io_loop, std::move(socket));
+  IREE_CHECK_OK(client.ConnectAndWait(sa));
+
+  sleep(1);
+  IREE_LOG(INFO) << "Opening device...";
+  client.hal_stub().OpenDevice();
+  IREE_LOG(INFO) << "Device opened";
+
+  sleep(1);
+  IREE_LOG(INFO) << "Closing...";
+  client.CloseAndWait();
+
+  IREE_LOG(INFO) << "Done. Draining IoLoop.";
+  io_loop->Run();
+  return 0;
+}

--- a/experimental/remoting/iree/remoting/simple/sample-echo-server-main.cc
+++ b/experimental/remoting/iree/remoting/simple/sample-echo-server-main.cc
@@ -1,0 +1,107 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+
+#include "experimental/remoting/iree/remoting/support/channel.h"
+#include "experimental/remoting/iree/remoting/support/io_loop.h"
+#include "experimental/remoting/iree/remoting/support/socket.h"
+#include "iree/base/api.h"
+#include "iree/base/logging.h"  // TODO: Needed for IREE_CHECK_OK
+
+using namespace iree::remoting;
+using namespace std::placeholders;
+
+class ProtocolHandler {
+ public:
+  ProtocolHandler(IoLoop &io_loop, IoBufferPool &buffer_pool,
+                  socket_t channel_fd)
+      : io_loop_(io_loop),
+        socket_(io_loop, buffer_pool, iovec_pool_, channel_fd) {
+    socket_.OnQuiescent(std::bind(&ProtocolHandler::OnQuiescent, this));
+    socket_.OnRead(std::bind(&ProtocolHandler::OnRead, this, _1, _2));
+    socket_.OnWrite(std::bind(&ProtocolHandler::OnWrite, this, _1));
+  }
+
+  void OnRead(iree_status_t status, IoBufferVec::Ptr iovec) {
+    if (!iree_status_is_ok(status)) {
+      auto code = iree_status_consume_code(status);
+      IREE_LOG(INFO) << "Read error: " << code;
+      socket_.Close();
+      return;
+    }
+
+    IREE_DLOG(INFO) << "Read complete: " << (message_number_++) << " ("
+                    << status << ")";
+    socket_.Write(std::move(iovec), true);
+    socket_.Read(256, /*read_fully=*/true);
+  }
+
+  void OnWrite(iree_status_t status) {
+    if (!iree_status_is_ok(status)) {
+      auto code = iree_status_consume_code(status);
+      IREE_LOG(INFO) << "Write error: " << code;
+      socket_.Close();
+      return;
+    }
+    IREE_DLOG(INFO) << "Write complete";
+  }
+
+  void OnQuiescent() {
+    IREE_LOG(INFO) << "ProtocolHandler::Destroy";
+    delete this;
+  }
+
+  void Initiate() { socket_.Read(4096, /*read_fully=*/true); }
+
+ private:
+  IoLoop &io_loop_;
+  IoBufferVec::Pool iovec_pool_;
+  SocketChannel socket_;
+  int message_number_ = 1;
+};
+
+int main(int argc, char **argv) {
+  int port = 3951;
+
+  // Create socket.
+  SocketAddress listen_addr = SocketAddress::AnyInet(3951);
+  Socket socket;
+  IREE_CHECK_OK(socket.Initialize(listen_addr.family(), SOCK_STREAM, 0));
+  IREE_LOG(INFO) << "Listen on [" << listen_addr.inet_addr_str()
+                 << "]:" << listen_addr.inet_port();
+  IREE_CHECK_OK(socket.BindAndListen(listen_addr));
+
+  // Start IoLoop.
+  std::unique_ptr<IoLoop> io_loop;
+  IREE_CHECK_OK(IoLoop::Create(io_loop));
+
+  IoBufferPool buffer_pool{4096};
+
+  io_loop->SubmitNew<IoAcceptRequest>(
+      socket.fd(), [&](IoAcceptRequest::Ptr request) {
+        IREE_LOG(INFO) << "Accepted connection: " << request->client_fd();
+        if (request->ok()) {
+          auto handler = new ProtocolHandler(*request->io_loop(), buffer_pool,
+                                             request->client_fd());
+          handler->Initiate();
+        }
+
+        // Submit again to accept the next connection.
+        request->io_loop()->Submit(std::move(request));
+      });
+
+  io_loop->Run();
+  return 0;
+}

--- a/experimental/remoting/iree/remoting/support/CMakeLists.txt
+++ b/experimental/remoting/iree/remoting/support/CMakeLists.txt
@@ -12,4 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_subdirectory(iree/remoting)
+iree_cc_library(
+  NAME
+    support
+  HDRS
+    "channel.h"
+    "io_buffer.h"
+    "io_loop.h"
+    "io_loop_uring.cc.inc"
+    "platform.h"
+    "socket.h"
+  SRCS
+    "channel.cc"
+    "io_buffer.cc"
+    "io_loop.cc"
+    "socket.cc"
+  DEPS
+    ::linux_uring
+    iree::base::api
+    iree::base::logging
+)
+
+iree_cc_library(
+  NAME
+    linux_uring
+  HDRS
+    "linux_uring.h"
+  DEPS
+    $<IF:${IREE_HAVE_IO_URING},liburing_liburing,>
+  DEFINES
+    $<IF:${IREE_HAVE_IO_URING},IREE_REMOTING_HAVE_URING=1,>
+)

--- a/experimental/remoting/iree/remoting/support/channel.cc
+++ b/experimental/remoting/iree/remoting/support/channel.cc
@@ -1,0 +1,290 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "experimental/remoting/iree/remoting/support/channel.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <vector>
+
+using namespace std::placeholders;
+
+namespace iree {
+namespace remoting {
+
+//===----------------------------------------------------------------------===//
+// Channel base classes
+//===----------------------------------------------------------------------===//
+
+void Channel::Write(IoBuffer::Ptr buffer, int32_t length, int32_t offset,
+                    bool flush) {
+  auto iovec = NewIoVec();
+  iovec->add(buffer->data_bytes() + offset, length, std::move(buffer));
+  Write(std::move(iovec), /*flush=*/flush);
+}
+
+void Channel::Write(const void *data, size_t length, bool flush) {
+  auto iovec = NewIoVec();
+  iovec->add(const_cast<void *>(data), length);
+  Write(std::move(iovec), /*flush=*/flush);
+}
+
+//===----------------------------------------------------------------------===//
+// SocketChannel
+//===----------------------------------------------------------------------===//
+
+SocketChannel::SocketChannel(IoLoop &io_loop, IoBufferPool &buffer_pool,
+                             IoBufferVec::Pool &iovec_pool, socket_t fd)
+    : Channel(buffer_pool, iovec_pool), io_loop_(io_loop), fd_(fd) {}
+
+SocketChannel::~SocketChannel() {
+  IREE_DVLOG(1) << "~SocketChannel";
+  iree_status_ignore(read_error_);
+}
+
+void SocketChannel::Close() {
+  if (close_initiated_) return;
+  close_initiated_ = true;
+  // Note that outstanding reads and writes are not necessarily cancelled by
+  // a close, but a socket shutdown can cause an orderly shutdown such that
+  // outstanding requests are cancelled prior to an actual close.
+  io_loop_.SubmitNew<IoSocketShutdownRequest>(
+      fd(), SHUT_RDWR,
+      std::bind(&SocketChannel::HandleShutdownOnClose, this, _1));
+}
+
+void SocketChannel::HandleShutdownOnClose(IoSocketShutdownRequest::Ptr r) {
+  IREE_DVLOG(1) << "SocketChannel::HandleShutdownOnClose";
+  io_loop_.SubmitNew<IoCloseSocketRequest>(
+      fd(), std::bind(&SocketChannel::HandleCloseComplete, this, _1));
+}
+
+void SocketChannel::HandleCloseComplete(IoCloseSocketRequest::Ptr r) {
+  IREE_DVLOG(1) << "SocketChanne::HandleCloseComplete";
+  close_complete_ = true;
+  if (on_close_) {
+    on_close_(r->ConsumeStatus());
+  }
+  SchedQuiescent();
+}
+
+void SocketChannel::Write(IoBufferVec::Ptr io_vector, bool flush) {
+  if (IREE_LIKELY(io_vector)) {
+    if (write_incoming_.call_count() == 0) {
+      // First write in this batch.
+      write_incoming_.accum() = std::move(io_vector);
+    } else {
+      // Subsequent write.
+      write_incoming_.accum()->append(*io_vector);
+    }
+    write_incoming_.call_count() += 1;
+    if (flush) {
+      write_incoming_.flushed() = true;
+      SchedWrite();
+    }
+  } else if (flush && !io_vector && write_incoming_.call_count() > 0) {
+    // Stand-alone flush with no io_vector.
+    write_incoming_.flushed() = true;
+    SchedWrite();
+  }
+}
+
+void SocketChannel::HandleWriteComplete(IoSocketVecRequest::Ptr r) {
+  IREE_DVLOG(1) << "SocketChannel::HandleWriteComplete: completed_bytes="
+                << r->complete_bytes();
+  WriteBuffer current;
+  current.TakeFrom(write_outgoing_);
+  assert(current.call_count() > 0 &&
+         "HandleWriteComplete with no active calls");
+
+  if (IREE_LIKELY(on_write_)) {
+    auto status = r->ConsumeStatus();
+    // Calls 1..N get a clone.
+    for (int i = 1; i < current.call_count(); ++i) {
+      on_write_(iree_status_clone(status));
+    }
+    // And 0 gets the original.
+    on_write_(status);
+  }
+
+  SchedWrite();
+  SchedQuiescent();
+}
+
+void SocketChannel::SchedWrite() {
+  if (write_incoming_.call_count() == 0 || write_outgoing_.call_count() > 0) {
+    // No pending write or write in progress. Do nothing.
+    return;
+  }
+  if (IREE_UNLIKELY(close_initiated_)) {
+    IREE_LOG(WARNING) << "SocketChannel: Dropping Write() after Close()";
+    return;
+  }
+  IREE_DVLOG(1) << "SocketChannel::SchedWrite: call_count="
+                << write_incoming_.call_count();
+  write_outgoing_.TakeFrom(write_incoming_);
+  assert(write_incoming_.call_count() == 0);
+  io_loop_.SubmitNew<IoSocketVecRequest>(
+      IoSocketVecRequest::ForWrite(), fd(), std::move(write_outgoing_.accum()),
+      std::bind(&SocketChannel::HandleWriteComplete, this, _1));
+}
+
+void SocketChannel::Read(int32_t max_size, bool read_fully) {
+  assert(max_size >= 0 && "Read size must be >= 0");
+  read_outgoing_.emplace_back(max_size, read_fully);
+  read_outgoing_bytes_ += max_size;
+  read_needs_sched_ = true;
+  if (!callback_critical_section_) {
+    SchedRead();
+  }
+}
+
+void SocketChannel::HandleReadComplete(IoSocketVecRequest::Ptr r) {
+  IREE_DVLOG(1) << "[ENTER] SocketChannel::HandleReadComplete(): inflight="
+                << read_inflight_ << ", received=" << r->complete_bytes()
+                << ", read_incoming.size=" << read_incoming_.size();
+
+  read_inflight_ -= 1;
+  // Handle error (either this request error'd or already in an error state).
+  if (IREE_UNLIKELY(!r->ok() || r->complete_bytes() == 0)) {
+    read_error_ = r->ConsumeStatus();
+    if (iree_status_is_ok(read_error_)) {
+      read_error_ = iree_make_status(IREE_STATUS_RESOURCE_EXHAUSTED);
+      IREE_DVLOG(1) << "SocketChannel::HandleReadComplete(): eof";
+    } else {
+      IREE_DVLOG(1) << "SocketChannel::HandleReadComplete(): read error = "
+                    << read_error_;
+    }
+  } else {
+    read_incoming_bytes_ += r->complete_bytes();
+    read_incoming_.emplace_back(std::move(r->iovec()), r->complete_bytes());
+  }
+
+  do {
+    callback_critical_section_ = true;
+    SchedRead();
+    callback_critical_section_ = false;
+  } while (read_needs_sched_);
+  SchedQuiescent();
+  IREE_DVLOG(1) << "[EXIT] SocketChannel::HandleReadComplete(): inflight="
+                << read_inflight_
+                << ", read_incoming.size=" << read_incoming_.size();
+}
+
+void SocketChannel::SchedRead() {
+  read_needs_sched_ = false;
+  // Service any client reads that can be fulfilled.
+  while (!read_outgoing_.empty()) {
+    ReadOutgoing op = read_outgoing_.front();
+    if (IREE_LIKELY(!op.fully() || read_incoming_bytes_ >= op.size())) {
+      // Op can be fulfilled.
+      IREE_DVLOG(1) << "SocketChannel::SchedRead(): Fulfilling read "
+                       "operation (outstanding="
+                    << read_outgoing_.size() << ")";
+      read_outgoing_.pop_front();
+      FulfillReadOp(op);
+    } else {
+      // Insufficient received to fulfill.
+      if (IREE_UNLIKELY(!iree_status_is_ok(read_error_) &&
+                        !read_outgoing_.empty())) {
+        // Call back with the read error.
+        read_outgoing_.pop_front();
+        if (on_read_) {
+          on_read_(iree_status_clone(read_error_), nullptr);
+        }
+      } else {
+        // Channel is not in error - wait for more data.
+        break;
+      }
+    }
+  }
+
+  // Schedule any new transport reads needed.
+  // TODO: This can be loosened up significantly in order to keep a healthy
+  // backlog of read requests pending.
+  if (!read_outgoing_.empty() && read_inflight_ == 0) {
+    if (IREE_UNLIKELY(close_initiated_)) {
+      IREE_LOG(WARNING) << "SocketChannel: Dropping Read() after Close()";
+      return;
+    }
+    IREE_DVLOG(1) << "SocketChannel::SchedRead(): Schedule vector read";
+    IoBuffer::Ptr buffer;
+    // TODO: Harvest any partially read buffer and reschedule in order to
+    // avoid excess buffer use on a trickling socket.
+    buffer = NewBuffer();
+    auto size = buffer->size();
+    int32_t offset = 0;
+
+    auto iovec = NewIoVec();
+    iovec->add(buffer->data(), size, std::move(buffer));
+    read_inflight_ += 1;
+    io_loop_.SubmitNew<IoSocketVecRequest>(
+        IoSocketVecRequest::ForRecv(), fd(), std::move(iovec),
+        std::bind(&SocketChannel::HandleReadComplete, this, _1));
+  } else {
+    IREE_DVLOG(1) << "SocketChannel::SchedRead(): "
+                  << "Not scheduling new read (read_outgoing.size="
+                  << read_outgoing_.size()
+                  << ", read_incoming.size=" << read_incoming_.size()
+                  << ", read_inflight=" << read_inflight_ << ")";
+  }
+}
+
+void SocketChannel::FulfillReadOp(ReadOutgoing op) {
+  auto client_iovec = NewIoVec();
+  int32_t complete_bytes = 0;
+  int32_t remain_bytes = op.size();
+  // Always transfer at least one (in the case of !fully()).
+  do {
+    if (read_incoming_.empty()) break;
+    ReadIncoming &incoming = read_incoming_.front();
+    int32_t transfer_size_bytes = incoming.iovec()->TransferTo(
+        *client_iovec, std::min(remain_bytes, incoming.available_bytes()));
+    incoming.available_bytes() -= transfer_size_bytes;
+    read_incoming_bytes_ -= transfer_size_bytes;
+    complete_bytes += transfer_size_bytes;
+    if (incoming.available_bytes() == 0) {
+      IREE_DVLOG(1) << "Recycling drained iovec";
+      read_incoming_.pop_front();
+    } else {
+      IREE_DVLOG(1) << "Not recycling iovec (available_bytes="
+                    << incoming.available_bytes() << ")";
+    }
+    remain_bytes -= transfer_size_bytes;
+  } while (remain_bytes > 0 && read_incoming_bytes_ > 0);
+
+  if (op.fully()) {
+    assert(remain_bytes == 0 &&
+           "Short read of FulfillReadOp for requested full read");
+  }
+
+  if (on_read_) {
+    on_read_(iree_ok_status(), std::move(client_iovec));
+  }
+}
+
+void SocketChannel::SchedQuiescent() {
+  if (IREE_LIKELY(!close_complete_ || quiescent_)) return;
+  if (write_outgoing_.call_count() == 0 && read_inflight_ == 0) {
+    IREE_DVLOG(1) << "SocketChannel: Enter quiescent state";
+    quiescent_ = true;
+    if (on_quiescent_) {
+      on_quiescent_();
+    }
+  }
+}
+
+}  // namespace remoting
+}  // namespace iree

--- a/experimental/remoting/iree/remoting/support/channel.h
+++ b/experimental/remoting/iree/remoting/support/channel.h
@@ -1,0 +1,306 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include "experimental/remoting/iree/remoting/support/io_buffer.h"
+#include "experimental/remoting/iree/remoting/support/io_loop.h"
+#include "experimental/remoting/iree/remoting/support/socket.h"
+#include "iree/base/api.h"
+
+#ifndef IREE_REMOTING_SUPPORT_CHANNEL_H_
+#define IREE_REMOTING_SUPPORT_CHANNEL_H_
+
+namespace iree {
+namespace remoting {
+
+//===----------------------------------------------------------------------===//
+// Channel Base Classes
+//
+// Channels present a view over indeterminate streams, allowing higher-level
+// operations such as full reads/writes and vector read/writes that allow
+// for simplified ergonomics for systems wishing to minimize downstream copies.
+//===----------------------------------------------------------------------===//
+
+// Base class shared between Input and Output channels.
+// Provides common definitions and shared facilities.
+class Channel {
+ public:
+  virtual ~Channel() = default;
+
+  // A callback that only receives a status.
+  using StatusCallback = std::function<void(iree_status_t status)>;
+
+  // A callback that received a status and vectorized results in the form of
+  // an IoVec. If the status is failing, |result| will be nullptr.
+  using VectorCallback =
+      std::function<void(iree_status_t status, IoBufferVec::Ptr result)>;
+
+  IoBufferPool &buffer_pool() { return buffer_pool_; }
+  IoBufferVec::Pool &iovec_pool() { return iovec_pool_; }
+
+  // Gets a fresh IoBufferVec from the pool.
+  IoBufferVec::Ptr NewIoVec() { return iovec_pool_.Get(); }
+
+  // Gets a fresh buffer from the pool.
+  IoBuffer::Ptr NewBuffer() { return buffer_pool_.Get(); }
+
+  // The optimal buffer size for this channel.
+  size_t buffer_size() { return buffer_pool_.buffer_data_size(); }
+
+  //===---------------------------------------------------------------------===/
+  // Close/quiesce operations
+  //===---------------------------------------------------------------------===/
+
+  // Asynchronously closes the channel. For bidi channels (i.e. Sockets), both
+  // sides will close the same underlying entity and only one should be
+  // closed. No matter how many times Close() is invoked, only one OnClose()
+  // will be called back.
+  void OnClose(StatusCallback on_close) { on_close_ = std::move(on_close); }
+  virtual void Close() = 0;
+
+  // Callback for when the channel becomes quiescent.
+  // Unless if an outside actor manipulates the channel, no further requests
+  // or callbacks will take place. This happens at some point after OnClose
+  // is called.
+  using QuiescentCallback = std::function<void()>;
+  void OnQuiescent(QuiescentCallback on_quiescent) {
+    on_quiescent_ = std::move(on_quiescent);
+  }
+
+  // Whether the channel is quiescent.
+  virtual bool is_quiescent() = 0;
+
+  //===---------------------------------------------------------------------===/
+  // Write operations
+  //===---------------------------------------------------------------------===/
+
+  // Writes the given IO vector to the channel, calling back with a status.
+  // Does not call back if nullptr. All backing buffers and data are treated
+  // as constant.
+  void OnWrite(StatusCallback on_write) { on_write_ = std::move(on_write); }
+  virtual void Write(IoBufferVec::Ptr io_vector, bool flush = true) = 0;
+
+  // Short-cut to perform a non-vectored write of a single buffer.
+  void Write(IoBuffer::Ptr buffer, int32_t offset, int32_t length,
+             bool flush = true);
+
+  // Short-cut to perform a non-vectored write of a single wrapped data pointer.
+  // Per the contract with IoBufferVec, the data pointer must be
+  // malloc-aligned.
+  void Write(const void *data, size_t length, bool flush = true);
+
+  // Null write whose only purpose is to flush.
+  void Flush() { Write(/*io_vector=*/IoBufferVec::Ptr(), /*flush=*/true); }
+
+  //===---------------------------------------------------------------------===/
+  // Read operations
+  //===---------------------------------------------------------------------===/
+
+  // Reads up to |max_size| bytes from the channel, invoking the given callback
+  // with the status and results. If |read_fully| is true, then exactly
+  // |max_size| bytes will be read (or a failing status will be returned).
+  void OnRead(VectorCallback on_read) { on_read_ = std::move(on_read); }
+  virtual void Read(int32_t max_size, bool read_fully) = 0;
+
+ protected:
+  Channel(IoBufferPool &buffer_pool, IoBufferVec::Pool &iovec_pool)
+      : buffer_pool_(buffer_pool), iovec_pool_(iovec_pool) {}
+  StatusCallback on_close_;
+  QuiescentCallback on_quiescent_;
+  StatusCallback on_write_;
+  VectorCallback on_read_;
+
+ private:
+  IoBufferPool &buffer_pool_;
+  IoBufferVec::Pool &iovec_pool_;
+};
+
+//===----------------------------------------------------------------------===//
+// Socket channels
+//===----------------------------------------------------------------------===//
+
+// An asynchronous bidi channel that wraps a socket via an IoLoop.
+// TODO: Move this to the Channel class as it describes the general contract.
+//
+// Writes:
+// -------
+// Writes are semi-buffered and sequenced, requiring a write with flush=true
+// in order to commit them to the medium. Note that |flush| is an advisory
+// signal: the implementation may choose to flush more aggressively.
+// There is also a facility for performing un-buffered writes, which send
+// immediately, but this is retained for cases that need it vs the default
+// because it requires great care in use.
+//
+// Reads:
+// ------
+// Reads are semi-buffered in order to service the read_fully case. Reads are
+// always scheduled for over-read at a buffer granularity and consumer
+// callbacks are serviced from these read buffers, allowing spanning reads of
+// sizes up to what an IoBufferVec can handle. Note that this is still zero
+// copy capable since results are delivered to consumers as an IoBufferVec that
+// may span multiple physical buffers. As a consequence, calls to Read() will
+// produce a sequence of callbacks matching the original calls regardless of
+// whether chained via callbacks or not.
+//
+// Reads should be submitted un-chained in order to provide more read buffer
+// depth to the transport layer (i.e. queue larger/fewer spanning reads for
+// higher throughput).
+//
+// Possible improvements in the future:
+//   - Uses std::deque in a few places for queues. Should be replaced with
+//     something with better memory ergonomics (i.e. deque can allocate 4KiB
+//     minimum on some standard libraries).
+//   - Additional read throughput can likely be had via read ahead, but this
+//     needs to be done carefully (and is different between server and client
+//     needs).
+class SocketChannel final : public Channel {
+ public:
+  SocketChannel(IoLoop &io_loop, IoBufferPool &buffer_pool,
+                IoBufferVec::Pool &iovec_pool, socket_t fd);
+  ~SocketChannel();
+
+  void Close() override;
+  void Read(int32_t max_size, bool read_fully) override;
+  using Channel::Read;
+  void Write(IoBufferVec::Ptr io_vector, bool flush = true) override;
+  using Channel::Flush;
+  using Channel::Write;
+
+  // The backing socket file descriptor.
+  socket_t fd() { return fd_; }
+  IoLoop &io_loop() { return io_loop_; }
+
+  // Whether the channel is quiescent.
+  bool is_quiescent() override { return quiescent_; }
+
+ private:
+  class ReadOutgoing {
+   public:
+    ReadOutgoing(int32_t size, bool fully) : size_(fully ? size : -size) {}
+    int32_t size() { return size_ >= 0 ? size_ : -size_; }
+    bool fully() { return size_ >= 0; }
+
+   private:
+    int32_t size_;
+  };
+  class ReadIncoming {
+   public:
+    ReadIncoming(IoBufferVec::Ptr iovec, int32_t available_bytes)
+        : iovec_(std::move(iovec)), available_bytes_(available_bytes) {}
+
+    IoBufferVec::Ptr &iovec() { return iovec_; }
+    int32_t &available_bytes() { return available_bytes_; }
+
+   private:
+    IoBufferVec::Ptr iovec_;
+    int32_t available_bytes_;
+  };
+  class WriteBuffer {
+   public:
+    WriteBuffer() = default;
+    WriteBuffer(IoBufferVec::Ptr accum) : accum_(std::move(accum)) {}
+    WriteBuffer(WriteBuffer &&other) = delete;
+
+    void TakeFrom(WriteBuffer &other) {
+      accum_ = std::move(other.accum_);
+      call_count_ = other.call_count_;
+      other.call_count_ = 0;
+      flushed_ = other.flushed_;
+      other.flushed_ = false;
+    }
+
+    IoBufferVec::Ptr &accum() { return accum_; }
+    int &call_count() { return call_count_; }
+    bool &flushed() { return flushed_; }
+
+   private:
+    IoBufferVec::Ptr accum_;
+    int call_count_ = 0;
+    bool flushed_ = false;
+  };
+
+  // Note that these persistent callbacks will always be std::bind()'d to
+  // |this|, which is a fast-path. Therefore we don't go to the trouble of
+  // pre-binding them on construction. Separate read and write completions
+  // are maintained to give the branch predictor a better time.
+  void HandleShutdownOnClose(IoSocketShutdownRequest::Ptr r);
+  void HandleCloseComplete(IoCloseSocketRequest::Ptr r);
+  void HandleReadComplete(IoSocketVecRequest::Ptr r);
+  void HandleWriteComplete(IoSocketVecRequest::Ptr r);
+
+  // Schedules any needed backing reads and notifies clients of any progress.
+  void SchedRead();
+  void FulfillReadOp(ReadOutgoing op);
+  void SchedWrite();
+  void SchedQuiescent();
+
+  IoLoop &io_loop_;
+  socket_t fd_;
+
+  // Sum of all bytes available in |read_incoming_|.
+  uint64_t read_incoming_bytes_ = 0;
+
+  // Sum of all bytes for outstanding reads in |read_outgoing_|. Used to
+  // manage the depth of the read request queue sent to the kernel.
+  uint64_t read_outgoing_bytes_ = 0;
+
+  // FIFO of data that has been received from the socket and is ready for
+  // consumption by the client.
+  std::deque<ReadIncoming> read_incoming_;
+
+  // FIFO of outstanding read requests waiting to be serviced.
+  std::deque<ReadOutgoing> read_outgoing_;
+
+  // Write requests being accumulated from the caller.
+  WriteBuffer write_incoming_;
+
+  // Write request that has been sent to the transport and is awaiting
+  // completion.
+  WriteBuffer write_outgoing_;
+
+  // If the channel is in read-error, remember that so all future reads can
+  // be failed.
+  iree_status_t read_error_ = iree_ok_status();
+
+  // Number of underlying read requests in-flight.
+  int32_t read_inflight_ = 0;
+
+  // Whether we are in a critical section that cannot be re-entered via
+  // a callback.
+  bool callback_critical_section_ : 1 = false;
+
+  // Whether read requests have been made that require scheduling.
+  bool read_needs_sched_ : 1 = false;
+
+  // Whether a close request has been initiated.
+  bool close_initiated_ : 1 = false;
+
+  // Whether a close request has been completed.
+  bool close_complete_ : 1 = false;
+
+  // Whether we have entered the quiescent state.
+  bool quiescent_ : 1 = false;
+};  // namespace remoting
+
+}  // namespace remoting
+}  // namespace iree
+
+#endif  // IREE_REMOTING_SUPPORT_CHANNEL_H_

--- a/experimental/remoting/iree/remoting/support/io_buffer.cc
+++ b/experimental/remoting/iree/remoting/support/io_buffer.cc
@@ -1,0 +1,93 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "experimental/remoting/iree/remoting/support/io_buffer.h"
+
+#include <cstdlib>
+#include <cstring>
+
+namespace iree {
+namespace remoting {
+
+//===----------------------------------------------------------------------===//
+// IoBufferPool
+//===----------------------------------------------------------------------===//
+
+IoBufferPool::~IoBufferPool() = default;
+IoBufferPool::Slab::~Slab() { std::free(data); }
+
+void IoBufferPool::GrowBuffers() {
+  size_t step_size = buffer_physical_size();
+  size_t alloc_size = step_size * slab_buffer_count_;
+  IREE_DLOG(INFO) << "IoBufferPool add slab (step_size=" << step_size
+                  << ", alloc_size=" << alloc_size << ")";
+
+  // If this ever becomes hot, this could be done in one alloc instead of two.
+  // Or various other smarter things...
+  slab_head_ = std::unique_ptr<Slab>(new Slab{
+      std::malloc(alloc_size),
+      std::move(slab_head_),
+  });
+
+  // Initialize each buffer and add to list.
+  auto current = static_cast<std::uint8_t *>(slab_head_->data);
+  for (size_t i = 0; i < slab_buffer_count_; ++i, current += step_size) {
+    IREE_DLOG(INFO) << "  + Add buffer to pool: "
+                    << static_cast<void *>(current);
+    head_ = new (current) IoBuffer(this, head_);
+  }
+}
+
+//===----------------------------------------------------------------------===//
+// IoBufferVec
+//===----------------------------------------------------------------------===//
+
+IoBufferVec::~IoBufferVec() {
+  clear();
+  free(entries_);
+  free(extras_);
+}
+
+IoBufferVec::Pool::~Pool() {
+  IoBufferVec *current = head_;
+  while (current) {
+    assert(current->is_free_ == 1);
+    IoBufferVec *next = current->link_.next;
+    delete current;
+    current = next;
+  }
+}
+
+void IoBufferVec::clear() {
+  // Explicitly release backing buffers.
+  for (uint32_t i = 0, e = size(); i < e; ++i) {
+    extras_[i].~Extra();
+  }
+  size_ = 0;
+}
+
+void IoBufferVec::Grow(uint32_t new_capacity) {
+  if (new_capacity == 0) {
+    capacity_ = std::max(2, capacity_ + capacity_ / 2);
+  } else {
+    capacity_ = std::max(new_capacity, capacity_);
+  }
+
+  entries_ = static_cast<portable_iovec_t *>(
+      realloc(entries_, sizeof(portable_iovec_t) * capacity_));
+  extras_ = static_cast<Extra *>(realloc(extras_, sizeof(Extra) * capacity_));
+}
+
+}  // namespace remoting
+}  // namespace iree

--- a/experimental/remoting/iree/remoting/support/io_buffer.h
+++ b/experimental/remoting/iree/remoting/support/io_buffer.h
@@ -1,0 +1,418 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include "experimental/remoting/iree/remoting/support/platform.h"
+#include "iree/base/api.h"
+#include "iree/base/logging.h"
+
+#ifndef IREE_REMOTING_SUPPORT_IO_BUFFER_H_
+#define IREE_REMOTING_SUPPORT_IO_BUFFER_H_
+
+namespace iree {
+namespace remoting {
+
+class IoBuffer;
+class IoBufferPool;
+
+//===----------------------------------------------------------------------===//
+// IO Buffers
+//===----------------------------------------------------------------------===//
+
+// Buffer within a IoBufferPool.
+// The IoBuffer itself is a POD type that does not require destruction.
+// It is physically laid out with the actual buffer data trailing it:
+//
+//   - IoBuffer (sizeof IoBuffer)
+//   - padding to alignof(IoBuffer)
+//   - char buffer_data[buffer_size]
+//   - padding to alignof(IoBuffer)
+//
+// While the alignment is not strictly necessary around the data, it simplifies
+// size planning when placing consecutive buffers in an allocation.
+//
+// Channel buffers are reference counted, allowing the same physical backing
+// buffer to be lifetime extended across IO operations in various ways. Eac
+// IoBuffer::Ptr instance strongly holds on to one reference. Additional
+// references can be made by calling Dup().
+//
+// Thread safety: Not currently thread safe (including reference counting).
+class IoBuffer {
+  struct PoolDeleter {
+    void operator()(IoBuffer *buffer) {
+      if (--buffer->ref_count_ == 0) {
+        buffer->Recycle();
+      }
+    }
+  };
+
+ public:
+  using Ptr = std::unique_ptr<IoBuffer, PoolDeleter>;
+
+  size_t size() const;
+  void *data();
+  std::uint8_t *data_bytes() { return static_cast<std::uint8_t *>(data()); }
+
+  // Creates a new strong reference to the same backing data.
+  Ptr Dup() {
+    ref_count_ += 1;
+    return Ptr(this);
+  }
+
+ private:
+  IoBuffer(IoBufferPool *owner, IoBuffer *next) : next_(next), owner_(owner) {}
+  void Recycle();
+  int ref_count_ = 0;
+  IoBuffer *next_;
+  IoBufferPool *owner_;
+  friend class IoBufferPool;
+  friend class IoBufferVec;
+};
+
+static_assert(std::is_standard_layout<IoBuffer>::value,
+              "IoBuffer should be standard_layout");
+#if __cplusplus >= 201703L
+static_assert(std::is_trivially_destructible<IoBuffer>::value,
+              "IoBuffer should be trivially_destructible");
+#endif
+
+// A pool of same-sized buffers intended for use in processing IO streams.
+// Thread safety: Not currently thread safe (including reference counting).
+class IoBufferPool {
+ public:
+  static constexpr size_t kDefaultSlabBufferCount = 8;
+  IoBufferPool(size_t buffer_data_size,
+               size_t slab_buffer_count = kDefaultSlabBufferCount)
+      : buffer_data_size_(buffer_data_size),
+        slab_buffer_count_(slab_buffer_count) {
+    GrowBuffers();
+  }
+  ~IoBufferPool();
+
+  // Gets a IoBuffer from the free-list, extending it as necessary.
+  IoBuffer::Ptr Get() {
+    if (!head_) GrowBuffers();
+    IoBuffer *current = head_;
+    assert(current->ref_count_ == 0);
+    current->ref_count_ = 1;
+    head_ = current->next_;
+    return IoBuffer::Ptr(current);
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Memory layout
+  //===--------------------------------------------------------------------===//
+  size_t buffer_data_size() const { return buffer_data_size_; }
+
+  // The size in memory of a buffer, consisting of the IoBuffer struct,
+  // internal alignment, data buffer, and trailing alignment.
+  size_t buffer_physical_size() const {
+    constexpr size_t align = alignof(IoBuffer);
+    size_t accum = AlignTo(sizeof(IoBuffer), align);
+    accum += buffer_data_size();
+    accum = AlignTo(accum, align);
+    return accum;
+  }
+
+  // Byte offset relative to a IoBuffer pointer of the data.
+  static constexpr size_t buffer_data_offset() {
+    return AlignTo(sizeof(IoBuffer), alignof(IoBuffer));
+  }
+
+ private:
+  // Buffers are allocated in a contiguous slab of memory, which is tracked
+  // in a linked list for cleanup.
+  struct Slab {
+    ~Slab();
+    void *data;
+    std::unique_ptr<Slab> next;
+  };
+
+  // Aligns |value| up to the given power-of-two |alignment| if required.
+  // https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
+  static constexpr size_t AlignTo(size_t value, size_t alignment) {
+    return (value + (alignment - 1)) & ~(alignment - 1);
+  }
+
+  // Allocates a new slab.
+  void GrowBuffers();
+
+  size_t buffer_data_size_;
+  size_t slab_buffer_count_;
+
+  IoBuffer *head_ = nullptr;
+  std::unique_ptr<Slab> slab_head_;
+  friend class IoBuffer;
+};
+
+inline size_t IoBuffer::size() const { return owner_->buffer_data_size(); }
+inline void *IoBuffer::data() {
+  void *base = static_cast<void *>(this);
+  char *base_bytes = static_cast<char *>(base);
+  return static_cast<void *>(base_bytes + IoBufferPool::buffer_data_offset());
+}
+
+inline void IoBuffer::Recycle() {
+  IREE_DLOG(INFO) << "  - Recycle buffer to pool: "
+                  << static_cast<void *>(this);
+  next_ = owner_->head_;
+  owner_->head_ = this;
+}
+
+//===----------------------------------------------------------------------===//
+// IoBufferVec
+//===----------------------------------------------------------------------===//
+
+// A wrapper around platform-specific iovec-like structs (base pointer + len).
+// This also adds the capability to attach an owned IoBuffer to back each
+// entry. In this way, buffer references can ber carried across various
+// boundaries, and the references will be released when this instance is
+// cleared, destroyed or returned to its pool.
+class IoBufferVec {
+  struct PoolDeleter {
+    void operator()(IoBufferVec *v);
+  };
+
+ public:
+  class Pool;
+  using Ptr = std::unique_ptr<IoBufferVec, PoolDeleter>;
+
+  IoBufferVec() { link_.owner = nullptr; }
+  IoBufferVec(const IoBufferVec &) = delete;
+  IoBufferVec(const IoBufferVec &&) = delete;
+  IoBufferVec &operator=(const IoBufferVec &) = delete;
+  ~IoBufferVec();
+
+  // Clears all entries.
+  void clear();
+  void reserve(uint32_t capacity) { Grow(capacity); }
+  uint32_t size() const { return size_; }
+
+  // Flattens the first |len| bytes of this iovec into |dest|. If there are
+  // less than |len| bytes, the contents of |dest| are undefined.
+  void FlattenTo(void *dest, size_t len);
+
+  // Copies up to |total_bytes| from this IoBufferVec into |other|, consuming
+  // data from any entries available. Returns |bytes_transferred|
+  // indicating how many bytes were transferred to |other|.
+  int32_t TransferTo(IoBufferVec &other, int32_t max_bytes);
+
+  const portable_iovec_t *front() {
+    assert(size_ > 0 && "IoBufferVec is empty");
+    return entries_;
+  }
+
+  const portable_iovec_t *operator[](uint32_t index) {
+    assert(index < size_ && "IoBufferVec index out of bounds");
+    return entries_ + index;
+  }
+
+  // Direct access to the iov_base.
+  void *iov_base(uint32_t index) {
+    return IREE_REMOTING_IOVEC_BASE(*(*this)[index]);
+  }
+  uint8_t *iov_base_bytes(uint32_t index) {
+    return static_cast<uint8_t *>(iov_base(index));
+  }
+  // Direct access to the iov_len.
+  size_t iov_len(uint32_t index) {
+    return IREE_REMOTING_IOVEC_LEN(*(*this)[index]);
+  }
+
+  // Gets the total size of all iovec entries.
+  // Meant for debugging: This loops, so don't rely on it for hot path code
+  // unless intended.
+  size_t total_iov_len() {
+    size_t accum = 0;
+    for (uint32_t i = 0, e = size(); i < e; ++i) {
+      accum += iov_len(i);
+    }
+    return accum;
+  }
+
+  // Backing buffer for the |index|'th entry or nullptr if not backed by a
+  // buffer.
+  IoBuffer *buffer(uint32_t index) {
+    return extras_[index].backing_buffer.get();
+  }
+
+  // Adds an iovec entry for the given raw pointer/length pair, potentially
+  // backed by a buffer.
+  void add(void *base, size_t len, IoBuffer::Ptr buffer = IoBuffer::Ptr()) {
+    size_t index = size_;
+    size_ += 1;
+    if (size_ >= capacity_) Grow(0);
+    IREE_REMOTING_IOVEC_BASE(entries_[index]) =
+        IREE_REMOTING_IOVEC_FROM_PTR(base);
+    IREE_REMOTING_IOVEC_LEN(entries_[index]) = len;
+    new (extras_ + index) Extra();
+    extras_[index].backing_buffer = std::move(buffer);
+  }
+
+  // Appends the contents of |other| onto this one, duping buffers as needed.
+  void append(IoBufferVec &other) {
+    uint32_t this_size = size();
+    uint32_t other_size = other.size();
+    uint32_t new_size = this_size + other_size;
+    if (capacity_ < new_size) Grow(new_size);
+    std::memcpy(entries_ + this_size, other.entries_,
+                sizeof(entries_[0]) * other_size);
+    std::memcpy(extras_ + this_size, other.extras_,
+                sizeof(extras_[0]) * other_size);
+    for (uint32_t i = 0, e = other_size; i < e; ++i) {
+      IoBuffer *backing_buffer = other.buffer(i);
+      if (backing_buffer) backing_buffer->ref_count_ += 1;
+    }
+    size_ = new_size;
+  }
+
+ private:
+  // Note: Order of members is laid out to minimize the size.
+  union {
+    // If is_free_ == 1, then the instance is in the free-list and the next
+    // pointer refers to the next free instance in the list.
+    IoBufferVec *next;
+    // If is_free_ == 0, then the instance is in use and owned by the given
+    // pool (if owner != nullptr). If owner == nullptr in this case, the
+    // instance is not owned (normal allocation).
+    IoBufferVec::Pool *owner;
+  } link_;
+
+  // |capacity| sized contiguous array of portable_iovec_t, matching the
+  // platform specific struct for passing to vector IO routines.
+  portable_iovec_t *entries_ = nullptr;
+  // |capacity| sized array of extra information for each portable iovec
+  // entry. This is maintained separated because we want to preserve the
+  // exact binary, contiguous layout of the iovec structure themselves, since
+  // that can be passed losslessly to platform-specific kernel calls.
+  struct Extra {
+    IoBuffer::Ptr backing_buffer;
+  };
+  Extra *extras_ = nullptr;
+
+  // Grows the contents. Guaranteed to increase the capacity by at least 1
+  // and promote contents to a heap buffer. If |new_capacity| > 0, then sizes
+  // it to the maximum of the current capacity or the stated capacity.
+  void Grow(uint32_t new_capacity);
+
+  uint32_t capacity_ : 15 = 0;
+  uint32_t size_ : 15 = 0;
+  uint32_t is_free_ : 1 = 0;
+  uint32_t is_inline_ : 1 = 1;
+};
+
+// A pool of IoBufferVec, typically used in contexts where regular usage
+// patterns are expected to stabilize to a fixed set of instances, saving
+// continual re-allocation.
+class IoBufferVec::Pool {
+ public:
+  ~Pool();
+
+  // Gets a pooled IoBufferVec from the free-list, extending it as necessary.
+  IoBufferVec::Ptr Get() {
+    IoBufferVec *current = head_;
+    if (current) {
+      // From the free-list.
+      assert(current->is_free_);
+      assert(current->size_ == 0);
+      head_ = current->link_.next;
+      current->is_free_ = 0;
+      current->link_.owner = this;
+      return IoBufferVec::Ptr(current);
+    }
+
+    // Create new.
+    IREE_DLOG(INFO) << "Allocate new IoBufferVec (for pool)";
+    current = new IoBufferVec();
+    current->link_.owner = this;
+    assert(current->is_free_ == 0);
+    return IoBufferVec::Ptr(current);
+  }
+
+ private:
+  IoBufferVec *head_ = nullptr;
+  friend class IoBufferVec::PoolDeleter;
+};
+
+inline void IoBufferVec::PoolDeleter::operator()(IoBufferVec *v) {
+  v->clear();
+  assert(v->is_free_ == 0);
+  assert(v->link_.owner != nullptr);
+  // Note that owner and next are aliases in the link_ union. Order below
+  // matters.
+  IoBufferVec::Pool *owner = v->link_.owner;
+  v->is_free_ = 1;
+  v->link_.next = owner->head_;
+  owner->head_ = v;
+}
+
+inline void IoBufferVec::FlattenTo(void *dest, size_t len) {
+  for (uint32_t i = 0, e = size(); i < e; ++i) {
+    const void *src = iov_base(i);
+    size_t chunk_len = std::min(iov_len(i), len);
+    std::memcpy(dest, src, chunk_len);
+    len -= chunk_len;
+    if (chunk_len == 0) break;
+  }
+}
+
+inline int32_t IoBufferVec::TransferTo(IoBufferVec &other, int32_t max_bytes) {
+  // TODO: This function is doing too much and should be refactored/simplified.
+  assert(max_bytes >= 0);
+  int32_t remain = max_bytes;
+  int32_t retired_count = 0;
+  for (uint32_t i = 0, e = size(); i < e; ++i) {
+    if (remain == 0) break;
+    auto &cur_iov_base_ptr = IREE_REMOTING_IOVEC_BASE(entries_[i]);
+    auto &cur_iov_len = IREE_REMOTING_IOVEC_LEN(entries_[i]);
+    auto &cur_backing_buffer = extras_[i].backing_buffer;
+    int32_t consume_len = std::min(remain, static_cast<int32_t>(cur_iov_len));
+    IoBuffer::Ptr dupped_buffer =
+        cur_backing_buffer ? cur_backing_buffer->Dup() : IoBuffer::Ptr();
+    // Consume from a raw iovec.
+    other.add(iov_base(i), consume_len, std::move(dupped_buffer));
+    cur_iov_len -= consume_len;
+    cur_iov_base_ptr = IREE_REMOTING_IOVEC_FROM_PTR(
+        reinterpret_cast<uint8_t *>(cur_iov_base_ptr) + consume_len);
+    if (cur_iov_len == 0) {
+      cur_backing_buffer.reset();
+      retired_count += 1;
+    }
+    remain -= consume_len;
+  }
+
+  // Compact.
+  if (retired_count > 0) {
+    uint32_t new_size = size() - retired_count;
+    std::memmove(entries_, entries_ + retired_count,
+                 sizeof(entries_[0]) * new_size);
+    std::memmove(extras_, extras_ + retired_count,
+                 sizeof(extras_[0]) * new_size);
+    size_ = new_size;
+  }
+
+  return max_bytes - remain;
+}
+
+}  // namespace remoting
+}  // namespace iree
+
+#endif  // IREE_REMOTING_SUPPORT_IO_BUFFER_H_

--- a/experimental/remoting/iree/remoting/support/io_loop.cc
+++ b/experimental/remoting/iree/remoting/support/io_loop.cc
@@ -1,0 +1,64 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "experimental/remoting/iree/remoting/support/io_loop.h"
+
+#include "experimental/remoting/iree/remoting/support/linux_uring.h"
+#include "iree/base/logging.h"
+
+#if IREE_REMOTING_HAVE_URING
+#include "experimental/remoting/iree/remoting/support/io_loop_uring.cc.inc"
+#endif
+
+namespace iree {
+namespace remoting {
+
+//------------------------------------------------------------------------------
+// IoLoop
+//------------------------------------------------------------------------------
+
+iree_status_t IoLoop::Create(std::unique_ptr<IoLoop> &created) {
+#if IREE_REMOTING_HAVE_URING
+  {
+    iree_status_t status = UringImpl::TryCreateSpecific(created);
+    if (iree_status_is_ok(status)) {
+      IREE_DVLOG(1) << "Created uring IoLoop";
+      return status;
+    }
+    iree_status_ignore(status);
+  }
+
+  IREE_DLOG(WARNING) << "No compatible IoLoop provider found";
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+#endif
+}
+
+void IoLoop::SubmitGeneric(IoRequest *request) {
+  // Note that most real systems will have a single implementation (or at
+  // most a couple), and they do not vary for the lifetime. We therefore
+  // probe them in priority order, avoiding an indirect dispatch.
+  auto t = impl_type_;
+#if IREE_REMOTING_HAVE_URING
+  if (t == ImplType::kUring) {
+    static_cast<UringImpl *>(this)->SubmitSpecific(request);
+    return;
+  }
+#endif
+
+  IREE_CHECK(false) << "SubmitGeneric unmatched ImplType: "
+                    << static_cast<int>(t);
+}
+
+}  // namespace remoting
+}  // namespace iree

--- a/experimental/remoting/iree/remoting/support/io_loop.h
+++ b/experimental/remoting/iree/remoting/support/io_loop.h
@@ -1,0 +1,388 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_REMOTING_SUPPORT_IO_LOOP_H_
+#define IREE_REMOTING_SUPPORT_IO_LOOP_H_
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include "experimental/remoting/iree/remoting/support/io_buffer.h"
+#include "experimental/remoting/iree/remoting/support/socket.h"
+#include "iree/base/api.h"
+
+namespace iree {
+namespace remoting {
+
+class IoLoop;
+class IoRequest;
+
+// Base class for IO requests.
+class IoRequest {
+ public:
+  enum class Type {
+    kAccept,
+    kSocketShutdown,
+    kSocketClose,
+    kSocketConnect,
+    // TODO: Split this in to kSocketVecWrite, kSocketVecRead and kSocketRecv.
+    kSocketVec,
+  };
+  using CompletionHandlerTy = void (*)(IoRequest *request,
+                                       void *completion_data);
+  IoRequest(Type type) : type_(type) {}
+  ~IoRequest() { ClearStatus(); }
+  Type type() const { return type_; }
+  IoLoop *io_loop() { return io_loop_; }
+
+  template <typename RequestTy>
+  struct Deleter {
+    void operator()(RequestTy *request) {
+      request->template Release<RequestTy>();
+    }
+  };
+
+  // Sets the untyped completion handler (also can be set in the constructor).
+  void SetCompletionHandler(void *completion_data,
+                            CompletionHandlerTy handler) {
+    completion_handler_ = handler;
+    completion_data_ = completion_data;
+  }
+
+  // Triggers the completion handler. Intended to be called by IoLoop
+  // implementations.
+  void HandleCompletion() {
+    if (completion_handler_) completion_handler_(this, completion_data_);
+  }
+
+  // Status handling.
+  bool ok() { return iree_status_is_ok(status_); }
+  // Consumes the status from the request, resetting it to ok and returning
+  // the prior. Caller now has responsibility for handling status.
+  iree_status_t ConsumeStatus() {
+    iree_status_t ret_status = status_;
+    status_ = iree_ok_status();
+    return ret_status;
+  }
+  // Clears any status that this request contains.
+  void ClearStatus() {
+    if (IREE_UNLIKELY(!iree_status_is_ok(status_))) {
+      status_ = iree_status_ignore(status_);
+    }
+  }
+  // Sets a new status on the request. Request takes ownership of the status.
+  void set_status(iree_status_t status) {
+    ClearStatus();
+    status_ = status;
+  }
+
+ protected:
+  void Retain() { ref_count_ += 1; }
+  template <typename RequestTy>
+  void Release();
+
+ private:
+  int ref_count_ = 1;
+  Type type_;
+  IoLoop *io_loop_ = nullptr;
+  // Because the completion handler is type erased and provided by the derived
+  // class, it is necessary that upon construction, an appropriate function
+  // pointer be installed to signal completion.
+  CompletionHandlerTy completion_handler_ = nullptr;
+  void *completion_data_ = nullptr;
+  iree_status_t status_ = iree_ok_status();
+
+  friend class IoLoop;
+};
+
+// A pointer to an IoRequest which delegates deletion to the IoLoop.
+template <typename T>
+using IoRequestPtr = std::unique_ptr<T, IoRequest::Deleter<T>>;
+
+// An IO event loop designed to be backed by queue-based kernel IO interfaces
+// (and emulated elsewhere).
+class IoLoop {
+ public:
+  enum class ImplType {
+    kUring,
+  };
+  virtual ~IoLoop() = default;
+
+  // The type of the implementation.
+  ImplType impl_type() const { return impl_type_; }
+
+  // Creates an IoLoop appropriate for this platform and features available.
+  static iree_status_t Create(std::unique_ptr<IoLoop> &created);
+
+  // Runs the IoLoop until drained.
+  using KeepRunningPredicate = std::function<bool()>;
+  virtual void Run(KeepRunningPredicate keep_running_predicate = nullptr) = 0;
+
+  // Custom allocator for IoRequests.
+  // TODO: Have a non-heap allocator.
+  template <typename RequestTy, typename... Args>
+  IoRequestPtr<RequestTy> NewRequest(Args &&... args) {
+    static_assert(std::is_convertible<RequestTy *, IoRequest *>::value,
+                  "Request must be a subclass of IoRequest");
+    RequestTy *request = AllocateRequest<RequestTy>();
+    new (request) RequestTy(std::forward<Args>(args)...);
+    request->io_loop_ = this;
+    return IoRequestPtr<RequestTy>(request);
+  }
+
+  // Submits a request. This will always result in the request's callback being
+  // invoked at a later date (not within the scope of this call).
+  template <typename RequestTy>
+  void Submit(IoRequestPtr<RequestTy> request) {
+    SubmitGeneric(request.release());
+  }
+
+  // Combines NewRequest and Submit into one call.
+  template <typename RequestTy, typename... Args>
+  void SubmitNew(Args &&... args) {
+    Submit(NewRequest<RequestTy>(std::forward<Args>(args)...));
+  }
+
+ protected:
+  int &inflight_count() { return inflight_count_; }
+
+ private:
+  // Forward-declare implementation types.
+  class UringImpl;
+
+  ImplType impl_type_;
+
+  // Number of requests in flight.
+  int inflight_count_ = 0;
+
+  // Initializes the loop with implementation specific information including:
+  //   - impl_type: The implementation type (closed hierarchy)
+  IoLoop(ImplType impl_type) : impl_type_(impl_type) {}
+
+  // Allocates uninitialized storage for the given request.
+  // TODO: Have a non-heap allocator.
+  template <typename RequestTy>
+  RequestTy *AllocateRequest() {
+    return static_cast<RequestTy *>(::operator new(sizeof(RequestTy)));
+  }
+
+  // Frees storage for a request pointer
+  // TODO: Have a non-heap allocator.
+  void FreeRequest(void *request) { ::operator delete(request); }
+
+  // Submits a request as a raw pointer, transferring ownership to this
+  // function. Eventually, request->HandleComplete() must be called.
+  void SubmitGeneric(IoRequest *request);
+
+  friend class IoRequest;
+};
+
+template <typename RequestTy>
+inline void IoRequest::Release() {
+  if (--ref_count_ == 0) {
+    RequestTy *typed_this = static_cast<RequestTy *>(this);
+    IoLoop *local_loop = this->io_loop();
+    typed_this->~RequestTy();
+    local_loop->FreeRequest(typed_this);
+  }
+}
+
+//------------------------------------------------------------------------------
+// Specific IO request types.
+//------------------------------------------------------------------------------
+
+// CRTP base class for derived IoRequest classes, implementing additional
+// mechanics.
+template <typename DerivedTy>
+class DerivedIoRequest : public IoRequest {
+ public:
+  // TODO: Unify the type-erased fp callback type with this std::function
+  // based one.
+  using CallbackTy = std::function<void(IoRequestPtr<DerivedTy> request)>;
+
+  DerivedIoRequest(Type type, CallbackTy on_complete = nullptr)
+      : IoRequest(type), on_complete_(std::move(on_complete)) {
+    if (on_complete_) {
+      SetCompletionHandler(nullptr,
+                           &DerivedIoRequest::DerivedCompletionHandler);
+    }
+  }
+
+ protected:
+  CallbackTy on_complete_;
+
+  static void DerivedCompletionHandler(IoRequest *base_request,
+                                       void *unused_data) {
+    // The completion handler always owns the IoRequest, so promote it back
+    // into a smart pointer. If there is a user level on_complete callback,
+    // it will be transferred there, and that code will decide whether it
+    // lives or dies.
+    DerivedTy *derived_request = static_cast<DerivedTy *>(base_request);
+    IoRequestPtr<DerivedTy> owned_request(derived_request);
+
+    if (derived_request->on_complete_) {
+      // Make sure the request survives for the duration of the callback,
+      // even if the callback drops the unique_ptr on the floor.
+      derived_request->Retain();
+      derived_request->on_complete_(std::move(owned_request));
+      derived_request->template Release<DerivedTy>();
+    }
+  }
+
+  friend class IoLoop;
+};
+
+// An IO request to accept a connection from a socket.
+class IoAcceptRequest final : public DerivedIoRequest<IoAcceptRequest> {
+ public:
+  using Ptr = IoRequestPtr<IoAcceptRequest>;
+  IoAcceptRequest(socket_t listen_fd, CallbackTy on_complete = nullptr)
+      : DerivedIoRequest(Type::kAccept, std::move(on_complete)),
+        listen_fd_(listen_fd) {}
+
+  socket_t listen_fd() { return listen_fd_; }
+  struct sockaddr_storage &client_addr() {
+    return client_addr_;
+  }
+  socklen_t &client_addr_size() { return client_addr_size_; }
+  socket_t &client_fd() { return client_fd_; }
+
+ private:
+  socket_t listen_fd_;
+  struct sockaddr_storage client_addr_;
+  socklen_t client_addr_size_ = sizeof(struct sockaddr_storage);
+  socket_t client_fd_ = -1;
+};
+
+// Closes a socket. This is separate from close() because on Windows, the two
+// are distinct.
+class IoCloseSocketRequest final
+    : public DerivedIoRequest<IoCloseSocketRequest> {
+ public:
+  using Ptr = IoRequestPtr<IoCloseSocketRequest>;
+  IoCloseSocketRequest(socket_t fd, CallbackTy on_complete = nullptr)
+      : DerivedIoRequest(Type::kSocketClose, std::move(on_complete)), fd_(fd) {}
+
+  socket_t &fd() { return fd_; }
+
+ private:
+  socket_t fd_;
+};
+
+// Connects a socket.
+class IoConnectSocketRequest final
+    : public DerivedIoRequest<IoConnectSocketRequest> {
+ public:
+  using Ptr = IoRequestPtr<IoConnectSocketRequest>;
+  IoConnectSocketRequest(socket_t fd, SocketAddress addr,
+                         CallbackTy on_complete = nullptr)
+      : DerivedIoRequest(Type::kSocketConnect, std::move(on_complete)),
+        fd_(fd),
+        addr_(addr) {}
+
+  socket_t &fd() { return fd_; }
+  SocketAddress &addr() { return addr_; }
+
+ private:
+  socket_t fd_;
+  SocketAddress addr_;
+};
+
+class IoSocketShutdownRequest final
+    : public DerivedIoRequest<IoSocketShutdownRequest> {
+ public:
+  using Ptr = IoRequestPtr<IoSocketShutdownRequest>;
+  IoSocketShutdownRequest(socket_t fd, int how = SHUT_WR,
+                          CallbackTy on_complete = nullptr)
+      : DerivedIoRequest(Type::kSocketShutdown, std::move(on_complete)),
+        fd_(fd),
+        how_(how) {}
+
+  socket_t &fd() { return fd_; }
+  int &how() { return how_; }
+
+ private:
+  socket_t fd_;
+  int how_;
+};
+
+// Vectored socket read or write request.
+// Note that this is mainly useful for write as the behavior on read is somewhat
+// under-documented and platform dependent (i.e. it can differ based on whether
+// the underylying syscall blocks to attempt to read the full vector or
+// returns when some data is available).
+class IoSocketVecRequest final : public DerivedIoRequest<IoSocketVecRequest> {
+ public:
+  class Flags {
+   public:
+    bool is_write() { return is_write_; }
+    bool use_readv() { return use_readv_; }
+
+   private:
+    Flags() = default;
+    bool is_write_ : 1 = false;
+    bool use_readv_ : 1 = false;
+    friend class IoSocketVecRequest;
+  };
+
+  static Flags ForWrite() {
+    Flags flags;
+    flags.is_write_ = true;
+    flags.use_readv_ = false;
+    return flags;
+  }
+
+  static Flags ForReadV() {
+    Flags flags;
+    flags.is_write_ = false;
+    flags.use_readv_ = true;
+    return flags;
+  }
+
+  static Flags ForRecv() {
+    Flags flags;
+    flags.is_write_ = false;
+    flags.use_readv_ = false;
+    return flags;
+  }
+
+  using Ptr = IoRequestPtr<IoSocketVecRequest>;
+  IoSocketVecRequest(Flags flags, socket_t fd, IoBufferVec::Ptr iovec,
+                     CallbackTy on_complete = nullptr)
+      : DerivedIoRequest(Type::kSocketVec, std::move(on_complete)),
+        iovec_(std::move(iovec)),
+        fd_(fd),
+        flags_(flags) {
+    if (flags_.is_write()) {
+      assert(flags_.use_readv() || iovec_->size() == 1);
+    }
+  }
+  Flags flags() { return flags_; }
+
+  IoBufferVec::Ptr &iovec() { return iovec_; }
+  socket_t &fd() { return fd_; }
+  size_t &complete_bytes() { return complete_bytes_; }
+
+ private:
+  IoBufferVec::Ptr iovec_;
+  socket_t fd_;
+  size_t complete_bytes_;
+  Flags flags_;
+};
+
+}  // namespace remoting
+}  // namespace iree
+
+#endif  // IREE_REMOTING_SUPPORT_IO_LOOP_H_

--- a/experimental/remoting/iree/remoting/support/io_loop_uring.cc.inc
+++ b/experimental/remoting/iree/remoting/support/io_loop_uring.cc.inc
@@ -1,0 +1,227 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace iree {
+namespace remoting {
+
+class IoLoop::UringImpl : public IoLoop {
+ public:
+  static constexpr unsigned kQueueEntries = 16;
+  UringImpl() : IoLoop(ImplType::kUring) { memset(&params, 0, sizeof(params)); }
+  ~UringImpl() override {
+    if (alloced) {
+      io_uring_queue_exit(&ring);
+    }
+  }
+
+  static iree_status_t TryCreateSpecific(std::unique_ptr<IoLoop> &created) {
+    auto self = std::make_unique<UringImpl>();
+    if (io_uring_queue_init_params(kQueueEntries, &self->ring, &self->params) <
+        0) {
+      return StatusFromErrno("io_uring_queue_init_params failed", errno);
+    }
+    self->alloced = true;
+
+    if ((self->params.features & IORING_FEAT_FAST_POLL)) {
+      self->has_fast_poll = true;
+    } else {
+      IREE_DVLOG(1)
+          << "IORING_FEAT_FAST_POLL not available (needs kernel>=5.6)";
+    }
+
+    // Children should not inherit the ring.
+    io_uring_ring_dontfork(&self->ring);
+
+    created = std::move(self);
+    return iree_ok_status();
+  }
+
+  void SubmitSpecific(IoRequest *request) {
+    IREE_DCHECK(request != nullptr) << "Cannot submit null IoRequest";
+    struct io_uring_sqe *sqe = io_uring_get_sqe(&ring);
+    // TODO: Something better?
+    IREE_CHECK(sqe != nullptr) << "Insufficient uring queue entries";
+    IREE_DVLOG(1) << "queueing request type "
+                  << static_cast<int>(request->type()) << " onto ring";
+    inflight_count() += 1;
+    PrepareRequest(request, sqe);
+    io_uring_sqe_set_flags(sqe, 0);
+    memcpy(&sqe->user_data, &request, sizeof(IoRequest *));
+
+    // TODO: There are a lot of ways to optimize syscall count here so that
+    // number of Submit() < number of syscalls.
+    int count = io_uring_submit(&ring);
+    IREE_DVLOG(1) << "io_uring_submit: count=" << count;
+  }
+
+  void Run(KeepRunningPredicate keep_running_predicate) override {
+    while (inflight_count() > 0) {
+      bool should_block =
+          keep_running_predicate ? keep_running_predicate() : true;
+      // Process completions.
+      struct io_uring_cqe *cqe;
+
+      int wait_count = should_block ? 1 : 0;
+      IREE_DVLOG(1) << "io_uring_wait_cqe_nr(): inflight=" << inflight_count()
+                    << ", nr=" << wait_count;
+      int rc = io_uring_wait_cqe_nr(&ring, &cqe, wait_count);
+      IREE_DVLOG(1) << "returned io_uring_wait_cqe_nr(): rc=" << rc;
+      if (rc == -EAGAIN) {
+        assert(!should_block && "got EAGAIN on blocking operation");
+        return;
+      }
+      IREE_CHECK(rc == 0);  // TODO: Better error handling.
+
+      unsigned head;
+      unsigned count = 0;
+      io_uring_for_each_cqe(&ring, head, cqe) {
+        ++count;
+        IoRequest *request;
+        memcpy(&request, &cqe->user_data, sizeof(IoRequest *));
+        IREE_DCHECK(request != nullptr)
+            << "IoRequest in io_uring_cqe userdata is null";
+        FillCompletedRequest(request, cqe);
+        request->HandleCompletion();
+        inflight_count() -= 1;
+      }
+      io_uring_cq_advance(&ring, count);
+    }
+  }
+
+  void PrepareRequest(IoRequest *request, struct io_uring_sqe *sqe) {
+    using Type = IoRequest::Type;
+    auto t = request->type();
+    switch (t) {
+      case Type::kAccept: {
+        auto *accept = static_cast<IoAcceptRequest *>(request);
+        io_uring_prep_accept(
+            sqe, accept->listen_fd(),
+            reinterpret_cast<struct sockaddr *>(&accept->client_addr()),
+            &accept->client_addr_size(), /*flags=*/0);
+        return;
+      }
+      case Type::kSocketClose: {
+        auto *close = static_cast<IoCloseSocketRequest *>(request);
+        io_uring_prep_close(sqe, close->fd());
+        return;
+      }
+      case Type::kSocketConnect: {
+        auto *connect = static_cast<IoConnectSocketRequest *>(request);
+        io_uring_prep_connect(sqe, connect->fd(), connect->addr().sockaddr(),
+                              connect->addr().addr_len());
+        return;
+      }
+      case Type::kSocketShutdown: {
+        auto *shutdown_req = static_cast<IoSocketShutdownRequest *>(request);
+        io_uring_prep_shutdown(sqe, shutdown_req->fd(), shutdown_req->how());
+        return;
+      }
+      case Type::kSocketVec: {
+        auto *socket_vec = static_cast<IoSocketVecRequest *>(request);
+        if (socket_vec->flags().is_write()) {
+          io_uring_prep_writev(sqe, socket_vec->fd(),
+                               socket_vec->iovec()->front(),
+                               socket_vec->iovec()->size(), /*offset=*/0);
+        } else {
+          if (socket_vec->flags().use_readv()) {
+            io_uring_prep_readv(sqe, socket_vec->fd(),
+                                socket_vec->iovec()->front(),
+                                socket_vec->iovec()->size(), /*offset=*/0);
+          } else {
+            void *buf = socket_vec->iovec()->iov_base(0);
+            size_t len = socket_vec->iovec()->iov_len(0);
+            io_uring_prep_recv(sqe, socket_vec->fd(), buf, len, /*flags=*/0);
+          }
+        }
+        return;
+      }
+      default:
+        IREE_CHECK(false) << "Unhandled Uring IoRequest::Type "
+                          << static_cast<int>(t);
+    }
+  }
+
+  void FillCompletedRequest(IoRequest *request, struct io_uring_cqe *cqe) {
+    int result = cqe->res;
+    if (result < 0) {
+      request->set_status(StatusFromErrno("syscall failed", -result));
+    } else {
+      request->ClearStatus();
+    }
+
+    using Type = IoRequest::Type;
+    auto t = request->type();
+    switch (t) {
+      case Type::kAccept: {
+        auto *accept = static_cast<IoAcceptRequest *>(request);
+        accept->client_fd() = result;
+        return;
+      }
+      case Type::kSocketClose: {
+        return;
+      }
+      case Type::kSocketConnect: {
+        return;
+      }
+      case Type::kSocketShutdown: {
+        if (result == -EINVAL) {
+          // Support for the shutdown op was recent. If not supported, just
+          // use the blocking version.
+          auto *shutdown_req = static_cast<IoSocketShutdownRequest *>(request);
+          IREE_DVLOG(1) << "Kernel does not support IORING_OP_SHUTDOWN: "
+                           "calling blocking version";
+          int rc = ::shutdown(shutdown_req->fd(), shutdown_req->how());
+          if (rc == 0) {
+            request->ClearStatus();
+          }
+        }
+        return;
+      }
+      case Type::kSocketVec: {
+        auto *socket_vec = static_cast<IoSocketVecRequest *>(request);
+        socket_vec->complete_bytes() = result >= 0 ? result : 0;
+        return;
+      }
+    }
+    IREE_CHECK(false) << "Unhandled Uring IoRequest::Type "
+                      << static_cast<int>(t);
+  }
+
+ private:
+  static iree_status_t StatusFromErrno(const char *message,
+                                       int explicit_errno) {
+    char msg_buf[128];
+    msg_buf[0] = 0;
+    char *actual_msg_buf;
+    auto code = iree_status_code_from_errno(explicit_errno);
+#ifdef _GNU_SOURCE
+    actual_msg_buf = strerror_r(explicit_errno, msg_buf, sizeof(msg_buf));
+#else
+    actual_msg_buf = msg_buf;
+    strerror_r(current_errno, msg_buf, sizeof(msg_buf))
+#endif
+    IREE_DLOG(WARNING) << message << ": " << actual_msg_buf;
+    return iree_make_status(code, "%s: %s", message, actual_msg_buf);
+  }
+
+  struct io_uring ring;
+  struct io_uring_params params;
+  bool alloced : 1 = false;
+  bool has_fast_poll : 1 = false;
+
+  friend class IoLoop;
+};
+
+}  // namespace remoting
+}  // namespace iree

--- a/experimental/remoting/iree/remoting/support/linux_uring.h
+++ b/experimental/remoting/iree/remoting/support/linux_uring.h
@@ -1,0 +1,20 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Wrapper around libiouring which can be included, even on systems that do not
+// support it.
+
+#if IREE_REMOTING_HAVE_URING
+#include <liburing.h>
+#endif

--- a/experimental/remoting/iree/remoting/support/platform.h
+++ b/experimental/remoting/iree/remoting/support/platform.h
@@ -1,0 +1,60 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_REMOTING_SUPPORT_PLATFORM_H_
+#define IREE_REMOTING_SUPPORT_PLATFORM_H_
+
+#if defined(_WIN64) || defined(_WIN32)
+// Winsock.
+#define IREE_REMOTING_IS_WINSOCK 1
+#include <Winerror.h>
+#include <winsock2.h>
+#else
+// Normal berkeley sockets.
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netinet/in.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+#endif
+
+// Socket type and constant mapping.
+#if IREE_REMOTING_IS_WINSOCK
+// Winsock.
+using socket_t = SOCKET;
+static constexpr SOCKET invalid_socket = INVALID_SOCKET;
+static constexpr int socket_error = SOCKET_ERROR;
+
+// struct iovec is WSABUF on windows. Note that the |buf| member is a CHAR*.
+// note that this is only compatible with Winsock. Scatter/gather file
+// operations on Windows use a completely different (and weirder) API.
+using portable_iovec_t = WSABUF;
+#define IREE_REMOTING_IOVEC_BASE(iov) (iov).buf
+#define IREE_REMOTING_IOVEC_LEN(iov) (iov).len
+#define IREE_REMOTING_IOVEC_FROM_PTR(ptr) reinterpret_cast<CHAR *>(ptr)
+#else
+// Sockets are just file descriptors.
+using socket_t = int;
+static constexpr int invalid_socket = -1;
+static constexpr int socket_error = -1;
+
+// struct iovec is just iovec.
+using portable_iovec_t = struct iovec;
+#define IREE_REMOTING_IOVEC_BASE(iov) (iov).iov_base
+#define IREE_REMOTING_IOVEC_LEN(iov) (iov).iov_len
+#define IREE_REMOTING_IOVEC_FROM_PTR(ptr) static_cast<void *>(ptr)
+#endif
+
+#endif  // IREE_REMOTING_SUPPORT_PLATFORM_H_

--- a/experimental/remoting/iree/remoting/support/socket.cc
+++ b/experimental/remoting/iree/remoting/support/socket.cc
@@ -1,0 +1,155 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "experimental/remoting/iree/remoting/support/socket.h"
+
+#include "iree/base/logging.h"  // TODO: Needed for IREE_CHECK_OK
+
+namespace iree {
+namespace remoting {
+
+iree_status_t SocketErrorToStatus(const char* message) {
+  iree_status_code_t code;
+#if IREE_REMOTING_IS_WINSOCK
+  code = iree_status_code_from_win32_error(WSAGetLastError());
+#else
+  code = iree_status_code_from_errno(errno);
+#endif
+  return iree_make_status(code, message);
+}
+
+SocketAddress::SocketAddress(sa_family_t family) : SocketAddress() {
+  switch (family) {
+    case AF_INET6:
+      addr_.s6.sin6_family = family;
+      addr_len_ = sizeof(addr_.s6);
+      break;
+    case AF_INET:
+      addr_.s4.sin_family = family;
+      addr_len_ = sizeof(addr_.s4);
+      break;
+    default:
+      IREE_LOG(ERROR) << "Unsupported sa_family_t = "
+                      << static_cast<unsigned>(family);
+  }
+}
+
+SocketAddress SocketAddress::AnyInet(in_port_t port, bool force_ipv4) {
+  SocketAddress sa(force_ipv4 ? AF_INET : AF_INET6);
+  if (force_ipv4) {
+    sa.addr().s4.sin_addr.s_addr = INADDR_ANY;
+    sa.addr().s4.sin_port = htons(port);
+  } else {
+    sa.addr().s6.sin6_addr = in6addr_any;
+    sa.addr().s6.sin6_port = htons(port);
+  }
+  return sa;
+}
+
+SocketAddress SocketAddress::ParseInet(const std::string& ip_text,
+                                       in_port_t port, bool force_ipv4) {
+  // Try to parse as IPV6.
+  if (!force_ipv4) {
+    SocketAddress sa(AF_INET6);
+    if (inet_pton(AF_INET6, ip_text.c_str(), &sa.addr().s6.sin6_addr)) {
+      sa.addr().s6.sin6_port = htons(port);
+      return sa;
+    }
+  }
+
+  // Fallback to try IPV4.
+  {
+    SocketAddress sa(AF_INET);
+    if (inet_pton(AF_INET, ip_text.c_str(), &sa.addr().s4.sin_addr)) {
+      sa.addr().s4.sin_port = htons(port);
+      return sa;
+    }
+  }
+
+  return SocketAddress();  // Invalid
+}
+
+std::string SocketAddress::inet_addr_str() const {
+  if (!is_inet()) return std::string();
+  auto f = family();
+  std::string s;
+  if (f == AF_INET6) {
+    s.resize(INET6_ADDRSTRLEN);
+    if (!inet_ntop(f, &addr_.s6.sin6_addr, &s.front(), s.size())) {
+      s.clear();
+    }
+  } else {
+    s.resize(INET_ADDRSTRLEN);
+    if (!inet_ntop(f, &addr_.s4.sin_addr.s_addr, &s.front(), s.size())) {
+      s.clear();
+    }
+  }
+  // inet_ntop writes a null terminated string, so resize to the actual.
+  s.resize(strlen(s.data()));
+  return s;
+}
+
+iree_status_t Socket::Initialize(int domain, int type, int protocol) {
+  if (is_valid()) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "Initialize must be called on an uninitialized socket");
+  }
+  fd_ = socket(domain, type, protocol);
+  if (!is_valid()) {
+    return SocketErrorToStatus("could not create socket");
+  }
+  return iree_ok_status();
+}
+
+iree_status_t Socket::BindAndListen(const SocketAddress& addr,
+                                    const BindAndListenOptions& options) {
+  const int val = 1;
+  if (setsockopt(fd(), SOL_SOCKET, SO_REUSEADDR, &val, sizeof(val)) ==
+      socket_error) {
+    return SocketErrorToStatus("could not set SO_REUSEADDR socket option");
+  }
+
+  // Bind and listen.
+  if (bind(fd(), addr.sockaddr(), addr.addr_len()) == socket_error) {
+    return SocketErrorToStatus("could not bind socket to address");
+  }
+  if (listen(fd(), options.backlog) == socket_error) {
+    return SocketErrorToStatus("could not listen on socket");
+  }
+
+  return iree_ok_status();
+}
+
+iree_status_t Socket::Close() {
+  if (fd_ == invalid_socket) {
+    return iree_ok_status();
+  }
+#if IREE_REMOTING_IS_WINSOCK
+  int rc = ::closesocket(fd_);
+#else
+  int rc = ::close(fd_);
+#endif
+  if (rc == socket_error) {
+    return SocketErrorToStatus("could not close socket");
+  }
+
+  fd_ = invalid_socket;
+  return iree_ok_status();
+}
+
+void Socket::CloseOrDie() { IREE_CHECK_OK(Close()); }
+
+}  // namespace remoting
+}  // namespace iree

--- a/experimental/remoting/iree/remoting/support/socket.h
+++ b/experimental/remoting/iree/remoting/support/socket.h
@@ -1,0 +1,145 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef IREE_REMOTING_SUPPORT_SOCKET_H_
+#define IREE_REMOTING_SUPPORT_SOCKET_H_
+
+#include <string>
+
+#include "experimental/remoting/iree/remoting/support/platform.h"
+#include "iree/base/api.h"
+
+namespace iree {
+namespace remoting {
+
+// Converts the result of the last socket error to a status in a platform
+// specific way.
+iree_status_t SocketErrorToStatus(const char *prefix);
+
+class SocketAddress {
+ public:
+  union Addr {
+    struct sockaddr sa;
+    struct sockaddr_in s4;
+    struct sockaddr_in6 s6;
+    struct sockaddr_storage ss;
+  };
+  SocketAddress() : addr_len_(0) { memset(&addr_, 0, sizeof(addr_)); }
+  SocketAddress(sa_family_t family);
+
+  // Whether the SocketAddress is valid.
+  bool is_valid() const { return family() != 0 && addr_len_ != 0; }
+
+  Addr &addr() { return addr_; }
+  const Addr &addr() const { return addr_; }
+  socklen_t &addr_len() { return addr_len_; }
+  const socklen_t &addr_len() const { return addr_len_; }
+
+  // Pointer to the generic sockaddr struct.
+  struct sockaddr *sockaddr() {
+    return &addr_.sa;
+  }
+  const struct sockaddr *sockaddr() const { return &addr_.sa; }
+  sa_family_t family() const { return addr_.sa.sa_family; }
+
+  // ---------------------------------------------------------------------------
+  // Accessors for INET family addresses. In general, these are generic for
+  // IPV4 and IPV6 unless noted.
+  // ---------------------------------------------------------------------------
+  // Initializes to an AF_INET or AF_INET6 any address on port.
+  // Optionally forces IPV4.
+  static SocketAddress AnyInet(in_port_t port, bool force_ipv4 = false);
+
+  // Initializes to an AF_INET or AF_INET6 from a textual form. The returned
+  // SocketAddress will be !is_valid() if parsing is not successful.
+  static SocketAddress ParseInet(const std::string &ip_text, in_port_t port,
+                                 bool force_ipv4 = false);
+
+  // Whether this is an INET family address.
+  bool is_inet() const {
+    auto f = family();
+    return f == AF_INET || f == AF_INET6;
+  }
+
+  // Returns the INET family port or -1 if not an INET address.
+  int inet_port() const {
+    if (!is_inet()) return -1;
+    auto f = family();
+    return ntohs(f == AF_INET6 ? addr_.s6.sin6_port : addr_.s4.sin_port);
+  }
+
+  // Returns the INET address as a string or the empty string if not an INET
+  // address.
+  std::string inet_addr_str() const;
+
+ private:
+  Addr addr_;
+  socklen_t addr_len_;
+};
+
+// Simple wrapper around a movable file descriptor for a socket with helpers
+// for common setup operations.
+class Socket {
+ public:
+  Socket() : fd_(invalid_socket) {}
+  Socket(socket_t fd) : fd_(fd) {}
+  Socket(const Socket &) = delete;
+  Socket(Socket &&other) : fd_(other.fd_) { other.fd_ = invalid_socket; }
+  Socket &operator=(const Socket &other) = delete;
+
+  ~Socket() { CloseOrDie(); }
+
+  // Initializes the socket for the given domain, type and protocol. See the
+  // BSD socket() function for documentation.
+  iree_status_t Initialize(int domain, int type, int protocol);
+
+  // One-stop mechanism to create a socket, bind and listen.
+  // The socket must not be is_valid().
+  struct BindAndListenOptions {
+    int backlog = 128;
+  };
+  iree_status_t BindAndListen(const SocketAddress &addr,
+                              const BindAndListenOptions &options);
+  iree_status_t BindAndListen(const SocketAddress &addr) {
+    BindAndListenOptions options;
+    return BindAndListen(addr, options);
+  }
+
+  // Whether the file descriptor is a valid handle.
+  bool is_valid() { return fd_ != invalid_socket; }
+
+  // Gets the file descriptor.
+  socket_t fd() { return fd_; }
+
+  // Gets the file descriptor, releasing this instance's ownership of it.
+  socket_t release_fd() {
+    socket_t ret = fd_;
+    fd_ = invalid_socket;
+    return ret;
+  }
+
+  // Closes the socket in a platform neutral way.
+  iree_status_t Close();
+
+  // Closes the socket, dieing if there is an error.
+  void CloseOrDie();
+
+ private:
+  socket_t fd_;
+};
+
+}  // namespace remoting
+}  // namespace iree
+
+#endif  // IREE_REMOTING_SUPPORT_SOCKET_H_

--- a/iree/base/flatcc.h
+++ b/iree/base/flatcc.h
@@ -1,4 +1,4 @@
-#// Copyright 2020 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Async IO support library, currently implemented against io_uring on Linux, since that is the lowest cost abstraction and we can adapt the rest as needed (support/ dir).
* Start of a flatbuffer schema to define the remoting protocol for the HAL, etc (schemas/).
* Stream, transport and message level abstractions for implementing the remoting protocol (protocol_v1/).
* Really simple client stub for the HAL (protocol_v1/hal_stub.h). Need to extend the facilities to support routing salient response messages to the stub and then most of the work is filling out this layer.
* Some simple POC binaries for test client and server (simple/).
* Tested client and server on Linux 5.10.1 kernel with ASAN, but otherwise, real testing requires some more facilities in place.