### PR TITLE
Remove "linalg_on_tensors" from test target names.

### DIFF
--- a/iree/test/e2e/models/BUILD
+++ b/iree/test/e2e/models/BUILD
@@ -49,7 +49,7 @@ iree_lit_test_suite(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_linalg_on_tensors_dylib-llvm-aot_dylib",
+    name = "check_dylib-llvm-aot_dylib",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["-iree-input-type=mhlo"],
     driver = "dylib",
@@ -65,7 +65,7 @@ iree_check_single_backend_test_suite(
 # )
 
 iree_check_single_backend_test_suite(
-    name = "check_linalg_on_tensors_vulkan-spirv_vulkan",
+    name = "check_vulkan-spirv_vulkan",
     timeout = "long",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["-iree-input-type=mhlo"],
@@ -74,7 +74,7 @@ iree_check_single_backend_test_suite(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_linalg_on_tensors_cuda_cuda",
+    name = "check_cuda_cuda",
     timeout = "long",
     srcs = CHECK_FRAMEWORK_TESTS,
     compiler_flags = ["-iree-input-type=mhlo"],

--- a/iree/test/e2e/models/CMakeLists.txt
+++ b/iree/test/e2e/models/CMakeLists.txt
@@ -31,7 +31,7 @@ iree_lit_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_linalg_on_tensors_dylib-llvm-aot_dylib
+    check_dylib-llvm-aot_dylib
   SRCS
     "bert_encoder_unrolled_fake_weights.mlir"
     "mobilenetv3_fake_weights.mlir"
@@ -45,7 +45,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_linalg_on_tensors_vulkan-spirv_vulkan
+    check_vulkan-spirv_vulkan
   SRCS
     "bert_encoder_unrolled_fake_weights.mlir"
     "mobilenetv3_fake_weights.mlir"
@@ -59,7 +59,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
-    check_linalg_on_tensors_cuda_cuda
+    check_cuda_cuda
   SRCS
     "bert_encoder_unrolled_fake_weights.mlir"
     "mobilenetv3_fake_weights.mlir"

--- a/iree/test/e2e/xla_ops/partial/BUILD
+++ b/iree/test/e2e/xla_ops/partial/BUILD
@@ -24,7 +24,7 @@ package(
 )
 
 iree_check_single_backend_test_suite(
-    name = "check_linalg_on_tensors_vulkan-spirv_vulkan_f16",
+    name = "check_vulkan-spirv_vulkan_f16",
     srcs = [
         "add_f16.mlir",
         "dot_f16.mlir",

--- a/iree/test/e2e/xla_ops/partial/CMakeLists.txt
+++ b/iree/test/e2e/xla_ops/partial/CMakeLists.txt
@@ -12,7 +12,7 @@ iree_add_all_subdirs()
 
 iree_check_single_backend_test_suite(
   NAME
-    check_linalg_on_tensors_vulkan-spirv_vulkan_f16
+    check_vulkan-spirv_vulkan_f16
   SRCS
     "add_f16.mlir"
     "dot_f16.mlir"


### PR DESCRIPTION
We're using linalg on tensors throughout the project now, so these names can be shortened.