### PR TITLE
enable mixed-shapes testcases

### DIFF
--- a/iree/test/e2e/regression/generate_e2e_matmul_tests.py
+++ b/iree/test/e2e/regression/generate_e2e_matmul_tests.py
@@ -99,9 +99,7 @@ def get_test_generators():
           # Generators using general random matrices
           ("random", "random", "random", "dynamic"),
           ("random", "random", "random", "static"),
-          # TODO: enable 'mixed' testcases. For now they cause iree-opt
-          # errors.
-          #("random", "random", "random", "mixed"),
+          ("random", "random", "random", "mixed"),
       ],
       "large": [
           # Fewer generators are used for large shapes, to limit the


### PR DESCRIPTION
During development of PR #7347, I got `iree-opt` failures in the `mixed` shapes testcases. Both in CI and locally. The boundaries of what failed were a bit fuzzy but it seemed to fail more consistently with ASan, and with the vmvx target backend. So I had just disabled he mixed testcases for now.

This morning I wanted to debug that so I reenabled the mixed testcases, and now I can't reproduce any problem. Maybe something just got fixed in the compiler! If that happened coincidentally, that's all the more reason to secure that now with this test.