### PR TITLE
Add iree_vm_value_{none,i8,i16} functions.

### DIFF
--- a/iree/vm/value.h
+++ b/iree/vm/value.h
@@ -58,6 +58,26 @@ typedef struct iree_vm_value_t {
   };
 } iree_vm_value_t;
 
+static inline iree_vm_value_t iree_vm_value_make_none() {
+  iree_vm_value_t result;
+  result.type = IREE_VM_VALUE_TYPE_NONE;
+  return result;
+}
+
+static inline iree_vm_value_t iree_vm_value_make_i8(int8_t value) {
+  iree_vm_value_t result;
+  result.type = IREE_VM_VALUE_TYPE_I8;
+  result.i8 = value;
+  return result;
+}
+
+static inline iree_vm_value_t iree_vm_value_make_i16(int16_t value) {
+  iree_vm_value_t result;
+  result.type = IREE_VM_VALUE_TYPE_I16;
+  result.i16 = value;
+  return result;
+}
+
 static inline iree_vm_value_t iree_vm_value_make_i32(int32_t value) {
   iree_vm_value_t result;
   result.type = IREE_VM_VALUE_TYPE_I32;


### PR DESCRIPTION
The _none function leaves the data union uninitialized. If you want something else, please specify what. Do we want to zero the full 8 bytes?
