### PR TITLE
Roll foward adding command_buffer_dispatch_test.

### DIFF
--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -17,4 +17,10 @@ iree_hal_cts_test_suite(
     "\"PTXE\""
   DEPS
     experimental::rocm::registration
+  EXCLUDED_TESTS
+    # Non-push descriptor sets are not implemented in the ROCm backend yet.
+    "descriptor_set"
+    # Semaphores are not implemented in the ROCm backend yet.
+    "semaphore_submission"
+    "semaphore"
 )

--- a/experimental/rocm/cts/CMakeLists.txt
+++ b/experimental/rocm/cts/CMakeLists.txt
@@ -18,6 +18,9 @@ iree_hal_cts_test_suite(
   DEPS
     experimental::rocm::registration
   EXCLUDED_TESTS
+    # This test depends on iree_hal_rocm_direct_command_buffer_update_buffer
+    # via iree_hal_buffer_view_allocate_buffer, which is not implemented yet.
+    "command_buffer_dispatch"
     # Non-push descriptor sets are not implemented in the ROCm backend yet.
     "descriptor_set"
     # Semaphores are not implemented in the ROCm backend yet.

--- a/iree/hal/cts/CMakeLists.txt
+++ b/iree/hal/cts/CMakeLists.txt
@@ -8,14 +8,15 @@ set(IREE_ALL_CTS_TESTS
   "allocator"
   "buffer_mapping"
   "command_buffer"
-  "descriptor_set_layout"
+  "command_buffer_dispatch"
   "descriptor_set"
+  "descriptor_set_layout"
   "driver"
   "event"
   "executable_cache"
   "executable_layout"
-  "semaphore_submission"
   "semaphore"
+  "semaphore_submission"
   PARENT_SCOPE
 )
 
@@ -23,12 +24,14 @@ set(IREE_ALL_CTS_TESTS
 # If the compiler is disabled or a HAL driver implementation is not yet
 # connected to a functional compiler target, these tests can be skipped.
 set(IREE_EXECUTABLE_CTS_TESTS
+  "command_buffer_dispatch"
   "executable_cache"
   PARENT_SCOPE
 )
 
 # List of testdata/{name}.mlir source files.
 set(IREE_ALL_CTS_EXECUTABLE_SOURCES
+  "command_buffer_dispatch_test"
   "executable_cache_test"
   PARENT_SCOPE
 )
@@ -75,6 +78,18 @@ iree_cc_library(
     command_buffer_test_library
   HDRS
     "command_buffer_test.h"
+  DEPS
+    ::cts_test_base
+    iree::base
+    iree::hal
+    iree::testing::gtest
+)
+
+iree_cc_library(
+  NAME
+    command_buffer_dispatch_test_library
+  HDRS
+    "command_buffer_dispatch_test.h"
   DEPS
     ::cts_test_base
     iree::base

--- a/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/iree/hal/cts/command_buffer_dispatch_test.h
@@ -1,0 +1,143 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_CTS_COMMAND_BUFFER_DISPATCH_TEST_H_
+#define IREE_HAL_CTS_COMMAND_BUFFER_DISPATCH_TEST_H_
+
+#include "iree/base/api.h"
+#include "iree/base/string_view.h"
+#include "iree/hal/api.h"
+#include "iree/hal/cts/cts_test_base.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree {
+namespace hal {
+namespace cts {
+
+class command_buffer_dispatch_test : public CtsTestBase {
+ protected:
+  void PrepareAbsExecutable() {
+    IREE_ASSERT_OK(iree_hal_executable_cache_create(
+        device_, iree_make_cstring_view("default"), &executable_cache_));
+
+    iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] =
+        {
+            {0, IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
+            {1, IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},
+        };
+    IREE_ASSERT_OK(iree_hal_descriptor_set_layout_create(
+        device_, IREE_HAL_DESCRIPTOR_SET_LAYOUT_USAGE_TYPE_PUSH_ONLY,
+        IREE_ARRAYSIZE(descriptor_set_layout_bindings),
+        descriptor_set_layout_bindings, &descriptor_set_layout_));
+    IREE_ASSERT_OK(iree_hal_executable_layout_create(
+        device_, /*push_constants=*/0, /*set_layout_count=*/1,
+        &descriptor_set_layout_, &executable_layout_));
+
+    iree_hal_executable_spec_t executable_spec;
+    executable_spec.caching_mode =
+        IREE_HAL_EXECUTABLE_CACHING_MODE_ALIAS_PROVIDED_DATA;
+    executable_spec.executable_format =
+        iree_make_cstring_view(get_test_executable_format());
+    executable_spec.executable_data = get_test_executable_data(
+        iree_make_cstring_view("command_buffer_dispatch_test.bin"));
+    executable_spec.executable_layout_count = 1;
+    executable_spec.executable_layouts = &executable_layout_;
+
+    IREE_ASSERT_OK(iree_hal_executable_cache_prepare_executable(
+        executable_cache_, &executable_spec, &executable_));
+  }
+
+  void CleanupExecutable() {
+    iree_hal_executable_release(executable_);
+    iree_hal_executable_layout_release(executable_layout_);
+    iree_hal_descriptor_set_layout_release(descriptor_set_layout_);
+    iree_hal_executable_cache_release(executable_cache_);
+  }
+
+  iree_hal_executable_cache_t* executable_cache_ = NULL;
+  iree_hal_descriptor_set_layout_t* descriptor_set_layout_ = NULL;
+  iree_hal_executable_layout_t* executable_layout_ = NULL;
+  iree_hal_executable_t* executable_ = NULL;
+};
+
+TEST_P(command_buffer_dispatch_test, DispatchAbs) {
+  PrepareAbsExecutable();
+
+  iree_hal_command_buffer_t* command_buffer;
+  IREE_ASSERT_OK(iree_hal_command_buffer_create(
+      device_,
+      IREE_HAL_COMMAND_BUFFER_MODE_ONE_SHOT |
+          IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION,
+      IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_HAL_QUEUE_AFFINITY_ANY,
+      &command_buffer));
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
+
+  // Create input and output buffers.
+  iree_hal_buffer_view_t* input_buffer_view = NULL;
+  float input_data[1] = {-2.5f};
+  IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
+      device_allocator_, /*shape=*/NULL,
+      /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
+      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+      IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_TRANSFER,
+      iree_make_const_byte_span((void*)input_data, sizeof(input_data)),
+      &input_buffer_view));
+  iree_hal_buffer_t* output_buffer = NULL;
+  IREE_ASSERT_OK(iree_hal_allocator_allocate_buffer(
+      device_allocator_,
+      IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_VISIBLE,
+      IREE_HAL_BUFFER_USAGE_DISPATCH | IREE_HAL_BUFFER_USAGE_MAPPING,
+      sizeof(float), iree_const_byte_span_empty(), &output_buffer));
+
+  iree_hal_descriptor_set_binding_t descriptor_set_bindings[] = {
+      {/*binding=*/0, iree_hal_buffer_view_buffer(input_buffer_view),
+       /*offset=*/0, iree_hal_buffer_view_byte_length(input_buffer_view)},
+      {/*binding=*/1, output_buffer, iree_hal_buffer_byte_offset(output_buffer),
+       iree_hal_buffer_byte_length(output_buffer)},
+  };
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_push_descriptor_set(
+      command_buffer, executable_layout_, /*set=*/0,
+      IREE_ARRAYSIZE(descriptor_set_bindings), descriptor_set_bindings));
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_dispatch(
+      command_buffer, executable_, /*entry_point=*/0,
+      /*workgroup_x=*/1, /*workgroup_y=*/1, /*workgroup_z=*/1));
+  IREE_ASSERT_OK(iree_hal_command_buffer_execution_barrier(
+      command_buffer,
+      /*source_stage_mask=*/IREE_HAL_EXECUTION_STAGE_DISPATCH |
+          IREE_HAL_EXECUTION_STAGE_TRANSFER |
+          IREE_HAL_EXECUTION_STAGE_COMMAND_RETIRE,
+      /*target_stage_mask=*/IREE_HAL_EXECUTION_STAGE_COMMAND_ISSUE |
+          IREE_HAL_EXECUTION_STAGE_DISPATCH | IREE_HAL_EXECUTION_STAGE_TRANSFER,
+      IREE_HAL_EXECUTION_BARRIER_FLAG_NONE, /*memory_barrier_count=*/0,
+      /*memory_barriers=*/NULL,
+      /*buffer_barrier_count=*/0, /*buffer_barriers=*/NULL));
+
+  IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
+
+  IREE_ASSERT_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_DISPATCH,
+                                            command_buffer));
+
+  float out_value;
+  IREE_ASSERT_OK(iree_hal_buffer_read_data(output_buffer, /*source_offset=*/0,
+                                           &out_value, sizeof(out_value)));
+  EXPECT_EQ(2.5f, out_value);
+
+  iree_hal_command_buffer_release(command_buffer);
+  iree_hal_buffer_release(output_buffer);
+  iree_hal_buffer_view_release(input_buffer_view);
+  CleanupExecutable();
+}
+
+}  // namespace cts
+}  // namespace hal
+}  // namespace iree
+
+#endif  // IREE_HAL_CTS_COMMAND_BUFFER_DISPATCH_TEST_H_

--- a/iree/hal/cts/command_buffer_test.h
+++ b/iree/hal/cts/command_buffer_test.h
@@ -16,12 +16,6 @@
 #include "iree/testing/gtest.h"
 #include "iree/testing/status_matchers.h"
 
-// TODO(scotttodd): split into several tests, for example:
-//     command_buffer_recording_test (recording/lifetime)
-//     command_buffer_dispatch_test
-//     command_buffer_fill_test (filling buffers)
-//     command_buffer_e2e_test (barriers, dispatches)
-
 namespace iree {
 namespace hal {
 namespace cts {

--- a/iree/hal/cts/cts_test_template.cc.in
+++ b/iree/hal/cts/cts_test_template.cc.in
@@ -51,7 +51,7 @@ iree_const_byte_span_t get_test_executable_data(iree_string_view_t file_name) {
   }
   // TODO(scotttodd): error handling / reporting? This a sharp edge.
 #endif
-  return {NULL, 0};
+  return iree_const_byte_span_empty();
 }
 
 INSTANTIATE_TEST_SUITE_P(CTS, IREE_CTS_TEST_CLASS_NAME,

--- a/iree/hal/cts/descriptor_set_test.h
+++ b/iree/hal/cts/descriptor_set_test.h
@@ -19,10 +19,7 @@ namespace cts {
 
 class descriptor_set_test : public CtsTestBase {};
 
-// TODO(scotttodd): enable once any driver implements non-push descriptor sets
-//   * also test with buffers in the bindings
-//   * also test usage in iree_hal_command_buffer_bind_descriptor_set
-TEST_P(descriptor_set_test, DISABLED_CreateWithTwoBindings) {
+TEST_P(descriptor_set_test, CreateWithTwoBindings) {
   iree_hal_descriptor_set_layout_t* descriptor_set_layout;
   iree_hal_descriptor_set_layout_binding_t descriptor_set_layout_bindings[] = {
       {/*binding=*/0, /*type=*/IREE_HAL_DESCRIPTOR_TYPE_STORAGE_BUFFER},

--- a/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
+++ b/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
@@ -1,0 +1,37 @@
+// Bootstrapped from this source IR:
+//
+// func @abs(%input : tensor<f32>) -> (tensor<f32>) {
+//   %result = math.abs %input : tensor<f32>
+//   return %result : tensor<f32>
+// }
+
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+
+hal.executable.source public @executable {
+  hal.executable.entry_point public @abs layout(#executable_layout)
+
+  builtin.module {
+    func @abs() {
+      %c0 = arith.constant 0 : index
+
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<readonly:f32>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<writeonly:f32>
+
+      %2 = flow.dispatch.tensor.load %0, offsets = [], sizes = [], strides = [] : !flow.dispatch.tensor<readonly:f32> -> tensor<f32>
+      %3 = linalg.init_tensor [] : tensor<f32>
+      %4 = linalg.generic {indexing_maps = [affine_map<() -> ()>, affine_map<() -> ()>], iterator_types = []} ins(%2 : tensor<f32>) outs(%3 : tensor<f32>) {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %5 = math.abs %arg0 : f32
+        linalg.yield %5 : f32
+      } -> tensor<f32>
+      flow.dispatch.tensor.store %4, %1, offsets = [], sizes = [], strides = [] : tensor<f32> -> !flow.dispatch.tensor<writeonly:f32>
+
+      return
+    }
+  }
+}

--- a/iree/hal/cuda/cts/CMakeLists.txt
+++ b/iree/hal/cuda/cts/CMakeLists.txt
@@ -18,6 +18,8 @@ iree_hal_cts_test_suite(
   DEPS
     iree::hal::cuda::registration
   EXCLUDED_TESTS
+    # Non-push descriptor sets are not implemented in the CUDA backend yet.
+    "descriptor_set"
     # Semaphores are not implemented in the CUDA backend yet.
     "semaphore_submission"
     "semaphore"

--- a/iree/hal/cuda/cts/CMakeLists.txt
+++ b/iree/hal/cuda/cts/CMakeLists.txt
@@ -18,6 +18,9 @@ iree_hal_cts_test_suite(
   DEPS
     iree::hal::cuda::registration
   EXCLUDED_TESTS
+    # This test depends on iree_hal_cuda_stream_command_buffer_update_buffer
+    # via iree_hal_buffer_view_allocate_buffer, which is not implemented yet.
+    "command_buffer_dispatch"
     # Non-push descriptor sets are not implemented in the CUDA backend yet.
     "descriptor_set"
     # Semaphores are not implemented in the CUDA backend yet.

--- a/iree/hal/vulkan/cts/CMakeLists.txt
+++ b/iree/hal/vulkan/cts/CMakeLists.txt
@@ -17,4 +17,7 @@ iree_hal_cts_test_suite(
     "\"SPVE\""
   DEPS
     iree::hal::vulkan::registration
+  EXCLUDED_TESTS
+    # Non-push descriptor sets are not implemented in the Vulkan backend yet.
+    "descriptor_set"
 )


### PR DESCRIPTION
Just disabled the new test on CUDA and ROCm for now, because of a dependency from test helpers to

https://github.com/google/iree/blob/0a7bfaf4696f7cbe0e6f638d812f1d0c6d2976d1/iree/hal/cuda/stream_command_buffer.c#L200-L206

https://github.com/google/iree/blob/0a7bfaf4696f7cbe0e6f638d812f1d0c6d2976d1/experimental/rocm/direct_command_buffer.c#L219-L225