### PR TITLE
Trim e2e matmul tests and share MLIR code across testcases

### DIFF
--- a/iree/test/e2e/regression/generate_e2e_matmul_tests.py
+++ b/iree/test/e2e/regression/generate_e2e_matmul_tests.py
@@ -211,7 +211,7 @@ local_pseudorandom_state = 1
 # A static size value, i.e. a size value that could appear in a MLIR type
 # such as 'tensor<?x4xf32>'. None means a dynamic size, similar to '?' in MLIR.
 @dataclasses.dataclass
-class StaticSize:
+class DimSize:
   value: typing.Optional[int]
 
 
@@ -219,28 +219,28 @@ class StaticSize:
 # or None (which maps to MLIR '?') depending on dynamicity.
 def static_size(x: int, dynamicity: Dynamicity):
   if dynamicity == Dynamicity.DYNAMIC:
-    return StaticSize(None)
+    return DimSize(None)
   elif dynamicity == Dynamicity.STATIC:
-    return StaticSize(x)
+    return DimSize(x)
   elif dynamicity == Dynamicity.MIXED:
     global local_pseudorandom_state
     # Same as C++ std::minstd_rand.
     # Using a local pseudorandom generator implementation ensures that it's
     # completely reproducible, across runs and across machines.
     local_pseudorandom_state = (local_pseudorandom_state * 48271) % 2147483647
-    return StaticSize(x if local_pseudorandom_state > 1073741824 else None)
+    return DimSize(x if local_pseudorandom_state > 1073741824 else None)
   else:
     raise ValueError(dynamicity)
 
 
 # Stringification used for generating MLIR types, e.g. tensor<?x?xf32>.
-def int_or_question_mark(s: StaticSize):
+def int_or_question_mark(s: DimSize):
   return s.value or "?"
 
 
 # Stringification used for generating alphanumeric identifiers, e.g.
 # func @somefunction_DYNxDYNxf32, where we can't use "?" characters.
-def int_or_DYN(s: StaticSize):
+def int_or_DYN(s: DimSize):
   return s.value or "DYN"
 
 
@@ -251,12 +251,12 @@ def int_or_DYN(s: StaticSize):
 # These string values are used to generate MLIR function names and tensor shapes.
 @dataclasses.dataclass
 class TestInputMatricesStaticShapes:
-  lhs_rows: StaticSize
-  lhs_cols: StaticSize
-  rhs_rows: StaticSize
-  rhs_cols: StaticSize
-  acc_rows: StaticSize
-  acc_cols: StaticSize
+  lhs_rows: DimSize
+  lhs_cols: DimSize
+  rhs_rows: DimSize
+  rhs_cols: DimSize
+  acc_rows: DimSize
+  acc_cols: DimSize
 
 
 # Helper for generate_function. Generates TestInputMatricesStaticShapes, i.e.


### PR DESCRIPTION
When I wrote these tests, I put great care in ensuring low test *run* latency. But I didn't think about test *compilation* latency.

So this PR reduces these build times in two different ways:
1. By commenting out half of the shapes in `get_test_shapes`. I've retained ~ 50% of the shapes that I believe provide ~ 90% of the coverage.  The remaining 10% coverage will only start to matter later when we start to make the matmul implementation do more complicated things, and we can uncomment those shapes then.
2. By ensuring that testcases that test the same exact code (differing only by runtime data) actually share that code already at the source level (without relying on CSE, which might kick in too late to recover the best compilation latency), by changing `generate_function_name` to generate the same exact name, so that we're sure that we insert only one. There are two sub-cases here:
  a. Testcases that differ in dynamic shape dimensions. Before we could have functions `foo_2x2(tensor<?x?xf32>)` and `foo_3x3(tensor<?x?xf32>)` doing the same thing, only differing in the dynamic shapes that they are called on. Now it's `foo_DYNxDYN(tensor<?x?xf32>)`.
  b. Testcases that differ in the generator of matrix element that they are called with. Before we would have `foo_identity(tensor<4x4xf32>)` and `foo_random(tensor<4x4xf32)`. Now it's just `foo(tensor<4x4xf32>)`.

Before:
```
$ time cmake --build .
[0/2] Re-checking globbed directories...
[28/28] Generating e2e_matmul_direct_i8_small_dylib-llvm-aot_dylib.vmfb

real	0m56.333s
user	10m24.481s
sys	3m46.072s
```

After:
```
$ time cmake --build .
[0/2] Re-checking globbed directories...
[28/28] Generating e2e_matmul_mmt4d_i8_small_dylib-llvm-aot_dylib.vmfb

real	0m22.573s
user	3m34.928s
sys	1m23.833s
```
