### PR TITLE
Revert "[CUDA] Remove loop from workgroup distribution if possible"

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPURemoveTrivialLoops.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPURemoveTrivialLoops.cpp
@@ -19,94 +19,20 @@ namespace mlir {
 namespace iree_compiler {
 
 /// If the value is a threadID return the range [0, workgroupSize-1].
-/// If the number of workgroup is known also return the range of workgroupId ad
-/// workgroupCount.
-static Optional<std::pair<AffineExpr, AffineExpr>> getWorkgroupRange(
-    Value processorValue, SmallVectorImpl<Value> & /*dims*/,
-    SmallVectorImpl<Value> & /*symbols*/, ArrayRef<int64_t> workgroupCount,
+static Optional<std::pair<AffineExpr, AffineExpr>> threadIdMinMax(
+    Value value, SmallVectorImpl<Value> &dims, SmallVectorImpl<Value> &symbols,
     ArrayRef<int64_t> workgroupSize) {
-  if (auto idOp = processorValue.getDefiningOp<gpu::ThreadIdOp>()) {
+  if (auto idOp = value.getDefiningOp<gpu::ThreadIdOp>()) {
     unsigned index = StringSwitch<unsigned>(idOp.dimension())
                          .Case("x", 0)
                          .Case("y", 1)
                          .Case("z", 2);
-    OpBuilder b(processorValue.getContext());
+    OpBuilder b(value.getContext());
     AffineExpr zero = b.getAffineConstantExpr(0);
     AffineExpr ubExpr = b.getAffineConstantExpr(workgroupSize[index]);
     return std::make_pair(zero, ubExpr - 1);
   }
-  if (workgroupCount.empty()) return llvm::None;
-
-  if (auto idOp =
-          processorValue.getDefiningOp<IREE::HAL::InterfaceWorkgroupIDOp>()) {
-    OpBuilder builder(processorValue.getContext());
-    unsigned index = idOp.dimension().getZExtValue();
-    AffineExpr zero = builder.getAffineConstantExpr(0);
-    AffineExpr ubExpr = builder.getAffineConstantExpr(workgroupCount[index]);
-    return std::make_pair(zero, ubExpr - 1);
-  }
-  if (auto dimOp = processorValue
-                       .getDefiningOp<IREE::HAL::InterfaceWorkgroupCountOp>()) {
-    OpBuilder builder(processorValue.getContext());
-    unsigned index = dimOp.dimension().getZExtValue();
-    AffineExpr bound = builder.getAffineConstantExpr(workgroupCount[index]);
-    return std::make_pair(bound, bound);
-  }
-  return llvm::None;
-}
-
-/// Infer the number of workgroups by looking at the tiled loop and the number
-/// of element per workgroups.
-static SmallVector<int64_t> getNumWorkgroup(
-    FuncOp funcOp, IREE::HAL::ExecutableEntryPointOp entryPointOp) {
-  SmallVector<TiledLoopInfo> tiledLoopInfo = getTiledLoopInfo(funcOp);
-  SmallVector<int64_t> workloadSize(tiledLoopInfo.size());
-  for (TiledLoopInfo &tileInfo : tiledLoopInfo) {
-    if (tileInfo.distributionDim >= workloadSize.size())
-      return SmallVector<int64_t>();
-    if (!tileInfo.lb.is<Attribute>() || !tileInfo.ub.is<Attribute>() ||
-        !tileInfo.step.is<Attribute>()) {
-      continue;
-    }
-    int64_t lb = tileInfo.lb.get<Attribute>().cast<IntegerAttr>().getInt();
-    int64_t ub = tileInfo.ub.get<Attribute>().cast<IntegerAttr>().getInt();
-    int64_t step = tileInfo.step.get<Attribute>().cast<IntegerAttr>().getInt();
-    if (step == 0) return SmallVector<int64_t>();
-    workloadSize[tileInfo.distributionDim] = (ub - lb) / step;
-  }
-  auto translationInfo = getTranslationInfo(entryPointOp);
-  if (!translationInfo) return SmallVector<int64_t>();
-
-  ArrayAttr workloadPerWorkgroupAttr = translationInfo.workloadPerWorkgroup();
-  if (!workloadPerWorkgroupAttr) return SmallVector<int64_t>();
-  auto workloadPerWorkgroup = llvm::to_vector<4>(llvm::map_range(
-      workloadPerWorkgroupAttr,
-      [](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
-  if (workloadSize.size() != workloadPerWorkgroup.size())
-    return SmallVector<int64_t>();
-  SmallVector<int64_t> numWorkgroups;
-  for (auto pair : llvm::zip(workloadSize, workloadPerWorkgroup)) {
-    auto workload = std::get<0>(pair);
-    auto size = std::get<1>(pair);
-    numWorkgroups.push_back(llvm::divideCeil(workload, size));
-  }
-  numWorkgroups.resize(kNumMaxParallelDims, 1);
-  return numWorkgroups;
-}
-
-static void removeOneTripTiledLoops(FuncOp funcOp,
-                                    ArrayRef<int64_t> workgroupSize,
-                                    ArrayRef<int64_t> numWorkgroups) {
-  auto getWorkgroupRangeFn = [numWorkgroups, workgroupSize](
-                                 Value processorValue,
-                                 SmallVectorImpl<Value> &dims,
-                                 SmallVectorImpl<Value> &symbols) {
-    return getWorkgroupRange(processorValue, dims, symbols, numWorkgroups,
-                             workgroupSize);
-  };
-  OwningRewritePatternList patterns(funcOp.getContext());
-  populateRemoveSingleIterationLoopPattern(patterns, getWorkgroupRangeFn);
-  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  return {};
 }
 
 namespace {
@@ -118,13 +44,20 @@ class LLVMGPURemoveSingleIterationLoopPass
     FuncOp funcOp = getOperation();
     auto entryPointOp = getEntryPoint(funcOp);
     if (!entryPointOp) return;
-
-    SmallVector<int64_t> workgroupSize = getWorkgroupSize(entryPointOp);
-    SmallVector<int64_t> numWorkgroups = getNumWorkgroup(funcOp, entryPointOp);
-
-    removeOneTripTiledLoops(funcOp, workgroupSize, numWorkgroups);
+    auto workgroupSize = getWorkgroupSize(entryPointOp);
+    workgroupSize.resize(3, 1);
+    auto getThreadIdMinMax = [&workgroupSize](Value value,
+                                              SmallVectorImpl<Value> &dims,
+                                              SmallVectorImpl<Value> &symbols) {
+      return threadIdMinMax(value, dims, symbols, workgroupSize);
+    };
+    MLIRContext *context = funcOp->getContext();
+    OwningRewritePatternList patterns(context);
+    populateRemoveSingleIterationLoopPattern(patterns, getThreadIdMinMax);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
   }
 };
+
 }  // namespace
 
 std::unique_ptr<OperationPass<FuncOp>>

--- a/iree/compiler/Codegen/LLVMGPU/test/remove_loops.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/remove_loops.mlir
@@ -1,5 +1,4 @@
-// RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-llvmgpu-remove-single-iteration-loop))))' %s | IreeFileCheck %s
-
+// RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(builtin.module(builtin.func(iree-llvmgpu-remove-single-iteration-loop))))' %s | IreeFileCheck %s
 
 // CHECK-LABEL: func @dispatch_0()
 hal.executable private @dispatch_0  {
@@ -33,64 +32,6 @@ hal.executable private @dispatch_0  {
              gpu.barrier
           }
         }
-        return
-      }
-    }
-  }
-}
-
-// -----
-
-// CHECK-LABEL: func @workgroup_tile_loop()
-hal.executable private @workgroup_tile_loop  {
-  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @workgroup_tile_loop attributes {
-      interface = @io,
-      ordinal = 0 : index,
-      translation.info = {passPipeline = "LLVMGPUDistribute", workloadPerWorkgroup = [32]}
-    }
-    builtin.module {
-      builtin.func @workgroup_tile_loop() {
-        %c2048 = arith.constant 2048 : index
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_count_x = hal.interface.workgroup.count[0] : index
-        %idx = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
-        %countx = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
-        // CHECK-NOT: scf.for
-        //     CHECK: gpu.barrier
-        scf.for %arg0 = %idx to %c2048 step %countx {
-          gpu.barrier
-        }
-
-        return
-      }
-    }
-  }
-}
-
-// -----
-
-// CHECK-LABEL: func @workgroup_tile_loop_negative()
-hal.executable private @workgroup_tile_loop_negative  {
-  hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.entry_point @workgroup_tile_loop_negative attributes {
-      interface = @io,
-      ordinal = 0 : index,
-      translation.info = {passPipeline = "LLVMGPUDistribute", workloadPerWorkgroup = [16]}
-    }
-    builtin.module {
-      builtin.func @workgroup_tile_loop_negative() {
-        %c2048 = arith.constant 2048 : index
-        %workgroup_id_x = hal.interface.workgroup.id[0] : index
-        %workgroup_count_x = hal.interface.workgroup.count[0] : index
-        %idx = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
-        %countx = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
-        //     CHECK: scf.for
-        //     CHECK: gpu.barrier
-        scf.for %arg0 = %idx to %c2048 step %countx {
-          gpu.barrier
-        }
-
         return
       }
     }

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -105,7 +105,6 @@ struct TiledLoopInfo {
   OpFoldResult lb;
   OpFoldResult ub;
   OpFoldResult step;
-  Optional<int64_t> workgroupSize;
   unsigned distributionDim;
 };
 using RootOpFilteringFn = std::function<bool(Operation *)>;
@@ -122,9 +121,6 @@ LogicalResult getFilteredOps(FuncOp funcOp, RootOpFilteringFn filteringFn,
 LogicalResult getComputeOps(FuncOp funcOp,
                             SmallVectorImpl<Operation *> &computeOps,
                             SmallVectorImpl<TiledLoopInfo> &tiledLoops);
-
-/// Collect information about loops matching tiled+distribute pattern.
-SmallVector<TiledLoopInfo> getTiledLoopInfo(FuncOp funcOp);
 
 }  // namespace iree_compiler
 }  // namespace mlir


### PR DESCRIPTION
Breaks the build on real GPUs by zeroing out input to mhlo.sort. The
real GPU builds are stuck for some reason, so it only just finished:

https://source.cloud.google.com/results/invocations/81ed0a10-78a7-4a56-9479-7192c81bf78c/targets

Reverts google/iree#7362