### PR TITLE
Create an e2e SingleTilingExpert pass pipeline for CPU backend.

### DIFF
--- a/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -141,8 +141,6 @@ void addIREEComprehensiveBufferizePasses(
     OpPassManager &passManager,
     std::unique_ptr<linalg::comprehensive_bufferize::AllocationCallbacks>
         allocationFns) {
-  passManager.addNestedPass<FuncOp>(
-      createConvertToDestinationPassingStylePass());
   passManager.addPass(
       createIREEComprehensiveBufferizePass(std::move(allocationFns)));
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -12,6 +12,8 @@ include "iree/compiler/Codegen/Dialect/IREECodegenDialect.td"
 // List of pre-existing pipelines for translating executables.
 def CPU_Default
     : StrEnumAttrCase<"CPUDefault">;
+def CPU_SingleTilingExpert
+    : StrEnumAttrCase<"CPUSingleTilingExpert">;
 def CPU_TensorToVectors
     : StrEnumAttrCase<"CPUTensorToVectors">;
 def CPU_TileFuseAndVectorize
@@ -43,10 +45,11 @@ def None
 def DispatchLoweringPassPipelineEnum : StrEnumAttr<
     "DispatchLoweringPassPipeline",
     "identifier for pass pipeline use to lower dispatch region",
-    [CPU_Default, CPU_TensorToVectors, CPU_TileFuseAndVectorize,
-     LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
-     LLVMGPU_MatmulTensorCore, SPIRV_Distribute, SPIRV_DistributeCopy,
-     SPIRV_Vectorize, SPIRV_VectorizeToCooperativeOps, None]> {
+    [CPU_Default, CPU_SingleTilingExpert, CPU_TensorToVectors,
+     CPU_TileFuseAndVectorize, LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize,
+     LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore, SPIRV_Distribute,
+     SPIRV_DistributeCopy, SPIRV_Vectorize, SPIRV_VectorizeToCooperativeOps,
+     None]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
 }
 

--- a/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -30,6 +30,7 @@ cc_library(
         "//iree/compiler/Codegen:PassHeaders",
         "//iree/compiler/Codegen/Common",
         "//iree/compiler/Codegen/Dialect:IREECodegenDialect",
+        "//iree/compiler/Codegen/Sandbox",
         "//iree/compiler/Codegen/Transforms",
         "//iree/compiler/Codegen/Utils",
         "//iree/compiler/Dialect/Flow/IR",

--- a/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -62,6 +62,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Codegen::PassHeaders
+    iree::compiler::Codegen::Sandbox
     iree::compiler::Codegen::Transforms
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::Flow::IR

--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -9,6 +9,7 @@
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "llvm/ADT/Triple.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -475,7 +476,83 @@ static LogicalResult setRootConfig(
       getDispatchLoweringPassPipeline(entryPointFn, fftOp));
 }
 
-/// Finds the root operation in the given list of linalg operations and sets
+/// Sets the lowering configuration for a generic op to use SingleTilingExpert.
+static LogicalResult setRootConfig(
+    FuncOp entryPointFn, linalg::GenericOp genericOp,
+    ArrayRef<LoopTilingAndDistributionInfo> tiledLoops) {
+  // If there is already a set configuration, do nothing.
+  if (getLoweringConfig(genericOp)) return success();
+
+  // For VMVX, do not use vectorization. Just lower as default.
+  if (isVMVXBackend(entryPointFn)) return success();
+
+  // If there are no loops, there is nothing to do.
+  unsigned numLoops = genericOp.getNumLoops();
+  if (numLoops == 0) return success();
+
+  Optional<int64_t> nativeVectorSizeInBytes =
+      getNativeVectorSizeInBytes(entryPointFn);
+  if (!nativeVectorSizeInBytes) {
+    // For now if there is nothing specified in the `hal.executable.variant`,
+    // just use a default.
+    nativeVectorSizeInBytes = clNativeVectorSizeInBytes;
+  }
+  SmallVector<int64_t> nativeVectorSize(numLoops, 1);
+  auto inputOutputOpOperands = genericOp.getInputAndOutputOperands();
+  for (auto map : llvm::enumerate(genericOp.getIndexingMaps())) {
+    // Check the fastest varying dimension of the operand. Set the vector size
+    // of the corresponding loop to the vector size.
+    if (map.value().getNumResults() == 0) continue;
+    auto fastestVaryingDimExpr =
+        map.value().getResults().back().dyn_cast<AffineDimExpr>();
+    if (!fastestVaryingDimExpr) continue;
+    unsigned fastestVaryingDim = fastestVaryingDimExpr.getPosition();
+
+    // If the indexing map has result it has to be a shaped type.
+    auto operandType =
+        inputOutputOpOperands[map.index()]->get().getType().cast<ShapedType>();
+    Type elemType = operandType.getElementType();
+    if (!elemType.isIntOrFloat()) continue;
+
+    unsigned byteWidth =
+        std::max<unsigned>(elemType.getIntOrFloatBitWidth() / 8, 1);
+    unsigned currVectorSize = nativeVectorSizeInBytes.getValue() / byteWidth;
+    nativeVectorSize[fastestVaryingDim] =
+        std::max<int64_t>(nativeVectorSize[fastestVaryingDim], currVectorSize);
+  }
+  if (llvm::all_of(nativeVectorSize, [](int64_t vs) { return vs == 1; })) {
+    // Nothing to vectorize just lower to loops.
+    return success();
+  }
+
+  // Set the flow level tiling to the default.
+  SmallVector<int64_t> prunedNativeVectorSize(tiledLoops.size(), 1);
+  if (!tiledLoops.empty()) {
+    SmallVector<unsigned> partitionedLoops = getPartitionedLoops(genericOp);
+    for (auto loopDim : llvm::enumerate(partitionedLoops)) {
+      prunedNativeVectorSize[loopDim.index()] =
+          nativeVectorSize[loopDim.value()];
+    }
+  }
+  SmallVector<int64_t> workloadPerWorkgroup =
+      getDefaultWorkloadPerWorkgroup(tiledLoops, prunedNativeVectorSize);
+  setTranslationInfo(entryPointFn,
+                     DispatchLoweringPassPipeline::CPUSingleTilingExpert,
+                     workloadPerWorkgroup,
+                     /*workgroupSize=*/ArrayRef<int64_t>{});
+
+  SmallVector<int64_t> l1TileSizes = nativeVectorSize;
+  TileSizesListType tileSizes;
+  tileSizes.push_back({});  // Empty since nothing to do for first level tiling.
+  tileSizes.push_back(l1TileSizes);
+  auto config = IREE::Codegen::LoweringConfigAttr::get(
+      entryPointFn.getContext(), tileSizes, nativeVectorSize);
+  setLoweringConfig(genericOp, config);
+
+  return success();
+}
+
+/// Finds the root operation in the given list of Linalg operations and sets
 /// its configuration. Returns error for multiple root operations.
 static LogicalResult setRootConfig(
     FuncOp entryPointFn, ArrayRef<Operation *> computeOps,
@@ -488,6 +565,15 @@ static LogicalResult setRootConfig(
                 IREE::LinalgExt::FftOp>([&](auto op) {
             return setRootConfig(entryPointFn, op, tiledLoops);
           })
+          .Case<linalg::GenericOp>([&](auto genericOp) {
+            if (genericOp.getNumLoops() == genericOp.getNumParallelLoops()) {
+              // Ignore parallel elementwise operations now. They will be set as
+              // roots ops if there are no other ops that can be treated as a
+              // root op.
+              return success();
+            }
+            return setRootConfig(entryPointFn, genericOp, tiledLoops);
+          })
           .Default([&](Operation *op) { return success(); });
     };
     if (failed(setRootConfigFn(computeOp))) {
@@ -495,10 +581,36 @@ static LogicalResult setRootConfig(
     }
     if (getLoweringConfig(computeOp)) {
       if (rootOp) {
-        return computeOp->emitError(
+        return computeOp->emitOpError(
             "unhandled multiple roots in dispatch region");
       }
       rootOp = computeOp;
+    }
+  }
+  if (rootOp) return success();
+
+  // If there are any other ops other than `linalg.generic`, `linalg.copy` or
+  // `linalg.fill` then just use the default.
+  for (auto computeOp : computeOps) {
+    if (!isa<linalg::GenericOp, linalg::CopyOp, linalg::FillOp>(computeOp)) {
+      return success();
+    }
+  }
+
+  // If there are no root ops, then check for a single `linalg.generic` op. Make
+  // this the root, and vectorize the operation.
+  for (auto computeOp : computeOps) {
+    if (auto genericOp = dyn_cast<linalg::GenericOp>(computeOp)) {
+      if (failed(setRootConfig(entryPointFn, genericOp, tiledLoops))) {
+        return failure();
+      }
+      if (getLoweringConfig(computeOp)) {
+        if (rootOp) {
+          return computeOp->emitOpError(
+              "unhanlded multiple parallel generic ops within a dispatch");
+        }
+        rootOp = computeOp;
+      }
     }
   }
   return success();

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -34,7 +34,7 @@ class LLVMCPULowerExecutableTargetPass
       const LLVMCPULowerExecutableTargetPass &pass) {}
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Codegen::IREECodegenDialect, IREE::HAL::HALDialect,
-                    linalg::LinalgDialect, LLVM::LLVMDialect,
+                    linalg::LinalgDialect, LLVM::LLVMDialect, scf::SCFDialect,
                     vector::VectorDialect>();
   }
 
@@ -174,6 +174,12 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
           case IREE::Codegen::DispatchLoweringPassPipeline::None:
             addCPUDefaultPassPipeline(nestedModulePM);
+            break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::
+              CPUSingleTilingExpert:
+            nestedModulePM.addNestedPass<FuncOp>(
+                createConvertToDestinationPassingStylePass());
+            addSingleTilingExpertPassPipeline(nestedModulePM);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUTensorToVectors:
             addTensorToVectorsPassPipeline(nestedModulePM, lowerToVectors);

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -10,6 +10,7 @@
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Passes.h"
 #include "iree/compiler/Codegen/LLVMCPU/KernelDispatch.h"
 #include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Sandbox/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
 #include "mlir/Dialect/Arithmetic/Transforms/Passes.h"
@@ -165,6 +166,27 @@ void addTensorToVectorsPassPipeline(OpPassManager &passManager,
   passManager.addNestedPass<FuncOp>(createForOpCanonicalizationPass());
 
   passManager.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+}
+
+void addSingleTilingExpertPassPipeline(OpPassManager &passManager) {
+  passManager.addPass(createCanonicalizerPass());
+  // Add the sandbox single tiling expert to tile and vectorize.
+  passManager.addNestedPass<FuncOp>(createLinalgSingleTilingExpertPass(
+      static_cast<int64_t>(TilingLevel::L1Tiles), true));
+
+  // TODO(ravishankarm): This is commented cause this is WIP, to be enabled
+  // soon.
+  // auto callbacks =
+  //     std::make_unique<linalg::comprehensive_bufferize::AllocationCallbacks>(
+  //         cpuComprehensiveBufferizeAllocationFn,
+  //         cpuComprehensiveBufferizeDeallocationFn,
+  //         cpuComprehensiveBufferizeCopyFn);
+  // addIREEComprehensiveBufferizePasses(passManager, std::move(callbacks));
+  addLinalgBufferizePasses(passManager, cpuAllocationFunction);
+
+  // Add the vector lowering expert.
+  OpPassManager &nestedFuncPassManager = passManager.nest<FuncOp>();
+  addLowerToVectorTransforms(nestedFuncPassManager);
 }
 
 void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -201,6 +201,10 @@ LogicalResult verifyTensorToVectorsPassPipelineConfig(
 void addTensorToVectorsPassPipeline(OpPassManager &passManager,
                                     bool lowerToVectors = true);
 
+/// Populates the passes needed to do one-level tile + vectorize of linalg ops
+/// using the Codegen drivers from sandbox.
+void addSingleTilingExpertPassPipeline(OpPassManager &passManager);
+
 /// Populates the passes needed to multi level tile, fuse and vectorize lowering
 /// of linalg ops on tensors to vectors operations.
 void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,

--- a/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -8,6 +8,7 @@
 #include "iree/compiler/Codegen/Sandbox/PassDetail.h"
 #include "iree/compiler/Codegen/Sandbox/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Linalg/IR/LinalgOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
@@ -21,6 +22,8 @@
 
 using namespace mlir;
 using namespace mlir::linalg;
+
+#define DEBUG_TYPE "iree-linalg-tensor-codegen-driver"
 
 //===----------------------------------------------------------------------===//
 // IREE specific functions
@@ -231,6 +234,7 @@ void LinalgSingleTilingExpertPass::runOnOperation() {
 }
 
 void LinalgVectorLoweringPass::runOnOperation() {
+  LLVM_DEBUG(llvm::dbgs() << "\n ---- Stage : " << vectorLoweringStage;);
   vector::VectorTransposeLowering vectorTransposeLowering =
       llvm::StringSwitch<vector::VectorTransposeLowering>(
           lowerVectorTransposeTo.getValue())

--- a/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/iree/compiler/Codegen/Utils/Utils.cpp
@@ -55,6 +55,12 @@ bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp) {
   return variantOp.target().getBackend().getValue() == "vmvx";
 }
 
+bool isVMVXBackend(FuncOp entryPointFn) {
+  auto variantOp =
+      entryPointFn->getParentOfType<IREE::HAL::ExecutableVariantOp>();
+  return isVMVXBackend(variantOp);
+}
+
 //===----------------------------------------------------------------------===//
 // Utility functions to get untiled op shapes
 //===----------------------------------------------------------------------===//

--- a/iree/compiler/Codegen/Utils/Utils.h
+++ b/iree/compiler/Codegen/Utils/Utils.h
@@ -33,6 +33,7 @@ llvm::StringMap<IREE::HAL::ExecutableEntryPointOp> getAllEntryPoints(
 IREE::HAL::ExecutableEntryPointOp getEntryPoint(FuncOp funcOp);
 
 bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp);
+bool isVMVXBackend(FuncOp entryPointFn);
 
 //===----------------------------------------------------------------------===//
 // Utility functions to get untiled op shapes


### PR DESCRIPTION
This is currently only used for linalg.generic ops and is a means to
vectorize these operations by default.