### PR TITLE
Remove mhlo Gather to TorchIndexSelect conversion

### DIFF
--- a/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -858,7 +858,6 @@ struct MHLOToMHLOPreprocessingPass
     mhlo::PopulateEinsumToDotGeneralPatterns(context, &patterns);
     mhlo::PopulateUnfuseBatchNormPatterns(context, &patterns);
     mhlo::PopulateComplexLoweringPatterns(context, &patterns);
-    mhlo::PopulateGatherToTorchIndexSelectPatterns(context, &patterns);
     patterns
         .insert<ExtractReduceWindowOpPaddingAttributes,
                 AdjustDepthwiseFilterShape, ScatterRank0Value, ExpandRngNormal>(


### PR DESCRIPTION
This was added to support VMLA which is long deleted and lowering to linalg is covered by Gather.