### PR TITLE
First step of adding nccl headers to the build.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -47,3 +47,6 @@
 [submodule "third_party/musl"]
 	path = third_party/musl
 	url = https://github.com/powderluv/musl.git
+[submodule "third_party/nccl"]
+	path = third_party/nccl
+	url = https://github.com/NVIDIA/nccl.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -435,17 +435,19 @@ if(IREE_TARGET_BACKEND_CUDA OR IREE_HAL_DRIVER_CUDA)
     # We define the magic IREE_CUDA_DEPS_DIR env var in our CI docker images if we
     # have a stripped down CUDA toolkit suitable for compiling available. We
     # trigger on this below as a fallback for locating headers and libdevice
-    # files.
-    # TODO: Remove this in favor of a full CUDA toolkit.
+    # files. See build_tools/docker/base/fetch_cuda_deps.sh for what this
+    # includes (it does not include enough for the normal CMake toolkit search
+    # to succeed).
     set(CUDAToolkit_ROOT "$ENV{IREE_CUDA_DEPS_DIR}")
     message(STATUS "Using CUDA minimal deps for CI using IREE_CUDA_DEPS = ${CUDAToolkit_ROOT}")
-  elseif(NOT CUDAToolkit_ROOT)
-    # Auto-download and setup CUDAToolkit_ROOT
-    message(STATUS "CUDAToolkit_ROOT not defined: downloading expected version")
-    add_subdirectory(build_tools/third_party/cuda EXCLUDE_FROM_ALL)
+  else()
+    if(NOT CUDAToolkit_ROOT)
+      # Auto-download and setup CUDAToolkit_ROOT
+      message(STATUS "CUDAToolkit_ROOT not defined: downloading expected version")
+      add_subdirectory(build_tools/third_party/cuda EXCLUDE_FROM_ALL)
+    endif()
+    find_package(CUDAToolkit REQUIRED)
   endif()
-
-  find_package(CUDAToolkit REQUIRED)
 endif()
 
 # If an explicit libdevice file was not specified, and the compiler backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,24 +431,21 @@ set(IREE_CUDA_LIBDEVICE_PATH "" CACHE STRING "Absolute path to an appropriate li
 # If any CUDA features are being built, try to locate a CUDA SDK. We will fall
 # back to this as needed for specific features.
 if(IREE_TARGET_BACKEND_CUDA OR IREE_HAL_DRIVER_CUDA)
-  find_package(CUDAToolkit)
-
-  if(NOT CUDAToolkit_FOUND)
-    if(DEFINED ENV{IREE_CUDA_DEPS_DIR})
-      # We define the magic IREE_CUDA_DEPS_DIR env var in our CI docker images if we
-      # have a stripped down CUDA toolkit suitable for compiling available. We
-      # trigger on this below as a fallback for locating headers and libdevice
-      # files.
-      set(CUDAToolkit_ROOT "$ENV{IREE_CUDA_DEPS_DIR}")
-      message(STATUS "CUDA SDK not found by CMake but using IREE_CUDA_DEPS = ${CUDAToolkit_ROOT}")
-    else()
-      # If we haven't found CUDA deps, download at least enough to build for CUDA.
-      # This will define IREE_CUDA_DOWNLOAD_LIBDEVICE_PATH & IREE_CUDA_DOWNLOAD_INCLUDE_PATH
-      # vars with the target deps.
-      message(STATUS "CUDA SDK not found by CMake but downloading dependencies")
-      add_subdirectory(build_tools/third_party/cuda EXCLUDE_FROM_ALL)
-    endif()
+  if(DEFINED ENV{IREE_CUDA_DEPS_DIR})
+    # We define the magic IREE_CUDA_DEPS_DIR env var in our CI docker images if we
+    # have a stripped down CUDA toolkit suitable for compiling available. We
+    # trigger on this below as a fallback for locating headers and libdevice
+    # files.
+    # TODO: Remove this in favor of a full CUDA toolkit.
+    set(CUDAToolkit_ROOT "$ENV{IREE_CUDA_DEPS_DIR}")
+    message(STATUS "Using CUDA minimal deps for CI using IREE_CUDA_DEPS = ${CUDAToolkit_ROOT}")
+  elseif(NOT CUDAToolkit_ROOT)
+    # Auto-download and setup CUDAToolkit_ROOT
+    message(STATUS "CUDAToolkit_ROOT not defined: downloading expected version")
+    add_subdirectory(build_tools/third_party/cuda EXCLUDE_FROM_ALL)
   endif()
+
+  find_package(CUDAToolkit REQUIRED)
 endif()
 
 # If an explicit libdevice file was not specified, and the compiler backend
@@ -469,9 +466,6 @@ if(IREE_TARGET_BACKEND_CUDA)
     # are hard and such. In this case, if the user went to the trouble to
     # tell us where it is, we have enough information.
     set(IREE_CUDA_LIBDEVICE_PATH "${CUDAToolkit_ROOT}/nvvm/libdevice/libdevice.10.bc")
-  elseif(IREE_CUDA_DOWNLOAD_LIBDEVICE_PATH)
-    message(STATUS "Using downloaded CUDA libdevice")
-    set(IREE_CUDA_LIBDEVICE_PATH "${IREE_CUDA_DOWNLOAD_LIBDEVICE_PATH}")
   else()
     message(FATAL_ERROR "Building with IREE_TARGET_BACKEND_CUDA requires either a CUDA SDK (consult CMake docs for your version: https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html) or an explicit path to libdevice (set with -DIREE_CUDA_LIBDEVICE_PATH=/path/to/libdevice.10.bc)")
   endif()
@@ -496,9 +490,6 @@ if(IREE_HAL_DRIVER_CUDA)
     else()
       message(SEND_ERROR "Using explicitly specified CUDAToolkit_ROOT, could not find cuda.h at: ${CUDAToolkit_INCLUDE_DIRS}")
     endif()
-  elseif(IREE_CUDA_DOWNLOAD_INCLUDE_PATH)
-    message(STATUS "Using downloaded CUDA includes")
-    set(CUDAToolkit_INCLUDE_DIRS "${IREE_CUDA_DOWNLOAD_INCLUDE_PATH}")
   else()
     message(SEND_ERROR "Cannot build IREE runtime CUDA components (-DIREE_HAL_DRIVER_CUDA=ON) because a CUDA SDK was not found. Consult CMake docs for your version: https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html")
   endif()

--- a/build_tools/third_party/cuda/CMakeLists.txt
+++ b/build_tools/third_party/cuda/CMakeLists.txt
@@ -4,76 +4,71 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-set(_TARGET_DIR ${CMAKE_CURRENT_BINARY_DIR})
-set(_DOWNLOAD_SCRIPT_URL "https://raw.githubusercontent.com/NVIDIA/build-system-archive-import-examples/44dfb51fad75a8a2f1044a4fe221aba70571b86f/parse_redist.py")
-set(_DOWNLOAD_DIR ${_TARGET_DIR}/download)
-set(_DOWNLOAD_SCRIPT_PATH ${_DOWNLOAD_DIR}/parse_redist.py)
+function(fetch_cuda_toolkit)
+  # Parameters to the download script.
+  # Look for an appropriate redistrib_*.json here to verify:
+  #   https://developer.download.nvidia.com/compute/cuda/redist/
+  set(_VERSION "11.6.2")
+  set(_PRODUCT "cuda")
+  if(UNIX)
+    set(_OS "linux")
+  elseif(WIN32)
+    set(_OS "windows")
+  else()
+    message(SEND_ERROR "Unsupported OS environment. Must be Windows or Linux.")
+    return()
+  endif()
+  # CUDA is only supported on Linux/Windows where x64 is the only arch for now.
+  set(_ARCH "x86_64")
 
-# Parameters to the download script.
-# Look for an appropriate redistrib_*.json here to verify:
-#   https://developer.download.nvidia.com/compute/cuda/redist/
-set(_VERSION "11.6.2")
-set(_PRODUCT "cuda")
-if(UNIX)
-  set(_OS "linux")
-elseif(WIN32)
-  set(_OS "windows")
-else()
-  message(SEND_ERROR "Unsupported OS environment. Must be Windows or Linux.")
-  return()
-endif()
-# CUDA is only supported on Linux/Windows where x64 is the only arch for now.
-set(_ARCH "x86_64")
+  set(_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/${_VERSION}")
+  set(_DOWNLOAD_SCRIPT_URL "https://raw.githubusercontent.com/NVIDIA/build-system-archive-import-examples/44dfb51fad75a8a2f1044a4fe221aba70571b86f/parse_redist.py")
+  set(_DOWNLOAD_SCRIPT_PATH "${_TARGET_DIR}/parse_redist.py")
 
-# Components that we need to fetch.
-set(_COMPONENTS_FO_FETCH "")
-list(APPEND _COMPONENTS_FO_FETCH "cuda_nvcc")
-list(APPEND _COMPONENTS_FO_FETCH "cuda_cudart")
+  # Only download if haven't already.
+  # This will produce a unified directory tree under:
+  #   flat/$OS-$ARCH
+  set(_ARCH_DIR "${_TARGET_DIR}/${_OS}-${_ARCH}")
+  set(_TOUCH_FILE "${_TARGET_DIR}/cuda_toolkit.downloaded")
 
-# Paths within the arch specific installation that we want to retain.
-set(_RETAIN_PATHS "")
-list(APPEND _RETAIN_PATHS "LICENSE")
-list(APPEND _RETAIN_PATHS "nvvm/libdevice/libdevice.10.bc")
-list(APPEND _RETAIN_PATHS "include/cuda.h")
+  if(NOT EXISTS "${_TOUCH_FILE}")
+    # Components that we need to fetch.
+    set(_COMPONENTS_TO_FETCH "")
+    list(APPEND _COMPONENTS_TO_FETCH "cuda_nvcc")
+    list(APPEND _COMPONENTS_TO_FETCH "cuda_cudart")
 
-message(STATUS "Extracting to ${_TARGET_DIR}")
-file(MAKE_DIRECTORY ${_DOWNLOAD_DIR})
+    message(STATUS "Extracting to ${_TARGET_DIR}")
+    file(MAKE_DIRECTORY ${_TARGET_DIR})
 
-# First fetch the download script to the tmp dir.
-file(DOWNLOAD ${_DOWNLOAD_SCRIPT_URL} ${_DOWNLOAD_SCRIPT_PATH})
+    # First fetch the download script to the tmp dir.
+    file(DOWNLOAD ${_DOWNLOAD_SCRIPT_URL} ${_DOWNLOAD_SCRIPT_PATH})
 
-# Then use the download script to fetch and flatten each component we want
-# into the tmp dir.
-# This will produce a unified directory tree under:
-#   flat/$OS-$ARCH
-set(SRC_DIR "${_DOWNLOAD_DIR}/${_OS}-${_ARCH}")
-foreach(COMPONENT ${_COMPONENTS_FO_FETCH})
-  message(STATUS "Downloading component ${COMPONENT}")
-  execute_process(COMMAND ${Python3_EXECUTABLE} "${_DOWNLOAD_SCRIPT_PATH}"
-    --label "${_VERSION}"
-    --product "${_PRODUCT}"
-    --os "${_OS}"
-    --arch "${_ARCH}"
-    --component "${COMPONENT}"
-    --output "${_DOWNLOAD_DIR}")
-endforeach()
+    # Then use the download script to fetch and flatten each component we want
+    # into the target dir.
+    foreach(COMPONENT ${_COMPONENTS_TO_FETCH})
+      message(STATUS "Downloading component ${COMPONENT}")
+      execute_process(COMMAND ${Python3_EXECUTABLE} "${_DOWNLOAD_SCRIPT_PATH}"
+        --label "${_VERSION}"
+        --product "${_PRODUCT}"
+        --os "${_OS}"
+        --arch "${_ARCH}"
+        --component "${COMPONENT}"
+        --output "${_TARGET_DIR}")
+    endforeach()
+  endif()
 
-if(NOT EXISTS "${SRC_DIR}")
-  message(FATAL_ERROR "Download did not produce expected source dir: ${SRC_DIR}")
-  return()
-endif()
+  if(NOT EXISTS "${_ARCH_DIR}")
+    message(FATAL_ERROR "Download did not produce expected source dir: ${_ARCH_DIR}")
+    return()
+  endif()
 
-foreach(REL_PATH ${_RETAIN_PATHS})
-  set(SRC_FILE "${SRC_DIR}/${REL_PATH}")
-  set(TARGET_FILE "${_TARGET_DIR}/${REL_PATH}")
-  message(STATUS "Copy ${SRC_FILE} -> ${TARGET_FILE}")
-  file(COPY ${SRC_FILE} DESTINATION ${TARGET_FILE})
-endforeach()
+  file(TOUCH "${_TOUCH_FILE}")
+  set(CUDAToolkit_ROOT "${_ARCH_DIR}" PARENT_SCOPE)
+endfunction()
 
-# Delete tmp directory.
-file(REMOVE_RECURSE ${_DOWNLOAD_DIR})
-
-# Set vars for downloaded cuda deps
-set(IREE_CUDA_DOWNLOAD_LIBDEVICE_PATH
-    "${_TARGET_DIR}/nvvm/libdevice/libdevice.10.bc/libdevice.10.bc" PARENT_SCOPE)
-set(IREE_CUDA_DOWNLOAD_INCLUDE_PATH "${_TARGET_DIR}/include" PARENT_SCOPE)
+fetch_cuda_toolkit()
+message(STATUS "Using downloaded CUDA toolkit: ${CUDAToolkit_ROOT}")
+set(CUDAToolkit_ROOT "${CUDAToolkit_ROOT}" PARENT_SCOPE)
+# For some reason having the BIN_DIR set wrong can cause mayhem. Just make
+# sure it is right.
+set(CUDAToolkit_BIN_DIR "${CUDAToolkit_ROOT}/bin" PARENT_SCOPE)

--- a/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
@@ -77,6 +77,8 @@ iree_cc_library(
     iree::base::core_headers
     iree::base::internal::dynamic_library
     iree::base::tracing
+    # Will define IREE_HAS_NCCL_HEADERS
+    iree_nccl_headers
   PUBLIC
 )
 

--- a/runtime/src/iree/hal/drivers/cuda/cuda_headers.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_headers.h
@@ -7,6 +7,10 @@
 #ifndef IREE_HAL_DRIVERS_CUDA_CUDA_HEADERS_H_
 #define IREE_HAL_DRIVERS_CUDA_CUDA_HEADERS_H_
 
-#include "cuda.h"  // IWYU pragma: export
+#include <cuda.h>  // IWYU pragma: export
+
+#ifdef IREE_HAS_NCCL_HEADERS
+#include <nccl.h>  // IWYU pragma: export
+#endif
 
 #endif  // IREE_HAL_DRIVERS_CUDA_CUDA_HEADERS_H_

--- a/runtime/src/iree/hal/drivers/cuda/nccl/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/nccl/CMakeLists.txt
@@ -1,0 +1,34 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+include(ExternalProject)
+
+# Since we are only using NCCL via dynamic linking, we just need some of the
+# headers. These are built as part of the NCCL Makefiles (they include some
+# substitutions), and we only generate those.
+find_program(MAKE_EXE NAMES gmake nmake make)
+ExternalProject_add(iree_nccl_headers_import
+  SOURCE_DIR "${IREE_SOURCE_DIR}/third_party/nccl/src"
+  BUILD_IN_SOURCE 1
+  CONFIGURE_COMMAND ""
+  INSTALL_COMMAND ""
+  BUILD_COMMAND "${MAKE_EXE}"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/nccl.h"
+    "${CMAKE_CURRENT_BINARY_DIR}/include/nccl_net.h"
+    "BUILDDIR=${CMAKE_CURRENT_BINARY_DIR}"
+)
+
+add_library(iree_nccl_headers INTERFACE)
+add_dependencies(iree_nccl_headers iree_nccl_headers_import)
+target_include_directories(iree_nccl_headers
+  INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+)
+
+target_compile_definitions(iree_nccl_headers
+  INTERFACE
+    IREE_HAS_NCCL_HEADERS
+)


### PR DESCRIPTION
* I ended up reworking the CUDA toolkit download because we really need to full toolkit now (or at least more headers from it), and the support that was implemented had some issues.
* I made it conditional to use an external toolkit if CUDAToolkit_ROOT is specified and download/use an internal toolkit otherwise. This is a change of behavior but probably reasonable: I've never had much success with the pure auto-detection without setting a CUDAToolkit_ROOT to a pre-installed version.
* Just uses the nccl make machinery to auto-gen the header files and make them accessible. This may be overkill: it is just doing token replacement of some version bits. Open to feedback here.

I suspect that before landing this, I will need to make a corresponding change on the CI to include more of the toolkit.