### PR TITLE
Early-exit from try_steal_task when there are no victims.

### DIFF
--- a/iree/task/executor_impl.h
+++ b/iree/task/executor_impl.h
@@ -94,6 +94,12 @@ struct iree_task_executor_t {
   // on already woken workers.
   iree_atomic_task_affinity_set_t worker_idle_mask;
 
+  // A bitset indicating which workers have tasks pending in their queues.
+  // This does not include tasks that are in-flight; it's just queue depth > 0.
+  // Note that this may not be coherent with any of the other masks and should
+  // only be used for probabilistic queries ("_could_ we use worker X?" vs can).
+  iree_atomic_task_affinity_set_t worker_pending_mask;
+
   // Specifies how many workers threads there are.
   // For now this number is fixed per executor however if we wanted to enable
   // live join/leave behavior we could change this to a registration mechanism.

--- a/iree/task/queue.c
+++ b/iree/task/queue.c
@@ -43,7 +43,8 @@ void iree_task_queue_append_from_lifo_list_unsafe(iree_task_queue_t* queue,
 }
 
 iree_task_t* iree_task_queue_flush_from_lifo_slist(
-    iree_task_queue_t* queue, iree_atomic_task_slist_t* source_slist) {
+    iree_task_queue_t* queue, iree_atomic_task_slist_t* source_slist,
+    bool* out_empty) {
   // Perform the flush and swap outside of the lock; acquiring the list is
   // atomic and then we own it exclusively.
   iree_task_list_t suffix;
@@ -56,14 +57,17 @@ iree_task_t* iree_task_queue_flush_from_lifo_slist(
   iree_slim_mutex_lock(&queue->mutex);
   if (did_flush) iree_task_list_append(&queue->list, &suffix);
   iree_task_t* next_task = iree_task_list_pop_front(&queue->list);
+  *out_empty = iree_task_list_is_empty(&queue->list);
   iree_slim_mutex_unlock(&queue->mutex);
 
   return next_task;
 }
 
-iree_task_t* iree_task_queue_pop_front(iree_task_queue_t* queue) {
+iree_task_t* iree_task_queue_pop_front(iree_task_queue_t* queue,
+                                       bool* out_empty) {
   iree_slim_mutex_lock(&queue->mutex);
   iree_task_t* next_task = iree_task_list_pop_front(&queue->list);
+  *out_empty = iree_task_list_is_empty(&queue->list);
   iree_slim_mutex_unlock(&queue->mutex);
   return next_task;
 }

--- a/iree/task/queue.h
+++ b/iree/task/queue.h
@@ -138,15 +138,19 @@ void iree_task_queue_append_from_lifo_list_unsafe(iree_task_queue_t* queue,
 // Flushes the |source_slist| LIFO mailbox into the task queue in FIFO order.
 // Returns the first task in the queue upon success; the task may be
 // pre-existing or from the newly flushed tasks.
+// |out_empty| is set to true if the queue is empty after the pop.
 //
 // Must only be called from the owning worker's thread.
 iree_task_t* iree_task_queue_flush_from_lifo_slist(
-    iree_task_queue_t* queue, iree_atomic_task_slist_t* source_slist);
+    iree_task_queue_t* queue, iree_atomic_task_slist_t* source_slist,
+    bool* out_empty);
 
 // Pops a task from the front of the queue if any are available.
+// |out_empty| is set to true if the queue is empty after the pop.
 //
 // Must only be called from the owning worker's thread.
-iree_task_t* iree_task_queue_pop_front(iree_task_queue_t* queue);
+iree_task_t* iree_task_queue_pop_front(iree_task_queue_t* queue,
+                                       bool* out_empty);
 
 // Tries to steal up to |max_tasks| from the back of the queue.
 // Returns NULL if no tasks are available and otherwise up to |max_tasks| tasks

--- a/iree/task/worker.c
+++ b/iree/task/worker.c
@@ -30,7 +30,7 @@ iree_status_t iree_task_worker_initialize(
   out_worker->worker_bit = iree_task_affinity_for_worker(worker_index);
   out_worker->ideal_thread_affinity = topology_group->ideal_thread_affinity;
   out_worker->constructive_sharing_mask =
-      topology_group->constructive_sharing_mask;
+      topology_group->constructive_sharing_mask ^ out_worker->worker_bit;
   out_worker->max_theft_attempts =
       executor->worker_count / IREE_TASK_EXECUTOR_MAX_THEFT_ATTEMPTS_DIVISOR;
   iree_prng_minilcg128_initialize(iree_prng_splitmix64_next(seed_prng),
@@ -216,7 +216,9 @@ static bool iree_task_worker_pump_once(
   // Check the local work queue for any work we know we should start
   // processing immediately. Other workers may try to steal some of this work
   // if we take too long.
-  iree_task_t* task = iree_task_queue_pop_front(&worker->local_task_queue);
+  bool queue_empty = false;
+  iree_task_t* task =
+      iree_task_queue_pop_front(&worker->local_task_queue, &queue_empty);
 
   // Check the mailbox to see if we have incoming work that has been posted.
   // We try to greedily move it to our local work list so that we can work
@@ -228,8 +230,17 @@ static bool iree_task_worker_pump_once(
     // first place (large uneven workloads for various workers, bad distribution
     // in the face of heterogenous multi-core architectures where some workers
     // complete tasks faster than others, etc).
-    task = iree_task_queue_flush_from_lifo_slist(&worker->local_task_queue,
-                                                 &worker->mailbox_slist);
+    task = iree_task_queue_flush_from_lifo_slist(
+        &worker->local_task_queue, &worker->mailbox_slist, &queue_empty);
+  }
+  if (queue_empty) {
+    // Queue depth is 0; we may have gotten a task but we know that there's
+    // nothing else waiting in the next loop so we can tell other workers not
+    // to try to steal tasks from us. New submissions that come in after this
+    // (while we are processing the task we may have gotten) will reset the bit.
+    iree_atomic_task_affinity_set_fetch_and(
+        &worker->executor->worker_pending_mask, ~worker->worker_bit,
+        iree_memory_order_seq_cst);
   }
 
   // If we ran out of work assigned to this specific worker try to steal some


### PR DESCRIPTION
Saves it from showing in traces and doing some useless PRNG work.

This saves 4ms of CPU time (x16 threads) in MobileSSD.

Fixes #5569.