### PR TITLE
Install external libraries and IREE runtime headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,13 +408,26 @@ if(IREE_ENABLE_THREADING)
   add_subdirectory(third_party/benchmark EXCLUDE_FROM_ALL)
   iree_set_cpuinfo_cmake_options()
   add_subdirectory(third_party/cpuinfo EXCLUDE_FROM_ALL)
+  # We don't want to install cpuinfo headers.
+  install(
+    TARGETS cpuinfo
+    COMPONENT IREERuntime
+    PUBLIC_HEADER OPTIONAL EXCLUDE_FROM_ALL
+  )
 endif()
 
 add_subdirectory(build_tools/third_party/flatcc EXCLUDE_FROM_ALL)
 
 add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
 
+# Install targets for external libraries that are EXCLUDE_FROM_ALL.
 # TODO(scotttodd): Iterate some more and find a better place for this.
+install(
+  TARGETS flatcc_parsing
+  COMPONENT IREERuntime
+  PUBLIC_HEADER OPTIONAL EXCLUDE_FROM_ALL
+)
+
 if (NOT CMAKE_CROSSCOMPILING)
   install(
     TARGETS iree-flatcc-cli

--- a/iree/compiler/BUILD
+++ b/iree/compiler/BUILD
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
@@ -15,3 +17,7 @@ package(
 #===------------------------------------------------------------------------===#
 # TODO(#3817): expose :compiler as the public C API.
 # TODO(#3817): expose :cc as the public C++ wrapper API.
+
+iree_cmake_extra_content(
+    content = "set(IREE_DISABLE_INSTALL_HEADERS ON)",
+)

--- a/iree/compiler/CMakeLists.txt
+++ b/iree/compiler/CMakeLists.txt
@@ -7,7 +7,7 @@
 #                                                                              #
 # To disable autogeneration for this file entirely, delete this header.        #
 ################################################################################
-
+set(IREE_DISABLE_INSTALL_HEADERS ON)
 iree_add_all_subdirs()
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/runtime/CMakeLists.txt
+++ b/iree/runtime/CMakeLists.txt
@@ -51,6 +51,9 @@ iree_cc_library(
 iree_cc_unified_library(
   NAME
     unified
+  INSTALL_COMPONENT
+    IREERuntime
   ROOT
     ::impl
 )
+

--- a/iree/samples/BUILD
+++ b/iree/samples/BUILD
@@ -4,8 +4,14 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
+)
+
+iree_cmake_extra_content(
+    content = "set(IREE_DISABLE_INSTALL_HEADERS ON)",
 )

--- a/iree/samples/CMakeLists.txt
+++ b/iree/samples/CMakeLists.txt
@@ -7,7 +7,7 @@
 #                                                                              #
 # To disable autogeneration for this file entirely, delete this header.        #
 ################################################################################
-
+set(IREE_DISABLE_INSTALL_HEADERS ON)
 iree_add_all_subdirs()
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/iree/testing/BUILD
+++ b/iree/testing/BUILD
@@ -6,10 +6,16 @@
 
 # Testing utilities for IREE.
 
+load("//iree:build_defs.oss.bzl", "iree_cmake_extra_content")
+
 package(
     default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
+)
+
+iree_cmake_extra_content(
+    content = "set(IREE_DISABLE_INSTALL_HEADERS ON)",
 )
 
 cc_library(

--- a/iree/tools/CMakeLists.txt
+++ b/iree/tools/CMakeLists.txt
@@ -12,6 +12,8 @@ if(NOT ${IREE_ENABLE_THREADING})
   return()
 endif()
 
+set(IREE_DISABLE_INSTALL_HEADERS ON)
+
 add_subdirectory(android)
 add_subdirectory(test)
 add_subdirectory(utils)


### PR DESCRIPTION
Our install directory is a bit of a mess and needs more triage. This PR just enables a minimal set of installations to plausibly build, including runtime headers and bundled external libraries (cpuinfo, libflatcc_parsing).

I haven't actually tried to build something but this at least makes it feasible that a mortal could in fact do so. Missing pieces are a config.h with compiler definitions and a package config file with necessary libraries to link against (but there are only three now so not too hard to figure out).

Progress on #7026