### PR TITLE
iree_atomic_ref_count_inc returns void

### DIFF
--- a/iree/base/internal/atomics_test.cc
+++ b/iree/base/internal/atomics_test.cc
@@ -92,8 +92,11 @@ TEST(AtomicPtr, CompareExchange) {
 TEST(AtomicRefCount, IncDec) {
   iree_atomic_ref_count_t count;
   iree_atomic_ref_count_init(&count);
-  EXPECT_EQ(1, iree_atomic_ref_count_inc(&count));
-  EXPECT_EQ(2, iree_atomic_ref_count_inc(&count));
+  EXPECT_EQ(1, count);
+  iree_atomic_ref_count_inc(&count);
+  EXPECT_EQ(2, count);
+  iree_atomic_ref_count_inc(&count);
+  EXPECT_EQ(3, count);
   EXPECT_EQ(3, iree_atomic_ref_count_dec(&count));
   EXPECT_EQ(2, iree_atomic_ref_count_dec(&count));
   EXPECT_EQ(1, iree_atomic_ref_count_dec(&count));


### PR DESCRIPTION
(This is on top of PR #7284).

Callers of iree_atomic_ref_count_inc typically don't need it to return a
value (unlike iree_atomic_ref_count_dec), so we make sure that it does not,
which allows the implementation to use faster atomic instructions where
available, e.g. STADD on ARMv8.1-a.

In theory, compilers should perform this optimization when the
instruction is available and the return value of the fetch_add builtin
function is not used. In practice, at the moment, neither Clang nor GCC
do, but at least it's possible. If we cared, we could make the
optimization at any time with inline asm.

This commit ensures that the call sites don't use the return value, which would prevent such optimizations.