### PR TITLE
Refactor CMake rules for connecting to TF binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ endif()
 
 option(IREE_ENABLE_RUNTIME_TRACING "Enables instrumented runtime tracing." OFF)
 option(IREE_ENABLE_COMPILER_TRACING "Enables instrumented compiler tracing." OFF)
+option(IREE_ENABLE_THREADING "Builds IREE in with thread library support." ON)
 
 option(IREE_BUILD_COMPILER "Builds the IREE compiler." ON)
 option(IREE_BUILD_TESTS "Builds IREE unit tests." ON)
@@ -40,10 +41,9 @@ option(IREE_BUILD_SAMPLES "Builds IREE sample projects." ON)
 option(IREE_BUILD_TRACY "Builds tracy server tools." OFF)
 
 option(IREE_BUILD_TENSORFLOW_ALL "Builds all TensorFlow compiler frontends." OFF)
-option(IREE_BUILD_TENSORFLOW_COMPILER "Builds TensorFlow compiler frontend." OFF)
-option(IREE_BUILD_TFLITE_COMPILER "Builds the TFLite compiler frontend." OFF)
-option(IREE_BUILD_XLA_COMPILER "Builds TensorFlow XLA compiler frontend." OFF)
-option(IREE_ENABLE_THREADING "Builds IREE in with thread library support." ON)
+option(IREE_BUILD_TENSORFLOW_COMPILER "Builds TensorFlow compiler frontend." "${IREE_BUILD_TENSORFLOW_ALL}")
+option(IREE_BUILD_TFLITE_COMPILER "Builds the TFLite compiler frontend." "${IREE_BUILD_TENSORFLOW_ALL}")
+option(IREE_BUILD_XLA_COMPILER "Builds TensorFlow XLA compiler frontend." "${IREE_BUILD_TENSORFLOW_ALL}")
 
 set(IREE_HAL_DRIVERS_TO_BUILD "all"
   CACHE STRING "Semicolon-separated list of HAL drivers to build, or \"all\".")
@@ -66,15 +66,12 @@ if(${IREE_BUILD_TENSORFLOW_ALL} OR
   set(IREE_ENABLE_TENSORFLOW ON)
 endif()
 
+
 option(IREE_BUILD_BINDINGS_TFLITE "Builds the IREE TFLite C API compatibility shim" ON)
 option(IREE_BUILD_BINDINGS_TFLITE_JAVA "Builds the IREE TFLite Java bindings with the C API compatibility shim" ON)
 
 # Default python bindings to enabled for some features.
-if(${IREE_ENABLE_TENSORFLOW})
-  option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" ON)
-else()
-  option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" OFF)
-endif()
+option(IREE_BUILD_PYTHON_BINDINGS "Builds the IREE python bindings" "${IREE_ENABLE_TENSORFLOW}")
 
 #-------------------------------------------------------------------------------
 # Experimental project flags

--- a/integrations/tensorflow/CMakeLists.txt
+++ b/integrations/tensorflow/CMakeLists.txt
@@ -8,57 +8,10 @@
 # dependent code under this directory tree. The CMake support is limited to
 # compiler binaries and python bindings.
 #
-# Bazel is a beast that likes to be the center of the universe. There is some
-# fragility in delegating to it in this fashion.
-#
 # If this directory is included, then building TensorFlow is assumed (the
 # config option happens at the higher level).
 
-set(_bazel_targets)
-set(_executable_paths)
-
-set(IREE_TF_TOOLS_ROOT
-    "${CMAKE_SOURCE_DIR}/integrations/tensorflow/bazel-bin/iree_tf_compiler"
-    CACHE STRING "Root directory for IREE TensorFlow integration binaries")
-
-
-if(${IREE_BUILD_TENSORFLOW_COMPILER} OR ${IREE_BUILD_TENSORFLOW_ALL})
-  add_executable(iree_tf_compiler_iree-import-tf IMPORTED GLOBAL)
-  set_property(TARGET iree_tf_compiler_iree-import-tf
-    PROPERTY IMPORTED_LOCATION
-        "${IREE_TF_TOOLS_ROOT}/iree-import-tf"
-  )
-endif()
-
-if(${IREE_BUILD_TFLITE_COMPILER} OR ${IREE_BUILD_TENSORFLOW_ALL})
-  add_executable(iree_tf_compiler_iree-import-tflite IMPORTED GLOBAL)
-  set_property(TARGET iree_tf_compiler_iree-import-tflite
-    PROPERTY IMPORTED_LOCATION
-        "${IREE_TF_TOOLS_ROOT}/iree-import-tflite"
-  )
-endif()
-
-if(${IREE_BUILD_XLA_COMPILER} OR ${IREE_BUILD_TENSORFLOW_ALL})
-  add_executable(iree_tf_compiler_iree-import-xla IMPORTED GLOBAL)
-  set_property(TARGET iree_tf_compiler_iree-import-xla
-    PROPERTY IMPORTED_LOCATION
-        "${IREE_TF_TOOLS_ROOT}/iree-import-xla"
-  )
-endif()
-
-if(${IREE_BUILD_TESTS})
-  add_executable(iree_tf_compiler_iree-tf-opt IMPORTED GLOBAL)
-  set_property(TARGET iree_tf_compiler_iree-tf-opt
-    PROPERTY IMPORTED_LOCATION
-        "${IREE_TF_TOOLS_ROOT}/iree-tf-opt"
-  )
-
-  add_executable(iree_tf_compiler_iree-opt-tflite IMPORTED GLOBAL)
-  set_property(TARGET iree_tf_compiler_iree-opt-tflite
-    PROPERTY IMPORTED_LOCATION
-        "${IREE_TF_TOOLS_ROOT}/iree-opt-tflite"
-  )
-endif()
+add_subdirectory(iree_tf_compiler)
 
 if(${IREE_BUILD_PYTHON_BINDINGS})
   add_subdirectory(bindings/python)

--- a/integrations/tensorflow/bindings/python/iree/tools/tf/CMakeLists.txt
+++ b/integrations/tensorflow/bindings/python/iree/tools/tf/CMakeLists.txt
@@ -14,12 +14,12 @@ iree_py_library(
     tf
   SRCS ${_srcs}
   DEPS
-  iree_tf_compiler_iree-import-tf
+  integrations::tensorflow::iree_tf_compiler::iree-import-tf
 )
 
 iree_symlink_tool(
   TARGET tf
-  FROM_TOOL_TARGET iree_tf_compiler_iree-import-tf
+  FROM_TOOL_TARGET integrations::tensorflow::iree_tf_compiler::iree-import-tf
   TO_EXE_NAME iree-import-tf
 )
 
@@ -29,13 +29,13 @@ iree_py_install_package(
   MODULE_PATH iree/tools/tf
   FILES_MATCHING ${_srcs}
   DEPS
-    iree_tf_compiler_iree-import-tf
+    integrations::tensorflow::iree_tf_compiler::iree-import-tf
 )
 
 # Since imported, need to resolve the TARGET_FILE ourselves instead of
 # install TARGETS form.
 install(
-  PROGRAMS "$<TARGET_FILE:iree_tf_compiler_iree-import-tf>"
+  PROGRAMS "$<TARGET_FILE:integrations::tensorflow::iree_tf_compiler::iree-import-tf>"
   DESTINATION "${PY_INSTALL_MODULE_DIR}"
   COMPONENT "${PY_INSTALL_COMPONENT}"
 )

--- a/integrations/tensorflow/bindings/python/iree/tools/tflite/CMakeLists.txt
+++ b/integrations/tensorflow/bindings/python/iree/tools/tflite/CMakeLists.txt
@@ -14,12 +14,12 @@ iree_py_library(
     tflite
   SRCS ${_srcs}
   DEPS
-    iree_tf_compiler_iree-import-tflite
+    integrations::tensorflow::iree_tf_compiler::iree-import-tflite
 )
 
 iree_symlink_tool(
   TARGET tflite
-  FROM_TOOL_TARGET iree_tf_compiler_iree-import-tflite
+  FROM_TOOL_TARGET integrations::tensorflow::iree_tf_compiler::iree-import-tflite
   TO_EXE_NAME iree-import-tflite
 )
 
@@ -29,13 +29,13 @@ iree_py_install_package(
   MODULE_PATH iree/tools/tflite
   FILES_MATCHING ${_srcs}
   DEPS
-    iree_tf_compiler_iree-import-tflite
+    integrations::tensorflow::iree_tf_compiler::iree-import-tflite
 )
 
 # Since imported, need to resolve the TARGET_FILE ourselves instead of
 # install TARGETS form.
 install(
-  PROGRAMS "$<TARGET_FILE:iree_tf_compiler_iree-import-tflite>"
+  PROGRAMS "$<TARGET_FILE:integrations::tensorflow::iree_tf_compiler::iree-import-tflite>"
   DESTINATION "${PY_INSTALL_MODULE_DIR}"
   COMPONENT "${PY_INSTALL_COMPONENT}"
 )

--- a/integrations/tensorflow/bindings/python/iree/tools/xla/CMakeLists.txt
+++ b/integrations/tensorflow/bindings/python/iree/tools/xla/CMakeLists.txt
@@ -14,12 +14,12 @@ iree_py_library(
     xla
   SRCS ${_srcs}
   DEPS
-    iree_tf_compiler_iree-import-xla
+    integrations::tensorflow::iree_tf_compiler::iree-import-xla
 )
 
 iree_symlink_tool(
   TARGET xla
-  FROM_TOOL_TARGET iree_tf_compiler_iree-import-xla
+  FROM_TOOL_TARGET integrations::tensorflow::iree_tf_compiler::iree-import-xla
   TO_EXE_NAME iree-import-xla
 )
 
@@ -29,13 +29,13 @@ iree_py_install_package(
   MODULE_PATH iree/tools/xla
   FILES_MATCHING ${_srcs}
   DEPS
-    iree_tf_compiler_iree-import-xla
+    integrations::tensorflow::iree_tf_compiler::iree-import-xla
 )
 
 # Since imported, need to resolve the TARGET_FILE ourselves instead of
 # install TARGETS form.
 install(
-  PROGRAMS "$<TARGET_FILE:iree_tf_compiler_iree-import-xla>"
+  PROGRAMS "$<TARGET_FILE:integrations::tensorflow::iree_tf_compiler::iree-import-xla>"
   DESTINATION "${PY_INSTALL_MODULE_DIR}"
   COMPONENT "${PY_INSTALL_COMPONENT}"
 )

--- a/integrations/tensorflow/iree_tf_compiler/CMakeLists.txt
+++ b/integrations/tensorflow/iree_tf_compiler/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright 2020 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(IREE_TF_TOOLS_ROOT
+    "${CMAKE_SOURCE_DIR}/integrations/tensorflow/bazel-bin/iree_tf_compiler"
+    CACHE STRING "Root directory for IREE TensorFlow integration binaries")
+
+iree_package_name(_PACKAGE_NAME)
+iree_package_ns(_PACKAGE_NS)
+
+function(configure_tf_binary BINARY_NAME)
+  set(_NAME "${_PACKAGE_NAME}_${BINARY_NAME}")
+  add_executable("${_NAME}" IMPORTED GLOBAL)
+  set_property(TARGET ${_NAME}
+    PROPERTY IMPORTED_LOCATION
+        "${IREE_TF_TOOLS_ROOT}/${BINARY_NAME}"
+  )
+  add_executable(${_PACKAGE_NS}::${BINARY_NAME} ALIAS ${_NAME})
+  add_executable(${BINARY_NAME} ALIAS ${_NAME})
+endfunction()
+
+if(${IREE_BUILD_TENSORFLOW_COMPILER})
+  configure_tf_binary("iree-import-tf")
+endif()
+
+if(${IREE_BUILD_TFLITE_COMPILER})
+  configure_tf_binary("iree-import-tflite")
+endif()
+
+if(${IREE_BUILD_XLA_COMPILER})
+  configure_tf_binary("iree-import-xla")
+endif()
+
+if(${IREE_BUILD_TESTS})
+  configure_tf_binary("iree-tf-opt")
+  configure_tf_binary("iree-opt-tflite")
+endif()


### PR DESCRIPTION
This makes the imported TF binaries more uniform with our other binaries
in terms of their naming and the convenience aliases. It also factors
some common logic into a function.

This is only one option for changing the way the binaries are
referenced. We could also use unqualified name (since we set it up so
our binaries are globally unique and available by their basename). I
don't think we ever came up with a consistent rule for that, other than
that we shouldn't use the underscore-mangled name that only exists 
because CMake has weird restrictions on some target names (but not
aliases).