### PR TITLE
Add LinalgExtToLoops to SPIR-V pipeline.

### DIFF
--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -16,6 +16,7 @@
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/SPIRV/MemorySpace.h"
+#include "iree/compiler/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Shape/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
@@ -69,6 +70,7 @@ void addSPIRVTileAndVectorizePassPipeline(OpPassManager &pm) {
   pm.addPass(createCanonicalizerPass());
 
   pm.addNestedPass<FuncOp>(createSPIRVCopyToWorkgroupMemoryPass());
+  pm.addNestedPass<FuncOp>(linalg_ext::createLinalgExtToLoopsPass());
   pm.addNestedPass<FuncOp>(createConvertLinalgToLoopsPass());
   pm.addPass(createLowerAffinePass());
   pm.addPass(createCanonicalizerPass());

--- a/iree/test/e2e/xla_ops/BUILD
+++ b/iree/test/e2e/xla_ops/BUILD
@@ -320,6 +320,7 @@ iree_check_single_backend_test_suite(
             "dynamic_update_slice.mlir",
             "exponential.mlir",
             "exponential_minus_one.mlir",
+            "fft.mlir",
             "finite.mlir",
             "floor.mlir",
             "gather.mlir",
@@ -349,7 +350,6 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
-            "fft.mlir",  # TODO(GH-6388): Enable the test.
             "round.mlir",
             "scatter.mlir",  # TODO(GH-6388): Enable the test.
             "scatter_dynamic.mlir",  # TODO(GH-6388): Enable the test.

--- a/iree/test/e2e/xla_ops/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/CMakeLists.txt
@@ -221,6 +221,7 @@ iree_check_single_backend_test_suite(
     "dynamic_update_slice.mlir"
     "exponential.mlir"
     "exponential_minus_one.mlir"
+    "fft.mlir"
     "finite.mlir"
     "floor.mlir"
     "gather.mlir"


### PR DESCRIPTION
This enables fft e2e testing on vulkan-spirv backend.

There are issues to compile sort and scatter ops, so they are not
enabled. It fails in FlattenMemRefSubspanPass.

It is a step toward https://github.com/google/iree/issues/6388