### PR TITLE
Get iree-run-trace file in repository-agnostic way

### DIFF
--- a/iree/tools/test/iree-run-trace.mlir
+++ b/iree/tools/test/iree-run-trace.mlir
@@ -1,4 +1,4 @@
-// RUN: (iree-translate -iree-input-type=tosa -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-trace --driver=vmvx iree/tools/test/iree-run-trace.yaml) | IreeFileCheck %s
+// RUN: (iree-translate -iree-input-type=tosa -iree-hal-target-backends=vmvx -iree-mlir-to-vm-bytecode-module %s | iree-run-trace --driver=vmvx "$(dirname %s)/iree-run-trace.yaml") | IreeFileCheck %s
 
 //      CHECK: --- CALL[module.simple_mul] ---
 // CHECK-NEXT: 4xf32=10 4 6 8


### PR DESCRIPTION
This allows the path to work regardless of where the repository root is,
which, for instance, is different in Google's internal monorepo. Longer-
term, we should be using actual lit and can do substitutions with `%S`.