### PR TITLE
Working slice op lowering around when attributes and types not match.

### DIFF
--- a/iree/compiler/InputConversion/MHLO/test/BUILD
+++ b/iree/compiler/InputConversion/MHLO/test/BUILD
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "convert_complex_to_real.mlir",
             "dynamic_shape.mlir",
             "fft.mlir",
+            "invalid_slice.mlir",
             "legalize_input_types.mlir",
             "mhlo_to_mhlo_preprocessing.mlir",
             "mhlo_to_mhlo_preprocessing_canoncalize_dot_general.mlir",

--- a/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
+++ b/iree/compiler/InputConversion/MHLO/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "convert_complex_to_real.mlir"
     "dynamic_shape.mlir"
     "fft.mlir"
+    "invalid_slice.mlir"
     "legalize_input_types.mlir"
     "mhlo_to_mhlo_preprocessing.mlir"
     "mhlo_to_mhlo_preprocessing_canoncalize_dot_general.mlir"

--- a/iree/compiler/InputConversion/MHLO/test/invalid_slice.mlir
+++ b/iree/compiler/InputConversion/MHLO/test/invalid_slice.mlir
@@ -1,0 +1,14 @@
+// RUN: iree-opt -split-input-file -iree-mhlo-to-linalg-on-tensors -canonicalize %s | IreeFileCheck %s
+
+func @invalid_slice(%arg0: tensor<6xi32>) -> tensor<3xi32> {
+  %0 = "mhlo.slice"(%arg0) {
+    limit_indices = dense<5> : tensor<1xi64>,
+    start_indices = dense<0> : tensor<1xi64>,
+    strides = dense<2> : tensor<1xi64>
+  } : (tensor<6xi32>) -> tensor<3xi32>
+  return %0 : tensor<3xi32>
+}
+// CHECK-LABEL: func @invalid_slice
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK:         %[[RES.+]] = tensor.extract_slice %[[ARG0]][0] [3] [2] : tensor<6xi32> to tensor<3xi32>
+// CHECK:         return %[[RES]]


### PR DESCRIPTION
There are case that mhlo.slice is invalid, see https://github.com/google/iree/issues/6402

The pattern really should not exist but it's caused by upstream lowering. We should remove the pattern once the issue is triaged and the verifier is improved. For now, adding the pattern to unblock some models compilation.