### PR TITLE
Add smoketest_linalg_on_tensors to LLVM and Vulkan-SPIRV targets.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/LLVM/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/test/BUILD
@@ -27,6 +27,7 @@ iree_lit_test_suite(
         [
             "binary_op.mlir",
             "matmul_op.mlir",
+            "smoketest_linalg_on_tensors.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Dialect/HAL/Target/LLVM/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "binary_op.mlir"
     "matmul_op.mlir"
+    "smoketest_linalg_on_tensors.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_linalg_on_tensors.mlir
@@ -1,0 +1,27 @@
+// RUN: iree-opt -split-input-file -iree-hal-transformation-pipeline -iree-hal-target-backends=dylib-llvm-aot --iree-flow-dispatch-linalg-on-tensors -iree-codegen-llvm-experimental-linalg-on-tensors %s | IreeFileCheck %s
+
+#map = affine_map<(d0) -> (d0)>
+flow.executable @add_dispatch_0 {
+  flow.dispatch.entry @add_dispatch_0 attributes {
+    signature = (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>,
+    workgroup_rank = 3 : index
+  }
+  module  {
+    func @add_dispatch_0(%arg0: !flow.dispatch.tensor<readonly:16xf32>, %arg1: !flow.dispatch.tensor<readonly:16xf32>, %arg2: !flow.dispatch.tensor<writeonly:16xf32>) {
+      %0 = linalg.init_tensor [16] : tensor<16xf32>
+      %1 = flow.dispatch.tensor.load %arg0 : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
+      %2 = flow.dispatch.tensor.load %arg1 : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
+      %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%1, %2 : tensor<16xf32>, tensor<16xf32>) outs(%0 : tensor<16xf32>) {
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+        %4 = addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> tensor<16xf32>
+      flow.dispatch.tensor.store %3, %arg2 : tensor<16xf32> -> !flow.dispatch.tensor<writeonly:16xf32>
+      return
+    }
+  }
+}
+
+// CHECK:       hal.executable.binary @llvm_aot attributes {
+// CHECK-SAME:     data = dense
+// CHECK-SAME:     format = 1145850178 : i32} {

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/BUILD
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/BUILD
@@ -24,7 +24,10 @@ package(
 iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
-        ["smoketest.mlir"],
+        [
+            "smoketest.mlir",
+            "smoketest_linalg_on_tensors.mlir",
+        ],
         include = ["*.mlir"],
     ),
     data = [

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "smoketest.mlir"
+    "smoketest_linalg_on_tensors.mlir"
   DATA
     iree::tools::IreeFileCheck
     iree::tools::iree-opt

--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest_linalg_on_tensors.mlir
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest_linalg_on_tensors.mlir
@@ -1,0 +1,27 @@
+// RUN: iree-opt -split-input-file -iree-hal-transformation-pipeline -iree-hal-target-backends=vulkan-spirv -iree-codegen-spirv-experimental-linalg-on-tensors %s | IreeFileCheck %s
+
+#map = affine_map<(d0) -> (d0)>
+flow.executable @add_dispatch_0 {
+  flow.dispatch.entry @add_dispatch_0 attributes {
+    signature = (tensor<16xf32>, tensor<16xf32>) -> tensor<16xf32>,
+    workgroup_rank = 3 : index
+  }
+  module  {
+    func @add_dispatch_0(%arg0: !flow.dispatch.tensor<readonly:16xf32>, %arg1: !flow.dispatch.tensor<readonly:16xf32>, %arg2: !flow.dispatch.tensor<writeonly:16xf32>) {
+      %0 = linalg.init_tensor [16] : tensor<16xf32>
+      %1 = flow.dispatch.tensor.load %arg0 : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
+      %2 = flow.dispatch.tensor.load %arg1 : !flow.dispatch.tensor<readonly:16xf32> -> tensor<16xf32>
+      %3 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%1, %2 : tensor<16xf32>, tensor<16xf32>) outs(%0 : tensor<16xf32>) {
+      ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+        %4 = addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> tensor<16xf32>
+      flow.dispatch.tensor.store %3, %arg2 : tensor<16xf32> -> !flow.dispatch.tensor<writeonly:16xf32>
+      return
+    }
+  }
+}
+
+//      CHECK:   hal.executable.binary @vulkan_spirv attributes
+// CHECK-SAME:     data = dense
+// CHECK-SAME:     format = 1397773893 : i32}


### PR DESCRIPTION
The purpose is to check if hal.executable.binary has correct
information, e.g., @llvm_aot, format in the attributes. Although this
does not adapt the tests from legacy pass, we can drop those tests and
use the added one when migrating to Linalg on tensors.

Part of https://github.com/google/iree/issues/5155