### PR TITLE
Fix include of EmitC generated headers

### DIFF
--- a/iree/samples/emitc_modules/add_module_test.cc
+++ b/iree/samples/emitc_modules/add_module_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "iree/samples/emitc_modules/add_module.module"
+#include "iree/samples/emitc_modules/add_module.vmfb"
 
 #include "iree/base/status.h"
 #include "iree/testing/gtest.h"

--- a/iree/vm/test/emitc/module_test.cc
+++ b/iree/vm/test/emitc/module_test.cc
@@ -18,8 +18,8 @@
 #include "iree/base/status.h"
 #include "iree/testing/gtest.h"
 #include "iree/vm/api.h"
-#include "iree/vm/test/emitc/arithmetic_ops.module"
-#include "iree/vm/test/emitc/shift_ops.module"
+#include "iree/vm/test/emitc/arithmetic_ops.vmfb"
+#include "iree/vm/test/emitc/shift_ops.vmfb"
 
 namespace {
 


### PR DESCRIPTION
The EmitC pass is currently broken due to the renaming done with #4729. This fixes the issue till we finally have a better solution that not uses `iree_bytecode_module.cmake`.