### PR TITLE
Enable a few more clang-tidy checks with fixes

### DIFF
--- a/compiler/src/.clang-tidy
+++ b/compiler/src/.clang-tidy
@@ -9,7 +9,5 @@ Checks: >
         -misc-unused-using-decls,
         -llvm-else-after-return,
         -llvm-include-order,
-        -llvm-qualified-auto,
-        -misc-redundant-expression,
-        -llvm-namespace-comment
+        -llvm-qualified-auto
 

--- a/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractOpPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractOpPass.cpp
@@ -18,7 +18,7 @@ namespace iree_compiler {
 
 namespace {
 #include "iree/compiler/Codegen/Common/FoldTensorExtractOp.cpp.inc"
-}
+}  // namespace
 
 namespace {
 /// Upstream canonicalization passes fold

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -2048,7 +2048,7 @@ static OpFoldResult foldCmpNEFOp(T op, ArrayRef<Attribute> operands) {
         if (ordering == ORDERED) {
           return result != APFloat::cmpEqual;
         } else {
-          return result != APFloat::cmpEqual || result == APFloat::cmpUnordered;
+          return result != APFloat::cmpEqual && result != APFloat::cmpUnordered;
         }
       });
 }

--- a/runtime/src/.clang-tidy
+++ b/runtime/src/.clang-tidy
@@ -1,7 +1,1 @@
-
-Checks: >
-        -clang-analyzer-deadcode*,
-        -clang-analyzer-cplusplus*,
-        -clang-analyzer-core*
-
-HeaderFilterRegex: '.*^(third_party|googletest).*'
+Checks: -clang-analyzer-cplusplus*,-clang-analyzer-core*

--- a/runtime/src/iree/tooling/vm_util.cc
+++ b/runtime/src/iree/tooling/vm_util.cc
@@ -46,7 +46,6 @@ static iree_status_t CreateBufferViewFromFile(
         IREE_STATUS_RESOURCE_EXHAUSTED,
         "a shape rank of %zu is just a little bit excessive, eh?", shape_rank);
   }
-  shape_result = iree_status_ignore(shape_result);
   iree_hal_dim_t* shape =
       (iree_hal_dim_t*)iree_alloca(shape_rank * sizeof(iree_hal_dim_t));
   IREE_RETURN_IF_ERROR(iree_hal_parse_shape_and_element_type(

--- a/runtime/src/iree/tooling/vm_util.cc
+++ b/runtime/src/iree/tooling/vm_util.cc
@@ -46,6 +46,7 @@ static iree_status_t CreateBufferViewFromFile(
         IREE_STATUS_RESOURCE_EXHAUSTED,
         "a shape rank of %zu is just a little bit excessive, eh?", shape_rank);
   }
+  iree_status_ignore(shape_result);
   iree_hal_dim_t* shape =
       (iree_hal_dim_t*)iree_alloca(shape_rank * sizeof(iree_hal_dim_t));
   IREE_RETURN_IF_ERROR(iree_hal_parse_shape_and_element_type(


### PR DESCRIPTION
We can enable a few more clang-tidy checks by correcting a few minor bugs.