### PR TITLE
Add `--iree-llvm-embedded-linker-path=` to compiler invocation.

### DIFF
--- a/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/binaries.py
+++ b/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/binaries.py
@@ -30,6 +30,7 @@ __all__ = [
 
 _BUILTIN_TOOLS = [
     "ireec",
+    "iree-lld",
     "iree-translate",
 ]
 
@@ -41,6 +42,7 @@ _TOOL_MODULE_MAP = {
     # in the external 'core' module. This is used for some outside packaging
     # options.
     "ireec": "iree.tools.core",
+    "iree-lld": "iree.tools.core",
     "iree-import-tflite": "iree.tools.tflite",
     "iree-import-xla": "iree.tools.xla",
     "iree-import-tf": "iree.tools.tf",

--- a/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/core.py
+++ b/llvm-external-projects/iree-compiler-api/python/iree/compiler/tools/core.py
@@ -10,6 +10,7 @@
 # TODO(#4131) python>=3.7: Use postponed type annotations.
 
 from enum import Enum
+import logging
 import subprocess
 from typing import Any, Dict, List, Optional, Sequence, Union
 
@@ -190,6 +191,10 @@ def build_compile_command_line(input_file: str, tfs: TempFileSaver,
 
   # Translation to perform.
   cl.append("--iree-mlir-to-vm-bytecode-module")
+
+  # Tool paths.
+  lld_path = find_tool("iree-lld")
+  cl.append(f"--iree-llvm-embedded-linker-path={lld_path}")
 
   # MLIR flags.
   if options.output_mlir_debuginfo:


### PR DESCRIPTION
Also sets up `iree-lld` as a tool in the Python API.