### PR TITLE
Taking the leap: combine TF->MHLO, CHLO->Linalg, MHLO->Linalg, TF->TOSA, and TOSA->Linalg.

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/TF/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TF/BUILD
@@ -38,6 +38,7 @@ cc_library(
         "@iree//iree/compiler/Dialect/HAL/IR:HALDialect",
         "@iree//iree/compiler/Dialect/IREE/IR",
         "@iree//iree/compiler/Dialect/Shape/Transforms",
+        "@iree//iree/compiler/InputConversion/TOSA",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgOps",
@@ -58,6 +59,7 @@ cc_library(
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:lower_tf_lib",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_types",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_saved_model_passes",
+        "@org_tensorflow//tensorflow/compiler/mlir/tosa:tf_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/xla:xla_legalize_tf",
     ],
 )

--- a/integrations/tensorflow/iree_tf_compiler/TF/ConvertToMHLO.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/ConvertToMHLO.cpp
@@ -101,6 +101,10 @@ class ConvertToMHLOPass : public PassWrapper<ConvertToMHLOPass, FunctionPass> {
     // pattern in the legalize-tf pass.
     target.addIllegalOp<mhlo::LogisticOp>();
 
+    // IREE lacks a lowering for DynamicConvOp and it is unclear what value it
+    // brings.
+    target.addIllegalOp<mhlo::DynamicConvOp>();
+
     // In general, IREE does not support DynamicBroadcastInDim ops that do not
     // resolve to a static form. This excludes any TF2XLA expansions which
     // we ultimately lack a linalg lowering for. Matches the corresponding


### PR DESCRIPTION
(sub-titled: so, yeah, multi-level lowering is a thing)

* There are a number of design issues in MHLO related to dynamic shapes and the kind of direct lowerings to linalg that we prefer.
* Incidentally, for a number of important things that MHLO doesn't lower (or to our standards), TOSA does.
* This patch mashes them all together in the TF import pipeline, preferring MHLO conversions and falling back to TOSA.
* This allows all TF ops to lower with dynamic batch size MobileNetV3 (#6357).
* Required a patch to the mhlo.reduce_window lowerings, which were missing a case for dynamic shapes (causing a verifier error): #6365
* Unfortunately, the TOSA->Linalg conversions still need some work for dynamic shape cases, so import still fails -- but does get tantalizingly close.

The following ops are left:
```
%18 = "tosa.conv2d"(%14, %17, %cst_240) {dilation = [1, 1]
, pad = [0, 1, 0, 1], stride = [2, 2]} : (tensor<?x224x224x3xf32>, tensor<16x3x3x3xf32>, tensor<16xf32>) -> tensor<?x112x112x16xf32>
%59 = "tosa.depthwise_conv2d"(%58, %cst_7, %cst_240) {dilation = [1, 1], pad = [1, 1, 1, 1], stride = [1, 1]} : (tensor<?x112x112x16xf32>, tensor<3x3x16x1xf32>, tensor<16xf32>) -> tensor<?x112x112x16xf32>
```

Looking at the conversions for the above, I believe it should be possible to start phasing in dynamic shape aware lowerings for them. Once that is in place, MobileNetV3 with dynamic batch size should run on IREE.