### PR TITLE
Add the prototype of the unified benchmark pipeline

### DIFF
--- a/build_tools/buildkite/pipelines/benchmark.yml
+++ b/build_tools/buildkite/pipelines/benchmark.yml
@@ -1,0 +1,1 @@
+fragment/bootstrap-trusted.yml

--- a/build_tools/buildkite/pipelines/benchmark/linux-benchmark.yml
+++ b/build_tools/buildkite/pipelines/benchmark/linux-benchmark.yml
@@ -7,11 +7,11 @@
 steps:
   - label: ":hammer_and_wrench: Build"
     key: "build"
-    commands:
-      - "docker run --user=$(id -u):$(id -g) --volume=\\${HOME?}:\\${HOME?} --volume=/etc/passwd:/etc/passwd:ro --volume=/etc/group:/etc/group:ro --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/frontends@sha256:5868b0de784a590d710c837c3799d9d52456510e6db3d555661ba5f9f87ce213 build_tools/cmake/build_linux_benchmark.sh"
-      - "tar --exclude='*.tar.gz' --exclude='*.tgz' --exclude='*.mlir' --exclude='*.tflite' -czvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz build-host/benchmark_suites"
-      - "find build-host/benchmark_suites -name '*.mlir' | tar -czvf source-mlir-models-${BUILDKITE_BUILD_NUMBER}.tgz -T -"
-      - "tar -czvf iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz build-linux-x86_64/tools/iree-benchmark-module build-linux-x86_64/tools/build_config.txt"
+    commands: |
+      docker run --user=$(id -u):$(id -g) --volume="\${HOME?}:\${HOME?}" --volume=/etc/passwd:/etc/passwd:ro --volume=/etc/group:/etc/group:ro --volume="\$PWD:\$IREE_DOCKER_WORKDIR" --workdir="\${IREE_DOCKER_WORKDIR}" --rm gcr.io/iree-oss/frontends@sha256:5868b0de784a590d710c837c3799d9d52456510e6db3d555661ba5f9f87ce213 build_tools/cmake/build_linux_benchmark.sh
+      tar --exclude='*.tar.gz' --exclude='*.tgz' --exclude='*.mlir' --exclude='*.tflite' -czvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz build-host/benchmark_suites
+      find build-host/benchmark_suites -name '*.mlir' | tar -czvf source-mlir-models-${BUILDKITE_BUILD_NUMBER}.tgz -T -
+      tar -czvf iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz build-linux-x86_64/tools/iree-benchmark-module build-linux-x86_64/tools/build_config.txt
     agents:
       - "queue=build"
     env:
@@ -24,13 +24,13 @@ steps:
   - wait
 
   - label: ":stopwatch: Benchmark on Intel Cascade Lake CPU (GCP-c2-standard-16)"
-    commands:
-      - "git clean -fdx"
-      - "buildkite-agent artifact download --step build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
-      - "buildkite-agent artifact download --step build iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./"
-      - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
-      - "tar -xzvf iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
-      - "python3 build_tools/benchmarks/run_benchmarks_on_linux.py --device_model=GCP-c2-standard-16 --cpu_uarch=CascadeLake --normal_benchmark_tool_dir=build-linux-x86_64/tools/ -o benchmark-results-gcp-cpu-${BUILDKITE_BUILD_NUMBER}.json --verbose build-host/"
+    commands: |
+      git clean -fdx
+      buildkite-agent artifact download --step build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./
+      buildkite-agent artifact download --step build iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./
+      tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz
+      tar -xzvf iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz
+      python3 build_tools/benchmarks/run_benchmarks_on_linux.py --device_model=GCP-c2-standard-16 --cpu_uarch=CascadeLake --normal_benchmark_tool_dir=build-linux-x86_64/tools/ -o benchmark-results-gcp-cpu-${BUILDKITE_BUILD_NUMBER}.json --verbose build-host/
     agents:
       - "gcp:machine-type=c2-standard-16"
       - "queue=benchmark-x86_64"

--- a/build_tools/buildkite/pipelines/benchmark/linux-benchmark.yml
+++ b/build_tools/buildkite/pipelines/benchmark/linux-benchmark.yml
@@ -1,0 +1,39 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+steps:
+  - label: ":hammer_and_wrench: Build"
+    key: "build"
+    commands:
+      - "docker run --user=$(id -u):$(id -g) --volume=\\${HOME?}:\\${HOME?} --volume=/etc/passwd:/etc/passwd:ro --volume=/etc/group:/etc/group:ro --volume=\\$PWD:\\$IREE_DOCKER_WORKDIR --workdir=\\$IREE_DOCKER_WORKDIR --rm gcr.io/iree-oss/frontends@sha256:5868b0de784a590d710c837c3799d9d52456510e6db3d555661ba5f9f87ce213 build_tools/cmake/build_linux_benchmark.sh"
+      - "tar --exclude='*.tar.gz' --exclude='*.tgz' --exclude='*.mlir' --exclude='*.tflite' -czvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz build-host/benchmark_suites"
+      - "find build-host/benchmark_suites -name '*.mlir' | tar -czvf source-mlir-models-${BUILDKITE_BUILD_NUMBER}.tgz -T -"
+      - "tar -czvf iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz build-linux-x86_64/tools/iree-benchmark-module build-linux-x86_64/tools/build_config.txt"
+    agents:
+      - "queue=build"
+    env:
+      IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+    artifact_paths:
+      - "benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "source-mlir-models-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
+
+  - wait
+
+  - label: ":stopwatch: Benchmark on Intel Cascade Lake CPU (GCP-c2-standard-16)"
+    commands:
+      - "git clean -fdx"
+      - "buildkite-agent artifact download --step build benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "buildkite-agent artifact download --step build iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz ./"
+      - "tar -xzvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "tar -xzvf iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
+      - "python3 build_tools/benchmarks/run_benchmarks_on_linux.py --device_model=GCP-c2-standard-16 --cpu_uarch=CascadeLake --normal_benchmark_tool_dir=build-linux-x86_64/tools/ -o benchmark-results-gcp-cpu-${BUILDKITE_BUILD_NUMBER}.json --verbose build-host/"
+    agents:
+      - "gcp:machine-type=c2-standard-16"
+      - "queue=benchmark-x86_64"
+    artifact_paths:
+      - "benchmark-results-gcp-cpu-${BUILDKITE_BUILD_NUMBER}.json"
+    timeout_in_minutes: "10"

--- a/build_tools/buildkite/pipelines/trusted/benchmark.yml
+++ b/build_tools/buildkite/pipelines/trusted/benchmark.yml
@@ -1,0 +1,51 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Note: this runs on trusted agents, since we want the authorization checks to
+# themselves be run on trusted agents. The pipeline itself is uploaded from
+# the main repository via bootstrap-trusted.yml and it fetches the scripts only
+# from the main repository.
+agents:
+  queue: "orchestration"
+  security: "trusted"
+
+steps:
+  - label: "Launch x86_64 benchmark pipeline"
+    plugins:
+      - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:
+          repos:
+            - config:
+                - url: ${BUILDKITE_REPO}
+                  ref: ${CONFIG_FETCH_REF}
+    commands:
+      - "git clean -fdx"
+      - |
+        export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
+            --secret=iree-buildkite-presubmit-pipelines)"
+        ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
+            --output-build-json=build.json jerry-benchmark-x86-64
+      - |
+        mkdir benchmark-results-x86_64
+        buildkite-agent artifact download "benchmark-results-*.json" \
+            benchmark-results-x86_64/ --build \
+            $(cat build.json | python -c "import json,sys;print(json.load(sys.stdin)['id'])")
+    artifact_paths:
+      - "benchmark-results-x86_64/*.json"
+
+  - label: ":lower_left_crayon: Comment benchmark results on pull request"
+    plugins:
+      - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:
+          repos:
+            - config:
+                - url: ${BUILDKITE_REPO}
+                  ref: ${CONFIG_FETCH_REF}
+    commands:
+      - git clean -fdx
+      - |
+        buildkite-agent artifact download "benchmark-results-*/*.json" .
+        ./build_tools/benchmarks/post_benchmarks_as_pr_comment.py \
+            --verbose --query-base \
+            benchmark-results-*/*.json"

--- a/build_tools/buildkite/pipelines/trusted/benchmark.yml
+++ b/build_tools/buildkite/pipelines/trusted/benchmark.yml
@@ -13,7 +13,7 @@ agents:
   security: "trusted"
 
 steps:
-  - label: "Launch x86_64 benchmark pipeline"
+  - label: "Launch Linux benchmark pipeline"
     plugins:
       - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:
           repos:
@@ -26,14 +26,14 @@ steps:
         export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
             --secret=iree-buildkite-presubmit-pipelines)"
         ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
-            --output-build-json=build.json jerry-benchmark-x86-64
+            --output-build-json=build.json jerry-benchmark-linux
       - |
-        mkdir benchmark-results-x86_64
+        mkdir benchmark-results-linux
         buildkite-agent artifact download "benchmark-results-*.json" \
-            benchmark-results-x86_64/ --build \
+            benchmark-results-linux/ --build \
             $(cat build.json | python -c "import json,sys;print(json.load(sys.stdin)['id'])")
     artifact_paths:
-      - "benchmark-results-x86_64/*.json"
+      - "benchmark-results-linux/*.json"
 
   - label: ":lower_left_crayon: Comment benchmark results on pull request"
     plugins:

--- a/build_tools/buildkite/pipelines/trusted/benchmark.yml
+++ b/build_tools/buildkite/pipelines/trusted/benchmark.yml
@@ -37,6 +37,8 @@ steps:
     artifact_paths:
       - "benchmark-results-linux/*.json"
 
+  - wait
+
   - label: ":lower_left_crayon: Comment benchmark results on pull request"
     plugins:
       - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:

--- a/build_tools/buildkite/pipelines/trusted/benchmark.yml
+++ b/build_tools/buildkite/pipelines/trusted/benchmark.yml
@@ -13,7 +13,7 @@ agents:
   security: "trusted"
 
 steps:
-  - label: "Launch Linux benchmark pipeline"
+  - label: ":fast_forward: Launch Linux benchmark pipeline"
     plugins:
       - https://github.com/GMNGeoffrey/smooth-checkout-buildkite-plugin#24e54e7729:
           repos:

--- a/build_tools/buildkite/pipelines/trusted/benchmark.yml
+++ b/build_tools/buildkite/pipelines/trusted/benchmark.yml
@@ -22,11 +22,13 @@ steps:
                   ref: ${CONFIG_FETCH_REF}
     commands:
       - "git clean -fdx"
+      # TODO(pzread): Replace the jerry-benchmark-linux with the formal one.
       - |
         export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
             --secret=iree-buildkite-presubmit-pipelines)"
         ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
             --output-build-json=build.json jerry-benchmark-linux
+      # TODO(pzread): Add jq to the agents and replace the python command.
       - |
         mkdir benchmark-results-linux
         buildkite-agent artifact download "benchmark-results-*.json" \
@@ -43,8 +45,11 @@ steps:
                 - url: ${BUILDKITE_REPO}
                   ref: ${CONFIG_FETCH_REF}
     commands:
-      - git clean -fdx
+      - "git clean -fdx"
       - |
+        export GITHUB_TOKEN="$(gcloud secrets versions access latest \
+            --secret=iree-github-token)" \
+        export IREE_DASHBOARD_URL="https://perf.iree.dev" \
         buildkite-agent artifact download "benchmark-results-*/*.json" .
         ./build_tools/benchmarks/post_benchmarks_as_pr_comment.py \
             --verbose --query-base \

--- a/build_tools/buildkite/pipelines/trusted/benchmark.yml
+++ b/build_tools/buildkite/pipelines/trusted/benchmark.yml
@@ -4,10 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Note: this runs on trusted agents, since we want the authorization checks to
-# themselves be run on trusted agents. The pipeline itself is uploaded from
-# the main repository via bootstrap-trusted.yml and it fetches the scripts only
-# from the main repository.
+# Note: this runs on trusted agents, since it needs access to post a PR
+# comment. The pipeline itself is uploaded from the main repository via
+# bootstrap-trusted.yml and it fetches the scripts only from the main
+# repository.
 agents:
   queue: "orchestration"
   security: "trusted"

--- a/build_tools/buildkite/pipelines/trusted/benchmark.yml
+++ b/build_tools/buildkite/pipelines/trusted/benchmark.yml
@@ -20,20 +20,18 @@ steps:
             - config:
                 - url: ${BUILDKITE_REPO}
                   ref: ${CONFIG_FETCH_REF}
-    commands:
-      - "git clean -fdx"
+    commands: |
+      git clean -fdx
       # TODO(pzread): Replace the jerry-benchmark-linux with the formal one.
-      - |
-        export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
-            --secret=iree-buildkite-presubmit-pipelines)"
-        ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
-            --output-build-json=build.json jerry-benchmark-linux
+      export BUILDKITE_ACCESS_TOKEN="$(gcloud secrets versions access latest \
+          --secret=iree-buildkite-presubmit-pipelines)"
+      ./build_tools/buildkite/scripts/wait_for_pipeline_success.py \
+          --output-build-json=build.json jerry-benchmark-linux
       # TODO(pzread): Add jq to the agents and replace the python command.
-      - |
-        mkdir benchmark-results-linux
-        buildkite-agent artifact download "benchmark-results-*.json" \
-            benchmark-results-linux/ --build \
-            $(cat build.json | python -c "import json,sys;print(json.load(sys.stdin)['id'])")
+      mkdir benchmark-results-linux
+      buildkite-agent artifact download "benchmark-results-*.json" \
+          benchmark-results-linux/ --build \
+          $(cat build.json | python -c "import json,sys;print(json.load(sys.stdin)['id'])")
     artifact_paths:
       - "benchmark-results-linux/*.json"
 
@@ -46,13 +44,12 @@ steps:
             - config:
                 - url: ${BUILDKITE_REPO}
                   ref: ${CONFIG_FETCH_REF}
-    commands:
-      - "git clean -fdx"
-      - |
-        export GITHUB_TOKEN="$(gcloud secrets versions access latest \
-            --secret=iree-github-token)" \
+    commands: |
+      git clean -fdx
+      export GITHUB_TOKEN="$(gcloud secrets versions access latest \
+          --secret=iree-github-token)" \
         export IREE_DASHBOARD_URL="https://perf.iree.dev" \
         buildkite-agent artifact download "benchmark-results-*/*.json" .
         ./build_tools/benchmarks/post_benchmarks_as_pr_comment.py \
             --verbose --query-base \
-            benchmark-results-*/*.json"
+            "benchmark-results-*/*.json"


### PR DESCRIPTION
This change adds the prototype of benchmark pipeline which follows the new unified structure.

Instead of having multiple standalone benchmark pipelines for each architecture, there is a "main pipeline" to selectively launch the child benchmark pipelines, collect, and upload the results.

The "main pipeline" is run in the trusted agent as it needs to access the Github and dashboard token. It is safe to do so since all scripts are checked out from the merged code and those scripts can safely process the untrusted JSON data (benchmark results).