### PR TITLE
Enable remote caching on the integrations GPU build as well

### DIFF
--- a/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake-bazel/linux/x86-turing/build.sh
@@ -36,7 +36,16 @@ echo "Initializing submodules"
 pushd integrations/tensorflow
 BAZEL_CMD=(bazel --noworkspace_rc --bazelrc=build_tools/bazel/iree-tf.bazelrc)
 BAZEL_BINDIR="$(${BAZEL_CMD[@]?} info bazel-bin)"
-"${BAZEL_CMD[@]?}" build --config=generic_clang //iree_tf_compiler:all
+# Technically, the cache key of the `remote_cache_tf_integrations` config
+# references the Docker image used by the non-GPU build that includes
+# swiftshader. In practice though, the part that matters for building these
+# binaries is common to both of them.
+# TODO(gcmn): Split this out into a multistage build so we only build these
+# once anyway.
+"${BAZEL_CMD[@]?}" build \
+   --config=generic_clang \
+   --config=remote_cache_tf_integrations \
+   //iree_tf_compiler:all
 popd
 
 


### PR DESCRIPTION
https://github.com/google/iree/pull/6867 enabled this for the
swiftshader integrations build, to good effect, frequently halving the
time for the whole workflow. We don't run these builds on presubmit by
default, but they're running on machines with real GPUs, so the
resources are actually much more precious. Due to GCE constraints on
machines with real GPUs, they build machines are also only 16 cores.

Technically, these builds are running in slightly different docker
containers and so should perhaps have different cache keys, but the only
difference is in the final stage either installing nvidia or swiftshader
and that only makes a difference for the CMake part of each build when
we run vulkan tests.

Tested: Bazel part of the turing presubmit run on this PR took under a
minute instead of the typical 45 minutes
(https://source.cloud.google.com/results/invocations/c23ee21c-2ca8-4717-896d-83e39e49e281
vs
https://source.cloud.google.com/results/invocations/8511982d-8120-4e18-985f-5f68be93d4a8)