### PR TITLE
Add benchmark models for RISC-V targets

### DIFF
--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -110,6 +110,7 @@ set(MOBILENET_V1_MODULE
   TAGS
     "fp32,imagenet"
   SOURCE
+    # TODO(mariecwhite): Add the source information of where it is mirrored from.
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
   ENTRY_FUNCTION
     "main"

--- a/benchmarks/TFLite/CMakeLists.txt
+++ b/benchmarks/TFLite/CMakeLists.txt
@@ -104,6 +104,19 @@ set(MOBILEBERT_FP16_MODULE
     "1x384xi32,1x384xi32,1x384xi32"
 )
 
+set(MOBILENET_V1_MODULE
+  NAME
+    "MobileNetV1"
+  TAGS
+    "fp32,imagenet"
+  SOURCE
+    "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
+  ENTRY_FUNCTION
+    "main"
+  FUNCTION_INPUTS
+    "1x224x224x3xf32"
+)
+
 set(MOBILENET_V2_MODULE
   NAME
     "MobileNetV2"
@@ -131,6 +144,20 @@ set(MOBILENET_V3SMALL_MODULE
     "main"
   FUNCTION_INPUTS
     "1x224x224x3xf32"
+)
+
+set(PERSON_DETECT_INT8_MODULE
+  NAME
+    "PersonDetect"
+  TAGS
+    "int8"
+  SOURCE
+    # Mirror of https://github.com/tensorflow/tflite-micro/raw/aeac6f39e5c7475cea20c54e86d41e3a38312546/tensorflow/lite/micro/models/person_detect.tflite
+    "https://storage.googleapis.com/iree-model-artifacts/person_detect.tflite"
+  ENTRY_FUNCTION
+    "main"
+  FUNCTION_INPUTS
+    "1x96x96x1xi8"
 )
 
 ################################################################################

--- a/benchmarks/TFLite/linux-riscv.cmake
+++ b/benchmarks/TFLite/linux-riscv.cmake
@@ -61,9 +61,8 @@ iree_benchmark_suite(
 )
 
 # CPU, Dylib-Sync, RV32-Generic, full-inference
-# Note this target is for codegen only, it can't not run the inference without
-# the cross-compile runtime and the emulator
-
+# Note this target is for codegen only. Inference is only possible with
+# the cross-compiled runtime and an emulator.
 iree_benchmark_suite(
   GROUP_NAME
     "linux-riscv"

--- a/benchmarks/TFLite/linux-riscv.cmake
+++ b/benchmarks/TFLite/linux-riscv.cmake
@@ -42,7 +42,9 @@ iree_benchmark_suite(
     "linux-riscv"
 
   MODULES
+    "${DEEPLABV3_FP32_MODULE}"
     "${MOBILEBERT_FP32_MODULE}"
+    "${MOBILENET_V1_MODULE}"
 
   BENCHMARK_MODES
     "full-inference,default-flags"
@@ -52,6 +54,31 @@ iree_benchmark_suite(
     "CPU-RV64-Generic"
   TRANSLATION_FLAGS
     ${LINUX_RV64_GENERIC_CPU_TRANSLATION_FLAGS}
+  BENCHMARK_TOOL
+    iree-benchmark-module
+  DRIVER
+    "dylib-sync"
+)
+
+# CPU, Dylib-Sync, RV32-Generic, full-inference
+# Note this target is for codegen only, it can't not run the inference without
+# the cross-compile runtime and the emulator
+
+iree_benchmark_suite(
+  GROUP_NAME
+    "linux-riscv"
+
+  MODULES
+    "${PERSON_DETECT_INT8_MODULE}"
+
+  BENCHMARK_MODES
+    "full-inference,default-flags"
+  TARGET_BACKEND
+    "dylib-llvm-aot"
+  TARGET_ARCHITECTURE
+    "CPU-RV32-Generic"
+  TRANSLATION_FLAGS
+    ${LINUX_RV32_GENERIC_CPU_TRANSLATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   DRIVER


### PR DESCRIPTION
The benchmark metrics currently aim for compilation statistics. To run
the full inference, the cross-compile runtime and the RISC-V
environment needs to be in CI to run the inference properly.

Also, a more code-size-conscious set of codegen flags should be used
when we have the benchmark infrastructure updated to consume different
benchmark targets more effectively.