### PR TITLE
Split peeling from TileOp transform

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -99,23 +99,24 @@ def MatchOp : Transform_Op<"match"> {
 //===----------------------------------------------------------------------===//
 
 def TileOp : Linalg_Transform_Operation<"tile",
-    [TransformOpInterface, TargetableSingleOperandTransformOpTrait]> {
+    [TransformOpInterface]> {
   let description = [{Indicates that ops of a specific kind in the given
   function should be tiled with the options provided as attributes.}];
 
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$interchange,
-                   DefaultValuedAttr<I64ArrayAttr, "{}">:$peel,
                    DefaultValuedAttr<BoolAttr, "false">:$scalarize_dyn_dims);
-  let results = (outs PDL_Operation:$transformed);
+  let results = (outs PDL_Operation:$tiled_linalg_op,
+                      Variadic<PDL_Operation>:$loops);
 
-  let assemblyFormat = "$target attr-dict";
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::linalg::LinalgOp> applyToOne(
-        ::mlir::linalg::LinalgOp target);
+    ::mlir::LogicalResult apply(
+        ::mlir::linalg::transform::TransformResults &transformResults,
+        ::mlir::linalg::transform::TransformState &state);
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/python/iree/compiler/dialects/_iree_linalg_transform_ops_ext.py
+++ b/llvm-external-projects/iree-dialects/python/iree/compiler/dialects/_iree_linalg_transform_ops_ext.py
@@ -177,24 +177,35 @@ class TileOp:
                *,
                sizes: IntListArg = None,
                interchange: IntListArg = None,
-               peel: IntListArg = None,
                scalarize_dyn_dims: BoolArg = None,
                loc=None,
                ip=None):
     sizes = _ensure_int_array_attr(sizes, [])
     interchange = _ensure_int_array_attr(interchange, [])
-    peel = _ensure_int_array_attr(peel, [])
     scalarize_dyn_dims = _ensure_bool_attr(scalarize_dyn_dims, False)
     operation_type = pdl.OperationType.get()
-
-    super().__init__(operation_type,
+    tile_size_zero = _ensure_int_attr(0)
+    # Number of loops = number of tile sizes != 0
+    num_loops = sum(1 for _ in filter(lambda i: i != tile_size_zero, sizes))
+    super().__init__(operation_type, [operation_type] * num_loops,
                      target,
                      sizes,
                      interchange,
-                     peel,
                      scalarize_dyn_dims,
                      loc=loc,
                      ip=ip)
+
+
+class PeelLoopOp:
+  """Specialization for the PeelLoopOp class."""
+
+  def __init__(self,
+               target: Union[ir.Value, ir.Operation, ir.OpView],
+               *,
+               loc=None,
+               ip=None):
+    operation_type = pdl.OperationType.get()
+    super().__init__(operation_type, target, loc=loc, ip=ip)
 
 
 class PadOp:

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/double-tiling.mlir
@@ -37,8 +37,8 @@ pdl.pattern @pdl_target: benefit(1) {
 }
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
-  %1 = tile %0 {interchange = [0, 2, 1], peel = [], scalarize_dyn_dims = false, sizes = [32, 32, 32]}
-  %2 = tile %1 {interchange = [0, 1, 2], peel = [], scalarize_dyn_dims = false, sizes = [4, 4, 1]}
+  %1, %loops1:3 = tile %0 {interchange = [0, 2, 1], scalarize_dyn_dims = false, sizes = [32, 32, 32]}
+  %2, %loops2:3 = tile %1 {interchange = [0, 1, 2], scalarize_dyn_dims = false, sizes = [4, 4, 1]}
   %3 = pad %2 {padding_values=["0.0", "0.0", "0.0"], pack_paddings = [1, 1, 1], hoist_paddings = [6, 6, 0], transpose_paddings = [[1, 0], [0, 1]]}
   %4 = vectorize %3  {vectorize_padding = true}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/expert.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/expert.mlir
@@ -28,7 +28,7 @@ iree_linalg_transform.sequence {
   // This should match the strategy below.
   // EXPAND-NOT: expert apply
   // EXPAND: %[[OP:.*]] = match @pdl_target
-  // EXPAND: %[[HANDLE:.*]] = tile %[[OP]] {sizes = [4, 4, 4]}
+  // EXPAND: %[[HANDLE:.*]], %{{.*}}:3 = tile %[[OP]] {sizes = [4, 4, 4]}
   // EXPAND: %[[HANDLE2:.*]] = vectorize %[[HANDLE]] {vectorize_padding = true}
   // EXPAND: bufferize
   // EXPAND: lower_vectors {multireduction_lowering = "innerreduce"}
@@ -63,7 +63,7 @@ module @strategies {
     rewrite %root {
       %tile = operation "iree_linalg_transform.tile"(%target : !pdl.value) {
         "sizes" = %tile_sizes
-      } -> (%transformed : !pdl.type)
+      } -> (%transformed, %transformed, %transformed, %transformed : !pdl.type, !pdl.type, !pdl.type, !pdl.type)
       %handle = result 0 of %tile
 
       %vectorize = operation "iree_linalg_transform.vectorize"(%handle : !pdl.value) {
@@ -111,14 +111,14 @@ iree_linalg_transform.sequence {
   // This should match the strategy below.
   // EXPAND-NOT: expert apply
   // EXPAND: %[[OP:.*]] = match @pdl_target2
-  // EXPAND: %[[HANDLE:.*]] = tile %[[OP]] {sizes = [32, 8, 8]}
-  // EXPAND: %[[HANDLE2:.*]] = tile %[[HANDLE]] {sizes = [4, 4, 4]}
+  // EXPAND: %[[HANDLE:.*]], %{{.*}}:3 = tile %[[OP]] {sizes = [32, 8, 8]}
+  // EXPAND: %[[HANDLE2:.*]], %{{.*}}:3 = tile %[[HANDLE]] {sizes = [4, 4, 4]}
   // EXPAND: %[[HANDLE3:.*]] = vectorize %[[HANDLE2]] {vectorize_padding = false}
   // EXPAND: bufferize
   // EXPAND: lower_vectors {multireduction_lowering = "innerparallel"}
   // EXPAND: lower_to_llvm
   %0 = match @pdl_target2
-  %1 = tile %0 {sizes = [32, 8, 8]}
+  %1, %loops:3 = tile %0 {sizes = [32, 8, 8]}
   expert apply "single_tiling" to %1
   {
     tile_sizes = [4, 4, 4],
@@ -146,7 +146,7 @@ module @strategies {
     rewrite %root {
       %tile = operation "iree_linalg_transform.tile"(%target : !pdl.value)  {
         "sizes" = %tile_sizes
-      } -> (%transformed : !pdl.type)
+      } -> (%transformed, %transformed, %transformed, %transformed : !pdl.type, !pdl.type, !pdl.type, !pdl.type)
       %handle = result 0 of %tile
 
       %vectorize = operation "iree_linalg_transform.vectorize"(%handle : !pdl.value) {

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
@@ -128,7 +128,7 @@ iree_linalg_transform.sequence {
   %0 = match @pdl_target
   // expected-error @below {{failed to apply}}
   vectorize
-  tile %0
+  tile %0 {sizes = [32, 32, 32]}
 }
 
 // -----
@@ -174,6 +174,6 @@ iree_linalg_transform.sequence {
   %1 = match @pdl_target2
 
   // Add references to handles produced by match so that they are not DCE'd.
-  tile %0
-  tile %1
+  tile %0 {sizes = [32, 32, 32]}
+  tile %1 {sizes = [32, 32, 32]}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/invalid.mlir
@@ -2,10 +2,18 @@
 
 iree_linalg_transform.sequence {
   %0 = match @match
+  // expected-error@below {{expected `sizes` attribute}}
+  tile %0
+}
+
+// -----
+
+iree_linalg_transform.sequence {
+  %0 = match @match
   // expected-error@below {{result #0 has more than one use}}
-  %1 = tile %0
+  %1, %loops:3 = tile %0 {sizes = [32, 32, 32]}
   // expected-note@below {{used here as operand #0}}
-  tile %1
+  tile %1 {sizes = [32, 32, 32]}
   // expected-note@below {{used here as operand #0}}
   vectorize %1
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
@@ -4,12 +4,12 @@
 iree_linalg_transform.sequence {
   // CHECK: %[[OPS:.*]] = match @{{.*}}
   %0 = match @match1
-  // CHECK: %[[TILED:.*]] = tile %[[OPS]] {
+  // CHECK: %[[TILED:.*]], %{{.*}}:3 = tile %[[OPS]] {
   // CHECK-DAG: sizes = [4, 4, 4]
   // CHECK: }
-  %1 = tile %0 {sizes = [4, 4, 4]}
-  // CHECK: %[[TILED2:.*]] = tile %[[TILED]]
-  %2 = tile %1 {sizes = [2, 2, 2]}
+  %1, %loops1:3 = tile %0 {sizes = [4, 4, 4]}
+  // CHECK: %[[TILED2:.*]], %{{.*}}:3 = tile %[[TILED]]
+  %2, %loops2:3  = tile %1 {sizes = [2, 2, 2]}
   // CHECK: %[[PADDED:.*]] = pad %[[TILED2]] {pack_paddings = [1, 1, 0]}
   %3 = pad %2 {pack_paddings = [1, 1, 0]}
   // CHECK: decompose

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -26,7 +26,7 @@ pdl.pattern @pdl_target : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
-  %1 = tile %0 {sizes = [4, 4, 4]}
+  %1, %loops:3 = tile %0 {sizes = [4, 4, 4]}
   %2 = vectorize %1 {vectorize_padding = true}
   bufferize
   lower_vectors { multireduction_lowering = "innerreduce"}

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-and-peel.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-and-peel.mlir
@@ -1,0 +1,46 @@
+// RUN: iree-dialects-opt -linalg-interp-transforms %s | FileCheck %s
+
+// CHECK-LABEL: func @matmul_tensors(
+func @matmul_tensors(
+  %arg0: tensor<126x127xf32>, %arg1: tensor<127x128xf32>, %arg2: tensor<126x128xf32> { linalg.inplaceable = true})
+    -> tensor<126x128xf32> {
+  // CHECK-DAG: %[[c124:.*]] = arith.constant 124 : index
+  // CHECK-DAG: %[[c127:.*]] = arith.constant 127 : index
+  // CHECK-DAG: %[[c128:.*]] = arith.constant 128 : index
+
+  // CHECK: scf.for {{.*}} to %[[c124]]
+  // CHECK:   scf.for {{.*}} to %[[c128]]
+  // CHECK:     scf.for {{.*}} to %[[c124]]
+  // CHECK:       linalg.matmul {{.*}} ins({{.*}} : tensor<4x4xf32>, tensor<4x4xf32>) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+  // CHECK:     linalg.matmul {{.*}} ins({{.*}} : tensor<4x3xf32>, tensor<3x4xf32>) outs({{.*}} : tensor<4x4xf32>) -> tensor<4x4xf32>
+  // CHECK: scf.for {{.*}} to %[[c128]]
+  // CHECK:   scf.for {{.*}} to %[[c127]]
+  // CHECK:     linalg.matmul {{.*}} ins({{.*}} : tensor<2x?xf32>, tensor<?x4xf32>) outs({{.*}} : tensor<2x4xf32>) -> tensor<2x4xf32>
+  %0 = linalg.matmul  ins(%arg0, %arg1: tensor<126x127xf32>, tensor<127x128xf32>)
+                     outs(%arg2: tensor<126x128xf32>)
+    -> tensor<126x128xf32>
+
+  return %0 : tensor<126x128xf32>
+}
+
+
+pdl.pattern @pdl_target : benefit(1) {
+  %args = operands
+  %results = types
+  %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+  %1 = pdl.attribute @matmul_tensors
+  apply_native_constraint "nestedInFunc"(%0, %1 : !pdl.operation, !pdl.attribute)
+  // TODO: we don't want this, but it is the required terminator for pdl.pattern
+  rewrite %0 with "iree_linalg_transform.apply"
+}
+
+iree_linalg_transform.sequence {
+  %0 = match @pdl_target
+  %linalg_op, %loops:3 = tile %0 {sizes = [4, 4, 4]}
+
+  // Note: The order in which the loops are peeled is important. If %loop#2 is
+  // peeled first, the partial iteration of %loop#0 will also contain a peeled
+  // version of %loop#2.
+  peel_loop %loops#0
+  peel_loop %loops#2
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-interchange.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile-interchange.mlir
@@ -30,8 +30,8 @@ pdl.pattern @target_pattern : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @target_pattern
-  %1 = tile %0 {interchange = [0, 2, 1], sizes = [3, 5, 14]}
-  %2 = tile %1 {sizes = [3, 5, 2]}
+  %1, %loops1:3 = tile %0 {interchange = [0, 2, 1], sizes = [3, 5, 14]}
+  %2, %loops2:3 = tile %1 {sizes = [3, 5, 2]}
   %3 = vectorize %2 {vectorize_padding = true}
 }
 
@@ -68,7 +68,7 @@ pdl.pattern @target_pattern : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @target_pattern
-  %1 = tile %0 {interchange = [2, 1, 0], sizes = [3, 5, 14]}
-  %2 = tile %1 {sizes = [3, 5, 2]}
+  %1, %loops1:3 = tile %0 {interchange = [2, 1, 0], sizes = [3, 5, 14]}
+  %2, %loops2:3 = tile %1 {sizes = [3, 5, 2]}
   %3 = vectorize %2 {vectorize_padding = true}
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/tile.mlir
@@ -41,6 +41,6 @@ pdl.pattern @pdl_target : benefit(1) {
 
 iree_linalg_transform.sequence {
   %0 = match @pdl_target
-  %1 = tile %0 {sizes = [4, 4, 4]}
+  %1, %loops:3 = tile %0 {sizes = [4, 4, 4]}
   print %1 {name = "Tiled"} 
 }


### PR DESCRIPTION
- peel is no longer an attribute of TileOp.
- TileOp returns the tiled LinalgOp and each loop as results.
- The parser/printer of TileOp are hand-written to avoid having to specify the loop handle results in the type signature. Instead, the number of results is inferred from the size of the sizes ArrayAttr in the parser.
- Add a test case for tiling + peeling.
    
Merged from https://github.com/google/iree-llvm-sandbox/pull/410
    
Author: Matthias Springer <springerm@google.com>