### PR TITLE
Use backward buffer allocation in HLOToLinalgOnBuffers

### DIFF
--- a/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
+++ b/iree/compiler/Conversion/HLOToLinalg/HLOToLinalgOnBuffers.cpp
@@ -197,6 +197,9 @@ struct ConvertToLinalgBufferOp : public OpConversionPattern<SrcOpTy> {
     resultBuffers.reserve(op->getNumResults());
     for (auto result : llvm::enumerate(op->getResults())) {
       Value resultBuffer = resultTensorToBufferMap.lookup(result.value());
+      // TODO(hanchung): Remove the buffer allocation once every lowering moves
+      // to tensors world. The current logic only works for linalg::LinalgOp, so
+      // we still need to allocate buffers for some ops, e.g., mhlo.conv, etc.
       if (!resultBuffer) {
         if (auto shapedType = result.value().getType().dyn_cast<ShapedType>()) {
           if (shapedType.hasStaticShape()) {
@@ -1323,7 +1326,31 @@ struct HALInterfaceStoreTensorOpEraser final
 /// property of the buffer. The map `resultTensorToBufferMap` is updated to
 /// associate the tensor value that is stored with the buffer created. So when
 /// that value is seen during lowering the correct result buffer is used.
-///
+static Value createBufferForResultTensor(IREE::HAL::InterfaceStoreTensorOp op,
+                                         OpBuilder &builder) {
+  if (!matchPattern(op.offset(), m_Zero())) {
+    op.emitError("unhandled non-zero offset");
+    return nullptr;
+  }
+
+  // Get the corresponding memref type from the tensor type.
+  Value tensor = op.operand();
+  auto tensorType = tensor.getType().cast<RankedTensorType>();
+  auto bindingOp = op.queryBindingOp();
+  assert(bindingOp);
+  auto bufferType = getTensorBackingBufferType(tensorType, bindingOp.type());
+
+  // Create the placeholder op for the backing buffer. Make sure shape
+  // annotation is carried over if exists.
+  auto phOp = builder.create<IREE::PlaceholderOp>(op.getLoc(), bufferType,
+                                                  "interface buffer");
+  phOp->setAttr(getBindingAttrName(), op.binding());
+  StringRef attrName = getOperandResultNumAttrName();
+  if (Attribute operandResultNumAttr = op->getAttr(attrName))
+    phOp->setAttr(attrName, operandResultNumAttr);
+  return phOp.getResult();
+}
+
 /// There might be a sequence of view-like operations on memref, which dont
 /// modify the buffer, but just the way they are referenced. For example,
 ///
@@ -1346,38 +1373,16 @@ struct HALInterfaceStoreTensorOpEraser final
 /// in reality its semantics is a copy semantics. As long as the operand for the
 /// tensor_reshape operation has a single use (the tensor_reshape) there
 /// distinction can be ignored.
-static LogicalResult createAndPropagateBufferUsedForResultTensor(
-    IREE::HAL::InterfaceStoreTensorOp op, OutputBufferMap &outputBufferMap,
-    TensorToBufferMap &resultTensorToBufferMap, OpBuilder &builder) {
-  if (!matchPattern(op.offset(), m_Zero())) {
-    return op.emitError("unhandled non-zero offset");
-  }
-
-  // Get the corresponding memref type from the tensor type.
-  Value tensor = op.operand();
-  auto tensorType = tensor.getType().cast<RankedTensorType>();
-  auto bindingOp = op.queryBindingOp();
-  assert(bindingOp);
-  auto bufferType = getTensorBackingBufferType(tensorType, bindingOp.type());
-
-  // Create the placeholder op for the backing buffer. Make sure shape
-  // annotation is carried over if exists.
-  auto phOp = builder.create<IREE::PlaceholderOp>(op.getLoc(), bufferType,
-                                                  "interface buffer");
-  phOp->setAttr(getBindingAttrName(), op.binding());
-  StringRef attrName = getOperandResultNumAttrName();
-  if (Attribute operandResultNumAttr = op->getAttr(attrName))
-    phOp->setAttr(attrName, operandResultNumAttr);
-  Value buffer = phOp;
-  outputBufferMap[op] = buffer;
-
+static LogicalResult propagateBufferUsedForResultTensor(
+    Value tensor, Value buffer, TensorToBufferMap &resultTensorToBufferMap,
+    OpBuilder &builder, Location loc) {
   resultTensorToBufferMap.insert(std::make_pair(tensor, buffer));
   while (true) {
     if (auto tieShapeOp = tensor.getDefiningOp<Shape::TieShapeOp>()) {
       if (!tieShapeOp.result().hasOneUse()) break;
       builder.setInsertionPointAfter(tieShapeOp.shape().getDefiningOp());
       auto newTieShapeOp = builder.create<Shape::TieShapeOp>(
-          op.getLoc(), buffer.getType(), buffer, tieShapeOp.shape());
+          loc, buffer.getType(), buffer, tieShapeOp.shape());
       tensor = tieShapeOp.operand();
       buffer = newTieShapeOp.result();
       resultTensorToBufferMap.insert(std::make_pair(tensor, buffer));
@@ -1388,8 +1393,8 @@ static LogicalResult createAndPropagateBufferUsedForResultTensor(
       tensor = tensorReshapeOp.src();
       if (resultTensorToBufferMap.count(tensor)) break;
       auto newReshapeOp = builder.create<linalg::ReshapeOp>(
-          op.getLoc(), getMemrefTypeForTensor(tensorReshapeOp.getSrcType()),
-          buffer, tensorReshapeOp.reassociation());
+          loc, getMemrefTypeForTensor(tensorReshapeOp.getSrcType()), buffer,
+          tensorReshapeOp.reassociation());
       buffer = newReshapeOp.result();
       resultTensorToBufferMap.insert(std::make_pair(tensor, buffer));
       continue;
@@ -1405,12 +1410,49 @@ static LogicalResult createAndPropagateBufferUsedForResultTensors(
     FuncOp funcOp, OutputBufferMap &outputBufferMap,
     TensorToBufferMap &resultTensorToBufferMap) {
   OpBuilder builder(funcOp.getBody());
-  auto walkResult = funcOp.walk(
-      [&](IREE::HAL::InterfaceStoreTensorOp storeTensorOp) -> WalkResult {
-        return createAndPropagateBufferUsedForResultTensor(
-            storeTensorOp, outputBufferMap, resultTensorToBufferMap, builder);
-      });
-  return failure(walkResult.wasInterrupted());
+  for (auto &block : funcOp.body().getBlocks()) {
+    // Walks in a reverse way, because we create placeholders for output buffers
+    // and temp buffers, and propagate them to their defining ops.
+    for (auto op = block.rbegin(); op != block.rend(); op++) {
+      if (auto storeTensorOp =
+              dyn_cast<IREE::HAL::InterfaceStoreTensorOp>(*op)) {
+        Value tensor = storeTensorOp.operand();
+        Value buffer = createBufferForResultTensor(storeTensorOp, builder);
+        outputBufferMap[storeTensorOp] = buffer;
+        if (failed(propagateBufferUsedForResultTensor(tensor, buffer,
+                                                      resultTensorToBufferMap,
+                                                      builder, op->getLoc()))) {
+          return failure();
+        }
+        continue;
+      }
+
+      if (auto linalgOp = dyn_cast<linalg::LinalgOp>(*op)) {
+        for (auto result : llvm::enumerate(op->getResults())) {
+          Value resultBuffer = resultTensorToBufferMap.lookup(result.value());
+          if (resultBuffer) continue;
+          if (auto shapedType =
+                  result.value().getType().dyn_cast<ShapedType>()) {
+            if (shapedType.hasStaticShape()) {
+              resultBuffer = builder.create<AllocOp>(
+                  op->getLoc(), getMemrefTypeForTensor(shapedType));
+            }
+          }
+          if (!resultBuffer) {
+            return op->emitError("failed to create buffer for result #")
+                   << result.index();
+          }
+          if (failed(propagateBufferUsedForResultTensor(
+                  result.value(), resultBuffer, resultTensorToBufferMap,
+                  builder, op->getLoc()))) {
+            return failure();
+          }
+        }
+      }
+    }
+  }
+
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Conversion/HLOToLinalg/test/linalg_tensor_to_buffer.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/linalg_tensor_to_buffer.mlir
@@ -208,12 +208,12 @@ module {
 
 // CHECK-LABEL: func @store_value_twice
 //   CHECK-DAG:   %[[T0:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0, operand_result_index = 1 : i32}
-//       CHECK:   %[[T1:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
-//       CHECK:   %[[T2:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
+//   CHECK-DAG:   %[[T1:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
+//   CHECK-DAG:   %[[T2:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[T2]] :
-//  CHECK-SAME:     outs(%[[T0]] :
-//       CHECK:   linalg.copy(%[[T0]], %[[T1]])
+//  CHECK-SAME:     outs(%[[T1]] :
+//       CHECK:   linalg.copy(%[[T1]], %[[T0]])
 
 // -----
 
@@ -253,14 +253,14 @@ module {
 }
 
 // CHECK-LABEL: func @store_reshape_src_and_result_0
-//       CHECK:   %[[T0:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
-//       CHECK:   %[[T1:.*]] = linalg.reshape %[[T0]]
-//       CHECK:   %[[T2:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0, operand_result_index = 1 : i32}
-//       CHECK:   %[[T3:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
+//  CHECK-DAG:   %[[T0:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0, operand_result_index = 1 : i32}
+//  CHECK-DAG:   %[[T1:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
+//  CHECK-DAG:   %[[T2:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
 //       CHECK:   linalg.generic
-//  CHECK-SAME:     ins(%[[T3]] :
-//  CHECK-SAME:     outs(%[[T1]] :
-//       CHECK:   linalg.copy(%[[T1]], %[[T2]])
+//  CHECK-SAME:     ins(%[[T2]] :
+//  CHECK-SAME:     outs(%[[T0]] :
+//       CHECK:   %[[T3:.*]] = linalg.reshape %[[T0]]
+//       CHECK:   linalg.copy(%[[T3]], %[[T1]])
 //       CHECK:   return
 
 // -----
@@ -304,11 +304,11 @@ module {
 //   CHECK-DAG:   %[[T0:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0, operand_result_index = 1 : i32}
 //   CHECK-DAG:   %[[T1:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
 //   CHECK-DAG:   %[[T2:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
+//   CHECK-DAG:   %[[T3:.*]] = linalg.reshape %[[T1]]
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[T2]] :
-//  CHECK-SAME:     outs(%[[T0]] :
-//       CHECK:   %[[T3:.*]] = linalg.reshape %[[T0]]
-//       CHECK:   linalg.copy(%[[T3]], %[[T1]])
+//  CHECK-SAME:     outs(%[[T3]] :
+//       CHECK:   linalg.copy(%[[T3]], %[[T0]])
 //       CHECK:   return
 
 // -----
@@ -358,15 +358,15 @@ module {
 
 // CHECK-LABEL: func @store_reshape_src_and_result_2
 //   CHECK-DAG:   %[[T0:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret0, operand_result_index = 1 : i32}
-//       CHECK:   %[[T1:.*]] = linalg.reshape %[[T0]]
-//   CHECK-DAG:   %[[T2:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
-//   CHECK-DAG:   %[[T3:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret2, operand_result_index = 3 : i32}
+//   CHECK-DAG:   %[[T1:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
+//   CHECK-DAG:   %[[T2:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret2, operand_result_index = 3 : i32}
+//   CHECK-DAG:   %[[T3:.*]] = linalg.reshape %[[T2]]
 //   CHECK-DAG:   %[[T4:.*]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
 //       CHECK:   linalg.generic
-//  CHECK-SAME:   ins(%[[T4]] :
-//  CHECK-SAME:   outs(%[[T1]] :
-//       CHECK:   linalg.copy(%[[T0]], %[[T2]])
-//       CHECK:   linalg.copy(%[[T0]], %[[T3]])
+//  CHECK-SAME:     ins(%[[T4]] :
+//  CHECK-SAME:     outs(%[[T3]] :
+//       CHECK:   linalg.copy(%[[T2]], %[[T0]])
+//       CHECK:   linalg.copy(%[[T2]], %[[T1]])
 //       CHECK:   return
 
 // -----
@@ -458,20 +458,20 @@ module {
 }
 
 // CHECK-LABEL: func @generic_reshape_reshape
+//       CHECK:   %[[RET1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
+//       CHECK:   %[[RET1_RESHAPE0:.+]] = linalg.reshape %[[RET1]]
+//  CHECK-SAME:     memref<1x1000xf32> into memref<1x1x1x1000xf32>
+//       CHECK:   %[[RET1_RESHAPE1:.+]] = linalg.reshape %[[RET1_RESHAPE0]]
+//  CHECK-SAME:     memref<1x1x1x1000xf32> into memref<1000xf32>
 //       CHECK:   %[[RET0:.+]] = iree.placeholder
 //  CHECK-SAME:     binding = @legacy_io::@ret0, operand_result_index = 1 : i32
-//       CHECK:   %[[RET0_RESHAPE:.+]] = linalg.reshape %[[RET0]]
-//  CHECK-SAME:     memref<1x1x1x1000xf32> into memref<1000xf32>
-//       CHECK:   %[[RET1:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@ret1, operand_result_index = 2 : i32}
 //       CHECK:   %[[ARG0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0, operand_result_index = 0 : i32}
 //       CHECK:   %[[ARG0_RESHAPE:.+]] = linalg.reshape %[[ARG0]]
 //  CHECK-SAME:     memref<1x1x1x1000xf32> into memref<1000xf32>
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[ARG0_RESHAPE]] :
-//  CHECK-SAME:     outs(%[[RET0_RESHAPE]] :
-//       CHECK:   %[[RET0_RESHAPE2:.+]] = linalg.reshape %[[RET0]]
-//  CHECK-SAME:     memref<1x1x1x1000xf32> into memref<1x1000xf32>
-//       CHECK:   linalg.copy(%[[RET0_RESHAPE2]], %[[RET1]])
+//  CHECK-SAME:     outs(%[[RET1_RESHAPE1]] :
+//       CHECK:   linalg.copy(%[[RET1_RESHAPE0]], %[[RET0]])
 
 // -----
 
@@ -522,4 +522,3 @@ module {
 //  CHECK-SAME:     ) outs(%[[RET0]]
 //  CHECK-SAME:     )
 //       CHECK:   return
-

--- a/iree/compiler/Conversion/HLOToLinalg/test/pipeline_test.mlir
+++ b/iree/compiler/Conversion/HLOToLinalg/test/pipeline_test.mlir
@@ -52,8 +52,8 @@ module {
 //   CHECK-DAG:   %[[ARG0:.+]] = iree.placeholder for "interface buffer" {binding = @legacy_io::@arg0}
 //       CHECK:   linalg.generic
 //  CHECK-SAME:     ins(%[[ARG0]], %[[ARG1]] :
-//  CHECK-SAME:     outs(%[[RET0]] :
-//       CHECK:   linalg.copy(%[[RET0]], %[[RET1]])
+//  CHECK-SAME:     outs(%[[RET1]] :
+//       CHECK:   linalg.copy(%[[RET1]], %[[RET0]])
 
 // -----
 


### PR DESCRIPTION
Previously, we allocate temp buffers for results that can not find
mapping from tensor to memref in ConvertToLinalgBufferOp class. In a
later pass, we will eliminate temp buffers at tile and fuse stage. This
patch moves the temp buffer allocation logic to
propagateBufferUsedForResultTensor method, so the temp buffer can be
reused correctly. E.g.,

```mlir
module {
  func @matmul_add() {
    %c0 = constant 0 : index
    %cst = constant 0.000000e+00 : f32
    %0 = linalg.init_tensor [32, 64] : tensor<32x64xf32>
    %1 = hal.interface.load.tensor @legacy_io::@arg0, offset = %c0 : tensor<32x48xf32>
    %2 = hal.interface.load.tensor @legacy_io::@arg1, offset = %c0 : tensor<48x64xf32>
    %3 = hal.interface.load.tensor @legacy_io::@arg2, offset = %c0 : tensor<32x64xf32>
    %4 = dynamic_tensor_from_elements  {
    ^bb0(%arg0: index, %arg1: index):  // no predecessors
      yield %cst : f32
    } : tensor<32x64xf32>
    %5 = linalg.matmul ins(%1, %2 : tensor<32x48xf32>, tensor<48x64xf32>)
                       outs(%4 : tensor<32x64xf32>) -> tensor<32x64xf32>
    %6 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                                          affine_map<(d0, d1) -> (d0, d1)>,
                                          affine_map<(d0, d1) -> (d0, d1)>],
                         iterator_types = ["parallel", "parallel"]
    } ins(%3, %5 : tensor<32x64xf32>, tensor<32x64xf32>)
      outs(%0 : tensor<32x64xf32>) {
    ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):  // no predecessors
      %7 = addf %arg0, %arg1 : f32
      linalg.yield %7 : f32
    } -> tensor<32x64xf32>
    hal.interface.store.tensor %6, @legacy_io::@ret0, offset = %c0 : tensor<32x64xf32>
    return
  }
  hal.interface @legacy_io attributes {sym_visibility = "private"} {
    hal.interface.binding @arg0, set=0, binding=0, type="StorageBuffer", access="Read"
    hal.interface.binding @arg1, set=0, binding=1, type="StorageBuffer", access="Read"
    hal.interface.binding @arg2, set=0, binding=2, type="StorageBuffer", access="Read"
    hal.interface.binding @ret0, set=0, binding=3, type="StorageBuffer", access="Write"
  }
}
```

The buffer used in `dynamic_tensor_from_elements` and `linalg.matmul`
should be the same. However, we didn't propagate the temp buffer that
created by `linalg.matmul` to it's producers.

note: the example is not added in this patch. It will be added when
upstream mhlo.dot -> linalg.matmul to XLA repo. The current tests also
cover the change in the patch.