### PR TITLE
Add new pipeline for Sparse operation.

### DIFF
--- a/iree/compiler/Codegen/Common/BUILD
+++ b/iree/compiler/Codegen/Common/BUILD
@@ -46,6 +46,7 @@ cc_library(
         "OptimizeVectorTransferPass.cpp",
         "RemoveTrivialLoops.cpp",
         "SetNumWorkgroupsPass.cpp",
+        "SparsePreBufferization.cpp",
         "VectorizeConv.cpp",
         "VectorizeMMT4d.cpp",
     ],

--- a/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_cc_library(
     "OptimizeVectorTransferPass.cpp"
     "RemoveTrivialLoops.cpp"
     "SetNumWorkgroupsPass.cpp"
+    "SparsePreBufferization.cpp"
     "VectorizeConv.cpp"
     "VectorizeMMT4d.cpp"
   DEPS

--- a/iree/compiler/Codegen/Common/SparsePreBufferization.cpp
+++ b/iree/compiler/Codegen/Common/SparsePreBufferization.cpp
@@ -1,0 +1,87 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Return the function symbol associated with `name` or create it if it doesn't
+/// exist.
+static FlatSymbolRefAttr getOrCreateFunc(ModuleOp module, Location loc,
+                                         StringRef name, Type result,
+                                         ValueRange operands) {
+  MLIRContext *context = module.getContext();
+  auto func = module.lookupSymbol<FuncOp>(name);
+  if (!func) {
+    OpBuilder moduleBuilder(module.getBodyRegion());
+    moduleBuilder
+        .create<FuncOp>(loc, name,
+                        FunctionType::get(context, operands.getTypes(), result))
+        .setPrivate();
+  }
+  return SymbolRefAttr::get(context, name);
+}
+
+namespace {
+
+constexpr static StringRef kNewSparseFuncName = "newSparseTensor";
+
+/// This pass convert `newSparseTensor` builtin from tensor to memref world. It
+/// inserts bufferization.to_tensor_op at the boundary.
+struct SparsePreBufferizationPass
+    : public SparsePreBufferizationBase<SparsePreBufferizationPass> {
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    ModuleOp moduleOp = getOperation();
+    SmallVector<CallOp> callToReplace;
+    moduleOp.walk([&callToReplace](CallOp callOp) {
+      if (callOp.getCallee() == kNewSparseFuncName) {
+        callToReplace.push_back(callOp);
+      }
+    });
+    for (auto callOp : callToReplace) {
+      OpBuilder b(callOp);
+      Location loc = callOp.getLoc();
+      StringRef name = kNewSparseFuncName;
+      SmallVector<Value> args;
+      for (Value operand : callOp->getOperands()) {
+        auto tensorType = operand.getType().dyn_cast<RankedTensorType>();
+        if (!tensorType) {
+          args.push_back(operand);
+          continue;
+        }
+        Type newType =
+            MemRefType::get(tensorType.getShape(), tensorType.getElementType());
+        Value newarg =
+            b.create<bufferization::ToTensorOp>(loc, newType, operand);
+        args.push_back(newarg);
+      }
+      Type ptrType = callOp.getResult(0).getType();
+      Operation *newCall = b.create<CallOp>(
+          loc, ptrType, getOrCreateFunc(moduleOp, loc, name, ptrType, args),
+          args);
+      callOp.replaceAllUsesWith(newCall);
+      callOp.erase();
+      auto module = newCall->getParentOfType<ModuleOp>();
+      auto func = module.lookupSymbol<FuncOp>(name);
+      func.setType(
+          FunctionType::get(context, ValueRange(args).getTypes(), ptrType));
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<ModuleOp>> createSparsePreBufferize() {
+  return std::make_unique<SparsePreBufferizationPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -18,6 +18,8 @@ def CPU_TensorToVectors
     : StrEnumAttrCase<"CPUTensorToVectors">;
 def CPU_TileFuseAndVectorize
     : StrEnumAttrCase<"CPUTileFuseAndVectorize">;
+def CPU_Sparse
+    : StrEnumAttrCase<"CPUSparse">;
 
 def LLVMGPU_SimpleDistribute
     : StrEnumAttrCase<"LLVMGPUDistribute">;
@@ -46,10 +48,10 @@ def DispatchLoweringPassPipelineEnum : StrEnumAttr<
     "DispatchLoweringPassPipeline",
     "identifier for pass pipeline use to lower dispatch region",
     [CPU_Default, CPU_SingleTilingExpert, CPU_TensorToVectors,
-     CPU_TileFuseAndVectorize, LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize,
-     LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore, SPIRV_Distribute,
-     SPIRV_DistributeCopy, SPIRV_Vectorize, SPIRV_VectorizeToCooperativeOps,
-     None]> {
+     CPU_TileFuseAndVectorize, CPU_Sparse, LLVMGPU_SimpleDistribute,
+     LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
+     SPIRV_Distribute, SPIRV_DistributeCopy, SPIRV_Vectorize,
+     SPIRV_VectorizeToCooperativeOps, None]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
 }
 

--- a/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -64,6 +64,8 @@ cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:ReconcileUnrealizedCasts",
         "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SparseTensor",
+        "@llvm-project//mlir:SparseTensorTransforms",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:StandardOpsTransforms",
         "@llvm-project//mlir:TensorDialect",

--- a/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -50,6 +50,8 @@ iree_cc_library(
     MLIRReconcileUnrealizedCasts
     MLIRSCF
     MLIRSCFToStandard
+    MLIRSparseTensor
+    MLIRSparseTensorTransforms
     MLIRStandard
     MLIRStandardOpsTransforms
     MLIRStandardToLLVM

--- a/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -751,6 +751,12 @@ void ConvertToLLVMPass::runOnOperation() {
   // Don't apply patterns to private function (e.g num_workgroups func).
   target.addDynamicallyLegalOp<FuncOp>([&](FuncOp funcOp) {
     if (isEntryPoint(funcOp)) return false;
+    for (Type type : funcOp.getType().getInputs()) {
+      if (type.isa<MemRefType>()) return false;
+    }
+    for (Type type : funcOp.getType().getResults()) {
+      if (type.isa<MemRefType>()) return false;
+    }
     return true;
   });
   target.addDynamicallyLegalDialect<StandardOpsDialect, mlir::math::MathDialect,

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -188,6 +188,9 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
               CPUTileFuseAndVectorize:
             addTileFuseAndVectorizePassPipeline(nestedModulePM, lowerToVectors);
             break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::CPUSparse:
+            addCPUSparsePassPipeline(nestedModulePM);
+            break;
           default:
             llvm_unreachable("Unsupported pipeline on CPU target.");
         }

--- a/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -16,6 +16,7 @@
 #include "mlir/Conversion/SCFToStandard/SCFToStandard.h"
 #include "mlir/Dialect/Arithmetic/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
+#include "mlir/Dialect/SparseTensor/Transforms/Passes.h"
 #include "mlir/Dialect/StandardOps/Transforms/Passes.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
@@ -226,6 +227,16 @@ void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
 
   passManager.addNestedPass<FuncOp>(createForOpCanonicalizationPass());
   passManager.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+}
+
+void addCPUSparsePassPipeline(OpPassManager &passManager) {
+  passManager.addPass(createCanonicalizerPass());
+  passManager.addPass(createSparsificationPass());
+  passManager.addPass(createSparseTensorConversionPass());
+
+  passManager.addPass(createSparsePreBufferize());
+  addLinalgBufferizePasses(passManager, cpuAllocationFunction);
+  passManager.addPass(createFuncBufferizePass());
 }
 
 void addCPUDefaultPassPipeline(OpPassManager &passManager) {

--- a/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -26,6 +26,7 @@ iree_lit_test_suite(
             "illegal_configuration.mlir",
             "materialize_launch_configuration.mlir",
             "synchronize_symbol_visibility.mlir",
+            "sparse_pipeline.mlir",
             "test_config_mmt4d.mlir",
             "tile_and_vectorize.mlir",
             "tile_fuse_and_vectorize.mlir",

--- a/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -20,6 +20,7 @@ iree_lit_test_suite(
     "hal_interface_workgroup_info.mlir"
     "illegal_configuration.mlir"
     "materialize_launch_configuration.mlir"
+    "sparse_pipeline.mlir"
     "synchronize_symbol_visibility.mlir"
     "test_config_mmt4d.mlir"
     "tile_and_vectorize.mlir"

--- a/iree/compiler/Codegen/LLVMCPU/test/sparse_pipeline.mlir
+++ b/iree/compiler/Codegen/LLVMCPU/test/sparse_pipeline.mlir
@@ -1,0 +1,52 @@
+// RUN: iree-opt -pass-pipeline='hal.executable(hal.executable.variant(iree-codegen-linalg-to-llvm-pipeline))' %s | IreeFileCheck %s
+
+#executable_layout = #hal.executable.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+
+hal.executable @sparse_dispatch {
+hal.executable.variant public @embedded_elf_x86_64, target = <"llvm", "embedded-elf-x86_64", {data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}> {
+  hal.executable.entry_point public @_large_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 1, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
+  ^bb0(%arg0: index, %arg1: index, %arg2: index):  // no predecessors
+    %c1 = arith.constant 1 : index
+    hal.return %c1, %c1, %c1 : index, index, index
+  }
+  builtin.module  {
+    func @_large_dispatch_0() {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.constant.load[0] values([0 : index]) : index
+      %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<readonly:8x8xf32>
+      %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%0) alignment(32) : !flow.dispatch.tensor<readonly:8xf32>
+      %3 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(32) : !flow.dispatch.tensor<writeonly:8xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [8, 8], strides = [1, 1] : !flow.dispatch.tensor<readonly:8x8xf32> -> tensor<8x8xf32>
+      %5 = flow.dispatch.tensor.load %2, offsets = [0], sizes = [8], strides = [1] : !flow.dispatch.tensor<readonly:8xf32> -> tensor<8xf32>
+      %6 = linalg.init_tensor [8] : tensor<8xf32>
+      %7 = sparse_tensor.convert %4 : tensor<8x8xf32> to tensor<8x8xf32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 0, indexBitWidth = 0 }>>
+      %8 = linalg.fill(%cst, %6) : f32, tensor<8xf32> -> tensor<8xf32>
+      %9 = linalg.generic {doc = "X(i) += A(i,j) * B(j)", indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%7, %5 : tensor<8x8xf32, #sparse_tensor.encoding<{ dimLevelType = [ "dense", "compressed" ], pointerBitWidth = 0, indexBitWidth = 0 }>>, tensor<8xf32>) outs(%8 : tensor<8xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):  // no predecessors
+        %10 = arith.mulf %arg0, %arg1 : f32
+        %11 = arith.addf %arg2, %10 : f32
+        linalg.yield %11 : f32
+      } -> tensor<8xf32>
+      flow.dispatch.tensor.store %9, %3, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !flow.dispatch.tensor<writeonly:8xf32>
+      return
+    }
+  }
+}
+}
+
+//     CHECK-LABEL: hal.executable public @sparse_dispatch
+//           CHECK:  %[[SB0:.+]] = llvm.call @newSparseTensor
+//           CHECK:  llvm.call @addEltF32(%[[SB0]]
+//           CHECK:  %[[SB1:.+]] = llvm.call @newSparseTensor({{.*}}, %[[SB0:.+]])
+//           CHECK:  %{{.*}} = llvm.call @sparsePointers(%[[SB1]], %{{.*}}) : (!llvm.ptr<i8>, i64) -> !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+//           CHECK:  %{{.*}} = llvm.call @sparseIndices(%[[SB1]], %{{.*}}) : (!llvm.ptr<i8>, i64) -> !llvm.struct<(ptr<i64>, ptr<i64>, i64, array<1 x i64>, array<1 x i64>)>
+//           CHECK:  %{{.*}} = llvm.call @sparseValuesF32(%[[SB1]]) : (!llvm.ptr<i8>) -> !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<1 x i64>, array<1 x i64>)>
+//           CHECK:     %{{.*}} = llvm.fmul %{{.*}}, %{{.*}} : f32
+//           CHECK:     %{{.*}} = llvm.fadd %{{.*}}, %{{.*}} : f32

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -107,6 +107,9 @@ std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeConvPass();
 /// Creates a pass to vectorize a very specific form of linalg.conv ops.
 std::unique_ptr<OperationPass<FuncOp>> createLinalgToVectorVectorizeMMT4dPass();
 
+/// Create a pass that pre convert some tensor to memref for sparse related ops.
+std::unique_ptr<OperationPass<ModuleOp>> createSparsePreBufferize();
+
 /// Pass to optimize vector transfer_read and transfer_write.
 std::unique_ptr<OperationPass<FuncOp>> createOptimizeVectorTransferPass();
 
@@ -213,6 +216,9 @@ void addSingleTilingExpertPassPipeline(OpPassManager &passManager);
 /// of linalg ops on tensors to vectors operations.
 void addTileFuseAndVectorizePassPipeline(OpPassManager &passManager,
                                          bool lowerToVectors = true);
+
+/// Populates the passes needed to lower ops handling sparse tensor type.
+void addCPUSparsePassPipeline(OpPassManager &passManager);
 
 //----------------------------------------------------------------------------//
 // LLVMCPU Pass Pipelines for lowering to LLVM dialect.

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -108,6 +108,13 @@ def LinalgToVectorVectorizeMMT4d :
   let constructor =
       "mlir::iree_compiler::createLinalgToVectorVectorizeMMT4dPass()";
 }
+
+def SparsePreBufferization :
+    Pass<"iree-codegen-pre-bufferize-sparse", "ModuleOp"> {
+  let summary = "Does pre-bufferization for some sparse ops";
+  let constructor =
+      "mlir::iree_compiler::createSparsePreBufferize()";
+}
 //------------------------------------------------------------------------------
 // LLVMCPU
 //------------------------------------------------------------------------------

--- a/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -87,6 +87,7 @@ cc_library(
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SparseTensor",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",

--- a/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_cc_library(
     MLIRMemRefTransforms
     MLIRPass
     MLIRSCF
+    MLIRSparseTensor
     MLIRStandard
     MLIRSupport
     MLIRTensor

--- a/iree/tools/BUILD
+++ b/iree/tools/BUILD
@@ -160,6 +160,7 @@ cc_library(
         "@llvm-project//mlir:SPIRVDialect",
         "@llvm-project//mlir:SPIRVTransforms",
         "@llvm-project//mlir:Shape",
+        "@llvm-project//mlir:SparseTensor",
         "@llvm-project//mlir:StandardOps",
         "@llvm-project//mlir:StandardToSPIRV",
         "@llvm-project//mlir:TensorInferTypeOpInterfaceImpl",

--- a/iree/tools/init_mlir_dialects.h
+++ b/iree/tools/init_mlir_dialects.h
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/SCF/SCF.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/Shape/IR/Shape.h"
+#include "mlir/Dialect/SparseTensor/IR/SparseTensor.h"
 #include "mlir/Dialect/StandardOps/IR/Ops.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
@@ -54,7 +55,8 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   vector::VectorDialect,
                   tensor::TensorDialect,
                   tosa::TosaDialect,
-                  shape::ShapeDialect>();
+                  shape::ShapeDialect,
+                  sparse_tensor::SparseTensorDialect>();
   // clang-format on
   tensor::registerInferTypeOpInterfaceExternalModels(registry);
 


### PR DESCRIPTION
This is the first step to support Sparse tensor ops in IREE. This does
bufferization in two steps since sparse bufferization is not yet
integrated in the general bufferization.

Since sparse codegen relies on library we need few workarounds and
cannot run out of the box as we don't support linking libraries on the
device side. Once sparse moves to full codegen we will be able to run
end to end ops.