### PR TITLE
Lower mhlo.complex benefit to 0

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/ConvertComplexToReal.cpp
@@ -348,7 +348,7 @@ void populateMHLOComplexToRealPatterns(MLIRContext *context,
   // ElideComplexPattern.
   // Doing it this way makes error messages nice because a failure will report
   // which remaining live op is keeping it from being erased.
-  patterns.insert<ElideComplexPattern>(typeConverter, context);
+  patterns.insert<ElideComplexPattern>(typeConverter, context, 0);
   patterns.insert<ElideRealPattern>(typeConverter, context);
   patterns.insert<ElideImagPattern>(typeConverter, context);
 }

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/fft.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/fft.mlir
@@ -27,7 +27,12 @@ func.func @rfft_1d(%input: tensor<32xf32>) -> (tensor<17xf32>, tensor<17xf32>) {
 // CHECK:        %[[ImagRes:.+]] = linalg.vecmat
 // CHECK-SAME:     ins(%[[Arg0]], %[[ImagMatrix]] : tensor<32xf32>, tensor<32x17xf32>)
 // CHECK-SAME:     outs(%[[ImagFill]] : tensor<17xf32>) -> tensor<17xf32>
-// CHECK:        return %[[RealRes]], %[[ImagRes]] : tensor<17xf32>, tensor<17xf32>
+// CHECK:        %[[ComplexRes:.*]] = linalg.generic
+// CHECK:        %[[ReRes:.*]] = linalg.generic
+// CHECK-SAME:     ins(%[[ComplexRes]]
+// CHECK:        %[[ImRes:.*]] = linalg.generic
+// CHECK-SAME:     ins(%[[ComplexRes]]
+// CHECK:        return %[[ReRes]], %[[ImRes]] : tensor<17xf32>, tensor<17xf32>
 
 // -----
 
@@ -58,4 +63,9 @@ func.func @rfft_2d(%input: tensor<1x32xf32>) -> (tensor<1x17xf32>, tensor<1x17xf
 // CHECK:        %[[ImagRes:.+]] = linalg.matmul
 // CHECK-SAME:     ins(%[[Arg0]], %[[ImagMatrix]] : tensor<1x32xf32>, tensor<32x17xf32>)
 // CHECK-SAME:     outs(%[[ImagFill]] : tensor<1x17xf32>) -> tensor<1x17xf32>
-// CHECK:        return %[[RealRes]], %[[ImagRes]] : tensor<1x17xf32>, tensor<1x17xf32>
+// CHECK:        %[[ComplexRes:.*]] = linalg.generic
+// CHECK:        %[[ReRes:.*]] = linalg.generic
+// CHECK-SAME:     ins(%[[ComplexRes]]
+// CHECK:        %[[ImRes:.*]] = linalg.generic
+// CHECK-SAME:     ins(%[[ComplexRes]]
+// CHECK:        return %[[ReRes]], %[[ImRes]] : tensor<1x17xf32>, tensor<1x17xf32>


### PR DESCRIPTION
Avoid using pattern unless there is no other patterns in rewrite set
that can. This allows reusing patterns populated from this pass with
others which handle mhlo.complex.

Related to #7621.
