### PR TITLE
[CUDA][HAL] Map HAL events to CUDA graph edges

### DIFF
--- a/iree/hal/cuda/cuda_event.h
+++ b/iree/hal/cuda/cuda_event.h
@@ -24,6 +24,12 @@ iree_status_t iree_hal_cuda_event_create(
     iree_hal_cuda_context_wrapper_t* context_wrapper,
     iree_hal_event_t** out_event);
 
+void iree_hal_cuda_event_set_sync_node(iree_hal_event_t* base_event,
+                                       CUgraphNode node);
+
+CUgraphNode iree_hal_cuda_event_get_sync_node(
+    const iree_hal_event_t* base_event);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/iree/hal/cuda/dynamic_symbol_tables.h
+++ b/iree/hal/cuda/dynamic_symbol_tables.h
@@ -18,6 +18,8 @@ CU_PFN_DECL(cuGraphAddMemsetNode, CUgraphNode*, CUgraph, const CUgraphNode*,
             size_t, const CUDA_MEMSET_NODE_PARAMS*, CUcontext)
 CU_PFN_DECL(cuGraphAddKernelNode, CUgraphNode*, CUgraph, const CUgraphNode*,
             size_t, const CUDA_KERNEL_NODE_PARAMS*)
+CU_PFN_DECL(cuGraphAddEmptyNode, CUgraphNode *, CUgraph, const CUgraphNode *,
+            size_t)
 CU_PFN_DECL(cuGraphCreate, CUgraph*, unsigned int)
 CU_PFN_DECL(cuGraphDestroy, CUgraph)
 CU_PFN_DECL(cuGraphExecDestroy, CUgraphExec)


### PR DESCRIPTION
Make events nodes in the cuda graph and add edges from and to all
dispatches than needs to be order relatively to the event.

This removes the graph serialization happening before and instead only
add edges when events or barrier are present.