### PR TITLE
Fuse `tensor.pad` with producers.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -64,11 +64,6 @@ static llvm::cl::opt<bool> clEnablePaddingLinalgOps(
                    "flow-padding-size"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clEnableFusePaddingIntoConsumerOps(
-    "iree-flow-enable-fuse-padding-into-consumer-ops",
-    llvm::cl::desc("Enable fusing linalg pad_tensor ops into consumer ops"),
-    llvm::cl::init(false));
-
 static llvm::cl::opt<int> clLinalgOpsPaddingSize(
     "iree-flow-linalg-ops-padding-size",
     llvm::cl::desc("Enable padding linalg ops to an integer multiple of "
@@ -189,10 +184,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   buildGlobalOptimizationPassPipeline(passManager, transformOptions);
 
   FunctionLikeNest(passManager)
-      // Pad tensors.
-      .addPredicatedPass((!clEnableFusePaddingIntoConsumerOps),
-                         IREE::Flow::createPadTensorToSubTensorInsertPass)
-
       // Preprocess the input to a form more amenable for fusion
       // - Convert all elementwise ops to Linalg
       // - Remove unit-extent dimensions.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -27,6 +27,7 @@ iree_lit_test_suite(
             "dispatch_linalg_on_tensors_fusion.mlir",
             "expand_tensor_shapes.mlir",
             "export_benchmark_funcs.mlir",
+            "fuse_pad_with_consumer.mlir",
             "infer_numeric_narrowing.mlir",
             "initialize_empty_tensor.mlir",
             "inject_dispatch_tracing.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_lit_test_suite(
     "dispatch_linalg_on_tensors_fusion.mlir"
     "expand_tensor_shapes.mlir"
     "export_benchmark_funcs.mlir"
+    "fuse_pad_with_consumer.mlir"
     "infer_numeric_narrowing.mlir"
     "initialize_empty_tensor.mlir"
     "inject_dispatch_tracing.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fuse_pad_with_consumer.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fuse_pad_with_consumer.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt --split-input-file --verify-diagnostics --iree-flow- --pass-pipeline="func.func(iree-flow-dispatch-linalg-on-tensors-pass), cse, canonicalize, cse" %s | FileCheck %s
+
+func.func @pad_op_consumer_fusion(%arg0 : tensor<?x?xf32>, %low0 : index,
+  %low1: index, %high0 : index, %high1 : index, %arg1 : tensor<?x?xf32>,
+  %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.pad %arg0 low[%low0, %low1] high[%high0, %high1] {
+    ^bb0(%b0 : index, %b1 : index):
+      tensor.yield %cst : f32
+  } : tensor<?x?xf32> to tensor<?x?xf32>
+  %1 = linalg.matmul ins(%0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//      CHECK: func.func @pad_op_consumer_fusion
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:       (%[[ARG0]]
+// CHECK-NEXT:     %[[ARG7:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:?x?xf32>
+//      CHECK:     %[[PAD:.+]] = tensor.pad %[[ARG7]]
+//      CHECK:     linalg.matmul ins(%[[PAD]]
+//      CHECK:   return %[[DISPATCH]]

--- a/iree/test/e2e/tensor_ops/BUILD
+++ b/iree/test/e2e/tensor_ops/BUILD
@@ -34,6 +34,7 @@ iree_check_single_backend_test_suite(
         # keep sorted
         [
             "extract_slice.mlir",
+            "pad.mlir",
             "tensor_insert_slice.mlir",
         ],
         include = ["*.mlir"],
@@ -51,6 +52,7 @@ iree_check_single_backend_test_suite(
         # keep sorted
         [
             "extract_slice.mlir",
+            "pad.mlir",
             "tensor_insert_slice.mlir",
         ],
         include = ["*.mlir"],
@@ -75,6 +77,7 @@ iree_check_single_backend_test_suite(
         # keep sorted
         [
             "extract_slice.mlir",
+            "pad.mlir",
             "tensor_insert_slice.mlir",
         ],
         include = ["*.mlir"],

--- a/iree/test/e2e/tensor_ops/CMakeLists.txt
+++ b/iree/test/e2e/tensor_ops/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_check_single_backend_test_suite(
     check_dylib-llvm-aot_dylib
   SRCS
     "extract_slice.mlir"
+    "pad.mlir"
     "tensor_insert_slice.mlir"
   TARGET_BACKEND
     "dylib-llvm-aot"
@@ -41,6 +42,7 @@ iree_check_single_backend_test_suite(
     check_cuda
   SRCS
     "extract_slice.mlir"
+    "pad.mlir"
     "tensor_insert_slice.mlir"
   TARGET_BACKEND
     "cuda"
@@ -59,6 +61,7 @@ iree_check_single_backend_test_suite(
     check_vulkan-spirv_vulkan
   SRCS
     "extract_slice.mlir"
+    "pad.mlir"
     "tensor_insert_slice.mlir"
   TARGET_BACKEND
     "vulkan-spirv"

--- a/iree/test/e2e/tensor_ops/pad.mlir
+++ b/iree/test/e2e/tensor_ops/pad.mlir
@@ -1,0 +1,29 @@
+func.func @pad_only() {
+  %c0 = arith.constant 0 : i32
+  %c1 = arith.constant 1 : i32
+  %0 = linalg.init_tensor [4, 5] : tensor<4x5xi32>
+  %1 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1) -> ()>, affine_map<(d0, d1) -> (d0, d1)>],
+      iterator_types = ["parallel", "parallel"]}
+      ins(%c1 : i32) outs(%0 : tensor<4x5xi32>) {
+      ^bb0(%b0: i32, %b1 : i32):
+        linalg.yield %c1 : i32
+    } -> tensor<4x5xi32>
+  %2 = tensor.pad %1 low[2, 3] high[4, 5] {
+    ^bb0(%arg0 : index, %arg1 : index):
+      tensor.yield %c0 : i32
+  } : tensor<4x5xi32> to tensor<10x13xi32>
+  check.expect_eq_const(%2, dense<[
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+    [0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+    [0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+    [0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+  ]> : tensor<10x13xi32>) : tensor<10x13xi32>
+  return
+}


### PR DESCRIPTION
Allow `tensor.insert_slice` operation to get folded with its
producers. This effectively is a fusion of pad operations with its
producers (with an additional fill of the result buffer with the padde
value).

Fixes #2783.