### PR TITLE
Add vm.abs.i32 and vm.abs.i64 ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -4521,6 +4521,8 @@ void populateVMToEmitCPatterns(ConversionTarget &conversionTarget,
                                                          "vm_rem_i32u");
   patterns.add<GenericOpConversion<IREE::VM::FMAI32Op>>(typeConverter, context,
                                                         "vm_fma_i32");
+  patterns.add<GenericOpConversion<IREE::VM::AbsI32Op>>(typeConverter, context,
+                                                        "vm_abs_i32");
   patterns.add<GenericOpConversion<IREE::VM::NotI32Op>>(typeConverter, context,
                                                         "vm_not_i32");
   patterns.add<GenericOpConversion<IREE::VM::AndI32Op>>(typeConverter, context,
@@ -4716,6 +4718,8 @@ void populateVMToEmitCPatterns(ConversionTarget &conversionTarget,
                                                          "vm_rem_i64u");
   patterns.add<GenericOpConversion<IREE::VM::FMAI64Op>>(typeConverter, context,
                                                         "vm_fma_i64");
+  patterns.add<GenericOpConversion<IREE::VM::AbsI64Op>>(typeConverter, context,
+                                                        "vm_abs_i64");
   patterns.add<GenericOpConversion<IREE::VM::NotI64Op>>(typeConverter, context,
                                                         "vm_not_i64");
   patterns.add<GenericOpConversion<IREE::VM::AndI64Op>>(typeConverter, context,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -941,6 +941,16 @@ void FMAI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<CanonicalizeFMA<FMAI64Op, MulI64Op, AddI64Op>>(context);
 }
 
+OpFoldResult AbsI32Op::fold(ArrayRef<Attribute> operands) {
+  return constFoldUnaryOp<IntegerAttr>(operands,
+                                       [](const APInt &a) { return a.abs(); });
+}
+
+OpFoldResult AbsI64Op::fold(ArrayRef<Attribute> operands) {
+  return constFoldUnaryOp<IntegerAttr>(operands,
+                                       [](const APInt &a) { return a.abs(); });
+}
+
 //===----------------------------------------------------------------------===//
 // Floating-point arithmetic
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpcodesCore.td
@@ -104,6 +104,7 @@ def VM_OPC_DivI32U               : VM_OPC<0x26, "DivI32U">;
 def VM_OPC_RemI32S               : VM_OPC<0x27, "RemI32S">;
 def VM_OPC_RemI32U               : VM_OPC<0x28, "RemI32U">;
 def VM_OPC_FMAI32                : VM_OPC<0x29, "FMAI32">;
+def VM_OPC_AbsI32                : VM_OPC<0x77, "AbsI32">;
 
 // 64-bit integer arithmetic:
 def VM_OPC_AddI64                : VM_OPC<0x2A, "AddI64">;
@@ -114,6 +115,7 @@ def VM_OPC_DivI64U               : VM_OPC<0x2E, "DivI64U">;
 def VM_OPC_RemI64S               : VM_OPC<0x2F, "RemI64S">;
 def VM_OPC_RemI64U               : VM_OPC<0x30, "RemI64U">;
 def VM_OPC_FMAI64                : VM_OPC<0x31, "FMAI64">;
+def VM_OPC_AbsI64                : VM_OPC<0x78, "AbsI64">;
 
 // 32-bit integer bit manipulation:
 def VM_OPC_NotI32                : VM_OPC<0x32, "NotI32">;
@@ -266,6 +268,7 @@ def VM_CoreOpcodeAttr :
     VM_OPC_RemI32S,
     VM_OPC_RemI32U,
     VM_OPC_FMAI32,
+    VM_OPC_AbsI32,
 
     VM_OPC_AddI64,
     VM_OPC_SubI64,
@@ -275,6 +278,7 @@ def VM_CoreOpcodeAttr :
     VM_OPC_RemI64S,
     VM_OPC_RemI64U,
     VM_OPC_FMAI64,
+    VM_OPC_AbsI64,
 
     VM_OPC_NotI32,
     VM_OPC_AndI32,

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -2069,6 +2069,18 @@ def VM_FMAI64Op :
   let hasCanonicalizer = 1;
 }
 
+def VM_AbsI32Op :
+    VM_UnaryArithmeticOp<I32, "abs.i32", VM_OPC_AbsI32> {
+  let summary = [{integer absolute-value operation}];
+  let hasFolder = 1;
+}
+
+def VM_AbsI64Op :
+    VM_UnaryArithmeticOp<I64, "abs.i64", VM_OPC_AbsI64> {
+  let summary = [{integer absolute-value operation}];
+  let hasFolder = 1;
+}
+
 //===----------------------------------------------------------------------===//
 // Floating-point arithmetic
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -2972,7 +2972,7 @@ def VM_CmpNZI64Op :
 def VM_CmpEQF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.eq.f32.o", VM_OPC_CmpEQF32O,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{floating-point equality comparison operation}];
+  let summary = [{ordered floating-point equality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -2980,7 +2980,7 @@ def VM_CmpEQF32OOp :
 def VM_CmpEQF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.eq.f64.o", VM_OPC_CmpEQF64O,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{floating-point equality comparison operation}];
+  let summary = [{ordered floating-point equality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -2988,7 +2988,7 @@ def VM_CmpEQF64OOp :
 def VM_CmpEQF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.eq.f32.u", VM_OPC_CmpEQF32U,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{floating-point equality comparison operation}];
+  let summary = [{unordered floating-point equality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -2996,7 +2996,7 @@ def VM_CmpEQF32UOp :
 def VM_CmpEQF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.eq.f64.u", VM_OPC_CmpEQF64U,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{floating-point equality comparison operation}];
+  let summary = [{unordered floating-point equality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3004,7 +3004,7 @@ def VM_CmpEQF64UOp :
 def VM_CmpNEF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.ne.f32.o", VM_OPC_CmpNEF32O,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{floating-point inequality comparison operation}];
+  let summary = [{ordered floating-point inequality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3012,7 +3012,7 @@ def VM_CmpNEF32OOp :
 def VM_CmpNEF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.ne.f64.o", VM_OPC_CmpNEF64O,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{floating-point inequality comparison operation}];
+  let summary = [{ordered floating-point inequality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3020,7 +3020,7 @@ def VM_CmpNEF64OOp :
 def VM_CmpNEF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.ne.f32.u", VM_OPC_CmpNEF32U,
                           [VM_ExtF32, Commutative]> {
-  let summary = [{floating-point inequality comparison operation}];
+  let summary = [{unordered floating-point inequality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3028,7 +3028,7 @@ def VM_CmpNEF32UOp :
 def VM_CmpNEF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.ne.f64.u", VM_OPC_CmpNEF64U,
                           [VM_ExtF64, Commutative]> {
-  let summary = [{floating-point inequality comparison operation}];
+  let summary = [{unordered floating-point inequality comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3036,7 +3036,7 @@ def VM_CmpNEF64UOp :
 def VM_CmpLTF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.lt.f32.o", VM_OPC_CmpLTF32O,
                           [VM_ExtF32]> {
-  let summary = [{floating-point less-than comparison operation}];
+  let summary = [{ordered floating-point less-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3044,7 +3044,7 @@ def VM_CmpLTF32OOp :
 def VM_CmpLTF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.lt.f64.o", VM_OPC_CmpLTF64O,
                           [VM_ExtF64]> {
-  let summary = [{floating-point less-than comparison operation}];
+  let summary = [{ordered floating-point less-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3052,7 +3052,7 @@ def VM_CmpLTF64OOp :
 def VM_CmpLTF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.lt.f32.u", VM_OPC_CmpLTF32U,
                           [VM_ExtF32]> {
-  let summary = [{floating-point less-than comparison operation}];
+  let summary = [{unordered floating-point less-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3060,7 +3060,7 @@ def VM_CmpLTF32UOp :
 def VM_CmpLTF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.lt.f64.u", VM_OPC_CmpLTF64U,
                           [VM_ExtF64]> {
-  let summary = [{floating-point less-than comparison operation}];
+  let summary = [{unordered floating-point less-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3068,35 +3068,35 @@ def VM_CmpLTF64UOp :
 def VM_CmpLTEF32OOp :
     VM_BinaryComparisonOp<F32, "cmp.lte.f32.o", VM_OPC_CmpLTEF32O,
                                 [VM_ExtF32]> {
-  let summary = [{floating-point less-than-or-equal comparison operation}];
+  let summary = [{ordered floating-point less-than-or-equal comparison operation}];
   let hasFolder = 1;
 }
 
 def VM_CmpLTEF64OOp :
     VM_BinaryComparisonOp<F64, "cmp.lte.f64.o", VM_OPC_CmpLTEF64O,
                           [VM_ExtF64]> {
-  let summary = [{floating-point less-than-or-equal comparison operation}];
+  let summary = [{ordered floating-point less-than-or-equal comparison operation}];
   let hasFolder = 1;
 }
 
 def VM_CmpLTEF32UOp :
     VM_BinaryComparisonOp<F32, "cmp.lte.f32.u", VM_OPC_CmpLTEF32U,
                           [VM_ExtF32]> {
-  let summary = [{floating-point less-than-or-equal comparison operation}];
+  let summary = [{unordered floating-point less-than-or-equal comparison operation}];
   let hasFolder = 1;
 }
 
 def VM_CmpLTEF64UOp :
     VM_BinaryComparisonOp<F64, "cmp.lte.f64.u", VM_OPC_CmpLTEF64U,
                           [VM_ExtF64]> {
-  let summary = [{floating-point less-than-or-equal comparison operation}];
+  let summary = [{unordered floating-point less-than-or-equal comparison operation}];
   let hasFolder = 1;
 }
 
 def VM_CmpGTF32OOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gt.f32.o",
                                 [VM_ExtF32]> {
-  let summary = [{floating-point greater-than comparison operation}];
+  let summary = [{ordered floating-point greater-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3104,7 +3104,7 @@ def VM_CmpGTF32OOp :
 def VM_CmpGTF64OOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gt.f64.o",
                                 [VM_ExtF64]> {
-  let summary = [{floating-point greater-than comparison operation}];
+  let summary = [{ordered floating-point greater-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3112,7 +3112,7 @@ def VM_CmpGTF64OOp :
 def VM_CmpGTF32UOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gt.f32.u",
                                 [VM_ExtF32]> {
-  let summary = [{floating-point greater-than comparison operation}];
+  let summary = [{unordered floating-point greater-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3120,7 +3120,7 @@ def VM_CmpGTF32UOp :
 def VM_CmpGTF64UOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gt.f64.u",
                                 [VM_ExtF64]> {
-  let summary = [{floating-point greater-than comparison operation}];
+  let summary = [{unordered floating-point greater-than comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3128,7 +3128,7 @@ def VM_CmpGTF64UOp :
 def VM_CmpGTEF32OOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gte.f32.o",
                                 [VM_ExtF32]> {
-  let summary = [{floating-point greater-than-or-equal comparison operation}];
+  let summary = [{ordered floating-point greater-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3136,7 +3136,7 @@ def VM_CmpGTEF32OOp :
 def VM_CmpGTEF64OOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gte.f64.o",
                                 [VM_ExtF64]> {
-  let summary = [{floating-point greater-than-or-equal comparison operation}];
+  let summary = [{ordered floating-point greater-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3144,7 +3144,7 @@ def VM_CmpGTEF64OOp :
 def VM_CmpGTEF32UOp :
     VM_BinaryComparisonPseudoOp<F32, "cmp.gte.f32.u",
                                 [VM_ExtF32]> {
-  let summary = [{floating-point greater-than-or-equal comparison operation}];
+  let summary = [{unordered floating-point greater-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3152,7 +3152,7 @@ def VM_CmpGTEF32UOp :
 def VM_CmpGTEF64UOp :
     VM_BinaryComparisonPseudoOp<F64, "cmp.gte.f64.u",
                                 [VM_ExtF64]> {
-  let summary = [{floating-point greater-than-or-equal comparison operation}];
+  let summary = [{unordered floating-point greater-than-or-equal comparison operation}];
   let hasCanonicalizer = 1;
   let hasFolder = 1;
 }
@@ -3160,7 +3160,7 @@ def VM_CmpGTEF64UOp :
 def VM_CmpNZF32OOp :
     VM_UnaryComparisonPseudoOp<F32, "cmp.nz.f32.o",
                                [VM_ExtF32]> {
-  let summary = [{floating-point non-zero comparison operation}];
+  let summary = [{ordered floating-point non-zero comparison operation}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];
@@ -3171,7 +3171,7 @@ def VM_CmpNZF32OOp :
 def VM_CmpNZF64OOp :
     VM_UnaryComparisonPseudoOp<F64, "cmp.nz.f64.o",
                                [VM_ExtF64]> {
-  let summary = [{floating-point non-zero comparison operation}];
+  let summary = [{ordered floating-point non-zero comparison operation}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];
@@ -3182,7 +3182,7 @@ def VM_CmpNZF64OOp :
 def VM_CmpNZF32UOp :
     VM_UnaryComparisonPseudoOp<F32, "cmp.nz.f32.u",
                                [VM_ExtF32]> {
-  let summary = [{floating-point non-zero comparison operation}];
+  let summary = [{unordered floating-point non-zero comparison operation}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];
@@ -3193,7 +3193,7 @@ def VM_CmpNZF32UOp :
 def VM_CmpNZF64UOp :
     VM_UnaryComparisonPseudoOp<F64, "cmp.nz.f64.u",
                                [VM_ExtF64]> {
-  let summary = [{floating-point non-zero comparison operation}];
+  let summary = [{unordered floating-point non-zero comparison operation}];
   let description = [{
     Compares the given floating-point operand for a non-zero value.
   }];

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
@@ -213,6 +213,20 @@ vm.module @rem_i32_folds {
 
 // -----
 
+// CHECK-LABEL: @abs_i32_folds
+vm.module @abs_i32_folds {
+  // CHECK-LABEL: @abs_i32_const
+  vm.func @abs_i32_const() -> i32 {
+    // CHECK: %c2 = vm.const.i32 2
+    // CHECK-NEXT: vm.return %c2 : i32
+    %cn2 = vm.const.i32 -2
+    %0 = vm.abs.i32 %cn2 : i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @not_i32_folds
 vm.module @not_i32_folds {
   // CHECK-LABEL: @not_i32_const

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/arithmetic_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/arithmetic_ops.mlir
@@ -77,6 +77,28 @@ vm.module @my_module {
 
 // -----
 
+// CHECK-LABEL: @fma_i32
+vm.module @my_module {
+  vm.func @fma_i32(%arg0 : i32, %arg1 : i32, %arg2 : i32) -> i32 {
+    // CHECK: %0 = vm.fma.i32 %arg0, %arg1, %arg2 : i32
+    %0 = vm.fma.i32 %arg0, %arg1, %arg2 : i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
+// CHECK-LABEL: @abs_i32
+vm.module @my_module {
+  vm.func @abs_i32(%arg0 : i32) -> i32 {
+    // CHECK: %0 = vm.abs.i32 %arg0 : i32
+    %0 = vm.abs.i32 %arg0 : i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @not_i32
 vm.module @my_module {
   vm.func @not_i32(%arg0 : i32) -> i32 {

--- a/runtime/src/iree/vm/bytecode_dispatch.c
+++ b/runtime/src/iree/vm/bytecode_dispatch.c
@@ -1523,6 +1523,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
     DISPATCH_OP_CORE_BINARY_I32(RemI32S, vm_rem_i32s);
     DISPATCH_OP_CORE_BINARY_I32(RemI32U, vm_rem_i32u);
     DISPATCH_OP_CORE_TERNARY_I32(FMAI32, vm_fma_i32);
+    DISPATCH_OP_CORE_UNARY_I32(AbsI32, vm_abs_i32);
     DISPATCH_OP_CORE_UNARY_I32(NotI32, vm_not_i32);
     DISPATCH_OP_CORE_BINARY_I32(AndI32, vm_and_i32);
     DISPATCH_OP_CORE_BINARY_I32(OrI32, vm_or_i32);
@@ -1537,6 +1538,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
     DISPATCH_OP_CORE_BINARY_I64(RemI64S, vm_rem_i64s);
     DISPATCH_OP_CORE_BINARY_I64(RemI64U, vm_rem_i64u);
     DISPATCH_OP_CORE_TERNARY_I64(FMAI64, vm_fma_i64);
+    DISPATCH_OP_CORE_UNARY_I64(AbsI64, vm_abs_i64);
     DISPATCH_OP_CORE_UNARY_I64(NotI64, vm_not_i64);
     DISPATCH_OP_CORE_BINARY_I64(AndI64, vm_and_i64);
     DISPATCH_OP_CORE_BINARY_I64(OrI64, vm_or_i64);

--- a/runtime/src/iree/vm/generated/bytecode_op_table.h
+++ b/runtime/src/iree/vm/generated/bytecode_op_table.h
@@ -126,8 +126,8 @@ typedef enum {
   IREE_VM_OP_CORE_BufferFillI64 = 0x74,
   IREE_VM_OP_CORE_CtlzI32 = 0x75,
   IREE_VM_OP_CORE_CtlzI64 = 0x76,
-  IREE_VM_OP_CORE_RSV_0x77,
-  IREE_VM_OP_CORE_RSV_0x78,
+  IREE_VM_OP_CORE_AbsI32 = 0x77,
+  IREE_VM_OP_CORE_AbsI64 = 0x78,
   IREE_VM_OP_CORE_RSV_0x79,
   IREE_VM_OP_CORE_RSV_0x7A,
   IREE_VM_OP_CORE_RSV_0x7B,
@@ -385,8 +385,8 @@ typedef enum {
     OPC(0x74, BufferFillI64) \
     OPC(0x75, CtlzI32) \
     OPC(0x76, CtlzI64) \
-    RSV(0x77) \
-    RSV(0x78) \
+    OPC(0x77, AbsI32) \
+    OPC(0x78, AbsI64) \
     RSV(0x79) \
     RSV(0x7A) \
     RSV(0x7B) \
@@ -1556,4 +1556,3 @@ typedef enum {
     RSV(0xFD) \
     RSV(0xFE) \
     RSV(0xFF)
-

--- a/runtime/src/iree/vm/ops.h
+++ b/runtime/src/iree/vm/ops.h
@@ -60,6 +60,7 @@ static inline int32_t vm_rem_i32u(int32_t lhs, int32_t rhs) {
 static inline int32_t vm_fma_i32(int32_t a, int32_t b, int32_t c) {
   return a * b + c;
 }
+static inline int32_t vm_abs_i32(int32_t operand) { return abs(operand); }
 static inline int32_t vm_not_i32(int32_t operand) {
   return (int32_t)(~((uint32_t)operand));
 }
@@ -185,6 +186,7 @@ static inline int64_t vm_rem_i64u(int64_t lhs, int64_t rhs) {
 static inline int64_t vm_fma_i64(int64_t a, int64_t b, int64_t c) {
   return a * b + c;
 }
+static inline int64_t vm_abs_i64(int64_t operand) { return labs(operand); }
 static inline int64_t vm_not_i64(int64_t operand) {
   return (int64_t)(~((uint64_t)operand));
 }

--- a/runtime/src/iree/vm/test/arithmetic_ops.mlir
+++ b/runtime/src/iree/vm/test/arithmetic_ops.mlir
@@ -98,6 +98,16 @@ vm.module @arithmetic_ops {
     vm.return
   }
 
+  vm.export @test_abs_i32
+  vm.func @test_abs_i32() {
+    %c1 = vm.const.i32 -1
+    %c1dno = util.do_not_optimize(%c1) : i32
+    %v = vm.abs.i32 %c1dno : i32
+    %c2 = vm.const.i32 1
+    vm.check.eq %v, %c2, "abs(-1)=1" : i32
+    vm.return
+  }
+
   vm.export @test_not_i32
   vm.func @test_not_i32() {
     %c1 = vm.const.i32 0

--- a/runtime/src/iree/vm/test/arithmetic_ops_i64.mlir
+++ b/runtime/src/iree/vm/test/arithmetic_ops_i64.mlir
@@ -98,6 +98,16 @@ vm.module @arithmetic_ops_i64 {
     vm.return
   }
 
+  vm.export @test_abs_i64
+  vm.func @test_abs_i64() {
+    %c1 = vm.const.i64 -1
+    %c1dno = util.do_not_optimize(%c1) : i64
+    %v = vm.abs.i64 %c1dno : i64
+    %c2 = vm.const.i64 1
+    vm.check.eq %v, %c2, "abs(-1)=1" : i64
+    vm.return
+  }
+
   vm.export @test_not_i64
   vm.func @test_not_i64() {
     %c1 = vm.const.i64 0


### PR DESCRIPTION
I want these for https://github.com/google/iree/issues/5854.

Also included

* a tiny documentation change to float comparison op summaries (point out that "o" == "ordered" and "u" == "unordered" for comparisons)
* a printing/parsing test for `vm.fma.i32`