### PR TITLE
Add a pass to convert some std ops to mhlo ops.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -60,6 +60,7 @@ cc_library(
         "PassDetail.h",
         "Passes.cpp",
         "PrePostPartitioningConversion.cpp",
+        "StandardToHLOPreprocessing.cpp",
         "StripAndSplatConstantVariables.cpp",
     ],
     hdrs = [

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     "PassDetail.h"
     "Passes.cpp"
     "PrePostPartitioningConversion.cpp"
+    "StandardToHLOPreprocessing.cpp"
     "StripAndSplatConstantVariables.cpp"
   DEPS
     LLVMSupport

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -72,6 +72,8 @@ namespace Flow {
 // dialects like linalg.
 static void buildHLOInputTransformPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(
+      IREE::Flow::createStandardToHLOPreprocessingPass());
+  passManager.addNestedPass<FuncOp>(
       IREE::Flow::createHLOToHLOPreprocessingPass());
   // TODO(ataei): This should run as part of createHLOToHLOPreprocessingPass
   // which will break VMLA backend.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -77,6 +77,11 @@ std::unique_ptr<OperationPass<ModuleOp>> createLegalizeInputTypesPass();
 /// backends.
 std::unique_ptr<OperationPass<FuncOp>> createHLOToHLOPreprocessingPass();
 
+/// Creates a pass to convert some std ops to mhlo ops. This provides more
+/// opportunities for fusion. It could prevent unnecessary host readback of
+/// device memory because most of std ops are run on host side.
+std::unique_ptr<OperationPass<FuncOp>> createStandardToHLOPreprocessingPass();
+
 // Runs pre-partitioning conversion passes to convert to the flow dialect.
 // This converts some input ops directly to flow ops when doing so has a
 // benefit. Other ops are left unmodified and will be outlined later on.

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -126,4 +126,10 @@ def StripAndSplatConstantVariables :
   let constructor = "mlir::iree_compiler::IREE::Flow::createStripAndSplatConstantVariablesPass()";
 }
 
+def StandardToHLOPreprocessing :
+    Pass<"iree-flow-std-to-hlo-preprocessing", "FuncOp"> {
+  let summary = "Apply std to hlo transformations for some std ops";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createStandardToHLOPreprocessingPass()";
+}
+
 #endif  // IREE_DIALECT_FLOW_PASSES

--- a/iree/compiler/Dialect/Flow/Transforms/StandardToHLOPreprocessing.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/StandardToHLOPreprocessing.cpp
@@ -1,0 +1,83 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+
+class SelectOpConverter : public OpRewritePattern<SelectOp> {
+ public:
+  using OpRewritePattern<SelectOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(SelectOp op,
+                                PatternRewriter &rewriter) const override {
+    auto extractOp = op.condition().getDefiningOp<tensor::ExtractOp>();
+    if (!extractOp) return failure();
+    Value cond = extractOp.tensor();
+    if (cond.getType().cast<RankedTensorType>().getRank() > 0) return failure();
+
+    auto type = op.true_value().getType().cast<RankedTensorType>();
+    if (!type.hasStaticShape()) return failure();
+
+    if (type.getRank() > 0) {
+      auto shape = type.getShape();
+      auto condType = RankedTensorType::get(shape, rewriter.getI1Type());
+      auto shapeAttr = DenseIntElementsAttr::get(
+          RankedTensorType::get(shape.size(), rewriter.getI64Type()), shape);
+      cond = rewriter.create<mhlo::BroadcastOp>(op.getLoc(), condType, cond,
+                                                shapeAttr);
+    }
+    rewriter.replaceOpWithNewOp<mhlo::SelectOp>(op, cond, op.true_value(),
+                                                op.false_value());
+    return success();
+  }
+};
+
+struct StandardToHLOPreprocessingPass
+    : public StandardToHLOPreprocessingBase<StandardToHLOPreprocessingPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<mhlo::MhloDialect, tensor::TensorDialect, StandardOpsDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    OwningRewritePatternList patterns(&getContext());
+    patterns.insert<SelectOpConverter>(
+        context);
+    (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createStandardToHLOPreprocessingPass() {
+  return std::make_unique<StandardToHLOPreprocessingPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -48,6 +48,7 @@ iree_lit_test_suite(
             "outline_dispatch_regions2.mlir",
             "outline_large_constants.mlir",
             "pre_partitioning_conversion.mlir",
+            "std_to_hlo_preprocessing.mlir",
             "strip_and_splat_constant_variables.mlir",
             "transformation.mlir",
         ],

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_lit_test_suite(
     "outline_dispatch_regions2.mlir"
     "outline_large_constants.mlir"
     "pre_partitioning_conversion.mlir"
+    "std_to_hlo_preprocessing.mlir"
     "strip_and_splat_constant_variables.mlir"
     "transformation.mlir"
   DATA

--- a/iree/compiler/Dialect/Flow/Transforms/test/std_to_hlo_preprocessing.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/std_to_hlo_preprocessing.mlir
@@ -1,0 +1,30 @@
+// RUN: iree-opt -split-input-file -iree-flow-std-to-hlo-preprocessing %s | IreeFileCheck %s
+
+func @select_scalar(%arg0: tensor<i1>, %arg1: tensor<i32>, %arg2: tensor<i32>) -> tensor<i32> {
+  %0 = tensor.extract %arg0[] : tensor<i1>
+  %1 = select %0, %arg1, %arg2 : tensor<i32>
+  return %1 : tensor<i32>
+}
+// CHECK-LABEL: func @select_scalar
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
+// CHECK:         %[[RES:.*]] = "mhlo.select"(%[[ARG0]], %[[ARG1]], %[[ARG2]])
+// CHECK:         return %[[RES]]
+
+// -----
+
+func @select_1d(%arg0: tensor<i1>, %arg1: tensor<4xi32>, %arg2: tensor<4xi32>) -> tensor<4xi32> {
+  %0 = tensor.extract %arg0[] : tensor<i1>
+  %1 = select %0, %arg1, %arg2 : tensor<4xi32>
+  return %1 : tensor<4xi32>
+}
+// CHECK-LABEL: func @select_1d
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
+// CHECK:         %[[BROADCAST:.*]] = "mhlo.broadcast"(%[[ARG0]]) {
+// CHECK-SAME:      broadcast_sizes = dense<4> : tensor<1xi64>
+// CHECK-SAME:    } : (tensor<i1>) -> tensor<4xi1>
+// CHECK:         %[[RES:.*]] = "mhlo.select"(%[[BROADCAST]], %[[ARG1]], %[[ARG2]])
+// CHECK:         return %[[RES]]


### PR DESCRIPTION
This provides more opportunities for fusion. It could prevent
unnecessary host readback of device memory because most of std ops are
run on host side.