### PR TITLE
Move common input conversion before dialect specific conversion.

### DIFF
--- a/iree/compiler/Translation/IREEVM.cpp
+++ b/iree/compiler/Translation/IREEVM.cpp
@@ -125,6 +125,8 @@ void buildIREEVMTransformPassPipeline(
   // and must run before generating bindings.
   // After input processing, there should only be IREE legal types in
   // signatures.
+  buildCommonInputConversionPassPipeline(passManager);
+
   switch (inputOptions.type) {
     case InputDialectOptions::Type::none:
       break;
@@ -139,7 +141,6 @@ void buildIREEVMTransformPassPipeline(
       MHLO::buildMHLOInputConversionPassPipeline(passManager);
       break;
   }
-  buildCommonInputConversionPassPipeline(passManager);
 
   // Now that inputs are legalized, generate wrapper for entry functions.
   if (bindingOptions.native) {


### PR DESCRIPTION
This was a definite bug as dialect-specific conversion expects to be running on internalized IR. This was manifesting with errors related to input legalization in the presence of load/store globals.