### PR TITLE
Bump existing Sandbox passes to @ c219306

### DIFF
--- a/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -93,6 +93,7 @@ struct LinalgFusePass : public LinalgFuseBase<LinalgFusePass> {
     this->pad = options.pad;
     this->packPaddings = options.packPaddings;
     this->hoistPaddings = options.hoistPaddings;
+    this->transposePaddings = options.transposePaddings;
     this->vectorize = options.vectorize;
     this->vectorizePadding = options.vectorizePadding;
     this->tilingLevel = options.tilingLevel;
@@ -113,6 +114,7 @@ struct LinalgSingleTilingExpertPass
     this->pad = options.pad;
     this->packPaddings = options.packPaddings;
     this->hoistPaddings = options.hoistPaddings;
+    this->transposePaddings = options.transposePaddings;
     this->packPaddings = options.packPaddings;
     this->scalarizeDynamicDims = options.scalarizeDynamicDims;
     this->generalize = options.generalize;
@@ -176,10 +178,8 @@ void LinalgFusePass::runOnOperation() {
     doTiling = true;
     tilingOptions.tileSizes = {tileSizes.begin(), tileSizes.end()};
   }
-  if (!tileInterchange.empty()) {
-    tilingOptions.tileInterchange = {tileInterchange.begin(),
-                                     tileInterchange.end()};
-  }
+  tilingOptions.tileInterchange = {tileInterchange.begin(),
+                                   tileInterchange.end()};
 
   // Set up padding options.
   // TODO: Replace the lambdas by either functions defined in MLIR core or even
@@ -195,10 +195,22 @@ void LinalgFusePass::runOnOperation() {
                ? hoistPaddings[opOperand.getOperandNumber()]
                : 0;
   };
+  auto transposeFunc = [&](OpOperand &opOperand) {
+    SmallVector<int64_t> transposeVector = {};
+    if (opOperand.getOperandNumber() >= transposePaddings.size())
+      return transposeVector;
+    SmallVector<StringRef> elems;
+    StringRef(transposePaddings[opOperand.getOperandNumber()])
+        .split(elems, ':');
+    for (StringRef elem : elems)
+      transposeVector.push_back(std::stoi(elem.str()));
+    return transposeVector;
+  };
   LinalgPaddingOptions paddingOptions;
   paddingOptions.setPaddingValueComputationFunction(getNeutralOfLinalgOp);
   paddingOptions.setPaddingNoFoldComputationFunction(packFunc);
   paddingOptions.setPaddingHoistComputationFunction(hoistingFunc);
+  paddingOptions.setPaddingTransposeComputationFunction(transposeFunc);
 
   CodegenStrategy strategy;
   strategy.tileAndFuseIf(doTiling, anchorOpName, tilingOptions)
@@ -209,7 +221,9 @@ void LinalgFusePass::runOnOperation() {
   OpPassManager dynamicPM(FuncOp::getOperationName());
   strategy.configurePassPipeline(dynamicPM, funcOp.getContext());
 
-  if (failed(runPipeline(dynamicPM, funcOp))) return signalPassFailure();
+  if (failed(runPipeline(dynamicPM, funcOp))) {
+    return signalPassFailure();
+  }
 }
 
 void LinalgSingleTilingExpertPass::runOnOperation() {
@@ -246,17 +260,29 @@ void LinalgSingleTilingExpertPass::runOnOperation() {
                ? hoistPaddings[opOperand.getOperandNumber()]
                : 0;
   };
+  auto transposeFunc = [&](OpOperand &opOperand) {
+    SmallVector<int64_t> transposeVector = {};
+    if (opOperand.getOperandNumber() >= transposePaddings.size())
+      return transposeVector;
+    SmallVector<StringRef> elems;
+    StringRef(transposePaddings[opOperand.getOperandNumber()])
+        .split(elems, ':');
+    for (StringRef elem : elems)
+      transposeVector.push_back(std::stoi(elem.str()));
+    return transposeVector;
+  };
   LinalgPaddingOptions paddingOptions;
   paddingOptions.setPaddingValueComputationFunction(getNeutralOfLinalgOp);
   paddingOptions.setPaddingNoFoldComputationFunction(packFunc);
   paddingOptions.setPaddingHoistComputationFunction(hoistingFunc);
+  paddingOptions.setPaddingTransposeComputationFunction(transposeFunc);
 
   CodegenStrategy strategy;
   StringRef genericOpName = GenericOp::getOperationName();
   strategy.tileIf(doTiling, anchorOpName, tilingOptions)
       .padIf(pad, anchorOpName, paddingOptions)
+      .decomposeIf(decomposeToLowerDimOp)
       .generalizeIf(generalize, anchorOpName)
-      // TODO: decomposeToLowerDimIf when the need arises.
       .interchangeIf(!iteratorInterchange.empty(), iteratorInterchange)
       .vectorizeIf(vectorize, generalize ? genericOpName : anchorOpName,
                    nullptr, vectorizePadding);
@@ -264,12 +290,9 @@ void LinalgSingleTilingExpertPass::runOnOperation() {
   // Created a nested OpPassManager and run.
   OpPassManager dynamicPM(FuncOp::getOperationName());
   strategy.configurePassPipeline(dynamicPM, funcOp.getContext());
-
-  if (decomposeToLowerDimOp) {
-    dynamicPM.addPass(createLinalgStrategyDecomposePass());
+  if (failed(runPipeline(dynamicPM, funcOp))) {
+    return signalPassFailure();
   }
-
-  if (failed(runPipeline(dynamicPM, funcOp))) return signalPassFailure();
 }
 
 void LinalgVectorLoweringPass::runOnOperation() {
@@ -349,7 +372,9 @@ void LinalgVectorLoweringPass::runOnOperation() {
   OpPassManager dynamicPM(FuncOp::getOperationName());
   FuncOp funcOp = getOperation();
   strategy.configurePassPipeline(dynamicPM, funcOp.getContext());
-  if (failed(runPipeline(dynamicPM, funcOp))) return signalPassFailure();
+  if (failed(runPipeline(dynamicPM, funcOp))) {
+    return signalPassFailure();
+  }
 }
 
 std::unique_ptr<OperationPass<FuncOp>> mlir::createLinalgFusePass() {

--- a/iree/compiler/Codegen/Sandbox/Passes.h
+++ b/iree/compiler/Codegen/Sandbox/Passes.h
@@ -20,6 +20,7 @@ struct LinalgFusePassOptions {
   bool pad = false;
   SmallVector<int64_t> packPaddings = {};
   SmallVector<int64_t> hoistPaddings = {};
+  SmallVector<std::string> transposePaddings = {};
   bool vectorize = false;
   bool vectorizePadding = false;
   int64_t tilingLevel = -1;
@@ -40,6 +41,7 @@ struct LinalgSingleTilingExpertPassOptions {
   bool pad = false;
   SmallVector<int64_t> packPaddings = {};
   SmallVector<int64_t> hoistPaddings = {};
+  SmallVector<std::string> transposePaddings = {};
   bool scalarizeDynamicDims = false;
   bool generalize = false;
   SmallVector<int64_t> iteratorInterchange = {};

--- a/iree/compiler/Codegen/Sandbox/Passes.td
+++ b/iree/compiler/Codegen/Sandbox/Passes.td
@@ -32,13 +32,15 @@ def LinalgFuse : Pass<"linalg-fuse", "FuncOp"> {
     ListOption<"hoistPaddings", "hoist-paddings", "int64_t",
                "Hoist padding depths.",
                "llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated">,
-
+    ListOption<"transposePaddings", "transpose-paddings", "std::string",
+               "Transpose paddings.",
+               "llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated">,
     // Vectorization options.
     Option<"vectorize", "vectorize", "bool", /*default=*/"false",
       "Rewrite the linalg op as a vector operation.">,
     Option<"vectorizePadding", "vectorize-padding", "bool", /*default=*/"false",
-      "Rewrite all linalg.pad_tensor ops in the function to vector form.">,
-  
+      "Rewrite all tensor.pad ops in the function to vector form.">,
+
     // IREE specific options
     Option<"tilingLevel", "tiling-level", "int64_t", /*default=*/"-1",
       "Use default tiling level used to retrieve the configuration from lowering.config">
@@ -77,6 +79,9 @@ def LinalgSingleTilingExpert
                "llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated">,
     ListOption<"hoistPaddings", "hoist-paddings", "int64_t",
                "Hoist padding depths.",
+               "llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated">,
+    ListOption<"transposePaddings", "transpose-paddings", "std::string",
+               "Transpose paddings.",
                "llvm::cl::ZeroOrMore, llvm::cl::MiscFlags::CommaSeparated">,
     Option<"scalarizeDynamicDims", "scalarize-dynamic-dims", "bool",
       /*default=*/"false", "Tile dynamic dimensions by 1.">,


### PR DESCRIPTION

- Add transposePaddings options to passes.
- Use CodegenStrategy to decompose convolutions. [https://github.com/google/iree-llvm-sandbox/pull/69]