### PR TITLE
Revert "[spirv] Remove createStdExpandOpsPass in pass pipelines"

### DIFF
--- a/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -118,6 +118,7 @@ static void addLowerToSPIRVPasses(OpPassManager &pm) {
   // subview ops.
   pm.addPass(memref::createFoldSubViewOpsPass());
   pm.addNestedPass<FuncOp>(Shape::createFoldDimOverShapeCarryingOpPass());
+  pm.addNestedPass<FuncOp>(createStdExpandOpsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 


### PR DESCRIPTION
Reverts google/iree#7276. This causes test failures on Pixel 4.