### PR TITLE
Fix bugs in PromoteI1ToI8Pass and move it to common input conversion.

### DIFF
--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -52,7 +52,6 @@ cc_library(
         "PadTensorToSubTensorInsert.cpp",
         "PassDetail.h",
         "Passes.cpp",
-        "PromoteI1ToI8Pass.cpp",
         "StripAndSplatConstantVariables.cpp",
         "TypeConverter.cpp",
         "VerifyInputLegality.cpp",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -49,7 +49,6 @@ iree_cc_library(
     "PadTensorToSubTensorInsert.cpp"
     "PassDetail.h"
     "Passes.cpp"
-    "PromoteI1ToI8Pass.cpp"
     "StripAndSplatConstantVariables.cpp"
     "TypeConverter.cpp"
     "VerifyInputLegality.cpp"

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -133,12 +133,6 @@ def PadTensorToSubTensorInsert :
   let constructor = "mlir::iree_compiler::IREE::Flow::createPadTensorToSubTensorInsertPass()";
 }
 
-def PromoteI1ToI8 :
-    Pass<"iree-flow-promote-i1-to-i8", "mlir::FuncOp"> {
-  let summary = "Legalizes i1 tensor constants to i8s";
-  let constructor = "mlir::iree_compiler::IREE::Flow::createPromoteI1ToI8Pass()";
-}
-
 def StripAndSplatConstantVariables :
     Pass<"iree-flow-strip-and-splat-constant-variables", "mlir::ModuleOp"> {
   let summary = "Strips constant util.globals and replaces them with splats.";

--- a/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -37,7 +37,6 @@ iree_lit_test_suite(
             "outline_large_constants.mlir",
             "pad_linalg_ops.mlir",
             "pad_tensor_to_tensor.mlir",
-            "promote_i1_to_i8.mlir",
             "strip_and_splat_constant_variables.mlir",
             "transformation.mlir",
             "verify_input_ir.mlir",

--- a/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -34,7 +34,6 @@ iree_lit_test_suite(
     "outline_large_constants.mlir"
     "pad_linalg_ops.mlir"
     "pad_tensor_to_tensor.mlir"
-    "promote_i1_to_i8.mlir"
     "strip_and_splat_constant_variables.mlir"
     "transformation.mlir"
     "verify_input_ir.mlir"

--- a/iree/compiler/InputConversion/Common/BUILD
+++ b/iree/compiler/InputConversion/Common/BUILD
@@ -46,6 +46,7 @@ cc_library(
     srcs = [
         "IREEImportPublic.cpp",
         "Passes.cpp",
+        "PromoteI1ToI8Pass.cpp",
         "TopLevelSCFToCFG.cpp",
     ],
     hdrs = [

--- a/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
   SRCS
     "IREEImportPublic.cpp"
     "Passes.cpp"
+    "PromoteI1ToI8Pass.cpp"
     "TopLevelSCFToCFG.cpp"
   DEPS
     ::PassHeaders

--- a/iree/compiler/InputConversion/Common/Passes.h
+++ b/iree/compiler/InputConversion/Common/Passes.h
@@ -27,6 +27,7 @@ void buildCommonInputConversionPassPipeline(OpPassManager &passManager);
 
 std::unique_ptr<OperationPass<FuncOp>> createTopLevelSCFToCFGPass();
 std::unique_ptr<OperationPass<ModuleOp>> createIREEImportPublicPass();
+std::unique_ptr<OperationPass<FuncOp>> createPromoteI1ToI8Pass();
 
 //===----------------------------------------------------------------------===//
 // Register all Passes

--- a/iree/compiler/InputConversion/Common/Passes.td
+++ b/iree/compiler/InputConversion/Common/Passes.td
@@ -21,4 +21,10 @@ def IREEImportPublic :
   let constructor = "mlir::iree_compiler::createIREEImportPublicPass()";
 }
 
+def PromoteI1ToI8 :
+    Pass<"iree-promote-i1-to-i8", "mlir::FuncOp"> {
+  let summary = "Legalizes i1 tensor constants to i8s";
+  let constructor = "mlir::iree_compiler::createPromoteI1ToI8Pass()";
+}
+
 #endif // IREE_COMPILER_INPUTCONVERSION_COMMON_PASSES

--- a/iree/compiler/InputConversion/Common/test/BUILD
+++ b/iree/compiler/InputConversion/Common/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "iree_import_public.mlir",
+            "promote_i1_to_i8.mlir",
             "top_level_scf_to_cfg.mlir",
         ],
         include = ["*.mlir"],

--- a/iree/compiler/InputConversion/Common/test/CMakeLists.txt
+++ b/iree/compiler/InputConversion/Common/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "iree_import_public.mlir"
+    "promote_i1_to_i8.mlir"
     "top_level_scf_to_cfg.mlir"
   DATA
     iree::tools::IreeFileCheck

--- a/iree/compiler/InputConversion/Common/test/promote_i1_to_i8.mlir
+++ b/iree/compiler/InputConversion/Common/test/promote_i1_to_i8.mlir
@@ -1,5 +1,4 @@
-
-// RUN: iree-opt -split-input-file -pass-pipeline='builtin.func(iree-flow-promote-i1-to-i8)' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -pass-pipeline='builtin.func(iree-promote-i1-to-i8)' %s | IreeFileCheck %s
 
 // CHECK: #[[$MAP:.+]] = affine_map<(d0) -> (d0)>
 

--- a/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -64,6 +64,8 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
       mlir::iree_compiler::createConvertMHLOToLinalgExtPass());
   passManager.addNestedPass<FuncOp>(
       mlir::iree_compiler::createMHLOToLinalgOnTensorsPass());
+  passManager.addNestedPass<FuncOp>(
+      mlir::iree_compiler::createPromoteI1ToI8Pass());
 
   // Note that some MHLO ops are left by the above and must resolve via
   // canonicalization. See comments in the above pass and find a better way.

--- a/iree/compiler/InputConversion/TOSA/BUILD
+++ b/iree/compiler/InputConversion/TOSA/BUILD
@@ -53,7 +53,6 @@ cc_library(
     deps = [
         ":PassHeaders",
         ":PassesIncGen",
-        "//iree/compiler/Dialect/Flow/Transforms",
         "//iree/compiler/InputConversion/Common",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFToStandard",

--- a/iree/compiler/InputConversion/TOSA/CMakeLists.txt
+++ b/iree/compiler/InputConversion/TOSA/CMakeLists.txt
@@ -51,7 +51,6 @@ iree_cc_library(
     MLIRTosaToSCF
     MLIRTosaToStandard
     MLIRTransforms
-    iree::compiler::Dialect::Flow::Transforms
     iree::compiler::InputConversion::Common
   PUBLIC
 )

--- a/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -6,12 +6,13 @@
 
 #include "iree/compiler/InputConversion/TOSA/Passes.h"
 
-#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "iree/compiler/InputConversion/Common/Passes.h"
 #include "mlir/Conversion/TosaToLinalg/TosaToLinalg.h"
 #include "mlir/Conversion/TosaToSCF/TosaToSCF.h"
 #include "mlir/Conversion/TosaToStandard/TosaToStandard.h"
 #include "mlir/Dialect/Tosa/Transforms/Passes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Pass/PassOptions.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
@@ -43,7 +44,7 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(tosa::createTosaMakeBroadcastablePass());
   passManager.addNestedPass<FuncOp>(tosa::createTosaToStandard());
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
-  passManager.addNestedPass<FuncOp>(IREE::Flow::createPromoteI1ToI8Pass());
+  passManager.addNestedPass<FuncOp>(createPromoteI1ToI8Pass());
   passManager.addNestedPass<FuncOp>(tosa::createTosaToLinalgOnTensors());
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
 


### PR DESCRIPTION
Deletes inserting the op right before the first use of the constant.
Generating the op right after the constant guarantees the dominitio
because the constant already meets it. Plus, a constant could be used in
different blocks. In this context, it will crash in the check.

Also adds the pass to MHLO pipeline.