### PR TITLE
Avoid discarding parsed input buffers.

### DIFF
--- a/iree/hal/local/executable_library_benchmark.c
+++ b/iree/hal/local/executable_library_benchmark.c
@@ -275,7 +275,8 @@ static iree_status_t iree_hal_executable_library_run(
         iree_hal_buffer_view_byte_length(buffer_views[i]);
     iree_hal_buffer_mapping_t buffer_mapping;
     IREE_RETURN_IF_ERROR(iree_hal_buffer_map_range(
-        buffer, IREE_HAL_MEMORY_ACCESS_ALL, 0, buffer_length, &buffer_mapping));
+        buffer, IREE_HAL_MEMORY_ACCESS_READ | IREE_HAL_MEMORY_ACCESS_WRITE, 0,
+        buffer_length, &buffer_mapping));
     binding_ptrs[i] = buffer_mapping.contents.data;
     binding_lengths[i] = (size_t)buffer_mapping.contents.data_length;
   }


### PR DESCRIPTION
IREE_HAL_MEMORY_ACCESS_ALL discards, which is not great if you actually care about the contents 🤦