### PR TITLE
Manually set the floating point status in workers and around sync dispatch.

### DIFF
--- a/iree/base/internal/BUILD
+++ b/iree/base/internal/BUILD
@@ -334,7 +334,6 @@ cc_library(
     ],
     hdrs = ["threading.h"],
     deps = [
-        ":fpu_state",
         ":internal",
         ":synchronization",
         "//build_tools:default_linkopts",

--- a/iree/base/internal/CMakeLists.txt
+++ b/iree/base/internal/CMakeLists.txt
@@ -345,7 +345,6 @@ iree_cc_library(
     "threading_win32.c"
   DEPS
     ${CMAKE_DL_LIBS}
-    ::fpu_state
     ::internal
     ::synchronization
     iree::base

--- a/iree/base/internal/threading_pthreads.c
+++ b/iree/base/internal/threading_pthreads.c
@@ -22,7 +22,6 @@
 
 #include "iree/base/internal/atomics.h"
 #include "iree/base/internal/call_once.h"
-#include "iree/base/internal/fpu_state.h"
 #include "iree/base/internal/synchronization.h"
 #include "iree/base/internal/threading.h"
 #include "iree/base/tracing.h"
@@ -82,10 +81,6 @@ static int iree_thread_set_name(pthread_t handle, const char* name) {
 }
 
 static void* iree_thread_start_routine(void* param) {
-  // We cannot rely on the global process settings for FPU state.
-  // Be explicit here on what we need.
-  iree_fpu_state_push(IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO);
-
   // NOTE: we own a reference to the thread handle so that the creation
   // thread can't delete this out from under us.
   iree_thread_t* thread = (iree_thread_t*)param;

--- a/iree/task/BUILD
+++ b/iree/task/BUILD
@@ -71,6 +71,7 @@ cc_library(
         "//iree/base:tracing",
         "//iree/base/internal",
         "//iree/base/internal:atomic_slist",
+        "//iree/base/internal:fpu_state",
         "//iree/base/internal:prng",
         "//iree/base/internal:synchronization",
         "//iree/base/internal:threading",

--- a/iree/task/CMakeLists.txt
+++ b/iree/task/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_cc_library(
     iree::base::core_headers
     iree::base::internal
     iree::base::internal::atomic_slist
+    iree::base::internal::fpu_state
     iree::base::internal::prng
     iree::base::internal::synchronization
     iree::base::internal::threading

--- a/iree/task/worker.c
+++ b/iree/task/worker.c
@@ -9,6 +9,7 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "iree/base/internal/fpu_state.h"
 #include "iree/base/internal/math.h"
 #include "iree/base/tracing.h"
 #include "iree/task/executor_impl.h"
@@ -350,6 +351,10 @@ static void iree_task_worker_pump_until_exit(iree_task_worker_t* worker) {
 // Thread entry point for each worker.
 static int iree_task_worker_main(iree_task_worker_t* worker) {
   IREE_TRACE_ZONE_BEGIN(thread_zone);
+
+  // We cannot rely on the global process settings for FPU state.
+  // Be explicit here on what we need.
+  iree_fpu_state_push(IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO);
 
   // Reset affinity (as it can change over time).
   // TODO(benvanik): call this after waking in case CPU hotplugging happens.


### PR DESCRIPTION
* In iree-benchmark-trace (and presumably other C binaries), IREE_FPU_STATE_FLAG_FLUSH_DENORMALS_TO_ZERO was not enabled.
* The state on Python also seems indeterminant.
* This was causing a 4-5x slowdown on some workloads.
* Fixes #7363