### PR TITLE
Rework Python driver/device creation.

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -67,6 +67,7 @@ iree_py_library(
     "iree/runtime/flags.py"
     "iree/runtime/function.py"
     "iree/runtime/system_api.py"
+    "iree/runtime/system_setup.py"
     "iree/runtime/tracing.py"
     "iree/runtime/scripts/iree_benchmark_trace/__main__.py"
     "iree/runtime/scripts/iree_run_trace/__main__.py"
@@ -145,6 +146,13 @@ iree_py_test(
     system_api_test
   SRCS
     "tests/system_api_test.py"
+)
+
+iree_py_test(
+  NAME
+    system_setup_test
+  SRCS
+    "tests/system_setup_test.py"
 )
 
 iree_py_test(

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -242,15 +242,10 @@ py::object HalDriver::Create(const std::string& device_uri,
 
   // Create.
   iree_hal_driver_t* driver;
-  iree_status_t status = iree_hal_driver_registry_try_create(
-      iree_hal_driver_registry_default(), driver_name, iree_allocator_system(),
-      &driver);
-  if (iree_status_is_not_found(status)) {
-    std::string msg("Driver not found: ");
-    msg.append(driver_name.data, driver_name.size);
-    throw std::invalid_argument(std::move(msg));
-  }
-  CheckApiStatus(status, "Error creating driver");
+  CheckApiStatus(iree_hal_driver_registry_try_create(
+                     iree_hal_driver_registry_default(), driver_name,
+                     iree_allocator_system(), &driver),
+                 "Error creating driver");
 
   // Cache.
   py::object driver_obj = py::cast(HalDriver::StealFromRawPtr(driver));
@@ -320,15 +315,10 @@ HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id) {
 HalDevice HalDriver::CreateDeviceByURI(std::string& device_uri) {
   iree_hal_device_t* device;
   iree_string_view_t device_uri_sv{device_uri.data(), device_uri.size()};
-  iree_status_t status = iree_hal_driver_create_device_by_uri(
-      raw_ptr(), device_uri_sv, iree_allocator_system(), &device);
-  if (iree_status_is_not_found(status) ||
-      iree_status_is_unimplemented(status)) {
-    std::string message("Device not found: ");
-    message.append(device_uri);
-    throw std::invalid_argument(std::move(message));
-  }
-  CheckApiStatus(status, "Error creating device");
+  CheckApiStatus(
+      iree_hal_driver_create_device_by_uri(raw_ptr(), device_uri_sv,
+                                           iree_allocator_system(), &device),
+      "Error creating device");
   return HalDevice::StealFromRawPtr(device);
 }
 

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -236,10 +236,59 @@ HalDriver HalDriver::Create(const std::string& driver_name) {
   return HalDriver::StealFromRawPtr(driver);
 }
 
+py::list HalDriver::QueryAvailableDevices() {
+  iree_hal_device_info_t* device_infos;
+  iree_host_size_t count;
+  CheckApiStatus(iree_hal_driver_query_available_devices(
+                     raw_ptr(), iree_allocator_system(), &device_infos, &count),
+                 "Error querying devices");
+  py::list results;
+  for (iree_host_size_t i = 0; i < count; ++i) {
+    results.append(py::make_tuple(
+        py::cast(device_infos[i].device_id),
+        py::str(device_infos[i].name.data, device_infos[i].name.size)));
+  }
+
+  iree_allocator_free(iree_allocator_system(), device_infos);
+  return results;
+}
+
 HalDevice HalDriver::CreateDefaultDevice() {
   iree_hal_device_t* device;
   CheckApiStatus(iree_hal_driver_create_default_device(
                      raw_ptr(), iree_allocator_system(), &device),
+                 "Error creating default device");
+  return HalDevice::StealFromRawPtr(device);
+}
+
+HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id) {
+  // Since the device ids are supposed to be opaque, we need to verify
+  // them by querying available devices.
+  py::list available_devices = QueryAvailableDevices();
+  bool found = false;
+  py::object compare_device_id = py::cast(device_id);
+  for (auto record : available_devices) {
+    // Each record is a tuple of (device_id, name).
+    auto record_tuple = py::cast<py::tuple>(record);
+    py::object found_device_id = record_tuple[0];
+    if (found_device_id == compare_device_id) {
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    std::string msg;
+    msg.append("Device id ");
+    msg.append(std::to_string(device_id));
+    msg.append(" not found. Available devices: ");
+    msg.append(py::repr(available_devices));
+    throw std::invalid_argument(std::move(msg));
+  }
+
+  iree_hal_device_t* device;
+  CheckApiStatus(iree_hal_driver_create_device(
+                     raw_ptr(), device_id, iree_allocator_system(), &device),
                  "Error creating default device");
   return HalDevice::StealFromRawPtr(device);
 }
@@ -443,9 +492,24 @@ void SetupHalBindings(pybind11::module m) {
 
   py::class_<HalDriver>(m, "HalDriver")
       .def_static("query", &HalDriver::Query)
-      .def_static("create", &HalDriver::Create, py::arg("driver_name"))
       .def("create_default_device", &HalDriver::CreateDefaultDevice,
-           py::keep_alive<0, 1>());
+           py::keep_alive<0, 1>())
+      .def("create_device", &HalDriver::CreateDevice, py::keep_alive<0, 1>())
+      .def(
+          "create_device",
+          [](HalDriver& self, py::tuple device_info) -> HalDevice {
+            // Alias of create_device that takes a tuple as returned from
+            // query_available_devices for convenience.
+            auto device_id = py::cast<iree_hal_device_id_t>(device_info[0]);
+            return self.CreateDevice(device_id);
+          },
+          py::keep_alive<0, 1>())
+      .def("query_available_devices", &HalDriver::QueryAvailableDevices);
+
+  // We cache drivers at the Python level so we hide the actual native
+  // entry point to create them directly so that it doesn't show up in
+  // the public API.
+  m.def("_create_hal_driver", &HalDriver::Create, py::arg("driver_name"));
 
   py::class_<HalAllocator>(m, "HalAllocator")
       .def("trim",

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -89,11 +89,13 @@ class HalDevice : public ApiRefCounted<HalDevice, iree_hal_device_t> {
 class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {
  public:
   static std::vector<std::string> Query();
-  static HalDriver Create(const std::string& driver_name);
+  static py::object Create(const std::string& device_uri,
+                           py::dict& driver_cache);
 
   py::list QueryAvailableDevices();
   HalDevice CreateDefaultDevice();
   HalDevice CreateDevice(iree_hal_device_id_t device_id);
+  HalDevice CreateDeviceByURI(std::string& device_uri);
 };
 
 class HalAllocator : public ApiRefCounted<HalAllocator, iree_hal_allocator_t> {

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -91,7 +91,9 @@ class HalDriver : public ApiRefCounted<HalDriver, iree_hal_driver_t> {
   static std::vector<std::string> Query();
   static HalDriver Create(const std::string& driver_name);
 
+  py::list QueryAvailableDevices();
   HalDevice CreateDefaultDevice();
+  HalDevice CreateDevice(iree_hal_device_id_t device_id);
 };
 
 class HalAllocator : public ApiRefCounted<HalAllocator, iree_hal_allocator_t> {

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -42,6 +42,12 @@ from ._binding import (
 from .array_interop import *
 from .benchmark import *
 from .system_api import *
+from .system_setup import (
+    get_device_by_name,
+    get_first_device_by_name,
+    get_driver,
+    query_available_drivers,
+)
 from .function import *
 from .tracing import *
 

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -43,8 +43,8 @@ from .array_interop import *
 from .benchmark import *
 from .system_api import *
 from .system_setup import (
-    get_device_by_name,
-    get_first_device_by_name,
+    get_device,
+    get_first_device,
     get_driver,
     query_available_drivers,
 )

--- a/runtime/bindings/python/iree/runtime/_binding.py
+++ b/runtime/bindings/python/iree/runtime/_binding.py
@@ -15,4 +15,5 @@ the way this trampoline functions.
 import sys
 
 from iree import _runtime
+
 sys.modules[__name__] = _runtime

--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -35,7 +35,7 @@ from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 from . import _binding
 from .function import FunctionInvoker
-from .system_setup import get_first_device_by_name
+from .system_setup import get_first_device
 from . import tracing
 
 import numpy as np
@@ -68,7 +68,7 @@ class Config:
     if device is not None:
       self.device = device
     else:
-      self.device = get_first_device_by_name(
+      self.device = get_first_device(
           driver_name.split(",") if driver_name is not None else None)
 
     self.vm_instance = _binding.VmInstance()

--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -35,15 +35,10 @@ from typing import Any, List, Mapping, Optional, Sequence, Tuple, Union
 
 from . import _binding
 from .function import FunctionInvoker
+from .system_setup import get_first_device_by_name
 from . import tracing
 
 import numpy as np
-
-# Environment key for a comma-delimitted list of drivers to try to load.
-PREFERRED_DRIVER_ENV_KEY = "IREE_DEFAULT_DRIVER"
-
-# Default value for IREE_DRIVER
-DEFAULT_IREE_DRIVER_VALUE = "local-task,vulkan"
 
 # Mapping from IREE target backends to their corresponding drivers.
 TARGET_BACKEND_TO_DRIVER = {
@@ -53,56 +48,9 @@ TARGET_BACKEND_TO_DRIVER = {
 }
 
 
-def _create_default_iree_driver(
-    driver_names: Optional[Sequence[str]] = None) -> _binding.HalDriver:
-  """Returns a default driver based on environment settings."""
-  # TODO(laurenzo): Ideally this should take a VmModule and join any explicitly
-  # provided driver list with environmental constraints and what the module
-  # was compiled for.
-  if driver_names is None:
-    # Read from environment.
-    driver_names = os.environ.get(PREFERRED_DRIVER_ENV_KEY)
-    if driver_names is None:
-      driver_names = DEFAULT_IREE_DRIVER_VALUE
-    driver_names = driver_names.split(",")
-  available_driver_names = _binding.HalDriver.query()
-  driver_exceptions = {}
-  for driver_name in driver_names:
-    if driver_name not in available_driver_names:
-      logging.error("Could not create driver %s (not registered)", driver_name)
-      continue
-    try:
-      driver = _binding.HalDriver.create(driver_name)
-    except Exception as ex:  # pylint: disable=broad-except
-      logging.exception("Could not create default driver %s", driver_name)
-      driver_exceptions[driver_name] = ex
-      continue
-
-    # Sanity check creation of the default device and skip the driver if
-    # this fails (this works around issues where the driver is present
-    # but there are no devices). This default initialization scheme needs
-    # to be improved.
-    try:
-      device = driver.create_default_device()
-    except Exception as ex:
-      logging.exception("Could not create default driver device %s",
-                        driver_name)
-      driver_exceptions[driver_name] = ex
-      continue
-
-    logging.debug("Created IREE driver %s: %r", driver_name, driver)
-    return driver
-
-  # All failed.
-  raise RuntimeError(
-      f"Could not create any requested driver {repr(driver_names)} (available="
-      f"{repr(available_driver_names)}) : {repr(driver_exceptions)}")
-
-
 class Config:
   """System configuration."""
 
-  driver: _binding.HalDriver
   device: _binding.HalDevice
   vm_instance: _binding.VmInstance
   default_vm_modules: Tuple[_binding.VmModule, ...]
@@ -110,11 +58,20 @@ class Config:
 
   def __init__(self,
                driver_name: Optional[str] = None,
+               *,
+               device: Optional[_binding.HalDevice] = None,
                tracer: Optional[tracing.Tracer] = None):
+    # Either use an explicit device or auto config based on driver names.
+    if device is not None and driver_name is not None:
+      raise ValueError(
+          "Either 'device' or 'driver_name' can be specified (not both)")
+    if device is not None:
+      self.device = device
+    else:
+      self.device = get_first_device_by_name(
+          driver_name.split(",") if driver_name is not None else None)
+
     self.vm_instance = _binding.VmInstance()
-    self.driver = _create_default_iree_driver(
-        driver_name.split(",") if driver_name is not None else None)
-    self.device = self.driver.create_default_device()
     hal_module = _binding.create_hal_module(self.device)
     self.default_vm_modules = (hal_module,)
     self.tracer = tracer or tracing.get_default_tracer()
@@ -123,16 +80,6 @@ class Config:
                    self.tracer.trace_path)
     else:
       self.tracer = None
-
-
-_global_config = None
-
-
-def _get_global_config():
-  global _global_config
-  if _global_config is None:
-    _global_config = Config()
-  return _global_config
 
 
 def _bool_to_int8(
@@ -245,8 +192,7 @@ class SystemContext:
   """Global system."""
 
   def __init__(self, vm_modules=None, config: Optional[Config] = None):
-    self._config = config if config is not None else _get_global_config()
-    logging.debug("SystemContext driver=%r", self._config.driver)
+    self._config = config if config is not None else Config()
     self._is_dynamic = vm_modules is None
     if self._is_dynamic:
       init_vm_modules = None

--- a/runtime/bindings/python/iree/runtime/system_setup.py
+++ b/runtime/bindings/python/iree/runtime/system_setup.py
@@ -1,0 +1,151 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Process-global driver instantiation and discovery."""
+
+from typing import Collection, Dict, Optional, Sequence, Union
+
+import logging
+import os
+from threading import RLock
+
+from ._binding import _create_hal_driver, HalDevice, HalDriver
+
+_GLOBAL_DRIVERS = {}  # type: Dict[str, Union[HalDriver, Exception]]
+_GLOBAL_DEVICES_BY_NAME = {}  # type: Dict[str, Union[HalDevice, Exception]]
+
+_LOCK = RLock()
+
+DEFAULT_DRIVER_NAMES = "dylib,cuda,vulkan,vmvx"
+
+
+def query_available_drivers() -> Collection[str]:
+  """Returns a collection of driver names that are available."""
+  return HalDriver.query()
+
+
+def get_driver(driver_name: str) -> HalDriver:
+  """Gets or creates a driver by name."""
+  with _LOCK:
+    existing = _GLOBAL_DRIVERS.get(driver_name)
+    if existing is not None:
+      if isinstance(existing, Exception):
+        raise existing
+      else:
+        return existing
+
+    available_names = query_available_drivers()
+    if driver_name not in available_names:
+      raise ValueError(
+          f"Driver '{driver_name}' is not compiled into this binary")
+
+    try:
+      driver = _create_hal_driver(driver_name)
+    except Exception as ex:
+      _GLOBAL_DRIVERS[driver_name] = ex
+      raise
+    _GLOBAL_DRIVERS[driver_name] = driver
+    return driver
+
+
+def get_device_by_name(name_spec: str) -> HalDevice:
+  """Gets a cached device by name.
+
+  Args:
+    name_spec: The name of a driver or "{driver_name}:{index}" to create
+      a specific device. If the indexed form is not used, the driver
+      will be asked to create its default device.
+  Returns:
+    A HalDevice.
+  """
+  with _LOCK:
+    existing = _GLOBAL_DEVICES_BY_NAME.get(name_spec)
+    if existing is None:
+      # Not existing.
+      # Split into driver_name[:device_index]
+      try:
+        colon_pos = name_spec.index(":")
+      except ValueError:
+        driver_name = name_spec
+        device_index = None
+      else:
+        driver_name = name_spec[0:colon_pos]
+        device_index = name_spec[colon_pos + 1:]
+        try:
+          device_index = int(device_index)
+        except ValueError:
+          raise ValueError(f"Could not parse device name {name_spec}")
+
+      driver = get_driver(driver_name)
+      device_id = None
+      if device_index is not None:
+        device_infos = driver.query_available_devices()
+        if device_index >= len(device_infos):
+          raise ValueError(f"Device index {device_index} is out of range. "
+                           f"Found devices {device_infos}")
+        device_id, device_name = device_infos[0]
+
+      try:
+        if device_id is None:
+          logging.info("Creating default device for driver %s", driver_name)
+          device = driver.create_default_device()
+        else:
+          logging.info("Creating device %d (%s) for driver %s", device_id,
+                       device_name, driver_name)
+          device = driver.create_device(device_id)
+      except Exception as ex:
+        _GLOBAL_DEVICES_BY_NAME[name_spec] = ex
+        raise
+      else:
+        _GLOBAL_DEVICES_BY_NAME[name_spec] = device
+        return device
+
+    # Existing.
+    if isinstance(existing, Exception):
+      raise existing
+    return existing
+
+
+def get_first_device_by_name(
+    name_specs: Optional[Sequence[str]] = None) -> HalDevice:
+  """Gets the first valid (cached) device for a prioritized list of names.
+
+  If no driver_names are given, and an environment variable of
+  IREE_DEFAULT_DEVICE is available, then it is treated as a comma delimitted
+  list of driver names to try.
+
+  This is meant to be used for default/automagic startup and is not suitable
+  for any kind of multi-device setup.
+
+  Args:
+    name_specs: Search list of device names to probe.
+  Returns:
+    A HalDevice instance.
+  """
+  # Parse from environment or defaults if not explicitly provided.
+  if name_specs is None:
+    name_specs = os.environ.get("IREE_DEFAULT_DEVICE")
+    if name_specs is None:
+      name_specs = DEFAULT_DRIVER_NAMES
+    name_specs = [s.strip() for s in name_specs.split(",")]
+
+  last_exception = None
+  for name_spec in name_specs:
+    try:
+      return get_device_by_name(name_spec)
+    except ValueError:
+      # Driver not known.
+      continue
+    except Exception as ex:
+      # Failure to create driver.
+      logging.info(f"Failed to create device {name_spec}: {ex}")
+      last_exception = ex
+      continue
+
+  if last_exception:
+    raise RuntimeError("Could not create device. "
+                       "Exception for last tried follows.") from last_exception
+  else:
+    raise ValueError(f"No device found from list {name_specs}")

--- a/runtime/bindings/python/iree/runtime/system_setup.py
+++ b/runtime/bindings/python/iree/runtime/system_setup.py
@@ -66,7 +66,7 @@ def get_first_device(device_uris: Optional[Sequence[str]] = None,
   for any kind of multi-device setup.
 
   Args:
-    device_urs: Explicit list of device URIs to try.
+    device_uris: Explicit list of device URIs to try.
     cache: Whether to cache the device (default True).
   Returns:
     A HalDevice instance.

--- a/runtime/bindings/python/status_utils.cc
+++ b/runtime/bindings/python/status_utils.cc
@@ -15,6 +15,8 @@ PyObject* ApiStatusToPyExcClass(iree_status_t status) {
   switch (iree_status_code(status)) {
     case IREE_STATUS_INVALID_ARGUMENT:
       return PyExc_ValueError;
+    case IREE_STATUS_NOT_FOUND:
+      return PyExc_ValueError;
     case IREE_STATUS_OUT_OF_RANGE:
       return PyExc_IndexError;
     case IREE_STATUS_UNIMPLEMENTED:

--- a/runtime/bindings/python/tests/array_interop_test.py
+++ b/runtime/bindings/python/tests/array_interop_test.py
@@ -16,7 +16,7 @@ class DeviceHalTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.device = iree.runtime.get_device_by_name("local-task")
+    self.device = iree.runtime.get_device("local-task")
     self.allocator = self.device.allocator
     # Make sure device setup maintains proper references.
     gc.collect()

--- a/runtime/bindings/python/tests/array_interop_test.py
+++ b/runtime/bindings/python/tests/array_interop_test.py
@@ -16,9 +16,10 @@ class DeviceHalTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.driver = iree.runtime.HalDriver.create("local-task")
-    self.device = self.driver.create_default_device()
+    self.device = iree.runtime.get_device_by_name("local-task")
     self.allocator = self.device.allocator
+    # Make sure device setup maintains proper references.
+    gc.collect()
 
   def testGcShutdownFiasco(self):
     init_ary = np.zeros([3, 4], dtype=np.int32) + 2
@@ -29,8 +30,6 @@ class DeviceHalTest(unittest.TestCase):
     self.allocator = None
     gc.collect()
     self.device = None
-    gc.collect()
-    self.driver = None
     gc.collect()
 
     # Now drop the ary and make sure nothing crashes (which would indicate

--- a/runtime/bindings/python/tests/devices_cli_test.py
+++ b/runtime/bindings/python/tests/devices_cli_test.py
@@ -1,0 +1,68 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from typing import Tuple
+
+from io import StringIO
+import unittest
+import sys
+
+from iree.runtime.scripts.iree_devices import __main__ as cli
+
+
+def run_cli(*args) -> Tuple[int, str, str]:
+  capture_stdout = StringIO()
+  capture_stderr = StringIO()
+  sys.stdout = capture_stdout
+  sys.stderr = capture_stderr
+  try:
+    rc = cli.main(args)
+  finally:
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+  return rc, capture_stdout.getvalue(), capture_stderr.getvalue()
+
+
+class DevicesCliTest(unittest.TestCase):
+
+  def testLs(self):
+    rc, output, err = run_cli("ls")
+    self.assertEqual(rc, 0)
+    self.assertIn("vmvx:0\tdefault", output)
+
+  def testLsTryCreate(self):
+    rc, output, err = run_cli("ls", "--try-create")
+    self.assertEqual(rc, 0)
+    self.assertIn("vmvx:0\tdefault\tSUCCESS", output)
+
+  def testLsTryCreateExplicitDriver(self):
+    rc, output, err = run_cli("ls", "--try-create", "-d", "vmvx")
+    self.assertEqual(rc, 0)
+    self.assertIn("vmvx:0\tdefault\tSUCCESS", output)
+
+  def testLsTryCreateExplicitDriverNotFound(self):
+    rc, output, err = run_cli("ls", "--try-create", "-d", "DOES_NOT_EXIST")
+    self.assertEqual(rc, 0)
+    self.assertIn("Could not create driver DOES_NOT_EXIST", err)
+
+  def testTestIndexedDevice(self):
+    rc, output, err = run_cli("test", "vmvx:0")
+    self.assertEqual(rc, 0)
+    self.assertIn("Creating device vmvx:0... SUCCESS", output)
+
+  def testTestDefaultDevice(self):
+    rc, output, err = run_cli("test", "vmvx")
+    self.assertEqual(rc, 0)
+    self.assertIn("Creating device vmvx... SUCCESS", output)
+
+  def testTestNonExisting(self):
+    rc, output, err = run_cli("test", "NOT_EXISTING")
+    self.assertEqual(rc, 1)
+    self.assertIn("Creating device NOT_EXISTING... ERROR", output)
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/runtime/bindings/python/tests/hal_test.py
+++ b/runtime/bindings/python/tests/hal_test.py
@@ -61,7 +61,7 @@ class DeviceHalTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.device = iree.runtime.get_device_by_name("local-task")
+    self.device = iree.runtime.get_device("local-task")
     self.allocator = self.device.allocator
     gc.collect()
 

--- a/runtime/bindings/python/tests/hal_test.py
+++ b/runtime/bindings/python/tests/hal_test.py
@@ -5,6 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import iree.runtime
+
+import gc
 import numpy as np
 import unittest
 
@@ -59,9 +61,9 @@ class DeviceHalTest(unittest.TestCase):
 
   def setUp(self):
     super().setUp()
-    self.driver = iree.runtime.HalDriver.create("local-task")
-    self.device = self.driver.create_default_device()
+    self.device = iree.runtime.get_device_by_name("local-task")
     self.allocator = self.device.allocator
+    gc.collect()
 
   def testTrim(self):
     self.allocator.trim()

--- a/runtime/bindings/python/tests/system_api_test.py
+++ b/runtime/bindings/python/tests/system_api_test.py
@@ -43,8 +43,8 @@ class SystemApiTest(unittest.TestCase):
     config = iree.runtime.Config("nothere1,local-task")
 
   def test_multi_config_caches(self):
-    config1 = iree.runtime.Config("nothere1,dylib")
-    config2 = iree.runtime.Config("nothere1,dylib")
+    config1 = iree.runtime.Config("nothere1,local-sync")
+    config2 = iree.runtime.Config("nothere1,local-sync")
     self.assertIs(config1.device, config2.device)
 
   def test_empty_dynamic(self):

--- a/runtime/bindings/python/tests/system_api_test.py
+++ b/runtime/bindings/python/tests/system_api_test.py
@@ -36,12 +36,16 @@ def create_simple_mul_module():
 class SystemApiTest(unittest.TestCase):
 
   def test_non_existing_driver(self):
-    with self.assertRaisesRegex(RuntimeError,
-                                "Could not create any requested driver"):
+    with self.assertRaisesRegex(ValueError, "No device found from list"):
       config = iree.runtime.Config("nothere1,nothere2")
 
   def test_subsequent_driver(self):
     config = iree.runtime.Config("nothere1,local-task")
+
+  def test_multi_config_caches(self):
+    config1 = iree.runtime.Config("nothere1,dylib")
+    config2 = iree.runtime.Config("nothere1,dylib")
+    self.assertIs(config1.device, config2.device)
 
   def test_empty_dynamic(self):
     ctx = iree.runtime.SystemContext()
@@ -133,6 +137,14 @@ class SystemApiTest(unittest.TestCase):
     results = arithmetic.simple_mul(arg0, arg1)
     print("SIMPLE_MUL RESULTS:", results)
     np.testing.assert_allclose(results, [4., 10., 18., 28.])
+
+  def test_load_multiple_modules(self):
+    # Doing default device configuration multiple times should be valid
+    # (if this were instantiating drivers multiple times, it can trigger
+    # a crash, depending on whether the driver supports multi-instantiation).
+    m = create_simple_mul_module()
+    m1 = iree.runtime.load_vm_module(m)
+    m2 = iree.runtime.load_vm_module(m)
 
 
 if __name__ == "__main__":

--- a/runtime/bindings/python/tests/system_setup_test.py
+++ b/runtime/bindings/python/tests/system_setup_test.py
@@ -15,27 +15,27 @@ class DeviceSetupTest(unittest.TestCase):
   def testQueryDriversDevices(self):
     driver_names = ss.query_available_drivers()
     print(f"Drivers: {driver_names}")
-    self.assertIn("vmvx", driver_names)
-    self.assertIn("dylib", driver_names)
+    self.assertIn("local-sync", driver_names)
+    self.assertIn("local-task", driver_names)
 
-    for driver_name in ["vmvx", "dylib"]:
+    for driver_name in ["local-sync", "local-task"]:
       driver = ss.get_driver(driver_name)
       print(f"Driver {driver_name}: {driver}")
       device_infos = driver.query_available_devices()
       print(f"DeviceInfos: {device_infos}")
-      if driver_name == "vmvx":
+      if driver_name == "local-sync":
         # We happen to know that this should have one device_info
         self.assertEqual(device_infos, [(0, "default")])
 
   def testCreateBadDeviceId(self):
-    driver = ss.get_driver("vmvx")
+    driver = ss.get_driver("local-sync")
     with self.assertRaises(
         ValueError,
         msg="Device id 5555 not found. Available devices: [(0, 'default')]"):
       _ = driver.create_device(5555)
 
   def testCreateDevice(self):
-    driver = ss.get_driver("vmvx")
+    driver = ss.get_driver("local-sync")
     infos = driver.query_available_devices()
     # Each info record is (device_id, name)
     device1 = driver.create_device(infos[0][0])
@@ -43,17 +43,16 @@ class DeviceSetupTest(unittest.TestCase):
     device2 = driver.create_device(infos[0])
 
   def testCreateDeviceByName(self):
-    device1 = ss.get_device_by_name("vmvx")
-    device2 = ss.get_device_by_name("vmvx:0")
-    device3 = ss.get_device_by_name("vmvx:0")
+    device1 = ss.get_device("local-task")
+    device2 = ss.get_device("local-sync")
+    device3 = ss.get_device("local-sync")
+    device4 = ss.get_device("local-sync", cache=False)
     self.assertIsNot(device1, device2)
+    self.assertIsNot(device3, device4)
     self.assertIs(device2, device3)
 
-    with self.assertRaises(
-        ValueError,
-        msg="Device index 5555 is out of range. Found devices [(0, 'default')]"
-    ):
-      _ = ss.get_device_by_name("vmvx:5555")
+    with self.assertRaises(ValueError, msg="Device not found: local-sync://1"):
+      _ = ss.get_device("local-sync://1")
 
 
 if __name__ == "__main__":

--- a/runtime/bindings/python/tests/system_setup_test.py
+++ b/runtime/bindings/python/tests/system_setup_test.py
@@ -1,0 +1,61 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import unittest
+
+from iree.runtime import system_setup as ss
+
+
+class DeviceSetupTest(unittest.TestCase):
+
+  def testQueryDriversDevices(self):
+    driver_names = ss.query_available_drivers()
+    print(f"Drivers: {driver_names}")
+    self.assertIn("vmvx", driver_names)
+    self.assertIn("dylib", driver_names)
+
+    for driver_name in ["vmvx", "dylib"]:
+      driver = ss.get_driver(driver_name)
+      print(f"Driver {driver_name}: {driver}")
+      device_infos = driver.query_available_devices()
+      print(f"DeviceInfos: {device_infos}")
+      if driver_name == "vmvx":
+        # We happen to know that this should have one device_info
+        self.assertEqual(device_infos, [(0, "default")])
+
+  def testCreateBadDeviceId(self):
+    driver = ss.get_driver("vmvx")
+    with self.assertRaises(
+        ValueError,
+        msg="Device id 5555 not found. Available devices: [(0, 'default')]"):
+      _ = driver.create_device(5555)
+
+  def testCreateDevice(self):
+    driver = ss.get_driver("vmvx")
+    infos = driver.query_available_devices()
+    # Each info record is (device_id, name)
+    device1 = driver.create_device(infos[0][0])
+    # Should also take the info tuple directly for convenience.
+    device2 = driver.create_device(infos[0])
+
+  def testCreateDeviceByName(self):
+    device1 = ss.get_device_by_name("vmvx")
+    device2 = ss.get_device_by_name("vmvx:0")
+    device3 = ss.get_device_by_name("vmvx:0")
+    self.assertIsNot(device1, device2)
+    self.assertIs(device2, device3)
+
+    with self.assertRaises(
+        ValueError,
+        msg="Device index 5555 is out of range. Found devices [(0, 'default')]"
+    ):
+      _ = ss.get_device_by_name("vmvx:5555")
+
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO)
+  unittest.main()

--- a/runtime/bindings/python/tests/vm_test.py
+++ b/runtime/bindings/python/tests/vm_test.py
@@ -60,7 +60,7 @@ class VmTest(unittest.TestCase):
 
   @classmethod
   def setUp(self):
-    self.device = iree.runtime.get_device_by_name(
+    self.device = iree.runtime.get_device(
         iree.compiler.core.DEFAULT_TESTING_DRIVER)
     self.hal_module = iree.runtime.create_hal_module(self.device)
 

--- a/runtime/bindings/python/tests/vm_test.py
+++ b/runtime/bindings/python/tests/vm_test.py
@@ -59,14 +59,10 @@ def create_simple_dynamic_abs_module():
 class VmTest(unittest.TestCase):
 
   @classmethod
-  def setUpClass(cls):
-    super().setUpClass()
-    driver_names = iree.runtime.HalDriver.query()
-    logging.info("driver_names: %s", driver_names)
-    cls.driver = iree.runtime.HalDriver.create(
+  def setUp(self):
+    self.device = iree.runtime.get_device_by_name(
         iree.compiler.core.DEFAULT_TESTING_DRIVER)
-    cls.device = cls.driver.create_default_device()
-    cls.hal_module = iree.runtime.create_hal_module(cls.device)
+    self.hal_module = iree.runtime.create_hal_module(self.device)
 
   def test_variant_list(self):
     l = iree.runtime.VmVariantList(5)

--- a/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
@@ -139,7 +139,7 @@ static iree_status_t iree_hal_sync_driver_create_device_by_path(
     const iree_string_pair_t* params, iree_allocator_t host_allocator,
     iree_hal_device_t** out_device) {
   if (!iree_string_view_is_empty(device_path)) {
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
                             "device paths not yet implemented");
   }
   return iree_hal_sync_driver_create_device_by_id(

--- a/runtime/src/iree/hal/drivers/local_task/task_driver.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_driver.c
@@ -146,7 +146,7 @@ static iree_status_t iree_hal_task_driver_create_device_by_path(
     const iree_string_pair_t* params, iree_allocator_t host_allocator,
     iree_hal_device_t** out_device) {
   if (!iree_string_view_is_empty(device_path)) {
-    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+    return iree_make_status(IREE_STATUS_NOT_FOUND,
                             "device paths not yet implemented");
   }
   return iree_hal_task_driver_create_device_by_id(


### PR DESCRIPTION
APIs removed:
  * HalDriver.create() (use iree.runtime.get_driver(driver_name) to get a
    cached instance).
  * Environment variable IREE_DEFAULT_DRIVER renamed to
    IREE_DEFAULT_DEVICE to better reflect the new syntax.
  * Config.driver attribute (no longer captured by this class)

APIs added:
  * iree.runtime.query_available_drivers() (alias of HalDriver.query())
  * iree.runtime.get_driver(device_uri)
  * iree.runtime.get_device(device_uri)
  * iree.runtime.get_first_device(device_uris)
  * iree.runtime.Config(, device: HalDevice) (to configure with an
    explicit device)
  * HalDriver.create_device(device_id: Union[int, tuple])
  * HalDriver.query_available_devices()
  * HalDriver.create_device_by_uri(device_uri: str)

Both driver and device lookup is done by a device URI, as defined by the runtime (when creating a driver, only the 'scheme' is used). Driver instances are cached by name in the native code, which should avoid various bad behavior in terms of driver lifetimes and lack of care to process state. Devices are optionally (default True) cached at the Python level.

Fixes #9277
Expected to fix #9936