### PR TITLE
Drop hc.bc from the list of device libs pulled in by ROCM backend

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTargetUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTargetUtils.cpp
@@ -98,7 +98,7 @@ static std::vector<std::string> GetROCDLPaths(std::string targetChip,
   std::string chipId = targetChip.substr(lenOfChipPrefix);
   std::string chip_isa_bc = "oclc_isa_version_" + chipId + ".bc";
   static const std::vector<std::string> rocdl_filenames(
-      {"hc.bc", "opencl.bc", "ocml.bc", "ockl.bc", "oclc_finite_only_off.bc",
+      {"opencl.bc", "ocml.bc", "ockl.bc", "oclc_finite_only_off.bc",
        "oclc_daz_opt_off.bc", "oclc_correctly_rounded_sqrt_on.bc",
        "oclc_unsafe_math_off.bc", "oclc_wavefrontsize64_on.bc", chip_isa_bc});
 


### PR DESCRIPTION
This lib is deprecated and gives an error starting with ROCm 5.0 see
https://github.com/tensorflow/tensorflow/commit/a808d1ec5a1dfa6c28d8595d787f71c26ccf3683
Also was reported in this issue
https://github.com/google/iree/issues/8917 and this PR will close it.

Fixes #8917.