### PR TITLE
Add a case using tensorcore in matmul test

### DIFF
--- a/iree/test/e2e/matmul/BUILD
+++ b/iree/test/e2e/matmul/BUILD
@@ -139,6 +139,34 @@ py_binary(
     "LLVMGPUMatmulSimt",
 ]]
 
+# Testing Ampere+ tensorcore path.
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f32_gpu_large_%s" % compilation_info,
+    compiler_flags = [
+        "--iree-cuda-llvm-target-arch=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f32",
+        "--shapes=gpu_large",
+        "--compilation_info=%s" % compilation_info,
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    trace_runner = "//iree/tools:iree-e2e-matmul-test",
+) for compilation_info in [
+    "LLVMGPUMatmulTensorCore",
+]]
+
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_%s_large_split_k" % lhs_rhs_type,
     compiler_flags = [

--- a/iree/test/e2e/matmul/CMakeLists.txt
+++ b/iree/test/e2e/matmul/CMakeLists.txt
@@ -199,6 +199,31 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulTensorCore
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUMatmulTensorCore"
+  TRACE_RUNNER
+    iree_tools_iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-cuda-llvm-target-arch=sm_80"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_direct_f32_large_split_k
   GENERATOR
     "generate_e2e_matmul_tests.py"


### PR DESCRIPTION
Now that we have Ampere buildbots we can test this path.