### PR TITLE
Add outstanding changes for lowering linalg_ext.scan to PTX

### DIFF
--- a/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -27,6 +27,8 @@ def LLVMGPU_MatmulSimt
     : StrEnumAttrCase<"LLVMGPUMatmulSimt">;
 def LLVMGPU_MatmulTensorCore
     : StrEnumAttrCase<"LLVMGPUMatmulTensorCore">;
+def LLVMGPU_WarpLevelScan
+    : StrEnumAttrCase<"LLVMGPUWarpLevelScan">;
 
 def SPIRV_Distribute
     : StrEnumAttrCase<"SPIRVDistribute">;
@@ -49,7 +51,7 @@ def DispatchLoweringPassPipelineEnum : StrEnumAttr<
      CPU_TileFuseAndVectorize, LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize,
      LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore, SPIRV_Distribute,
      SPIRV_DistributeCopy, SPIRV_Vectorize,SPIRV_VectorizeToCooperativeOps,
-     None]> {
+     LLVMGPU_WarpLevelScan, None]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
 }
 

--- a/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -26,6 +26,7 @@ cc_library(
         "LLVMGPUVectorLowering.cpp",
         "LLVMGPUVectorization.cpp",
         "Passes.cpp",
+        "VectorScanToGPU.cpp",
     ],
     hdrs = [
         "ConvertToLLVM.h",

--- a/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_cc_library(
     "LLVMGPUVectorLowering.cpp"
     "LLVMGPUVectorization.cpp"
     "Passes.cpp"
+    "VectorScanToGPU.cpp"
   DEPS
     IREELinalgExtDialect
     IREELinalgExtPasses

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -151,6 +151,9 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulTensorCore:
         addGPUMatmulTensorCorePassPipeline(nestedModulePM);
         break;
+      case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUWarpLevelScan:
+        addGPUWarpLevelScanPassPipeline(nestedModulePM);
+        break;
       default:
         llvm_unreachable("Unsupported pipeline on GPU target.");
     }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -57,8 +57,10 @@ static void populateTilingReductionPatterns(RewritePatternSet &patterns) {
       ArrayRef<StringAttr>{},
       StringAttr::get(context, getWorkgroupKTiledMarker()));
   linalg::TilingPatterns<linalg::MatmulOp, linalg::BatchMatmulOp,
-                         linalg::GenericOp>::insert(patterns, tilingOptions,
+                         linalg::GenericOp, IREE::LinalgExt::ScanOp>::insert(patterns, tilingOptions,
                                                     filter);
+  patterns.insert<IREE::LinalgExt::TiledOpInterfaceTilingPattern>(
+      context, tilingOptions, filter);
 }
 
 /// Patterns for warp level tiling.

--- a/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -141,6 +141,37 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm) {
   pm.addNestedPass<FuncOp>(createLLVMGPUPipeliningPass());
 }
 
+void addGPUWarpLevelScanPassPipeline(OpPassManager &pm) {
+  //===--------------------------------------------------------------------===//
+  // Initial clean up.
+  //===--------------------------------------------------------------------===//
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  // Distribute linalg onto warps within the workgroup.
+  pm.addNestedPass<FuncOp>(
+      createLLVMGPUTileAndDistribute(/*distributeToWarp=*/true));
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
+  pm.addNestedPass<FuncOp>(createRemoveSingleIterationLoopPass());
+
+  // LinalgExt -> vector
+  pm.addNestedPass<FuncOp>(
+      mlir::iree_compiler::IREE::LinalgExt::createScanVectorizationPass());
+  pm.addNestedPass<FuncOp>(createCanonicalizerPass());
+  pm.addPass(createLowerAffinePass());
+  pm.addNestedPass<FuncOp>(createLoopInvariantCodeMotionPass());
+  pm.addNestedPass<FuncOp>(createCSEPass());
+  pm.addNestedPass<FuncOp>(createOptimizeVectorTransferPass());
+
+  // Vector -> MMA ops
+  pm.addNestedPass<FuncOp>(memref::createFoldSubViewOpsPass());
+  pm.addNestedPass<FuncOp>(createConvertVectorScanToGPUPass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+}
+
 void addGPUSimpleDistributePassPipeline(OpPassManager &pm) {
   //===--------------------------------------------------------------------===//
   // Initial clean up.

--- a/iree/compiler/Codegen/LLVMGPU/VectorScanToGPU.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/VectorScanToGPU.cpp
@@ -1,0 +1,238 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstddef>
+#include <cstdint>
+
+#include "iree/compiler/Codegen/LLVMGPU/LLVMGPUUtils.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "mlir/Dialect/GPU/Passes.h"
+#include "mlir/Dialect/StandardOps/IR/Ops.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+static Value createElementwiseOp(OpBuilder& b, Location loc, Value lhs,
+                                 Value rhs, vector::CombiningKind kind,
+                                 bool isInteger) {
+  switch (kind) {
+    case vector::CombiningKind::ADD:
+      if (isInteger)
+        return b.create<arith::AddIOp>(loc, lhs, rhs);
+      else
+        return b.create<arith::AddFOp>(loc, lhs, rhs);
+    case vector::CombiningKind::MAXF:
+      return b.create<arith::MaxFOp>(loc, lhs, rhs);
+    case vector::CombiningKind::MINF:
+      return b.create<arith::MinFOp>(loc, lhs, rhs);
+    case vector::CombiningKind::MUL:
+      if (isInteger)
+        return b.create<arith::MulIOp>(loc, lhs, rhs);
+      else
+        return b.create<arith::MulFOp>(loc, lhs, rhs);
+    default:
+      break;
+  }
+  return nullptr;
+}
+
+static Value warpScan(OpBuilder& b, Location loc, Value val,
+                      vector::CombiningKind kind, bool isInteger, Type elemType) {
+  std::array<Type, 2> shuffleType = {val.getType(), b.getI1Type()};
+  Value activeWidth =
+      b.create<arith::ConstantIntOp>(loc, 32, b.getI32Type());
+  Value value = val;
+  Value zero = b.create<arith::ConstantOp>(loc, elemType, b.getZeroAttr(elemType));
+  for (int i = 1; i < kWarpSize; i <<= 1) {
+    Value offset = b.create<arith::ConstantIntOp>(loc, i, b.getI32Type());
+    auto shuffleOp = b.create<gpu::ShuffleOp>(loc, shuffleType, value, offset,
+                                              activeWidth, gpu::ShuffleMode::UP);
+    auto selectOp = b.create<arith::SelectOp>(loc, shuffleOp->getResult(1), 
+        shuffleOp->getResult(0), zero);
+    value = createElementwiseOp(b, loc, value, selectOp->getResult(0), kind, isInteger);
+  }
+  return value;
+}
+
+static Value broadcastToAllLanes(OpBuilder& b, Location loc, Value val) {
+  std::array<Type, 2> shuffleType = {val.getType(), b.getI1Type()};
+  Value activeWidth =
+      b.create<arith::ConstantIntOp>(loc, 32, b.getI32Type());
+  Value zero = b.create<arith::ConstantIntOp>(loc, 31, b.getI32Type());
+  return b
+      .create<gpu::ShuffleOp>(loc, shuffleType, val, zero, activeWidth, gpu::ShuffleMode::IDX)
+      .getResult(0);
+}
+
+struct ConvertScanToGPU final
+    : public OpRewritePattern<vector::ScanOp> {
+  using OpRewritePattern<vector::ScanOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::ScanOp op,
+                                PatternRewriter& rewriter) const override {
+    if (op.getSourceType().getNumElements() != kWarpSize)
+      return failure();
+    auto funcOp = op->getParentOfType<FuncOp>();
+    if (!funcOp) return failure();
+
+    rewriter.setInsertionPoint(&funcOp.front(), funcOp.front().begin());
+    mlir::Value laneId = rewriter.create<mlir::gpu::ThreadIdOp>(
+        op.getLoc(), rewriter.getIndexType(), gpu::Dimension::x);
+    rewriter.setInsertionPoint(op);
+    mlir::AffineExpr d0 = rewriter.getAffineDimExpr(0);
+    laneId = mlir::makeComposedAffineApply(
+        rewriter, op.getLoc(), d0 % rewriter.getAffineConstantExpr(kWarpSize),
+        {laneId});
+
+    auto vecType = VectorType::get(
+        SmallVector<int64_t>(op.getSourceType().getRank(), 1),
+        op.getSourceType().getElementType());
+    // Distribute the value on the warp lanes.
+    Value distributedVal = rewriter.create<vector::ExtractMapOp>(
+        op.getLoc(), vecType, op.source(), laneId);
+    distributedVal = rewriter.create<vector::ExtractOp>(
+        op.getLoc(), distributedVal,
+        SmallVector<int64_t>(vecType.getRank(), 0));
+
+    auto initialVecType = VectorType::get(
+        SmallVector<int64_t>(op.getInitialValueType().getRank(), 1),
+        op.getInitialValueType().getElementType());
+    Value distributedAccVal;
+    int64_t initialVecRank = initialVecType.getRank();
+    if (initialVecRank == 0) {
+      distributedAccVal = rewriter.create<vector::ExtractElementOp>(op.getLoc(),
+          op.initial_value());
+    } else if (initialVecRank == 1) {
+      Value zero = rewriter.create<arith::ConstantIndexOp>(op->getLoc(), 0);
+      distributedAccVal = rewriter.create<vector::ExtractElementOp>(op.getLoc(),
+          op.initial_value(), zero);
+    } else {
+      distributedAccVal = rewriter.create<vector::ExtractMapOp>(
+          op.getLoc(), initialVecType, op.initial_value(), laneId);
+      distributedAccVal = rewriter.create<vector::ExtractOp>(
+          op.getLoc(), distributedVal,
+          SmallVector<int64_t>(initialVecType.getRank(), 0));
+    }
+
+    bool isInteger = vecType.getElementType().isa<IntegerType>();
+
+    Value v = warpScan(rewriter, op.getLoc(), distributedVal, op.kind(),
+                       isInteger, vecType.getElementType());
+    v = createElementwiseOp(rewriter, op.getLoc(), distributedAccVal, 
+        v, op.kind(), isInteger);
+
+    SmallVector<int64_t> broadcastShape(vecType.getRank(), 1);
+    Value broadcastVec = rewriter.create<vector::BroadcastOp>(op.getLoc(),
+        VectorType::get(broadcastShape, op.getSourceType().getElementType()), v);
+    Value v1 = rewriter.create<vector::InsertMapOp>(op.getLoc(),
+        broadcastVec, op.dest(), laneId);
+
+    Value v2 = broadcastToAllLanes(rewriter, op.getLoc(), v);
+    if (initialVecRank <= 1) {
+      SmallVector<int64_t> shape;
+      if (initialVecRank == 1) {
+        shape.push_back(1);
+      }
+      v2 = rewriter.create<vector::BroadcastOp>(op.getLoc(),
+          VectorType::get(shape, op.getSourceType().getElementType()), v2);
+    }
+
+    rewriter.replaceOp(op, {v1, v2});
+    return success();
+  }
+};
+
+/// Converts extract_map(broadcast) to broadcast(extract_map).
+/// Example:
+/// ```
+/// %b = vector.broadcast %a : vector<32xf32> to vector<2x32xf32>
+/// %e = vector.extract_map %b[%id0, %id1] : vector<2x32xf32> to vector<1x4xf32>
+/// ```
+/// to:
+/// ```
+/// %e = vector.extract_map %a[%id1] : vector<32xf32> to vector<4xf32>
+/// %b = vector.broadcast %e : vector<4xf32> to vector<1x4xf32>
+/// ```
+struct ExtractMapBroadcastPattern final
+    : public OpRewritePattern<vector::ExtractMapOp> {
+  using OpRewritePattern<vector::ExtractMapOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::ExtractMapOp op,
+                                PatternRewriter &rewriter) const override {
+    auto broadcast = op.vector().getDefiningOp<vector::BroadcastOp>();
+    if (!broadcast)
+      return failure();
+    auto srcVecType = broadcast.getSourceType().dyn_cast<VectorType>();
+    if (!srcVecType) {
+      // Special case if the source is a scalar we don't need to distribute
+      // anything we can just broadcast the original source.
+      rewriter.replaceOpWithNewOp<vector::BroadcastOp>(op, op.getResultType(),
+                                                       broadcast.source());
+      return success();
+    }
+    VectorType dstVecType = broadcast.getVectorType();
+    SmallVector<int64_t> extractShape(srcVecType.getShape().begin(),
+                                      srcVecType.getShape().end());
+    SmallVector<Value> ids;
+    int64_t rankDiff = dstVecType.getRank() - srcVecType.getRank();
+    for (unsigned i : llvm::seq(unsigned(0), op.map().getNumResults())) {
+      unsigned dim = op.map().getDimPosition(i);
+      // If the dimension was broadcasted we don't need to distribute it.
+      if (dim - rankDiff >= srcVecType.getRank() ||
+          srcVecType.getDimSize(dim - rankDiff) != dstVecType.getDimSize(dim))
+        continue;
+      // It is not a broadcasted dimension and it is distributed by the
+      // extract_map. We need to propagate the distribution id and ajust the
+      // shape.
+      extractShape[i] = op.getResultType().getDimSize(i);
+      ids.push_back(op.ids()[i]);
+    }
+    Value source = broadcast.source();
+    // If there are still any dimension distributed add a new extract_map.
+    if (!ids.empty()) {
+      VectorType newVecType =
+          VectorType::get(extractShape, dstVecType.getElementType());
+      source = rewriter.create<vector::ExtractMapOp>(op.getLoc(), newVecType,
+                                                     source, ids);
+    }
+    rewriter.replaceOpWithNewOp<vector::BroadcastOp>(op, op.getResultType(),
+                                                     source);
+    return success();
+  }
+};
+
+struct LLVMGPUScanToGPUPass
+    : public LLVMGPUScanToGPUBase<LLVMGPUScanToGPUPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<gpu::GPUDialect, AffineDialect>();
+  }
+
+  void runOnOperation() override {
+    FuncOp funcOp = getOperation();
+    RewritePatternSet patterns(funcOp.getContext());
+    patterns.insert<ConvertScanToGPU, ExtractMapBroadcastPattern>(
+        funcOp.getContext());
+    vector::populatePropagateVectorDistributionPatterns(patterns);
+    (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+  }
+};
+
+}  // anonymous namespace
+
+std::unique_ptr<OperationPass<FuncOp>> createConvertVectorScanToGPUPass() {
+  return std::make_unique<LLVMGPUScanToGPUPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "legalize.mlir",
             "tensorcore_vectorization.mlir",
             "vectorization.mlir",
+            "vector_scan_to_gpu.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_lit_test_suite(
     "nvvm_pipeline_test.mlir"
     "rocdl_pipeline_test.mlir"
     "tensorcore_vectorization.mlir"
+    "vector_scan_to_gpu.mlir"
     "vectorization.mlir"
   TOOLS
     FileCheck

--- a/iree/compiler/Codegen/LLVMGPU/test/vector_scan_to_gpu.mlir
+++ b/iree/compiler/Codegen/LLVMGPU/test/vector_scan_to_gpu.mlir
@@ -1,0 +1,57 @@
+// RUN: iree-opt -iree-llvmgpu-scan-to-gpu %s | FileCheck %s
+
+func @scan1d(%arg0: memref<32xi32>, %arg1: memref<i32>, %arg2: memref<32xi32>) {
+  %c0 = arith.constant 0 : index
+  %c0_i32 = arith.constant 0 : i32
+  %0 = vector.transfer_read %arg0[%c0], %c0_i32 {in_bounds = [true]} : memref<32xi32>, vector<32xi32>
+  %1 = vector.transfer_read %arg1[], %c0_i32 : memref<i32>, vector<i32>
+  %dest, %acc = vector.scan <add>, %0, %1 {inclusive = true, reduction_dim = 0 : i64} : vector<32xi32>, vector<i32>
+  vector.transfer_write %dest, %arg2[%c0] {in_bounds = [true]} : vector<32xi32>, memref<32xi32>
+  vector.transfer_write %acc, %arg1[] : vector<i32>, memref<i32>
+  return
+}
+
+// CHECK:      #map = affine_map<()[s0] -> (s0 mod 32)>
+// CHECK:      func @scan1d
+// CHECK-SAME:   %[[ARG0:.+]]: memref<32xi32>,
+// CHECK-SAME:   %[[ARG1:.+]]: memref<i32>,
+// CHECK-SAME:   %[[ARG2:.+]]: memref<32xi32>
+// CHECK:        %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK:        %[[C32_I32:.+]] = arith.constant 32 : i32
+// CHECK:        %[[C1_I32:.+]] = arith.constant 1 : i32
+// CHECK:        %[[C2_I32:.+]] = arith.constant 2 : i32
+// CHECK:        %[[C4_I32:.+]] = arith.constant 4 : i32
+// CHECK:        %[[C8_I32:.+]] = arith.constant 8 : i32
+// CHECK:        %[[C16_I32:.+]] = arith.constant 16 : i32
+// CHECK:        %[[C31_I32:.+]] = arith.constant 31 : i32
+// CHECK:        %[[A0:.+]] = gpu.thread_id  x
+// CHECK:        %[[A1:.+]] = affine.apply #map()[%[[A0]]]
+// CHECK:        %[[A2:.+]] = vector.transfer_read %[[ARG0]][%[[A1]]], %[[C0_I32]] {in_bounds = [true]} : memref<32xi32>, vector<1xi32>
+// CHECK:        %[[A3:.+]] = vector.transfer_read %[[ARG1]][], %[[C0_I32]] : memref<i32>, vector<i32>
+// CHECK:        %[[A4:.+]] = vector.extract %[[A2]][0] : vector<1xi32>
+// CHECK:        %[[A5:.+]] = vector.extractelement %[[A3]][] : vector<i32>
+// CHECK:        %[[RESULT:.+]], %[[VALID:.+]] = gpu.shuffle  up %[[A4]], %[[C1_I32]], %[[C32_I32]] : i32
+// CHECK:        %[[A6:.+]] = select %[[VALID]], %[[RESULT]], %[[C0_I32]] : i32
+// CHECK:        %[[A7:.+]] = arith.addi %[[A4]], %[[A6]] : i32
+// CHECK:        %[[RESULT_0:.+]], %[[VALID_1:.+]] = gpu.shuffle  up %[[A7]], %[[C2_I32]], %[[C32_I32]] : i32
+// CHECK:        %[[A8:.+]] = select %[[VALID_1]], %[[RESULT_0]], %[[C0_I32]] : i32
+// CHECK:        %[[A9:.+]] = arith.addi %[[A7]], %[[A8]] : i32
+// CHECK:        %[[RESULT_2:.+]], %[[VALID_3:.+]] = gpu.shuffle  up %[[A9]], %[[C4_I32]], %[[C32_I32]] : i32
+// CHECK:        %[[A10:.+]] = select %[[VALID_3]], %[[RESULT_2]], %[[C0_I32]] : i32
+// CHECK:        %[[A11:.+]] = arith.addi %[[A9]], %[[A10]] : i32
+// CHECK:        %[[RESULT_4:.+]], %[[VALID_5:.+]] = gpu.shuffle  up %[[A11]], %[[C8_I32]], %[[C32_I32]] : i32
+// CHECK:        %[[A12:.+]] = select %[[VALID_5]], %[[RESULT_4]], %[[C0_I32]] : i32
+// CHECK:        %[[A13:.+]] = arith.addi %[[A11]], %[[A12]] : i32
+// CHECK:        %[[RESULT_6:.+]], %[[VALID_7:.+]] = gpu.shuffle  up %[[A13]], %[[C16_I32]], %[[C32_I32]] : i32
+// CHECK:        %[[A14:.+]] = select %[[VALID_7]], %[[RESULT_6]], %[[C0_I32]] : i32
+// CHECK:        %[[A15:.+]] = arith.addi %[[A13]], %[[A14]] : i32
+// CHECK:        %[[A16:.+]] = arith.addi %[[A5]], %[[A15]] : i32
+// CHECK:        %[[A17:.+]] = vector.broadcast %[[A16]] : i32 to vector<1xi32>
+// CHECK:        %[[RESULT_8:.+]], %[[VALID_9:.+]] = gpu.shuffle  idx %[[A16]], %[[C31_I32]], %[[C32_I32]] : i32
+// CHECK:        %[[A18:.+]] = vector.broadcast %[[RESULT_8]] : i32 to vector<i32>
+// CHECK:        %[[A19:.+]] = affine.apply #map()[%[[A0]]]
+// CHECK:        vector.transfer_write %[[A17]], %[[ARG2]][%[[A19]]] {in_bounds = [true]} : vector<1xi32>, memref<32xi32>
+// CHECK:        vector.transfer_write %[[A18]], %[[ARG1]][] : vector<i32>, memref<i32>
+// CHECK:        return
+// CHECK:      }
+// CHECK:    }

--- a/iree/compiler/Codegen/Passes.h
+++ b/iree/compiler/Codegen/Passes.h
@@ -256,6 +256,8 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm);
 /// Lowering using tensorcore operations.
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm);
 
+void addGPUWarpLevelScanPassPipeline(OpPassManager &pm);
+
 /// Simple lowering only distributute linalg ops on blocks and threads. This
 /// will result in scalar operations. Expects pass manager to be a module-level
 /// pass manager.
@@ -296,6 +298,8 @@ createLLVMGPUDistributeSharedMemoryCopy();
 
 /// Apply software pipelining.
 std::unique_ptr<OperationPass<FuncOp>> createLLVMGPUPipeliningPass();
+
+std::unique_ptr<OperationPass<FuncOp>> createConvertVectorScanToGPUPass();
 
 //------------------------------------------------------------------------------
 // SPIR-V Passes

--- a/iree/compiler/Codegen/Passes.td
+++ b/iree/compiler/Codegen/Passes.td
@@ -253,6 +253,12 @@ def LLVMGPUPipelining :
   let constructor = "mlir::iree_compiler::createLLVMGPUPipeliningPass()";
 }
 
+def LLVMGPUScanToGPU :
+    Pass<"iree-llvmgpu-scan-to-gpu", "FuncOp"> {
+  let summary = "Convert vector scan ops to gpu ops.";
+  let constructor = "mlir::iree_compiler::createConvertVectorScanToGPUPass()";
+}
+
 //------------------------------------------------------------------------------
 // SPIR-V
 //------------------------------------------------------------------------------

--- a/iree/test/e2e/linalg_ext_ops/scan.mlir
+++ b/iree/test/e2e/linalg_ext_ops/scan.mlir
@@ -1,136 +1,187 @@
 func @scan_1d_dim0_inclusive_sum() {
-  %input = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]> : tensor<6xf32>
+  %input = util.unfoldable_constant dense<1.0> : tensor<32xf32>
 
-  %init = linalg.init_tensor [6] : tensor<6xf32>
+  %init = linalg.init_tensor [32] : tensor<32xf32>
   %t0 = util.unfoldable_constant dense<0.0> : tensor<f32>
   %0:2 = iree_linalg_ext.scan
          dimension(0) inclusive(true)
-         ins(%input : tensor<6xf32>)
-         outs(%init, %t0 : tensor<6xf32>, tensor<f32>) {
+         ins(%input : tensor<32xf32>)
+         outs(%init, %t0 : tensor<32xf32>, tensor<f32>) {
            ^bb0(%arg0 : f32, %arg1 : f32):
              %sum = arith.addf %arg0, %arg1 : f32
              iree_linalg_ext.yield %sum : f32
-         } -> tensor<6xf32>, tensor<f32>
+         } -> tensor<32xf32>, tensor<f32>
 
   check.expect_almost_eq_const(
       %0#0,
-      dense<[1.0, 3.0, 6.0, 10.0, 15.0, 21.0]> : tensor<6xf32>
-  ) : tensor<6xf32>
+      dense<[
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0,
+        14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0, 25.0,
+        26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0
+      ]> : tensor<32xf32>
+  ) : tensor<32xf32>
 
   check.expect_almost_eq_const(
       %0#1,
-      dense<21.0> : tensor<f32>
+      dense<32.0> : tensor<f32>
   ) : tensor<f32>
 
   return
 }
 
 func @scan_1d_dim0_exclusive_sum() {
-  %input = util.unfoldable_constant dense<[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]> : tensor<6xf32>
+  %input = util.unfoldable_constant dense<1.0> : tensor<32xf32>
 
-  %init = linalg.init_tensor [6] : tensor<6xf32>
+  %init = linalg.init_tensor [32] : tensor<32xf32>
   %t0 = util.unfoldable_constant dense<10.0> : tensor<f32>
   %0:2 = iree_linalg_ext.scan
          dimension(0) inclusive(false)
-         ins(%input : tensor<6xf32>)
-         outs(%init, %t0 : tensor<6xf32>, tensor<f32>) {
+         ins(%input : tensor<32xf32>)
+         outs(%init, %t0 : tensor<32xf32>, tensor<f32>) {
            ^bb0(%arg0 : f32, %arg1 : f32):
              %sum = arith.addf %arg0, %arg1 : f32
              iree_linalg_ext.yield %sum : f32
-         } -> tensor<6xf32>, tensor<f32>
+         } -> tensor<32xf32>, tensor<f32>
 
   check.expect_almost_eq_const(
       %0#0,
-      dense<[10.0, 11.0, 13.0, 16.0, 20.0, 25.0]> : tensor<6xf32>
-  ) : tensor<6xf32>
+      dense<[
+        10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0, 21.0,
+        22.0, 23.0, 24.0, 25.0, 26.0, 27.0, 28.0, 29.0, 30.0, 31.0, 32.0, 33.0,
+        34.0, 35.0, 36.0, 37.0, 38.0, 39.0, 40.0, 41.0
+      ]> : tensor<32xf32>
+  ) : tensor<32xf32>
 
   check.expect_almost_eq_const(
       %0#1,
-      dense<25.0> : tensor<f32>
+      dense<41.0> : tensor<f32>
   ) : tensor<f32>
 
   return
 }
 
-func @scan_1d_dim0_inclusive_mul() {
-  %input = util.unfoldable_constant dense<[1, 2, 3, 4, 5, 6]> : tensor<6xi32>
+func @scan_1d_dim0_exclusive_mul() {
+  %input = util.unfoldable_constant dense<2> : tensor<32xi32>
 
-  %init = linalg.init_tensor [6] : tensor<6xi32>
+  %init = linalg.init_tensor [32] : tensor<32xi32>
   %t0 = util.unfoldable_constant dense<1> : tensor<i32>
   %0:2 = iree_linalg_ext.scan
-         dimension(0) inclusive(true)
-         ins(%input : tensor<6xi32>)
-         outs(%init, %t0 : tensor<6xi32>, tensor<i32>) {
+         dimension(0) inclusive(false)
+         ins(%input : tensor<32xi32>)
+         outs(%init, %t0 : tensor<32xi32>, tensor<i32>) {
            ^bb0(%arg0 : i32, %arg1 : i32):
              %sum = arith.muli %arg0, %arg1 : i32
              iree_linalg_ext.yield %sum : i32
-         } -> tensor<6xi32>, tensor<i32>
+         } -> tensor<32xi32>, tensor<i32>
 
   check.expect_eq_const(
       %0#0,
-      dense<[1, 2, 6, 24, 120, 720]> : tensor<6xi32>
-  ) : tensor<6xi32>
+      dense<[
+        0x1,0x2,0x4,0x8,0x10,0x20,0x40,0x80,0x100,0x200,0x400,0x800,0x1000,
+        0x2000, 0x4000,0x8000,0x10000,0x20000,0x40000,0x80000,0x100000,0x200000,
+        0x400000,0x800000,0x1000000,0x2000000,0x4000000,0x8000000,0x10000000,
+        0x20000000,0x40000000,0x80000000
+      ]> : tensor<32xi32>
+  ) : tensor<32xi32>
 
   check.expect_eq_const(
       %0#1,
-      dense<720> : tensor<i32>
+      dense<0x80000000> : tensor<i32>
   ) : tensor<i32>
 
   return
 }
 
 func @scan_2d_dim0_inclusive_sum() {
-  %input = util.unfoldable_constant dense<[[1, 2, 3],
-                                           [4, 5, 6]]> : tensor<2x3xi32>
+  %input = util.unfoldable_constant dense<1> : tensor<32x3xi32>
 
-  %init = linalg.init_tensor [2, 3] : tensor<2x3xi32>
+  %init = linalg.init_tensor [32, 3] : tensor<32x3xi32>
   %t0 = util.unfoldable_constant dense<[0, 0, 0]> : tensor<3xi32>
   %0:2 = iree_linalg_ext.scan
          dimension(0) inclusive(true)
-         ins(%input : tensor<2x3xi32>)
-         outs(%init, %t0 : tensor<2x3xi32>, tensor<3xi32>) {
+         ins(%input : tensor<32x3xi32>)
+         outs(%init, %t0 : tensor<32x3xi32>, tensor<3xi32>) {
            ^bb0(%arg0 : i32, %arg1 : i32):
              %sum = arith.addi %arg0, %arg1 : i32
              iree_linalg_ext.yield %sum : i32
-         } -> tensor<2x3xi32>, tensor<3xi32>
+         } -> tensor<32x3xi32>, tensor<3xi32>
 
   check.expect_eq_const(
       %0#0,
-      dense<[[1, 2, 3], [5, 7, 9]]> : tensor<2x3xi32>
-  ) : tensor<2x3xi32>
+      dense<[
+        [ 1,  1,  1],
+        [ 2,  2,  2],
+        [ 3,  3,  3],
+        [ 4,  4,  4],
+        [ 5,  5,  5],
+        [ 6,  6,  6],
+        [ 7,  7,  7],
+        [ 8,  8,  8],
+        [ 9,  9,  9],
+        [10, 10, 10],
+        [11, 11, 11],
+        [12, 12, 12],
+        [13, 13, 13],
+        [14, 14, 14],
+        [15, 15, 15],
+        [16, 16, 16],
+        [17, 17, 17],
+        [18, 18, 18],
+        [19, 19, 19],
+        [20, 20, 20],
+        [21, 21, 21],
+        [22, 22, 22],
+        [23, 23, 23],
+        [24, 24, 24],
+        [25, 25, 25],
+        [26, 26, 26],
+        [27, 27, 27],
+        [28, 28, 28],
+        [29, 29, 29],
+        [30, 30, 30],
+        [31, 31, 31],
+        [32, 32, 32]
+      ]> : tensor<32x3xi32>
+  ) : tensor<32x3xi32>
 
   check.expect_eq_const(
       %0#1,
-      dense<[5, 7, 9]> : tensor<3xi32>
+      dense<32> : tensor<3xi32>
   ) : tensor<3xi32>
 
   return
 }
 
-func @scan_2d_dim1_inclusive_sum() {
-  %input = util.unfoldable_constant dense<[[1, 2, 3],
-                                           [4, 5, 6]]> : tensor<2x3xi32>
-
-  %init = linalg.init_tensor [2, 3] : tensor<2x3xi32>
-  %t0 = util.unfoldable_constant dense<[0, 0]> : tensor<2xi32>
-  %0:2 = iree_linalg_ext.scan
-         dimension(1) inclusive(true)
-         ins(%input : tensor<2x3xi32>)
-         outs(%init, %t0 : tensor<2x3xi32>, tensor<2xi32>) {
-           ^bb0(%arg0 : i32, %arg1 : i32):
-             %sum = arith.addi %arg0, %arg1 : i32
-             iree_linalg_ext.yield %sum : i32
-         } -> tensor<2x3xi32>, tensor<2xi32>
-
-  check.expect_eq_const(
-      %0#0,
-      dense<[[1, 3, 6], [4, 9, 15]]> : tensor<2x3xi32>
-  ) : tensor<2x3xi32>
-
-  check.expect_eq_const(
-      %0#1,
-      dense<[6, 15]> : tensor<2xi32>
-  ) : tensor<2xi32>
-
-  return
-}
+//func @scan_2d_dim1_inclusive_sum() {
+//  %input = util.unfoldable_constant dense<1> : tensor<2x32xi32>
+//
+//  %init = linalg.init_tensor [2, 32] : tensor<2x32xi32>
+//  %t0 = util.unfoldable_constant dense<[0, 0]> : tensor<2xi32>
+//  %0:2 = iree_linalg_ext.scan
+//         dimension(1) inclusive(true)
+//         ins(%input : tensor<2x32xi32>)
+//         outs(%init, %t0 : tensor<2x32xi32>, tensor<2xi32>) {
+//           ^bb0(%arg0 : i32, %arg1 : i32):
+//             %sum = arith.addi %arg0, %arg1 : i32
+//             iree_linalg_ext.yield %sum : i32
+//         } -> tensor<2x32xi32>, tensor<2xi32>
+//
+//  check.expect_eq_const(
+//      %0#0,
+//      dense<[
+//        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+//        14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+//        26, 27, 28, 29, 30, 31, 32],
+//        [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13,
+//        14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+//        26, 27, 28, 29, 30, 31, 32]
+//      ]> : tensor<2x32xi32>
+//  ) : tensor<2x32xi32>
+//
+//  check.expect_eq_const(
+//      %0#1,
+//      dense<32> : tensor<2xi32>
+//  ) : tensor<2xi32>
+//
+//  return
+//}

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.h
@@ -20,6 +20,8 @@ std::unique_ptr<OperationPass<FuncOp>> createLinalgExtToLoopsPass();
 
 std::unique_ptr<OperationPass<>> createPadContractionToBlockSizePass();
 
+std::unique_ptr<OperationPass<FuncOp>> createScanVectorizationPass();
+
 void registerPasses();
 
 }  // namespace LinalgExt

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Passes.td
@@ -44,4 +44,10 @@ def PadContractionToBlockSize :
   ];
 }
 
+def ScanVectorization :
+    Pass<"iree-linalg-ext-scan-vec", "FuncOp"> {
+  let summary = "Test pass for vectorizing scan op";
+  let constructor = "mlir::iree_compiler::IREE::LinalgExt::createScanVectorizationPass()";
+}
+
 #endif  // IREE_DIALECT_LINALGEXT_PASSES

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/CMakeLists.txt
@@ -3,6 +3,7 @@ add_mlir_library(IREELinalgExtPasses
   PadContractionToBlockSize.cpp
   Passes.cpp
   Tiling.cpp
+  ScanVectorization.cpp
 
   DEPENDS
   IREELinalgExtTransformsPassesIncGen

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/ScanVectorization.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/ScanVectorization.cpp
@@ -1,0 +1,115 @@
+// Copyright 2021 The IREE Authors
+ //
+ // Licensed under the Apache License v2.0 with LLVM Exceptions.
+ // See https://llvm.org/LICENSE.txt for license information.
+ // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/PassDetail.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Passes.h"
+#include "mlir/Conversion/VectorToSCF/VectorToSCF.h"
+#include "mlir/Dialect/Linalg/Transforms/Hoisting.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/VectorTransforms.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+#define DEBUG_TYPE "iree-linalg-ext-scan-vec"
+
+using namespace mlir;
+namespace IREE = mlir::iree_compiler::IREE;
+using namespace IREE::LinalgExt;
+
+namespace {
+
+static llvm::Optional<vector::CombiningKind>
+getKindForOp(Operation *scanOp) {
+  return llvm::TypeSwitch<Operation *, llvm::Optional<vector::CombiningKind>>(
+             scanOp)
+      .Case<arith::AddIOp, arith::AddFOp>(
+          [&](auto op) { return vector::CombiningKind::ADD; })
+      .Case<arith::AndIOp>([&](auto op) { return vector::CombiningKind::AND; })
+      .Case<arith::MaxSIOp>(
+          [&](auto op) { return vector::CombiningKind::MAXSI; })
+      .Case<arith::MaxFOp>([&](auto op) { return vector::CombiningKind::MAXF; })
+      .Case<arith::MinSIOp>(
+          [&](auto op) { return vector::CombiningKind::MINSI; })
+      .Case<arith::MinFOp>([&](auto op) { return vector::CombiningKind::MINF; })
+      .Case<arith::MulIOp, arith::MulFOp>(
+          [&](auto op) { return vector::CombiningKind::MUL; })
+      .Case<arith::OrIOp>([&](auto op) { return vector::CombiningKind::OR; })
+      .Case<arith::XOrIOp>([&](auto op) { return vector::CombiningKind::XOR; })
+      .Default([&](auto op) { return llvm::None; });
+}
+
+struct VectorizeScanPattern : public OpRewritePattern<ScanOp> {
+  using OpRewritePattern<ScanOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(ScanOp op,
+                                PatternRewriter &rewriter) const override {
+    auto inputType = op.input().getType().cast<ShapedType>();
+    auto inputShape = inputType.getShape();
+    auto accumulatorType = op.accumulator().getType().cast<ShapedType>();
+    auto accumulatorShape = accumulatorType.getShape();
+    VectorType ivType = VectorType::get(accumulatorShape, accumulatorType.getElementType());
+    VectorType readType = VectorType::get(inputShape, inputType.getElementType());
+    BlockAndValueMapping bvm;
+    Location loc = op.getLoc();
+    Value zero = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    int64_t rank = inputType.getRank();
+    SmallVector<Value> indices(rank, zero);
+    Value readValue = rewriter.create<vector::TransferReadOp>(loc, readType, op.input(), indices);
+    bvm.map(op.region().getArgument(0), readValue);
+    SmallVector<Value> accIndices = indices;
+    accIndices.pop_back();
+    Value accValue = rewriter.create<vector::TransferReadOp>(loc, ivType, op.accumulator(), accIndices);
+
+    llvm::Optional<vector::CombiningKind> maybeKind;
+    maybeKind = getKindForOp(&(op.region().front().front()));
+    if (!maybeKind)
+      return failure();
+    int64_t reductionDim = op.dimension();
+    auto scanOp = rewriter.create<vector::ScanOp>(loc, readType, ivType,
+        *maybeKind, readValue, accValue,
+        reductionDim, op.inclusive());
+    auto writeScanResultOp = rewriter.create<vector::TransferWriteOp>(loc, 
+        scanOp.dest(), op.output(), indices);
+    auto writeReductionResultOp = rewriter.create<vector::TransferWriteOp>(loc, 
+        scanOp.accumulated_value(), op.accumulator(), accIndices);
+    rewriter.replaceOp(op, writeScanResultOp.getResults());
+    return success();
+  }
+};
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Pass
+//===----------------------------------------------------------------------===//
+
+namespace {
+struct ScanVectorizationPass
+    : public ScanVectorizationBase<ScanVectorizationPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
+    patterns.insert<VectorizeScanPattern>(context);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<FuncOp>>
+IREE::LinalgExt::createScanVectorizationPass() {
+  return std::make_unique<ScanVectorizationPass>();
+}

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Tiling.cpp
@@ -198,6 +198,8 @@ FailureOr<TiledOp> tileInterfaceOp(OpBuilder &b, TiledOpInterface tilableOp,
   tileSizes.resize(iteratorTypes.size(), zeroAttr);
   for (auto en : llvm::enumerate(iteratorTypes)) {
     if (en.value() == getParallelIteratorTypeName()) continue;
+    if (isa<IREE::LinalgExt::ScanOp>(tilableOp.getOperation()))
+        continue;
     if (!isUntiledLoop(tileSizes[en.index()])) {
       return static_cast<LogicalResult>(tilableOp.emitOpError(
           "unimplemented tiling of non-parallel loop iterator type"));

--- a/llvm-external-projects/iree-dialects/test/iree_linalgext/scan_vectorization.mlir
+++ b/llvm-external-projects/iree-dialects/test/iree_linalgext/scan_vectorization.mlir
@@ -1,0 +1,37 @@
+// RUN: iree-dialects-opt -iree-linalg-ext-scan-vec -split-input-file %s | FileCheck  %s
+
+#map = affine_map<(d0)[s0] -> (d0 + s0)>
+func @scan_1d(%arg1 : memref<5024xi32>, %arg2 : memref<i32>, %arg3: memref<5024xi32>) {
+  %c32 = arith.constant 32 : index
+  %c5024 = arith.constant 5024 : index
+  %c0 = arith.constant 0 : index
+  scf.for %arg0 = %c0 to %c5024 step %c32 {
+    %7 = memref.subview %arg1[%arg0] [32] [1] : memref<5024xi32> to memref<32xi32, #map>
+    %8 = memref.subview %arg3[%arg0] [32] [1] : memref<5024xi32> to memref<32xi32, #map>
+    iree_linalg_ext.scan dimension(0) inclusive(true) ins(%7 : memref<32xi32, #map>) outs(%8, %arg2 : memref<32xi32, #map>, memref<i32>) {
+    ^bb0(%arg4: i32, %arg5: i32):
+      %9 = arith.addi %arg4, %arg5 : i32
+      iree_linalg_ext.yield %9 : i32
+    }
+  }
+  return
+}
+
+// CHECK:       #map = affine_map<(d0)[s0] -> (d0 + s0)>
+// CHECK:       func @scan_1d(
+// CHECK-SAME:    %[[ARG1:.+]]: memref<5024xi32>,
+// CHECK-SAME:    %[[ARG2:.+]]: memref<i32>,
+// CHECK-SAME:    %[[ARG3:.+]]: memref<5024xi32>
+// CHECK:         %[[C32:.+]] = arith.constant 32 : index
+// CHECK:         %[[C5024:.+]] = arith.constant 5024 : index
+// CHECK:         %[[C0:.+]] = arith.constant 0 : index
+// CHECK:         %[[C0_I32:.+]] = arith.constant 0 : i32
+// CHECK:         scf.for %[[ARG0:.+]] = %[[C0]] to %[[C5024]] step %[[C32]]
+// CHECK:           %[[V0:.+]] = memref.subview %[[ARG1]][%[[ARG0]]] [32] [1] : memref<5024xi32> to memref<32xi32, #map>
+// CHECK:           %[[V1:.+]] = memref.subview %[[ARG3]][%[[ARG0]]] [32] [1] : memref<5024xi32> to memref<32xi32, #map>
+// CHECK:           %[[V2:.+]] = vector.transfer_read %[[V0]][%[[C0]]], %[[C0_I32]] {in_bounds = [true]} : memref<32xi32, #map>, vector<32xi32>
+// CHECK:           %[[V3:.+]] = vector.transfer_read %[[ARG2]][], %[[C0_I32]] : memref<i32>, vector<i32>
+// CHECK:           %[[DEST:.+]], %[[ACCVAL:.+]] = vector.scan <add>, %[[V2]], %[[V3]] {inclusive = true, reduction_dim = 0 : i64} : vector<32xi32>, vector<i32>
+// CHECK:           vector.transfer_write %[[DEST]], %[[V1]][%[[C0]]] {in_bounds = [true]} : vector<32xi32>, memref<32xi32, #map>
+// CHECK:           vector.transfer_write %[[ACCVAL]], %[[ARG2]][] : vector<i32>, memref<i32>
+// CHECK:         return


### PR DESCRIPTION
This patch adds the outstanding changes required to compile
linalg_ext.scan to PTX. Specifically, it adds the following
- A pass to lower linalg_ext.scan -> vector.scan (with test)
- A pass to lower vector.scan -> gpu.shuffle (with test)
- A scan lowering config

Also, the e2e tests are updated since the GPU version only works
on inputs that are multiples of the CUDA warp size (32).

However, there are still some outstanding issues with this patch:
- As is, this patch will not run on top of master IREE until
  mlir has been updated to include a bug fix (D119202)
- For 2d scan, I have only been able to get the test working
  if the reduction dimension is 0, not 1. So that test is
  currently disabled.