### PR TITLE
Enable cupti library support with header files to IREE. Implementation of dynamic_cupti_test for library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,6 +332,7 @@ set(IREE_CUDA_LIBDEVICE_PATH "" CACHE STRING "Absolute path to an appropriate li
 # If any CUDA features are being built, try to locate a CUDA SDK. We will fall
 # back to this as needed for specific features.
 if(IREE_TARGET_BACKEND_CUDA OR IREE_HAL_DRIVER_CUDA)
+  enable_language(CUDA )# Enables the CUDAToolkit_LIBRARY_ROOT variable from CUDAToolkit as well as the CUDA::cupti target if it exists.
   find_package(CUDAToolkit)
 endif()
 
@@ -381,6 +382,25 @@ if(IREE_HAL_DRIVER_CUDA)
     message(SEND_ERROR "Cannot build IREE runtime CUDA components (-DIREE_HAL_DRIVER_CUDA=ON) because a CUDA SDK was not found. Consult CMake docs for your version: https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html")
   endif()
 endif()
+
+if(IREE_HAL_DRIVER_CUDA AND IREE_ENABLE_RUNTIME_TRACING)
+  find_path(
+    CUPTI_INCLUDE_DIR
+    NAMES
+      "cupti.h"
+    PATHS ${CUDAToolkit_LIBRARY_ROOT}
+    PATH_SUFFIXES extras/CUPTI/include
+  )
+  if(CUPTI_INCLUDE_DIR)
+    set(CUPTIToolkit_INCLUDE_DIRS "${CUPTI_INCLUDE_DIR}")
+    message(STATUS "Using CUPTI INCLUDE_DIRS from found SDK: ${CUPTIToolkit_INCLUDE_DIRS}")
+  else()
+    set(CUPTIToolkit_INCLUDE_DIRS "")
+    message(STATUS "Unable to locate CUPTI. CUDA tracy disabled.")
+  endif(CUPTI_INCLUDE_DIR)
+else()
+  set(CUPTIToolkit_INCLUDE_DIRS "")
+endif(IREE_HAL_DRIVER_CUDA AND IREE_ENABLE_RUNTIME_TRACING)
 
 #-------------------------------------------------------------------------------
 # MLIR/LLVM Dependency

--- a/iree/hal/cuda/CMakeLists.txt
+++ b/iree/hal/cuda/CMakeLists.txt
@@ -12,6 +12,12 @@ if(NOT CUDAToolkit_INCLUDE_DIRS)
   message(FATAL_ERROR "No CUDA SDK includes found: should have been set globally")
 endif()
 
+if (CUPTIToolkit_INCLUDE_DIRS)
+  set(_IREE_CUDA_HEADERS_DEFINES "IREE_ENABLE_CUPTI")
+else()
+  set(_IREE_CUDA_HEADERS_DEFINES "")
+endif (CUPTIToolkit_INCLUDE_DIRS)
+
 iree_add_all_subdirs()
 
 iree_cc_library(
@@ -61,6 +67,8 @@ iree_cc_library(
     iree::hal::utils::deferred_command_buffer
     iree::hal::utils::resource_set
     iree::schemas::cuda_executable_def_c_fbs
+  DEFINES
+    ${_IREE_CUDA_HEADERS_DEFINES}
   PUBLIC
 )
 
@@ -70,16 +78,20 @@ iree_cc_library(
   HDRS
     "dynamic_symbols.h"
   TEXTUAL_HDRS
+    "dynamic_cupti_tables.h"
     "dynamic_symbol_tables.h"
   SRCS
     "cuda_headers.h"
     "dynamic_symbols.c"
   INCLUDES
     ${CUDAToolkit_INCLUDE_DIRS}
+    ${CUPTIToolkit_INCLUDE_DIRS}
   DEPS
     iree::base::core_headers
     iree::base::internal::dynamic_library
     iree::base::tracing
+  DEFINES
+    ${_IREE_CUDA_HEADERS_DEFINES}
   PUBLIC
 )
 
@@ -96,3 +108,19 @@ iree_cc_test(
   LABELS
     "driver=cuda"
 )
+
+if (CUPTIToolkit_INCLUDE_DIRS)
+iree_cc_test(
+  NAME
+    dynamic_cupti_test
+  SRCS
+    "dynamic_cupti_test.cc"
+  DEPS
+    ::dynamic_symbols
+    iree::base
+    iree::testing::gtest
+    iree::testing::gtest_main
+  LABELS
+    "driver=cuda"
+)
+endif(CUPTIToolkit_INCLUDE_DIRS)

--- a/iree/hal/cuda/cuda_headers.h
+++ b/iree/hal/cuda/cuda_headers.h
@@ -9,4 +9,8 @@
 
 #include "cuda.h"  // IWYU pragma: export
 
+#if IREE_ENABLE_CUPTI  // CUPTI is only used for tracing
+#include "cupti.h"
+#endif  // IREE_ENABLE_CUPTI
+
 #endif  // IREE_HAL_CUDA_CUDA_HEADERS_H_

--- a/iree/hal/cuda/dynamic_cupti_tables.h
+++ b/iree/hal/cuda/dynamic_cupti_tables.h
@@ -1,0 +1,26 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+CUPTI_PFN_DECL(cuptiActivityEnable, CUpti_ActivityKind)
+CUPTI_PFN_DECL(cuptiActivityFlushAll, uint32_t)
+CUPTI_PFN_DECL(cuptiActivityGetAttribute, CUpti_ActivityAttribute, size_t*,
+               void*)
+CUPTI_PFN_DECL(cuptiActivityGetNextRecord, uint8_t*, size_t, CUpti_Activity**)
+CUPTI_PFN_DECL(cuptiActivityGetNumDroppedRecords, CUcontext, uint32_t, size_t*)
+CUPTI_PFN_DECL(cuptiActivitySetAttribute, CUpti_ActivityAttribute, size_t*,
+               void*)
+CUPTI_PFN_DECL(cuptiActivityRegisterCallbacks, CUpti_BuffersCallbackRequestFunc,
+               CUpti_BuffersCallbackCompleteFunc)
+CUPTI_PFN_DECL(cuptiEnableDomain, uint32_t, CUpti_SubscriberHandle,
+               CUpti_CallbackDomain)
+CUPTI_PFN_DECL(cuptiGetResultString, CUptiResult result, const char** str)
+CUPTI_PFN_DECL(cuptiGetTimestamp, uint64_t*)
+CUPTI_PFN_DECL(cuptiSubscribe, CUpti_SubscriberHandle*, CUpti_CallbackFunc,
+               void*)
+CUPTI_PFN_DECL(cuptiActivityPushExternalCorrelationId,
+               CUpti_ExternalCorrelationKind, uint64_t)
+CUPTI_PFN_DECL(cuptiActivityPopExternalCorrelationId,
+               CUpti_ExternalCorrelationKind, uint64_t*)

--- a/iree/hal/cuda/dynamic_cupti_test.cc
+++ b/iree/hal/cuda/dynamic_cupti_test.cc
@@ -1,0 +1,62 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/base/api.h"
+#include "iree/hal/cuda/dynamic_symbols.h"
+#include "iree/testing/gtest.h"
+
+namespace iree {
+namespace hal {
+namespace cuda {
+namespace {
+
+#define CUPTI_CHECK_ERRORS(expr)           \
+  {                                        \
+    CUptiResult status = expr;             \
+    IREE_ASSERT_EQ(CUPTI_SUCCESS, status); \
+  }
+
+// Buffer request callack for CUPTI activity records.
+void bufferRequested(uint8_t** buffer, size_t* size, size_t* max_num_records) {}
+
+// Buffer completed callack for CUPTI activity records.
+void bufferCompleted(CUcontext ctx, uint32_t stream_id, uint8_t* buffer,
+                     size_t size, size_t valid_size) {}
+
+TEST(DynamicCuptiTest, CreateFromSystemLoader) {
+  iree_hal_cuda_dynamic_symbols_t symbols;
+  iree_status_t status = iree_hal_cuda_dynamic_symbols_initialize(
+      iree_allocator_system(), &symbols);
+  if (!iree_status_is_ok(status)) {
+    iree_status_fprint(stderr, status);
+    iree_status_ignore(status);
+    std::cerr << "Symbols cannot be loaded, skipping test.";
+    GTEST_SKIP();
+  }
+
+  // Device timestamp querying
+  uint64_t timestamp1 = 0;
+  uint64_t timestamp2 = 0;
+  CUPTI_CHECK_ERRORS(symbols.cuptiGetTimestamp(&timestamp1));
+  CUPTI_CHECK_ERRORS(symbols.cuptiGetTimestamp(&timestamp2));
+  IREE_ASSERT_GT(timestamp2, timestamp1);
+  IREE_ASSERT_NE(timestamp1, 0);
+  IREE_ASSERT_NE(timestamp2, 0);
+
+  // Activity API record collection and callbacks
+  CUPTI_CHECK_ERRORS(
+      symbols.cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL));
+  CUPTI_CHECK_ERRORS(
+      symbols.cuptiActivityRegisterCallbacks(bufferRequested, bufferCompleted));
+  CUPTI_CHECK_ERRORS(symbols.cuptiActivityFlushAll(0));
+
+  iree_hal_cuda_dynamic_symbols_deinitialize(&symbols);
+}
+
+}  // namespace
+}  // namespace cuda
+}  // namespace hal
+}  // namespace iree

--- a/iree/hal/cuda/dynamic_symbols.h
+++ b/iree/hal/cuda/dynamic_symbols.h
@@ -21,11 +21,20 @@ extern "C" {
 // the declarations in `cuda.h`.
 typedef struct iree_hal_cuda_dynamic_symbols_t {
   iree_dynamic_library_t* loader_library;
+  iree_dynamic_library_t* cupti_library;
 
 #define CU_PFN_DECL(cudaSymbolName, ...) \
   CUresult (*cudaSymbolName)(__VA_ARGS__);
 #include "iree/hal/cuda/dynamic_symbol_tables.h"  // IWYU pragma: export
 #undef CU_PFN_DECL
+
+#if IREE_ENABLE_CUPTI  // CUPTI is only used for tracing.
+#define CUPTI_PFN_DECL(cuptiSymbolName, ...) \
+  CUptiResult (*cuptiSymbolName)(__VA_ARGS__);
+#include "iree/hal/cuda/dynamic_cupti_tables.h"  // IWYU pragma: export
+#undef CUPTI_PFN_DECL
+#endif  // IREE_ENABLE_CUPTI
+
 } iree_hal_cuda_dynamic_symbols_t;
 
 // Initializes |out_syms| in-place with dynamically loaded CUDA symbols.


### PR DESCRIPTION
Modified from https://github.com/google/iree/pull/8095 after changes in https://github.com/google/iree/pull/8235.

Integration of CUPTI library into IREE for collecting CUDA runtime trace information. Requires a local install of the CUDA toolkit with the CUPTI library addon. 

`dynamic_cupti_tests.cc` tests the CUPTI api on a machine with  CUPTI libraries are successfully loaded. 

All CUPTI library code is guarded and only activated if `IREE_TRACING_FEATURES `and the CUDA backend are enabled. 

Followup changes: 
* CUDA tracing implementation 