### PR TITLE
WIP: enable transpose fusion to debug mmt4d perf regression

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionUtils.cpp
@@ -21,7 +21,7 @@ namespace Flow {
 
 static llvm::cl::opt<bool> clFuseTranspose(
     "iree-flow-fuse-transpose", llvm::cl::desc("Enable fusing transpose"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 /// For the fusion of root op -> elementwise operation to be bufferized
 /// in-place without use of extra memory, the result of the root operation

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -91,7 +91,7 @@ static llvm::cl::opt<std::string> clMmt4dTargetOptions(
 static llvm::cl::opt<bool> clNormalizeInputIndexingMap(
     "iree-flow-normalize-input-indexing-map",
     llvm::cl::desc("Enable normalizing input indexing map to identity"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 namespace mlir {
 namespace iree_compiler {


### PR DESCRIPTION
This is not for code review. This is for debugging the perf regression on mmt4d when the transpose fusion is enabled.