### PR TITLE
Revert "[CUDA] Perf tweaks to improve occupancy and reductions performance"

### DIFF
--- a/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -39,7 +39,6 @@ static void getMatmulConfig(SmallVectorImpl<TileWorkgroupSizePair> &tileSizes) {
   tileSizes.push_back(TileWorkgroupSizePair({{32, 128, 32}, {32, 8, 1}}));
   tileSizes.push_back(TileWorkgroupSizePair({{128, 64, 8}, {16, 8, 1}}));
   tileSizes.push_back(TileWorkgroupSizePair({{16, 256, 32}, {64, 2, 1}}));
-  tileSizes.push_back(TileWorkgroupSizePair({{8, 32, 32}, {8, 8, 1}}));
 
   tileSizes.push_back(TileWorkgroupSizePair({{8, 128, 4}, {32, 1, 1}}));
   tileSizes.push_back(TileWorkgroupSizePair({{16, 64, 4}, {16, 2, 1}}));
@@ -155,8 +154,8 @@ static LogicalResult setRootDefaultConfig(FuncOp entryPoint, Operation *op) {
   }
 
   size_t numLoops = partitionedLoops.back() + 1;
-  // To get peak occupancy we need a workgroup size of at least two warps.
-  std::array<int64_t, 3> workgroupSize = {2 * cudaWarpSize, 1, 1};
+
+  std::array<int64_t, 3> workgroupSize = {cudaWarpSize, 1, 1};
   unsigned vectorSize = 4;
   SmallVector<int64_t, 4> workgroupTileSizes(numLoops, 1);
   // Set all non-parallel loops to zero tile size.
@@ -198,14 +197,15 @@ static LogicalResult setRootDefaultConfig(FuncOp entryPoint, Operation *op) {
   // Set the inner most parallel loop to `lowerTs`.
   for (int64_t depth = numLoops; depth > 0; depth--) {
     if (partitionedLoopsSet.count(depth - 1)) {
-      workgroupTileSizes[depth - 1] = workgroupSize[0] * vectorSize;
+      workgroupTileSizes[depth - 1] = cudaWarpSize * vectorSize;
       break;
     }
   }
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(op)) {
-    // Tile reduction dimension to 4 to allow doing load4 if the reduction size
-    // is the most inner dimension.
-    workgroupTileSizes.append(linalgOp.getNumReductionLoops(), 4);
+    // Tile reduction dimension to 1. Using a large tile size may allow better
+    // scheduling and could help in case one of the input has transpose.
+    // TODO(thomasraoux): improve the heuristic.
+    workgroupTileSizes.append(linalgOp.getNumReductionLoops(), 1);
   }
   tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
   return setOpConfigAndEntryPointFnTranslation(

--- a/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -33,12 +33,12 @@ hal.executable @add_dispatch_0 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[256]{{\]}}}
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 256)>
+//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[128]{{\]}}}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
 //      CHECK: hal.executable.entry_point public @add_dispatch_0
 // CHECK-SAME:     passPipeline = "LLVMGPUVectorize"
-// CHECK-SAME:     workloadPerWorkgroup = [256]
-// CHECK-SAME:     workgroup_size = [64 : index, 1 : index, 1 : index]
+// CHECK-SAME:     workloadPerWorkgroup = [128]
+// CHECK-SAME:     workgroup_size = [32 : index, 1 : index, 1 : index]
 // CHECK-NEXT:   ^bb0(%[[ARG0:[a-zA-Z0-9]+]]: index,
 //  CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
 //  CHECK-DAG:     %[[NWGS_X:.+]] = affine.apply #[[MAP0]]()[%[[ARG0]]]
@@ -246,10 +246,10 @@ hal.executable @tensor_insert {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[1, 256]{{\]}}}
-//  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 256)>
+//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[1, 128]{{\]}}}
+//  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 128)>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
-// CHECK-SAME:   translation.info = {passPipeline = "LLVMGPUVectorize", workloadPerWorkgroup = [256, 1]}
+// CHECK-SAME:   translation.info = {passPipeline = "LLVMGPUVectorize", workloadPerWorkgroup = [128, 1]}
 // CHECK-NEXT:   %[[ARG0:[a-zA-Z0-9_]+]]: index
 // CHECK-SAME:   %[[ARG1:[a-zA-Z0-9_]+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index


### PR DESCRIPTION
Breaks the build on real GPUs by zeroing out input to mhlo.sort. The
real GPU builds are stuck for some reason, so it only just finished:

https://source.cloud.google.com/results/invocations/81ed0a10-78a7-4a56-9479-7192c81bf78c/targets

Reverts https://github.com/google/iree/pull/7366 and
https://github.com/google/iree/commit/ebb3e65459