### PR TITLE
Re-enable SPIR-V linking in VulkanSPIRVTarget.cpp.

### DIFF
--- a/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -156,9 +156,6 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     buildSPIRVCodegenPassPipeline(passManager);
   }
 
-  // TODO(antiagainst): Re-enable SPIR-V linking once the tensorflow integration
-  // crash is fixed.
-#if 0
   LogicalResult linkExecutables(mlir::ModuleOp moduleOp) override {
     // Note: Vulkan flavored SPIR-V does not have linking in the conventional
     // sense. For example, there is no cross-module symbol reference and symbol
@@ -270,7 +267,6 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
 
     return success();
   }
-#endif
 
   LogicalResult serializeExecutable(IREE::HAL::ExecutableVariantOp variantOp,
                                     OpBuilder &executableBuilder) override {


### PR DESCRIPTION
This generally increases compile time and can either improve or degrade runtime performance depending on the runtime Vulkan ICD. For example, a debug build of SwiftShader may be significantly slower with this, while an opt build of SwiftShader or a native driver may be faster. Most of the runtime effects occur at startup, as the driver is given a smaller number of (potentially) more complex shaders. Linking can also improve binary size and enable more whole program optimizations.

See https://github.com/google/iree/issues/7819