### PR TITLE
Replace llvm_unreachable by assert(false) or pass failures

### DIFF
--- a/integrations/tensorflow/iree-dialects/lib/Dialect/PyDM/IR/PyDMDialect.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/PyDM/IR/PyDMDialect.cpp
@@ -64,7 +64,8 @@ Operation *IREEPyDMDialect::materializeConstant(OpBuilder &builder,
     return builder.create<PYDM::SuccessOp>(loc, type);
   }
 
-  llvm_unreachable("unhandled iree_pydm constant materialization");
+  assert(false && "unhandled iree_pydm constant materialization");
+  return nullptr;
 }
 
 //------------------------------------------------------------------------------
@@ -145,7 +146,8 @@ Optional<int> PYDM::IntegerType::getNumericSubTypeCode() const {
       stc = IntegerSubTypeCode::Integer64;
       break;
     default: {
-      llvm_unreachable("unsupported numeric bitwidth");
+      stc = IntegerSubTypeCode::Integer8;  // Arbitrarily picked value.
+      assert(false && "unsupported numeric bitwidth");
     }
   }
   return static_cast<int>(stc);
@@ -195,7 +197,7 @@ Type PYDM::ListType::getElementStorageType() const {
              "unboxed list should have uniform element type");
       return getUniformElementType();
     default:
-      llvm_unreachable("unsupported storage class");
+      assert(false && "unsupported storage class");
       return {};
   }
 }
@@ -251,7 +253,7 @@ Optional<int> PYDM::RealType::getNumericSubTypeCode() const {
           .Case([](Float32Type t) { return RealSubTypeCode::FP32; })
           .Case([](Float64Type t) { return RealSubTypeCode::FP64; })
           .Default([](Type t) {
-            llvm_unreachable("unsupported float type");
+            assert(false && "unsupported float type");
             return RealSubTypeCode::FP64;
           });
   return static_cast<int>(stc);

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/PyDM/Transforms/ToIREE/LoweringPatterns.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/PyDM/Transforms/ToIREE/LoweringPatterns.cpp
@@ -1008,7 +1008,8 @@ class SequenceCloneBuiltinConversion
       return tupleType.getElementStorageType();
     }
 
-    llvm_unreachable("unsupported list type");
+    assert(false && "unsupported list type");
+    return Type();
   }
 };
 

--- a/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/SavedModelToIreeABI.cpp
@@ -131,7 +131,8 @@ struct StructureLevel {
       return IREE::Input::ListType::get(variantType.getContext(), variantType);
     }
 
-    llvm_unreachable("Unknown LevelType");
+    assert(false && "Unknown LevelType");
+    return Type();
   }
 
   // For List/Dict/Tuple levels, returns the size of the list that is needed
@@ -147,7 +148,8 @@ struct StructureLevel {
       return children.size();
     }
 
-    llvm_unreachable("Unsupported LevelType for getNeededListSize");
+    assert(false && "Unsupported LevelType for getNeededListSize");
+    return 0;
   }
 
   // Creates a JSON reflection type record describing this entity.
@@ -190,7 +192,7 @@ struct StructureLevel {
         return json::Value(std::move(typeRecord));
       }
       default:
-        llvm_unreachable("Unsupported LevelType");
+        assert(false && "Unsupported LevelType");
     }
 
     return json::Value(nullptr);
@@ -233,7 +235,7 @@ struct StructureLevel {
       }
       return;
     }
-    llvm_unreachable("unhandled StructureLevel type");
+    assert(false && "unhandled StructureLevel type");
   }
 
   // Emits operations to recursively create this structure from the given
@@ -287,7 +289,8 @@ struct StructureLevel {
       }
       return listValue;
     }
-    llvm_unreachable("unhandled StructureLevel type");
+    assert(false && "unhandled StructureLevel type");
+    return Value();
   }
 
   // Emits operations to load this instance from a parent list value at the

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
@@ -210,7 +210,7 @@ int main(int argc, char **argv) {
                                   savedModelTags);
       break;
     default:
-      llvm_unreachable("unsupported import type enum");
+      assert(false && "unsupported import type enum");
   }
   if (!module) return 1;
 

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -228,7 +228,7 @@ int main(int argc, char **argv) {
       break;
     }
     default:
-      llvm_unreachable("illegal XlaFormat");
+      assert(false && "illegal XlaFormat");
   }
 
   // Find the entry function and annotate it as exported.

--- a/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
+++ b/iree/compiler/Codegen/Common/RemoveTrivialLoops.cpp
@@ -31,7 +31,7 @@ static unsigned dimToIndex(gpu::Dimension dim) {
     case gpu::Dimension::z:
       return 2;
     default:
-      llvm_unreachable("invalid dimension");
+      assert(false && "invalid dimension");
       return 0;
   }
 }

--- a/iree/compiler/Codegen/Interfaces/ProcessorOpInterfaces.cpp
+++ b/iree/compiler/Codegen/Interfaces/ProcessorOpInterfaces.cpp
@@ -23,10 +23,9 @@ static unsigned dimToIndex(gpu::Dimension dim) {
       return 1;
     case gpu::Dimension::z:
       return 2;
-    default:
-      llvm_unreachable("invalid dimension");
-      return 0;
   }
+  assert(false && "invalid dimension");
+  return 0;
 }
 
 struct ThreadIdOpInterface

--- a/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -190,7 +190,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addTileFuseAndVectorizePassPipeline(nestedModulePM, lowerToVectors);
             break;
           default:
-            llvm_unreachable("Unsupported pipeline on CPU target.");
+            variantOp.emitOpError("Unsupported pipeline on CPU target.");
+            return signalPassFailure();
         }
       }
     }

--- a/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -155,7 +155,8 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
         addGPUMatmulTensorCorePassPipeline(nestedModulePM);
         break;
       default:
-        llvm_unreachable("Unsupported pipeline on GPU target.");
+        variantOp.emitOpError("Unsupported pipeline on GPU target.");
+        return signalPassFailure();
     }
   }
 

--- a/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -111,7 +111,8 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
         addSPIRVTileAndVectorizeToCooperativeOpsPassPipeline(nestedModulePM);
         break;
       default:
-        llvm_unreachable("Unsupported pipeline on GPU target.");
+        variantOp.emitOpError("Unsupported pipeline on GPU target.");
+        return signalPassFailure();
     }
   }
 

--- a/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
+++ b/iree/compiler/Dialect/Flow/IR/FlowTypes.cpp
@@ -143,7 +143,7 @@ static void printShapedType(DispatchTensorType &type, AsmPrinter &p) {
       p << "writeonly";
       break;
     default:
-      llvm_unreachable("unhandled access");
+      assert(false && "unhandled access");
   }
   p << ":";
   for (int64_t dim : type.getShape()) {
@@ -212,7 +212,7 @@ void FlowDialect::printType(Type type, DialectAsmPrinter &p) const {
   if (auto inputType = type.dyn_cast<DispatchTensorType>()) {
     IREE::Flow::printType(inputType, p);
   } else if (failed(generatedTypePrinter(type, p))) {
-    llvm_unreachable("unknown Flow type");
+    assert(false && "unknown Flow type");
   }
 }
 

--- a/iree/compiler/Dialect/Flow/Transforms/OptimizeNumerics.cpp
+++ b/iree/compiler/Dialect/Flow/Transforms/OptimizeNumerics.cpp
@@ -63,7 +63,8 @@ Value castNumeric(Value origValue, Type toType, bool isSigned,
     // If we need int<->int and float<->float, implement those cases. Since
     // this is just needed for things in this file, it is ok to leave it
     // under implemented.
-    llvm_unreachable("unsupported numeric cast");
+    assert(false && "unsupported numeric cast");
+    return Value();
   }
 }
 

--- a/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -859,7 +859,7 @@ void HALDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
       })
       .Default([&](Attribute) {
         if (failed(generatedAttributePrinter(attr, p))) {
-          llvm_unreachable("unhandled HAL attribute kind");
+          assert(false && "unhandled HAL attribute kind");
         }
       });
 }
@@ -920,7 +920,7 @@ void HALDialect::printType(Type type, DialectAsmPrinter &p) const {
   } else if (type.isa<SemaphoreType>()) {
     p << "semaphore";
   } else {
-    llvm_unreachable("unknown HAL type");
+    assert(false && "unknown HAL type");
   }
 }
 

--- a/iree/compiler/Dialect/HAL/Target/MetalSPIRV/SPIRVToMSL.cpp
+++ b/iree/compiler/Dialect/HAL/Target/MetalSPIRV/SPIRVToMSL.cpp
@@ -76,7 +76,7 @@ class SPIRVToMSLCompiler : public SPIRV_CROSS_NAMESPACE::CompilerMSL {
             return;
           }
           // TODO(antiagainst): push constant
-          llvm_unreachable("unspported storage class in SPIRVToMSLCompiler");
+          assert(false && "unspported storage class in SPIRVToMSLCompiler");
         });
 
     llvm::sort(descriptors);
@@ -111,8 +111,8 @@ llvm::Optional<MetalShader> crossCompileSPIRVToMSL(
   auto descriptors = spvCrossCompiler.getBufferSetBindingPairs();
   for (const auto& descriptor : descriptors) {
     if (descriptor.set != 0) {
-      llvm_unreachable(
-          "multiple descriptor set unimplemented in SPIRVToMSLCompiler");
+      assert(false &&
+             "multiple descriptor set unimplemented in SPIRVToMSLCompiler");
     }
 
     SPIRV_CROSS_NAMESPACE::MSLResourceBinding binding = {};

--- a/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -203,7 +203,7 @@ class TargetBackend {
   // binary format (such as to the IREE VM) will fail.
   virtual LogicalResult serializeExecutable(
       IREE::HAL::ExecutableVariantOp variantOp, OpBuilder &executableBuilder) {
-    llvm_unreachable("unimplemented serializeExecutable");
+    assert(false && "unimplemented serializeExecutable");
     return failure();
   }
 

--- a/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
+++ b/iree/compiler/Dialect/Stream/Conversion/PatternUtils.cpp
@@ -37,9 +37,10 @@ ConvertedTensor consumeTensorOperand(Location loc, Value operand,
         castOp.getOperand(1),
     };
   }
-  llvm_unreachable(
-      "unexpected operand; should have either been converted from tensor or "
-      "not");
+  assert(false &&
+         "unexpected operand; expected either a IREE::Stream::ResourceType or "
+         "the result of a mlir::UnrealizedConversionCastOp");
+  return ConvertedTensor();
 }
 
 }  // namespace iree_compiler

--- a/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -115,7 +115,7 @@ static void setInsertionPointToParentExecutionScope(Operation *op,
   } else if (auto parentOp = op->getParentOfType<CmdExecuteOp>()) {
     rewriter.setInsertionPoint(parentOp);
   } else {
-    llvm_unreachable("must be nested within an execution region");
+    assert(false && "must be nested within an execution region");
   }
 }
 

--- a/iree/compiler/Dialect/Stream/Transforms/OutlineConstants.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/OutlineConstants.cpp
@@ -112,7 +112,7 @@ class OutlineConstantsPass : public OutlineConstantsBase<OutlineConstantsPass> {
         // Directly replace constant with global constant value.
         replacement = loadOp.result();
       } else {
-        llvm_unreachable("unhandled constant op type");
+        assert(false && "unhandled constant op type");
       }
 
       originalOp->getResult(0).replaceAllUsesWith(replacement);

--- a/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
@@ -57,7 +57,7 @@ struct ConstantSlice {
       return opaqueAttr.getNumElements() *
              opaqueAttr.getElementType().getIntOrFloatBitWidth();
     } else {
-      llvm_unreachable("invalid constant attr type");
+      assert(false && "invalid constant attr type");
       return 0;
     }
   }

--- a/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
+++ b/iree/compiler/Dialect/Stream/Transforms/VerifyLowerings.cpp
@@ -88,7 +88,7 @@ class Verifier {
     auto wrapperFn = [=](Type baseType) { return fn(baseType.cast<TypeT>()); };
     if (typeVerifiers.insert({TypeID::get<TypeT>(), wrapperFn}).second ==
         false) {
-      llvm_unreachable("already registered for this type");
+      assert(false && "already registered for this type");
     }
   }
 

--- a/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
+++ b/iree/compiler/Dialect/Util/IR/UtilAttrs.cpp
@@ -170,7 +170,7 @@ static LogicalResult serializeSplatValue(Attribute splatAttr, int64_t count,
       return failure();
     }
   } else {
-    llvm_unreachable("unhandled serializable splat value");
+    assert(false && "unhandled serializable splat value");
     return failure();
   }
 

--- a/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
+++ b/iree/compiler/Dialect/Util/IR/UtilTypes.cpp
@@ -627,7 +627,7 @@ void UtilDialect::printType(Type type, DialectAsmPrinter &os) const {
     }
     os << ">";
   } else {
-    llvm_unreachable("unhandled IREE type");
+    assert(false && "unhandled IREE type");
   }
 }
 

--- a/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
+++ b/iree/compiler/Dialect/VM/Analysis/ValueLiveness.cpp
@@ -325,7 +325,7 @@ bool ValueLiveness::isLastValueUse(Value value, Operation *useOp,
       return operandIndex >= operand.getOperandNumber();
     }
   }
-  llvm_unreachable("value not used by operand");
+  assert(false && "value not used by operand");
   return false;
 }
 

--- a/iree/compiler/Dialect/VM/Conversion/MathToVM/ConvertMathToVM.cpp
+++ b/iree/compiler/Dialect/VM/Conversion/MathToVM/ConvertMathToVM.cpp
@@ -45,7 +45,7 @@ class UnaryArithmeticOpConversion : public OpConversionPattern<SrcOpTy> {
             srcOp, adaptor.getOperand().getType(), adaptor.getOperand());
         break;
       default:
-        llvm_unreachable("invalid target type");
+        assert(false && "invalid target type");
     }
     return success();
   }
@@ -74,7 +74,7 @@ class BinaryArithmeticOpConversion : public OpConversionPattern<SrcOpTy> {
             adaptor.getRhs());
         break;
       default:
-        llvm_unreachable("invalid target type");
+        assert(false && "invalid target type");
     }
     return success();
   }

--- a/iree/compiler/Dialect/VM/IR/VMDialect.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMDialect.cpp
@@ -189,7 +189,7 @@ void VMDialect::printAttribute(Attribute attr, DialectAsmPrinter &p) const {
         typedAttr.print(p);
       })
       .Default(
-          [](Attribute) { llvm_unreachable("unhandled VM attribute kind"); });
+          [](Attribute) { assert(false && "unhandled VM attribute kind"); });
 }
 
 //===----------------------------------------------------------------------===//
@@ -273,7 +273,7 @@ void VMDialect::printType(Type type, DialectAsmPrinter &os) const {
     }
     os << ">";
   } else {
-    llvm_unreachable("unhandled VM type");
+    assert(false && "unhandled VM type");
   }
 }
 

--- a/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -584,7 +584,7 @@ static Attribute convertConstIntegerValue(Attribute value) {
           adjustedType, llvm::to_vector<4>(v.getValues<Attribute>()));
     }
   }
-  llvm_unreachable("unexpected attribute type");
+  assert(false && "unexpected attribute type");
   return Attribute();
 }
 
@@ -597,7 +597,7 @@ static FloatType getFloatType(int bitwidth, MLIRContext *context) {
     case 64:
       return FloatType::getF64(context);
     default:
-      llvm_unreachable("unhandled floating point type");
+      assert(false && "unhandled floating point type");
       return {};
   }
 }
@@ -621,7 +621,7 @@ static Attribute convertConstFloatValue(Attribute value) {
           adjustedType, llvm::to_vector<4>(v.getValues<Attribute>()));
     }
   }
-  llvm_unreachable("unexpected attribute type");
+  assert(false && "unexpected attribute type");
   return Attribute();
 }
 

--- a/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -851,7 +851,7 @@ LogicalResult translateModuleToBytecode(IREE::VM::ModuleOp moduleOp,
       break;
     }
     default:
-      llvm_unreachable("unimplemented output format");
+      assert(false && "unimplemented output format");
   }
   output.flush();
 

--- a/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
+++ b/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
@@ -529,7 +529,7 @@ bool CppEmitter::shouldMapToUnsigned(IntegerType::SignednessSemantics val) {
   case IntegerType::Unsigned:
     return true;
   default:
-    llvm_unreachable("unsupported IntegerType");
+    assert(false && "unsupported IntegerType");
   }
 }
 

--- a/iree/compiler/Dialect/Vulkan/IR/VulkanDialect.cpp
+++ b/iree/compiler/Dialect/Vulkan/IR/VulkanDialect.cpp
@@ -207,7 +207,7 @@ void VulkanDialect::printAttribute(Attribute attr,
   if (auto targetEnv = attr.dyn_cast<TargetEnvAttr>())
     print(targetEnv, printer);
   else
-    llvm_unreachable("unhandled Vulkan attribute kind");
+    assert(false && "unhandled Vulkan attribute kind");
 }
 
 }  // namespace Vulkan

--- a/iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.cpp
+++ b/iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.cpp
@@ -37,7 +37,8 @@ spirv::Version convertVersion(Vulkan::TargetEnvAttr vkTargetEnv) {
     default:
       break;
   }
-  llvm_unreachable("unhandled Vulkan version!");
+  assert(false && "unhandled Vulkan version!");
+  return spirv::Version::V_1_0;
 }
 
 /// Gets the corresponding SPIR-V extensions for the given Vulkan target

--- a/iree/compiler/Dialect/Vulkan/Utils/TargetTriple.cpp
+++ b/iree/compiler/Dialect/Vulkan/Utils/TargetTriple.cpp
@@ -49,7 +49,7 @@ spirv::Vendor getVendor(const TargetTriple &triple) {
           return spirv::Vendor::Unknown;
       }
     default:
-      llvm_unreachable("unhandled vendor");
+      assert(false && "unhandled vendor");
       return spirv::Vendor::Unknown;
   }
 }
@@ -70,7 +70,7 @@ spirv::DeviceType getDeviceType(const TargetTriple &triple) {
     case TargetTripleArch::QC_Adreno:
       return spirv::DeviceType::IntegratedGPU;
     default:
-      llvm_unreachable("unhandled device type");
+      assert(false && "unhandled device type");
       return spirv::DeviceType::Unknown;
   }
 }

--- a/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
+++ b/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
@@ -36,7 +36,8 @@ Type convertComplexTensorTypeToReal(Type complexTensorType) {
   } else if (auto tt = complexTensorType.dyn_cast<UnrankedTensorType>()) {
     return UnrankedTensorType::get(newElementType);
   }
-  llvm_unreachable("unknown TensorType subclass");
+  assert(false && "unknown TensorType subclass");
+  return Type();
 }
 
 // Add and subtraction are elementwise and can be distributed across the real

--- a/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -166,7 +166,8 @@ Value createLinalgMatmulOnTensors(OpBuilder b, Location loc,
                                     ValueRange{zeroTensor})
           .getResult(0);
     default:
-      llvm_unreachable("unhandled matmul type");
+      assert(false && "unhandled matmul type");
+      return Value();
   }
 }
 

--- a/iree/samples/custom_modules/dialect/custom_dialect.cc
+++ b/iree/samples/custom_modules/dialect/custom_dialect.cc
@@ -91,7 +91,7 @@ void CustomDialect::printType(Type type, DialectAsmPrinter &p) const {
   if (type.isa<MessageType>()) {
     p << "message";
   } else {
-    llvm_unreachable("unknown type");
+    assert(false && "unknown type");
   }
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/PyDM/IR/PyDMDialect.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/PyDM/IR/PyDMDialect.cpp
@@ -64,7 +64,8 @@ Operation *IREEPyDMDialect::materializeConstant(OpBuilder &builder,
     return builder.create<PYDM::SuccessOp>(loc, type);
   }
 
-  llvm_unreachable("unhandled iree_pydm constant materialization");
+  assert(false && "unhandled iree_pydm constant materialization");
+  return nullptr;
 }
 
 //------------------------------------------------------------------------------
@@ -145,7 +146,8 @@ Optional<int> PYDM::IntegerType::getNumericSubTypeCode() const {
       stc = IntegerSubTypeCode::Integer64;
       break;
     default: {
-      llvm_unreachable("unsupported numeric bitwidth");
+      stc = IntegerSubTypeCode::Integer8;  // Arbitrarily picked value.
+      assert(false && "unsupported numeric bitwidth");
     }
   }
   return static_cast<int>(stc);
@@ -195,7 +197,7 @@ Type PYDM::ListType::getElementStorageType() const {
              "unboxed list should have uniform element type");
       return getUniformElementType();
     default:
-      llvm_unreachable("unsupported storage class");
+      assert(false && "unsupported storage class");
       return {};
   }
 }
@@ -251,7 +253,7 @@ Optional<int> PYDM::RealType::getNumericSubTypeCode() const {
           .Case([](Float32Type t) { return RealSubTypeCode::FP32; })
           .Case([](Float64Type t) { return RealSubTypeCode::FP64; })
           .Default([](Type t) {
-            llvm_unreachable("unsupported float type");
+            assert(false && "unsupported float type");
             return RealSubTypeCode::FP64;
           });
   return static_cast<int>(stc);

--- a/llvm-external-projects/iree-dialects/lib/Dialect/PyDM/Transforms/ToIREE/LoweringPatterns.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/PyDM/Transforms/ToIREE/LoweringPatterns.cpp
@@ -1008,7 +1008,8 @@ class SequenceCloneBuiltinConversion
       return tupleType.getElementStorageType();
     }
 
-    llvm_unreachable("unsupported list type");
+    assert(false && "unsupported list type");
+    return Type();
   }
 };
 


### PR DESCRIPTION
All of the uses were in iree/compiler or other compiler directories, so
none of them was plausibly sufficiently performance-critical to justify
the risk of having the control flow potentially reach a
llvm_unreachable.

Past discussions on this topic:
https://discord.com/channels/689900678990135345/690605510243778641/938257593590251540
https://github.com/google/iree/pull/8192#pullrequestreview-869779071
https://discourse.llvm.org/t/llvm-unreachable-is-widely-misused/60587/2

This is intentionally 2 separate commits. The first, main commit is the automated change. It's generated by:
```
git grep -lF 'llvm_unreachable(' | xargs sed -i 's/llvm_unreachable(/assert(false \&\& /g'
```

The [second commit](https://github.com/google/iree/pull/8521/commits/94bbefcabe122de8125343e61991f18181137651) is the manual fixups.  Most of them are places where there used to be a `llvm_unreachable` at the end of a non-void function, and no `return` statement, and now that it's an `assert`, a `return` statement is required.  This is actually a great example of the dangerousness of `llvm_unreachable`. That it allowed one to omit the `return` statement was not an abstract, compiler-frontend-only kind of C++ detail. It was literally resulting in omitted `ret` instructions in the generated binaries. If we ever hit such statements (and looking at the occurrences, it seems inevitable that we would), the program would literally run instructions past the function's end.

The [only other thing](https://github.com/google/iree/pull/8521/commits/94bbefcabe122de8125343e61991f18181137651#diff-ff6464cf78136e8048bcdd853a3efd9260b2b7187e172dc27c362b34703fdf3b) in those manual fixups was one instance where a variable was left uninitialized in an error case, and again the `llvm_unreachable` silenced that, and now that it's an `assert` we have to take care of that.

EDIT: [another commit](https://github.com/google/iree/pull/8521/commits/7a9de501cc6d984030cdb6febff7e1b9bf84d861) adding more manual fixes.

Another dangerous pattern that we had, was `llvm_unreachable` in `default:` case of `switch` statements. That causes the compiler to drop bounds checks guarding the jump-table implemening the `switch`, potentially jumping to an arbitrary destination.