### PR TITLE
Ignore llvm-project.branch-pin in CODEOWNERS.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,7 @@
 /third_party/ @GMNGeoffrey @ScottTodd @stellaraccident
 # Except for routinely-updated submodules
 /third_party/llvm-project @ghost
+/third_party/llvm-project.branch-pin @ghost
 /third_party/tensorflow @ghost
 /third_party/mlir-hlo @ghost
 


### PR DESCRIPTION
Not sure what this is, but it should be treated like `third_party/llvm-project/`.

See https://github.com/iree-org/iree/pull/9614