### PR TITLE
Added TosaToStandard to iree-opt by default

### DIFF
--- a/iree/tools/init_mlir_passes.h
+++ b/iree/tools/init_mlir_passes.h
@@ -83,6 +83,7 @@ inline void registerMlirPasses() {
 
   // TOSA.
   registerTosaToLinalgOnTensorsPass();
+  registerTosaToStandardPass();
 }
 
 }  // namespace mlir


### PR DESCRIPTION
Useful for testing the TOSA front-end to have both TosaTo* passes included.