### PR TITLE
Making runtime APIs with sized arrays consistently (count, array).

### DIFF
--- a/compiler/src/iree/compiler/ConstEval/Runtime.cpp
+++ b/compiler/src/iree/compiler/ConstEval/Runtime.cpp
@@ -281,8 +281,8 @@ void CompiledBinary::initialize(void* data, size_t length) {
   // Context.
   std::array<iree_vm_module_t*, 2> modules = {hal_module, main_module};
   IREE_CHECK_OK(iree_vm_context_create_with_modules(
-      runtime.instance, IREE_VM_CONTEXT_FLAG_NONE, modules.data(),
-      modules.size(), iree_allocator_system(), &context));
+      runtime.instance, IREE_VM_CONTEXT_FLAG_NONE, modules.size(),
+      modules.data(), iree_allocator_system(), &context));
 }
 
 InMemoryCompiledBinary::~InMemoryCompiledBinary() { deinitialize(); }

--- a/docs/website/docs/bindings/c-api.md
+++ b/docs/website/docs/bindings/c-api.md
@@ -163,7 +163,7 @@ iree_vm_context_t* context = NULL;
 iree_vm_module_t* modules[2] = {hal_module, bytecode_module};
 IREE_CHECK_OK(iree_vm_context_create_with_modules(
     instance, IREE_VM_CONTEXT_FLAG_NONE,
-    modules, IREE_ARRAYSIZE(modules),
+    IREE_ARRAYSIZE(modules), modules,
     iree_allocator_system(), &context));
 // References to the modules can be released now.
 iree_vm_module_release(hal_module);

--- a/experimental/rocm/rocm_driver.c
+++ b/experimental/rocm/rocm_driver.c
@@ -115,8 +115,8 @@ static uint8_t* iree_hal_rocm_populate_device_info(
 
 static iree_status_t iree_hal_rocm_driver_query_available_devices(
     iree_hal_driver_t* base_driver, iree_allocator_t host_allocator,
-    iree_hal_device_info_t** out_device_infos,
-    iree_host_size_t* out_device_info_count) {
+    iree_host_size_t* out_device_info_count,
+    iree_hal_device_info_t** out_device_infos) {
   iree_hal_rocm_driver_t* driver = iree_hal_rocm_driver_cast(base_driver);
   // Query the number of available ROCM devices.
   int device_count = 0;

--- a/experimental/web/sample_static/main.c
+++ b/experimental/web/sample_static/main.c
@@ -120,8 +120,8 @@ int run_sample(iree_sample_state_t* state, float* image_data) {
   iree_hal_dim_t buffer_shape[] = {1, 28, 28, 1};
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_hal_device_allocator(state->device), buffer_shape,
-        IREE_ARRAYSIZE(buffer_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+        iree_hal_device_allocator(state->device), IREE_ARRAYSIZE(buffer_shape),
+        buffer_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -126,7 +126,7 @@ py::object HalAllocator::AllocateBufferCopy(
   iree_hal_buffer_view_t* hal_buffer_view;
   CheckApiStatus(
       iree_hal_buffer_view_create(
-          hal_buffer, dims.data(), dims.size(), *element_type, encoding_type,
+          hal_buffer, dims.size(), dims.data(), *element_type, encoding_type,
           iree_hal_allocator_host_allocator(raw_ptr()), &hal_buffer_view),
       "Error allocating buffer_view");
   iree_hal_buffer_release(hal_buffer);
@@ -210,12 +210,12 @@ py::str HalBufferView::Repr() {
 //------------------------------------------------------------------------------
 
 std::vector<std::string> HalDriver::Query() {
-  iree_hal_driver_info_t* driver_infos = NULL;
   iree_host_size_t driver_info_count = 0;
+  iree_hal_driver_info_t* driver_infos = NULL;
   CheckApiStatus(
       iree_hal_driver_registry_enumerate(iree_hal_driver_registry_default(),
-                                         iree_allocator_system(), &driver_infos,
-                                         &driver_info_count),
+                                         iree_allocator_system(),
+                                         &driver_info_count, &driver_infos),
       "Error enumerating HAL drivers");
   std::vector<std::string> driver_names(driver_info_count);
   for (iree_host_size_t i = 0; i < driver_info_count; ++i) {

--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -142,7 +142,7 @@ class HalBuffer : public ApiRefCounted<HalBuffer, iree_hal_buffer_t> {
     iree_hal_encoding_type_t encoding_type =
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR;
     CheckApiStatus(iree_hal_buffer_view_create(
-                       raw_ptr(), shape.s.data(), shape.s.size(), element_type,
+                       raw_ptr(), shape.s.size(), shape.s.data(), element_type,
                        encoding_type, iree_allocator_system(), &bv),
                    "Error creating buffer view");
     return HalBufferView::StealFromRawPtr(bv);

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -93,8 +93,8 @@ VmContext VmContext::Create(VmInstance* instance,
       module_handles[i] = (*modules)[i]->raw_ptr();
     }
     auto status = iree_vm_context_create_with_modules(
-        instance->raw_ptr(), IREE_VM_CONTEXT_FLAG_NONE, module_handles.data(),
-        module_handles.size(), iree_allocator_system(), &context);
+        instance->raw_ptr(), IREE_VM_CONTEXT_FLAG_NONE, module_handles.size(),
+        module_handles.data(), iree_allocator_system(), &context);
     CheckApiStatus(status, "Error creating vm context with modules");
   }
 
@@ -108,8 +108,8 @@ void VmContext::RegisterModules(std::vector<VmModule*> modules) {
   for (size_t i = 0, e = module_handles.size(); i < e; ++i) {
     module_handles[i] = modules[i]->raw_ptr();
   }
-  auto status = iree_vm_context_register_modules(raw_ptr(), &module_handles[0],
-                                                 module_handles.size());
+  auto status = iree_vm_context_register_modules(
+      raw_ptr(), module_handles.size(), &module_handles[0]);
   CheckApiStatus(status, "Error registering modules");
 }
 

--- a/runtime/bindings/tflite/interpreter.c
+++ b/runtime/bindings/tflite/interpreter.c
@@ -34,11 +34,11 @@ static iree_status_t _TfLiteInterpreterPrepareHAL(
   iree_hal_driver_registry_t* driver_registry =
       iree_hal_driver_registry_default();
 
-  iree_hal_driver_info_t* driver_infos = NULL;
   iree_host_size_t driver_info_count = 0;
+  iree_hal_driver_info_t* driver_infos = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_driver_registry_enumerate(
-      driver_registry, interpreter->allocator, &driver_infos,
-      &driver_info_count));
+      driver_registry, interpreter->allocator, &driver_info_count,
+      &driver_infos));
 
   // TODO(benvanik): figure out how we want to emulate device selection; may
   // just say "whatever is first" on a query.
@@ -371,7 +371,7 @@ static iree_status_t _TfLiteInterpreterCreate(
   // IREE functions that will call custom ops through TfLiteRegistrations.
   IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
       interpreter->instance, IREE_VM_CONTEXT_FLAG_NONE,
-      interpreter->all_modules, IREE_ARRAYSIZE(interpreter->all_modules),
+      IREE_ARRAYSIZE(interpreter->all_modules), interpreter->all_modules,
       interpreter->allocator, &interpreter->context));
 
   // Setup all I/O tensors and buffer views.

--- a/runtime/bindings/tflite/tensor.c
+++ b/runtime/bindings/tflite/tensor.c
@@ -123,7 +123,7 @@ iree_status_t _TfLiteTensorReallocateIfNeeded(
   iree_device_size_t allocation_size = 0;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_buffer_compute_view_size(
-              shape_dims, tensor->shape_rank, element_type,
+              tensor->shape_rank, shape_dims, element_type,
               IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, &allocation_size));
   allocation_size *= storage_scalar;
 

--- a/runtime/src/iree/base/bitfield.c
+++ b/runtime/src/iree/base/bitfield.c
@@ -9,9 +9,10 @@
 #include <stdlib.h>
 #include <string.h>
 
-IREE_API_EXPORT iree_status_t iree_bitfield_format(
-    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
-    iree_host_size_t mapping_count, iree_string_builder_t* string_builder) {
+IREE_API_EXPORT iree_status_t
+iree_bitfield_format(uint32_t value, iree_host_size_t mapping_count,
+                     const iree_bitfield_string_mapping_t* mappings,
+                     iree_string_builder_t* string_builder) {
   uint32_t remaining_bits = value;
   int i = 0;
   for (iree_host_size_t mapping_index = 0; mapping_index < mapping_count;
@@ -39,14 +40,15 @@ IREE_API_EXPORT iree_status_t iree_bitfield_format(
   return iree_ok_status();
 }
 
-IREE_API_EXPORT iree_string_view_t iree_bitfield_format_inline(
-    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
-    iree_host_size_t mapping_count, iree_bitfield_string_temp_t* out_temp) {
+IREE_API_EXPORT iree_string_view_t
+iree_bitfield_format_inline(uint32_t value, iree_host_size_t mapping_count,
+                            const iree_bitfield_string_mapping_t* mappings,
+                            iree_bitfield_string_temp_t* out_temp) {
   iree_string_builder_t string_builder;
   iree_string_builder_initialize_with_storage(
       out_temp->buffer, IREE_ARRAYSIZE(out_temp->buffer), &string_builder);
   iree_status_t status =
-      iree_bitfield_format(value, mappings, mapping_count, &string_builder);
+      iree_bitfield_format(value, mapping_count, mappings, &string_builder);
   if (iree_status_is_ok(status)) {
     return iree_string_builder_view(&string_builder);
   }

--- a/runtime/src/iree/base/bitfield.h
+++ b/runtime/src/iree/base/bitfield.h
@@ -46,17 +46,18 @@ typedef struct iree_bitfield_string_mapping_t {
 //  // Produces the string "A|B":
 //  IREE_RETURN_IF_ERROR(iree_bitfield_format(
 //      MY_BITFIELD_A | MY_BITFIELD_B,
-//      my_bitfield_mappings, IREE_ARRAYSIZE(my_bitfield_mappings),
+//      IREE_ARRAYSIZE(my_bitfield_mappings), my_bitfield_mappings,
 //      &string_builder));
 //
 //  // Produces the string "ALL":
 //  IREE_RETURN_IF_ERROR(iree_bitfield_format(
 //      MY_BITFIELD_A | MY_BITFIELD_B | MY_BITFIELD_C,
-//      my_bitfield_mappings, IREE_ARRAYSIZE(my_bitfield_mappings),
+//      IREE_ARRAYSIZE(my_bitfield_mappings), my_bitfield_mappings,
 //      &string_builder));
-IREE_API_EXPORT iree_status_t iree_bitfield_format(
-    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
-    iree_host_size_t mapping_count, iree_string_builder_t* string_builder);
+IREE_API_EXPORT iree_status_t
+iree_bitfield_format(uint32_t value, iree_host_size_t mapping_count,
+                     const iree_bitfield_string_mapping_t* mappings,
+                     iree_string_builder_t* string_builder);
 
 // Stack storage for iree_bitfield_format_inline temporary strings.
 typedef struct iree_bitfield_string_temp_t {
@@ -72,11 +73,12 @@ typedef struct iree_bitfield_string_temp_t {
 //  iree_bitfield_string_temp_t temp;
 //  iree_string_view_t my_str = iree_bitfield_format_inline(
 //      MY_BITFIELD_A | MY_BITFIELD_B,
-//      my_bitfield_mappings, IREE_ARRAYSIZE(my_bitfield_mappings),
+//      IREE_ARRAYSIZE(my_bitfield_mappings), my_bitfield_mappings,
 //      &temp);
-IREE_API_EXPORT iree_string_view_t iree_bitfield_format_inline(
-    uint32_t value, const iree_bitfield_string_mapping_t* mappings,
-    iree_host_size_t mapping_count, iree_bitfield_string_temp_t* out_temp);
+IREE_API_EXPORT iree_string_view_t
+iree_bitfield_format_inline(uint32_t value, iree_host_size_t mapping_count,
+                            const iree_bitfield_string_mapping_t* mappings,
+                            iree_bitfield_string_temp_t* out_temp);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/base/bitfield_test.cc
+++ b/runtime/src/iree/base/bitfield_test.cc
@@ -26,7 +26,7 @@ std::string FormatBitfieldValue(
     uint32_t value,
     const iree_bitfield_string_mapping_t (&mappings)[mapping_count]) {
   iree_bitfield_string_temp_t temp;
-  auto sv = iree_bitfield_format_inline(value, mappings, mapping_count, &temp);
+  auto sv = iree_bitfield_format_inline(value, mapping_count, mappings, &temp);
   return std::string(sv.data, sv.size);
 }
 
@@ -48,7 +48,7 @@ TEST(BitfieldTest, FormatBitfieldValueEmpty) {
       {0, IREE_SV("UNUSED")},
   };
   iree_bitfield_string_temp_t temp;
-  auto sv = iree_bitfield_format_inline(MY_BITFIELD_NONE, mappings, 0, &temp);
+  auto sv = iree_bitfield_format_inline(MY_BITFIELD_NONE, 0, mappings, &temp);
   EXPECT_TRUE(iree_string_view_is_empty(sv));
 }
 

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -34,7 +34,7 @@ IREE_API_EXPORT iree_string_view_t iree_hal_memory_type_format(
       {IREE_HAL_MEMORY_TYPE_HOST_CACHED, IREE_SVL("HOST_CACHED")},
       {IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE, IREE_SVL("DEVICE_VISIBLE")},
   };
-  return iree_bitfield_format_inline(value, mappings, IREE_ARRAYSIZE(mappings),
+  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
                                      out_temp);
 }
 
@@ -51,7 +51,7 @@ IREE_API_EXPORT iree_string_view_t iree_hal_memory_access_format(
       {IREE_HAL_MEMORY_ACCESS_MAY_ALIAS, IREE_SVL("MAY_ALIAS")},
       {IREE_HAL_MEMORY_ACCESS_ANY, IREE_SVL("ANY")},
   };
-  return iree_bitfield_format_inline(value, mappings, IREE_ARRAYSIZE(mappings),
+  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
                                      out_temp);
 }
 
@@ -65,7 +65,7 @@ IREE_API_EXPORT iree_string_view_t iree_hal_buffer_usage_format(
       {IREE_HAL_BUFFER_USAGE_MAPPING, IREE_SVL("MAPPING")},
       {IREE_HAL_BUFFER_USAGE_DISPATCH, IREE_SVL("DISPATCH")},
   };
-  return iree_bitfield_format_inline(value, mappings, IREE_ARRAYSIZE(mappings),
+  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
                                      out_temp);
 }
 

--- a/runtime/src/iree/hal/buffer_view.c
+++ b/runtime/src/iree/hal/buffer_view.c
@@ -24,8 +24,8 @@ struct iree_hal_buffer_view_t {
 };
 
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_create(
-    iree_hal_buffer_t* buffer, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
+    iree_hal_buffer_t* buffer, iree_host_size_t shape_rank,
+    const iree_hal_dim_t* shape, iree_hal_element_type_t element_type,
     iree_hal_encoding_type_t encoding_type, iree_allocator_t host_allocator,
     iree_hal_buffer_view_t** out_buffer_view) {
   IREE_ASSERT_ARGUMENT(buffer);
@@ -214,22 +214,22 @@ iree_hal_buffer_view_byte_length(const iree_hal_buffer_view_t* buffer_view) {
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_compute_offset(
-    const iree_hal_buffer_view_t* buffer_view, const iree_hal_dim_t* indices,
-    iree_host_size_t indices_count, iree_device_size_t* out_offset) {
+    const iree_hal_buffer_view_t* buffer_view, iree_host_size_t indices_count,
+    const iree_hal_dim_t* indices, iree_device_size_t* out_offset) {
   IREE_ASSERT_ARGUMENT(buffer_view);
   return iree_hal_buffer_compute_view_offset(
-      buffer_view->shape, buffer_view->shape_rank, buffer_view->element_type,
-      buffer_view->encoding_type, indices, indices_count, out_offset);
+      buffer_view->shape_rank, buffer_view->shape, buffer_view->element_type,
+      buffer_view->encoding_type, indices_count, indices, out_offset);
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_compute_range(
-    const iree_hal_buffer_view_t* buffer_view,
-    const iree_hal_dim_t* start_indices, iree_host_size_t indices_count,
-    const iree_hal_dim_t* lengths, iree_host_size_t lengths_count,
-    iree_device_size_t* out_start_offset, iree_device_size_t* out_length) {
+    const iree_hal_buffer_view_t* buffer_view, iree_host_size_t indices_count,
+    const iree_hal_dim_t* start_indices, iree_host_size_t lengths_count,
+    const iree_hal_dim_t* lengths, iree_device_size_t* out_start_offset,
+    iree_device_size_t* out_length) {
   IREE_ASSERT_ARGUMENT(buffer_view);
   return iree_hal_buffer_compute_view_range(
-      buffer_view->shape, buffer_view->shape_rank, buffer_view->element_type,
-      buffer_view->encoding_type, start_indices, indices_count, lengths,
-      lengths_count, out_start_offset, out_length);
+      buffer_view->shape_rank, buffer_view->shape, buffer_view->element_type,
+      buffer_view->encoding_type, indices_count, start_indices, lengths_count,
+      lengths, out_start_offset, out_length);
 }

--- a/runtime/src/iree/hal/buffer_view.h
+++ b/runtime/src/iree/hal/buffer_view.h
@@ -170,8 +170,8 @@ typedef struct iree_hal_buffer_view_t iree_hal_buffer_view_t;
 // Creates a buffer view with the given |buffer|.
 // |out_buffer_view| must be released by the caller.
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_create(
-    iree_hal_buffer_t* buffer, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
+    iree_hal_buffer_t* buffer, iree_host_size_t shape_rank,
+    const iree_hal_dim_t* shape, iree_hal_element_type_t element_type,
     iree_hal_encoding_type_t encoding_type, iree_allocator_t host_allocator,
     iree_hal_buffer_view_t** out_buffer_view);
 
@@ -248,16 +248,16 @@ iree_hal_buffer_view_byte_length(const iree_hal_buffer_view_t* buffer_view);
 // Calculates a byte offset into the |buffer_view| at the given indices.
 // Requires that the encoding and element type support indexing.
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_compute_offset(
-    const iree_hal_buffer_view_t* buffer_view, const iree_hal_dim_t* indices,
-    iree_host_size_t indices_count, iree_device_size_t* out_offset);
+    const iree_hal_buffer_view_t* buffer_view, iree_host_size_t indices_count,
+    const iree_hal_dim_t* indices, iree_device_size_t* out_offset);
 
 // Calculates a byte range into the |buffer_view| of the given contiguous range.
 // Requires that the encoding and element type support indexing.
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_compute_range(
-    const iree_hal_buffer_view_t* buffer_view,
-    const iree_hal_dim_t* start_indices, iree_host_size_t indices_count,
-    const iree_hal_dim_t* lengths, iree_host_size_t lengths_count,
-    iree_device_size_t* out_start_offset, iree_device_size_t* out_length);
+    const iree_hal_buffer_view_t* buffer_view, iree_host_size_t indices_count,
+    const iree_hal_dim_t* start_indices, iree_host_size_t lengths_count,
+    const iree_hal_dim_t* lengths, iree_device_size_t* out_start_offset,
+    iree_device_size_t* out_length);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_buffer_view_t implementation details

--- a/runtime/src/iree/hal/buffer_view_util.h
+++ b/runtime/src/iree/hal/buffer_view_util.h
@@ -25,7 +25,7 @@ extern "C" {
 
 // Calculates the allocation size of a buffer view.
 IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_size(
-    const iree_hal_dim_t* shape, iree_host_size_t shape_rank,
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
     iree_hal_element_type_t element_type,
     iree_hal_encoding_type_t encoding_type,
     iree_device_size_t* out_allocation_size);
@@ -33,19 +33,19 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_size(
 // Calculates a byte offset into a buffer at the given indices.
 // Only works with densely-packed representations.
 IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_offset(
-    const iree_hal_dim_t* shape, iree_host_size_t shape_rank,
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
     iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type, const iree_hal_dim_t* indices,
-    size_t indices_count, iree_device_size_t* out_offset);
+    iree_hal_encoding_type_t encoding_type, iree_host_size_t indices_count,
+    const iree_hal_dim_t* indices, iree_device_size_t* out_offset);
 
 // Calculates a byte range into a buffer of the given contiguous range.
 // Only works with densely-packed representations.
 IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_range(
-    const iree_hal_dim_t* shape, iree_host_size_t shape_rank,
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
     iree_hal_element_type_t element_type,
-    iree_hal_encoding_type_t encoding_type, const iree_hal_dim_t* start_indices,
-    iree_host_size_t indices_count, const iree_hal_dim_t* lengths,
-    iree_host_size_t lengths_count, iree_device_size_t* out_start_offset,
+    iree_hal_encoding_type_t encoding_type, iree_host_size_t indices_count,
+    const iree_hal_dim_t* start_indices, iree_host_size_t lengths_count,
+    const iree_hal_dim_t* lengths, iree_device_size_t* out_start_offset,
     iree_device_size_t* out_length);
 
 //===----------------------------------------------------------------------===//
@@ -59,8 +59,8 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_compute_view_range(
 //   2. iree_hal_allocator_allocate_buffer
 //   3. iree_hal_buffer_view_create
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_allocate_buffer(
-    iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
+    iree_hal_allocator_t* allocator, iree_host_size_t shape_rank,
+    const iree_hal_dim_t* shape, iree_hal_element_type_t element_type,
     iree_hal_encoding_type_t encoding_type,
     iree_hal_buffer_params_t buffer_params, iree_const_byte_span_t initial_data,
     iree_hal_buffer_view_t** out_buffer_view);
@@ -91,8 +91,8 @@ typedef iree_status_t(IREE_API_PTR* iree_hal_buffer_view_generator_callback_t)(
 //   3. iree_hal_buffer_map_range + callback + iree_hal_buffer_unmap_range
 //   4. iree_hal_buffer_view_create
 IREE_API_EXPORT iree_status_t iree_hal_buffer_view_generate_buffer(
-    iree_hal_allocator_t* allocator, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
+    iree_hal_allocator_t* allocator, iree_host_size_t shape_rank,
+    const iree_hal_dim_t* shape, iree_hal_element_type_t element_type,
     iree_hal_encoding_type_t encoding_type,
     iree_hal_buffer_params_t buffer_params,
     iree_hal_buffer_view_generator_callback_t callback, void* user_data,

--- a/runtime/src/iree/hal/command_buffer.c
+++ b/runtime/src/iree/hal/command_buffer.c
@@ -43,7 +43,7 @@ iree_hal_command_buffer_mode_format(iree_hal_command_buffer_mode_t value,
        IREE_SVL("ALLOW_INLINE_EXECUTION")},
       {IREE_HAL_COMMAND_BUFFER_MODE_UNVALIDATED, IREE_SVL("UNVALIDATED")},
   };
-  return iree_bitfield_format_inline(value, mappings, IREE_ARRAYSIZE(mappings),
+  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
                                      out_temp);
 }
 
@@ -56,7 +56,7 @@ IREE_API_EXPORT iree_string_view_t iree_hal_command_category_format(
       {IREE_HAL_COMMAND_CATEGORY_TRANSFER, IREE_SVL("TRANSFER")},
       {IREE_HAL_COMMAND_CATEGORY_DISPATCH, IREE_SVL("DISPATCH")},
   };
-  return iree_bitfield_format_inline(value, mappings, IREE_ARRAYSIZE(mappings),
+  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
                                      out_temp);
 }
 

--- a/runtime/src/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_dispatch_test.h
@@ -89,8 +89,8 @@ TEST_P(command_buffer_dispatch_test, DispatchAbs) {
   iree_hal_buffer_view_t* input_buffer_view = NULL;
   float input_data[1] = {-2.5f};
   IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-      device_allocator_, /*shape=*/NULL,
-      /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      device_allocator_,
+      /*shape_rank=*/0, /*shape=*/NULL, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, input_params,
       iree_make_const_byte_span((void*)input_data, sizeof(input_data)),
       &input_buffer_view));

--- a/runtime/src/iree/hal/cts/driver_test.h
+++ b/runtime/src/iree/hal/cts/driver_test.h
@@ -23,10 +23,10 @@ namespace cts {
 class driver_test : public CtsTestBase {};
 
 TEST_P(driver_test, QueryAndCreateAvailableDevices) {
+  iree_host_size_t device_info_count = 0;
   iree_hal_device_info_t* device_infos = NULL;
-  iree_host_size_t device_info_count;
   IREE_ASSERT_OK(iree_hal_driver_query_available_devices(
-      driver_, iree_allocator_system(), &device_infos, &device_info_count));
+      driver_, iree_allocator_system(), &device_info_count, &device_infos));
 
   std::cout << "Driver has " << device_info_count << " device(s)";
   for (iree_host_size_t i = 0; i < device_info_count; ++i) {

--- a/runtime/src/iree/hal/driver.c
+++ b/runtime/src/iree/hal/driver.c
@@ -20,15 +20,15 @@ IREE_HAL_API_RETAIN_RELEASE(driver);
 
 IREE_API_EXPORT iree_status_t iree_hal_driver_query_available_devices(
     iree_hal_driver_t* driver, iree_allocator_t host_allocator,
-    iree_hal_device_info_t** out_device_infos,
-    iree_host_size_t* out_device_info_count) {
+    iree_host_size_t* out_device_info_count,
+    iree_hal_device_info_t** out_device_infos) {
   IREE_ASSERT_ARGUMENT(driver);
-  IREE_ASSERT_ARGUMENT(out_device_infos);
   IREE_ASSERT_ARGUMENT(out_device_info_count);
+  IREE_ASSERT_ARGUMENT(out_device_infos);
   *out_device_info_count = 0;
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(driver, query_available_devices)(
-      driver, host_allocator, out_device_infos, out_device_info_count);
+      driver, host_allocator, out_device_info_count, out_device_infos);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
@@ -45,11 +45,11 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_create_device_by_ordinal(
   IREE_TRACE_ZONE_APPEND_VALUE(z0, (uint64_t)device_ordinal);
 
   // Query the devices from the driver.
-  iree_hal_device_info_t* device_infos = NULL;
   iree_host_size_t device_info_count = 0;
+  iree_hal_device_info_t* device_infos = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_hal_driver_query_available_devices(
-              driver, host_allocator, &device_infos, &device_info_count));
+              driver, host_allocator, &device_info_count, &device_infos));
 
   // Get the ID of the Nth device.
   iree_hal_device_id_t device_id = IREE_HAL_DEVICE_ID_DEFAULT;

--- a/runtime/src/iree/hal/driver.h
+++ b/runtime/src/iree/hal/driver.h
@@ -67,8 +67,8 @@ IREE_API_EXPORT void iree_hal_driver_release(iree_hal_driver_t* driver);
 // allocator by the caller.
 IREE_API_EXPORT iree_status_t iree_hal_driver_query_available_devices(
     iree_hal_driver_t* driver, iree_allocator_t host_allocator,
-    iree_hal_device_info_t** out_device_infos,
-    iree_host_size_t* out_device_info_count);
+    iree_host_size_t* out_device_info_count,
+    iree_hal_device_info_t** out_device_infos);
 
 // Creates a device with the given |device_ordinal| as enumerated by
 // iree_hal_driver_query_available_devices. The ordering of devices is driver
@@ -139,8 +139,8 @@ typedef struct iree_hal_driver_vtable_t {
 
   iree_status_t(IREE_API_PTR* query_available_devices)(
       iree_hal_driver_t* driver, iree_allocator_t host_allocator,
-      iree_hal_device_info_t** out_device_infos,
-      iree_host_size_t* out_device_info_count);
+      iree_host_size_t* out_device_info_count,
+      iree_hal_device_info_t** out_device_infos);
 
   iree_status_t(IREE_API_PTR* create_device_by_id)(
       iree_hal_driver_t* driver, iree_hal_device_id_t device_id,

--- a/runtime/src/iree/hal/driver_registry.c
+++ b/runtime/src/iree/hal/driver_registry.c
@@ -190,9 +190,11 @@ static iree_host_size_t iree_hal_driver_info_copy(
 
 IREE_API_EXPORT iree_status_t iree_hal_driver_registry_enumerate(
     iree_hal_driver_registry_t* registry, iree_allocator_t host_allocator,
-    iree_hal_driver_info_t** out_driver_infos,
-    iree_host_size_t* out_driver_info_count) {
+    iree_host_size_t* out_driver_info_count,
+    iree_hal_driver_info_t** out_driver_infos) {
   IREE_ASSERT_ARGUMENT(registry);
+  IREE_ASSERT_ARGUMENT(out_driver_info_count);
+  IREE_ASSERT_ARGUMENT(out_driver_infos);
   IREE_TRACE_ZONE_BEGIN(z0);
 
   *out_driver_info_count = 0;
@@ -210,7 +212,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_enumerate(
     const iree_hal_driver_info_t* driver_infos = NULL;
     iree_host_size_t driver_info_count = 0;
     status =
-        factory->enumerate(factory->self, &driver_infos, &driver_info_count);
+        factory->enumerate(factory->self, &driver_info_count, &driver_infos);
     if (!iree_status_is_ok(status)) break;
     total_driver_info_count += driver_info_count;
     for (iree_host_size_t j = 0; j < driver_info_count; j++) {
@@ -241,7 +243,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_enumerate(
       const iree_hal_driver_info_t* driver_infos = NULL;
       iree_host_size_t driver_info_count = 0;
       status =
-          factory->enumerate(factory->self, &driver_infos, &driver_info_count);
+          factory->enumerate(factory->self, &driver_info_count, &driver_infos);
       if (!iree_status_is_ok(status)) break;
       for (iree_host_size_t j = 0; j < driver_info_count; j++) {
         string_storage_ptr += iree_hal_driver_info_copy(
@@ -288,7 +290,7 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_try_create(
     const iree_hal_driver_info_t* driver_infos = NULL;
     iree_host_size_t driver_info_count = 0;
     status =
-        factory->enumerate(factory->self, &driver_infos, &driver_info_count);
+        factory->enumerate(factory->self, &driver_info_count, &driver_infos);
     if (!iree_status_is_ok(status)) break;
 
     // Scan for the specific driver by name.

--- a/runtime/src/iree/hal/driver_registry.h
+++ b/runtime/src/iree/hal/driver_registry.h
@@ -55,8 +55,8 @@ typedef struct iree_hal_driver_factory_t {
   //
   // Called with the driver registry lock held; may be called from any thread.
   iree_status_t(IREE_API_PTR* enumerate)(
-      void* self, const iree_hal_driver_info_t** out_driver_infos,
-      iree_host_size_t* out_driver_info_count);
+      void* self, iree_host_size_t* out_driver_info_count,
+      const iree_hal_driver_info_t** out_driver_infos);
 
   // Tries to create a driver as previously queried with enumerate.
   // |driver_id| is the opaque ID returned from enumeration; note that there may
@@ -135,8 +135,8 @@ IREE_API_EXPORT iree_status_t iree_hal_driver_registry_unregister_factory(
 // completing and any attempt to instantiate the driver.
 IREE_API_EXPORT iree_status_t iree_hal_driver_registry_enumerate(
     iree_hal_driver_registry_t* registry, iree_allocator_t host_allocator,
-    iree_hal_driver_info_t** out_driver_infos,
-    iree_host_size_t* out_driver_info_count);
+    iree_host_size_t* out_driver_info_count,
+    iree_hal_driver_info_t** out_driver_infos);
 
 // Attempts to create a driver registered with the given canonical driver name.
 // Effectively enumerate + find by name + try_create if found. Factories are

--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -129,8 +129,8 @@ static bool iree_hal_cuda_is_valid_device(iree_hal_cuda_driver_t* driver,
 
 static iree_status_t iree_hal_cuda_driver_query_available_devices(
     iree_hal_driver_t* base_driver, iree_allocator_t host_allocator,
-    iree_hal_device_info_t** out_device_infos,
-    iree_host_size_t* out_device_info_count) {
+    iree_host_size_t* out_device_info_count,
+    iree_hal_device_info_t** out_device_infos) {
   iree_hal_cuda_driver_t* driver = iree_hal_cuda_driver_cast(base_driver);
   // Query the number of available CUDA devices.
   int device_count = 0;
@@ -173,10 +173,10 @@ static iree_status_t iree_hal_cuda_driver_select_default_device(
     iree_hal_driver_t* base_driver, iree_hal_cuda_dynamic_symbols_t* syms,
     int default_device_index, iree_allocator_t host_allocator,
     CUdevice* out_device) {
-  iree_hal_device_info_t* out_device_infos;
-  iree_host_size_t device_count;
+  iree_hal_device_info_t* device_infos = NULL;
+  iree_host_size_t device_count = 0;
   IREE_RETURN_IF_ERROR(iree_hal_cuda_driver_query_available_devices(
-      base_driver, host_allocator, &out_device_infos, &device_count));
+      base_driver, host_allocator, &device_count, &device_infos));
   iree_status_t status = iree_ok_status();
   if (device_count == 0) {
     status = iree_make_status(IREE_STATUS_UNAVAILABLE,
@@ -186,9 +186,9 @@ static iree_status_t iree_hal_cuda_driver_select_default_device(
                               "default device %d not found (of %ld enumerated)",
                               default_device_index, device_count);
   } else {
-    *out_device = (CUdevice)out_device_infos[default_device_index].device_id;
+    *out_device = (CUdevice)device_infos[default_device_index].device_id;
   }
-  iree_allocator_free(host_allocator, out_device_infos);
+  iree_allocator_free(host_allocator, device_infos);
   return status;
 }
 

--- a/runtime/src/iree/hal/drivers/cuda/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/cuda/registration/driver_module.c
@@ -27,8 +27,8 @@ IREE_FLAG(bool, cuda_allow_inline_execution, false,
 IREE_FLAG(int32_t, cuda_default_index, 0, "Index of the default CUDA device.");
 
 static iree_status_t iree_hal_cuda_driver_factory_enumerate(
-    void* self, const iree_hal_driver_info_t** out_driver_infos,
-    iree_host_size_t* out_driver_info_count) {
+    void* self, iree_host_size_t* out_driver_info_count,
+    const iree_hal_driver_info_t** out_driver_infos) {
   // NOTE: we could query supported cuda versions or featuresets here.
   static const iree_hal_driver_info_t driver_infos[1] = {{
       .driver_name = iree_string_view_literal("cuda"),

--- a/runtime/src/iree/hal/drivers/local_sync/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/local_sync/registration/driver_module.c
@@ -14,8 +14,8 @@
 #include "iree/hal/local/loaders/registration/init.h"
 
 static iree_status_t iree_hal_local_sync_driver_factory_enumerate(
-    void* self, const iree_hal_driver_info_t** out_driver_infos,
-    iree_host_size_t* out_driver_info_count) {
+    void* self, iree_host_size_t* out_driver_info_count,
+    const iree_hal_driver_info_t** out_driver_infos) {
   static const iree_hal_driver_info_t default_driver_info = {
       .driver_name = IREE_SVL("local-sync"),
       .full_name = IREE_SVL("Local executable execution using a lightweight "

--- a/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_driver.c
@@ -97,8 +97,8 @@ static void iree_hal_sync_driver_destroy(iree_hal_driver_t* base_driver) {
 
 static iree_status_t iree_hal_sync_driver_query_available_devices(
     iree_hal_driver_t* base_driver, iree_allocator_t host_allocator,
-    iree_hal_device_info_t** out_device_infos,
-    iree_host_size_t* out_device_info_count) {
+    iree_host_size_t* out_device_info_count,
+    iree_hal_device_info_t** out_device_infos) {
   static const iree_hal_device_info_t device_infos[1] = {
       {
           .device_id = IREE_HAL_SYNC_DEVICE_ID_DEFAULT,

--- a/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
@@ -15,8 +15,8 @@
 #include "iree/task/api.h"
 
 static iree_status_t iree_hal_local_task_driver_factory_enumerate(
-    void* self, const iree_hal_driver_info_t** out_driver_infos,
-    iree_host_size_t* out_driver_info_count) {
+    void* self, iree_host_size_t* out_driver_info_count,
+    const iree_hal_driver_info_t** out_driver_infos) {
   static const iree_hal_driver_info_t driver_infos[1] = {
       {
           .driver_name = IREE_SVL("local-task"),

--- a/runtime/src/iree/hal/drivers/local_task/task_driver.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_driver.c
@@ -103,8 +103,8 @@ static void iree_hal_task_driver_destroy(iree_hal_driver_t* base_driver) {
 
 static iree_status_t iree_hal_task_driver_query_available_devices(
     iree_hal_driver_t* base_driver, iree_allocator_t host_allocator,
-    iree_hal_device_info_t** out_device_infos,
-    iree_host_size_t* out_device_info_count) {
+    iree_host_size_t* out_device_info_count,
+    iree_hal_device_info_t** out_device_infos) {
   static const iree_hal_device_info_t device_infos[1] = {
       {
           .device_id = IREE_HAL_TASK_DEVICE_ID_DEFAULT,

--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -102,7 +102,7 @@ typedef enum iree_hal_vulkan_extensibility_set_e {
 IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
     iree_hal_vulkan_features_t requested_features,
     iree_hal_vulkan_extensibility_set_t set, iree_host_size_t string_capacity,
-    const char** out_string_values, iree_host_size_t* out_string_count);
+    iree_host_size_t* out_string_count, const char** out_string_values);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_vulkan_syms_t

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -73,8 +73,8 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
 }
 
 static iree_status_t iree_hal_vulkan_driver_factory_enumerate(
-    void* self, const iree_hal_driver_info_t** out_driver_infos,
-    iree_host_size_t* out_driver_info_count) {
+    void* self, iree_host_size_t* out_driver_info_count,
+    const iree_hal_driver_info_t** out_driver_infos) {
   // NOTE: we could query supported vulkan versions or featuresets here.
   static const iree_hal_driver_info_t driver_infos[1] = {{
       /*driver_name=*/iree_make_cstring_view("vulkan"),

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -45,7 +45,7 @@ using namespace iree::hal::vulkan;
 IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
     iree_hal_vulkan_features_t requested_features,
     iree_hal_vulkan_extensibility_set_t set, iree_host_size_t string_capacity,
-    const char** out_string_values, iree_host_size_t* out_string_count) {
+    iree_host_size_t* out_string_count, const char** out_string_values) {
   *out_string_count = 0;
 
   iree_status_t status = iree_ok_status();
@@ -676,12 +676,12 @@ static iree_status_t iree_hal_vulkan_device_query_extensibility_set(
     iree_hal_vulkan_extensibility_set_t set, iree::Arena* arena,
     iree_hal_vulkan_string_list_t* out_string_list) {
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_query_extensibility_set(
-      requested_features, set, 0, NULL, &out_string_list->count));
+      requested_features, set, 0, &out_string_list->count, NULL));
   out_string_list->values = (const char**)arena->AllocateBytes(
       out_string_list->count * sizeof(out_string_list->values[0]));
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_query_extensibility_set(
-      requested_features, set, out_string_list->count, out_string_list->values,
-      &out_string_list->count));
+      requested_features, set, out_string_list->count, &out_string_list->count,
+      out_string_list->values));
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -158,12 +158,12 @@ static iree_status_t iree_hal_vulkan_driver_query_extensibility_set(
     iree_hal_vulkan_extensibility_set_t set, iree::Arena* arena,
     iree_hal_vulkan_string_list_t* out_string_list) {
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_query_extensibility_set(
-      requested_features, set, 0, NULL, &out_string_list->count));
+      requested_features, set, 0, &out_string_list->count, NULL));
   out_string_list->values = (const char**)arena->AllocateBytes(
       out_string_list->count * sizeof(out_string_list->values[0]));
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_query_extensibility_set(
-      requested_features, set, out_string_list->count, out_string_list->values,
-      &out_string_list->count));
+      requested_features, set, out_string_list->count, &out_string_list->count,
+      out_string_list->values));
   return iree_ok_status();
 }
 
@@ -377,8 +377,8 @@ static uint8_t* iree_hal_vulkan_populate_device_info(
 
 static iree_status_t iree_hal_vulkan_driver_query_available_devices(
     iree_hal_driver_t* base_driver, iree_allocator_t host_allocator,
-    iree_hal_device_info_t** out_device_infos,
-    iree_host_size_t* out_device_info_count) {
+    iree_host_size_t* out_device_info_count,
+    iree_hal_device_info_t** out_device_infos) {
   iree_hal_vulkan_driver_t* driver = iree_hal_vulkan_driver_cast(base_driver);
 
   // Query all devices from the Vulkan instance.

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -562,8 +562,9 @@ static iree_status_t iree_hal_vmvx_module_loader_try_load(
         bytecode_module,
     };
     status = iree_vm_context_create_with_modules(
-        executable_loader->instance, IREE_VM_CONTEXT_FLAG_NONE, modules,
-        IREE_ARRAYSIZE(modules), executable_loader->host_allocator, &context);
+        executable_loader->instance, IREE_VM_CONTEXT_FLAG_NONE,
+        IREE_ARRAYSIZE(modules), modules, executable_loader->host_allocator,
+        &context);
   }
 
   // Executable takes ownership of the entire context (including the bytecode

--- a/runtime/src/iree/hal/string_util.h
+++ b/runtime/src/iree/hal/string_util.h
@@ -22,13 +22,13 @@ extern "C" {
 // (the same as produced by iree_hal_format_shape).
 IREE_API_EXPORT iree_status_t iree_hal_parse_shape(
     iree_string_view_t value, iree_host_size_t shape_capacity,
-    iree_hal_dim_t* out_shape, iree_host_size_t* out_shape_rank);
+    iree_host_size_t* out_shape_rank, iree_hal_dim_t* out_shape);
 
 // Converts shape dimensions into a `4x5x6` format.
 //
 // Follows the standard API string formatting rules. See iree/base/api.h.
 IREE_API_EXPORT iree_status_t
-iree_hal_format_shape(const iree_hal_dim_t* shape, iree_host_size_t shape_rank,
+iree_hal_format_shape(iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
                       iree_host_size_t buffer_capacity, char* buffer,
                       iree_host_size_t* out_buffer_length);
 
@@ -53,7 +53,7 @@ IREE_API_EXPORT iree_status_t iree_hal_format_element_type(
 // iree_hal_parse_element_type. Ignores any training `=`.
 IREE_API_EXPORT iree_status_t iree_hal_parse_shape_and_element_type(
     iree_string_view_t value, iree_host_size_t shape_capacity,
-    iree_hal_dim_t* out_shape, iree_host_size_t* out_shape_rank,
+    iree_host_size_t* out_shape_rank, iree_hal_dim_t* out_shape,
     iree_hal_element_type_t* out_element_type);
 
 // Parses a serialized element of |element_type| to its in-memory form.
@@ -100,8 +100,8 @@ IREE_API_EXPORT iree_status_t iree_hal_parse_buffer_elements(
 //
 // Follows the standard API string formatting rules. See iree/base/api.h.
 IREE_API_EXPORT iree_status_t iree_hal_format_buffer_elements(
-    iree_const_byte_span_t data, const iree_hal_dim_t* shape,
-    iree_host_size_t shape_rank, iree_hal_element_type_t element_type,
+    iree_const_byte_span_t data, iree_host_size_t shape_rank,
+    const iree_hal_dim_t* shape, iree_hal_element_type_t element_type,
     iree_host_size_t max_element_count, iree_host_size_t buffer_capacity,
     char* buffer, iree_host_size_t* out_buffer_length);
 

--- a/runtime/src/iree/hal/string_util_test.cc
+++ b/runtime/src/iree/hal/string_util_test.cc
@@ -39,7 +39,7 @@ StatusOr<Shape> ParseShape(const std::string& value) {
   do {
     status =
         iree_hal_parse_shape(iree_string_view_t{value.data(), value.size()},
-                             shape.size(), shape.data(), &actual_rank);
+                             shape.size(), &actual_rank, shape.data());
     shape.resize(actual_rank);
   } while (iree_status_is_out_of_range(status));
   IREE_RETURN_IF_ERROR(std::move(status));
@@ -53,7 +53,7 @@ StatusOr<std::string> FormatShape(iree::span<const iree_hal_dim_t> value) {
   iree_status_t status = iree_ok_status();
   do {
     status =
-        iree_hal_format_shape(value.data(), value.size(), buffer.size() + 1,
+        iree_hal_format_shape(value.size(), value.data(), buffer.size() + 1,
                               &buffer[0], &actual_length);
     buffer.resize(actual_length);
   } while (iree_status_is_out_of_range(status));
@@ -108,7 +108,7 @@ StatusOr<ShapeAndType> ParseShapeAndElementType(const std::string& value) {
   do {
     status = iree_hal_parse_shape_and_element_type(
         iree_string_view_t{value.data(), value.size()}, shape.size(),
-        shape.data(), &actual_rank, &element_type);
+        &actual_rank, shape.data(), &element_type);
     shape.resize(actual_rank);
   } while (iree_status_is_out_of_range(status));
   IREE_RETURN_IF_ERROR(std::move(status));
@@ -184,7 +184,7 @@ StatusOr<std::string> FormatBufferElements(iree::span<const T> data,
     status = iree_hal_format_buffer_elements(
         iree_const_byte_span_t{reinterpret_cast<const uint8_t*>(data.data()),
                                data.size() * sizeof(T)},
-        shape.data(), shape.size(), element_type, max_element_count,
+        shape.size(), shape.data(), element_type, max_element_count,
         result.size() + 1, &result[0], &actual_length);
     result.resize(actual_length);
   } while (iree_status_is_out_of_range(status));
@@ -459,7 +459,7 @@ struct BufferView final
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR;
     BufferView buffer_view;
     iree_status_t status = iree_hal_buffer_view_create(
-        buffer, shape.data(), shape.size(), element_type, encoding_type,
+        buffer, shape.size(), shape.data(), element_type, encoding_type,
         iree_allocator_system(), &buffer_view);
     IREE_RETURN_IF_ERROR(std::move(status));
     return std::move(buffer_view);

--- a/runtime/src/iree/modules/check/check_test.cc
+++ b/runtime/src/iree/modules/check/check_test.cc
@@ -63,7 +63,7 @@ class CheckTest : public ::testing::Test {
   void SetUp() override {
     std::vector<iree_vm_module_t*> modules = {hal_module_, check_module_};
     IREE_ASSERT_OK(iree_vm_context_create_with_modules(
-        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
     allocator_ = iree_hal_device_allocator(device_);
   }
@@ -88,7 +88,7 @@ class CheckTest : public ::testing::Test {
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_INT_32,
+        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_INT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(int32_t)),
@@ -110,7 +110,7 @@ class CheckTest : public ::testing::Test {
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_16,
+        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_FLOAT_16,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(uint16_t)),
@@ -132,7 +132,7 @@ class CheckTest : public ::testing::Test {
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(float)),
@@ -154,7 +154,7 @@ class CheckTest : public ::testing::Test {
                    IREE_HAL_BUFFER_USAGE_TRANSFER |
                    IREE_HAL_BUFFER_USAGE_MAPPING;
     IREE_ASSERT_OK(iree_hal_buffer_view_allocate_buffer(
-        allocator_, shape.data(), shape.size(), IREE_HAL_ELEMENT_TYPE_FLOAT_64,
+        allocator_, shape.size(), shape.data(), IREE_HAL_ELEMENT_TYPE_FLOAT_64,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
         iree_make_const_byte_span(contents.data(),
                                   contents.size() * sizeof(double)),

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -610,7 +610,7 @@ IREE_VM_ABI_EXPORT(iree_hal_module_buffer_view_create,  //
 
   iree_hal_buffer_view_t* buffer_view = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_buffer_view_create(
-      source_buffer, shape_dims, shape_rank, element_type, encoding_type,
+      source_buffer, shape_rank, shape_dims, element_type, encoding_type,
       state->host_allocator, &buffer_view));
   rets->r0 = iree_hal_buffer_view_move_ref(buffer_view);
   return iree_ok_status();
@@ -749,10 +749,10 @@ IREE_VM_ABI_EXPORT(iree_hal_module_buffer_view_assert,  //
     char expected_shape_str[32];
     iree_host_size_t expected_shape_str_length = 0;
     IREE_RETURN_IF_ERROR(iree_hal_format_shape(
-        actual_shape_dims, actual_shape_rank, sizeof(actual_shape_str),
+        actual_shape_rank, actual_shape_dims, sizeof(actual_shape_str),
         actual_shape_str, &actual_shape_str_length));
     IREE_RETURN_IF_ERROR(iree_hal_format_shape(
-        expected_shape_dims, expected_shape_rank, sizeof(expected_shape_str),
+        expected_shape_rank, expected_shape_dims, sizeof(expected_shape_str),
         expected_shape_str, &expected_shape_str_length));
     shape_status = iree_status_annotate_f(
         shape_status, "expected shape %.*s, actual shape %.*s",

--- a/runtime/src/iree/runtime/demo/hello_world_explained.c
+++ b/runtime/src/iree/runtime/demo/hello_world_explained.c
@@ -195,8 +195,8 @@ static iree_status_t iree_runtime_demo_perform_mul(
       static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
       status = iree_hal_buffer_view_allocate_buffer(
           device_allocator,
-          // Shape dimensions and rank:
-          arg0_shape, IREE_ARRAYSIZE(arg0_shape),
+          // Shape rank and dimensions:
+          IREE_ARRAYSIZE(arg0_shape), arg0_shape,
           // Element type:
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,
           // Encoding type:
@@ -232,7 +232,7 @@ static iree_status_t iree_runtime_demo_perform_mul(
       static const iree_hal_dim_t arg1_shape[1] = {4};
       static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
       status = iree_hal_buffer_view_allocate_buffer(
-          device_allocator, arg1_shape, IREE_ARRAYSIZE(arg1_shape),
+          device_allocator, IREE_ARRAYSIZE(arg1_shape), arg1_shape,
           IREE_HAL_ELEMENT_TYPE_FLOAT_32,
           IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
           (iree_hal_buffer_params_t){

--- a/runtime/src/iree/runtime/demo/hello_world_terse.c
+++ b/runtime/src/iree/runtime/demo/hello_world_terse.c
@@ -81,8 +81,8 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   static const iree_hal_dim_t arg0_shape[1] = {4};
   static const float arg0_data[4] = {1.0f, 1.1f, 1.2f, 1.3f};
   IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
-      iree_runtime_session_device_allocator(session), arg0_shape,
-      IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      iree_runtime_session_device_allocator(session),
+      IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
@@ -104,8 +104,8 @@ static void iree_runtime_demo_perform_mul(iree_runtime_session_t* session) {
   static const iree_hal_dim_t arg1_shape[1] = {4};
   static const float arg1_data[4] = {10.0f, 100.0f, 1000.0f, 10000.0f};
   IREE_CHECK_OK(iree_hal_buffer_view_allocate_buffer(
-      iree_runtime_session_device_allocator(session), arg1_shape,
-      IREE_ARRAYSIZE(arg1_shape), IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      iree_runtime_session_device_allocator(session),
+      IREE_ARRAYSIZE(arg1_shape), arg1_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
       IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/runtime/src/iree/runtime/session.c
+++ b/runtime/src/iree/runtime/session.c
@@ -97,7 +97,8 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_create_with_device(
     status = iree_hal_module_create(device, host_allocator, &hal_module);
   }
   if (iree_status_is_ok(status)) {
-    status = iree_vm_context_register_modules(session->context, &hal_module, 1);
+    status = iree_vm_context_register_modules(
+        session->context, /*module_count=*/1, /*modules=*/&hal_module);
   }
   if (iree_status_is_ok(status)) {
     status = iree_vm_context_resolve_module_state(session->context, hal_module,
@@ -189,8 +190,9 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_append_module(
   IREE_TRACE_ZONE_APPEND_TEXT(z0, iree_vm_module_name(module).data,
                               iree_vm_module_name(module).size);
 
-  iree_status_t status = iree_vm_context_register_modules(
-      iree_runtime_session_context(session), &module, 1);
+  iree_status_t status =
+      iree_vm_context_register_modules(iree_runtime_session_context(session),
+                                       /*module_count=*/1, /*modules=*/&module);
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/runtime/src/iree/tooling/vm_util.cc
+++ b/runtime/src/iree/tooling/vm_util.cc
@@ -37,7 +37,7 @@ static iree_status_t CreateBufferViewFromFile(
   iree_hal_element_type_t element_type = IREE_HAL_ELEMENT_TYPE_NONE;
   iree_host_size_t shape_rank = 0;
   iree_status_t shape_result = iree_hal_parse_shape_and_element_type(
-      metadata, 0, NULL, &shape_rank, &element_type);
+      metadata, 0, &shape_rank, NULL, &element_type);
   if (!iree_status_is_ok(shape_result) &&
       !iree_status_is_out_of_range(shape_result)) {
     return shape_result;
@@ -50,7 +50,7 @@ static iree_status_t CreateBufferViewFromFile(
   iree_hal_dim_t* shape =
       (iree_hal_dim_t*)iree_alloca(shape_rank * sizeof(iree_hal_dim_t));
   IREE_RETURN_IF_ERROR(iree_hal_parse_shape_and_element_type(
-      metadata, shape_rank, shape, &shape_rank, &element_type));
+      metadata, shape_rank, &shape_rank, shape, &element_type));
 
   // TODO(benvanik): allow specifying the encoding.
   iree_hal_encoding_type_t encoding_type =
@@ -75,7 +75,7 @@ static iree_status_t CreateBufferViewFromFile(
       file,
   };
   iree_status_t status = iree_hal_buffer_view_generate_buffer(
-      device_allocator, shape, shape_rank, element_type, encoding_type,
+      device_allocator, shape_rank, shape, element_type, encoding_type,
       buffer_params,
       +[](iree_hal_buffer_mapping_t* mapping, void* user_data) {
         auto* read_params = reinterpret_cast<read_params_t*>(user_data);

--- a/runtime/src/iree/vm/bytecode_dispatch_test.cc
+++ b/runtime/src/iree/vm/bytecode_dispatch_test.cc
@@ -82,7 +82,7 @@ class VMBytecodeDispatchTest
 
     std::vector<iree_vm_module_t*> modules = {bytecode_module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
   }
 

--- a/runtime/src/iree/vm/bytecode_module_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode_module_benchmark.cc
@@ -89,7 +89,7 @@ static iree_status_t RunFunction(benchmark::State& state,
   std::array<iree_vm_module_t*, 2> modules = {import_module, bytecode_module};
   iree_vm_context_t* context = NULL;
   IREE_CHECK_OK(iree_vm_context_create_with_modules(
-      instance, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+      instance, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
       iree_allocator_system(), &context));
 
   iree_vm_function_t function;

--- a/runtime/src/iree/vm/bytecode_module_size_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode_module_size_benchmark.cc
@@ -24,7 +24,7 @@ extern "C" int main(int argc, char** argv) {
 
   iree_vm_context_t* context = nullptr;
   iree_vm_context_create_with_modules(instance, IREE_VM_CONTEXT_FLAG_NONE,
-                                      &module, /*module_count=*/1,
+                                      /*module_count=*/1, &module,
                                       iree_allocator_system(), &context);
 
   iree_vm_function_t function;

--- a/runtime/src/iree/vm/context.h
+++ b/runtime/src/iree/vm/context.h
@@ -57,7 +57,7 @@ IREE_API_EXPORT iree_status_t iree_vm_context_create(
 // |out_context| must be released by the caller.
 IREE_API_EXPORT iree_status_t iree_vm_context_create_with_modules(
     iree_vm_instance_t* instance, iree_vm_context_flags_t flags,
-    iree_vm_module_t** modules, iree_host_size_t module_count,
+    iree_host_size_t module_count, iree_vm_module_t** modules,
     iree_allocator_t allocator, iree_vm_context_t** out_context);
 
 // Retains the given |context| for the caller.
@@ -77,8 +77,8 @@ iree_vm_context_flags(const iree_vm_context_t* context);
 // order provided.
 // The modules will be retained by the context until destruction.
 IREE_API_EXPORT iree_status_t iree_vm_context_register_modules(
-    iree_vm_context_t* context, iree_vm_module_t** modules,
-    iree_host_size_t module_count);
+    iree_vm_context_t* context, iree_host_size_t module_count,
+    iree_vm_module_t** modules);
 
 // Freezes a context such that no more modules can be registered.
 // This can be used to ensure that context contents cannot be modified by other

--- a/runtime/src/iree/vm/native_module_test.cc
+++ b/runtime/src/iree/vm/native_module_test.cc
@@ -41,7 +41,7 @@ class VMNativeModuleTest : public ::testing::Test {
     // will be allocated.
     std::vector<iree_vm_module_t*> modules = {module_a, module_b};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
 
     // No longer need the modules as the context retains them.

--- a/runtime/src/iree/vm/test/emitc/module_test.cc
+++ b/runtime/src/iree/vm/test/emitc/module_test.cc
@@ -127,7 +127,7 @@ class VMCModuleTest : public ::testing::Test,
 
     std::vector<iree_vm_module_t*> modules = {module_};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
 
     iree_vm_module_release(module_);

--- a/samples/dynamic_shapes/main.c
+++ b/samples/dynamic_shapes/main.c
@@ -20,8 +20,8 @@ iree_status_t reduce_sum_1d(iree_runtime_session_t* session, const int* values,
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_runtime_session_device_allocator(session), arg0_shape,
-        IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
+        iree_runtime_session_device_allocator(session),
+        IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
@@ -70,8 +70,8 @@ iree_status_t reduce_sum_2d(iree_runtime_session_t* session, const int* values,
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_runtime_session_device_allocator(session), arg0_shape,
-        IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
+        iree_runtime_session_device_allocator(session),
+        IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
@@ -111,8 +111,8 @@ iree_status_t add_one(iree_runtime_session_t* session, const int* values,
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_runtime_session_device_allocator(session), arg0_shape,
-        IREE_ARRAYSIZE(arg0_shape), IREE_HAL_ELEMENT_TYPE_SINT_32,
+        iree_runtime_session_device_allocator(session),
+        IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/samples/emitc_modules/add_module_test.cc
+++ b/samples/emitc_modules/add_module_test.cc
@@ -25,7 +25,7 @@ class VMAddModuleTest : public ::testing::Test {
 
     std::vector<iree_vm_module_t*> modules = {add_module};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
 
     iree_vm_module_release(add_module);

--- a/samples/emitc_modules/import_module_test.cc
+++ b/samples/emitc_modules/import_module_test.cc
@@ -29,7 +29,7 @@ class VMImportModuleTest : public ::testing::Test {
     // Note: order matters as module_a imports from module_b
     std::vector<iree_vm_module_t*> modules = {module_b, module_a};
     IREE_CHECK_OK(iree_vm_context_create_with_modules(
-        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
 
     iree_vm_module_release(module_a);

--- a/samples/simple_embedding/simple_embedding.c
+++ b/samples/simple_embedding/simple_embedding.c
@@ -57,7 +57,7 @@ iree_status_t Run() {
   iree_vm_context_t* context = NULL;
   iree_vm_module_t* modules[] = {hal_module, bytecode_module};
   IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
-      instance, IREE_VM_CONTEXT_FLAG_NONE, &modules[0], IREE_ARRAYSIZE(modules),
+      instance, IREE_VM_CONTEXT_FLAG_NONE, IREE_ARRAYSIZE(modules), &modules[0],
       iree_allocator_system(), &context));
   iree_vm_module_release(hal_module);
   iree_vm_module_release(bytecode_module);
@@ -80,7 +80,7 @@ iree_status_t Run() {
   iree_hal_buffer_view_t* arg0_buffer_view = NULL;
   iree_hal_buffer_view_t* arg1_buffer_view = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
-      iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
+      iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
@@ -89,7 +89,7 @@ iree_status_t Run() {
       },
       iree_make_const_byte_span(kFloat4, sizeof(kFloat4)), &arg0_buffer_view));
   IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
-      iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
+      iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
       IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
       (iree_hal_buffer_params_t){
           .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/samples/static_library/static_library_demo.c
+++ b/samples/static_library/static_library_demo.c
@@ -121,7 +121,7 @@ iree_status_t Run() {
 
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
+        iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
         IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
@@ -134,7 +134,7 @@ iree_status_t Run() {
   }
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_hal_device_allocator(device), shape, IREE_ARRAYSIZE(shape),
+        iree_hal_device_allocator(device), IREE_ARRAYSIZE(shape), shape,
         IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/samples/variables_and_state/main.c
+++ b/samples/variables_and_state/main.c
@@ -48,8 +48,8 @@ iree_status_t counter_set_value(iree_runtime_session_t* session,
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_runtime_session_device_allocator(session), /*shape=*/NULL,
-        /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_SINT_32,
+        iree_runtime_session_device_allocator(session),
+        /*shape_rank=*/0, /*shape=*/NULL, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
@@ -81,8 +81,8 @@ iree_status_t counter_add_to_value(iree_runtime_session_t* session, int x) {
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
     status = iree_hal_buffer_view_allocate_buffer(
-        iree_runtime_session_device_allocator(session), /*shape=*/NULL,
-        /*shape_rank=*/0, IREE_HAL_ELEMENT_TYPE_SINT_32,
+        iree_runtime_session_device_allocator(session), /*shape_rank=*/0,
+        /*shape=*/NULL, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
             .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,

--- a/tools/android/run_module_app/src/main.cc
+++ b/tools/android/run_module_app/src/main.cc
@@ -114,8 +114,8 @@ Status RunModule(const IreeModuleInvocation& invocation) {
   // Order matters. The input module will likely be dependent on the hal module.
   std::array<iree_vm_module_t*, 2> modules = {hal_module, input_module};
   IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
-                           instance, IREE_VM_CONTEXT_FLAG_NONE, modules.data(),
-                           modules.size(), iree_allocator_system(), &context),
+                           instance, IREE_VM_CONTEXT_FLAG_NONE, modules.size(),
+                           modules.data(), iree_allocator_system(), &context),
                        "creating context");
 
   const std::string& function_name = invocation.entry_function;

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -329,7 +329,7 @@ class IREEBenchmark {
     // module.
     std::array<iree_vm_module_t*, 2> modules = {hal_module_, input_module_};
     IREE_RETURN_IF_ERROR(iree_vm_context_create_with_modules(
-        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.data(), modules.size(),
+        instance_, IREE_VM_CONTEXT_FLAG_NONE, modules.size(), modules.data(),
         iree_allocator_system(), &context_));
 
     IREE_TRACE_FRAME_MARK_END_NAMED("init");

--- a/tools/iree-check-module-main.cc
+++ b/tools/iree-check-module-main.cc
@@ -65,7 +65,7 @@ class CheckModuleTest : public ::testing::Test {
         instance_,
         FLAG_trace_execution ? IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION
                              : IREE_VM_CONTEXT_FLAG_NONE,
-        modules_.data(), modules_.size(), iree_allocator_system(), &context_));
+        modules_.size(), modules_.data(), iree_allocator_system(), &context_));
   }
   void TearDown() override { iree_vm_context_release(context_); }
 

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -83,8 +83,8 @@ static iree_status_t allocate_host_buffer_view_like(
     iree_hal_allocator_t* hal_allocator, iree_hal_buffer_view_t* src,
     iree_hal_buffer_view_t** dst) {
   return iree_hal_buffer_view_allocate_buffer(
-      hal_allocator, iree_hal_buffer_view_shape_dims(src),
-      iree_hal_buffer_view_shape_rank(src),
+      hal_allocator, iree_hal_buffer_view_shape_rank(src),
+      iree_hal_buffer_view_shape_dims(src),
       iree_hal_buffer_view_element_type(src),
       iree_hal_buffer_view_encoding_type(src),
       (iree_hal_buffer_params_t){
@@ -101,8 +101,8 @@ static iree_status_t allocate_device_buffer_view_like(
     iree_hal_allocator_t* hal_allocator, iree_hal_buffer_view_t* src,
     iree_const_byte_span_t initial_data, iree_hal_buffer_view_t** dst) {
   return iree_hal_buffer_view_allocate_buffer(
-      hal_allocator, iree_hal_buffer_view_shape_dims(src),
-      iree_hal_buffer_view_shape_rank(src),
+      hal_allocator, iree_hal_buffer_view_shape_rank(src),
+      iree_hal_buffer_view_shape_dims(src),
       iree_hal_buffer_view_element_type(src),
       iree_hal_buffer_view_encoding_type(src),
       (iree_hal_buffer_params_t){
@@ -778,8 +778,8 @@ static iree_status_t make_device_identity_matrix_like(
     iree_hal_device_t* device, iree_hal_allocator_t* hal_allocator,
     iree_hal_buffer_view_t* src, iree_hal_buffer_view_t** dst) {
   return iree_hal_buffer_view_generate_buffer(
-      hal_allocator, iree_hal_buffer_view_shape_dims(src),
-      iree_hal_buffer_view_shape_rank(src),
+      hal_allocator, iree_hal_buffer_view_shape_rank(src),
+      iree_hal_buffer_view_shape_dims(src),
       iree_hal_buffer_view_element_type(src),
       iree_hal_buffer_view_encoding_type(src),
       (iree_hal_buffer_params_t){

--- a/tools/iree-run-mlir-main.cc
+++ b/tools/iree-run-mlir-main.cc
@@ -176,11 +176,11 @@ Status GetTargetBackends(std::vector<std::string>* out_target_backends) {
       mlir::iree_compiler::IREE::HAL::TargetOptions::FromFlags::get().targets;
   if (target_backends.empty()) {
     iree_allocator_t host_allocator = iree_allocator_system();
-    iree_hal_driver_info_t* driver_infos = NULL;
     iree_host_size_t driver_info_count = 0;
+    iree_hal_driver_info_t* driver_infos = NULL;
     IREE_RETURN_IF_ERROR(iree_hal_driver_registry_enumerate(
-        iree_hal_available_driver_registry(), host_allocator, &driver_infos,
-        &driver_info_count));
+        iree_hal_available_driver_registry(), host_allocator,
+        &driver_info_count, &driver_infos));
     for (iree_host_size_t i = 0; i < driver_info_count; ++i) {
       target_backends.push_back(std::string(driver_infos[i].driver_name.data,
                                             driver_infos[i].driver_name.size));
@@ -383,7 +383,7 @@ Status EvaluateFunctions(iree_vm_instance_t* instance,
             instance,
             trace_execution_flag ? IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION
                                  : IREE_VM_CONTEXT_FLAG_NONE,
-            modules.data(), modules.size(), iree_allocator_system(), &context),
+            modules.size(), modules.data(), iree_allocator_system(), &context),
         "Creating context");
 
     // Invoke the function and print results.

--- a/tools/iree-run-module-main.cc
+++ b/tools/iree-run-module-main.cc
@@ -126,7 +126,7 @@ iree_status_t Run() {
           instance,
           FLAG_trace_execution ? IREE_VM_CONTEXT_FLAG_TRACE_EXECUTION
                                : IREE_VM_CONTEXT_FLAG_NONE,
-          modules.data(), modules.size(), iree_allocator_system(), &context),
+          modules.size(), modules.data(), iree_allocator_system(), &context),
       "creating context");
 
   std::string function_name = std::string(FLAG_entry_function);


### PR DESCRIPTION
I think I'd originally been using (array, count) to match things like
the std::string constructor, but I think it makes it harder to read
when not actually constructing a span.