### PR TITLE
Make convolution vectorization patterns support tensor

### DIFF
--- a/iree/compiler/Codegen/Common/test/vectorize_linalg_conv.mlir
+++ b/iree/compiler/Codegen/Common/test/vectorize_linalg_conv.mlir
@@ -1,13 +1,9 @@
 // RUN: iree-opt -split-input-file -iree-codegen-vectorize-linalg-conv -canonicalize -cse %s | IreeFileCheck %s
 
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @vectorize_conv(%filter: memref<2x1x3x4xf32>, %input: memref<2x2x2x3xf32>, %output: memref<2x2x2x4xf32>) {
-  %0 = memref.subview %filter[0, 0, 0, 0] [1, 1, 3, 4] [1, 1, 1, 1]  : memref<2x1x3x4xf32> to memref<1x1x3x4xf32>
-  %1 = memref.subview %input[0, 0, 0, 0] [1, 2, 2, 3] [1, 1, 1, 1]  : memref<2x2x2x3xf32> to memref<1x2x2x3xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [1, 2, 2, 4] [1, 1, 1, 1]  : memref<2x2x2x4xf32> to memref<1x2x2x4xf32>
+func @vectorize_conv(%filter: memref<1x1x3x4xf32>, %input: memref<1x2x2x3xf32>, %output: memref<1x2x2x4xf32>) {
   linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
-     ins (%1, %0: memref<1x2x2x3xf32>, memref<1x1x3x4xf32>)
-    outs (%2: memref<1x2x2x4xf32>)
+     ins (%input, %filter: memref<1x2x2x3xf32>, memref<1x1x3x4xf32>)
+    outs (%output: memref<1x2x2x4xf32>)
   return
 }
 
@@ -16,15 +12,11 @@ func @vectorize_conv(%filter: memref<2x1x3x4xf32>, %input: memref<2x2x2x3xf32>, 
 // CHECK: #map2 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
 // CHECK: func @vectorize_conv
-// CHECK-SAME: %[[FILTER_ARG:.+]]: memref<2x1x3x4xf32>,
-// CHECK-SAME: %[[INPUT_ARG:.+]]: memref<2x2x2x3xf32>,
-// CHECK-SAME: %[[OUTPUT_ARG:.+]]: memref<2x2x2x4xf32>
+// CHECK-SAME: %[[FILTER_SUBVIEW:.+]]: memref<1x1x3x4xf32>,
+// CHECK-SAME: %[[INPUT_SUBVIEW:.+]]: memref<1x2x2x3xf32>,
+// CHECK-SAME: %[[OUTPUT_SUBVIEW:.+]]: memref<1x2x2x4xf32>
 
 // CHECK: %[[FLOAT_ZERO:.+]] = arith.constant 0.000000e+00 : f32
-
-// CHECK-DAG: %[[FILTER_SUBVIEW:.+]] = memref.subview %[[FILTER_ARG]]{{.*}} to memref<1x1x3x4xf32>
-// CHECK-DAG: %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT_ARG]]{{.*}} to memref<1x2x2x3xf32>
-// CHECK-DAG: %[[OUTPUT_SUBVIEW:.+]] = memref.subview %[[OUTPUT_ARG]]{{.*}} to memref<1x2x2x4xf32>
 
 // Read in the filter and get slices
 // CHECK: %[[FILTER_VECTOR:.+]] = vector.transfer_read %[[FILTER_SUBVIEW]][%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true]} : memref<1x1x3x4xf32>, vector<3x4xf32>
@@ -79,155 +71,222 @@ func @vectorize_conv(%filter: memref<2x1x3x4xf32>, %input: memref<2x2x2x3xf32>, 
 // -----
 
 // CHECK-LABEL: func @do_not_vectorize_conv_with_non_1_batch
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @do_not_vectorize_conv_with_non_1_batch(%filter: memref<2x1x4x4xf32>, %input: memref<3x1x7x4xf32>, %output: memref<3x1x4x4xf32>) {
-  %0 = memref.subview %filter[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<2x1x4x4xf32> to memref<1x1x4x4xf32>
-  %1 = memref.subview %input[0, 0, 0, 0] [2, 1, 7, 4] [1, 1, 1, 1]  : memref<3x1x7x4xf32> to memref<2x1x7x4xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [2, 1, 4, 4] [1, 1, 1, 1]  : memref<3x1x4x4xf32> to memref<2x1x4x4xf32>
+func @do_not_vectorize_conv_with_non_1_batch(%filter: memref<1x1x4x4xf32>, %input: memref<2x1x7x4xf32>, %output: memref<2x1x4x4xf32>) {
   // CHECK: linalg.conv_2d_nhwc_hwcf
   linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
-     ins (%1, %0: memref<2x1x7x4xf32>, memref<1x1x4x4xf32>)
-    outs (%2: memref<2x1x4x4xf32>)
+     ins (%input, %filter: memref<2x1x7x4xf32>, memref<1x1x4x4xf32>)
+    outs (%output: memref<2x1x4x4xf32>)
   return
 }
 
 // -----
 
 // CHECK-LABEL: func @do_not_vectorize_conv_with_non_1_filter_height
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @do_not_vectorize_conv_with_non_1_filter_height(%filter: memref<3x1x4x4xf32>, %input: memref<2x2x7x4xf32>, %output: memref<2x1x4x4xf32>) {
-  %0 = memref.subview %filter[0, 0, 0, 0] [2, 1, 4, 4] [1, 1, 1, 1]  : memref<3x1x4x4xf32> to memref<2x1x4x4xf32>
-  %1 = memref.subview %input[0, 0, 0, 0] [1, 2, 7, 4] [1, 1, 1, 1]  : memref<2x2x7x4xf32> to memref<1x2x7x4xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<2x1x4x4xf32> to memref<1x1x4x4xf32>
+func @do_not_vectorize_conv_with_non_1_filter_height(%filter: memref<2x1x4x4xf32>, %input: memref<1x2x7x4xf32>, %output: memref<1x1x4x4xf32>) {
   // CHECK: linalg.conv_2d_nhwc_hwcf
   linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
-     ins (%1, %0: memref<1x2x7x4xf32>, memref<2x1x4x4xf32>)
-    outs (%2: memref<1x1x4x4xf32>)
+     ins (%input, %filter: memref<1x2x7x4xf32>, memref<2x1x4x4xf32>)
+    outs (%output: memref<1x1x4x4xf32>)
   return
 }
 
 // -----
 
 // CHECK-LABEL: func @do_not_vectorize_conv_with_non_1_filter_width
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @do_not_vectorize_conv_with_non_1_filter_width(%filter: memref<2x2x4x4xf32>, %input: memref<2x1x8x4xf32>, %output: memref<2x1x4x4xf32>) {
-  %0 = memref.subview %filter[0, 0, 0, 0] [1, 2, 4, 4] [1, 1, 1, 1]  : memref<2x2x4x4xf32> to memref<1x2x4x4xf32>
-  %1 = memref.subview %input[0, 0, 0, 0] [1, 1, 8, 4] [1, 1, 1, 1]  : memref<2x1x8x4xf32> to memref<1x1x8x4xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<2x1x4x4xf32> to memref<1x1x4x4xf32>
+func @do_not_vectorize_conv_with_non_1_filter_width(%filter: memref<1x2x4x4xf32>, %input: memref<1x1x8x4xf32>, %output: memref<1x1x4x4xf32>) {
   // CHECK: linalg.conv_2d_nhwc_hwcf
   linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
-     ins (%1, %0: memref<1x1x8x4xf32>, memref<1x2x4x4xf32>)
-    outs (%2: memref<1x1x4x4xf32>)
+     ins (%input, %filter: memref<1x1x8x4xf32>, memref<1x2x4x4xf32>)
+    outs (%output: memref<1x1x4x4xf32>)
   return
 }
 
 // -----
 
 // CHECK-LABEL: func @do_not_vectorize_conv_with_non_1_dilation
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @do_not_vectorize_conv_with_non_1_dilation(%filter: memref<2x1x4x4xf32>, %input: memref<2x1x7x4xf32>, %output: memref<2x1x4x4xf32>) {
-  %0 = memref.subview %filter[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<2x1x4x4xf32> to memref<1x1x4x4xf32>
-  %1 = memref.subview %input[0, 0, 0, 0] [1, 1, 7, 4] [1, 1, 1, 1]  : memref<2x1x7x4xf32> to memref<1x1x7x4xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<2x1x4x4xf32> to memref<1x1x4x4xf32>
+func @do_not_vectorize_conv_with_non_1_dilation(%filter: memref<1x1x4x4xf32>, %input: memref<1x1x7x4xf32>, %output: memref<1x1x4x4xf32>) {
   // CHECK: linalg.conv_2d_nhwc_hwcf
   linalg.conv_2d_nhwc_hwcf {dilations = dense<[2, 1]> : vector<2xi64>, strides = dense<2> : vector<2xi64>}
-     ins (%1, %0: memref<1x1x7x4xf32>, memref<1x1x4x4xf32>)
-    outs (%2: memref<1x1x4x4xf32>)
+     ins (%input, %filter: memref<1x1x7x4xf32>, memref<1x1x4x4xf32>)
+    outs (%output: memref<1x1x4x4xf32>)
   return
 }
 
 // -----
 
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @vectorize_depthwise_conv(%input: memref<2x3x3x8xf32>, %filter: memref<2x1x8xf32>, %output: memref<2x2x2x8xf32>) {
-  %0 = memref.subview %input[0, 0, 0, 0] [1, 3, 3, 8] [1, 1, 1, 1]  : memref<2x3x3x8xf32> to memref<1x3x3x8xf32>
-  %1 = memref.subview %filter[0, 0, 0] [1, 1, 8] [1, 1, 1]  : memref<2x1x8xf32> to memref<1x1x8xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [1, 2, 2, 8] [1, 1, 1, 1]  : memref<2x2x2x8xf32> to memref<1x2x2x8xf32>
-  linalg.depthwise_conv2D_nhw {dilations = dense<2> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%0, %1 : memref<1x3x3x8xf32>, memref<1x1x8xf32>) outs(%2 : memref<1x2x2x8xf32>)
+func @vectorize_depthwise_conv(%input: memref<1x3x3x8xf32>, %filter: memref<1x1x8xf32>, %output: memref<1x2x2x8xf32>) {
+  linalg.depthwise_conv2D_nhw {dilations = dense<2> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%input, %filter : memref<1x3x3x8xf32>, memref<1x1x8xf32>) outs(%output : memref<1x2x2x8xf32>)
   return
 }
 
 // CHECK-LABEL: func @vectorize_depthwise_conv
-// CHECK-SAME: %[[INPUT_ARG:.+]]: memref<2x3x3x8xf32>,
-// CHECK-SAME: %[[FILTER_ARG:.+]]: memref<2x1x8xf32>,
-// CHECK-SAME: %[[OUTPUT_ARG:.+]]: memref<2x2x2x8xf32>
+// CHECK-SAME: %[[INPUT_SUBVIEW:.+]]: memref<1x3x3x8xf32>,
+// CHECK-SAME: %[[FILTER_SUBVIEW:.+]]: memref<1x1x8xf32>,
+// CHECK-SAME: %[[OUTPUT_SUBVIEW:.+]]: memref<1x2x2x8xf32>
 
 // CHECK: %[[FLOAT_ZERO:.+]] = arith.constant 0.000000e+00 : f32
 
-// CHECK-DAG: %[[INPUT_SUBVIEW:.+]] = memref.subview %[[INPUT_ARG]]{{.*}} to memref<1x3x3x8xf32>
-// CHECK-DAG: %[[FILTER_SUBVIEW:.+]] = memref.subview %[[FILTER_ARG]]{{.*}} to memref<1x1x8xf32>
-// CHECK-DAG: %[[OUTPUT_SUBVIEW:.+]] = memref.subview %[[OUTPUT_ARG]]{{.*}} to memref<1x2x2x8xf32>
-
-// CHECK: %[[FILTER_VECTOR:.+]] = vector.transfer_read %[[FILTER_SUBVIEW]][%c0, %c0, %c0], %cst {in_bounds = [true]} : memref<1x1x8xf32>, vector<8xf32>
+// CHECK: %[[FILTER_VECTOR:.+]] = vector.transfer_read %[[FILTER_SUBVIEW]][%c0, %c0, %c0], %cst {in_bounds = [true, true, true]} : memref<1x1x8xf32>, vector<1x1x8xf32>
 
 // Common filter #0
-// CHECK:      %[[FILTER_0:.+]] = vector.extract_strided_slice %[[FILTER_VECTOR]] {offsets = [0], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+// CHECK: %[[FILTER_0_SLICE:.+]] = vector.extract_strided_slice %[[FILTER_VECTOR]] {offsets = [0, 0, 0], sizes = [1, 1, 4], strides = [1, 1, 1]} : vector<1x1x8xf32> to vector<1x1x4xf32>
+// CHECK:       %[[FILTER_0:.+]] = vector.shape_cast %[[FILTER_0_SLICE]] : vector<1x1x4xf32> to vector<1x1x1x4xf32>
 
-// CHECK: %[[OUTPUT_0_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c0], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_0_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c0, %c0], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_0_0:.+]] = vector.fma %[[INPUT_0_0]], %[[FILTER_0]], %[[OUTPUT_0_0]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_0_0]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c0] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_0_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_0_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_0_0:.+]] = vector.fma %[[INPUT_0_0]], %[[FILTER_0]], %[[OUTPUT_0_0]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_0_0]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
-// CHECK: %[[OUTPUT_0_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c0], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_0_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c2, %c0], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_0_1:.+]] = vector.fma %[[INPUT_0_1]], %[[FILTER_0]], %[[OUTPUT_0_1]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_0_1]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c0] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_0_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_0_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c2, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_0_1:.+]] = vector.fma %[[INPUT_0_1]], %[[FILTER_0]], %[[OUTPUT_0_1]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_0_1]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
-// CHECK: %[[OUTPUT_1_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c0], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_1_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c0, %c0], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_1_0:.+]] = vector.fma %[[INPUT_1_0]], %[[FILTER_0]], %[[OUTPUT_1_0]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_1_0]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c0] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_1_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_1_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c0, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_1_0:.+]] = vector.fma %[[INPUT_1_0]], %[[FILTER_0]], %[[OUTPUT_1_0]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_1_0]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
-// CHECK: %[[OUTPUT_1_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c0], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_1_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c2, %c0], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_1_1:.+]] = vector.fma %[[INPUT_1_1]], %[[FILTER_0]], %[[OUTPUT_1_1]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_1_1]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c0] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_1_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_1_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c2, %c0], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_1_1:.+]] = vector.fma %[[INPUT_1_1]], %[[FILTER_0]], %[[OUTPUT_1_1]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_1_1]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c0] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
 // Common filter #1
-// CHECK: %[[FILTER_1:.+]] = vector.extract_strided_slice %[[FILTER_VECTOR]] {offsets = [4], sizes = [4], strides = [1]} : vector<8xf32> to vector<4xf32>
+// CHECK: %[[FILTER_1_SLICE:.+]] = vector.extract_strided_slice %[[FILTER_VECTOR]] {offsets = [0, 0, 4], sizes = [1, 1, 4], strides = [1, 1, 1]} : vector<1x1x8xf32> to vector<1x1x4xf32>
+// CHECK:       %[[FILTER_1:.+]] = vector.shape_cast %[[FILTER_1_SLICE]] : vector<1x1x4xf32> to vector<1x1x1x4xf32>
 
-// CHECK: %[[OUTPUT_0_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c4], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_0_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c0, %c4], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_0_0:.+]] = vector.fma %[[INPUT_0_0]], %[[FILTER_1]], %[[OUTPUT_0_0]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_0_0]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c4] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_0_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_0_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c0, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_0_0:.+]] = vector.fma %[[INPUT_0_0]], %[[FILTER_1]], %[[OUTPUT_0_0]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_0_0]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c0, %c4] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
-// CHECK: %[[OUTPUT_0_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c4], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_0_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c2, %c4], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_0_1:.+]] = vector.fma %[[INPUT_0_1]], %[[FILTER_1]], %[[OUTPUT_0_1]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_0_1]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c4] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_0_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_0_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c0, %c2, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_0_1:.+]] = vector.fma %[[INPUT_0_1]], %[[FILTER_1]], %[[OUTPUT_0_1]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_0_1]], %[[OUTPUT_SUBVIEW]][%c0, %c0, %c1, %c4] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
-// CHECK: %[[OUTPUT_1_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c4], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_1_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c0, %c4], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_1_0:.+]] = vector.fma %[[INPUT_1_0]], %[[FILTER_1]], %[[OUTPUT_1_0]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_1_0]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c4] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_1_0:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_1_0:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c0, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_1_0:.+]] = vector.fma %[[INPUT_1_0]], %[[FILTER_1]], %[[OUTPUT_1_0]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_1_0]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c0, %c4] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
-// CHECK: %[[OUTPUT_1_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c4], %cst {in_bounds = [true]} : memref<1x2x2x8xf32>, vector<4xf32>
-// CHECK:  %[[INPUT_1_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c2, %c4], %cst {in_bounds = [true]} : memref<1x3x3x8xf32>, vector<4xf32>
-// CHECK:    %[[FMA_1_1:.+]] = vector.fma %[[INPUT_1_1]], %[[FILTER_1]], %[[OUTPUT_1_1]] : vector<4xf32>
-// CHECK: vector.transfer_write %[[FMA_1_1]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c4] {in_bounds = [true]} : vector<4xf32>, memref<1x2x2x8xf32>
+// CHECK: %[[OUTPUT_1_1:.+]] = vector.transfer_read %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x2x2x8xf32>, vector<1x1x1x4xf32>
+// CHECK:  %[[INPUT_1_1:.+]] = vector.transfer_read %[[INPUT_SUBVIEW]][%c0, %c2, %c2, %c4], %cst {in_bounds = [true, true, true, true]} : memref<1x3x3x8xf32>, vector<1x1x1x4xf32>
+// CHECK:    %[[FMA_1_1:.+]] = vector.fma %[[INPUT_1_1]], %[[FILTER_1]], %[[OUTPUT_1_1]] : vector<1x1x1x4xf32>
+// CHECK: vector.transfer_write %[[FMA_1_1]], %[[OUTPUT_SUBVIEW]][%c0, %c1, %c1, %c4] {in_bounds = [true, true, true, true]} : vector<1x1x1x4xf32>, memref<1x2x2x8xf32>
 
 // -----
 
 // CHECK-LABEL: func @do_not_vectorize_depthwise_conv_with_non_1_filter_height
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @do_not_vectorize_depthwise_conv_with_non_1_filter_height(%input: memref<2x2x3x4xf32>, %filter: memref<3x1x4xf32>, %output: memref<2x1x2x4xf32>) {
-  %0 = memref.subview %input[0, 0, 0, 0] [1, 2, 3, 4] [1, 1, 1, 1]  : memref<2x2x3x4xf32> to memref<1x2x3x4xf32>
-  %1 = memref.subview %filter[0, 0, 0] [2, 1, 4] [1, 1, 1]  : memref<3x1x4xf32> to memref<2x1x4xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [1, 1, 2, 4] [1, 1, 1, 1]  : memref<2x1x2x4xf32> to memref<1x1x2x4xf32>
+func @do_not_vectorize_depthwise_conv_with_non_1_filter_height(%input: memref<1x2x3x4xf32>, %filter: memref<2x1x4xf32>, %output: memref<1x1x2x4xf32>) {
   // CHECK: linalg.depthwise_conv2D_nhw
-  linalg.depthwise_conv2D_nhw {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%0, %1 : memref<1x2x3x4xf32>, memref<2x1x4xf32>) outs(%2 : memref<1x1x2x4xf32>)
+  linalg.depthwise_conv2D_nhw {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+     ins(%input, %filter : memref<1x2x3x4xf32>, memref<2x1x4xf32>)
+    outs(%output : memref<1x1x2x4xf32>)
   return
 }
 
 // -----
 
 // CHECK-LABEL: func @do_not_vectorize_depthwise_conv_with_non_1_filter_width
-// Passing bigger buffers to avoid memref.subview fold awawy.
-func @do_not_vectorize_depthwise_conv_with_non_1_filter_width(%input: memref<2x1x4x4xf32>, %filter: memref<2x2x4xf32>, %output: memref<2x1x2x4xf32>) {
-  %0 = memref.subview %input[0, 0, 0, 0] [1, 1, 4, 4] [1, 1, 1, 1]  : memref<2x1x4x4xf32> to memref<1x1x4x4xf32>
-  %1 = memref.subview %filter[0, 0, 0] [1, 2, 4] [1, 1, 1]  : memref<2x2x4xf32> to memref<1x2x4xf32>
-  %2 = memref.subview %output[0, 0, 0, 0] [1, 1, 2, 4] [1, 1, 1, 1]  : memref<2x1x2x4xf32> to memref<1x1x2x4xf32>
+func @do_not_vectorize_depthwise_conv_with_non_1_filter_width(%input: memref<1x1x4x4xf32>, %filter: memref<1x2x4xf32>, %output: memref<1x1x2x4xf32>) {
   // CHECK: linalg.depthwise_conv2D_nhw
-  linalg.depthwise_conv2D_nhw {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%0, %1 : memref<1x1x4x4xf32>, memref<1x2x4xf32>) outs(%2 : memref<1x1x2x4xf32>)
+  linalg.depthwise_conv2D_nhw {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+     ins(%input, %filter : memref<1x1x4x4xf32>, memref<1x2x4xf32>)
+    outs(%output : memref<1x1x2x4xf32>)
   return
 }
+
+// -----
+
+func @vectorize_conv(%filter: tensor<1x1x3x4xf32>, %input: tensor<1x2x2x3xf32>, %init: tensor<1x2x2x4xf32>) -> tensor<1x2x2x4xf32> {
+  %0 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : vector<2xi64>, strides = dense<1> : vector<2xi64>}
+     ins (%input, %filter: tensor<1x2x2x3xf32>, tensor<1x1x3x4xf32>)
+    outs (%init: tensor<1x2x2x4xf32>) -> tensor<1x2x2x4xf32>
+  return %0 : tensor<1x2x2x4xf32>
+}
+
+// CHECK-LABEL: func @vectorize_conv
+//  CHECK-SAME: %[[FILTER_TENSOR:.+]]: tensor<1x1x3x4xf32>,
+//  CHECK-SAME: %[[INPUT_TENSOR:.+]]: tensor<1x2x2x3xf32>,
+//  CHECK-SAME: %[[INIT_TENSOR:.+]]: tensor<1x2x2x4xf32>
+
+//         CHECK: vector.transfer_read %[[FILTER_TENSOR]]
+// CHECK-COUNT-3: vector.extract_strided_slice
+
+//         CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+//         CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK-COUNT-3: vector.contract
+//         CHECK: %[[WRITE0:.+]] =  vector.transfer_write %{{.+}}, %[[INIT_TENSOR]]
+
+//         CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+//         CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK-COUNT-3: vector.contract
+//         CHECK: %[[WRITE1:.+]] =  vector.transfer_write %{{.+}}, %[[WRITE0]]
+
+//         CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+//         CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK-COUNT-3: vector.contract
+//         CHECK: %[[WRITE2:.+]] =  vector.transfer_write %{{.+}}, %[[WRITE1]]
+
+//         CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+//         CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK-COUNT-3: vector.contract
+//         CHECK: %[[WRITE3:.+]] =  vector.transfer_write %{{.+}}, %[[WRITE2]]
+
+// -----
+
+func @vectorize_depthwise_conv(%input: tensor<1x3x3x8xf32>, %filter: tensor<1x1x8xf32>, %init: tensor<1x2x2x8xf32>) -> tensor<1x2x2x8xf32> {
+  %0 = linalg.depthwise_conv2D_nhw {dilations = dense<2> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
+     ins(%input, %filter : tensor<1x3x3x8xf32>, tensor<1x1x8xf32>)
+    outs(%init : tensor<1x2x2x8xf32>) -> tensor<1x2x2x8xf32>
+  return %0 : tensor<1x2x2x8xf32>
+}
+
+// CHECK-LABEL: func @vectorize_depthwise_conv
+// CHECK-SAME: %[[INPUT_TENSOR:.+]]: tensor<1x3x3x8xf32>,
+// CHECK-SAME: %[[FILTER_TENSOR:.+]]: tensor<1x1x8xf32>,
+// CHECK-SAME: %[[INIT_TENSOR:.+]]: tensor<1x2x2x8xf32>
+
+// CHECK: vector.transfer_read %[[FILTER_TENSOR]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE0:.+]] = vector.transfer_write %{{.+}}, %[[INIT_TENSOR]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE1:.+]] = vector.transfer_write %{{.+}}, %[[WRITE0]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE2:.+]] = vector.transfer_write %{{.+}}, %[[WRITE1]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE3:.+]] = vector.transfer_write %{{.+}}, %[[WRITE2]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE4:.+]] = vector.transfer_write %{{.+}}, %[[WRITE3]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE5:.+]] = vector.transfer_write %{{.+}}, %[[WRITE4]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE6:.+]] = vector.transfer_write %{{.+}}, %[[WRITE5]]
+
+// CHECK: vector.transfer_read %[[INIT_TENSOR]]
+// CHECK: vector.transfer_read %[[INPUT_TENSOR]]
+// CHECK: vector.fma
+// CHECK: %[[WRITE7:.+]] = vector.transfer_write %{{.+}}, %[[WRITE6]]

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -295,8 +295,6 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
           contractLoweringPatterns,
           vector::VectorTransformsOptions().setVectorTransformsOptions(
               vector::VectorContractLowering::OuterProduct));
-      vector::populateVectorMaskOpLoweringPatterns(contractLoweringPatterns);
-      vector::populateVectorShapeCastLoweringPatterns(contractLoweringPatterns);
       (void)applyPatternsAndFoldGreedily(funcOp,
                                          std::move(contractLoweringPatterns));
     }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -185,9 +185,9 @@ hal.executable private @depthwise_conv_static_shape_f32  {
 
 // check tiling loop along filter height/width and input channel
 //      CHECK:    scf.for %{{.+}} = %c0 to %c3 step %c1
-// CHECK-SAME:        -> (vector<4xf32>)
+// CHECK-SAME:        -> (vector<1x1x1x4xf32>)
 //      CHECK:      scf.for %{{.+}} = %c0 to %c3 step %c1
-// CHECK-SAME:          -> (vector<4xf32>)
+// CHECK-SAME:          -> (vector<1x1x1x4xf32>)
 
 
 // CHECK: vector.fma


### PR DESCRIPTION
This is a preliminary step to move bufferization to be after
vectorization in the SPIR-V backend. Generally this is just
very simple changes, other than that for depthwise conv,
changed the generated vectors' shapes a bit.

I'm in the process to upstream these patterns too; but that
may take a while to finally land and replace this. So for now
just make minor changes to extend them to support tensors.