### PR TITLE
[spirv] Remove cooperative matrix support from main pipelines

### DIFF
--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -273,8 +273,7 @@ createSPIRVLowerExecutableTargetPass();
 /// WARNING: DO NOT USE. This is a legacy pass that is to be deprecated.
 std::unique_ptr<OperationPass<FuncOp>> createSPIRVRemoveOneTripTiledLoopPass();
 
-/// Pass to tile and distribute Linalg ops with buffer semantics to subgroups
-/// and invocations.
+/// Pass to tile and distribute Linalg ops with buffer semantics to invocations.
 std::unique_ptr<OperationPass<FuncOp>> createSPIRVTileAndDistributePass();
 
 /// Pass to tile Linalg ops with buffer semantics to subgroups and vectorize to

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -242,7 +242,7 @@ def SPIRVRemoveOneTripTiledLoop :
 // TODO: Rename argument to be fully qualified.
 def SPIRVTileAndDistribute : Pass<"iree-spirv-tile-and-distribute", "FuncOp"> {
   let summary = "Tile and distribute Linalg ops with buffer semantics to "
-                "subgroups and invocations";
+                "invocations";
   let constructor = "mlir::iree_compiler::createSPIRVTileAndDistributePass()";
 }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -6,8 +6,8 @@
 
 //===- SPIRVTileAndDistribute.cpp -----------------------------------------===//
 //
-// This pass tiles and distributes Linalg ops with buffer semantics to subgroups
-// and invocations.
+// This pass tiles and distributes Linalg ops with buffer semantics to
+// invocations.
 //
 //===----------------------------------------------------------------------===//
 
@@ -68,81 +68,6 @@ static linalg::LinalgTransformationFilter getLinalgMatchAndReplaceMarker(
 /// Converts a symbolic GPU processor dimension to its numeric one.
 static unsigned dimToIndex(StringRef dim) {
   return StringSwitch<unsigned>(dim).Case("x", 0).Case("y", 1).Case("z", 2);
-}
-
-//===----------------------------------------------------------------------===//
-// Subgroup tiling patterns
-//===----------------------------------------------------------------------===//
-
-/// Computes the Value for subgroupID along each dimension given number of
-/// subgroups `numSubGroups` along each dimension (x-first, y-second, z-third).
-static SmallVector<linalg::ProcInfo, 2> getSubgroupIdsAndCounts(
-    OpBuilder &builder, Location loc, ArrayRef<int64_t> numSubgroups) {
-  Type indexType = builder.getIndexType();
-  Value subgroupId = builder.create<gpu::SubgroupIdOp>(loc, indexType);
-  SmallVector<linalg::ProcInfo, 2> procInfo(numSubgroups.size());
-
-  // subgroupID
-  //   = id.z * nsubgroups.y * nsubgroups.x + id.y * nsubgroups.x + id.x
-  for (size_t i = 0, e = numSubgroups.size(); i != e; ++i) {
-    Value nprocs = builder.create<arith::ConstantIndexOp>(loc, numSubgroups[i]);
-    AffineExpr d0 = getAffineDimExpr(0, builder.getContext());
-    AffineExpr s0 = getAffineSymbolExpr(0, builder.getContext());
-    Value procId =
-        makeComposedAffineApply(builder, loc, d0 % s0, {subgroupId, nprocs});
-    procInfo[e - i - 1] = linalg::ProcInfo{procId, nprocs};
-    subgroupId = builder.create<arith::DivSIOp>(loc, subgroupId, nprocs);
-  }
-  return procInfo;
-}
-
-namespace {
-/// Pattern to tile linalg.matmul for subgroups.
-struct TileMatmulSubgroupPattern
-    : public linalg::LinalgTilingPattern<linalg::MatmulOp> {
-  using Base = linalg::LinalgTilingPattern<linalg::MatmulOp>;
-  TileMatmulSubgroupPattern(MLIRContext *context,
-                            linalg::LinalgTilingOptions options,
-                            linalg::LinalgTransformationFilter marker,
-                            PatternBenefit benefit = 1)
-      : Base(context, options, marker, benefit) {}
-};
-}  // namespace
-
-/// Patterns for second level tiling to target subgroups.
-static void populateTilingToSubgroupPatterns(MLIRContext *context,
-                                             RewritePatternSet &patterns) {
-  auto getInnerTileSizeFn = [&](OpBuilder &builder,
-                                Operation *operation) -> SmallVector<Value, 4> {
-    SmallVector<int64_t> tileSizes = getTileSizes(operation, 1);
-    return llvm::to_vector<4>(
-        llvm::map_range(tileSizes, [&](int64_t v) -> Value {
-          return builder.create<arith::ConstantIndexOp>(operation->getLoc(), v);
-        }));
-  };
-
-  auto getSubgroupProcInfoFn = [&](OpBuilder &builder, Location loc,
-                                   ArrayRef<Range> parallelLoopRanges) {
-    // TODO(ravishankarm): For now assume that there is always a single subgroup
-    std::array<int64_t, 3> numSubgroups = {1, 1, 1};
-    return getSubgroupIdsAndCounts(builder, loc, numSubgroups);
-  };
-
-  linalg::LinalgLoopDistributionOptions subgroupDistributionOptions;
-  subgroupDistributionOptions.procInfo = getSubgroupProcInfoFn;
-  subgroupDistributionOptions.distributionMethod = {
-      {linalg::DistributionMethod::CyclicNumProcsEqNumIters,
-       linalg::DistributionMethod::CyclicNumProcsEqNumIters}};
-
-  patterns.insert<TileMatmulSubgroupPattern>(
-      context,
-      linalg::LinalgTilingOptions()
-          .setLoopType(linalg::LinalgTilingLoopType::ParallelLoops)
-          .setTileSizeComputationFunction(getInnerTileSizeFn)
-          .setDistributionOptions(subgroupDistributionOptions),
-      getLinalgMatchAndReplaceMarker(
-          {getWorkgroupMemoryMarker(), getWorkgroupMarker()},
-          getVectorizeMarker(), context));
 }
 
 //===----------------------------------------------------------------------===//
@@ -288,36 +213,32 @@ void SPIRVTileAndDistributePass::runOnOperation() {
   auto entryPointOp = getEntryPoint(funcOp);
   if (!entryPointOp) return;
 
-  {  // Tile and distribute to subgroups.
-    RewritePatternSet subgroupTilingPatterns(&getContext());
-    populateTilingToSubgroupPatterns(context, subgroupTilingPatterns);
-    (void)applyPatternsAndFoldGreedily(funcOp,
-                                       std::move(subgroupTilingPatterns));
-
-    RewritePatternSet canonicalizationPatterns =
-        linalg::getLinalgTilingCanonicalizationPatterns(context);
-    populateAffineMinCanonicalizationPattern(canonicalizationPatterns);
-    (void)applyPatternsAndFoldGreedily(funcOp,
-                                       std::move(canonicalizationPatterns));
-    promoteSingleIterationLoops(funcOp);
-
-    LLVM_DEBUG({
-      llvm::dbgs() << "--- After tiling to subgroups ---\n";
-      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-      llvm::dbgs() << "\n\n";
-    });
-  }
-
   {  // Tile and distribute to invocations.
     RewritePatternSet invocationTilingPatterns(&getContext());
     populateTilingToInvocationPatterns(context, invocationTilingPatterns);
     (void)applyPatternsAndFoldGreedily(funcOp,
                                        std::move(invocationTilingPatterns));
 
-    // Remove trip-one loops created during cyclic loop distribution if we can
-    // prove the tiling was perfect.
-    RewritePatternSet canoncalizationPatterns(context);
-    populateAffineMinSCFCanonicalizationPattern(canoncalizationPatterns);
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After tiling to invocations ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+  }
+
+  {
+    RewritePatternSet canonicalizationPatterns =
+        linalg::getLinalgTilingCanonicalizationPatterns(context);
+
+    populateAffineMinCanonicalizationPattern(canonicalizationPatterns);
+
+    // Add patterns to fold affine.min ops created for convolution input
+    // subtensor/subview sizes. They have the affine map of
+    // (d0) -> (<tile-size>, <dim-size> - d0 * <stride>)>(%<processor-id>)`.
+    populateFoldGPUProcessorIDUsesPatterns(context, canonicalizationPatterns);
+
+    // Add patterns to remove trip-one loops created during cyclic loop
+    // distribution, if we can prove the tiling was perfect.
     SmallVector<int64_t> workgroupSize = getWorkgroupSize(entryPointOp);
     if (workgroupSize.empty()) {
       entryPointOp.emitError("expected to have workgroup_size attribute");
@@ -328,21 +249,14 @@ void SPIRVTileAndDistributePass::runOnOperation() {
                                             SmallVectorImpl<Value> &symbols) {
       return getThreadRange(processorValue, dims, symbols, workgroupSize);
     };
-    populateRemoveSingleIterationLoopPattern(canoncalizationPatterns,
+    populateRemoveSingleIterationLoopPattern(canonicalizationPatterns,
                                              getThreadRangeFn);
-    (void)applyPatternsAndFoldGreedily(funcOp,
-                                       std::move(canoncalizationPatterns));
 
-    // Perform generic canonicalization.
-    RewritePatternSet threadLevelTilingCanonicalizationPatterns =
-        linalg::getLinalgTilingCanonicalizationPatterns(context);
-    populateAffineMinCanonicalizationPattern(
-        threadLevelTilingCanonicalizationPatterns);
-    (void)applyPatternsAndFoldGreedily(
-        funcOp, std::move(threadLevelTilingCanonicalizationPatterns));
+    (void)applyPatternsAndFoldGreedily(funcOp,
+                                       std::move(canonicalizationPatterns));
 
     LLVM_DEBUG({
-      llvm::dbgs() << "--- After tiling to invocations ---\n";
+      llvm::dbgs() << "--- After loop/affine canonicalization ---\n";
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
@@ -353,14 +267,12 @@ void SPIRVTileAndDistributePass::runOnOperation() {
     auto marker = getLinalgMatchAndReplaceMarker(getTileReductionMarker(),
                                                  getVectorizeMarker(), context);
     populateTilingReductionPatterns(context, reductionTilingPatterns, marker);
-    populateFoldGPUProcessorIDUsesPatterns(context, reductionTilingPatterns);
-    scf::populateSCFForLoopCanonicalizationPatterns(reductionTilingPatterns);
     (void)applyPatternsAndFoldGreedily(funcOp,
                                        std::move(reductionTilingPatterns));
 
     RewritePatternSet canonicalizationPatterns =
         linalg::getLinalgTilingCanonicalizationPatterns(context);
-    populateAffineMinCanonicalizationPattern(canonicalizationPatterns);
+    scf::populateSCFForLoopCanonicalizationPatterns(canonicalizationPatterns);
     (void)applyPatternsAndFoldGreedily(funcOp,
                                        std::move(canonicalizationPatterns));
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -33,42 +33,7 @@ namespace mlir {
 namespace iree_compiler {
 namespace {
 
-/// Returns the cooperative matrix (M, N, K) sizes that are supported by the
-/// target environment and match the given parameters.
-static Optional<SmallVector<int64_t, 4>> getCooperativeMatmulSubgroupSize(
-    spirv::ResourceLimitsAttr resourceLimits, Type lhsType, Type rhsType,
-    Type initType, Type resultType) {
-  auto range = resourceLimits.cooperative_matrix_properties_nv()
-                   .getAsRange<spirv::CooperativeMatrixPropertiesNVAttr>();
-  for (auto coopMatmulProperties : range) {
-    if (coopMatmulProperties.a_type().getValue() == lhsType &&
-        coopMatmulProperties.b_type().getValue() == rhsType &&
-        coopMatmulProperties.c_type().getValue() == initType &&
-        coopMatmulProperties.result_type().getValue() == resultType &&
-        coopMatmulProperties.scope().getValue() == spirv::Scope::Subgroup) {
-      return SmallVector<int64_t, 4>{
-          coopMatmulProperties.m_size().getValue().getSExtValue(),
-          coopMatmulProperties.n_size().getValue().getSExtValue(),
-          coopMatmulProperties.k_size().getValue().getSExtValue()};
-    }
-  }
-  return llvm::None;
-}
-
-/// Returns true if the target environment attached to `op`'s ancestor op
-/// supports cooperative matrix.
-bool useCooperativeMatrix(Operation *op) {
-  auto attr = getSPIRVTargetEnvAttr(op);
-  if (!attr) return false;
-
-  auto targetEnv = spirv::TargetEnv(attr);
-  return targetEnv.allows(spirv::Capability::CooperativeMatrixNV) &&
-         targetEnv.allows(spirv::Extension::SPV_NV_cooperative_matrix);
-}
-
 Optional<SmallVector<int64_t, 4>> getSPIRVNativeVectorSize(Operation *op) {
-  bool useCoopMatrix = useCooperativeMatrix(op);
-
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
     if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>()) {
       // Use 4-element vectors for elementwise ops.
@@ -77,57 +42,24 @@ Optional<SmallVector<int64_t, 4>> getSPIRVNativeVectorSize(Operation *op) {
       return nativeSize;
     }
   } else if (auto vtOp = dyn_cast<VectorTransferOpInterface>(op)) {
-    if (useCoopMatrix) {
-      if (auto writeOp = dyn_cast<vector::TransferWriteOp>(op)) {
-        // Unroll cooperative martrix store based on the size of the contract.
-        auto insert =
-            writeOp.vector().getDefiningOp<vector::InsertStridedSliceOp>();
-        if (!insert) return llvm::None;
-        ArrayRef<int64_t> shape = insert.getSourceVectorType().getShape();
-        return SmallVector<int64_t, 4>(shape.begin(), shape.end());
-      } else if (auto readOp = dyn_cast<vector::TransferReadOp>(op)) {
-        // Unroll cooperative martrix load based on the size of the contract.
-        VectorType dstVec;
-        for (Operation *users : op->getUsers()) {
-          auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
-          if (!extract) return llvm::None;
-          auto vecType = extract.getResult().getType().cast<VectorType>();
-          if (dstVec && dstVec != vecType) return llvm::None;
-          dstVec = vecType;
-        }
-        return SmallVector<int64_t, 4>(dstVec.getShape().begin(),
-                                       dstVec.getShape().end());
+    auto rank = vtOp.getVectorType().getRank();
+    SmallVector<int64_t, 4> nativeSize(rank, 1);
+    for (auto dim : llvm::enumerate(vtOp.permutation_map().getResults())) {
+      if (auto dimExpr = dim.value().dyn_cast<AffineDimExpr>()) {
+        if (dimExpr.getPosition() == vtOp.permutation_map().getNumDims() - 1)
+          nativeSize[dim.index()] = 4;
       }
-    } else {
-      auto rank = vtOp.getVectorType().getRank();
-      SmallVector<int64_t, 4> nativeSize(rank, 1);
-      for (auto dim : llvm::enumerate(vtOp.permutation_map().getResults())) {
-        if (auto dimExpr = dim.value().dyn_cast<AffineDimExpr>()) {
-          if (dimExpr.getPosition() == vtOp.permutation_map().getNumDims() - 1)
-            nativeSize[dim.index()] = 4;
-        }
-      }
-      return nativeSize;
     }
+    return nativeSize;
   } else if (auto contractOp = dyn_cast<vector::ContractionOp>(op)) {
-    if (useCoopMatrix) {
-      auto targetEnv = spirv::TargetEnv(getSPIRVTargetEnvAttr(op));
-      return getCooperativeMatmulSubgroupSize(
-          targetEnv.getResourceLimits(),
-          contractOp.getLhsType().getElementType(),
-          contractOp.getRhsType().getElementType(),
-          contractOp.getAccType().cast<VectorType>().getElementType(),
-          contractOp.getResultType().cast<VectorType>().getElementType());
-    } else {
-      unsigned lastParalleldim = 0;
-      for (auto it : llvm::enumerate(contractOp.iterator_types())) {
-        if (isParallelIterator(it.value())) lastParalleldim = it.index();
-      }
-      SmallVector<int64_t, 4> nativeSize(contractOp.iterator_types().size(), 1);
-      nativeSize[lastParalleldim] = 4;
-      // Map to vec4 fma operations.
-      return nativeSize;
+    unsigned lastParalleldim = 0;
+    for (auto it : llvm::enumerate(contractOp.iterator_types())) {
+      if (isParallelIterator(it.value())) lastParalleldim = it.index();
     }
+    SmallVector<int64_t, 4> nativeSize(contractOp.iterator_types().size(), 1);
+    nativeSize[lastParalleldim] = 4;
+    // Map to vec4 fma operations.
+    return nativeSize;
   }
   return llvm::None;
 }
@@ -150,58 +82,6 @@ void populateVectorUnrollPatterns(MLIRContext *context,
       vector::UnrollVectorOptions().setNativeShapeFn(getSPIRVNativeVectorSize));
 }
 
-/// Workaround SPIR-V backend limitations. SPIR-V vetorization pass relies on
-/// unrolling to reduce instructions to a vector size we can convert to SPIR-V.
-/// When vectorization creates transpose those block unrolling and result in
-/// large vector we currently cannot lower. For now we always merge the
-/// transpose into the contract op so that it can be unrolled.
-// TODO(thomasraoux): Make transpose work with the current unrolling mechanism
-// or replace unrolling.
-class CombineContractTranspose final
-    : public OpRewritePattern<vector::ContractionOp> {
- public:
-  using OpRewritePattern<vector::ContractionOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(vector::ContractionOp op,
-                                PatternRewriter &rewriter) const override {
-    // Perform lhs + rhs transpositions to conform to matmul row-major
-    // semantics. Bail out if the contraction cannot be put in this form.
-    MLIRContext *ctx = op.getContext();
-    Location loc = op.getLoc();
-    bool foundTranspose = false;
-    std::array<Value, 3> sources = {op.lhs(), op.rhs(), op.acc()};
-    SmallVector<AffineMap> newMaps;
-    SmallVector<Value> newSources;
-    for (auto source : llvm::enumerate(sources)) {
-      auto map =
-          op.indexing_maps()[source.index()].cast<AffineMapAttr>().getValue();
-      auto tranposeOp = source.value().getDefiningOp<vector::TransposeOp>();
-      if (!tranposeOp) {
-        newSources.push_back(source.value());
-        newMaps.push_back(map);
-        continue;
-      }
-      SmallVector<int64_t, 3> perm;
-      tranposeOp.getTransp(perm);
-      SmallVector<AffineExpr> exprs(perm.size());
-      for (auto remap : llvm::enumerate(perm)) {
-        exprs[remap.value()] = map.getResult(remap.index());
-      }
-      newMaps.push_back(
-          AffineMap::get(map.getNumDims(), map.getNumSymbols(), exprs, ctx));
-      newSources.push_back(tranposeOp.vector());
-      foundTranspose = true;
-    }
-    if (!foundTranspose) return failure();
-
-    Value res = rewriter.create<vector::ContractionOp>(
-        loc, newSources[0], newSources[1], newSources[2],
-        rewriter.getAffineMapArrayAttr(newMaps), op.iterator_types());
-    rewriter.replaceOp(op, res);
-    return success();
-  }
-};
-
 /// Vectorizes Linalg ops on buffer semantics.
 class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
  public:
@@ -215,9 +95,6 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     FuncOp funcOp = getOperation();
-
-    auto entryPointOp = getEntryPoint(funcOp);
-    if (!entryPointOp) return;
 
     {
       RewritePatternSet vectorizationPatterns(&getContext());
@@ -240,7 +117,6 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });
-
 
     {
       RewritePatternSet vectorUnrollPatterns(funcOp.getContext());
@@ -277,18 +153,7 @@ class SPIRVVectorizePass : public SPIRVVectorizeBase<SPIRVVectorizePass> {
       llvm::dbgs() << "\n\n";
     });
 
-    if (useCooperativeMatrix(funcOp)) {
-      // When using cooperative matrix we don't want to lower the contract,
-      // instead we want to merge contract and transpose so that they can be
-      // converted to cooperative matrix matmul op.
-      // TODO(thomasraoux): remove that once we support cooperative matrix
-      // lowering in MLIR core.
-      RewritePatternSet combineTransposePatterns(funcOp.getContext());
-      combineTransposePatterns.add<CombineContractTranspose>(
-          funcOp.getContext());
-      (void)applyPatternsAndFoldGreedily(funcOp,
-                                         std::move(combineTransposePatterns));
-    } else {
+    {
       RewritePatternSet contractLoweringPatterns(funcOp.getContext());
       vector::populateVectorBroadcastLoweringPatterns(contractLoweringPatterns);
       vector::populateVectorContractLoweringPatterns(

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -99,7 +99,7 @@ hal.executable private @conv_static_shape_f32  {
 
 // -----
 
-#config = {tileSizes = [[0, 2, 2, 32], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
+#config = {tileSizes = [[0, 4, 4, 16], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
 
 hal.executable private @depthwise_conv_static_shape_f32  {
   hal.interface @io {
@@ -111,7 +111,7 @@ hal.executable private @depthwise_conv_static_shape_f32  {
     hal.executable.entry_point @depthwise_conv_static_shape_f32 attributes {
       interface = @io,
       ordinal = 0 : index,
-      workgroup_size = [8: index, 2: index, 2: index],
+      workgroup_size = [4: index, 4: index, 4: index],
       translation.info = {passPipeline = "SPIRVVectorize", workloadPerWorkgroup = [16, 4, 4]}
     } {
     ^bb0(%arg0 : index, %arg1 : index, %arg2 : index):


### PR DESCRIPTION
We now have a dedicated pipeline for supporting cooperative
matrix. The special cases in the main pipelines can be removed
now.