### PR TITLE
[spirv] Unify matmul/convolution reduction tiling

### DIFF
--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -85,7 +85,7 @@ hal.executable @conv_112x112x512 {
 
 //                CHECK: func @conv_112x112x512()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 256], [], [0, 1, 8, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 256], [], [0, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -174,7 +174,7 @@ hal.executable @conv_112x112x32 {
 
 //                CHECK: func @conv_112x112x32()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 16, 32], [], [0, 4, 2, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 16, 32], [], [0, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -261,7 +261,7 @@ hal.executable @conv_16x16x16 {
 
 //                CHECK: func @conv_16x16x16()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 8, 8, 16], [], [0, 2, 2, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 8, 8, 16], [], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -350,7 +350,7 @@ hal.executable @dwconv_28x28x144 {
 
 //                CHECK: func @dwconv_28x28x144()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
 
 // -----
 
@@ -438,4 +438,4 @@ hal.executable @dwconv_4x4x8 {
 
 //                CHECK: func @dwconv_4x4x8()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 8], [], [0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 8], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -73,7 +73,7 @@ hal.executable @matmul_1024x2048x512 {
 
 //                CHECK: func @matmul_1024x2048x512()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 128, 4], [], [16, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 128], [], [16, 4], [0, 0, 4]]}
 
 // -----
 
@@ -150,7 +150,7 @@ hal.executable @matmul_3136x24x96 {
 
 //                CHECK: func @matmul_3136x24x96()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[448, 8, 4], [], [14, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[448, 8], [], [14, 4], [0, 0, 4]]}
 
 // -----
 
@@ -227,7 +227,7 @@ hal.executable @matmul_196x64x192 {
 
 //                CHECK: func @matmul_196x64x192()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[28, 64, 8], [], [7, 4, 8]]}
+//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[28, 64], [], [7, 4], [0, 0, 8]]}
 
 // -----
 
@@ -299,7 +299,7 @@ hal.executable @matmul_12544x96x16 {
 
 //                CHECK: func @matmul_12544x96x16()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[128, 32, 4], [], [16, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[128, 32], [], [16, 4], [0, 0, 4]]}
 
 // -----
 
@@ -376,7 +376,7 @@ hal.executable @matmul_49x160x576 {
 
 //                CHECK: func @matmul_49x160x576()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[7, 32, 8], [], [7, 4, 8]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[7, 32], [], [7, 4], [0, 0, 8]]}
 
 // -----
 
@@ -463,7 +463,7 @@ hal.executable @batch_matmul_4x384x384 {
 
 //                CHECK: func @batch_matmul_4x384x384()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32, 128, 4], [], [1, 16, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32, 128], [], [1, 16, 4], [0, 0, 0, 4]]}
 
 // -----
 
@@ -550,4 +550,4 @@ hal.executable @batch_matmul_4x8x8 {
 
 //                CHECK: func @batch_matmul_4x8x8()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 8, 8, 16], [], [1, 1, 4, 16]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 8, 8], [], [1, 1, 4], [0, 0, 0, 16]]}

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -85,7 +85,7 @@ hal.executable @conv_112x112x512 {
 
 //                CHECK: func @conv_112x112x512()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 4, 64], [], [0, 1, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 4, 64], [], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -174,7 +174,7 @@ hal.executable @conv_112x112x32 {
 
 //                CHECK: func @conv_112x112x32()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 32], [], [0, 1, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 32], [], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -261,7 +261,7 @@ hal.executable @conv_16x16x16 {
 
 //                CHECK: func @conv_16x16x16()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 2, 2, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -350,7 +350,7 @@ hal.executable @dwconv_28x28x144 {
 
 //                CHECK: func @dwconv_28x28x144()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 2, 2, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1]]}
 
 // -----
 
@@ -439,5 +439,5 @@ hal.executable @dwconv_1x2x8 {
 
 //                CHECK: func @dwconv_1x2x8()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 2, 8], [], [0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 2, 8], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
 

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -73,7 +73,7 @@ hal.executable @matmul_1024x2048x512 {
 
 //                CHECK: func @matmul_1024x2048x512()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[8, 32, 4], [], [4, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[8, 32], [], [4, 4], [0, 0, 4]]}
 
 // -----
 
@@ -150,7 +150,7 @@ hal.executable @matmul_3136x24x96 {
 
 //                CHECK: func @matmul_3136x24x96()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 8, 4], [], [4, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 8], [], [4, 4], [0, 0, 4]]}
 
 // -----
 
@@ -227,7 +227,7 @@ hal.executable @matmul_196x64x192 {
 
 //                CHECK: func @matmul_196x64x192()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[4, 32, 8], [], [2, 4, 8]]}
+//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[4, 32], [], [2, 4], [0, 0, 8]]}
 
 // -----
 
@@ -299,7 +299,7 @@ hal.executable @matmul_12544x96x16 {
 
 //                CHECK: func @matmul_12544x96x16()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[8, 32, 4], [], [4, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[8, 32], [], [4, 4], [0, 0, 4]]}
 
 // -----
 
@@ -375,7 +375,7 @@ hal.executable @matmul_49x160x576 {
 
 //                CHECK: func @matmul_49x160x576()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32, 8], [], [1, 4, 8]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32], [], [1, 4], [0, 0, 8]]}
 
 // -----
 
@@ -462,7 +462,7 @@ hal.executable @batch_matmul_4x384x384 {
 
 //                CHECK: func @batch_matmul_4x384x384()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 12, 32, 4], [], [1, 6, 4, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 12, 32], [], [1, 6, 4], [0, 0, 0, 4]]}
 
 // -----
 
@@ -550,4 +550,4 @@ hal.executable @batch_matmul_4x2x8 {
 
 //                CHECK: func @batch_matmul_4x2x8()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 2, 8, 8], [], [1, 1, 4, 8]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 2, 8], [], [1, 1, 4], [0, 0, 0, 8]]}

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline))' %s | IreeFileCheck %s
 
-#config = {tileSizes = [[8, 64, 4], [], [8, 4, 4]]}
+#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
 
 hal.executable private @fuse_and_vectorize_fill_matmul  {
   hal.interface @io {
@@ -70,7 +70,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul  {
 
 // -----
 
-#config = {tileSizes = [[8, 64, 4], [], [8, 4, 4]]}
+#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
 
 hal.executable private @fuse_and_vectorize_matmul_add  {
   hal.interface @io {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
@@ -8,7 +8,7 @@
 #map5 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-#config = {tileSizes = [[8, 16, 0], [], [1, 1, 1]]}
+#config = {tileSizes = [[8, 16], [], [1, 1], [0, 0, 1]]}
 
 hal.executable private @matmul  {
   hal.interface @io {
@@ -165,7 +165,7 @@ hal.executable private @conv_1d  {
 #map6 = affine_map<(d0)[s0] -> (4, -d0 + s0)>
 #map7 = affine_map<(d0)[s0] -> (32, -d0 + s0)>
 
-#config = {tileSizes = [[0, 1, 4, 32], [], [0, 1, 1, 1]]}
+#config = {tileSizes = [[0, 1, 4, 32], [], [0, 1, 1, 1], [0, 0, 0, 0, 1, 1, 4]]}
 
 hal.executable private @conv_no_padding  {
   hal.interface @io {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-set-num-workgroups,builtin.module(builtin.func(iree-spirv-tile-and-distribute,iree-spirv-vectorize))))' -canonicalize -cse %s | IreeFileCheck %s
 
-#config = {tileSizes = [[8, 64, 4], [], [8, 4, 4]]}
+#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
 
 hal.executable private @matmul_static_shape_f16  {
   hal.interface private @io  {
@@ -66,7 +66,7 @@ hal.executable private @matmul_static_shape_f16  {
 
 // -----
 
-#config = {tileSizes = [[8, 64, 4], [], [8, 4, 4]]}
+#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
 
 hal.executable private @matmul_static_shape_f32  {
   hal.interface private @io  {

--- a/iree/compiler/Codegen/Utils/MarkerUtils.cpp
+++ b/iree/compiler/Codegen/Utils/MarkerUtils.cpp
@@ -41,11 +41,7 @@ StringRef getCopyToWorkgroupMemoryMarker() {
   return "copy_to_workgroup_memory";
 }
 
-// This marker is needed because we tile a convolution op multiple times: 1)
-// workgroups, 2) invocations, and 3) tiling along filter's height/width and
-// input channel to generate loops for a single GPU invocation. This marker
-// is for the 3) step.
-StringRef getConvFilterTileMarker() { return "tile_conv_filter"; }
+StringRef getTileReductionMarker() { return "tile_reduction"; }
 
 StringRef getVectorizeMarker() { return "vectorize"; }
 

--- a/iree/compiler/Codegen/Utils/MarkerUtils.h
+++ b/iree/compiler/Codegen/Utils/MarkerUtils.h
@@ -41,8 +41,8 @@ StringRef getWorkgroupL1TileMarker();
 /// Workgroup memory.
 StringRef getCopyToWorkgroupMemoryMarker();
 
-/// Marker for tiling along convolution filter dimensions.
-StringRef getConvFilterTileMarker();
+/// Marker for tiling linalg reduction dimensions.
+StringRef getTileReductionMarker();
 
 /// Marker for operations that are going to be vectorized.
 StringRef getVectorizeMarker();


### PR DESCRIPTION
Previously we have been doing reduction dimension tiling for
matmuls at the time we do tiling and distribution to threads.
This can be confusing because we provide all (M, N, K) tile
sizes there but under the hood we treat them differently:
M/N gotten tiled and distributed, while K is just tiled.

While for convolution, we always only provide configuration
for parallel dimensions for workgroup/thread tiling and
distribution. Tiling for the reduction dimensions is handled
later. It's also inconsistent here.

Therefore this commit moves all reduction dimension tiling
into the same place for clarity and consistency.

This is a preliminary step towards revamping cooperative
matrix support, where we will have (M, N, K) tile sizes
for workgroup/subgroup tiling.