### PR TITLE
Change vector size computation for ops with mixed data lengths

### DIFF
--- a/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -122,9 +122,10 @@ static SmallVector<int64_t> getMinTilingSizesForEachDim(
     // If the indexing map has result it has to be a shaped type.
     auto operandType =
         inputOutputOpOperands[map.index()]->get().getType().cast<ShapedType>();
+    int64_t opVecSize = getVectorSize(entryPointFn, operandType);
+    int64_t currMinSize = minTileSizes[fastestVaryingDim];
     minTileSizes[fastestVaryingDim] =
-        std::max<int64_t>(minTileSizes[fastestVaryingDim],
-                          getVectorSize(entryPointFn, operandType));
+        currMinSize > 1 ? std::min<int64_t>(currMinSize, opVecSize) : opVecSize;
   }
   return minTileSizes;
 }


### PR DESCRIPTION
(#8849) This PR changes the algorithm that computes the vector sizes for
vectorizing operations with mixed data lengths. Instead of computing
the vector sizes based on the smallest element type we now use the
largest element type. This significantly reduces the code sizes and
register pressure/spilling on mixed data lengths scenarios. More fine
tuning is needed to determine the optimal vector size for each
particular code to be vectorized. 