### PR TITLE
Support regex for filtering drivers when benchmarking

### DIFF
--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -84,16 +84,16 @@ def compose_info_object(device_info: AndroidDeviceInfo,
 
 
 def filter_benchmarks_for_category(benchmark_category_dir: str,
-                                   cpu_target_arch: str,
-                                   gpu_target_arch: str,
+                                   cpu_target_arch_filter: str,
+                                   gpu_target_arch_filter: str,
                                    driver_filter: Optional[str],
                                    verbose: bool = False) -> Sequence[str]:
   """Filters benchmarks in a specific category for the given device.
   Args:
     benchmark_category_dir: the directory to a specific benchmark category.
-    cpu_target_arch: CPU target architecture.
-    gpu_target_arch: GPU target architecture.
-    driver_filter: only run benchmarks for the given driver if not None.
+    cpu_target_arch_filter: CPU target architecture filter regex.
+    gpu_target_arch_filter: GPU target architecture filter regex.
+    driver_filter: driver filter regex.
     verbose: whether to print additional debug info.
   Returns:
     A list containing all matched benchmark cases' directories.
@@ -119,9 +119,9 @@ def filter_benchmarks_for_category(benchmark_category_dir: str,
     # We can choose this benchmark if it matches the driver and CPU/GPU
     # architecture.
     matched_driver = (driver_filter is None or
-                      iree_driver == driver_filter.lower())
-    matched_arch = (target_arch == cpu_target_arch or
-                    target_arch == gpu_target_arch)
+                      re.match(driver_filter, iree_driver) is not None)
+    matched_arch = (re.match(cpu_target_arch_filter, target_arch) is not None or
+                    re.match(gpu_target_arch_filter, target_arch) is not None)
     should_choose = matched_driver and matched_arch
     if should_choose:
       matched_benchmarks.append(root)

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -437,8 +437,8 @@ def filter_and_run_benchmarks(
     benchmark_category_dir = os.path.join(root_benchmark_dir, directory)
     matched_benchmarks = filter_benchmarks_for_category(
         benchmark_category_dir=benchmark_category_dir,
-        cpu_target_arch=cpu_target_arch,
-        gpu_target_arch=gpu_target_arch,
+        cpu_target_arch_filter=cpu_target_arch,
+        gpu_target_arch_filter=gpu_target_arch,
         driver_filter=driver_filter,
         verbose=verbose)
     run_results, run_errors = run_benchmarks_for_category(
@@ -525,10 +525,11 @@ def parse_arguments():
                       default=None,
                       help="Path to the tool for collecting captured traces")
   parser.add_argument(
-      "--driver",
+      "--driver-filter-regex",
+      "--driver_filter_regex",
       type=str,
       default=None,
-      help="Only run benchmarks for a specific driver, e.g., 'vulkan'")
+      help="Only run benchmarks matching the given driver regex")
   parser.add_argument("--output",
                       "-o",
                       default=None,
@@ -655,7 +656,7 @@ def main(args):
   benchmarks, captures, errors = filter_and_run_benchmarks(
       device_info=device_info,
       root_build_dir=args.build_dir,
-      driver_filter=args.driver,
+      driver_filter=args.driver_filter_regex,
       tmp_dir=args.tmp_dir,
       normal_benchmark_tool_dir=os.path.realpath(
           args.normal_benchmark_tool_dir),


### PR DESCRIPTION
This prepares landing https://github.com/google/iree/pull/8018,
which would require us to turn off GPU benchmarking on Pixel 4.

It depends on https://github.com/google/iree/pull/8475;
only need to review the second commit. 