### PR TITLE
Migrate tosa tests to Linalg on tensors.

### DIFF
--- a/iree/test/e2e/tosa_ops/BUILD
+++ b/iree/test/e2e/tosa_ops/BUILD
@@ -67,6 +67,10 @@ ALL_SRCS = enforce_glob(
 iree_check_single_backend_test_suite(
     name = "check_vulkan-spirv_vulkan",
     srcs = ALL_SRCS,
+    compiler_flags = [
+        "-iree-flow-dispatch-linalg-on-tensors",
+        "-iree-codegen-spirv-experimental-linalg-on-tensors",
+    ],
     driver = "vulkan",
     target_backend = "vulkan-spirv",
 )
@@ -74,6 +78,10 @@ iree_check_single_backend_test_suite(
 iree_check_single_backend_test_suite(
     name = "check_dylib-llvm-aot_dylib",
     srcs = ALL_SRCS,
+    compiler_flags = [
+        "-iree-flow-dispatch-linalg-on-tensors",
+        "-iree-codegen-llvm-experimental-linalg-on-tensors",
+    ],
     driver = "dylib",
     target_backend = "dylib-llvm-aot",
 )

--- a/iree/test/e2e/tosa_ops/CMakeLists.txt
+++ b/iree/test/e2e/tosa_ops/CMakeLists.txt
@@ -47,6 +47,9 @@ iree_check_single_backend_test_suite(
     "vulkan-spirv"
   DRIVER
     "vulkan"
+  COMPILER_FLAGS
+    "-iree-flow-dispatch-linalg-on-tensors"
+    "-iree-codegen-spirv-experimental-linalg-on-tensors"
 )
 
 iree_check_single_backend_test_suite(
@@ -86,6 +89,9 @@ iree_check_single_backend_test_suite(
     "dylib-llvm-aot"
   DRIVER
     "dylib"
+  COMPILER_FLAGS
+    "-iree-flow-dispatch-linalg-on-tensors"
+    "-iree-codegen-llvm-experimental-linalg-on-tensors"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/test/e2e/tosa_ops/greater.mlir
+++ b/iree/test/e2e/tosa_ops/greater.mlir
@@ -2,7 +2,8 @@ func @tensor_float() attributes { iree.module.export } {
   %0 = iree.unfoldable_constant dense<[1.0, -1.5, 7.0, -2.0]> : tensor<4xf32>
   %1 = iree.unfoldable_constant dense<[5.0, 1.0, 7.0, -3.0]> : tensor<4xf32>
   %result = "tosa.greater"(%0, %1) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xi1>
-  check.expect_eq_const(%result, dense<[false, false, false, true]> : tensor<4xi1>) : tensor<4xi1>
+  %cast = std.zexti %result : tensor<4xi1> to tensor<4xi8>
+  check.expect_eq_const(%cast, dense<[0, 0, 0, 1]> : tensor<4xi8>) : tensor<4xi8>
   return
 }
 
@@ -10,8 +11,7 @@ func @tensor_int() attributes { iree.module.export } {
   %0 = iree.unfoldable_constant dense<[1, 0, 5, 3]> : tensor<4xi32>
   %1 = iree.unfoldable_constant dense<[5, 0, 1, 8]> : tensor<4xi32>
   %result = "tosa.greater"(%0, %1) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  check.expect_eq_const(%result, dense<[false, false, true, false]> : tensor<4xi1>) : tensor<4xi1>
+  %cast = std.zexti %result : tensor<4xi1> to tensor<4xi8>
+  check.expect_eq_const(%cast, dense<[0, 0, 1, 0]> : tensor<4xi8>) : tensor<4xi8>
   return
 }
-
-

--- a/iree/test/e2e/tosa_ops/greater_equal.mlir
+++ b/iree/test/e2e/tosa_ops/greater_equal.mlir
@@ -2,7 +2,8 @@ func @tensor_float() attributes { iree.module.export } {
   %0 = iree.unfoldable_constant dense<[1.0, -1.5, 7.0, -2.0]> : tensor<4xf32>
   %1 = iree.unfoldable_constant dense<[5.0, 1.0, 7.0, -3.0]> : tensor<4xf32>
   %result = "tosa.greater_equal"(%0, %1) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xi1>
-  check.expect_eq_const(%result, dense<[false, false, true, true]> : tensor<4xi1>) : tensor<4xi1>
+  %cast = std.zexti %result : tensor<4xi1> to tensor<4xi8>
+  check.expect_eq_const(%cast, dense<[0, 0, 1, 1]> : tensor<4xi8>) : tensor<4xi8>
   return
 }
 
@@ -10,6 +11,7 @@ func @tensor_int() attributes { iree.module.export } {
   %0 = iree.unfoldable_constant dense<[1, 0, 5, 3]> : tensor<4xi32>
   %1 = iree.unfoldable_constant dense<[5, 0, 1, 8]> : tensor<4xi32>
   %result = "tosa.greater_equal"(%0, %1) : (tensor<4xi32>, tensor<4xi32>) -> tensor<4xi1>
-  check.expect_eq_const(%result, dense<[false, true, true, false]> : tensor<4xi1>) : tensor<4xi1>
+  %cast = std.zexti %result : tensor<4xi1> to tensor<4xi8>
+  check.expect_eq_const(%cast, dense<[0, 1, 1, 0]> : tensor<4xi8>) : tensor<4xi8>
   return
 }

--- a/iree/test/e2e/tosa_ops/if.mlir
+++ b/iree/test/e2e/tosa_ops/if.mlir
@@ -1,8 +1,9 @@
 func @if_true_test() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<true> : tensor<i1>
+  %0 = iree.unfoldable_constant dense<1> : tensor<i8>
+  %cond = std.trunci %0 : tensor<i8> to tensor<i1>
   %1 = iree.unfoldable_constant dense<10> : tensor<i32>
   %path = iree.unfoldable_constant 1 : i32
-  %2 = "tosa.cond_if"(%0, %1) ( {
+  %2 = "tosa.cond_if"(%cond, %1) ( {
   ^bb0(%arg0 : tensor<i32>):
     check.expect_true(%path) : i32
     %3 = iree.unfoldable_constant dense<10> : tensor<i32>
@@ -18,10 +19,11 @@ func @if_true_test() attributes { iree.module.export } {
 }
 
 func @if_false_test() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<false> : tensor<i1>
+  %0 = iree.unfoldable_constant dense<0> : tensor<i8>
+  %cond = std.trunci %0 : tensor<i8> to tensor<i1>
   %1 = iree.unfoldable_constant dense<10> : tensor<i32>
   %path = iree.unfoldable_constant 0 : i32
-  %2 = "tosa.cond_if"(%0, %1) ( {
+  %2 = "tosa.cond_if"(%cond, %1) ( {
   ^bb0(%arg0 : tensor<i32>):
     check.expect_true(%path) : i32
     "tosa.yield"(%arg0) : (tensor<i32>) -> ()
@@ -35,4 +37,3 @@ func @if_false_test() attributes { iree.module.export } {
   check.expect_eq_const(%2, dense<20> : tensor<i32>) : tensor<i32>
   return
 }
-

--- a/iree/test/e2e/tosa_ops/select.mlir
+++ b/iree/test/e2e/tosa_ops/select.mlir
@@ -1,17 +1,19 @@
 func @tensor_float() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<[0, 0, 1, 1]> : tensor<4xi1>
+  %0 = iree.unfoldable_constant dense<[0, 0, 1, 1]> : tensor<4xi8>
+  %cond = std.trunci %0 : tensor<4xi8> to tensor<4xi1>
   %1 = iree.unfoldable_constant dense<[1.0, 5.0, 3.0, 4.0]> : tensor<4xf32>
   %2 = iree.unfoldable_constant dense<[5.0, 1.0, 3.0, 1.5]> : tensor<4xf32>
-  %result = "tosa.select"(%0, %1, %2) : (tensor<4xi1>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+  %result = "tosa.select"(%cond, %1, %2) : (tensor<4xi1>, tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   check.expect_almost_eq_const(%result, dense<[5.0, 1.0, 3.0, 4.0]> : tensor<4xf32>) : tensor<4xf32>
   return
 }
 
 func @tensor_int() attributes { iree.module.export } {
-  %0 = iree.unfoldable_constant dense<[0, 0, 1, 1]> : tensor<4xi1>
+  %0 = iree.unfoldable_constant dense<[0, 0, 1, 1]> : tensor<4xi8>
+  %cond = std.trunci %0 : tensor<4xi8> to tensor<4xi1>
   %1 = iree.unfoldable_constant dense<[1, 5, 3, 4]> : tensor<4xi32>
   %2 = iree.unfoldable_constant dense<[5, 1, 3, 1]> : tensor<4xi32>
-  %result = "tosa.select"(%0, %1, %2) : (tensor<4xi1>, tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
+  %result = "tosa.select"(%cond, %1, %2) : (tensor<4xi1>, tensor<4xi32>, tensor<4xi32>) -> tensor<4xi32>
   check.expect_eq_const(%result, dense<[5, 1, 3, 4]> : tensor<4xi32>) : tensor<4xi32>
   return
 }


### PR DESCRIPTION
There are some issues in i1 cases. Rewrite some tests to unblock Linalg
on tensors migration.

1. IREE currently does not serialze i1 constants as expected. It widen
   the i1 constants to i8 constants unconditionally.
2. Loading from or storing to i1 buffers is not common.

For more details, see https://github.com/google/iree/issues/5153 and
https://llvm.discourse.group/t/cant-create-op-with-replaced-op-in-dialect-conversion/3176/3