### PR TITLE
Improve control over transform dialect mapping of foreach_thread to GPU

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD
@@ -70,6 +70,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithmeticTransforms",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncTransforms",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:MemRefDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensions.h
@@ -13,6 +13,10 @@
 namespace mlir {
 class DialectRegistry;
 
+namespace func {
+class FuncOp;
+}
+
 namespace scf {
 class IfOp;
 }  // namespace scf

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformDialectExtensions/TransformDialectLLVMGPUExtensionsOps.td
@@ -17,7 +17,8 @@ def ForeachThreadToGpuAndTranslationInfo :
   Op<Transform_Dialect, "iree.foreach_thread_to_gpu_and_translation_info",
     [FunctionalStyleTransformOpTrait, 
      MemoryEffectsOpInterface,
-     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+     TransformEachOpTrait,
+     TransformOpInterface]> {
   let description = [{
     Target the whole hal.executable_variant op and rewrite all scf.foreach_thread
     to distributed gpu.thread_id and translation_info attribute.
@@ -67,11 +68,18 @@ def ForeachThreadToGpuAndTranslationInfo :
     ```
   }];
 
-  let arguments = (ins);
-  let results = (outs);
+  let arguments = (ins PDL_Operation:$target,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$workgroup_size);
+  let results = (outs PDL_Operation:$result);
 
-  let assemblyFormat = "attr-dict";
+  let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::func::FuncOp> applyToOne(
+      ::mlir::func::FuncOp target,
+      ::mlir::transform::TransformState &state);
+  }];
 }
 
 def VectorWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.warp_execute_on_lane_0",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -18,10 +18,16 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %0 = pdl_match @pdl_fill_target in %arg1
-    %tiling_0_result:2 = tile_to_foreach_thread_op %0 {num_threads = [5, 1]}
+    %foreach_thread, %tiled_fill = tile_to_foreach_thread_op %0 {num_threads = [5, 1], thread_dim_mapping = [1, 0, 2]}
+
     %1 = pdl_match @pdl_matmul_target in %arg1
-    %tiling_1_result:2 = tile_to_foreach_thread_op %1 {num_threads = [7, 9]}
+    %foreach_thread_2, %tiled_matmul = tile_to_foreach_thread_op %1 {num_threads = [7, 9]}
+
     transform.iree.bufferize
-    transform.iree.foreach_thread_to_gpu_and_translation_info
+
+    // Get the function to which to apply to.
+    %2 = pdl_match @pdl_matmul_target in %arg1
+    %func = transform.get_closest_isolated_parent %2
+    transform.iree.foreach_thread_to_gpu_and_translation_info %func { workgroup_size = [10, 11]}
   }
 }

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -376,6 +376,7 @@ cc_library(
         ":IREELinalgExtTransforms",
         ":IREELinalgTransformDialect",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:TransformDialect",
     ],

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
@@ -43,7 +43,8 @@ def TileToForeachOp :
     }];
 
   let arguments = (ins PDL_Operation:$target,
-                   DefaultValuedAttr<I64ArrayAttr, "{}">:$num_threads);
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$num_threads,
+                   DefaultValuedAttr<I64ArrayAttr, "{}">:$thread_dim_mapping);
   let results = (outs PDL_Operation:$tiled_op,
                       PDL_Operation:$tile_op);
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
@@ -33,8 +33,10 @@ struct TilingResult {
 struct ForeachThreadTilingPattern
     : public OpInterfaceRewritePattern<TilingInterface> {
   ForeachThreadTilingPattern(MLIRContext *context,
-                             linalg::LinalgTilingOptions opt)
-      : OpInterfaceRewritePattern<TilingInterface>(context), options(opt) {}
+                             linalg::LinalgTilingOptions opt,
+                             ArrayRef<int64_t> threadDimMapping)
+      : OpInterfaceRewritePattern<TilingInterface>(context), options(opt),
+        threadDimMapping(threadDimMapping.begin(), threadDimMapping.end()) {}
 
   FailureOr<TilingResult>
   returningMatchAndRewrite(TilingInterface op, PatternRewriter &rewriter) const;
@@ -46,6 +48,7 @@ struct ForeachThreadTilingPattern
 
 private:
   linalg::LinalgTilingOptions options;
+  SmallVector<int64_t> threadDimMapping;
 };
 
 /// Pattern to swap a `TilingInterface` op -> `tensor::ExtractSliceOp`.

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling-to-foreach-thread-op.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling-to-foreach-thread-op.mlir
@@ -26,6 +26,7 @@ module {
   // CHECK-NEXT:     scf.foreach_thread.parallel_insert_slice %[[RES]] into %[[C]]{{.*}} :
   // CHECK-SAME:       tensor<?x?xf32> into tensor<?x?xf32>
   // CHECK-NEXT:   }
+  // CHECK-NEXT: } {thread_dim_mapping = [1, 0]}
     %0 = linalg.matmul ins(%A, %B : tensor<?x?xf32>, tensor<?x?xf32>)
                       outs(%C : tensor<?x?xf32>) -> (tensor<?x?xf32>)
     return %0 : tensor<?x?xf32>
@@ -42,7 +43,7 @@ module {
     transform.structured.canonicalized_sequence %arg0 {
     ^bb1(%arg1: !pdl.operation):
       %0 = pdl_match @match_linalg_matmul in %arg1
-      %1:2 = tile_to_foreach_thread_op %0 {num_threads = [10, 20]}
+      %1:2 = tile_to_foreach_thread_op %0 {num_threads = [10, 20], thread_dim_mapping = [1, 0]}
     }
   }
 }


### PR DESCRIPTION
This revision takes advantage of the recently introduced `thread_dim_mapping` attribute to `scf.foreach_thread`.
We use it to rewrite the `transform.iree.foreach_thread_to_gpu_and_translation_info` transformation to take
the `workgroup_size` explicitly and operate at the level of a FuncOp.
All `std.foreach_thread` nested under the FuncOp are mapped to `workgroup_size` and predicated accordingly.

This revision also prefetches LLVM commits:
* a786f30c5d2a05591ba355ce1ffc05cdfb5bcfef
* ad8ae6ea170967c008a1e1c501cb8be2707a413c