### PR TITLE
[spirv] Remove unused subgroup level tiling configurations

### DIFF
--- a/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -184,7 +184,6 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
   auto pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
   TileSizesListType tileSizes;
   tileSizes.push_back(workgroupTileSizes);
-  tileSizes.emplace_back();  // Subgroup level
   tileSizes.push_back(invocationTileSizes);
   // Tiling along reduction dimensions
   if (isa<linalg::Conv2DNhwcHwcfOp>(linalgOp)) {
@@ -306,7 +305,6 @@ LogicalResult setMatmulOpConfig(linalg::LinalgOp op,
   auto pipeline = IREE::HAL::DispatchLoweringPassPipeline::SPIRVVectorize;
   TileSizesListType tileSizes;
   tileSizes.push_back(workgroupTileSizes);
-  tileSizes.emplace_back();
   tileSizes.push_back(invocationTileSizes);
   tileSizes.push_back(reductionTileSizes);
   return setOpConfigAndEntryPointFnTranslation(op->getParentOfType<FuncOp>(),
@@ -437,7 +435,6 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
 
   TileSizesListType tileSizes;
   tileSizes.push_back(workgroupTileSize);
-  tileSizes.emplace_back();  // Subgroup level.
   tileSizes.push_back(threadTileSize);
 
   return setOpConfigAndEntryPointFnTranslation(op->getParentOfType<FuncOp>(),

--- a/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVTileAndDistribute.cpp
@@ -78,12 +78,11 @@ static unsigned dimToIndex(StringRef dim) {
 static void populateTilingToInvocationPatterns(MLIRContext *context,
                                                RewritePatternSet &patterns) {
   linalg::TileSizeComputationFunction getInnerTileSizeFn =
-      [&](OpBuilder &builder, Operation *operation) {
-        SmallVector<int64_t> tileSizes = getTileSizes(operation, 2);
+      [&](OpBuilder &builder, Operation *op) {
+        SmallVector<int64_t> tileSizes = getTileSizes(op, 1);
         return llvm::to_vector<4>(
             llvm::map_range(tileSizes, [&](int64_t v) -> Value {
-              return builder.create<arith::ConstantIndexOp>(operation->getLoc(),
-                                                            v);
+              return builder.create<arith::ConstantIndexOp>(op->getLoc(), v);
             }));
       };
 
@@ -162,7 +161,7 @@ static void populateTilingReductionPatterns(
     MLIRContext *context, RewritePatternSet &patterns,
     linalg::LinalgTransformationFilter marker) {
   auto getTileSizeFn = [&](OpBuilder &builder, Operation *op) {
-    SmallVector<int64_t> tileSizes = getTileSizes(op, 3);
+    SmallVector<int64_t> tileSizes = getTileSizes(op, 2);
     return llvm::to_vector<4>(
         llvm::map_range(tileSizes, [&](int64_t v) -> Value {
           return builder.create<arith::ConstantIndexOp>(op->getLoc(), v);

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -85,7 +85,7 @@ hal.executable @conv_112x112x512 {
 
 //                CHECK: func @conv_112x112x512()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 256], [], [0, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 256], [0, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -174,7 +174,7 @@ hal.executable @conv_112x112x32 {
 
 //                CHECK: func @conv_112x112x32()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 16, 32], [], [0, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 16, 32], [0, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -261,7 +261,7 @@ hal.executable @conv_16x16x16 {
 
 //                CHECK: func @conv_16x16x16()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 8, 8, 16], [], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 8, 8, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -350,7 +350,7 @@ hal.executable @dwconv_28x28x144 {
 
 //                CHECK: func @dwconv_28x28x144()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
 
 // -----
 
@@ -438,4 +438,4 @@ hal.executable @dwconv_4x4x8 {
 
 //                CHECK: func @dwconv_4x4x8()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 8], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}

--- a/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_adreno_matmul.mlir
@@ -73,7 +73,7 @@ hal.executable @matmul_1024x2048x512 {
 
 //                CHECK: func @matmul_1024x2048x512()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 128], [], [16, 4], [0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 128], [16, 4], [0, 0, 4]]}
 
 // -----
 
@@ -150,7 +150,7 @@ hal.executable @matmul_3136x24x96 {
 
 //                CHECK: func @matmul_3136x24x96()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[448, 8], [], [14, 4], [0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[448, 8], [14, 4], [0, 0, 4]]}
 
 // -----
 
@@ -227,7 +227,7 @@ hal.executable @matmul_196x64x192 {
 
 //                CHECK: func @matmul_196x64x192()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[28, 64], [], [7, 4], [0, 0, 8]]}
+//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[28, 64], [7, 4], [0, 0, 8]]}
 
 // -----
 
@@ -299,7 +299,7 @@ hal.executable @matmul_12544x96x16 {
 
 //                CHECK: func @matmul_12544x96x16()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[128, 32], [], [16, 4], [0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[128, 32], [16, 4], [0, 0, 4]]}
 
 // -----
 
@@ -376,7 +376,7 @@ hal.executable @matmul_49x160x576 {
 
 //                CHECK: func @matmul_49x160x576()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[7, 32], [], [7, 4], [0, 0, 8]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[7, 32], [7, 4], [0, 0, 8]]}
 
 // -----
 
@@ -463,7 +463,7 @@ hal.executable @batch_matmul_4x384x384 {
 
 //                CHECK: func @batch_matmul_4x384x384()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32, 128], [], [1, 16, 4], [0, 0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32, 128], [1, 16, 4], [0, 0, 0, 4]]}
 
 // -----
 
@@ -550,4 +550,4 @@ hal.executable @batch_matmul_4x8x8 {
 
 //                CHECK: func @batch_matmul_4x8x8()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 8, 8], [], [1, 1, 4], [0, 0, 0, 16]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 8, 8], [1, 1, 4], [0, 0, 0, 16]]}

--- a/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
@@ -83,7 +83,7 @@ hal.executable @batch_matmul_1x3x32 {
 
 //                CHECK: func @batch_matmul_1x3x32()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 1, 4], [], [1, 1, 1]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 1, 4], [1, 1, 1]]}
 
 // -----
 
@@ -159,4 +159,4 @@ hal.executable private @matmul_64x16 {
 
 //                CHECK: func @matmul_64x16()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 4], [], [1, 1]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 4], [1, 1]]}

--- a/iree/compiler/Codegen/SPIRV/test/config_linalg_ext_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_linalg_ext_ops.mlir
@@ -108,7 +108,7 @@ hal.executable private @static_3d_sort  {
 
 //                CHECK: func @static_3d_sort()
 //                CHECK:   linalg_ext.sort
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 0, 16], [], [1, 0, 1]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 0, 16], [1, 0, 1]]}
 
 // -----
 

--- a/iree/compiler/Codegen/SPIRV/test/config_linalg_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_linalg_ops.mlir
@@ -100,7 +100,7 @@ hal.executable @tensor_insert {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[1, 16], [], [1, 1]{{\]}}}
+//  CHECK-DAG: #[[CONFIG:.+]] = {tileSizes = {{\[}}[1, 16], [1, 1]{{\]}}}
 //  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 16)>
 //      CHECK: hal.executable.entry_point public @tensor_insert_slice
 // CHECK-SAME:   translation.info = {passPipeline = "SPIRVDistribute", workloadPerWorkgroup = [16, 1]}

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -85,7 +85,7 @@ hal.executable @conv_112x112x512 {
 
 //                CHECK: func @conv_112x112x512()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 4, 64], [], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 4, 64], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -174,7 +174,7 @@ hal.executable @conv_112x112x32 {
 
 //                CHECK: func @conv_112x112x32()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 32], [], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 8, 32], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -261,7 +261,7 @@ hal.executable @conv_16x16x16 {
 
 //                CHECK: func @conv_16x16x16()
 //                CHECK:   linalg.conv_2d_nhwc_hwcf
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 // -----
 
@@ -350,7 +350,7 @@ hal.executable @dwconv_28x28x144 {
 
 //                CHECK: func @dwconv_28x28x144()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1]]}
 
 // -----
 
@@ -439,5 +439,5 @@ hal.executable @dwconv_1x2x8 {
 
 //                CHECK: func @dwconv_1x2x8()
 //                CHECK:   linalg.depthwise_conv2D_nhw
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 2, 8], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[0, 1, 2, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
 

--- a/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/config_mali_matmul.mlir
@@ -73,7 +73,7 @@ hal.executable @matmul_1024x2048x512 {
 
 //                CHECK: func @matmul_1024x2048x512()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[8, 32], [], [4, 4], [0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[8, 32], [4, 4], [0, 0, 4]]}
 
 // -----
 
@@ -150,7 +150,7 @@ hal.executable @matmul_3136x24x96 {
 
 //                CHECK: func @matmul_3136x24x96()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 8], [], [4, 4], [0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[32, 8], [4, 4], [0, 0, 4]]}
 
 // -----
 
@@ -227,7 +227,7 @@ hal.executable @matmul_196x64x192 {
 
 //                CHECK: func @matmul_196x64x192()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[4, 32], [], [2, 4], [0, 0, 8]]}
+//  CHECK-SAME{LITERAL}:      lowering.config = {tileSizes = [[4, 32], [2, 4], [0, 0, 8]]}
 
 // -----
 
@@ -299,7 +299,7 @@ hal.executable @matmul_12544x96x16 {
 
 //                CHECK: func @matmul_12544x96x16()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[8, 32], [], [4, 4], [0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config =  {tileSizes = [[8, 32], [4, 4], [0, 0, 4]]}
 
 // -----
 
@@ -375,7 +375,7 @@ hal.executable @matmul_49x160x576 {
 
 //                CHECK: func @matmul_49x160x576()
 //                CHECK:   linalg.matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32], [], [1, 4], [0, 0, 8]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 32], [1, 4], [0, 0, 8]]}
 
 // -----
 
@@ -462,7 +462,7 @@ hal.executable @batch_matmul_4x384x384 {
 
 //                CHECK: func @batch_matmul_4x384x384()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 12, 32], [], [1, 6, 4], [0, 0, 0, 4]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 12, 32], [1, 6, 4], [0, 0, 0, 4]]}
 
 // -----
 
@@ -550,4 +550,4 @@ hal.executable @batch_matmul_4x2x8 {
 
 //                CHECK: func @batch_matmul_4x2x8()
 //                CHECK:   linalg.batch_matmul
-//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 2, 8], [], [1, 1, 4], [0, 0, 0, 8]]}
+//  CHECK-SAME{LITERAL}:     lowering.config = {tileSizes = [[1, 2, 8], [1, 1, 4], [0, 0, 0, 8]]}

--- a/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-codegen-linalg-to-spirv-pipeline))' %s | IreeFileCheck %s
 
-#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
+#config = {tileSizes = [[8, 64], [8, 4], [0, 0, 4]]}
 
 hal.executable private @fuse_and_vectorize_fill_matmul  {
   hal.interface @io {
@@ -70,7 +70,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul  {
 
 // -----
 
-#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
+#config = {tileSizes = [[8, 64], [8, 4], [0, 0, 4]]}
 
 hal.executable private @fuse_and_vectorize_matmul_add  {
   hal.interface @io {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -36,7 +36,7 @@ hal.executable private @static_scatter_update_slice  {
             %8 = memref.subview %1[%arg0, 0] [1, 1] [1, 1] : memref<40x1xi32> to memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %9 = memref.cast %8 : memref<1x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>> to memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>
             %10 = memref.subview %2[0, %arg1] [100, %5] [1, 1] : memref<100x500xi32> to memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>
-            linalg_ext.scatter {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[1, 16], [], [1, 1]]}} ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
+            linalg_ext.scatter {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[1, 16], [1, 1]]}} ins(%7, %9 : memref<?x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>, memref<?x1xi32, affine_map<(d0, d1)[s0] -> (d0 + s0 + d1)>>) outs(%10 : memref<100x?xi32, affine_map<(d0, d1)[s0] -> (d0 * 500 + s0 + d1)>>)  {
             ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
               linalg_ext.yield %arg2 : i32
             }

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -30,8 +30,8 @@ hal.executable private @static_3d_sort  {
             %5 = memref.cast %4 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>> to memref<?x?x?xi32>
             %6 = memref.subview %1[%arg0, 0, %arg1] [1, 32, 16] [1, 1, 1] : memref<64x32x128xi32> to memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
             %7 = memref.cast %6 : memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>> to memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
-            linalg.copy(%5, %6) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[1, 0, 16], [], [1, 0, 1]]}} : memref<?x?x?xi32>, memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
-            linalg_ext.sort dimension(1) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[1, 0, 16], [], [1, 0, 1]]}} outs(%7 : memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>)  {
+            linalg.copy(%5, %6) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[1, 0, 16], [1, 0, 1]]}} : memref<?x?x?xi32>, memref<1x32x16xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>
+            linalg_ext.sort dimension(1) {__internal_linalg_transform__ = "workgroup", lowering.config = {tileSizes = [[1, 0, 16], [1, 0, 1]]}} outs(%7 : memref<?x32x?xi32, affine_map<(d0, d1, d2)[s0] -> (d0 * 4096 + s0 + d1 * 128 + d2)>>)  {
             ^bb0(%arg2: i32, %arg3: i32):  // no predecessors
               %8 = arith.cmpi slt, %arg2, %arg3 : i32
               linalg_ext.yield %8 : i1

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize.mlir
@@ -8,7 +8,7 @@
 #map5 = affine_map<(d0, d1, d2) -> (d2, d1)>
 #map6 = affine_map<(d0, d1, d2) -> (d0, d1)>
 
-#config = {tileSizes = [[8, 16], [], [1, 1], [0, 0, 1]]}
+#config = {tileSizes = [[8, 16], [1, 1], [0, 0, 1]]}
 
 hal.executable private @matmul  {
   hal.interface @io {
@@ -82,7 +82,7 @@ hal.executable private @matmul  {
 
 // -----
 
-#config = {tileSizes = [[1, 4, 32], [], [1, 1, 1]]}
+#config = {tileSizes = [[1, 4, 32], [1, 1, 1]]}
 
 hal.executable private @conv_1d  {
   hal.interface @io {
@@ -165,7 +165,7 @@ hal.executable private @conv_1d  {
 #map6 = affine_map<(d0)[s0] -> (4, -d0 + s0)>
 #map7 = affine_map<(d0)[s0] -> (32, -d0 + s0)>
 
-#config = {tileSizes = [[0, 1, 4, 32], [], [0, 1, 1, 1], [0, 0, 0, 0, 1, 1, 4]]}
+#config = {tileSizes = [[0, 1, 4, 32], [0, 1, 1, 1], [0, 0, 0, 0, 1, 1, 4]]}
 
 hal.executable private @conv_no_padding  {
   hal.interface @io {
@@ -292,7 +292,7 @@ hal.executable private @conv_no_padding  {
 
 // -----
 
-#config = {tileSizes = [[0, 0, 1, 4, 32], [], [0, 0, 1, 1, 1]]}
+#config = {tileSizes = [[0, 0, 1, 4, 32], [0, 0, 1, 1, 1]]}
 
 hal.executable private @conv_3d  {
   hal.interface @io {
@@ -365,7 +365,7 @@ hal.executable private @conv_3d  {
 #map6 = affine_map<()[s0] -> (32, s0 * -32 + 13)>
 #map7 = affine_map<(d0, d1, d2, d3)[s0] -> (d0 * 1092 + s0 + d1 * 78 + d2 * 6 + d3)>
 
-#config = {tileSizes = [[1, 4, 32], [], [1, 1, 1]]}
+#config = {tileSizes = [[1, 4, 32], [1, 1, 1]]}
 
 module  {
   hal.executable private @pooling_nhwc_max  {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-set-num-workgroups,builtin.module(builtin.func(iree-spirv-tile-and-distribute,iree-spirv-vectorize))))' -canonicalize -cse %s | IreeFileCheck %s
 
-#config = {tileSizes = [[1, 8, 64], [], [1, 8, 4], [0, 0, 0, 4]]}
+#config = {tileSizes = [[1, 8, 64], [1, 8, 4], [0, 0, 0, 4]]}
 
 hal.executable private @batch_matmul_static_shape  {
   hal.interface private @io  {
@@ -370,7 +370,7 @@ hal.executable private @batch_matmul_static_shape  {
 
 // -----
 
-#config = {tileSizes = [[1, 8, 64], [], [1, 8, 4], [0, 0, 0, 4]]}
+#config = {tileSizes = [[1, 8, 64], [1, 8, 4], [0, 0, 0, 4]]}
 
 hal.executable private @fused_fill_batch_matmul  {
   hal.interface private @io  {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-set-num-workgroups,builtin.module(builtin.func(canonicalize,iree-spirv-remove-one-trip-tiled-loop,iree-spirv-tile-and-distribute,iree-spirv-vectorize))))' -canonicalize -cse %s | IreeFileCheck %s
 
-#config = {tileSizes = [[0, 4, 4, 16], [], [0, 4, 1, 4], [0, 0, 0, 0, 1, 1, 4]]}
+#config = {tileSizes = [[0, 4, 4, 16], [0, 4, 1, 4], [0, 0, 0, 0, 1, 1, 4]]}
 
 hal.executable private @conv_static_shape_f32  {
   hal.interface @io {
@@ -99,7 +99,7 @@ hal.executable private @conv_static_shape_f32  {
 
 // -----
 
-#config = {tileSizes = [[0, 4, 4, 16], [], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
+#config = {tileSizes = [[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1]]}
 
 hal.executable private @depthwise_conv_static_shape_f32  {
   hal.interface @io {

--- a/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt -split-input-file -pass-pipeline='hal.executable(hal.executable.variant(iree-set-num-workgroups,builtin.module(builtin.func(iree-spirv-tile-and-distribute,iree-spirv-vectorize))))' -canonicalize -cse %s | IreeFileCheck %s
 
-#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
+#config = {tileSizes = [[8, 64], [8, 4], [0, 0, 4]]}
 
 hal.executable private @matmul_static_shape_f16  {
   hal.interface private @io  {
@@ -66,7 +66,7 @@ hal.executable private @matmul_static_shape_f16  {
 
 // -----
 
-#config = {tileSizes = [[8, 64], [], [8, 4], [0, 0, 4]]}
+#config = {tileSizes = [[8, 64], [8, 4], [0, 0, 4]]}
 
 hal.executable private @matmul_static_shape_f32  {
   hal.interface private @io  {

--- a/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
+++ b/iree/compiler/Codegen/SPIRV/test/vectorize_elementwise_ops.mlir
@@ -24,7 +24,7 @@ hal.executable private @elementwise_static_shape  {
         %ret0 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<128xf32>
         linalg.generic {
           __internal_linalg_transform__ = "workgroup",
-          lowering.config = {tileSizes = [[128], [], [4]]},
+          lowering.config = {tileSizes = [[128], [4]]},
           indexing_maps = [affine_map<(i) -> (i)>,
                            affine_map<(i) -> (i)>,
                            affine_map<(i) -> (i)>],
@@ -73,7 +73,7 @@ hal.executable private @elementwise_transpose  {
         %ret0 = hal.interface.binding.subspan @io::@ret0[%c0] : memref<128x8xf32>
         linalg.generic {
           __internal_linalg_transform__ = "workgroup",
-          lowering.config = {tileSizes = [[1, 32], [], [1, 1]]},
+          lowering.config = {tileSizes = [[1, 32], [1, 1]]},
           indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                            affine_map<(d0, d1) -> (d0)>,
                            affine_map<(d0, d1) -> (d0, d1)>],


### PR DESCRIPTION
Now we have cooperative matrix in its own pipeline. The main
pipelines do not need tiling at subgroup level anymore.