### PR TITLE
Register upstream LinalgTransformOps extensions in IREE

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform.mlir
@@ -22,7 +22,10 @@ hal.executable private @pad_matmul_static_dispatch_0 {
 
         //      CHECK: memref.assume_alignment %{{.*}}, 64 : memref<250x1020xf32>
         // CHECK-NEXT: linalg.fill ins(%{{.*}} : f32) outs(%{{.*}} : memref<250x1020xf32>)
-        // CHECK-NEXT: linalg.matmul{{.*}}ins(%{{.*}} : memref<250x500xf32>, memref<500x1020xf32>) outs(%{{.*}} : memref<250x1020xf32>)
+        // CHECK-NEXT: scf.for
+        //      CHECK:   memref.subview
+        //      CHECK:   memref.subview
+        //      CHECK:   linalg.matmul{{.*}}ins(%{{.*}} : memref<2x500xf32>, memref<500x1020xf32>) outs(%{{.*}} : memref<2x1020xf32>)
         // CHECK-NEXT: return
 
         %6 = linalg.matmul ins(%3, %4 : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%5 : tensor<250x1020xf32>) -> tensor<250x1020xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/linalg_transform_spec.mlir
@@ -13,6 +13,7 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %0 = pdl_match @pdl_matmul_target in %arg1
+    %tiled_linalg_op, %loops:1 = transform.structured.tile %0 {interchange = [], sizes = [2]}
     transform.iree.bufferize
   }
 }

--- a/compiler/src/iree/compiler/Tools/BUILD
+++ b/compiler/src/iree/compiler/Tools/BUILD
@@ -79,6 +79,7 @@ cc_library(
         "@llvm-project//mlir:LinalgPassIncGen",
         "@llvm-project//mlir:LinalgToLLVM",
         "@llvm-project//mlir:LinalgToSPIRV",
+        "@llvm-project//mlir:LinalgTransformOps",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",

--- a/compiler/src/iree/compiler/Tools/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Tools/CMakeLists.txt
@@ -106,6 +106,7 @@ iree_cc_library(
     MLIRLinalgToLLVM
     MLIRLinalgToSPIRV
     MLIRLinalgTransforms
+    MLIRLinalgTransformOps
     MLIRQuant
     MLIRQuantTransforms
     MLIRSCF

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/GPU/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/PDL/IR/PDL.h"
@@ -67,6 +68,9 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   shape::ShapeDialect>();
   // clang-format on
   tensor::registerInferTypeOpInterfaceExternalModels(registry);
+
+  // Register all dialect extensions.
+  linalg::registerTransformDialectExtension(registry);
 
 #ifdef IREE_HAVE_EMITC_DIALECT
   registry.insert<emitc::EmitCDialect>();

--- a/llvm-external-projects/iree-dialects/python/IREEDialectsModule.cpp
+++ b/llvm-external-projects/iree-dialects/python/IREEDialectsModule.cpp
@@ -128,7 +128,6 @@ PYBIND11_MODULE(_ireeDialects, m) {
   //===--------------------------------------------------------------------===//
   auto transform_m = m.def_submodule("transform");
   mlirIREETransformRegisterPasses();
-
   transform_m.def(
       "register_dialect",
       [](MlirContext context, bool load) {


### PR DESCRIPTION
Previously, the upstream transformation dialect was only registered to work with `iree-dialects-opt`.
This was not yet observable within `iree-opt` as the only transformation that is upstream at this point is `transform.structured.tile`.

This revision adds the proper registrations and a test that exercises the transformation.

This is also required to properly invoke `transform.structured.tile` from python.