### PR TITLE
Clean up GCC warning flags.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -190,20 +190,17 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wunused-comparison"
     "-Wvla"
 
-  # Disable some warnings to get GCC to build. Until we have a CI for this, we
-  # just need it for releases and extra diagnostics (or Werror) only bring pain.
-  # TODO(#6959): Trim these down and add -Werror -Wall once we have a CI.
+  # TODO(#6959): Enable -Werror once we have a presubmit CI.
   GCC
-    "-Wno-unused-but-set-parameter"
+    "-Wall"
+    "-Wno-address-of-packed-member"
     "-Wno-comment"
-    "-Wno-attributes"
-    "-Wno-strict-prototypes"
-    "-Wno-shadow-uncaptured-local"
-    "-Wno-gnu-zero-variadic-macro-arguments"
-    "-Wno-shadow-field-in-constructor"
-    "-Wno-unreachable-code-return"
-    "-Wno-missing-variable-declarations"
-    "-Wno-gnu-label-as-value"
+    "-Wno-format-zero-length"
+    # Technically UB but needed for intrusive ptrs
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-invalid-offsetof>
+    $<$<COMPILE_LANGUAGE:C>:-Wno-pointer-sign>
+    "-Wno-sign-compare"
+    "-Wno-unused-function"
 
   MSVC_OR_CLANG_CL
     # Default warning level (severe + significant + production quality).

--- a/iree/base/internal/atomics_test.cc
+++ b/iree/base/internal/atomics_test.cc
@@ -59,7 +59,7 @@ TEST(AtomicPtr, CompareExchange) {
   intptr_t ptr_1 = 0x1;
   intptr_t ptr_2 = 0x2;
   iree_atomic_intptr_t value = IREE_ATOMIC_VAR_INIT(ptr_0);
-  intptr_t ptr_expected = NULL;
+  intptr_t ptr_expected = 0;
 
   // OK: value == ptr_0, CAS(ptr_0 -> ptr_1)
   iree_atomic_store_intptr(&value, ptr_0, iree_memory_order_seq_cst);

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -517,8 +517,8 @@ LogicalResult getComputeOps(FuncOp funcOp,
   Optional<StringRef> marker = llvm::None;
   for (auto op : computeOps) {
     if (hasMarker(op)) {
-      assert(!marker || marker.getValue() == getMarkerOrNull(op) &&
-                            "expected all markers within op to be the same");
+      assert((!marker || marker.getValue() == getMarkerOrNull(op)) &&
+             "expected all markers within op to be the same");
       marker = getMarkerOrNull(op);
     }
   }

--- a/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -200,7 +200,7 @@ class ROCMTargetBackend final : public TargetBackend {
 
     iree_ROCMBlockSizeDef_vec_start(builder);
     auto blockSizes = workgroupSizes.begin();
-    for (auto shader : entryPointNames) {
+    for (int i = 0, e = entryPointNames.size(); i < e; ++i) {
       iree_ROCMBlockSizeDef_vec_push_create(builder, (*blockSizes)[0],
                                             (*blockSizes)[1], (*blockSizes)[2]);
       ++blockSizes;

--- a/third_party/mlir-emitc/lib/Target/Cpp/TranslateToCpp.cpp
+++ b/third_party/mlir-emitc/lib/Target/Cpp/TranslateToCpp.cpp
@@ -516,6 +516,8 @@ bool CppEmitter::shouldMapToUnsigned(IntegerType::SignednessSemantics val) {
     return false;
   case IntegerType::Unsigned:
     return true;
+  default:
+    llvm_unreachable("unsupported IntegerType");
   }
 }
 


### PR DESCRIPTION
* Enables `-Wall` and disables specific warnings, roughly consistent with what we carve out for clang.
* Does language specific disabling of a couple of flags that GCC warns are only applicable to C or C++.
* Fixes a few things that stricter warnings uncovered.