### PR TITLE
Add support for collecting statistics in the benchmark pipeline

### DIFF
--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -298,6 +298,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "vulkan"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # GPU, Vulkan, Mali, full-inference

--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -167,6 +167,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "dylib-sync"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # CPU, Dylib, 1 through 4 threads, big/little-core, full-inference.
@@ -194,6 +196,8 @@ iree_benchmark_suite(
     "dylib"
   RUNTIME_FLAGS
     "--task_topology_group_count=1"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # TODO(#7792): Re-enable these when we are able to run different benchmarks
@@ -222,6 +226,8 @@ iree_benchmark_suite(
 #     "dylib"
 #   RUNTIME_FLAGS
 #     "--task_topology_group_count=2"
+#
+#  COLLECT_COMPILATION_STATISTICS
 # )
 
 # iree_benchmark_suite(
@@ -248,6 +254,8 @@ iree_benchmark_suite(
 #     "dylib"
 #   RUNTIME_FLAGS
 #     "--task_topology_group_count=3"
+#
+#  COLLECT_COMPILATION_STATISTICS
 # )
 
 iree_benchmark_suite(
@@ -274,6 +282,8 @@ iree_benchmark_suite(
     "dylib"
   RUNTIME_FLAGS
     "--task_topology_group_count=4"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # GPU, Vulkan, Adreno, full-inference
@@ -324,6 +334,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "vulkan"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # GPU, Vulkan, Mali, full-inference
@@ -346,6 +358,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "vulkan"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 ################################################################################
@@ -388,6 +402,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "dylib-sync"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # TODO(#7792): Consider re-enabling little-core experimental-flags if we start
@@ -419,6 +435,8 @@ iree_benchmark_suite(
     "dylib"
   RUNTIME_FLAGS
     "--task_topology_group_count=1"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # TODO(#7792): Re-enable these when we are able to run different benchmarks
@@ -448,6 +466,8 @@ iree_benchmark_suite(
 #     "dylib"
 #   RUNTIME_FLAGS
 #     "--task_topology_group_count=2"
+#
+#  COLLECT_COMPILATION_STATISTICS
 # )
 
 # iree_benchmark_suite(
@@ -475,6 +495,8 @@ iree_benchmark_suite(
 #     "dylib"
 #   RUNTIME_FLAGS
 #     "--task_topology_group_count=3"
+#
+#  COLLECT_COMPILATION_STATISTICS
 # )
 
 iree_benchmark_suite(
@@ -502,6 +524,8 @@ iree_benchmark_suite(
     "dylib"
   RUNTIME_FLAGS
     "--task_topology_group_count=4"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 
@@ -529,6 +553,8 @@ iree_benchmark_suite(
     "vmvx"
   RUNTIME_FLAGS
     "--task_topology_group_count=4"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 
@@ -554,6 +580,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "vulkan"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # GPU, Vulkan, Mali, full-inference
@@ -578,6 +606,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "vulkan"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 iree_benchmark_suite(
@@ -598,6 +628,8 @@ iree_benchmark_suite(
     iree-benchmark-module
   DRIVER
     "vulkan"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # kernel-execution
@@ -637,6 +669,8 @@ iree_benchmark_suite(
     "vulkan"
   RUNTIME_FLAGS
     "--batch_size=16"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 # GPU, Vulkan, Mali, kernel-execution
@@ -664,6 +698,8 @@ iree_benchmark_suite(
     "vulkan"
   RUNTIME_FLAGS
     "--batch_size=32"
+
+  COLLECT_COMPILATION_STATISTICS
 )
 
 iree_benchmark_suite(
@@ -687,4 +723,6 @@ iree_benchmark_suite(
     "vulkan"
   RUNTIME_FLAGS
     "--batch_size=32"
+
+  COLLECT_COMPILATION_STATISTICS
 )

--- a/build_tools/benchmarks/collect_compilation_statistics_from_host.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_from_host.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Collects compilation statistics from the host machine."""
+
+import argparse
+import os
+import json
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, List, Sequence
+
+from common.benchmark_definition import (BenchmarkOrStatisticInfo,
+                                         StatisticInstance, StatisticResults,
+                                         execute_cmd_and_get_output)
+from common.benchmark_suite import (BENCHMARK_SUITE_REL_PATH,
+                                    compose_info_object,
+                                    filter_benchmarks_for_category)
+
+
+class StatisticTrait(Enum):
+  # This statistic won't change with different IREE drivers
+  DRIVER_AGONISTIC = 0
+
+
+# A class representing a statistic.
+@dataclass
+class Stat:
+  # Hierarchical description of the current statistic.
+  breadcrumb: Sequence[str]
+  # Traits of the current statistic.
+  trait: StatisticTrait
+
+
+# A list controlling which statistics to collect and publish.
+# This also serves as another level of control in case name changes. If so
+# we can turn this into a map to make sure they still match the old ones.
+KNOWN_STATISTICS = [
+    Stat(("stream-aggregate", "synchronization", "await-count"),
+         StatisticTrait.DRIVER_AGONISTIC),
+    Stat(("stream-aggregate", "execution", "transient-memory-size"),
+         StatisticTrait.DRIVER_AGONISTIC),
+    Stat(("stream-aggregate", "execution", "dispatch-count"),
+         StatisticTrait.DRIVER_AGONISTIC),
+    Stat(("stream-aggregate", "executable", "executable-count"),
+         StatisticTrait.DRIVER_AGONISTIC),
+]
+
+
+def get_git_commit_hash(commit: str) -> str:
+  return execute_cmd_and_get_output(['git', 'rev-parse', commit],
+                                    cwd=os.path.dirname(
+                                        os.path.realpath(__file__)))
+
+
+def recursively_get_from_dict(json_object: Dict[str, Any],
+                              keys: Sequence[str]) -> Any:
+  """Gets the value from the given dict in a recursive way using keys."""
+  if len(keys) == 1:
+    return json_object.get(keys[0])
+  if keys[0] not in json_object:
+    return None
+  return recursively_get_from_dict(json_object.get(keys[0]), keys[1:])
+
+
+def collect_compilation_statistics(root_build_dir: str,
+                                   verbose: bool = False
+                                  ) -> List[StatisticInstance]:
+  """Collects compilation statistics from the benchmark suite.
+
+  Args:
+    root_build_dir: the root build directory containing the built benchmark
+      suites.
+    verbose: whether to print additional debug information.
+
+  Returns:
+    A list of statistic dictionaries.
+  """
+  root_benchmark_dir = os.path.join(root_build_dir, BENCHMARK_SUITE_REL_PATH)
+
+  statistics = []
+
+  for directory in sorted(os.listdir(root_benchmark_dir)):
+    benchmark_category_dir = os.path.join(root_benchmark_dir, directory)
+    matched_benchmarks = filter_benchmarks_for_category(
+        benchmark_category_dir=benchmark_category_dir,
+        cpu_target_arch_filter=".*",
+        gpu_target_arch_filter=".*",
+        driver_filter=None,
+        verbose=verbose)
+
+    for benchmark_case_dir in matched_benchmarks:
+      stats_file = os.path.join(benchmark_case_dir,
+                                "compilation_statistics.json")
+      if not os.path.isfile(stats_file):
+        continue
+      with open(stats_file) as f:
+        json_object = json.loads(f.read())
+
+      for statistic in KNOWN_STATISTICS:
+        value = recursively_get_from_dict(json_object, statistic.breadcrumb)
+        if value is None:
+          continue
+        info = compose_info_object(
+            benchmark_category_dir=benchmark_category_dir,
+            benchmark_case_dir=benchmark_case_dir,
+            device_info=None,
+            statistic=statistic.breadcrumb,
+            ignore_driver=(statistic.trait == StatisticTrait.DRIVER_AGONISTIC))
+        statistics.append(StatisticInstance(info, value))
+
+  return statistics
+
+
+def parse_arguments():
+  """Parses command-line options."""
+
+  def check_dir_path(path):
+    if os.path.isdir(path):
+      return path
+    else:
+      raise argparse.ArgumentTypeError(path)
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      "build_dir",
+      metavar="<build-dir>",
+      type=check_dir_path,
+      help="Path to the build directory containing benchmark suites")
+  parser.add_argument("--output",
+                      "-o",
+                      default=None,
+                      help="Path to the output file")
+  parser.add_argument("--verbose",
+                      action="store_true",
+                      help="Print internal information during execution")
+
+  args = parser.parse_args()
+
+  return args
+
+
+def main(args):
+
+  results = StatisticResults()
+  commit = get_git_commit_hash("HEAD")
+  results.set_commit(commit)
+
+  stats = collect_compilation_statistics(root_build_dir=args.build_dir,
+                                         verbose=args.verbose)
+  for stat in stats:
+    results.statistics.append(stat)
+
+  if args.output is not None:
+    with open(args.output, "w") as f:
+      f.write(results.to_json_str())
+
+  if args.verbose:
+    print(results.commit)
+    print(results.statistics)
+
+
+if __name__ == "__main__":
+  main(parse_arguments())

--- a/build_tools/benchmarks/collect_compilation_statistics_from_host.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_from_host.py
@@ -12,7 +12,7 @@ import json
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Optional, Sequence
 
 from common.benchmark_definition import (BenchmarkOrStatisticInfo,
                                          StatisticInstance, StatisticResults,
@@ -33,21 +33,17 @@ class Stat:
   # Hierarchical description of the current statistic.
   breadcrumb: Sequence[str]
   # Traits of the current statistic.
-  trait: StatisticTrait
+  trait: Optional[StatisticTrait] = None
 
 
 # A list controlling which statistics to collect and publish.
 # This also serves as another level of control in case name changes. If so
 # we can turn this into a map to make sure they still match the old ones.
 KNOWN_STATISTICS = [
-    Stat(("stream-aggregate", "synchronization", "await-count"),
-         StatisticTrait.DRIVER_AGONISTIC),
-    Stat(("stream-aggregate", "execution", "transient-memory-size"),
-         StatisticTrait.DRIVER_AGONISTIC),
-    Stat(("stream-aggregate", "execution", "dispatch-count"),
-         StatisticTrait.DRIVER_AGONISTIC),
-    Stat(("stream-aggregate", "executable", "executable-count"),
-         StatisticTrait.DRIVER_AGONISTIC),
+    Stat(("stream-aggregate", "synchronization", "await-count")),
+    Stat(("stream-aggregate", "execution", "transient-memory-size")),
+    Stat(("stream-aggregate", "execution", "dispatch-count")),
+    Stat(("stream-aggregate", "executable", "executable-count")),
 ]
 
 

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -74,8 +74,9 @@ def aggregate_all_benchmarks_and_statistics(
 
         # Make sure each statistic has a unique name.
         name = str(statistic_case.statistic_info)
-        if name in statistic_results:
-          raise ValueError(f"Duplicated statistics: {name}")
+        if (name in statistic_results) and (
+            statistic_results[name] != StatisticData(statistic_case.value)):
+          raise ValueError(f"Inconsistent statistic values for '{name}'")
 
         statistic_results[name] = StatisticData(statistic_case.value)
     else:

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -4,21 +4,22 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import json
 import urllib.parse
 import markdown_strings as md
 
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Sequence, Tuple
 
-from .benchmark_definition import BenchmarkResults
+from .benchmark_definition import BenchmarkResults, StatisticResults
 from .benchmark_thresholds import BENCHMARK_THRESHOLDS, ThresholdUnit
 
 PERFBOARD_SERIES_PREFIX = "https://perf.iree.dev/serie?IREE?"
 
 
 @dataclass
-class AggregateBenchmarkLatency:
-  """An object for describing aggregate latency numbers for a benchmark."""
+class BenchmarkData:
+  """An object for describing latency numbers for a benchmark."""
   mean_time: int
   median_time: int
   stddev_time: int
@@ -26,49 +27,75 @@ class AggregateBenchmarkLatency:
   base_mean_time: Optional[int] = None
 
 
-def aggregate_all_benchmarks(
-    benchmark_files: Sequence[str],
+@dataclass
+class StatisticData:
+  """An object for describing values for a statistic."""
+  value: int
+  # The base value to compare against.
+  base_value: Optional[int] = None
+
+
+def aggregate_all_benchmarks_and_statistics(
+    result_files: Sequence[str],
     expected_pr_commit: Optional[str] = None,
-    verbose: bool = False) -> Dict[str, AggregateBenchmarkLatency]:
-  """Aggregates all benchmarks in the given files.
+    verbose: bool = False
+) -> Tuple[Dict[str, BenchmarkData], Dict[str, StatisticData]]:
+  """Aggregates all benchmarks and statistics in the given files.
 
   Args:
-  - benchmark_files: A list of JSON files, each can be decoded as a
-    BenchmarkResults.
+  - result_files: A list of JSON files, each can be decoded as a
+    BenchmarkResults or StatisticResults.
   - expected_pr_commit: An optional Git commit SHA to match against.
 
   Returns:
-  - A dict of benchmark names to AggregateBenchmarkLatency numbers.
+  - A tuple containing two dicts from names to BenchmarkData/StatisticData numbers.
   """
 
-  aggregate_results = {}
+  benchmark_results = {}
+  statistic_results = {}
 
-  for benchmark_file in benchmark_files:
+  for benchmark_file in result_files:
     with open(benchmark_file) as f:
       content = f.read()
-    file_results = BenchmarkResults.from_json_str(content)
+    is_statistics = "statistics" in json.loads(content)
+
+    if is_statistics:
+      file_results = StatisticResults.from_json_str(content)
+    else:
+      file_results = BenchmarkResults.from_json_str(content)
 
     if (expected_pr_commit is not None) and \
             (file_results.commit != expected_pr_commit):
       raise ValueError("Inconsistent pull request commit")
 
-    for benchmark_index in range(len(file_results.benchmarks)):
-      benchmark_case = file_results.benchmarks[benchmark_index]
+    if is_statistics:
+      for statistic_index in range(len(file_results.statistics)):
+        statistic_case = file_results.statistics[statistic_index]
 
-      # Make sure each benchmark has a unique name.
-      name = str(benchmark_case.benchmark_info)
-      if name in aggregate_results:
-        raise ValueError(f"Duplicated benchmarks: {name}")
+        # Make sure each statistic has a unique name.
+        name = str(statistic_case.statistic_info)
+        if name in statistic_results:
+          raise ValueError(f"Duplicated statistics: {name}")
 
-      # Now scan all benchmark iterations and find the aggregate results.
-      mean_time = file_results.get_aggregate_time(benchmark_index, "mean")
-      median_time = file_results.get_aggregate_time(benchmark_index, "median")
-      stddev_time = file_results.get_aggregate_time(benchmark_index, "stddev")
+        statistic_results[name] = StatisticData(statistic_case.value)
+    else:
+      for benchmark_index in range(len(file_results.benchmarks)):
+        benchmark_case = file_results.benchmarks[benchmark_index]
 
-      aggregate_results[name] = AggregateBenchmarkLatency(
-          mean_time, median_time, stddev_time)
+        # Make sure each benchmark has a unique name.
+        name = str(benchmark_case.benchmark_info)
+        if name in benchmark_results:
+          raise ValueError(f"Duplicated benchmarks: {name}")
 
-  return aggregate_results
+        # Now scan all benchmark iterations and find the aggregate results.
+        mean_time = file_results.get_aggregate_time(benchmark_index, "mean")
+        median_time = file_results.get_aggregate_time(benchmark_index, "median")
+        stddev_time = file_results.get_aggregate_time(benchmark_index, "stddev")
+
+        benchmark_results[name] = BenchmarkData(mean_time, median_time,
+                                                stddev_time)
+
+  return (benchmark_results, statistic_results)
 
 
 def _make_benchmark_clickable(name: str) -> str:
@@ -77,11 +104,12 @@ def _make_benchmark_clickable(name: str) -> str:
   return md.link(name, url)
 
 
-def _add_header_and_get_markdown_table(names: Tuple[str],
-                                       means: Tuple[Any],
-                                       medians: Tuple[int],
-                                       stddevs: Tuple[int],
-                                       size_cut: Optional[int] = None) -> str:
+def _add_header_and_get_markdown_table_for_benchmarks(
+    names: Tuple[str],
+    means: Tuple[Any],
+    medians: Tuple[int],
+    stddevs: Tuple[int],
+    size_cut: Optional[int] = None) -> str:
   """Generates a markdown table with proper headers for benchmarks.
 
   Args:
@@ -108,8 +136,7 @@ def _add_header_and_get_markdown_table(names: Tuple[str],
   return table_str
 
 
-def _sort_benchmarks_and_get_table(benchmarks: Dict[str,
-                                                    AggregateBenchmarkLatency],
+def _sort_benchmarks_and_get_table(benchmarks: Dict[str, BenchmarkData],
                                    size_cut: Optional[int] = None):
   """Sorts all benchmarks according to the improvement/regression ratio and
   returns a markdown table for it.
@@ -135,12 +162,11 @@ def _sort_benchmarks_and_get_table(benchmarks: Dict[str,
     str_means.append(f"{pr} (vs. {base}, {ratio:.2%}{direction})")
   str_means = tuple(str_means)
 
-  return _add_header_and_get_markdown_table(names, str_means, medians, stddevs,
-                                            size_cut)
+  return _add_header_and_get_markdown_table_for_benchmarks(
+      names, str_means, medians, stddevs, size_cut)
 
 
-def categorize_benchmarks_into_tables(benchmarks: Dict[
-    str, AggregateBenchmarkLatency],
+def categorize_benchmarks_into_tables(benchmarks: Dict[str, BenchmarkData],
                                       size_cut: Optional[int] = None) -> str:
   """Splits benchmarks into regressed/improved/similar/raw categories and
   returns their markdown tables.
@@ -197,9 +223,124 @@ def categorize_benchmarks_into_tables(benchmarks: Dict[
     ]
     names, means, medians, stddevs = zip(*raw_list)
     tables.append(
-        _add_header_and_get_markdown_table(names=names,
-                                           means=means,
-                                           medians=medians,
-                                           stddevs=stddevs,
-                                           size_cut=size_cut))
+        _add_header_and_get_markdown_table_for_benchmarks(names=names,
+                                                          means=means,
+                                                          medians=medians,
+                                                          stddevs=stddevs,
+                                                          size_cut=size_cut))
+  return "\n\n".join(tables)
+
+
+def _add_header_and_get_markdown_table_for_statistics(
+    names: Tuple[str],
+    values: Tuple[Any],
+    size_cut: Optional[int] = None) -> str:
+  """Generates a markdown table with proper headers for statistics.
+
+  Args:
+  - size_cut: If not None, only show the top N results for each table.
+  """
+  total_size = len(names)
+  if size_cut is not None:
+    names = names[0:size_cut]
+    values = values[0:size_cut]
+
+  names = tuple([_make_benchmark_clickable(name) for name in names])
+  names = ("Statistic Name",) + names
+  values = ("Value",) + values
+
+  table_str = md.table([names, values])
+  if size_cut is not None and size_cut < total_size:
+    table_str += "\n\n"
+    table_str += md.italics(
+        f"[Top {size_cut} out of {total_size} statistic results showed]")
+  return table_str
+
+
+def _sort_statistics_and_get_table(statistics: Dict[str, StatisticData],
+                                   size_cut: Optional[int] = None):
+  """Sorts all statistics according to the improvement/regression ratio and
+  returns a markdown table for it.
+
+  Args:
+  - size_cut: If not None, only show the top N results for each table.
+  """
+  sorted_statistics = []
+  for k, v in statistics.items():
+    ratio = abs(v.value - v.base_value) / v.base_value
+    sorted_statistics.append((k, (v.value, v.base_value, ratio)))
+  # Sort according to ratio in the reverse order.
+  sorted_statistics.sort(key=lambda statistic: statistic[1][2], reverse=True)
+
+  # Split each field into its own tuple in prepration for markdown table.
+  names, values = zip(*sorted_statistics)
+
+  # Turn the tuple about values into a string representation.
+  str_values = []
+  for pr, base, ratio in values:
+    direction = "↑" if pr > base else ("↓" if pr < base else "")
+    str_values.append(f"{pr} (vs. {base}, {ratio:.2%}{direction})")
+  str_values = tuple(str_values)
+
+  return _add_header_and_get_markdown_table_for_statistics(names, str_values)
+
+
+def categorize_statistics_into_tables(statistics: Dict[str, StatisticData],
+                                      size_cut: Optional[int] = None) -> str:
+  """Splits statistics into regressed/improved/similar/raw categories and
+  returns their markdown tables.
+
+    Args:
+    - statistics: A dictionary of statistic names to its aggregate info.
+    - size_cut: If not None, only show the top N results for each table.
+    """
+  regressed, improved, similar, raw = {}, {}, {}, {}
+
+  for name, results in statistics.items():
+    # If no informatio about the base result. Then we cannot analyze.
+    if results.base_value is None:
+      raw[name] = results
+      continue
+
+    similar_threshold = None
+    for threshold in BENCHMARK_THRESHOLDS:
+      if threshold.regex.match(name):
+        similar_threshold = threshold
+        break
+    if similar_threshold is None:
+      raise ValueError(f"no matched threshold setting for statistic: {name}")
+
+    current = results.value
+    base = results.base_value
+    if similar_threshold.unit == ThresholdUnit.PERCENTAGE:
+      ratio = abs(current - base) / base * 100
+    else:
+      ratio = abs(current - base)
+
+    if ratio <= similar_threshold.threshold:
+      similar[name] = results
+    elif current > base:
+      regressed[name] = results
+    else:
+      improved[name] = results
+
+  tables = []
+  if regressed:
+    tables.append(md.header("Regressed Statistics 🚩", 3))
+    tables.append(_sort_statistics_and_get_table(regressed, size_cut))
+  if improved:
+    tables.append(md.header("Improved Statistics 🎉", 3))
+    tables.append(_sort_statistics_and_get_table(improved, size_cut))
+  # If we want to abbreviate, similar results won't be interesting.
+  if similar and size_cut is None:
+    tables.append(md.header("Similar Statistics", 3))
+    tables.append(_sort_statistics_and_get_table(similar, size_cut))
+  if raw:
+    tables.append(md.header("Raw Statistics", 3))
+    raw_list = [(k, v.value) for k, v in raw.items()]
+    names, values = zip(*raw_list)
+    tables.append(
+        _add_header_and_get_markdown_table_for_statistics(names=names,
+                                                          values=values,
+                                                          size_cut=size_cut))
   return "\n\n".join(tables)

--- a/build_tools/benchmarks/diff_local_benchmarks.py
+++ b/build_tools/benchmarks/diff_local_benchmarks.py
@@ -23,8 +23,11 @@ def get_benchmark_result_markdown(base_benchmark_file: str,
                                   target_benchmark_file: str,
                                   verbose: bool = False) -> str:
   """Gets the full markdown summary of all benchmarks in files."""
-  base_benchmarks = aggregate_all_benchmarks([base_benchmark_file])
-  target_benchmarks = aggregate_all_benchmarks([target_benchmark_file])
+  # TODO: support diffing statistics
+  base_benchmarks = aggregate_all_benchmarks_and_statistics(
+      [base_benchmark_file])[0]
+  target_benchmarks = aggregate_all_benchmarks_and_statistics(
+      [target_benchmark_file])[0]
 
   # Update the target benchmarks with their corresponding base numbers.
   for bench in base_benchmarks:

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -43,7 +43,7 @@ import sys
 from typing import Any, Dict, List, Optional, Sequence, Tuple, TextIO, Set
 
 from common.benchmark_definition import (
-    AndroidDeviceInfo, BenchmarkInfo, BenchmarkResults, BenchmarkRun,
+    AndroidDeviceInfo, BenchmarkOrStatisticInfo, BenchmarkResults, BenchmarkRun,
     execute_cmd, execute_cmd_and_get_output, get_android_device_model,
     get_android_gpu_name, IREE_PRETTY_NAMES_TO_DRIVERS)
 from common.benchmark_suite import (BENCHMARK_SUITE_REL_PATH,
@@ -274,8 +274,8 @@ def run_benchmarks_for_category(
     with open(os.path.join(benchmark_case_dir, MODEL_TOOLFILE_NAME)) as f:
       tool = f.read().strip()
 
-    benchmark_info = compose_info_object(device_info, benchmark_category_dir,
-                                         benchmark_case_dir)
+    benchmark_info = compose_info_object(benchmark_category_dir,
+                                         benchmark_case_dir, device_info)
     benchmark_key = str(benchmark_info)
     # If we're not running the benchmark or the capture, just skip ahead.
     # No need to push files.
@@ -679,7 +679,7 @@ def main(args):
   for b in benchmarks:
     with open(b) as f:
       result_json_object = json.loads(f.read())
-    benchmark_info = BenchmarkInfo.from_device_info_and_name(
+    benchmark_info = BenchmarkOrStatisticInfo.from_device_info_and_name(
         device_info,
         os.path.splitext(os.path.basename(b))[0])
     benchmark_run = BenchmarkRun(benchmark_info, result_json_object["context"],

--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -10,6 +10,7 @@ steps:
   - label: "Build"
     commands:
       - "docker run --user=$(id -u):$(id -g) --volume=\\${HOME?}:\\${HOME?} --volume=/etc/passwd:/etc/passwd:ro --volume=/etc/group:/etc/group:ro --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/frontends@sha256:3eab65512589e7dabeced8aeb2c392e82f5bf1caafad7639e1b679be908ceb33 build_tools/cmake/build_android_benchmark.sh"
+      - "python3 build_tools/benchmarks/collect_compilation_statistics_from_host.py -o compilation-statistics-${BUILDKITE_BUILD_NUMBER}.json --verbose build-host/"
       - "tar --exclude='*.tar.gz' --exclude='*.tgz' --exclude='*.mlir' --exclude='*.tflite' -czvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz build-host/benchmark_suites"
       - "tar -czvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz build-android/iree/tools/iree-benchmark-module build-android-trace/iree/tools/iree-benchmark-module"
     if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
@@ -20,6 +21,7 @@ steps:
     artifact_paths:
       - "benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "compilation-statistics-${BUILDKITE_BUILD_NUMBER}.json"
 
   - wait
 
@@ -88,8 +90,9 @@ steps:
   - label: "Comment benchmark results on pull request"
     commands:
       - "git clean -fdx"
+      - "buildkite-agent artifact download --step Build compilation-statistics-*.json ./"
       - "buildkite-agent artifact download benchmark-results-*.json ./"
-      - "python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py --verbose --query-base benchmark-results-*.json"
+      - "python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py --verbose --query-base compilation-statistics-*.json benchmark-results-*.json"
     key: "post-on-pr"
     if: "build.pull_request.id != null && (build.pull_request.labels includes 'buildkite:benchmark')"
     agents:
@@ -98,8 +101,9 @@ steps:
   - label: "Push benchmark results to dashboard"
     commands:
       - "git clean -fdx"
+      - "buildkite-agent artifact download --step Build compilation-statistics-*.json ./"
       - "buildkite-agent artifact download benchmark-results-*.json ./"
-      - "python3 build_tools/benchmarks/upload_benchmarks_to_dashboard.py --verbose benchmark-results-*.json"
+      - "python3 build_tools/benchmarks/upload_benchmarks_to_dashboard.py --verbose compilation-statistics-*.json benchmark-results-*.json"
     key: "upload-to-dashboard"
     branches: "main"
     agents:


### PR DESCRIPTION
This commit wires up compilation statistics support in the benchmark
pipeline. We emit additional files during compilation to record compilation
statistics and then pick those files up for displaying either on pull request
or dashboard. 

Progress towards #6161 & #7972
