### PR TITLE
Adds a flag to iree-translate to disable tosa canonicalizations

### DIFF
--- a/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -17,10 +17,9 @@
 #include "mlir/Transforms/Passes.h"
 
 static llvm::cl::opt<bool> clDisableTosaDecompositions(
-  "iree-disable-tosa-decompositions",
-  llvm::cl::desc(
-      "Disables tosa canonicalizations used for optimization."),
-  llvm::cl::init(false));
+    "iree-disable-tosa-decompositions",
+    llvm::cl::desc("Disables tosa canonicalizations used for optimization."),
+    llvm::cl::init(false));
 
 namespace mlir {
 namespace iree_compiler {

--- a/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -16,6 +16,12 @@
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
 
+static llvm::cl::opt<bool> clDisableTosaDecompositions(
+  "iree-disable-tosa-decompositions",
+  llvm::cl::desc(
+      "Disables tosa canonicalizations used for optimization."),
+  llvm::cl::init(false));
+
 namespace mlir {
 namespace iree_compiler {
 
@@ -44,7 +50,7 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<FuncOp>(tosa::createTosaToStandard());
   passManager.addNestedPass<FuncOp>(mlir::createCanonicalizerPass());
 
-  tosa::addTosaToLinalgPasses(passManager);
+  tosa::addTosaToLinalgPasses(passManager, clDisableTosaDecompositions);
   passManager.addNestedPass<FuncOp>(tosa::createTosaToStandard());
 
   passManager.addNestedPass<FuncOp>(IREE::Flow::createStripSignednessPass());


### PR DESCRIPTION
The flag is passed through to LLVM in https://reviews.llvm.org/D120350