### PR TITLE
Don't hoist ops that are returned, as that's silly.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/HoistUnstreamableOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/HoistUnstreamableOps.cpp
@@ -31,11 +31,20 @@ static bool isStreamableOp(Operation *op) {
   return false;
 }
 
+static bool isReturned(Operation *op) {
+  for (auto result : op->getResults()) {
+    for (auto *user : result.getUsers()) {
+      if (user->hasTrait<OpTrait::IsTerminator>()) return true;
+    }
+  }
+  return false;
+}
+
 static llvm::SmallVector<Operation *, 16> getOpsToHoist(Block &block) {
   llvm::SmallVector<Operation *, 16> opsToHoist;
   for (Operation &op : block) {
     if (!isStreamableOp(&op) && !op.hasTrait<OpTrait::IsTerminator>() &&
-        MemoryEffectOpInterface::hasNoEffect(&op)) {
+        MemoryEffectOpInterface::hasNoEffect(&op) && !isReturned(&op)) {
       opsToHoist.push_back(&op);
     }
   }


### PR DESCRIPTION
hal.tensor.cast, which is used to cast transient tensors into buffer views
to return from a function, are getting hoisted today. The issue there is
that they are hoisted up to where the input tensor is produced - somewhere
inside of the middle of the function - and then stream formation splits
the stream there. This changes the hoisting to skip ops that are returned
from the block.

All this should die with the new stream reworking, but this stems
some of the badness for now.

No real speed difference in MobileSSD for me (as the task system rocks 😎)
but it does drop 60 allocations and a 7 host/device round trips:
![image](https://user-images.githubusercontent.com/75337/130882033-90b0fcd8-9d1b-43e7-87db-83893c15db8d.png)
->
![image](https://user-images.githubusercontent.com/75337/130882042-3425ce66-fbc4-48a8-85f8-8ae167828b14.png)
