### PR TITLE
Add branch in iree_package_ns macro to use the relative path directly

### DIFF
--- a/build_tools/cmake/README.md
+++ b/build_tools/cmake/README.md
@@ -1,0 +1,8 @@
+# IREE-specific cmake functions
+
+The functions in this directory are intended to be used within the IREE project.
+Using them outside IREE is ***entirely*** unsupported. IREE team reserves the
+right to break the out-of-tree usage at any time without notice, and will do so
+if it becomes more invasive or adds complexity to the project. Relying on these
+functions may be convenient for downstream projects, but they are doing so at
+their own risk.


### PR DESCRIPTION
Check `IREE_ROOT_DIR` to see if the macro is used out-of-tree, and apply
the relative source code path of the target instead of considering IREE's
specific code structure.

This allows external projects to use IREE macros like `iree_cc_binary` or
`iree_cc_library` to build targets.

For IREE codebase, this should be a no-op.