### PR TITLE
Lower VMVX linalg ops to microkernels.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -49,6 +49,9 @@ def SPIRV_VectorizeToCooperativeOps
 def SPIRV_VectorizeWithWorkgroupMemory
     : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 16>;
 
+def VMVX_Default
+    : I32EnumAttrCase<"VMVXDefault", 17>;
+
 def None
     : I32EnumAttrCase<"None", 0xff>;
 
@@ -66,7 +69,7 @@ def DispatchLoweringPassPipelineEnum
                     LLVMGPU_MatmulTensorCore, LLVMGPU_WarpReduction, 
                     SPIRV_Distribute, SPIRV_Vectorize,
                     SPIRV_VectorizeToCooperativeOps,
-                    SPIRV_VectorizeWithWorkgroupMemory, None
+                    SPIRV_VectorizeWithWorkgroupMemory, VMVX_Default, None
                   ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -424,9 +424,10 @@ static LogicalResult setDefaultRootConfig(
       partitionableLoops, lbs, ubs, minTileSizes, maxTileSizes);
   TileSizesListType tileSizes;
   tileSizes.emplace_back(std::move(flowTileSizes));
-  return setOpConfigAndEntryPointFnTranslation(
-      entryPointFn, partitionableLoopsInterfaceOp, tileSizes,
-      DispatchLoweringPassPipeline::CPUDefault);
+  auto loweringConfig = IREE::Codegen::LoweringConfigAttr::get(
+      entryPointFn.getContext(), tileSizes);
+  setLoweringConfig(partitionableLoopsInterfaceOp, loweringConfig);
+  return success();
 }
 
 static LogicalResult setMatmulPadRootConfig(
@@ -972,13 +973,18 @@ static LogicalResult setRootConfig(
 /// Set default configuration for Linalg ops.
 static LogicalResult setRootConfig(
     func::FuncOp entryPointFn, linalg::LinalgOp linalgOp,
-    ArrayRef<LoopTilingAndDistributionInfo> tiledLoops) {
+    ArrayRef<LoopTilingAndDistributionInfo> tiledLoops,
+    DispatchLoweringPassPipeline pipeline =
+        DispatchLoweringPassPipeline::CPUDefault) {
   if (getLoweringConfig(linalgOp)) return success();
 
   auto partitionableLoopOp =
       cast<PartitionableLoopsInterface>(linalgOp.getOperation());
   SmallVector<int64_t> lbs(linalgOp.getNumLoops(), 0);
   SmallVector<int64_t> ubs = linalgOp.getStaticLoopRanges();
+  auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
+      entryPointFn->getContext(), pipeline);
+  setTranslationInfo(entryPointFn, translationInfo);
   return setDefaultRootConfig(entryPointFn, partitionableLoopOp, lbs, ubs);
 }
 
@@ -987,7 +993,9 @@ static LogicalResult setRootConfig(
 static LogicalResult setRootConfig(
     func::FuncOp entryPointFn,
     IREE::LinalgExt::TiledOpInterface tiledOpInterfaceOp,
-    ArrayRef<LoopTilingAndDistributionInfo> tiledLoops) {
+    ArrayRef<LoopTilingAndDistributionInfo> tiledLoops,
+    DispatchLoweringPassPipeline pipeline =
+        DispatchLoweringPassPipeline::CPUDefault) {
   if (getLoweringConfig(tiledOpInterfaceOp)) return success();
 
   auto partitionableLoopOp =
@@ -1007,6 +1015,9 @@ static LogicalResult setRootConfig(
       iterationDomain, [&](Range r) { return getStaticValue(r.offset); }));
   auto ubs = llvm::to_vector(llvm::map_range(
       iterationDomain, [&](Range r) { return getStaticValue(r.size); }));
+  auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
+      entryPointFn->getContext(), pipeline);
+  setTranslationInfo(entryPointFn, translationInfo);
   return setDefaultRootConfig(entryPointFn, partitionableLoopOp, lbs, ubs);
 }
 
@@ -1049,7 +1060,8 @@ static LogicalResult setVMVXRootConfigImpl(
     return TypeSwitch<Operation *, LogicalResult>(op)
         .Case<linalg::LinalgOp, IREE::LinalgExt::TiledOpInterface>(
             [&](auto op) {
-              return setRootConfig(entryPointFn, op, tiledLoops);
+              return setRootConfig(entryPointFn, op, tiledLoops,
+                                   DispatchLoweringPassPipeline::VMVXDefault);
             })
         .Default([&](Operation *op) { return success(); });
   };

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -219,6 +219,9 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addCPUAArchDoubleTilingExpertPassPipeline(
                 executableLoweringPipeline);
             break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::VMVXDefault:
+            addVMVXDefaultPassPipeline(executableLoweringPipeline);
+            break;
           default:
             variantOp.emitOpError("Unsupported pipeline on CPU target.");
             return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -332,6 +332,13 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
   }
 }
 
+void addVMVXDefaultPassPipeline(OpPassManager &passManager) {
+  addTileAndDistributePasses(passManager);
+
+  OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+  addBufferizePasses(nestedModulePM);
+}
+
 void addDoubleTilingExpertPassPipeline(OpPassManager &passManager,
                                        bool enablePeeling, bool lowerToAVX2) {
   addTileAndDistributePasses(passManager);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
@@ -33,7 +33,7 @@ hal.executable private @matmul_static  {
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0]]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //      CHECK: hal.executable.export public @matmul_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
@@ -74,7 +74,7 @@ hal.executable @copy_op_dynamic {
   }
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //      CHECK: hal.executable.export public @copy_op_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:   linalg.generic
@@ -111,7 +111,7 @@ hal.executable private @static_1d_fft_stage2  {
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64]{{\]}}>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDefault>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //       CHECK: hal.executable.export public @static_1d_fft_stage2
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: func.func @static_1d_fft_stage2()

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -239,6 +239,10 @@ void populateUnfusedFMAOpsPassPatterns(MLIRContext *context,
 /// to memrefs
 void addCPUDefaultPassPipeline(OpPassManager &passManager);
 
+/// Populates the passes to lower to tiled/distributed/bufferized ops, suitable
+/// for library call dispatch and lowering to loops.
+void addVMVXDefaultPassPipeline(OpPassManager &passManager);
+
 /// Populates the passes to lower linalg ops on buffers. Currenly this pipeline
 /// is only used for dispatches that just copy data from input interfaces to
 /// output interface.

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/BUILD
@@ -26,6 +26,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/VM/Conversion",
         "//compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM",
         "//compiler/src/iree/compiler/Dialect/VM/IR",
+        "@llvm-project//mlir:ArithmeticDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_cc_library(
   SRCS
     "ConvertVMVXToVM.cpp"
   DEPS
+    MLIRArithmeticDialect
     MLIRFuncDialect
     MLIRIR
     MLIRPass

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
@@ -194,7 +194,6 @@ void populateVMVXToVMPatterns(MLIRContext *context,
                               TypeConverter &typeConverter,
                               SymbolTable &importSymbols,
                               RewritePatternSet &patterns) {
-  conversionTarget.addIllegalDialect<IREE::VMVX::VMVXDialect>();
   patterns.insert<AddOpConversion, CopyOpConversion, Fill2DOpConversion,
                   MatmulOpConversion>(context, importSymbols, typeConverter);
 }

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
@@ -6,7 +6,6 @@
 
 #include "iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.h"
 
-#include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXDialect.h"
 #include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXOps.h"
 #include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXTypes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/BUILD
@@ -17,6 +17,10 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "add.mlir",
+            "copy.mlir",
+            "fill.mlir",
+            "matmul.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/CMakeLists.txt
@@ -13,6 +13,11 @@ iree_add_all_subdirs()
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "add.mlir"
+    "copy.mlir"
+    "fill.mlir"
+    "matmul.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/add.mlir
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/add.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt --iree-vm-target-index-bits=64 --split-input-file \
+// RUN:   --iree-vm-conversion --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @add_2d_f32
+func.func @add_2d_f32(
+    // LHS
+    %arg0 : memref<128xf32>, %arg1 : index, %arg2 : index, %arg3 : index,
+    // RHS
+    %arg4 : memref<65536xf32>, %arg5 : index, %arg6 : index, %arg7 : index,
+    // OUT
+    %arg8 : memref<65536xf32>, %arg9 : index, %arg10 : index, %arg11 : index,
+    // SIZE
+    %arg12 : index, %arg13 : index) {
+
+  //      CHECK: vm.call @vmvx.add.2d.f32(
+  // CHECK-SAME:   %arg0, %arg1, %arg2, %arg3,
+  // CHECK-SAME:   %arg4, %arg5, %arg6, %arg7,
+  // CHECK-SAME:   %arg8, %arg9, %arg10, %arg11,
+  // CHECK-SAME    %[[S0]], %[[S1]])
+  // CHECK-SAME: : (!vm.buffer, i64, i64, i64, !vm.buffer, i64, i64, i64, !vm.buffer, i64, i64, i64, i64, i64) -> ()
+  vmvx.add lhs(%arg0 offset %arg1 strides[%arg2, %arg3] : memref<128xf32>)
+           rhs(%arg4 offset %arg5 strides[%arg6, %arg7] : memref<65536xf32>)
+           out(%arg8 offset %arg9 strides[%arg10, %arg11] : memref<65536xf32>)
+           sizes(%arg12, %arg13)
+  func.return
+}

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/copy.mlir
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/copy.mlir
@@ -1,0 +1,22 @@
+// RUN: iree-opt --iree-vm-target-index-bits=64 --split-input-file \
+// RUN:   --iree-vm-conversion --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @copy_2d_f32
+func.func @copy_2d_f32(
+    // INP
+    %arg0 : memref<65536xf32>, %arg1 : index, %arg2 : index, %arg3 : index,
+    // OUT
+    %arg4 : memref<65536xf32>, %arg5 : index, %arg6 : index, %arg7 : index,
+    // SIZE
+    %arg8 : index, %arg9 : index) {
+
+  //      CHECK: vm.call @vmvx.copy.2d.x32(
+  // CHECK-SAME:   %arg0, %arg1, %arg2, %arg3,
+  // CHECK-SAME:   %arg4, %arg5, %arg6, %arg7,
+  // CHECK-SAME:   %arg8, %arg9)
+  // CHECK-SAME: : (!vm.buffer, i64, i64, i64, !vm.buffer, i64, i64, i64, i64, i64) -> ()
+  vmvx.copy in(%arg0 offset %arg1 strides[%arg2, %arg3] : memref<65536xf32>)
+            out(%arg4 offset %arg5 strides[%arg6, %arg7] : memref<65536xf32>)
+            sizes(%arg8, %arg9)
+  func.return
+}

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/fill.mlir
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/fill.mlir
@@ -1,0 +1,17 @@
+// RUN: iree-opt --iree-vm-target-index-bits=64 --split-input-file \
+// RUN:   --iree-vm-conversion --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @fill2d_f32
+func.func @fill2d_f32(%arg0 : memref<65536xf32>, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : f32) {
+  // CHECK-DAG: %[[VALUE:.*]] = vm.bitcast.f32.i32 %arg5 : f32 -> i32
+  //     CHECK: vm.call @vmvx.fill.2d.x32(%[[VALUE]], %arg0, %arg1, %arg2, %arg3, %arg4) : (i32, !vm.buffer, i64, i64, i64, i64) -> ()
+  vmvx.fill2d scalar(%arg5 : f32) out(%arg0 offset %arg1 row_stride %arg2 : memref<65536xf32>) sizes(%arg3, %arg4)
+  func.return
+}
+
+// CHECK-LABEL: @fill2d_i32
+func.func @fill2d_i32(%arg0 : memref<65536xf32>, %arg1 : index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : i32) {
+  //     CHECK: vm.call @vmvx.fill.2d.x32(%arg5, {{.*}}) -> ()
+  vmvx.fill2d scalar(%arg5 : i32) out(%arg0 offset %arg1 row_stride %arg2 : memref<65536xf32>) sizes(%arg3, %arg4)
+  func.return
+}

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/matmul.mlir
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Conversion/VMVXToVM/test/matmul.mlir
@@ -1,0 +1,30 @@
+// RUN: iree-opt --iree-vm-target-index-bits=64 --split-input-file \
+// RUN:   --iree-vm-conversion --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @matmul_f32f32f32
+func.func @matmul_f32f32f32(
+    // LHS
+    %arg0 : memref<196608xf32>, %arg1 : index, %arg2 : index,
+    // RHS
+    %arg3 : memref<24576xf32>, %arg4 : index, %arg5 : index,
+    // OUT
+    %arg6 : memref<65536xf32>, %arg7 : index, %arg8 : index,
+    // SIZE
+    %arg9 : index, %arg10 : index, %arg11 : index,
+    // SCALE
+    %arg12 : f32, %arg13 : f32) {
+
+  //  CHECK-DAG: %[[ZERO:.*]] = vm.const.i32.zero
+  //      CHECK: vm.call @vmvx.matmul.f32f32f32(
+  // CHECK-SAME: %arg0, %arg1, %arg2,
+  // CHECK-SAME: %arg3, %arg4, %arg5,
+  // CHECK-SAME: %arg6, %arg7, %arg8,
+  // CHECK-SAME: %arg9, %arg10, %arg11, %arg12, %arg13, %[[ZERO]]) : (!vm.buffer, i64, i64, !vm.buffer, i64, i64, !vm.buffer, i64, i64, i64, i64, i64, f32, f32, i32) -> ()
+  vmvx.matmul lhs(%arg0 offset %arg1 row_stride %arg2 : memref<196608xf32>)
+              rhs(%arg3 offset %arg4 row_stride %arg5 : memref<24576xf32>)
+              out(%arg6 offset %arg7 row_stride %arg8 : memref<65536xf32>)
+              mnk(%arg9, %arg10, %arg11)
+              scale(%arg12 : f32, %arg13 : f32)
+              flags(0)
+  func.return
+}

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/BUILD
@@ -141,6 +141,7 @@ iree_tablegen_doc(
     tbl_outs = [
         (
             [
+                "--dialect=vmvx",
                 "--gen-dialect-doc",
             ],
             "VMVXDialect.md",

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/CMakeLists.txt
@@ -99,7 +99,7 @@ iree_tablegen_doc(
   TD_FILE
     "VMVXOps.td"
   OUTS
-    --gen-dialect-doc VMVXDialect.md
+    --dialect=vmvx --gen-dialect-doc VMVXDialect.md
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXBase.td
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXBase.td
@@ -27,6 +27,7 @@ def VMVX_Dialect : Dialect {
 
     See `vmvx.imports.mlir` for the full list of exported functions.
   }];
+  let emitAccessorPrefix = kEmitAccessorPrefix_Prefixed;
 }
 
 //===----------------------------------------------------------------------===//
@@ -50,7 +51,18 @@ def VMVX_HostBuffer : AnyTypeOf<[
   MutableByteBufferType,
 ]>;
 
-def VMVX_Buffer : MemRefRankOf<[I8, I16, I32, I64, F32, F64], [0, 1]>;
+def VMVX_ElementType : AnyTypeOf<[I8, I16, I32, I64, F32, F64]>;
+
+// A potentially non-contiguous buffer of unknown providence.
+def VMVX_NonContiguousBuffer : RankedOrUnrankedMemRefOf<
+    [I8, I16, I32, I64, F32, F64]>;
+
+// An assumed contiguous buffer.
+def VMVX_HasIdentityLayout : CPred<
+    [{ $_self.cast<::mlir::MemRefType>().getLayout().isIdentity() }]>;
+def VMVX_Buffer : Type<And<[
+  MemRefRankOf<[I8, I16, I32, I64, F32, F64], [1]>.predicate,
+  VMVX_HasIdentityLayout]>>;
 
 //===----------------------------------------------------------------------===//
 // VMVX op traits
@@ -61,6 +73,8 @@ def VMVX_Buffer : MemRefRankOf<[I8, I16, I32, I64, F32, F64], [0, 1]>;
 //===----------------------------------------------------------------------===//
 
 def VMVX_OpInterface : OpInterface<"VMVXOp"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::VMVX";
+
   let description = [{
     Interface for VMVX ops that can be used to customize the lowering.
     This is required as there is not a way to get reflection information about

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXDialect.cpp
@@ -38,6 +38,7 @@ class VMVXToVMConversionInterface : public VMConversionDialectInterface {
       SymbolTable &importSymbols, RewritePatternSet &patterns,
       ConversionTarget &conversionTarget,
       TypeConverter &typeConverter) const override {
+    conversionTarget.addIllegalDialect<IREE::VMVX::VMVXDialect>();
     populateVMVXToVMPatterns(getDialect()->getContext(), conversionTarget,
                              typeConverter, importSymbols, patterns);
   }

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXOps.cpp
@@ -19,11 +19,7 @@
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
-namespace VMVX {
-
-// (ops go here)
-
-}  // namespace VMVX
+namespace VMVX {}  // namespace VMVX
 }  // namespace IREE
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXOps.td
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXOps.td
@@ -18,4 +18,131 @@ class VMVX_PureOp<string mnemonic, list<Trait> traits = []> :
 // VMVX Ops: ABI
 //===----------------------------------------------------------------------===//
 
+def VMVX_AddOp : VMVX_Op<"add", [SameVariadicOperandSize]> {
+  let summary = "Performs a strided elementwise add of two same-rank buffers";
+  let description = [{
+    Performs addition in-place as if:
+      OUT = LHS + RHS
+
+    All operands have the same rank.
+  }];
+  let arguments = (ins
+    // LHS.
+    VMVX_Buffer:$lhs_buffer,
+    VMVX_Index:$lhs_offset,
+    Variadic<VMVX_Index>:$lhs_strides,
+    // RHS.
+    VMVX_Buffer:$rhs_buffer,
+    VMVX_Index:$rhs_offset,
+    Variadic<VMVX_Index>:$rhs_strides,
+    // OUT.
+    VMVX_Buffer:$out_buffer,
+    VMVX_Index:$out_offset,
+    Variadic<VMVX_Index>:$out_strides,
+
+    // Dimensions.
+    Variadic<VMVX_Index>:$sizes
+  );
+
+  let assemblyFormat = [{
+    `lhs` `` `(` $lhs_buffer `offset` $lhs_offset `strides` `[` $lhs_strides `]` `:` type($lhs_buffer) `)`
+    `rhs` `` `(` $rhs_buffer `offset` $rhs_offset `strides` `[` $rhs_strides `]` `:` type($rhs_buffer) `)`
+    `out` `` `(` $out_buffer `offset` $out_offset `strides` `[` $out_strides `]` `:` type($out_buffer) `)`
+    `sizes` `` `(` $sizes `)`
+    attr-dict
+  }];
+}
+
+def VMVX_CopyOp : VMVX_Op<"copy", [SameVariadicOperandSize]> {
+  let summary = "Copy from one buffer to another";
+  let arguments = (ins
+    // LHS.
+    VMVX_Buffer:$in_buffer,
+    VMVX_Index:$in_offset,
+    Variadic<VMVX_Index>:$in_strides,
+    // OUT.
+    VMVX_Buffer:$out_buffer,
+    VMVX_Index:$out_offset,
+    Variadic<VMVX_Index>:$out_strides,
+
+    // Dimensions.
+    Variadic<VMVX_Index>:$sizes
+  );
+  let assemblyFormat = [{
+    `in` `` `(` $in_buffer `offset` $in_offset `strides` `[` $in_strides `]` `:` type($in_buffer) `)`
+    `out` `` `(` $out_buffer `offset` $out_offset `strides` `[` $out_strides `]` `:` type($out_buffer) `)`
+    `sizes` `` `(` $sizes `)`
+    attr-dict
+  }];
+}
+
+def VMVX_Fill2DOp : VMVX_Op<"fill2d"> {
+  let summary = "Fill a tile with a scalar";
+  let description = [{
+    Fills a tile with dimensions [m, n] with a scalar.
+  }];
+  let arguments = (ins
+    VMVX_ElementType:$scalar,
+    VMVX_Buffer:$out_buffer,
+    VMVX_Index:$out_offset,
+    VMVX_Index:$out_row_stride,
+
+    // Dimensions.
+    VMVX_Index:$m,
+    VMVX_Index:$n
+  );
+
+  let assemblyFormat = [{
+    `scalar` `` `(` $scalar `:` type($scalar) `)`
+    `out` `` `(` $out_buffer `offset` $out_offset `row_stride` $out_row_stride `:` type($out_buffer) `)`
+    `sizes` `` `(` $m `,` $n `)`
+    attr-dict
+  }];
+}
+
+def VMVX_MatmulOp : VMVX_Op<"matmul"> {
+  let summary = "Matmul";
+  let description = [{
+    General matrix-multiply of the form:
+
+      OUT = alpha * (LHS * RHS) + beta * OUT
+  }];
+  let arguments = (ins
+    // Lhs buffer.
+    VMVX_Buffer:$lhs_buffer,
+    VMVX_Index:$lhs_offset,
+    VMVX_Index:$lhs_row_stride,
+    // Rhs buffer.
+    VMVX_Buffer:$rhs_buffer,
+    VMVX_Index:$rhs_offset,
+    VMVX_Index:$rhs_row_stride,
+    // Out buffer.
+    VMVX_Buffer:$out_buffer,
+    VMVX_Index:$out_offset,
+    VMVX_Index:$out_row_stride,
+
+    // Dimensions.
+    VMVX_Index:$m,
+    VMVX_Index:$n,
+    VMVX_Index:$k,
+
+    // Scale factors.
+    VMVX_ElementType:$alpha,
+    VMVX_ElementType:$beta,
+
+    // Execution flags.
+    I32Attr:$flags
+  );
+
+  let assemblyFormat = [{
+    `lhs` `` `(` $lhs_buffer `offset` $lhs_offset `row_stride` $lhs_row_stride `:` type($lhs_buffer) `)`
+    `rhs` `` `(` $rhs_buffer `offset` $rhs_offset `row_stride` $rhs_row_stride `:` type($rhs_buffer)`)`
+    `out` `` `(` $out_buffer `offset` $out_offset `row_stride` $out_row_stride `:` type($out_buffer) `)`
+    `mnk` `` `(` $m `,` $n `,` $k `)`
+    `scale` `` `(` $alpha `:` type($alpha) `,` $beta `:` type($beta) `)`
+    `flags` `` `(` $flags `)`
+    attr-dict
+  }];
+}
+
 #endif  // IREE_DIALECT_MODULES_VMVX_OPS

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXTypes.h
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/IR/VMVXTypes.h
@@ -23,18 +23,7 @@
 
 // clang-format off: must be included after all LLVM/MLIR headers.
 #include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXEnums.h.inc"  // IWYU pragma: export
-// clang-format on
-
-namespace mlir {
-namespace iree_compiler {
-namespace IREE {
-namespace VMVX {
-
 #include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXOpInterface.h.inc"  // IWYU pragma: export
-
-}  // namespace VMVX
-}  // namespace IREE
-}  // namespace iree_compiler
-}  // namespace mlir
+// clang-format on
 
 #endif  // IREE_COMPILER_DIALECT_MODULES_VMVX_IR_VMVXTYPES_H_

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/BUILD
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library")
+load("//build_tools/bazel:iree_tablegen.bzl", "iree_gentbl_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -12,16 +13,42 @@ package(
     licenses = ["notice"],  # Apache 2.0
 )
 
+iree_gentbl_cc_library(
+    name = "PassesIncGen",
+    tbl_outs = [
+        (
+            ["--gen-pass-decls"],
+            "Passes.h.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "Passes.td",
+    deps = ["@llvm-project//mlir:PassBaseTdFiles"],
+)
+
+iree_compiler_cc_library(
+    name = "PassHeaders",
+    hdrs = [
+        "PassDetail.h",
+        "Passes.h",
+        "Passes.h.inc",
+    ],
+    deps = [
+        ":PassesIncGen",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
 iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
         "Conversion.cpp",
+        "LowerLinalgMicrokernels.cpp",
         "Passes.cpp",
     ],
-    hdrs = [
-        "Passes.h",
-    ],
     deps = [
+        ":PassHeaders",
         "//compiler/src/iree/compiler/Codegen:PassHeaders",
         "//compiler/src/iree/compiler/Codegen/Common",
         "//compiler/src/iree/compiler/Codegen/LLVMCPU",

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/BUILD
@@ -47,6 +47,7 @@ iree_compiler_cc_library(
         "LowerLinalgMicrokernels.cpp",
         "Passes.cpp",
     ],
+    hdrs = ["Passes.h"],
     deps = [
         ":PassHeaders",
         "//compiler/src/iree/compiler/Codegen:PassHeaders",
@@ -66,7 +67,9 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineToStandard",
         "@llvm-project//mlir:AffineTransforms",
+        "@llvm-project//mlir:ArithmeticDialect",
         "@llvm-project//mlir:ArithmeticTransforms",
+        "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FuncTransforms",
         "@llvm-project//mlir:IR",

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/CMakeLists.txt
@@ -36,6 +36,8 @@ iree_cc_library(
 iree_cc_library(
   NAME
     Transforms
+  HDRS
+    "Passes.h"
   SRCS
     "Conversion.cpp"
     "LowerLinalgMicrokernels.cpp"
@@ -47,7 +49,9 @@ iree_cc_library(
     MLIRAffineDialect
     MLIRAffineToStandard
     MLIRAffineTransforms
+    MLIRArithmeticDialect
     MLIRArithmeticTransforms
+    MLIRBufferizationDialect
     MLIRFuncDialect
     MLIRFuncTransforms
     MLIRIR

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/CMakeLists.txt
@@ -10,15 +10,38 @@
 
 iree_add_all_subdirs()
 
+iree_tablegen_library(
+  NAME
+    PassesIncGen
+  TD_FILE
+    "Passes.td"
+  OUTS
+    --gen-pass-decls Passes.h.inc
+)
+
+iree_cc_library(
+  NAME
+    PassHeaders
+  HDRS
+    "PassDetail.h"
+    "Passes.h"
+    "Passes.h.inc"
+  DEPS
+    ::PassesIncGen
+    MLIRPass
+    MLIRTransforms
+  PUBLIC
+)
+
 iree_cc_library(
   NAME
     Transforms
-  HDRS
-    "Passes.h"
   SRCS
     "Conversion.cpp"
+    "LowerLinalgMicrokernels.cpp"
     "Passes.cpp"
   DEPS
+    ::PassHeaders
     IREELinalgExtPasses
     LLVMSupport
     MLIRAffineDialect

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/Conversion.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Dialect/Modules/VMVX/Conversion/StandardToVMVX/ConvertStandardToVMVX.h"
 #include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXDialect.h"
 #include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXTypes.h"
+#include "iree/compiler/Dialect/Modules/VMVX/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/VM/IR/VMDialect.h"
@@ -32,19 +33,12 @@ namespace IREE {
 namespace VMVX {
 
 // Runs conversion with registered input dialects.
-class ConversionPass
-    : public PassWrapper<ConversionPass, OperationPass<mlir::ModuleOp>> {
+class ConversionPass : public ConversionBase<ConversionPass> {
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Util::UtilDialect, IREE::HAL::HALDialect,
                     IREE::VM::VMDialect, IREE::VMVX::VMVXDialect,
                     memref::MemRefDialect>();
-  }
-
-  StringRef getArgument() const override { return "iree-vmvx-conversion"; }
-
-  StringRef getDescription() const override {
-    return "Converts from various dialects to the VMVX dialect";
   }
 
   void runOnOperation() override {
@@ -101,8 +95,6 @@ class ConversionPass
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createConversionPass() {
   return std::make_unique<ConversionPass>();
 }
-
-static PassRegistration<ConversionPass> pass;
 
 }  // namespace VMVX
 }  // namespace IREE

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/LowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/LowerLinalgMicrokernels.cpp
@@ -1,0 +1,807 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXDialect.h"
+#include "iree/compiler/Dialect/Modules/VMVX/IR/VMVXOps.h"
+#include "iree/compiler/Dialect/Modules/VMVX/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace VMVX {
+
+namespace {
+
+struct BufferDescriptor {
+  // The base buffer, corresponding to a row-major, contiguous memory layout.
+  Value baseBuffer;
+
+  // Size/offset/strides of the buffer.
+  Value offset;
+  SmallVector<Value> sizes;
+  SmallVector<Value> strides;
+
+  BufferDescriptor(Value baseBuffer, unsigned rank) : baseBuffer(baseBuffer) {
+    sizes.resize(rank);
+    strides.resize(rank);
+  }
+
+  unsigned getRank() { return strides.size(); }
+
+  /// Returns whether the innermost stride is statically 1. Many kernels
+  /// require this, so we provide the convenience here.
+  bool isUnitInnerStride() {
+    if (getRank() == 0) return true;
+    APInt stride;
+    if (!matchPattern(strides.back(), m_ConstantInt(&stride))) return false;
+    return stride.getZExtValue() == 1;
+  }
+
+  /// Casts the memref to a memref<?x...> that is safe for linear access
+  /// with element-based addressing.
+  Value castToLinear(Location loc, OpBuilder &builder) {
+    BaseMemRefType sourceType = baseBuffer.getType().cast<MemRefType>();
+    if (sourceType.getRank() <= 1) return baseBuffer;
+
+    // Insert the cast just after the original def to keep inner loops tidy.
+    OpBuilder::InsertionGuard restoreIp(builder);
+    Operation *def = baseBuffer.getDefiningOp();
+    if (def) builder.setInsertionPointAfter(def);
+
+    // Collapse to 1D.
+    ReassociationIndices reassociation;
+    reassociation.resize(sourceType.getRank());
+    for (int i = 0; i < sourceType.getRank(); ++i) {
+      reassociation[i] = i;
+    }
+    return builder.create<memref::CollapseShapeOp>(loc, baseBuffer,
+                                                   reassociation);
+  }
+};
+
+/// Computes a BufferDescriptor from a given |buffer| (expected to be of
+/// MemRefType). If the buffer is already in an identity layout, then size,
+/// strides, and offsets corresponding to that layout are returned. If not
+/// an identity layout, then will resolve one layer of memref::SubViewOp (
+/// run ComposeSubViews or equivalent to merge chaines of subviews before
+/// doing this).
+/// Returns a BufferDescriptor if parameters can be computed. Otherwise,
+/// returns nothing.
+/// TODO: All of this should be replaced with an upstream op to get
+/// offset/strides/sizes.
+Optional<BufferDescriptor> computeBufferDescriptor(Location loc, Value buffer,
+                                                   OpBuilder &builder) {
+  auto constant = [&](int64_t idxValue) -> Value {
+    return builder.create<arith::ConstantIndexOp>(loc, idxValue);
+  };
+  auto fillSize = [&](BufferDescriptor &desc, Value v) {
+    auto t = buffer.getType().cast<MemRefType>();
+    for (int i = 0; i < t.getRank(); ++i) {
+      if (t.isDynamicDim(i)) {
+        desc.sizes[i] = builder.create<memref::DimOp>(loc, buffer, i);
+      } else {
+        desc.sizes[i] = constant(t.getDimSize(i));
+      }
+    }
+  };
+
+  // Non-identity: Resolve to a bufferization.to_memref. Bufferization will
+  // insert these with a tensor argument and a symbolic/strided layout that
+  // cannot be resolved when coming from a constant. This seems like a bug
+  // (TODO: check into this). For now, we just rewrite it.
+  if (auto toMemref = llvm::dyn_cast_or_null<bufferization::ToMemrefOp>(
+          buffer.getDefiningOp())) {
+    auto t = buffer.getType().cast<MemRefType>();
+    if (!t.getLayout().isIdentity()) {
+      OpBuilder::InsertionGuard restoreIp(builder);
+      builder.setInsertionPoint(toMemref);
+      buffer = builder.create<bufferization::ToMemrefOp>(
+          toMemref.getLoc(),
+          MemRefType::get(t.getShape(), t.getElementType(), t.getMemorySpace()),
+          toMemref.getOperand());
+    }
+  }
+
+  // If identity, construct an identity layout.
+  auto bufferType = buffer.getType().cast<MemRefType>();
+  if (bufferType.getLayout().isIdentity()) {
+    int rank = bufferType.getRank();
+    BufferDescriptor desc(buffer, rank);
+    // Size.
+    fillSize(desc, buffer);
+    // Strides.
+    desc.strides[rank - 1] = constant(1);
+    for (int i = rank - 2; i >= 0; --i) {
+      desc.strides[i] = builder.create<arith::MulIOp>(loc, desc.strides[i + 1],
+                                                      desc.sizes[i + 1]);
+    }
+    // Offset.
+    desc.offset = constant(0);
+    return desc;
+  }
+
+  // Non-identity: Resolve to a subview op.
+  auto subViewOp = buffer.getDefiningOp<memref::SubViewOp>();
+  if (!subViewOp) return None;
+
+  // Insert before the subview op we are working on since we know everything
+  // dominates here.
+  OpBuilder::InsertionGuard restoreIp(builder);
+  builder.setInsertionPoint(subViewOp);
+
+  // Recursively resolve the descriptor of the subview's base.
+  auto sourceDesc = computeBufferDescriptor(loc, subViewOp.source(), builder);
+  if (!sourceDesc) return None;
+
+  // TODO: For the moment, don't deal with the rank reducing subview case.
+  if (bufferType.getRank() != sourceDesc->getRank()) return None;
+
+  // Compose the source descriptor by:
+  //   1. For each source stride, multiply by the subview stride (these are
+  //      really "stride multipliers", not strides).
+  //   2. Discard the source size, using the destination.
+  //   3. Add the offset, computing using the new strides.
+  BufferDescriptor composedDesc(sourceDesc->baseBuffer, bufferType.getRank());
+  fillSize(composedDesc, buffer);
+
+  // Stride multipliers.
+  for (int idx = 0; idx < composedDesc.getRank(); ++idx) {
+    if (subViewOp.isDynamicStride(idx)) {
+      // Dynamic stride multiplier.
+      composedDesc.strides[idx] = builder.create<arith::MulIOp>(
+          loc, sourceDesc->strides[idx], subViewOp.getDynamicStride(idx));
+    } else {
+      // Handle static strides, dealing with the 0/1 common cases without
+      // generating math ops.
+      int64_t staticStrideMultiplier = subViewOp.getStaticStride(idx);
+      if (staticStrideMultiplier == 1) {
+        composedDesc.strides[idx] = sourceDesc->strides[idx];
+      } else if (staticStrideMultiplier == 0) {
+        composedDesc.strides[idx] = constant(0);
+      } else {
+        Value strideMultiplier = constant(staticStrideMultiplier);
+        composedDesc.strides[idx] = builder.create<arith::MulIOp>(
+            loc, sourceDesc->strides[idx], strideMultiplier);
+      }
+    }
+  }
+
+  // Compute offset.
+  composedDesc.offset = sourceDesc->offset;
+  for (int idx = 0; idx < composedDesc.getRank(); ++idx) {
+    Value logicalOffset;
+    if (subViewOp.isDynamicOffset(idx)) {
+      logicalOffset = subViewOp.getDynamicOffset(idx);
+    } else {
+      int64_t staticOffset = subViewOp.getStaticOffset(idx);
+      if (staticOffset == 0) {
+        // Can just omit since all terms are added and this will multiply
+        // to 0.
+        continue;
+      }
+      logicalOffset = constant(staticOffset);
+    }
+    Value physicalOffset = builder.create<arith::MulIOp>(
+        loc, logicalOffset, composedDesc.strides[idx]);
+    composedDesc.offset =
+        builder.create<arith::AddIOp>(loc, composedDesc.offset, physicalOffset);
+  }
+
+  return composedDesc;
+}
+
+struct LinalgFillConversion : public OpRewritePattern<linalg::FillOp> {
+  using OpRewritePattern::OpRewritePattern;
+  struct OpInfo {
+    linalg::FillOp op;
+    Value scalar;
+    Value out;
+    Optional<BufferDescriptor> outDesc;
+
+    int64_t getRank() { return outDesc->getRank(); }
+
+    OpInfo(linalg::FillOp op) : op(op) {
+      scalar = op.inputs().front();
+      out = op.outputs().front();
+    }
+  };
+
+  LogicalResult matchAndRewrite(linalg::FillOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    OpInfo info(op);
+    info.outDesc = computeBufferDescriptor(loc, info.out, rewriter);
+    if (!info.outDesc) {
+      return rewriter.notifyMatchFailure(
+          op, "could not compute buffer descriptor for out");
+    }
+
+    // Switch based on specialization.
+    if (info.getRank() == 2 && info.outDesc->isUnitInnerStride()) {
+      return handle2DTile(info, rewriter);
+    }
+
+    return rewriter.notifyMatchFailure(op, "unhandled fill variant");
+  }
+
+  LogicalResult handle2DTile(OpInfo &info, PatternRewriter &rewriter) const {
+    auto loc = info.op.getLoc();
+
+    Value m = info.outDesc->sizes[0];
+    Value n = info.outDesc->sizes[1];
+    Value stride = info.outDesc->strides[0];
+    Value outBuffer = info.outDesc->castToLinear(loc, rewriter);
+
+    rewriter.replaceOpWithNewOp<VMVX::Fill2DOp>(
+        info.op, info.scalar, outBuffer, info.outDesc->offset, stride, m, n);
+    return success();
+  }
+};
+
+/// Decomposes a generic op for emission to support primitives.
+struct GenericPipelineDecomposer {
+  linalg::LinalgOp genericOp;
+  SmallVector<BufferDescriptor> inputAndOutputBufferDescriptors;
+
+  // Map each scalar at the edge (block arguments, yield values) to a buffer
+  // description.
+  class BufferInfo {
+   public:
+    unsigned operandIndex;
+    Value scalarValue;
+    AffineMap indexingMap;
+
+    // If this is an output buffer that directly yields from an input, then
+    // the corresponding input will be noted in this field.
+    BufferInfo *directlyYieldsInput = nullptr;
+
+    BufferInfo(unsigned operandIndex, Value scalarValue, AffineMap indexingMap)
+        : operandIndex(operandIndex),
+          scalarValue(scalarValue),
+          indexingMap(indexingMap) {}
+
+    bool isProjectedPermutation() {
+      return indexingMap.isProjectedPermutation();
+    }
+  };
+  DenseMap<Value, BufferInfo> inputValueToBuffer;
+  DenseMap<Value, BufferInfo> outputValueToBuffer;
+
+  GenericPipelineDecomposer(linalg::LinalgOp genericOp) : genericOp(genericOp) {
+    // Map scalar arguments within the body to input buffers.
+    auto indexingMaps = genericOp.getIndexingMaps();
+    Block *block = genericOp.getBlock();
+    auto inputCount = genericOp.getNumInputs();
+    for (auto it : llvm::enumerate(block->getArguments())) {
+      Value scalarValue = it.value();
+      // Inputs are first in the indexing maps, starting from 0.
+      AffineMap indexingMap = indexingMaps[it.index()];
+      inputValueToBuffer.insert(std::make_pair(
+          scalarValue, BufferInfo(it.index(), scalarValue, indexingMap)));
+    }
+
+    // And map terminator (yield) arguments to out buffers.
+    Operation *terminator = genericOp.getBlock()->getTerminator();
+    for (auto it : llvm::enumerate(terminator->getOperands())) {
+      Value scalarValue = it.value();
+      AffineMap indexingMap = indexingMaps[inputCount + it.index()];
+      auto insertIt = outputValueToBuffer.insert(std::make_pair(
+          scalarValue,
+          BufferInfo(inputCount + it.index(), scalarValue, indexingMap)));
+      // If directly yielding an input, just note that.
+      auto foundIt = inputValueToBuffer.find(scalarValue);
+      if (foundIt != inputValueToBuffer.end()) {
+        insertIt.first->second.directlyYieldsInput = &foundIt->second;
+      }
+    }
+  }
+
+  Location getLoc() { return genericOp.getLoc(); }
+
+  // Gets a descriptor associated with a buffer. Can only be called after
+  // beginTransformation.
+  BufferDescriptor &getDescriptor(BufferInfo &buffer) {
+    return inputAndOutputBufferDescriptors[buffer.operandIndex];
+  }
+
+  LogicalResult beginTransformation(PatternRewriter &rewriter) {
+    // Compute buffer descriptors for inputs/outputs.
+    for (auto it : llvm::enumerate(genericOp.getInputAndOutputOperands())) {
+      auto desc =
+          computeBufferDescriptor(getLoc(), it.value()->get(), rewriter);
+      if (!desc) {
+        return rewriter.notifyMatchFailure(genericOp, [&](Diagnostic &d) {
+          d << "could not compute buffer descriptor for operand #"
+            << it.index();
+        });
+      }
+      inputAndOutputBufferDescriptors.push_back(std::move(*desc));
+    }
+    return success();
+  }
+
+  void emitCopy(BufferInfo outputBuffer, BufferInfo inputBuffer,
+                PatternRewriter &rewriter) {
+    auto &outputDesc = getDescriptor(outputBuffer);
+    auto &inputDesc = getDescriptor(inputBuffer);
+    AffineMap inputMap = inputBuffer.indexingMap;
+    AffineMap outputMap = outputBuffer.indexingMap;
+    bool isProjectedPermutation =
+        inputMap.isProjectedPermutation() && outputMap.isProjectedPermutation();
+    unsigned rank = outputMap.getNumDims();
+
+    // Handle cases.
+    if (isProjectedPermutation && rank > 0 && rank <= 2) {
+      bool isTransposed = false;
+      if (rank == 2 && inputMap.isPermutation()) {
+        // Determine whether the map is transposed.
+        if (inputMap.getPermutedPosition(0) == 1 &&
+            inputMap.getPermutedPosition(1) == 0) {
+          isTransposed = true;
+        }
+      }
+
+      auto inpStrides = inputDesc.strides;
+      auto outStrides = outputDesc.strides;
+      auto outSize = outputDesc.sizes;
+      while (outStrides.size() < 2) {
+        // Left pad the input strides with zero (broadcasts leading dims).
+        outStrides.insert(outStrides.begin(),
+                          rewriter.create<arith::ConstantIndexOp>(getLoc(), 0));
+      }
+      while (inpStrides.size() < outStrides.size()) {
+        // Left pad the input strides with zero (broadcasts leading dims).
+        inpStrides.insert(inpStrides.begin(),
+                          rewriter.create<arith::ConstantIndexOp>(getLoc(), 0));
+      }
+      if (isTransposed) {
+        std::swap(inpStrides[0], inpStrides[1]);
+      }
+
+      auto inpBuffer = inputDesc.castToLinear(getLoc(), rewriter);
+      auto outBuffer = outputDesc.castToLinear(getLoc(), rewriter);
+      rewriter.create<VMVX::CopyOp>(getLoc(),
+                                    // INP
+                                    inpBuffer, inputDesc.offset, inpStrides,
+                                    // OUT
+                                    outBuffer, outputDesc.offset, outStrides,
+                                    // Dims
+                                    outSize);
+      return;
+    }
+
+    // TODO: Fallback create new generic.
+  }
+};
+
+struct LinalgGenericEmitter
+    : public OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
+  LogicalResult matchAndRewrite(linalg::LinalgOp op,
+                                PatternRewriter &rewriter) const override {
+    if (op->hasAttr("vmvxIgnore")) {
+      return failure();
+    }
+
+    if (op.getNumParallelLoops() != op.getNumLoops()) {
+      return rewriter.notifyMatchFailure(op, "not elementwise");
+    }
+
+    // TODO: Just trying to match a yield op now.
+    if (op.getBlock()->getOperations().size() != 1) {
+      return rewriter.notifyMatchFailure(
+          op, "TODO: Support fully general unrolling");
+    }
+
+    GenericPipelineDecomposer gpd(op);
+    if (failed(gpd.beginTransformation(rewriter))) {
+      rewriter.startRootUpdate(op);
+      op.getOperation()->setAttr("vmvxIgnore", rewriter.getUnitAttr());
+      rewriter.finalizeRootUpdate(op);
+      return success();
+    }
+
+    // TODO: Unroll normal body ops.
+
+    // Finally, emit any direct yields as a copy.
+    for (auto it : gpd.outputValueToBuffer) {
+      auto &outputBufferInfo = it.second;
+      if (outputBufferInfo.directlyYieldsInput) {
+        gpd.emitCopy(outputBufferInfo, *outputBufferInfo.directlyYieldsInput,
+                     rewriter);
+      }
+    }
+
+    // Fully converted.
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct LinalgGenericElementwiseUnroller
+    : public OpInterfaceRewritePattern<linalg::LinalgOp> {
+  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
+  struct OpInfo {
+    linalg::ContractionOpInterface contract;
+    linalg::LinalgOp op;
+    Block *body;
+    Operation *terminator;
+    SmallVector<BufferDescriptor> inputAndOutputBuffers;
+    // linalg::OpOperandVector inputAndOutputOperands;
+
+    // Mapping of scalar (internal to the Linalg op) SSA values and
+    // corresponding output buffers. These are assembled in reverse order while
+    // unrolling the op up from the terminator.
+    BlockAndValueMapping scalarToBufferMapping;
+
+    OpInfo(linalg::LinalgOp op) : op(op) {
+      body = op.getBlock();
+      terminator = body->getTerminator();
+    }
+
+    BufferDescriptor &getInput(int idx) { return inputAndOutputBuffers[idx]; }
+
+    BufferDescriptor &getOutput(int idx) {
+      return inputAndOutputBuffers[op.getNumInputs() + idx];
+    }
+  };
+
+  struct InputBuffer {
+    AffineMap inputMap;
+    BufferDescriptor &desc;
+  };
+
+  LogicalResult matchAndRewrite(linalg::LinalgOp op,
+                                PatternRewriter &rewriter) const override {
+    auto loc = op.getLoc();
+    OpInfo info(op);
+    if (op.getNumParallelLoops() != op.getNumLoops()) {
+      return rewriter.notifyMatchFailure(op, "not elementwise");
+    }
+
+    if (info.body->getOperations().size() != 2 ||
+        (!llvm::isa<arith::AddFOp>(info.body->front()))) {
+      // TODO: Support full generality before landing. Right now restricting to
+      // a single inner op (plus yield).
+      return rewriter.notifyMatchFailure(
+          op, "TODO: Support fully general unrolling");
+    }
+
+    // Compute buffer descriptors for inputs/outputs.
+    for (auto it : llvm::enumerate(op.getInputAndOutputOperands())) {
+      auto desc = computeBufferDescriptor(loc, it.value()->get(), rewriter);
+      if (!desc) {
+        return rewriter.notifyMatchFailure(op, [&](Diagnostic &d) {
+          d << "could not compute buffer descriptor for operand #"
+            << it.index();
+        });
+      }
+      info.inputAndOutputBuffers.push_back(std::move(*desc));
+    }
+
+    // Match every SSA value from the terminator to the corresponding output of
+    // the op. This equates to:
+    //   linalg.generic ... outs(%1, %2) {
+    //     %3 = ...
+    //     %4 = ...
+    //     linalg.yield %3, %4
+    //   }
+    auto indexingMaps = info.op.getIndexingMaps();
+    for (auto it : llvm::enumerate(info.terminator->getOperands())) {
+      int outputIndex = it.index();
+      Value scalar = it.value();
+      BufferDescriptor &outputBuffer = info.getOutput(it.index());
+      AffineMap outputMap = indexingMaps[info.op.getNumInputs() + outputIndex];
+      // TODO: Special case if yielding directly from a BlockArgument, as that
+      // implies a copy.
+      unrollOutputBufferProducers(info, scalar, outputBuffer, outputMap,
+                                  rewriter);
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+
+  void unrollOutputBufferProducers(OpInfo &info, Value outputScalar,
+                                   BufferDescriptor &outputBuffer,
+                                   AffineMap outputMap,
+                                   PatternRewriter &rewriter) const {
+    llvm::SmallPtrSet<Value, 4> neededProducers;
+    neededProducers.insert(outputScalar);
+
+    // First iterate from bottom to top in order to identify which scalar ops
+    // contribute to the output.
+    for (Operation *scalarOp = info.terminator->getPrevNode(); scalarOp;
+         scalarOp = scalarOp->getPrevNode()) {
+      if (llvm::any_of(scalarOp->getResults(),
+                       [&](Value v) { return neededProducers.contains(v); })) {
+        // Add all operands to the needed set.
+        for (auto operand : scalarOp->getOperands()) {
+          neededProducers.insert(operand);
+        }
+      }
+    }
+
+    // Associate the top-level scalar inputs to buffers and indexing map.
+    auto indexingMaps = info.op.getIndexingMaps();
+    llvm::DenseMap<Value, InputBuffer> scalarValueToInputBuffer;
+    for (auto it : llvm::enumerate(info.body->getArguments())) {
+      AffineMap inputMap = indexingMaps[it.index()];
+      scalarValueToInputBuffer.insert(std::make_pair(
+          it.value(),
+          InputBuffer{inputMap, info.inputAndOutputBuffers[it.index()]}));
+    }
+
+    // Now iterate from top to bottom, processing each operation that
+    // contributes to the output. Because we proceed from the inputs, which
+    // are often going to involve reading/computing less (i.e. they are the
+    // input to broadcasting), this gives us some extra flexibility to
+    // use intermediates that are sized to the correspondingly smaller
+    // number of elements. If we proceeded bottom-up, we would always be
+    // materializing output sized buffers. This optimization is not always
+    // possible, but it can only ever be done if iterating in this order.
+    for (Operation &scalarOp : info.body->getOperations()) {
+      if (!llvm::any_of(scalarOp.getResults(),
+                        [&](Value v) { return neededProducers.contains(v); })) {
+        // Not part of this output.
+        continue;
+      }
+
+      // For each result, get an output buffer to write into.
+      // TODO: For now we only match this against the actual overall output
+      // buffers, but we likely need to allocate temporaries.
+      SmallVector<InputBuffer> operandInputBuffers;
+      SmallVector<BufferDescriptor> resultOutputBuffers;
+      auto allocateOutputBuffer = [&](Value result) -> BufferDescriptor {
+        if (result == outputScalar) {
+          return outputBuffer;
+        }
+        assert(false && "oops. don't support intermediates yet");
+        return outputBuffer;
+      };
+      for (Value result : scalarOp.getResults()) {
+        resultOutputBuffers.push_back(allocateOutputBuffer(result));
+        BufferDescriptor &resultOutputBuffer = resultOutputBuffers.back();
+
+        // Associate this as an input buffer for a later stage.
+        // Note that here we make the assumption that we eagerly promote to the
+        // output buffer indexing map.
+        scalarValueToInputBuffer.insert(
+            std::make_pair(result, InputBuffer{outputMap, resultOutputBuffer}));
+      }
+      for (Value operand : scalarOp.getOperands()) {
+        auto found_it = scalarValueToInputBuffer.find(operand);
+        if (found_it == scalarValueToInputBuffer.end()) {
+          // TODO: Something weird with the generic: punt to emitting this as a
+          // standalone thing.
+          assert(false && "missing mapped input buffer");
+        }
+        operandInputBuffers.push_back(found_it->second);
+      }
+
+      // Switch on the op and emit.
+      if (llvm::isa<arith::AddFOp, arith::AddIOp>(scalarOp)) {
+        unrollVMVXBinaryOp<VMVX::AddOp>(info, scalarOp, operandInputBuffers,
+                                        resultOutputBuffers, outputMap,
+                                        rewriter);
+      } else {
+        assert(false && "should emit unrecognized op as generic");
+      }
+    }
+  }
+
+  template <typename TargetOpTy>
+  void unrollVMVXBinaryOp(OpInfo &info, Operation &srcOp,
+                          SmallVector<InputBuffer> &operandInputBuffers,
+                          SmallVector<BufferDescriptor> resultOutputBuffers,
+                          AffineMap outputMap,
+                          PatternRewriter &rewriter) const {
+    auto loc = info.op.getLoc();
+    Value oneSize = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    Value zeroOffset = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    auto expandRankTo = [&](SmallVector<Value> &dims, unsigned rank,
+                            Value fillIndex) {
+      while (dims.size() < rank) {
+        dims.insert(dims.begin(), fillIndex);
+      }
+    };
+
+    // TODO: This is not right and just so I can go home on a Thursday night.
+    // What we should be doing: affine.apply'ing the corresponding maps and
+    // then rank expanding.
+    auto lhsStrides = operandInputBuffers[0].desc.strides;
+    auto rhsStrides = operandInputBuffers[1].desc.strides;
+    auto outStrides = resultOutputBuffers[0].strides;
+    auto outSize = resultOutputBuffers[0].sizes;
+    unsigned commonRank = std::max(
+        std::max(lhsStrides.size(), rhsStrides.size()), outStrides.size());
+    expandRankTo(lhsStrides, commonRank, zeroOffset);
+    expandRankTo(rhsStrides, commonRank, zeroOffset);
+    expandRankTo(outStrides, commonRank, zeroOffset);
+    expandRankTo(outSize, commonRank, oneSize);
+
+    auto lhsBuffer = operandInputBuffers[0].desc.castToLinear(loc, rewriter);
+    auto rhsBuffer = operandInputBuffers[1].desc.castToLinear(loc, rewriter);
+    auto outBuffer = resultOutputBuffers[0].castToLinear(loc, rewriter);
+
+    rewriter.create<TargetOpTy>(
+        loc,
+        // LHS.
+        lhsBuffer, operandInputBuffers[0].desc.offset, lhsStrides,
+        // RHS.
+        rhsBuffer, operandInputBuffers[1].desc.offset, rhsStrides,
+        // OUT.
+        outBuffer, resultOutputBuffers[0].offset, outStrides,
+        // Dims.
+        outSize);
+  }
+};
+
+struct LinalgMatmulConversion
+    : public OpInterfaceRewritePattern<linalg::ContractionOpInterface> {
+  using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
+  struct OpInfo {
+    linalg::ContractionOpInterface contract;
+    linalg::LinalgOp op;
+
+    Value lhs;
+    Value rhs;
+    Value out;
+
+    Optional<BufferDescriptor> lhsDesc;
+    Optional<BufferDescriptor> rhsDesc;
+    Optional<BufferDescriptor> outDesc;
+
+    OpInfo(linalg::ContractionOpInterface contract)
+        : contract(contract),
+          op(llvm::cast<linalg::LinalgOp>(contract.getOperation())) {
+      lhs = contract.lhs();
+      rhs = contract.rhs();
+      out = op.outputs().front();
+    }
+
+    Value getOneValue(PatternRewriter &rewriter) {
+      Location loc = op.getLoc();
+      Type elementType = out.getType().cast<MemRefType>().getElementType();
+      if (auto floatType = elementType.dyn_cast<FloatType>()) {
+        return rewriter.create<arith::ConstantOp>(
+            loc, FloatAttr::get(floatType, 1.0));
+      } else if (elementType.isa<IntegerType>()) {
+        return rewriter.create<arith::ConstantIntOp>(loc, 1, elementType);
+      }
+
+      assert(false && "unknown element type");
+      return nullptr;
+    }
+  };
+
+  LogicalResult matchAndRewrite(linalg::ContractionOpInterface op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    OpInfo info(op);
+
+    // Check that buffer descriptors could be computed.
+    info.lhsDesc = computeBufferDescriptor(loc, info.lhs, rewriter);
+    if (!info.lhsDesc) {
+      return rewriter.notifyMatchFailure(
+          op, "could not compute buffer descriptor for lhs");
+    }
+    info.rhsDesc = computeBufferDescriptor(loc, info.rhs, rewriter);
+    if (!info.rhsDesc) {
+      return rewriter.notifyMatchFailure(
+          op, "could not compute buffer descriptor for rhs");
+    }
+    info.outDesc = computeBufferDescriptor(loc, info.out, rewriter);
+    if (!info.outDesc) {
+      return rewriter.notifyMatchFailure(
+          op, "could not compute buffer descriptor for out");
+    }
+
+    // Check for unit inner strides.
+    if (!info.lhsDesc->isUnitInnerStride()) {
+      return rewriter.notifyMatchFailure(op, "lhs has non-unit inner stride");
+    }
+    if (!info.rhsDesc->isUnitInnerStride()) {
+      return rewriter.notifyMatchFailure(op, "rhs has non-unit inner stride");
+    }
+    if (!info.outDesc->isUnitInnerStride()) {
+      return rewriter.notifyMatchFailure(op, "out has non-unit inner stride");
+    }
+
+    // Switch on contraction type.
+    if (info.contract.isRowMajorMatmul() ||
+        info.contract.isColumnMajorMatmul()) {
+      return handleConformingMatmul2D(info, rewriter);
+    }
+
+    return rewriter.notifyMatchFailure(op, "unsupported contraction variant");
+  }
+
+  LogicalResult handleConformingMatmul2D(OpInfo &info,
+                                         PatternRewriter &rewriter) const {
+    auto loc = info.op.getLoc();
+    // Determine m, n, k based on dims.
+    int flags = 0;
+    Value m, n, k;
+    if (info.contract.isRowMajorMatmul()) {
+      m = info.lhsDesc->sizes[0];
+      k = info.rhsDesc->sizes[0];
+      n = info.rhsDesc->sizes[1];
+    } else if (info.contract.isColumnMajorMatmul()) {
+      m = info.lhsDesc->sizes[0];
+      k = info.rhsDesc->sizes[1];
+      n = info.rhsDesc->sizes[0];
+      // TODO: Flag constants somewhere.
+      flags |= 1;
+    } else {
+      return failure();
+    }
+
+    // Alpha/beta: We always start the lowering with alpha/beta set to 1.
+    // Simplification patterns within VMVX will simplify this if possible.
+    Value alpha = info.getOneValue(rewriter);
+    Value beta = alpha;
+
+    auto lhsBuffer = info.lhsDesc->castToLinear(loc, rewriter);
+    auto rhsBuffer = info.rhsDesc->castToLinear(loc, rewriter);
+    auto outBuffer = info.outDesc->castToLinear(loc, rewriter);
+
+    rewriter.replaceOpWithNewOp<VMVX::MatmulOp>(
+        info.op,
+        // LHS
+        lhsBuffer, info.lhsDesc->offset, info.lhsDesc->strides[0],
+        // RHS
+        rhsBuffer, info.rhsDesc->offset, info.rhsDesc->strides[0],
+        // Out
+        outBuffer, info.outDesc->offset, info.outDesc->strides[0],
+        // m,n,k
+        m, n, k,
+        // alpha, beta
+        alpha, beta,
+        // flags
+        rewriter.getI32IntegerAttr(flags));
+    return success();
+  }
+};
+
+}  // namespace
+
+class LowerLinalgMicrokernelsPass
+    : public LowerLinalgMicrokernelsBase<LowerLinalgMicrokernelsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::VMVX::VMVXDialect, memref::MemRefDialect>();
+  }
+
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<LinalgFillConversion, LinalgGenericElementwiseUnroller,
+                    LinalgGenericEmitter, LinalgMatmulConversion>(
+        &getContext());
+
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+
+std::unique_ptr<Pass> createLowerLinalgMicrokernelsPass() {
+  return std::make_unique<LowerLinalgMicrokernelsPass>();
+}
+
+}  // namespace VMVX
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/PassDetail.h
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/PassDetail.h
@@ -1,0 +1,27 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_MODULES_VMVX_TRANSFORMS_PASS_DETAIL_H_
+#define IREE_COMPILER_DIALECT_MODULES_VMVX_TRANSFORMS_PASS_DETAIL_H_
+
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace VMVX {
+
+#define GEN_PASS_CLASSES
+#include "iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.h.inc"
+
+}  // namespace VMVX
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_MODULES_VMVX_TRANSFORMS_PASS_DETAIL_H_

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.h
@@ -37,6 +37,10 @@ void buildVMVXTransformPassPipeline(OpPassManager &passManager);
 
 void createVMVXTransformPassPipeline();
 
+// Lowers high level library calls from named ops and generics. This operates
+// at the bufferized linalg level.
+std::unique_ptr<Pass> createLowerLinalgMicrokernelsPass();
+
 //===----------------------------------------------------------------------===//
 // Dialect conversion
 //===----------------------------------------------------------------------===//
@@ -48,7 +52,7 @@ std::unique_ptr<OperationPass<mlir::ModuleOp>> createConversionPass();
 // Register all Passes
 //===----------------------------------------------------------------------===//
 
-inline void registerVMVXPasses() { createVMVXTransformPassPipeline(); }
+void registerVMVXPasses();
 
 }  // namespace VMVX
 }  // namespace IREE

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/Passes.td
@@ -1,0 +1,24 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_MODULES_VMVX_PASSES
+#define IREE_MODULES_VMVX_PASSES
+
+include "mlir/Pass/PassBase.td"
+
+def LowerLinalgMicrokernels :
+    Pass<"iree-vmvx-lower-linalg-microkernels", ""> {
+  let summary =
+      "Lowers linalg ops to the VMVX microkernel library";
+  let constructor = "mlir::iree_compiler::IREE::VMVX::createLowerLinalgMicrokernelsPass()";
+}
+
+def Conversion : Pass<"iree-vmvx-conversion", "mlir::ModuleOp"> {
+  let summary = "Converts from various dialects to the VMVX dialect";
+  let constructor = "mlir::iree_compiler::IREE::VMVX::createConversionPass()";
+}
+
+#endif  // IREE_MODULES_VMVX_PASSES

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/test/BUILD
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "lower_linalg_microkernels.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/test/CMakeLists.txt
@@ -13,6 +13,8 @@ iree_add_all_subdirs()
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "lower_linalg_microkernels.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/test/lower_linalg_microkernels.mlir
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/Transforms/test/lower_linalg_microkernels.mlir
@@ -1,0 +1,101 @@
+// RUN: iree-opt --pass-pipeline="func.func(iree-vmvx-lower-linalg-microkernels, canonicalize, cse)" %s | FileCheck %s
+
+// Verifies the indexing math generated in order to resolve subviews to 1D.
+// This incidentally also verifies vmvx.copy (non-transposed) lowering.
+// CHECK-LABEL: @subview_indexing_2d
+//   CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+//   CHECK-DAG: %[[C384:.*]] = arith.constant 384 : index
+//   CHECK-DAG: %[[C128:.*]] = arith.constant 128 : index
+//   CHECK-DAG: %[[C64:.*]] = arith.constant 64 : index
+//   CHECK-DAG: %[[I0:.*]] = arith.muli %arg2, %[[C128]] : index
+//   CHECK-DAG: %[[I1:.*]] = arith.addi %[[I0]], %arg3 : index
+//   CHECK-DAG: %[[I2:.*]] = arith.muli %arg3, %[[C384]] : index
+//   CHECK-DAG: %[[I3:.*]] = arith.addi %[[I2]], %arg2 : index
+//   CHECK-DAG: %[[ARG0_1D:.*]] = memref.collapse_shape %arg0 {{\[}}[0, 1]] : memref<384x128xf32> into memref<49152xf32>
+//   CHECK-DAG: %[[ARG1_1D:.*]] = memref.collapse_shape %arg1 {{\[}}[0, 1]] : memref<128x384xf32> into memref<49152xf32>
+//       CHECK: vmvx.copy in(%[[ARG1_1D]] offset %[[I3]] strides[%[[C384]], %[[C1]]] : memref<49152xf32>)
+//  CHECK-SAME:   out(%[[ARG0_1D]] offset %[[I1]] strides[%[[C128]], %[[C1]]] : memref<49152xf32>)
+//  CHECK-SAME:   sizes(%[[C64]], %[[C64]])
+func.func @subview_indexing_2d(%arg0 : memref<384x128xf32>, %arg1 : memref<128x384xf32>, %arg2 : index, %arg3 : index) {
+  %6 = memref.subview %arg0[%arg2, %arg3] [64, 64] [1, 1] : memref<384x128xf32> to memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
+  %7 = memref.subview %arg1[%arg3, %arg2] [64, 64] [1, 1] : memref<128x384xf32> to memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 384 + s0 + d1)>>
+  // A non-broadcasting 2d copy.
+  linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
+    ins(%7 : memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 384 + s0 + d1)>>)
+    outs(%6 : memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>) {
+  ^bb0(%arg4: f32, %arg5: f32):
+    linalg.yield %arg4 : f32
+  }
+  func.return
+}
+
+// Verifies that 2d generic with swapped dims lowers to vmvx.copy with swapped
+// strides.
+// CHECK-LABEL: @generic_2d_transposed_to_copy
+//   CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+//   CHECK-DAG: %[[C384:.*]] = arith.constant 384 : index
+//   CHECK-DAG: %[[C128:.*]] = arith.constant 128 : index
+//       CHECK: vmvx.copy in({{.*}} offset {{.*}} strides[%[[C1]], %[[C384]]] : memref<49152xf32>)
+//  CHECK-SAME:   out({{.*}} offset {{.*}} strides[%[[C128]], %[[C1]]] : memref<49152xf32>) sizes({{.*}})
+func.func @generic_2d_transposed_to_copy(%arg0 : memref<384x128xf32>, %arg1 : memref<128x384xf32>, %arg2 : index, %arg3 : index) {
+  %6 = memref.subview %arg0[%arg2, %arg3] [64, 64] [1, 1] : memref<384x128xf32> to memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>
+  %7 = memref.subview %arg1[%arg3, %arg2] [64, 64] [1, 1] : memref<128x384xf32> to memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 384 + s0 + d1)>>
+  // A transposed 2d copy.
+  linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
+    ins(%7 : memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 384 + s0 + d1)>>)
+    outs(%6 : memref<64x64xf32, affine_map<(d0, d1)[s0] -> (d0 * 128 + s0 + d1)>>) {
+  ^bb0(%arg4: f32, %arg5: f32):
+    linalg.yield %arg4 : f32
+  }
+  func.return
+}
+
+// CHECK-LABEL: @fill2d
+//   CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+//   CHECK-DAG: %[[C384:.*]] = arith.constant 384 : index
+//   CHECK-DAG: %[[C128:.*]] = arith.constant 128 : index
+//       CHECK: %[[ARG0_1D:.*]] = memref.collapse_shape %arg0 {{\[}}[0, 1]] : memref<384x128xf32> into memref<49152xf32>
+// CHECK: vmvx.fill2d scalar(%arg1 : f32) out(%[[ARG0_1D]] offset %[[C0]] row_stride %[[C128]] : memref<49152xf32>) sizes(%[[C384]], %[[C128]])
+func.func @fill2d(%arg0 : memref<384x128xf32>, %arg1 : f32) {
+  linalg.fill ins(%arg1 : f32) outs(%arg0 : memref<384x128xf32>)
+  func.return
+}
+
+// CHECK-LABEL: @matmul_row_major
+//   CHECK-DAG: %[[SCALE:.*]] = arith.constant 1.000000e+00 : f32
+//   CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+//   CHECK-DAG: %[[C384:.*]] = arith.constant 384 : index
+//   CHECK-DAG: %[[C64:.*]] = arith.constant 64 : index
+//   CHECK-DAG: %[[ARG0_1D:.*]] = memref.collapse_shape %arg0 {{\[}}[0, 1]] : memref<64x64xf32> into memref<4096xf32>
+//   CHECK-DAG: %[[ARG1_1D:.*]] = memref.collapse_shape %arg1 {{\[}}[0, 1]] : memref<64x384xf32> into memref<24576xf32>
+//   CHECK-DAG: %[[ARG2_1D:.*]] = memref.collapse_shape %arg2 {{\[}}[0, 1]] : memref<384x64xf32> into memref<24576xf32>
+//       CHECK: vmvx.matmul lhs(%[[ARG1_1D]] offset %c0 row_stride %c384 : memref<24576xf32>)
+//  CHECK-SAME:   rhs(%[[ARG2_1D]] offset %[[C0]] row_stride %[[C64]] : memref<24576xf32>)
+//  CHECK-SAME:   out(%[[ARG0_1D]] offset %[[C0]] row_stride %[[C64]] : memref<4096xf32>)
+//  CHECK-SAME:   mnk(%[[C64]], %[[C64]], %[[C384]]) scale(%[[SCALE]] : f32, %[[SCALE]] : f32)
+//  CHECK-SAME:   flags(0)
+func.func @matmul_row_major(%arg0 : memref<64x64xf32>, %arg1 : memref<64x384xf32>, %arg2 : memref<384x64xf32>) {
+  linalg.matmul
+      ins(%arg1, %arg2 : memref<64x384xf32>, memref<384x64xf32>)
+      outs(%arg0 : memref<64x64xf32>)
+  func.return
+}
+
+// CHECK-LABEL: @addf2d_rank_broadcast
+//   CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+//   CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+//   CHECK-DAG: %[[C64:.*]] = arith.constant 64 : index
+//   CHECK-DAG: %[[ARG0_1D:.*]] = memref.collapse_shape %arg0 {{\[}}[0, 1]] : memref<64x64xf32> into memref<4096xf32>
+//       CHECK: vmvx.add lhs(%arg1 offset %[[C0]] strides[%[[C0]], %[[C1]]] : memref<64xf32>)
+//  CHECK-SAME:   rhs(%[[ARG0_1D]] offset %[[C0]] strides[%[[C64]], %[[C1]]] : memref<4096xf32>)
+//  CHECK-SAME:   out(%[[ARG0_1D]] offset %[[C0]] strides[%[[C64]], %[[C1]]] : memref<4096xf32>)
+//  CHECK-SAME:   sizes(%[[C64]], %[[C64]])
+func.func @addf2d_rank_broadcast(%arg0 : memref<64x64xf32>, %arg1 : memref<64xf32>) {
+  linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]}
+    ins(%arg1 : memref<64xf32>) outs(%arg0 : memref<64x64xf32>) {
+  ^bb0(%arg2: f32, %arg3: f32):
+    %12 = arith.addf %arg2, %arg3 : f32
+    linalg.yield %12 : f32
+  }
+  func.return
+}

--- a/compiler/src/iree/compiler/Dialect/Modules/VMVX/vmvx.imports.mlir
+++ b/compiler/src/iree/compiler/Dialect/Modules/VMVX/vmvx.imports.mlir
@@ -29,4 +29,59 @@ vm.module @vmvx {
 // VMVX Ops: TODO
 //===----------------------------------------------------------------------===//
 
+// Note that we are thinking of specializing 1 and 2D variants and then
+// having a generic ND.
+vm.import @add.2d.f32(
+  %lhs_buffer : !vm.buffer,
+  %lhs_offset : i64,
+  %lhs_strides : tuple<i64, i64>,
+
+  %rhs_buffer : !vm.buffer,
+  %rhs_offset : i64,
+  %rhs_strides : tuple<i64, i64>,
+
+  %out_buffer : !vm.buffer,
+  %out_offset : i64,
+  %out_strides : tuple<i64, i64>,
+
+  %sizes : tuple<i64, i64>
+)
+
+vm.import @copy.2d.x32(
+  %in_buffer : !vm.buffer,
+  %in_offset : i64,
+  %in_strides : tuple<i64, i64>,
+  %out_buffer : !vm.buffer,
+  %out_offset : i64,
+  %out_strides : tuple<i64, i64>,
+  %sizes : tuple<i64, i64>
+)
+
+vm.import @fill.2d.x32(
+  %fill_value : i32,
+  %out_buffer : !vm.buffer,
+  %out_offset : i64,
+  %out_row_stride : i64,
+  %size_m : i64,
+  %size_n : i64
+)
+
+vm.import @matmul.f32f32f32(
+  %lhs_buffer : !vm.buffer,
+  %lhs_offset : i64,
+  %lhs_row_stride : i64,
+  %rhs_buffer : !vm.buffer,
+  %rhs_offset : i64,
+  %rhs_row_stride : i64,
+  %out_buffer : !vm.buffer,
+  %out_offset : i64,
+  %out_row_stride : i64,
+  %m : i64,
+  %n : i64,
+  %k : i64,
+  %alpha : f32,
+  %beta : f32,
+  %flags : i32
+)
+
 }  // module

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
@@ -246,6 +246,18 @@ class ConvertMemRefStoreOp : public OpConversionPattern<memref::StoreOp> {
   }
 };
 
+class ElideMemRefAssumeAlignmentOp
+    : public OpConversionPattern<memref::AssumeAlignmentOp> {
+ public:
+  using OpConversionPattern::OpConversionPattern;
+  LogicalResult matchAndRewrite(
+      memref::AssumeAlignmentOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 }  // namespace
 
 void populateMemRefToVMPatterns(MLIRContext *context,
@@ -274,10 +286,10 @@ void populateMemRefToVMPatterns(MLIRContext *context,
   patterns.insert<FoldAsNoOp<bufferization::ToMemrefOp>,
                   FoldAsNoOp<memref::AssumeAlignmentOp>,
                   FoldAsNoOp<memref::CastOp>>(typeConverter, context);
-  patterns
-      .insert<ConvertMemRefGlobalOp, ConvertMemRefGetGlobalOp,
-              ConvertMemRefAllocaOp, ConvertMemRefLoadOp, ConvertMemRefStoreOp>(
-          typeConverter, context);
+  patterns.insert<ConvertMemRefGlobalOp, ConvertMemRefGetGlobalOp,
+                  ConvertMemRefAllocaOp, ConvertMemRefLoadOp,
+                  ConvertMemRefStoreOp, ElideMemRefAssumeAlignmentOp>(
+      typeConverter, context);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/memref_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/memref_ops.mlir
@@ -51,3 +51,27 @@ module {
     return %1 : f32
   }
 }
+
+// -----
+
+module {
+  // CHECK-LABEL: @assume_alignment
+  func.func @assume_alignment(%buffer: memref<?xf32>) {
+    // CHECK-NOT: assume_alignment
+    memref.assume_alignment %buffer, 64 : memref<?xf32>
+    // CHECK: return
+    func.return
+  }
+}
+
+// -----
+
+module {
+  // CHECK-LABEL: @cast
+  func.func @cast(%buffer: memref<?xf32>) {
+    // CHECK-NOT: memref.cast
+    memref.cast %buffer : memref<?xf32> to memref<5xf32>
+    // CHECK: return
+    func.return
+  }
+}

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -3518,13 +3518,13 @@ def VM_CallOp : VM_CallBaseOp<"call"> {
       $_state.addTypes(callee.getFunctionType().getResults());
     }]>,
     OpBuilder<(ins "FlatSymbolRefAttr":$callee,
-      "ArrayRef<Type>":$resultTypes, CArg<"ValueRange", "{}">:$operands),
+      "mlir::TypeRange":$resultTypes, CArg<"ValueRange", "{}">:$operands),
     [{
       $_state.addOperands(operands);
       $_state.addAttribute("callee", callee);
       $_state.addTypes(resultTypes);
     }]>,
-    OpBuilder<(ins "StringRef":$callee, "ArrayRef<Type>":$resultTypes,
+    OpBuilder<(ins "StringRef":$callee, "mlir::TypeRange":$resultTypes,
       CArg<"ValueRange", "{}">:$operands),
     [{
       build($_builder, $_state, mlir::SymbolRefAttr::get($_builder.getContext(), callee),

--- a/runtime/src/iree/modules/vmvx/exports.inl
+++ b/runtime/src/iree/modules/vmvx/exports.inl
@@ -23,6 +23,9 @@
 
 // clang-format off
 
-EXPORT_FN("_placeholder", iree_vmvx_module_placeholder, v, v)
+EXPORT_FN("add.2d.f32", iree_vmvx_add2d_f32, rIIIrIIIrIIIII, v)
+EXPORT_FN("copy.2d.x32", iree_vmvx_copy2d_x32, rIIIrIIIII, v)
+EXPORT_FN("fill.2d.x32", iree_vmvx_fill2d_x32, irIIII, v)
+EXPORT_FN("matmul.f32f32f32", iree_vmvx_matmul_f32f32f32, rIIrIIrIIIIIffi, v)
 
 // clang-format on

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -476,16 +476,10 @@ IREE_VM_ABI_EXPORT(iree_vmvx_matmul_f32f32f32, iree_vmvx_module_state_t,
 }
 
 //===----------------------------------------------------------------------===//
-// VM module
-// interface
-// implementation
+// VM module interface implementation
 //===----------------------------------------------------------------------===//
 
-// NOTE: this must
-// match the
-// ordering of the
-// iree_vmvx_module_exports_
-// table.
+// NOTE: this must match the ordering of the iree_vmvx_module_exports_table.
 static const iree_vm_native_function_ptr_t iree_vmvx_module_funcs_[] = {
 #define EXPORT_FN(name, target_fn, arg_types, ret_types)       \
   {                                                            \

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -61,21 +61,431 @@ iree_vmvx_module_free_state(void* self, iree_vm_module_state_t* module_state) {
 }
 
 //===----------------------------------------------------------------------===//
-// TODO
+// Private shims not needed by anything else.
 //===----------------------------------------------------------------------===//
 
-// Placeholder to make the function pointer arrays happy (they can't be empty).
-IREE_VM_ABI_EXPORT(iree_vmvx_module_placeholder,  //
-                   iree_vmvx_module_state_t,      //
-                   v, v) {
+IREE_VM_ABI_FIXED_STRUCT(irIIII, {
+  union {
+    struct {
+      int32_t fill_value;
+      iree_vm_ref_t out_ref;
+      int64_t out_offset;
+      int64_t out_row_stride;
+      int64_t size0;
+      int64_t size1;
+    } IREE_ATTRIBUTE_PACKED fill2d_x32;
+    struct {
+      int32_t i0;
+      iree_vm_ref_t r1;
+      int64_t i2;
+      int64_t i3;
+      int64_t i4;
+      int64_t i5;
+    } IREE_ATTRIBUTE_PACKED raw;
+  };
+});
+
+IREE_VM_ABI_FIXED_STRUCT(rIIrIIrIIIIIffi, {
+  union {
+    struct {
+      iree_vm_ref_t lhs_ref;
+      int64_t lhs_offset;
+      int64_t lhs_row_stride;
+      iree_vm_ref_t rhs_ref;
+      int64_t rhs_offset;
+      int64_t rhs_row_stride;
+      iree_vm_ref_t out_ref;
+      int64_t out_offset;
+      int64_t out_row_stride;
+      int64_t m;
+      int64_t n;
+      int64_t k;
+      float alpha;
+      float beta;
+      int32_t flags;
+    } IREE_ATTRIBUTE_PACKED matmul_f32;
+    struct {
+      iree_vm_ref_t r0;
+      int64_t i1;
+      int64_t i2;
+      iree_vm_ref_t r3;
+      int64_t i4;
+      int64_t i5;
+      iree_vm_ref_t r6;
+      int64_t i7;
+      int64_t i8;
+      int64_t i9;
+      int64_t i10;
+      int64_t i11;
+      float i12;
+      float i13;
+      int32_t flags;
+    } IREE_ATTRIBUTE_PACKED raw;
+  };
+});
+
+IREE_VM_ABI_FIXED_STRUCT(rIIIrIIIII, {
+  union {
+    struct {
+      iree_vm_ref_t in_ref;
+      int64_t in_offset;
+      int64_t in_stride0;
+      int64_t in_stride1;
+      iree_vm_ref_t out_ref;
+      int64_t out_offset;
+      int64_t out_stride0;
+      int64_t out_stride1;
+      int64_t size0;
+      int64_t size1;
+    } IREE_ATTRIBUTE_PACKED unary2d;
+    struct {
+      iree_vm_ref_t r0;
+      int64_t i1;
+      int64_t i2;
+      int64_t i3;
+      iree_vm_ref_t r4;
+      int64_t i5;
+      int64_t i6;
+      int64_t i7;
+      int64_t i8;
+      int64_t i9;
+    } IREE_ATTRIBUTE_PACKED raw;
+  };
+});
+
+// Binary elementwise ops all have the same signature:
+// rIIIrIIIII
+IREE_VM_ABI_FIXED_STRUCT(rIIIrIIIrIIIII, {
+  union {
+    struct {
+      iree_vm_ref_t lhs_ref;
+      int64_t lhs_offset;
+      int64_t lhs_stride0;
+      int64_t lhs_stride1;
+      iree_vm_ref_t rhs_ref;
+      int64_t rhs_offset;
+      int64_t rhs_stride0;
+      int64_t rhs_stride1;
+      iree_vm_ref_t out_ref;
+      int64_t out_offset;
+      int64_t out_stride0;
+      int64_t out_stride1;
+      int64_t size0;
+      int64_t size1;
+    } IREE_ATTRIBUTE_PACKED binary2d;
+    struct {
+      iree_vm_ref_t r0;
+      int64_t i1;
+      int64_t i2;
+      int64_t i3;
+      iree_vm_ref_t r4;
+      int64_t i5;
+      int64_t i6;
+      int64_t i7;
+      iree_vm_ref_t r8;
+      int64_t i9;
+      int64_t i10;
+      int64_t i11;
+      int64_t i12;
+      int64_t i13;
+    } IREE_ATTRIBUTE_PACKED raw;
+  };
+});
+
+// Since these are private/unlikely to be general, mark as static. If there
+// ever becomes one of these in the common set, the compiler will complain.
+static IREE_VM_ABI_DEFINE_SHIM(irIIII, v);
+static IREE_VM_ABI_DEFINE_SHIM(rIIIrIIIII, v);
+static IREE_VM_ABI_DEFINE_SHIM(rIIrIIrIIIIIffi, v);
+static IREE_VM_ABI_DEFINE_SHIM(rIIIrIIIrIIIII, v);
+
+static iree_host_size_t iree_vmvx_2d_length_bound(
+    iree_host_size_t element_size, uint64_t size0, uint64_t size1,
+    uint64_t stride0, uint64_t stride1, uint64_t* overflow) {
+  // Check for 2d size/stride overflow conditions for the equation:
+  //   (size0 - 1) * stride0 + (size1 - 1) * stride1
+  // This limits each (multiplicand + 1) to the 32bit range. We can get
+  // smarter about this later or when scaling to >2D, but while limited, this
+  // is easy and correct.
+  *overflow |= (size0 & 0xffffffff00000000) | (size1 & 0xffffffff00000000) |
+               ((stride0 + 1) & 0xffffffff00000000) |
+               ((stride1 + 1) & 0xffffffff00000000);
+
+  uint64_t last_index = (size0 - 1) * stride0 + (size1 - 1) * stride1;
+  uint64_t max_size = (last_index + 1) * element_size;
+  iree_host_size_t max_size_size_t = (iree_host_size_t)max_size;
+  *overflow |= (max_size_size_t != max_size);  // No-op for 64bit size_t.
+  return max_size_size_t;
+}
+
+static iree_host_size_t iree_vmvx_cast_host_size(int64_t value,
+                                                 uint64_t* overflow) {
+  if (sizeof(iree_host_size_t) == 4) {
+    *overflow |= (uint64_t)value & 0xffffffff00000000ul;
+  }
+  return (iree_host_size_t)value;
+}
+
+#define BUFFER_2D_DECLS(name, dtype, offset, stride0, stride1, size0, size1) \
+  uint64_t name##_overflow = 0;                                              \
+  iree_host_size_t name##_size0 =                                            \
+      iree_vmvx_cast_host_size(size0, &name##_overflow);                     \
+  iree_host_size_t name##_size1 =                                            \
+      iree_vmvx_cast_host_size(size1, &name##_overflow);                     \
+  iree_host_size_t name##_stride0 =                                          \
+      iree_vmvx_cast_host_size(stride0, &name##_overflow);                   \
+  iree_host_size_t name##_stride1 =                                          \
+      iree_vmvx_cast_host_size(stride1, &name##_overflow);                   \
+  iree_host_size_t name##_length_bound = iree_vmvx_2d_length_bound(          \
+      sizeof(dtype), name##_size0, name##_size1, name##_stride0,             \
+      name##_stride1, &name##_overflow);                                     \
+  iree_host_size_t name##_offset =                                           \
+      sizeof(dtype) * iree_vmvx_cast_host_size(offset, &name##_overflow);    \
+  if (name##_overflow) {                                                     \
+    IREE_TRACE_ZONE_END(z0);                                                 \
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,                    \
+                            "buffer overflow for " #name);                   \
+  }
+
+#define MAP_BUFFER_2D_RO(name, dtype, buffer_ref, offset, stride0, stride1, \
+                         size0, size1)                                      \
+  iree_vm_buffer_t* name##_buffer;                                          \
+  iree_const_byte_span_t name##_span;                                       \
+  BUFFER_2D_DECLS(name, dtype, offset, stride0, stride1, size0, size1);     \
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(                                        \
+      z0, iree_vm_buffer_check_deref(buffer_ref, &name##_buffer))           \
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(                                        \
+      z0, iree_vm_buffer_map_ro(name##_buffer,       /*offset=*/            \
+                                name##_offset,       /*length=*/            \
+                                name##_length_bound, /*alignment=*/         \
+                                sizeof(dtype), &name##_span));              \
+  const dtype* name = (dtype*)name##_span.data
+
+#define MAP_BUFFER_2D_RW(name, dtype, buffer_ref, offset, stride0, stride1,  \
+                         size0, size1)                                       \
+  iree_vm_buffer_t* name##_buffer;                                           \
+  iree_byte_span_t name##_span;                                              \
+  BUFFER_2D_DECLS(name, dtype, offset, stride0, stride1, size0, size1);      \
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(                                         \
+      z0, iree_vm_buffer_check_deref(buffer_ref, &name##_buffer));           \
+  IREE_RETURN_AND_END_ZONE_IF_ERROR(                                         \
+      z0, iree_vm_buffer_map_rw(name##_buffer, /*offset=*/                   \
+                                name##_offset, /*length=*/                   \
+                                name##_length_bound,                         \
+                                /*alignment=*/sizeof(dtype), &name##_span)); \
+  dtype* name = (dtype*)name##_span.data
+
+//===----------------------------------------------------------------------===//
+// Exported
+// function
+// definitions
+//===----------------------------------------------------------------------===//
+
+IREE_VM_ABI_EXPORT(iree_vmvx_add2d_f32, iree_vmvx_module_state_t,
+                   rIIIrIIIrIIIII, v) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  MAP_BUFFER_2D_RO(lhs, float,
+                   /*buffer_ref=*/
+                   args->binary2d.lhs_ref,
+                   /*offset=*/
+                   args->binary2d.lhs_offset,
+                   /*stride0=*/
+                   args->binary2d.lhs_stride0,
+                   /*stride1=*/
+                   args->binary2d.lhs_stride1,
+                   /*size0=*/
+                   args->binary2d.size0,
+                   /*size1=*/
+                   args->binary2d.size1);
+  MAP_BUFFER_2D_RO(rhs, float,
+                   /*buffer_ref=*/
+                   args->binary2d.rhs_ref,
+                   /*offset=*/
+                   args->binary2d.rhs_offset,
+                   /*stride0=*/
+                   args->binary2d.rhs_stride0,
+                   /*stride1=*/
+                   args->binary2d.rhs_stride1,
+                   /*size0=*/
+                   args->binary2d.size0,
+                   /*size1=*/
+                   args->binary2d.size1);
+  MAP_BUFFER_2D_RW(out, float,
+                   /*buffer_ref=*/
+                   args->binary2d.out_ref,
+                   /*offset=*/
+                   args->binary2d.out_offset,
+                   /*stride0=*/
+                   args->binary2d.out_stride0,
+                   /*stride1=*/
+                   args->binary2d.out_stride1,
+                   /*size0=*/
+                   args->binary2d.size0,
+                   /*size1=*/
+                   args->binary2d.size1);
+
+  for (iree_device_size_t i = 0; i < out_size0; ++i) {
+    for (iree_device_size_t j = 0; j < out_size1; ++j) {
+      out[i * out_stride0 + j * out_stride1] =
+          lhs[i * lhs_stride0 + j * lhs_stride1] +
+          rhs[i * rhs_stride0 + j * rhs_stride1];
+    }
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_VM_ABI_EXPORT(iree_vmvx_copy2d_x32, iree_vmvx_module_state_t, rIIIrIIIII,
+                   v) {
+  MAP_BUFFER_2D_RO(in, int32_t,
+                   /*buffer_ref=*/
+                   args->unary2d.in_ref,
+                   /*offset=*/
+                   args->unary2d.in_offset,
+                   /*stride0=*/
+                   args->unary2d.in_stride0,
+                   /*stride1=*/
+                   args->unary2d.in_stride1,
+                   /*size0=*/
+                   args->unary2d.size0,
+                   /*size1=*/
+                   args->unary2d.size1);
+  MAP_BUFFER_2D_RW(out, int32_t,
+                   /*buffer_ref=*/
+                   args->unary2d.out_ref,
+                   /*offset=*/
+                   args->unary2d.out_offset,
+                   /*stride0=*/
+                   args->unary2d.out_stride0,
+                   /*stride1=*/
+                   args->unary2d.out_stride1,
+                   /*size0=*/
+                   args->unary2d.size0,
+                   /*size1=*/
+                   args->unary2d.size1);
+
+  IREE_TRACE_ZONE_BEGIN(z0);
+  for (iree_device_size_t j = 0; j < out_size0; ++j) {
+    for (iree_device_size_t i = 0; i < out_size1; ++i) {
+      out[j * out_stride0 + i * out_stride1] =
+          in[j * in_stride0 + i * in_stride1];
+    }
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_VM_ABI_EXPORT(iree_vmvx_fill2d_x32, iree_vmvx_module_state_t, irIIII, v) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  MAP_BUFFER_2D_RW(out, int32_t,
+                   /*buffer_ref=*/
+                   args->fill2d_x32.out_ref,
+                   /*offset=*/
+                   args->fill2d_x32.out_offset,
+                   /*stride0=*/
+                   args->fill2d_x32.out_row_stride,
+                   /*stride1=*/
+                   1,
+                   /*size0=*/
+                   args->fill2d_x32.size0,
+                   /*size1=*/
+                   args->fill2d_x32.size1);
+
+  for (iree_device_size_t i = 0; i < out_size0; ++i) {
+    for (iree_device_size_t j = 0; j < out_size1; ++j) {
+      out[i * out_stride0 + j] = args->fill2d_x32.fill_value;
+    }
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return iree_ok_status();
+}
+
+IREE_VM_ABI_EXPORT(iree_vmvx_matmul_f32f32f32, iree_vmvx_module_state_t,
+                   rIIrIIrIIIIIffi, v) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  MAP_BUFFER_2D_RO(lhs, float,
+                   /*buffer_ref=*/
+                   args->matmul_f32.lhs_ref,
+                   /*offset=*/
+                   args->matmul_f32.lhs_offset,
+                   /*stride0=*/
+                   args->matmul_f32.lhs_row_stride,
+                   /*stride1=*/
+                   1,
+                   /*size0=*/
+                   args->matmul_f32.m,
+                   /*size1=*/
+                   args->matmul_f32.k);
+  MAP_BUFFER_2D_RO(rhs, float,
+                   /*buffer_ref=*/
+                   args->matmul_f32.rhs_ref,
+                   /*offset=*/
+                   args->matmul_f32.rhs_offset,
+                   /*stride0=*/
+                   args->matmul_f32.rhs_row_stride,
+                   /*stride1=*/
+                   1,
+                   /*size0=*/
+                   args->matmul_f32.k,
+                   /*size1=*/
+                   args->matmul_f32.n);
+  MAP_BUFFER_2D_RW(out, float,
+                   /*buffer_ref=*/
+                   args->matmul_f32.out_ref,
+                   /*offset=*/
+                   args->matmul_f32.out_offset,
+                   /*stride0=*/
+                   args->matmul_f32.out_row_stride,
+                   /*stride1=*/
+                   1,
+                   /*size0=*/
+                   args->matmul_f32.m,
+                   /*size1=*/
+                   args->matmul_f32.n);
+
+  iree_host_size_t M = (iree_host_size_t)args->matmul_f32.m;
+  iree_host_size_t N = (iree_host_size_t)args->matmul_f32.n;
+  iree_host_size_t K = (iree_host_size_t)args->matmul_f32.k;
+
+  // TODO: Define
+  // flags more
+  // robustly.
+  if (args->matmul_f32.flags == 0) {
+    // Row major.
+    for (iree_device_size_t i = 0; i < M; ++i) {
+      for (iree_device_size_t k = 0; k < K; ++k) {
+        float apart = args->matmul_f32.alpha * lhs[i * lhs_stride0 + k];
+        for (iree_device_size_t j = 0; j < N; ++j) {
+          out[i * out_stride0 + j] +=
+              args->matmul_f32.beta * apart * rhs[k * rhs_stride0 + j];
+        }
+      }
+    }
+  } else {
+    IREE_TRACE_ZONE_END(z0);
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unsupported matmul flags: %x",
+                            (unsigned)args->matmul_f32.flags);
+  }
+
+  IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
 
 //===----------------------------------------------------------------------===//
-// VM module interface implementation
+// VM module
+// interface
+// implementation
 //===----------------------------------------------------------------------===//
 
-// NOTE: this must match the ordering of the iree_vmvx_module_exports_ table.
+// NOTE: this must
+// match the
+// ordering of the
+// iree_vmvx_module_exports_
+// table.
 static const iree_vm_native_function_ptr_t iree_vmvx_module_funcs_[] = {
 #define EXPORT_FN(name, target_fn, arg_types, ret_types)       \
   {                                                            \
@@ -87,7 +497,10 @@ static const iree_vm_native_function_ptr_t iree_vmvx_module_funcs_[] = {
 #undef EXPORT_FN
 };
 
-// NOTE: 0 length, but can't express that in C.
+// NOTE: 0 length,
+// but can't
+// express that in
+// C.
 static const iree_vm_native_import_descriptor_t iree_vmvx_module_imports_[1];
 
 static const iree_vm_native_export_descriptor_t iree_vmvx_module_exports_[] = {
@@ -104,13 +517,22 @@ static const iree_vm_native_export_descriptor_t iree_vmvx_module_exports_[] = {
 };
 static_assert(IREE_ARRAYSIZE(iree_vmvx_module_funcs_) ==
                   IREE_ARRAYSIZE(iree_vmvx_module_exports_),
-              "function pointer table must be 1:1 with exports");
+              "function "
+              "pointer "
+              "table must "
+              "be 1:1 with "
+              "exports");
 
 static const iree_vm_native_module_descriptor_t iree_vmvx_module_descriptor_ = {
-    .module_name = iree_string_view_literal("vmvx"),
+    .module_name = iree_string_view_literal("vmv"
+                                            "x"),
     .module_attr_count = 0,
     .module_attrs = NULL,
-    .import_count = 0,  // workaround for 0-length C struct
+    .import_count = 0,  // workaround
+                        // for
+                        // 0-length
+                        // C
+                        // struct
     .imports = iree_vmvx_module_imports_,
     .export_count = IREE_ARRAYSIZE(iree_vmvx_module_exports_),
     .exports = iree_vmvx_module_exports_,
@@ -123,15 +545,25 @@ IREE_API_EXPORT iree_status_t iree_vmvx_module_create(
   IREE_ASSERT_ARGUMENT(out_module);
   *out_module = NULL;
 
-  // Setup the interface with the functions we implement ourselves. Any function
-  // we omit will be handled by the base native module.
+  // Setup the
+  // interface with
+  // the functions
+  // we implement
+  // ourselves. Any
+  // function we
+  // omit will be
+  // handled by the
+  // base native
+  // module.
   static const iree_vm_module_t interface = {
       .destroy = iree_vmvx_module_destroy,
       .alloc_state = iree_vmvx_module_alloc_state,
       .free_state = iree_vmvx_module_free_state,
   };
 
-  // Allocate shared module state.
+  // Allocate
+  // shared module
+  // state.
   iree_host_size_t total_size =
       iree_vm_native_module_size() + sizeof(iree_vmvx_module_t);
   iree_vm_module_t* base_module = NULL;

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -324,8 +324,8 @@ IREE_VM_ABI_EXPORT(iree_vmvx_add2d_f32, iree_vmvx_module_state_t,
                    /*size1=*/
                    args->binary2d.size1);
 
-  for (iree_device_size_t i = 0; i < out_size0; ++i) {
-    for (iree_device_size_t j = 0; j < out_size1; ++j) {
+  for (iree_host_size_t i = 0; i < out_size0; ++i) {
+    for (iree_host_size_t j = 0; j < out_size1; ++j) {
       out[i * out_stride0 + j * out_stride1] =
           lhs[i * lhs_stride0 + j * lhs_stride1] +
           rhs[i * rhs_stride0 + j * rhs_stride1];
@@ -338,6 +338,7 @@ IREE_VM_ABI_EXPORT(iree_vmvx_add2d_f32, iree_vmvx_module_state_t,
 
 IREE_VM_ABI_EXPORT(iree_vmvx_copy2d_x32, iree_vmvx_module_state_t, rIIIrIIIII,
                    v) {
+  IREE_TRACE_ZONE_BEGIN(z0);
   MAP_BUFFER_2D_RO(in, int32_t,
                    /*buffer_ref=*/
                    args->unary2d.in_ref,
@@ -365,9 +366,8 @@ IREE_VM_ABI_EXPORT(iree_vmvx_copy2d_x32, iree_vmvx_module_state_t, rIIIrIIIII,
                    /*size1=*/
                    args->unary2d.size1);
 
-  IREE_TRACE_ZONE_BEGIN(z0);
-  for (iree_device_size_t j = 0; j < out_size0; ++j) {
-    for (iree_device_size_t i = 0; i < out_size1; ++i) {
+  for (iree_host_size_t j = 0; j < out_size0; ++j) {
+    for (iree_host_size_t i = 0; i < out_size1; ++i) {
       out[j * out_stride0 + i * out_stride1] =
           in[j * in_stride0 + i * in_stride1];
     }
@@ -393,8 +393,8 @@ IREE_VM_ABI_EXPORT(iree_vmvx_fill2d_x32, iree_vmvx_module_state_t, irIIII, v) {
                    /*size1=*/
                    args->fill2d_x32.size1);
 
-  for (iree_device_size_t i = 0; i < out_size0; ++i) {
-    for (iree_device_size_t j = 0; j < out_size1; ++j) {
+  for (iree_host_size_t i = 0; i < out_size0; ++i) {
+    for (iree_host_size_t j = 0; j < out_size1; ++j) {
       out[i * out_stride0 + j] = args->fill2d_x32.fill_value;
     }
   }
@@ -455,10 +455,10 @@ IREE_VM_ABI_EXPORT(iree_vmvx_matmul_f32f32f32, iree_vmvx_module_state_t,
   // robustly.
   if (args->matmul_f32.flags == 0) {
     // Row major.
-    for (iree_device_size_t i = 0; i < M; ++i) {
-      for (iree_device_size_t k = 0; k < K; ++k) {
+    for (iree_host_size_t i = 0; i < M; ++i) {
+      for (iree_host_size_t k = 0; k < K; ++k) {
         float apart = args->matmul_f32.alpha * lhs[i * lhs_stride0 + k];
-        for (iree_device_size_t j = 0; j < N; ++j) {
+        for (iree_host_size_t j = 0; j < N; ++j) {
           out[i * out_stride0 + j] +=
               args->matmul_f32.beta * apart * rhs[k * rhs_stride0 + j];
         }
@@ -517,11 +517,7 @@ static const iree_vm_native_export_descriptor_t iree_vmvx_module_exports_[] = {
 };
 static_assert(IREE_ARRAYSIZE(iree_vmvx_module_funcs_) ==
                   IREE_ARRAYSIZE(iree_vmvx_module_exports_),
-              "function "
-              "pointer "
-              "table must "
-              "be 1:1 with "
-              "exports");
+              "function pointer table must be 1:1 with exports");
 
 static const iree_vm_native_module_descriptor_t iree_vmvx_module_descriptor_ = {
     .module_name = iree_string_view_literal("vmv"

--- a/runtime/src/iree/vm/buffer.c
+++ b/runtime/src/iree/vm/buffer.c
@@ -37,14 +37,10 @@ static iree_status_t iree_vm_buffer_map(const iree_vm_buffer_t* buffer,
   return iree_ok_status();
 }
 
-// Maps a subrange to a span of bytes within the |buffer| for read-only access.
-// |offset| and |length| must match the provided |alignment| (1, 2, 4, 8) and
-// will be rounded toward zero if they do not.
-static iree_status_t iree_vm_buffer_map_ro(const iree_vm_buffer_t* buffer,
-                                           iree_host_size_t offset,
-                                           iree_host_size_t length,
-                                           iree_host_size_t alignment,
-                                           iree_const_byte_span_t* out_span) {
+IREE_API_EXPORT iree_status_t
+iree_vm_buffer_map_ro(const iree_vm_buffer_t* buffer, iree_host_size_t offset,
+                      iree_host_size_t length, iree_host_size_t alignment,
+                      iree_const_byte_span_t* out_span) {
   // Always allowed regardless of access.
   return iree_vm_buffer_map(buffer, offset, length, alignment,
                             (uint8_t**)&out_span->data, &out_span->data_length);
@@ -53,11 +49,10 @@ static iree_status_t iree_vm_buffer_map_ro(const iree_vm_buffer_t* buffer,
 // Maps a subrange to a span of bytes within the |buffer| for read/write access.
 // |offset| and |length| must match the provided |alignment| (1, 2, 4, 8) and
 // will be rounded toward zero if they do not.
-static iree_status_t iree_vm_buffer_map_rw(const iree_vm_buffer_t* buffer,
-                                           iree_host_size_t offset,
-                                           iree_host_size_t length,
-                                           iree_host_size_t alignment,
-                                           iree_byte_span_t* out_span) {
+IREE_API_EXPORT iree_status_t
+iree_vm_buffer_map_rw(const iree_vm_buffer_t* buffer, iree_host_size_t offset,
+                      iree_host_size_t length, iree_host_size_t alignment,
+                      iree_byte_span_t* out_span) {
   // Buffer requires mutable access.
   if (IREE_UNLIKELY(
           !iree_all_bits_set(buffer->access, IREE_VM_BUFFER_ACCESS_MUTABLE))) {

--- a/runtime/src/iree/vm/buffer.h
+++ b/runtime/src/iree/vm/buffer.h
@@ -155,6 +155,22 @@ IREE_API_EXPORT iree_status_t iree_vm_buffer_fill_elements(
     iree_host_size_t element_count, iree_host_size_t element_length,
     const void* value);
 
+// Maps a subrange to a span of bytes within the |buffer| for read-only access.
+// |offset| and |length| must match the provided |alignment| (1, 2, 4, 8) and
+// will be rounded toward zero if they do not.
+IREE_API_EXPORT iree_status_t
+iree_vm_buffer_map_ro(const iree_vm_buffer_t* buffer, iree_host_size_t offset,
+                      iree_host_size_t length, iree_host_size_t alignment,
+                      iree_const_byte_span_t* out_span);
+
+// Maps a subrange to a span of bytes within the |buffer| for read/write access.
+// |offset| and |length| must match the provided |alignment| (1, 2, 4, 8) and
+// will be rounded toward zero if they do not.
+IREE_API_EXPORT iree_status_t
+iree_vm_buffer_map_rw(const iree_vm_buffer_t* buffer, iree_host_size_t offset,
+                      iree_host_size_t length, iree_host_size_t alignment,
+                      iree_byte_span_t* out_span);
+
 // Reads |element_count| elements each of |element_length| bytes from the
 // |source_buffer| into |out_target_ptr|. The |source_offset|, in bytes, must be
 // aligned to at least the |element_length|.


### PR DESCRIPTION
This is a slash and burn that:

* Creates an opinionated small set of tiled math kernels that we implement via library calls.
* Lowers linalg->vmvx library calls for supported kernels.
* Implements the world's worst loopy versions of these in C (enough to be correct and show that it works).
* Fixes a number of rough spots in the various compilation paths for memrefs and VM compatibility.

The intent is to land this eventually behind a flag and to ultimately enable by default once we have converged on the right set of kernels. Since these library calls are cutting in after tiling/distribution, they are operating on small tiles and are externally parallelized. As such, they can be thought of as micro-kernels and should be much simpler than their full featured cousins. In addition, since they are mostly non-polymorphic and should be amenable to jitters, hand coding, etc.

On the fully_connected case I was iterating on (`%result = "tosa.fully_connected"(%0, %1, %2) : (tensor<512x384xf32>, tensor<128x384xf32>, tensor<128xf32>) -> tensor<512x128xf32>`), even with terrible loopy C kernels, this sped benchmarks of VMVX up by between 100-200x. Note that due to reasons, the above also includes a leading transpose, which is not yet lowered to library calls, so the interpreter is still doing quite a bit. Further note that there are additional peephole optimizations that I haven't done yet to eliminate the fill, fold the add and set flags on the matmul to disable accumulation. So plenty to do from here.

This PR isn't ready to submit yet: it is a slash-burn through a lot of layers and we'll be working to pick bits out and finish it.