### PR TITLE
Fix teardown race in threading_test

### DIFF
--- a/runtime/src/iree/base/internal/threading_test.cc
+++ b/runtime/src/iree/base/internal/threading_test.cc
@@ -126,15 +126,12 @@ TEST(ThreadTest, PriorityOverride) {
 
   struct entry_data_t {
     iree_atomic_int32_t value;
-    iree_notification_t barrier;
   } entry_data;
   iree_atomic_store_int32(&entry_data.value, 0, iree_memory_order_relaxed);
-  iree_notification_initialize(&entry_data.barrier);
   iree_thread_entry_t entry_fn = +[](void* entry_arg) -> int {
     auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
     iree_atomic_fetch_add_int32(&entry_data->value, 1,
-                                iree_memory_order_acq_rel);
-    iree_notification_post(&entry_data->barrier, IREE_ALL_WAITERS);
+                                iree_memory_order_release);
     return 0;
   };
 
@@ -155,15 +152,10 @@ TEST(ThreadTest, PriorityOverride) {
   EXPECT_NE(nullptr, override2);
 
   // Wait for the thread to finish.
-  iree_notification_await(
-      &entry_data.barrier,
-      +[](void* entry_arg) -> bool {
-        auto* entry_data = reinterpret_cast<struct entry_data_t*>(entry_arg);
-        return iree_atomic_load_int32(&entry_data->value,
-                                      iree_memory_order_relaxed) == 1;
-      },
-      &entry_data, iree_infinite_timeout());
-  iree_notification_deinitialize(&entry_data.barrier);
+  while (iree_atomic_load_int32(&entry_data.value, iree_memory_order_acquire) !=
+         1) {
+    iree_thread_yield();
+  }
 
   // Pop overrides (in opposite order intentionally).
   iree_thread_override_end(override0);


### PR DESCRIPTION
Another test-only teardown race. Unless you specifically want coverage for the notification code in this test, it's easiest to fix this one by just keeping the (already existing anyway) atomic `entry_data.value` as the sole synchronization mechanism here.

Then even there there was another separate issue: the way it used to be read with `relaxed` order wouldn't construct any happens-before relationship with the way it was stored with `release` order. Changed to reading it with `acquire` order to get such a relationship. Moreover, the fetch_add storing it didn't really need to be `acq_rel` as we only care about the store part having `release` order.

```
WARNING: ThreadSanitizer: data race (pid=1706527)
  Atomic read of size 1 at 0x7ffd0175deb8 by thread T3:
    #0 pthread_mutex_lock <null> (threading_test+0x2bd238)
    #1 iree_notification_post /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/synchronization.c:579:3 (threading_test+0x31c24a)
    #2 (anonymous namespace)::ThreadTest_PriorityOverride_Test::TestBody()::$_4::operator()(void*) const /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_test.cc:137:5 (threading_test+0x317480)
    #3 (anonymous namespace)::ThreadTest_PriorityOverride_Test::TestBody()::$_4::__invoke(void*) /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_test.cc:133:35 (threading_test+0x317480)
    #4 iree_thread_start_routine /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_pthreads.c:130:29 (threading_test+0x31d12d)

  Previous write of size 1 at 0x7ffd0175deb8 by main thread:
    #0 pthread_mutex_destroy <null> (threading_test+0x2a1838)
    #1 iree_notification_deinitialize /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/synchronization.c:575:3 (threading_test+0x31c21e)
    #2 (anonymous namespace)::ThreadTest_PriorityOverride_Test::TestBody() /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_test.cc:166:3 (threading_test+0x3173de)
    #3 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (threading_test+0x367b9f)
    #4 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (threading_test+0x367b9f)
    #5 testing::Test::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2682:5 (threading_test+0x3324ef)
    #6 testing::TestInfo::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2861:11 (threading_test+0x3340e2)
    #7 testing::TestSuite::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:3015:28 (threading_test+0x334fcc)
    #8 testing::internal::UnitTestImpl::RunAllTests() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5855:44 (threading_test+0x34ba98)
    #9 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (threading_test+0x368ecf)
    #10 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (threading_test+0x368ecf)
    #11 testing::UnitTest::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5438:10 (threading_test+0x34abe0)
    #12 RUN_ALL_TESTS() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/include/gtest/gtest.h:2490:46 (threading_test+0x31da8b)
    #13 main /usr/local/google/home/benoitjacob/iree/runtime/src/iree/testing/gtest_main.cc:17:10 (threading_test+0x31da8b)

  Location is stack of main thread.

  Location is global '??' at 0x7ffd0173f000 ([stack]+0x00000001eeb8)

  Thread T3 (tid=1706531, running) created by main thread at:
    #0 pthread_create <null> (threading_test+0x29ff5d)
    #1 iree_thread_create /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_pthreads.c:180:10 (threading_test+0x31cc39)
    #2 (anonymous namespace)::ThreadTest_PriorityOverride_Test::TestBody() /usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/internal/threading_test.cc:142:3 (threading_test+0x316db5)
    #3 void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (threading_test+0x367b9f)
    #4 void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (threading_test+0x367b9f)
    #5 testing::Test::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2682:5 (threading_test+0x3324ef)
    #6 testing::TestInfo::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2861:11 (threading_test+0x3340e2)
    #7 testing::TestSuite::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:3015:28 (threading_test+0x334fcc)
    #8 testing::internal::UnitTestImpl::RunAllTests() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5855:44 (threading_test+0x34ba98)
    #9 bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2607:10 (threading_test+0x368ecf)
    #10 bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:2643:14 (threading_test+0x368ecf)
    #11 testing::UnitTest::Run() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/src/gtest.cc:5438:10 (threading_test+0x34abe0)
    #12 RUN_ALL_TESTS() /usr/local/google/home/benoitjacob/iree/third_party/googletest/googletest/include/gtest/gtest.h:2490:46 (threading_test+0x31da8b)
    #13 main /usr/local/google/home/benoitjacob/iree/runtime/src/iree/testing/gtest_main.cc:17:10 (threading_test+0x31da8b)

SUMMARY: ThreadSanitizer: data race (/usr/local/google/home/benoitjacob/iree/build-tsan/runtime/src/iree/base/internal/threading_test+0x2bd238) in pthread_mutex_lock
```