### PR TITLE
Register -view-op-graph pass with IREE tools.

### DIFF
--- a/iree/tools/init_mlir_passes.h
+++ b/iree/tools/init_mlir_passes.h
@@ -46,6 +46,7 @@ inline void registerMlirPasses() {
   registerAffineScalarReplacementPass();
   registerParallelLoopCollapsingPass();
   registerPrintOpStatsPass();
+  registerViewOpGraphPassPass();
   registerStripDebugInfoPass();
   registerSymbolDCEPass();
 


### PR DESCRIPTION
This is used to print Graphviz DOT files for modules (for visualization and debugging). Using this pass from `mlir-opt` throws errors when IREE-specific dialects are encountered.

References:

* [documentation](https://mlir.llvm.org/docs/Passes/#-view-op-graph-print-graphviz-visualization-of-an-operation)
* [mlir/include/mlir/Transforms/Passes.td](https://github.com/llvm/llvm-project/blob/26b675d65eb2d1f117a39eee965652f590373232/mlir/include/mlir/Transforms/Passes.td#L695-L709)
* [mlir/lib/Transforms/ViewOpGraph.cpp](https://github.com/llvm/llvm-project/blob/main/mlir/lib/Transforms/ViewOpGraph.cpp)