### PR TITLE
Revert "Don't outline splat constants. (#6816)"

### DIFF
--- a/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -769,6 +769,15 @@ void TensorSplatOp::getCanonicalizationPatterns(
   results.insert<FoldSplatReshapeIntoSplat>(context);
 }
 
+OpFoldResult TensorSplatOp::fold(ArrayRef<Attribute> operands) {
+  if (operands.size() == 1 && operands.front()) {
+    // Splat value is constant and we can fold the operation.
+    return SplatElementsAttr::get(result().getType().cast<ShapedType>(),
+                                  operands[0]);
+  }
+  return {};
+}
+
 OpFoldResult TensorCloneOp::fold(ArrayRef<Attribute> operands) {
   if (operands[0]) {
     // Constants always fold.

--- a/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -839,6 +839,7 @@ def FLOW_TensorSplatOp : FLOW_PureOp<"tensor.splat", [
   }];
 
   let hasCanonicalizer = 1;
+  let hasFolder = 1;
 }
 
 def FLOW_TensorCloneOp : FLOW_PureOp<"tensor.clone", [

--- a/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
+++ b/iree/compiler/Dialect/Flow/IR/test/tensor_folding.mlir
@@ -154,6 +154,28 @@ func @storeConstScalar() -> tensor<i32> {
 
 // -----
 
+// CHECK-LABEL: @splatConst
+func @splatConst() -> tensor<4xi32> {
+  %0 = arith.constant 4 : i32
+  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<4> : tensor<4xi32>
+  %1 = flow.tensor.splat %0 : tensor<4xi32>
+  // CHECK-NEXT: return %[[C]]
+  return %1 : tensor<4xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @splatConstScalar
+func @splatConstScalar() -> tensor<i32> {
+  %0 = arith.constant 4 : i32
+  // CHECK-NEXT: %[[C:.+]] = arith.constant dense<4> : tensor<i32>
+  %1 = flow.tensor.splat %0 : tensor<i32>
+  // CHECK-NEXT: return %[[C]]
+  return %1 : tensor<i32>
+}
+
+// -----
+
 // CHECK-LABEL: @splatDynamicShape
 //  CHECK-SAME: (%[[DIM0:.+]]: index, %[[DIM1:.+]]: index)
 func @splatDynamicShape(%dim0: index, %dim1: index) -> tensor<?x?xi32> {

--- a/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgTensorOps.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgTensorOps.cpp
@@ -81,30 +81,11 @@ struct LinalgFillToFlowTensorSplat final
       // Don't convert linalg.fill ops that were fused together with other ops.
       return failure();
     }
+
     SmallVector<Value, 4> dynamicDims =
         getDynamicDimValues(rewriter, fillOp.getLoc(), fillOp.output());
     rewriter.replaceOpWithNewOp<TensorSplatOp>(
         fillOp, fillOp.output().getType(), fillOp.value(), dynamicDims);
-    return success();
-  }
-};
-
-struct ConvertSplatConstantOp : public OpRewritePattern<mlir::ConstantOp> {
-  using OpRewritePattern::OpRewritePattern;
-  LogicalResult matchAndRewrite(mlir::ConstantOp op,
-                                PatternRewriter &rewriter) const override {
-    if (op->getParentOfType<IREE::Flow::DispatchWorkgroupsOp>()) {
-      return rewriter.notifyMatchFailure(op, "ignoring dispatch ops");
-    }
-    auto splatAttr = op.getValue().dyn_cast<SplatElementsAttr>();
-    if (!splatAttr) {
-      return rewriter.notifyMatchFailure(op, "only looking for splats");
-    }
-    auto tensorType = op.getType().cast<TensorType>();
-    auto elementValue = rewriter.createOrFold<mlir::ConstantOp>(
-        op.getLoc(), tensorType.getElementType(), splatAttr.getSplatValue());
-    rewriter.replaceOpWithNewOp<IREE::Flow::TensorSplatOp>(
-        op, tensorType, elementValue, ValueRange{});
     return success();
   }
 };
@@ -135,8 +116,7 @@ struct ConvertLinalgTensorOpsPass
           LinalgTensorReshapeToFlowTensorReshape<linalg::TensorExpandShapeOp>>(
           context);
     } else {
-      patterns.insert<LinalgFillToFlowTensorSplat, ConvertSplatConstantOp>(
-          context);
+      patterns.insert<LinalgFillToFlowTensorSplat>(context);
     }
     IREE::Flow::TensorReshapeOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -131,8 +131,12 @@ createPadLinalgOpsToIntegerMultiplePass(int paddingSize = 4);
 //===----------------------------------------------------------------------===//
 
 // Outlines large tensor constants into util.globals at the module level.
-std::unique_ptr<OperationPass<mlir::ModuleOp>>
-createOutlineLargeConstantsPass();
+//
+// TODO(#5493): implement the support for inlining constants into the command
+// buffer and raise this value to one that is measured to be good.
+static constexpr size_t kMinLargeConstantSize = 1;
+std::unique_ptr<OperationPass<mlir::ModuleOp>> createOutlineLargeConstantsPass(
+    size_t minLargeConstantSize = kMinLargeConstantSize);
 
 // Deduplicates equivalent executables.
 std::unique_ptr<OperationPass<mlir::ModuleOp>>

--- a/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -102,12 +102,8 @@ def OutlineDispatchRegions :
 def OutlineLargeConstants :
     Pass<"iree-flow-outline-large-constants", "mlir::ModuleOp"> {
   let summary = "Outlines large tensor constants into util.globals at the module level.";
-  let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineLargeConstantsPass()";
-  let options = [
-    Option<"minStorageSize", "min-storage-size",
-           "int64_t", /*default=*/"64",
-           "Outlines constants with storage sizes > than this byte size.">
-  ];
+  // TODO(#5493): add a flag for this.
+  let constructor = "mlir::iree_compiler::IREE::Flow::createOutlineLargeConstantsPass(25)";
 }
 
 def PadLinalgOps :

--- a/iree/compiler/Dialect/Flow/Transforms/test/outline_large_constants.mlir
+++ b/iree/compiler/Dialect/Flow/Transforms/test/outline_large_constants.mlir
@@ -1,12 +1,10 @@
-// RUN: iree-opt -split-input-file -iree-flow-outline-large-constants='min-storage-size=9' %s | IreeFileCheck %s
+// RUN: iree-opt -split-input-file -iree-flow-outline-large-constants %s | IreeFileCheck %s
 
-// CHECK: util.global private @[[LARGE_VARIABLE:.+]] {noinline} = dense<{{.+}}> : tensor<8xf32>
-func @fn1() -> (tensor<2xf32>, tensor<512x128xf32>, tensor<8xf32>) {
+// CHECK: util.global private @[[LARGE_VARIABLE:.+]] {noinline} = dense<1.200000e+00> : tensor<512x128xf32>
+func @fn1() -> (tensor<2xf32>, tensor<512x128xf32>) {
   // CHECK-DAG: %[[SMALL_VALUE:.+]] = arith.constant dense<{{.+}}> : tensor<2xf32>
   %cst_0 = arith.constant dense<[0.0287729427, 0.0297581609]> : tensor<2xf32>
-  // CHECK-DAG: %[[SPLATG_VALUE:.+]] = arith.constant dense<{{.+}}> : tensor<512x128xf32>
+  // CHECK-DAG: %[[LARGE_VALUE:.+]] = util.global.load @[[LARGE_VARIABLE]] : tensor<512x128xf32>
   %cst_1 = arith.constant dense<1.2> : tensor<512x128xf32>
-  // CHECK-DAG: %[[LARGE_VALUE:.+]] = util.global.load @[[LARGE_VARIABLE]] : tensor<8xf32>
-  %cst_2 = arith.constant dense<[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0]> : tensor<8xf32>
-  return %cst_0, %cst_1, %cst_2 : tensor<2xf32>, tensor<512x128xf32>, tensor<8xf32>
+  return %cst_0, %cst_1 : tensor<2xf32>, tensor<512x128xf32>
 }

--- a/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
+++ b/iree/compiler/Dialect/HAL/Conversion/FlowToHAL/ConvertStreamOps.cpp
@@ -949,9 +949,6 @@ static Value splatFillPattern(Location loc, Value baseValue,
   baseValue = builder.createOrFold<arith::BitcastOp>(
       loc, builder.getIntegerType(baseBitWidth), baseValue);
 
-  // Treat i1 as i8.
-  if (baseBitWidth == 1) baseBitWidth = 8;
-
   switch (baseBitWidth) {
     case 8: {
       // (v << 24) | (v << 16) | (v << 8) | v


### PR DESCRIPTION
This reverts commit cc4f1734db7aab52873b3a8c1fbd5945419813d9.

Reason to revert: the change creates unaligned buffer fill