### PR TITLE
Update musl to point to a github fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,4 +52,4 @@
 	url = https://github.com/webgpu-native/webgpu-headers.git
 [submodule "third_party/musl"]
 	path = third_party/musl
-	url = git://git.musl-libc.org/musl
+	url = https://github.com/powderluv/musl.git


### PR DESCRIPTION
github.com offers a more reliable endpoint for fetching (especially for
frequent fetches from bots) and keeping all our git endpoints on GitHub
ensures that users don't need to vet the security of other endpoints. It
also maintains a uniform git server behavior for endpoints.

TEST=checks out