### PR TITLE
[vulkan] Append entry point name to executable creation Tracy zone

### DIFF
--- a/iree/hal/vulkan/native_executable.cc
+++ b/iree/hal/vulkan/native_executable.cc
@@ -286,6 +286,7 @@ iree_status_t iree_hal_vulkan_native_executable_create(
           flatbuffers_string_vec_at(entry_points_vec, i);
       executable->entry_points[i].name =
           iree_make_string_view(name, flatbuffers_string_len(name));
+      IREE_TRACE_ZONE_APPEND_TEXT(z0, name);
     }
   }
 


### PR DESCRIPTION
This helps to discover which dispatch is being compiled by the
driver compiler when debugging long compilation time.