### PR TITLE
Cleaning up function reflection attrs.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/CMakeLists.txt
@@ -21,7 +21,7 @@ iree_cc_library(
     LLVMSupport
     MLIRGPUOps
     MLIRIR
-    MLIRSPIRV
+    MLIRSPIRVDialect
     MLIRSPIRVSerialization
     SPIRV-Tools
     iree::compiler::Codegen::Dialect::IREECodegenDialect

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -236,19 +236,18 @@ static LogicalResult canonicalizeModule(BytecodeTargetOptions targetOptions,
 // the argument objects/attrs.
 static iree_vm_FunctionSignatureDef_ref_t createFunctionSignatureDef(
     FunctionType functionType, llvm::DenseMap<Type, int> &typeTable,
-    StringRef callingConvention,
-    iree_vm_ReflectionAttrDef_vec_ref_t reflectionAttrsRef,
+    StringRef callingConvention, iree_vm_AttrDef_vec_ref_t attrsRef,
     FlatbufferBuilder &fbb) {
   // If the signature would be empty then let's avoid writing the empty table.
   auto callingConventionRef = fbb.createString(callingConvention);
-  if (!callingConventionRef && !reflectionAttrsRef) {
+  if (!callingConventionRef && !attrsRef) {
     return 0;
   }
 
   iree_vm_FunctionSignatureDef_start(fbb);
   iree_vm_FunctionSignatureDef_calling_convention_add(fbb,
                                                       callingConventionRef);
-  iree_vm_FunctionSignatureDef_reflection_attrs_add(fbb, reflectionAttrsRef);
+  iree_vm_FunctionSignatureDef_attrs_add(fbb, attrsRef);
   return iree_vm_FunctionSignatureDef_end(fbb);
 }
 
@@ -260,8 +259,7 @@ static iree_vm_FunctionSignatureDef_ref_t makeImportFunctionSignatureDef(
   auto cconv = makeImportCallingConventionString(importOp);
   if (!cconv.hasValue()) return {};
   return createFunctionSignatureDef(importOp.getFunctionType(), typeTable,
-                                    cconv.getValue(), /*reflectionAttrsRef=*/0,
-                                    fbb);
+                                    cconv.getValue(), /*attrsRef=*/0, fbb);
 }
 
 // Returns a serialized function signature.
@@ -273,27 +271,25 @@ static iree_vm_FunctionSignatureDef_ref_t makeExportFunctionSignatureDef(
   if (!cconv.hasValue()) return {};
 
   // Reflection attributes.
-  iree_vm_ReflectionAttrDef_vec_ref_t reflectionAttrsRef = 0;
-  if (auto reflectionAttrs =
-          funcOp->getAttrOfType<DictionaryAttr>("iree.reflection")) {
-    SmallVector<iree_vm_ReflectionAttrDef_ref_t, 4> reflectionAttrRefs;
-    for (auto reflectionAttr : reflectionAttrs) {
-      auto key = reflectionAttr.getName().strref();
-      auto value = reflectionAttr.getValue().dyn_cast<StringAttr>();
+  iree_vm_AttrDef_vec_ref_t attrsRef = 0;
+  if (auto attrs = funcOp->getAttrOfType<DictionaryAttr>("iree.reflection")) {
+    SmallVector<iree_vm_AttrDef_ref_t, 4> attrRefs;
+    for (auto attr : attrs) {
+      auto key = attr.getName().strref();
+      auto value = attr.getValue().dyn_cast<StringAttr>();
       if (!value || key.empty()) continue;
       // NOTE: if we actually want to keep these we should dedupe them (as the
       // keys and likely several of the values are shared across all functions).
       auto valueRef = fbb.createString(value.getValue());
       auto keyRef = fbb.createString(key);
-      reflectionAttrRefs.push_back(
-          iree_vm_ReflectionAttrDef_create(fbb, keyRef, valueRef));
+      attrRefs.push_back(iree_vm_AttrDef_create(fbb, keyRef, valueRef));
     }
-    reflectionAttrsRef = iree_vm_ReflectionAttrDef_vec_create(
-        fbb, reflectionAttrRefs.data(), reflectionAttrRefs.size());
+    attrsRef =
+        iree_vm_AttrDef_vec_create(fbb, attrRefs.data(), attrRefs.size());
   }
 
   return createFunctionSignatureDef(funcOp.getFunctionType(), typeTable,
-                                    cconv.getValue(), reflectionAttrsRef, fbb);
+                                    cconv.getValue(), attrsRef, fbb);
 }
 
 // Returns a serialized function signature.
@@ -304,8 +300,7 @@ static iree_vm_FunctionSignatureDef_ref_t makeInternalFunctionSignatureDef(
   auto cconv = makeCallingConventionString(funcOp);
   if (!cconv.hasValue()) return {};
   return createFunctionSignatureDef(funcOp.getFunctionType(), typeTable,
-                                    cconv.getValue(), /*reflectionAttrsRef=*/0,
-                                    fbb);
+                                    cconv.getValue(), /*attrsRef=*/0, fbb);
 }
 
 // Builds a complete BytecodeModuleDef FlatBuffer object in |fbb|.

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/BUILD
@@ -18,8 +18,8 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "constant_encoding.mlir",
+            "function_attrs.mlir",
             "module_encoding_smoke.mlir",
-            "reflection_attrs.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/CMakeLists.txt
@@ -15,8 +15,8 @@ iree_lit_test_suite(
     lit
   SRCS
     "constant_encoding.mlir"
+    "function_attrs.mlir"
     "module_encoding_smoke.mlir"
-    "reflection_attrs.mlir"
   TOOLS
     FileCheck
     iree-compile

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/function_attrs.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/function_attrs.mlir
@@ -5,7 +5,7 @@
 vm.module @simple_module {
   vm.export @func
   // CHECK: "exported_functions":
-  // CHECK: "reflection_attrs":
+  // CHECK: "attrs":
   // CHECK:   "key": "f"
   // CHECK:   "value": "FOOBAR"
   // CHECK:   "key": "fv"

--- a/compiler/src/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/C/CModuleTarget.cpp
@@ -242,14 +242,14 @@ static LogicalResult buildModuleDescriptors(IREE::VM::ModuleOp &moduleOp,
   output << "static const iree_vm_native_module_descriptor_t " << descriptorName
          << " = {\n"
          << printStringView(moduleName) << ",\n"
+         << "0,\n"
+         << "NULL,\n"
          << importOps.size() << ",\n"
          << importName << ",\n"
          << exportOps.size() << ",\n"
          << exportName << ",\n"
          << exportOps.size() << ",\n"
          << functionName << ",\n"
-         << "0,\n"
-         << "NULL,\n"
          << "};\n";
 
   output << "\n";

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -41,17 +41,16 @@ class PyBufferReleaser {
 
 py::dict GetFunctionReflectionDict(iree_vm_function_t& f) {
   py::dict attrs;
-  for (int i = 0;; ++i) {
-    iree_string_view_t key;
-    iree_string_view_t value;
-    auto status = iree_vm_get_function_reflection_attr(f, i, &key, &value);
-    if (iree_status_is_not_found(status)) {
+  for (iree_host_size_t i = 0;; ++i) {
+    iree_string_pair_t attr;
+    auto status = iree_vm_function_get_attr(f, i, &attr);
+    if (iree_status_is_out_of_range(status)) {
       iree_status_ignore(status);
       break;
     }
     CheckApiStatus(status, "Error getting reflection attr");
-    py::str key_str(key.data, key.size);
-    py::str value_str(value.data, value.size);
+    py::str key_str(attr.key.data, attr.key.size);
+    py::str value_str(attr.value.data, attr.value.size);
     attrs[std::move(key_str)] = std::move(value_str);
   }
   return attrs;

--- a/runtime/bindings/tflite/interpreter.c
+++ b/runtime/bindings/tflite/interpreter.c
@@ -292,11 +292,11 @@ static iree_status_t _TfLiteInterpreterAllocate(
 static iree_status_t _TfLiteInterpreterPopulateIO(
     TfLiteInterpreter* interpreter) {
   iree_vm_function_t main_fn = interpreter->model->exports._main;
-  iree_string_view_t io_names_attr = iree_vm_function_reflection_attr(
+  iree_string_view_t io_names_attr = iree_vm_function_lookup_attr_by_name(
       &main_fn, iree_make_cstring_view("tfl.io.names"));
-  iree_string_view_t io_types_attr = iree_vm_function_reflection_attr(
+  iree_string_view_t io_types_attr = iree_vm_function_lookup_attr_by_name(
       &main_fn, iree_make_cstring_view("tfl.io.types"));
-  iree_string_view_t io_quant_attr = iree_vm_function_reflection_attr(
+  iree_string_view_t io_quant_attr = iree_vm_function_lookup_attr_by_name(
       &main_fn, iree_make_cstring_view("tfl.io.quant"));
 
   // Setup static tensor metadata.

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -216,8 +216,9 @@ static iree_status_t iree_hal_vmvx_executable_create(
           .linkage = IREE_VM_FUNCTION_LINKAGE_EXPORT,
           .ordinal = executable->entry_fn_ordinals[i],
       };
-      iree_string_view_t local_memory_str = iree_vm_function_reflection_attr(
-          &entry_fn, iree_make_cstring_view("local_memory"));
+      iree_string_view_t local_memory_str =
+          iree_vm_function_lookup_attr_by_name(
+              &entry_fn, iree_make_cstring_view("local_memory"));
       uint32_t local_memory_size = 0;
       if (!iree_string_view_is_empty(local_memory_str)) {
         iree_string_view_atoi_uint32(local_memory_str, &local_memory_size);

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -1407,8 +1407,8 @@ static const iree_vm_native_export_descriptor_t iree_hal_module_exports_[] = {
       .local_name = iree_string_view_literal(name),                \
       .calling_convention =                                        \
           iree_string_view_literal("0" #arg_types "_" #ret_types), \
-      .reflection_attr_count = 0,                                  \
-      .reflection_attrs = NULL,                                    \
+      .attr_count = 0,                                             \
+      .attrs = NULL,                                               \
   },
 #include "iree/modules/hal/exports.inl"  // IWYU pragma: keep
 #undef EXPORT_FN
@@ -1419,14 +1419,14 @@ static_assert(IREE_ARRAYSIZE(iree_hal_module_funcs_) ==
 
 static const iree_vm_native_module_descriptor_t iree_hal_module_descriptor_ = {
     .module_name = iree_string_view_literal("hal"),
+    .module_attr_count = 0,
+    .module_attrs = NULL,
     .import_count = 0,  // workaround for 0-length C struct
     .imports = iree_hal_module_imports_,
     .export_count = IREE_ARRAYSIZE(iree_hal_module_exports_),
     .exports = iree_hal_module_exports_,
     .function_count = IREE_ARRAYSIZE(iree_hal_module_funcs_),
     .functions = iree_hal_module_funcs_,
-    .reflection_attr_count = 0,
-    .reflection_attrs = NULL,
 };
 
 IREE_API_EXPORT iree_status_t

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -96,8 +96,8 @@ static const iree_vm_native_export_descriptor_t iree_vmvx_module_exports_[] = {
       .local_name = iree_string_view_literal(name),                \
       .calling_convention =                                        \
           iree_string_view_literal("0" #arg_types "_" #ret_types), \
-      .reflection_attr_count = 0,                                  \
-      .reflection_attrs = NULL,                                    \
+      .attr_count = 0,                                             \
+      .attrs = NULL,                                               \
   },
 #include "iree/modules/vmvx/exports.inl"  // IWYU pragma: keep
 #undef EXPORT_FN
@@ -108,14 +108,14 @@ static_assert(IREE_ARRAYSIZE(iree_vmvx_module_funcs_) ==
 
 static const iree_vm_native_module_descriptor_t iree_vmvx_module_descriptor_ = {
     .module_name = iree_string_view_literal("vmvx"),
+    .module_attr_count = 0,
+    .module_attrs = NULL,
     .import_count = 0,  // workaround for 0-length C struct
     .imports = iree_vmvx_module_imports_,
     .export_count = IREE_ARRAYSIZE(iree_vmvx_module_exports_),
     .exports = iree_vmvx_module_exports_,
     .function_count = IREE_ARRAYSIZE(iree_vmvx_module_funcs_),
     .functions = iree_vmvx_module_funcs_,
-    .reflection_attr_count = 0,
-    .reflection_attrs = NULL,
 };
 
 IREE_API_EXPORT iree_status_t iree_vmvx_module_create(

--- a/runtime/src/iree/schemas/bytecode_module_def.fbs
+++ b/runtime/src/iree/schemas/bytecode_module_def.fbs
@@ -11,7 +11,7 @@ file_identifier "IREE";
 file_extension "vmfb";
 
 // Arbitrary key/value reflection attribute.
-table ReflectionAttrDef {
+table AttrDef {
   key:string;
   value:string;
 }
@@ -31,11 +31,11 @@ table FunctionSignatureDef {
   // See iree/vm/module.h for more information.
   calling_convention:string;
 
-  // Function level reflection attributes.
+  // Function-level attributes, if any.
   // These are typically used to communicate additional ABI metadata needed
   // for dynamic invocation and host language mapping.
   // See: docs/developers/design_docs/function_abi.md
-  reflection_attrs:[ReflectionAttrDef];
+  attrs:[AttrDef];
 }
 
 enum ImportFlagBits:uint32 (bit_flags) {
@@ -211,6 +211,9 @@ table DebugDatabaseDef {
 table BytecodeModuleDef {
   // Module namespace used for fully-qualified function lookups.
   name:string (required);
+
+  // Module-level attributes, if any.
+  attrs:[AttrDef];
 
   // Type table mapping type IDs used within the module to type signatures.
   types:[TypeDef];

--- a/runtime/src/iree/vm/bytecode_module_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode_module_benchmark.cc
@@ -49,12 +49,12 @@ static const iree_vm_native_module_descriptor_t
         iree_make_cstring_view("native_import_module"),
         0,
         NULL,
+        0,
+        NULL,
         IREE_ARRAYSIZE(native_import_module_exports_),
         native_import_module_exports_,
         IREE_ARRAYSIZE(native_import_module_funcs_),
         native_import_module_funcs_,
-        0,
-        NULL,
 };
 
 static iree_status_t native_import_module_create(

--- a/runtime/src/iree/vm/module.h
+++ b/runtime/src/iree/vm/module.h
@@ -28,12 +28,6 @@ typedef struct iree_vm_stack_frame_t iree_vm_stack_frame_t;
 // Module / function reflection
 //===----------------------------------------------------------------------===//
 
-// A key-value pair of module/function reflection information.
-typedef struct iree_vm_reflection_attr_t {
-  iree_string_view_t key;
-  iree_string_view_t value;
-} iree_vm_reflection_attr_t;
-
 // Describes the type of a function reference.
 typedef enum iree_vm_function_linkage_e {
   // Function is internal to the module and may not be reflectable.
@@ -44,7 +38,6 @@ typedef enum iree_vm_function_linkage_e {
   IREE_VM_FUNCTION_LINKAGE_EXPORT = 2,
   // Function is an import from another module that may be unavailable.
   IREE_VM_FUNCTION_LINKAGE_IMPORT_OPTIONAL = 3,
-  // TODO(#1979): add linkage types for well-known functions like __init.
 } iree_vm_function_linkage_t;
 
 // A function reference that can be used with the iree_vm_function_* methods.
@@ -345,6 +338,20 @@ typedef struct iree_vm_module_t {
   // Returns the reflected signature of the module.
   iree_vm_module_signature_t(IREE_API_PTR* signature)(void* self);
 
+  // Gets a reflection attribute for the module by attribute index.
+  // The returned key and value strings are guaranteed valid for the life
+  // of the module. Note that not all modules have reflection attributes.
+  // Returns IREE_STATUS_OUT_OF_RANGE if index >= the number of attributes.
+  iree_status_t(IREE_API_PTR* get_module_attr)(void* self,
+                                               iree_host_size_t index,
+                                               iree_string_pair_t* out_attr);
+
+  // Looks up a function with the given name and linkage in the module.
+  // This may perform a linear scan and results should be cached.
+  iree_status_t(IREE_API_PTR* lookup_function)(
+      void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
+      iree_vm_function_t* out_function);
+
   // Gets one or more pieces of function information:
   // - |out_function| set to the function reference.
   // - |out_name| set to the function name.
@@ -354,11 +361,15 @@ typedef struct iree_vm_module_t {
       iree_vm_function_t* out_function, iree_string_view_t* out_name,
       iree_vm_function_signature_t* out_signature);
 
-  // Looks up a function with the given name and linkage in the module.
-  // This may perform a linear scan and results should be cached.
-  iree_status_t(IREE_API_PTR* lookup_function)(
-      void* self, iree_vm_function_linkage_t linkage, iree_string_view_t name,
-      iree_vm_function_t* out_function);
+  // Gets a reflection attribute for a function by attribute index.
+  // The returned key and value strings are guaranteed valid for the life
+  // of the module. Note that not all modules and functions have reflection
+  // attributes.
+  // Returns IREE_STATUS_OUT_OF_RANGE if index >= the number of attributes for
+  // the function.
+  iree_status_t(IREE_API_PTR* get_function_attr)(
+      void* self, iree_vm_function_linkage_t linkage, iree_host_size_t ordinal,
+      iree_host_size_t index, iree_string_pair_t* out_attr);
 
   // Resolves a stack |frame| from the module to a |out_source_location|, if
   // debug information is available.
@@ -413,19 +424,6 @@ typedef struct iree_vm_module_t {
   iree_status_t(IREE_API_PTR* resume_call)(
       void* self, iree_vm_stack_t* stack, iree_byte_span_t call_results,
       iree_vm_execution_result_t* out_result);
-
-  // TODO(benvanik): move this/refactor.
-  // Gets a reflection attribute for a function by index.
-  // The returned key and value strings are guaranteed valid for the life
-  // of the module. Note that not all modules and functions have reflection
-  // attributes.
-  // Returns IREE_STATUS_NOT_FOUND if index >= the number of attributes for
-  // the function.
-  // See: docs/developers/design_docs/function_abi.md
-  iree_status_t(IREE_API_PTR* get_function_reflection_attr)(
-      void* self, iree_vm_function_linkage_t linkage, iree_host_size_t ordinal,
-      iree_host_size_t index, iree_string_view_t* key,
-      iree_string_view_t* value);
 } iree_vm_module_t;
 
 // Initializes the interface of a module handle.
@@ -450,6 +448,22 @@ iree_vm_module_name(const iree_vm_module_t* module);
 // Returns the signature of the module describing the contents.
 IREE_API_EXPORT iree_vm_module_signature_t
 iree_vm_module_signature(const iree_vm_module_t* module);
+
+// Returns a value for the given reflection attribute |key|, if found.
+// Returns the empty string if the reflection data in general or the specific
+// key is not found.
+IREE_API_EXPORT iree_string_view_t iree_vm_module_lookup_attr_by_name(
+    const iree_vm_module_t* module, iree_string_view_t key);
+
+// Gets a reflection attribute for a module by index into the attribute list.
+// The returned key and value strings are guaranteed valid for the life
+// of the module. Note that not all modules have reflection attributes.
+//
+// Returns IREE_STATUS_OUT_OF_RANGE if index >= the number of attributes for
+// the function.
+IREE_API_EXPORT iree_status_t
+iree_vm_module_get_attr(const iree_vm_module_t* module, iree_host_size_t index,
+                        iree_string_pair_t* out_attr);
 
 // Looks up a function with the given name and linkage in the |module|.
 // This may perform a linear scan and results should be cached.
@@ -479,23 +493,25 @@ iree_vm_function_signature(const iree_vm_function_t* function);
 // Returns a value for the given reflection attribute |key|, if found.
 // Returns the empty string if the reflection data in general or the specific
 // key is not found.
-//
-// See: docs/developers/design_docs/function_abi.md for documentation on the
-// ABI.
-IREE_API_EXPORT iree_string_view_t iree_vm_function_reflection_attr(
+IREE_API_EXPORT iree_string_view_t iree_vm_function_lookup_attr_by_name(
     const iree_vm_function_t* function, iree_string_view_t key);
 
-// TODO(#1979): remove this and use iree_vm_function_reflection_attr.
-// Gets a reflection attribute for a function by index.
+// Gets a reflection attribute for a function by index into the attribute list.
 // The returned key and value strings are guaranteed valid for the life
-// of the module. Note that not all modules and functions have reflection
-// attributes.
-// Returns IREE_STATUS_NOT_FOUND if index >= the number of attributes for
+// of the module. Note that not all functions have reflection attributes.
+//
+// For more information on the function ABI and its reflection metadata see:
+// docs/developers/design_docs/function_abi.md
+//
+// Returns IREE_STATUS_OUT_OF_RANGE if index >= the number of attributes for
 // the function.
-// See: docs/developers/design_docs/function_abi.md
-IREE_API_EXPORT iree_status_t iree_vm_get_function_reflection_attr(
-    iree_vm_function_t function, iree_host_size_t index,
-    iree_string_view_t* key, iree_string_view_t* value);
+//
+// NOTE: always prefer to use iree_vm_function_lookup_attr_by_name; this should
+// only be used when exporting attributes into a generic data structure (JSON
+// or python dicts, etc).
+IREE_API_EXPORT iree_status_t
+iree_vm_function_get_attr(iree_vm_function_t function, iree_host_size_t index,
+                          iree_string_pair_t* out_attr);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/vm/native_module.h
+++ b/runtime/src/iree/vm/native_module.h
@@ -46,8 +46,8 @@ typedef struct iree_vm_native_export_descriptor_t {
   iree_string_view_t calling_convention;
 
   // An optional list of function-level reflection attributes.
-  iree_host_size_t reflection_attr_count;
-  const iree_vm_reflection_attr_t* reflection_attrs;
+  iree_host_size_t attr_count;
+  const iree_string_pair_t* attrs;
 } iree_vm_native_export_descriptor_t;
 
 typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target_t)(
@@ -86,6 +86,10 @@ typedef struct iree_vm_native_module_descriptor_t {
   // Name of the module prefixed on all exported functions.
   iree_string_view_t module_name;
 
+  // An optional list of module-level reflection attributes.
+  iree_host_size_t module_attr_count;
+  const iree_string_pair_t* module_attrs;
+
   // All imported function descriptors.
   // interface.resolve_import will be called for each import.
   // Imports must be in order sorted by name compatible with
@@ -104,10 +108,6 @@ typedef struct iree_vm_native_module_descriptor_t {
   // implementation and are optional if overriding begin_call.
   iree_host_size_t function_count;
   const iree_vm_native_function_ptr_t* functions;
-
-  // An optional list of module-level reflection attributes.
-  iree_host_size_t reflection_attr_count;
-  const iree_vm_reflection_attr_t* reflection_attrs;
 } iree_vm_native_module_descriptor_t;
 
 // Returns the size, in bytes, of the allocation required for native modules.

--- a/runtime/src/iree/vm/native_module_test.h
+++ b/runtime/src/iree/vm/native_module_test.h
@@ -116,12 +116,12 @@ static const iree_vm_native_module_descriptor_t module_a_descriptor_ = {
     iree_make_cstring_view("module_a"),
     0,
     NULL,
+    0,
+    NULL,
     IREE_ARRAYSIZE(module_a_exports_),
     module_a_exports_,
     IREE_ARRAYSIZE(module_a_funcs_),
     module_a_funcs_,
-    0,
-    NULL,
 };
 
 static iree_status_t module_a_create(iree_allocator_t allocator,
@@ -250,7 +250,7 @@ static const iree_vm_native_import_descriptor_t module_b_imports_[] = {
 static_assert(IREE_ARRAYSIZE(module_b_state_t::imports) ==
                   IREE_ARRAYSIZE(module_b_imports_),
               "import storage must be able to hold all imports");
-static const iree_vm_reflection_attr_t module_b_entry_attrs_[] = {
+static const iree_string_pair_t module_b_entry_attrs_[] = {
     {iree_make_cstring_view("key1"), iree_make_cstring_view("value1")},
 };
 static const iree_vm_native_export_descriptor_t module_b_exports_[] = {
@@ -262,14 +262,14 @@ static_assert(IREE_ARRAYSIZE(module_b_funcs_) ==
               "function pointer table must be 1:1 with exports");
 static const iree_vm_native_module_descriptor_t module_b_descriptor_ = {
     iree_make_cstring_view("module_b"),
+    0,
+    NULL,
     IREE_ARRAYSIZE(module_b_imports_),
     module_b_imports_,
     IREE_ARRAYSIZE(module_b_exports_),
     module_b_exports_,
     IREE_ARRAYSIZE(module_b_funcs_),
     module_b_funcs_,
-    0,
-    NULL,
 };
 
 static iree_status_t module_b_create(iree_allocator_t allocator,

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -80,7 +80,7 @@ IREE_FLAG(string, module_file, "-",
           "function. Defaults to stdin.");
 
 // TODO(hanchung): Extract the batch size using
-// iree_vm_function_reflection_attr.
+// iree_vm_function_lookup_attr_by_name.
 IREE_FLAG(
     int32_t, batch_size, 1,
     "The number of batch size, which is expected to match "
@@ -366,7 +366,7 @@ class IREEBenchmark {
 
       // We run anything with the 'benchmark' attribute.
       // If the attribute is not present we'll run anything that looks runnable.
-      iree_string_view_t benchmark_type = iree_vm_function_reflection_attr(
+      iree_string_view_t benchmark_type = iree_vm_function_lookup_attr_by_name(
           &function, IREE_SV("iree.benchmark"));
       if (iree_string_view_equal(benchmark_type, IREE_SV("dispatch"))) {
         iree::RegisterDispatchBenchmark(


### PR DESCRIPTION
This makes the attr queries consistent with the other API methods and
removes "reflection" from the name. Also plumbs through module attrs and
enables support for unit attrs (empty values).

Fixes #1979.