### PR TITLE
Hide latest release from website widget and update icons.

### DIFF
--- a/docs/website/docs/assets/stylesheets/extra.css
+++ b/docs/website/docs/assets/stylesheets/extra.css
@@ -13,3 +13,12 @@
   50% { filter: drop-shadow(0px 2px 0px black); }
   100% { filter: drop-shadow(0px 2px 3px black); }
 }
+
+/* Hide the "latest GitHub release", since we don't use concise version tags
+   https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/ */
+.md-source__fact--version {
+  display: none;
+}
+.md-source__fact:nth-child(1n+2)::before {
+  margin-left: 0;
+}

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -34,7 +34,7 @@ theme:
       primary: indigo
       accent: indigo
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/brightness-7
         name: Switch to dark mode
     # Dark mode
     - media: "(prefers-color-scheme: dark)"
@@ -42,7 +42,7 @@ theme:
       primary: blue
       accent: blue
       toggle:
-        icon: material/toggle-switch
+        icon: material/brightness-4
         name: Switch to light mode
 
 repo_url: https://github.com/google/iree


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/4010439/176032411-17f6ada2-bfbf-4562-ae79-ec6e845698ae.png)

After:
![image](https://user-images.githubusercontent.com/4010439/176032474-8d9d7e26-a921-4199-a5fa-8b05b387ee71.png)

(that will be `iree-org/iree` after https://github.com/iree-org/iree/pull/9635)

References:
* https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#color-palette-toggle (that lists other popular icon combinations)
* https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/ (and https://github.com/squidfunk/mkdocs-material/issues/3800#issuecomment-1090428115)