### PR TITLE
Add lowerings for MLProgram to Util dialect for global variables

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD
@@ -46,6 +46,7 @@ iree_compiler_cc_library(
     name = "Common",
     srcs = [
         "IREEImportPublic.cpp",
+        "ImportMLProgram.cpp",
         "Passes.cpp",
         "QuantizedMatmulToMatmul.cpp",
         "SanitizeModuleNames.cpp",
@@ -67,6 +68,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LinalgUtils",
+        "@llvm-project//mlir:MLProgramDialect",
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     "Passes.h"
   SRCS
     "IREEImportPublic.cpp"
+    "ImportMLProgram.cpp"
     "Passes.cpp"
     "QuantizedMatmulToMatmul.cpp"
     "SanitizeModuleNames.cpp"
@@ -54,6 +55,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRLinalgTransforms
     MLIRLinalgUtils
+    MLIRMLProgramDialect
     MLIRMemRefTransforms
     MLIRPass
     MLIRSCFDialect

--- a/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/ImportMLProgram.cpp
@@ -1,0 +1,118 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/InputConversion/Common/PassDetail.h"
+#include "iree/compiler/InputConversion/Common/Passes.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassManager.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+struct ImportMLProgramPass : public ImportMLProgramBase<ImportMLProgramPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Util::UtilDialect>();
+  }
+  void runOnOperation() override;
+};
+
+class IREETypeConverter : public TypeConverter {
+ public:
+  IREETypeConverter();
+};
+
+// Generic 1:1 conversion pattern which effectively just renames an op.
+// It does not support regions or ops with successors.
+class OneToOneConversionPattern : public ConversionPattern {
+ public:
+  OneToOneConversionPattern(TypeConverter &converter, StringRef srcName,
+                            StringRef targetName, MLIRContext *context,
+                            PatternBenefit benefit)
+      : ConversionPattern(converter, srcName, benefit, context),
+        targetName(targetName) {}
+  LogicalResult matchAndRewrite(
+      Operation *srcOp, ArrayRef<Value> operands,
+      ConversionPatternRewriter &rewriter) const override {
+    SmallVector<Type> resultTypes;
+    if (failed(typeConverter->convertTypes(srcOp->getResultTypes(),
+                                           resultTypes))) {
+      return srcOp->emitError()
+             << "could not convert result types to IREE internal types";
+    }
+
+    OperationState state(srcOp->getLoc(), targetName, operands, resultTypes,
+                         srcOp->getAttrs());
+    Operation *targetOp = rewriter.create(state);
+    rewriter.replaceOp(srcOp, targetOp->getResults());
+    return success();
+  }
+
+ private:
+  StringRef targetName;
+};
+
+class MLProgramGlobalOpPattern
+    : public OpConversionPattern<ml_program::GlobalOp> {
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      ml_program::GlobalOp srcOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newType = typeConverter->convertType(srcOp.getType());
+    if (!newType) return failure();
+    auto globalOp = rewriter.replaceOpWithNewOp<IREE::Util::GlobalOp>(
+        srcOp, srcOp.getName(), srcOp.getIsMutable(), newType,
+        srcOp.getValue());
+    globalOp.setVisibility(srcOp.getVisibility());
+    return success();
+  }
+};
+
+}  // namespace
+
+IREETypeConverter::IREETypeConverter() {
+  addConversion([](Type t) { return t; });
+}
+
+void ImportMLProgramPass::runOnOperation() {
+  auto &context = getContext();
+  RewritePatternSet patterns(&getContext());
+  ConversionTarget target(getContext());
+  target.addLegalDialect<IREE::Util::UtilDialect>();
+  target.addIllegalDialect<ml_program::MLProgramDialect>();
+  target.markUnknownOpDynamicallyLegal([](mlir::Operation *) { return true; });
+
+  IREETypeConverter typeConverter;
+  patterns.insert<MLProgramGlobalOpPattern>(typeConverter, &getContext(), 0);
+
+  PatternBenefit specific_benefit = 100;
+#define ONE_TO_ONE(SrcOpTy, TargetOpTy)           \
+  patterns.insert<OneToOneConversionPattern>(     \
+      typeConverter, SrcOpTy::getOperationName(), \
+      TargetOpTy::getOperationName(), &context, specific_benefit)
+
+  ONE_TO_ONE(ml_program::GlobalLoadOp, IREE::Util::GlobalLoadOp);
+  ONE_TO_ONE(ml_program::GlobalLoadConstOp, IREE::Util::GlobalLoadOp);
+  ONE_TO_ONE(ml_program::GlobalStoreOp, IREE::Util::GlobalStoreOp);
+
+  if (failed(applyFullConversion(getOperation(), target, std::move(patterns))))
+    signalPassFailure();
+}
+
+std::unique_ptr<OperationPass<ModuleOp>> createImportMLProgramPass() {
+  return std::make_unique<ImportMLProgramPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.cpp
@@ -21,6 +21,7 @@ namespace {
 
 void buildCommonInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createIREEImportPublicPass());
+  passManager.addPass(createImportMLProgramPass());
   passManager.addPass(createSanitizeModuleNamesPass());
 }
 

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.h
@@ -27,6 +27,7 @@ void buildCommonInputConversionPassPipeline(OpPassManager &passManager);
 //===----------------------------------------------------------------------===//
 
 std::unique_ptr<OperationPass<ModuleOp>> createIREEImportPublicPass();
+std::unique_ptr<OperationPass<ModuleOp>> createImportMLProgramPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createLinalgQuantizedMatmulToMatmulPass();
 std::unique_ptr<OperationPass<ModuleOp>> createSanitizeModuleNamesPass();

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.td
@@ -15,6 +15,12 @@ def IREEImportPublic :
   let constructor = "mlir::iree_compiler::createIREEImportPublicPass()";
 }
 
+def ImportMLProgram :
+    Pass<"iree-import-ml-program", "ModuleOp"> {
+  let summary = "Imports MLProgram dialect to IREE Equivalents.";
+  let constructor = "mlir::iree_compiler::createImportMLProgramPass()";
+}
+
 def LinalgQuantizedMatmulToMatmulPass
     : Pass<"iree-linalg-quantized-matmul-to-matmul", "func::FuncOp"> {
   let summary = "lower quantized_matmul to matmul";

--- a/compiler/src/iree/compiler/InputConversion/Common/test/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/BUILD
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "import_ml_program.mlir",
             "iree_import_public.mlir",
             "linalg_quantized_matmul_to_matmul.mlir",
             "sanitize_module_names.mlir",

--- a/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "import_ml_program.mlir"
     "iree_import_public.mlir"
     "linalg_quantized_matmul_to_matmul.mlir"
     "sanitize_module_names.mlir"

--- a/compiler/src/iree/compiler/InputConversion/Common/test/import_ml_program.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/import_ml_program.mlir
@@ -1,0 +1,46 @@
+// RUN: iree-opt --split-input-file --iree-import-ml-program %s | FileCheck %s
+
+// CHECK-LABEL: module @globals
+builtin.module @globals {
+  // CHECK: util.global public mutable @global2 = 51 : i32
+  ml_program.global public mutable @global2(51 : i32) : i32
+  // CHECK: util.global private mutable @global3 = 52 : i32
+  ml_program.global private mutable @global3(52 :i32) : i32
+  // CHECK: util.global private @global4 = 53 : i32
+  ml_program.global private @global4(53 : i32) : i32
+}
+
+// -----
+// CHECK-LABEL: module @global_load
+builtin.module @global_load {
+  ml_program.global private @v_loaded(dense<0> : tensor<4xi32>)  : tensor<4xi32>
+  func.func @loaded() {
+    // CHECK: util.global.load @v_loaded : tensor<4xi32>
+    %0 = ml_program.global_load @v_loaded : tensor<4xi32>
+    return
+  }
+}
+
+// -----
+// CHECK-LABEL: module @global_load_const
+builtin.module @global_load_const {
+  ml_program.global private @v_loaded(dense<0> : tensor<4xi32>)  : tensor<4xi32>
+  func.func @loaded() {
+    // CHECK: util.global.load @v_loaded : tensor<4xi32>
+    %0 = ml_program.global_load_const @v_loaded : tensor<4xi32>
+    return
+  }
+}
+
+// -----
+// CHECK-LABEL: module @global_store
+builtin.module @global_store {
+  ml_program.global private mutable @v_stored : tensor<4xi32>
+  func.func @stored() {
+    // CHECK: %[[CST:.*]] = arith.constant
+    %cst = arith.constant dense<5> : tensor<4xi32>
+    // CHECK: util.global.store %[[CST]], @v_stored : tensor<4xi32>
+    ml_program.global_store @v_stored = %cst : tensor<4xi32>
+    return
+  }
+}

--- a/compiler/src/iree/compiler/Tools/BUILD
+++ b/compiler/src/iree/compiler/Tools/BUILD
@@ -80,6 +80,7 @@ cc_library(
         "@llvm-project//mlir:LinalgToLLVM",
         "@llvm-project//mlir:LinalgToSPIRV",
         "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:MLProgramDialect",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:QuantOps",

--- a/compiler/src/iree/compiler/Tools/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Tools/CMakeLists.txt
@@ -102,6 +102,7 @@ iree_cc_library(
     MLIRLinalgToLLVM
     MLIRLinalgToSPIRV
     MLIRLinalgTransforms
+    MLIRMLProgramDialect
     MLIRQuantDialect
     MLIRQuantTransforms
     MLIRSCFDialect

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MLProgram/IR/MLProgram.h"
 #include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/PDL/IR/PDL.h"
@@ -52,6 +53,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   linalg::LinalgDialect,
                   math::MathDialect,
                   memref::MemRefDialect,
+                  ml_program::MLProgramDialect,
                   pdl::PDLDialect,
                   pdl_interp::PDLInterpDialect,
                   scf::SCFDialect,

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -37,6 +37,7 @@ iree_lit_test_suite(
         [
             "fill_i64.mlir",
             "globals.mlir",
+            "globals_ml_program.mlir",
             "libm_linking.mlir",
             "scalar.mlir",
             "trace_dispatch_tensors.mlir",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "fill_i64.mlir"
     "globals.mlir"
+    "globals_ml_program.mlir"
     "libm_linking.mlir"
     "scalar.mlir"
     "trace_dispatch_tensors.mlir"

--- a/tests/e2e/regression/globals_ml_program.mlir
+++ b/tests/e2e/regression/globals_ml_program.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv %s | FileCheck %s)
+
+module {
+  ml_program.global private mutable @counter(dense<2.0> : tensor<f32>): tensor<f32>
+
+  // CHECK: EXEC @get_state
+  func.func @get_state() -> tensor<f32> {
+    %0 = ml_program.global_load @counter : tensor<f32>
+    return %0 : tensor<f32>
+  }
+  // CHECK: f32=2
+
+  // CHECK: EXEC @inc
+  func.func @inc() -> tensor<f32> {
+    %0 = ml_program.global_load @counter : tensor<f32>
+    %c1 = arith.constant dense<1.0> : tensor<f32>
+    %1 = mhlo.add %0, %c1 : tensor<f32>
+    ml_program.global_store @counter = %1 : tensor<f32>
+    %2 = ml_program.global_load @counter : tensor<f32>
+    return %2 : tensor<f32>
+  }
+  // CHECK: f32=3
+}


### PR DESCRIPTION
MLProgram has stateful variables which represents stateful behavior.
CL includes lit tests along with a simple execution validating global variables,
loading, and storing values.