### PR TITLE
[RFC] Integrate MoltenVK for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -613,6 +613,9 @@ if(IREE_HAL_DRIVER_VULKAN)
   add_subdirectory(third_party/vulkan_headers EXCLUDE_FROM_ALL)
 endif()
 
+if(APPLE AND IREE_HAL_DRIVER_VULKAN)
+  add_subdirectory(build_tools/third_party/moltenVK EXCLUDE_FROM_ALL)
+endif()
 # TODO(scotttodd): Iterate some more and find a better place for this.
 if(NOT CMAKE_CROSSCOMPILING)
   install(

--- a/build_tools/third_party/moltenVK/CMakeLists.txt
+++ b/build_tools/third_party/moltenVK/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(MOLTENVK_LIB_PATH "${CMAKE_BINARY_DIR}/third_party/moltenVK/Package/Latest/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64/libMoltenVK.a")
+ExternalProject_Add(project_moltenVK
+    GIT_REPOSITORY https://github.com/KhronosGroup/MoltenVK
+    GIT_TAG 49f78f91a4883617011059625f79214fe50be940
+    BUILD_COMMAND make macos
+    CONFIGURE_COMMAND ./fetchDependencies --macos
+    INSTALL_COMMAND ""
+    SOURCE_DIR "${CMAKE_BINARY_DIR}/third_party/moltenVK"
+    BINARY_DIR "${CMAKE_BINARY_DIR}/third_party/moltenVK"
+    BUILD_BYPRODUCTS ${MOLTENVK_LIB_PATH}
+)
+
+add_library(moltenVK::runtime STATIC IMPORTED GLOBAL)
+add_dependencies(moltenVK::runtime project_moltenVK)
+set_property(TARGET moltenVK::runtime PROPERTY IMPORTED_LOCATION ${MOLTENVK_LIB_PATH})

--- a/runtime/bindings/tflite/CMakeLists.txt
+++ b/runtime/bindings/tflite/CMakeLists.txt
@@ -4,6 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+if(APPLE AND IREE_HAL_DRIVER_VULKAN)
+  # Add dependencies for Apple SoC GPU/MoltenVK.
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -framework QuartzCore -framework Metal -framework IOSurface -framework Cocoa -framework IOKit -framework CoreFoundation")
+endif()
 iree_add_all_subdirs()
 
 if(IREE_BUILD_BINDINGS_TFLITE_JAVA)

--- a/runtime/src/iree/CMakeLists.txt
+++ b/runtime/src/iree/CMakeLists.txt
@@ -4,4 +4,9 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+if(APPLE AND IREE_HAL_DRIVER_VULKAN)
+  # Add dependencies for Apple SoC GPU/MoltenVK.
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -framework QuartzCore -framework Metal -framework IOSurface -framework Cocoa -framework IOKit -framework CoreFoundation")
+endif()
+
 iree_add_all_subdirs()

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -107,6 +107,10 @@ iree_cc_library(
     iree::hal::drivers::vulkan::util::ref_ptr
   PUBLIC
 )
+add_dependencies(iree_hal_drivers_vulkan_dynamic_symbols project_moltenVK)
+target_link_libraries(iree_hal_drivers_vulkan_dynamic_symbols PUBLIC moltenVK::runtime)
+# target_link_directories(iree_hal_drivers_vulkan_dynamic_symbols PUBLIC "/Users/nodlabs/nod/MoltenVK/Package/Latest/MoltenVK/MoltenVK.xcframework/macos-arm64_x86_64")
+# target_link_libraries(iree_hal_drivers_vulkan_dynamic_symbols PUBLIC "MoltenVK")
 
 iree_cc_test(
   NAME

--- a/runtime/src/iree/hal/drivers/vulkan/dynamic_symbols.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/dynamic_symbols.cc
@@ -59,7 +59,7 @@ static constexpr const FunctionPtrInfo kDynamicFunctionPtrInfos[] = {
     IREE_VULKAN_DYNAMIC_SYMBOL_INSTANCE_DEVICE_TABLES(INS_PFN_FUNCTION_PTR,
                                                       DEV_PFN_FUNCTION_PTR)};
 
-static const char* kVulkanLoaderSearchNames[] = {
+static const char* kVulkanLoaderSearchNames[] = {NULL,
 #if defined(IREE_PLATFORM_ANDROID)
     "libvulkan.so",
 #elif defined(IREE_PLATFORM_IOS) || defined(IREE_PLATFORM_MACOS)

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -81,8 +81,8 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
   // extension are not fully conformant Vulkan implementations, the Vulkan
   // loader does not report those devices unless the application explicitly
   // asks for them.
-  ADD_EXT(IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_EXTENSIONS_REQUIRED,
-          VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
+  // ADD_EXT(IREE_HAL_VULKAN_EXTENSIBILITY_INSTANCE_EXTENSIONS_REQUIRED,
+  //         VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME);
 #endif
 
   // VK_KHR_storage_buffer_storage_class:

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_driver.cc
@@ -238,7 +238,7 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_driver_create(
   // There are no native Vulkan implementations on Apple platforms. Including
   // this bit allows the Vulkan loader to enumerate MoltenVK, which emulates
   // Vulkan on top of Metal, as an implementation.
-  create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
+  // create_info.flags = VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR;
 #else
   create_info.flags = 0;
 #endif

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -4,4 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+if(APPLE AND IREE_HAL_DRIVER_VULKAN)
+  # Add dependencies for Apple SoC GPU/MoltenVK.
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -framework QuartzCore -framework Metal -framework IOSurface -framework Cocoa -framework IOKit -framework CoreFoundation")
+endif()
 iree_add_all_subdirs()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -39,6 +39,11 @@ endif()
 add_subdirectory(android)
 add_subdirectory(test)
 
+if(APPLE AND IREE_HAL_DRIVER_VULKAN)
+  # Add dependencies for Apple SoC GPU/MoltenVK.
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -framework QuartzCore -framework Metal -framework IOSurface -framework Cocoa -framework IOKit -framework CoreFoundation")
+endif()
+
 iree_cc_binary(
   NAME
     iree-benchmark-module


### PR DESCRIPTION
The main purpose/intention of this patch is to make it easy for users to deploy on M1 or other Mac SoC GPUs. This does this by getting rid of the need for users to manually download/install vulkan on their macs.