### PR TITLE
Add `flow.dispatch.default_workgroup_count` op.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -66,18 +66,19 @@ static FailureOr<unsigned> getNumWorkloadValues(
   return tilingRoot.getNumLoops();
 }
 
-/// Method to find the root op, and based on the tile sizes and loops of the
-/// root op that are distributed, define the region on the
-/// `hal.executable.export` for the number of workgroups. Returns the tile
-/// sizes, interchange, and workloadPerWorkgroup.
-static LogicalResult defineWorkgroupCountRegion(
-    IREE::HAL::ExecutableExportOp exportOp, ArrayRef<Operation *> computeOps,
-    SmallVectorImpl<int64_t> &tileSizes, SmallVector<int64_t> &interchange,
+/// Method to lower the `flow.default_workgroup_count` op into the actual
+/// computation that returns the number of workgroups.
+static LogicalResult lowerDefaultWorkgroupCountOp(
+    IREE::Flow::DefaultWorkgroupCountOp workgroupCountOp,
+    ArrayRef<Operation *> computeOps, SmallVectorImpl<int64_t> &tileSizes,
+    SmallVector<int64_t> &interchange,
     SmallVectorImpl<int64_t> &workloadPerWorkgroup) {
+  auto workloadValues = workgroupCountOp.operands();
+
   // Find the lowering configuration of the root operation.
   FailureOr<Operation *> rootOp = getRootOp(computeOps);
   if (failed(rootOp)) {
-    return exportOp.emitOpError(
+    return workgroupCountOp.emitOpError(
         "unable to find root op for defining workgroup count "
         "region for export op");
   }
@@ -88,12 +89,6 @@ static LogicalResult defineWorkgroupCountRegion(
     return rootOp.getValue()->emitOpError(
         "expected root op to implement the partitionable loop interface to "
         "help define the workgroup count");
-  }
-
-  FailureOr<unsigned> numWorkloadValues = getNumWorkloadValues(computeOps);
-  if (failed(numWorkloadValues)) {
-    return exportOp.emitOpError(
-        "unable to determined number of workload values");
   }
 
   SmallVector<unsigned> partitionableLoops =
@@ -109,60 +104,56 @@ static LogicalResult defineWorkgroupCountRegion(
   interchange.assign(rootOpConfig.getTileInterchangeVals(0));
 
   // Resize tile sizes to the number of loops setting inner loops to 0.
-  tileSizes.resize(*numWorkloadValues, 0);
+  tileSizes.resize(workloadValues.size(), 0);
   // Check that the interchange vector is also equal to the number of loops
   if (!interchange.empty()) {
-    if (interchange.size() < *numWorkloadValues) {
-      auto seq = llvm::seq<int64_t>(interchange.size(), *numWorkloadValues);
+    if (interchange.size() < workloadValues.size()) {
+      auto seq = llvm::seq<int64_t>(interchange.size(), workloadValues.size());
       interchange.append(seq.begin(), seq.end());
     }
-    interchange.resize(*numWorkloadValues);
+    interchange.resize(workloadValues.size());
   }
   // For now assert that number of partitionable loops are less than the
   // supported max.
   // TODO(ravishankarm): Relax this restriction.
   if (partitionableLoops.size() > kNumMaxParallelDims) {
-    return exportOp.emitOpError(
+    return workgroupCountOp.emitOpError(
                "expected number of partitionable loops to be less than or "
                "equal to ")
            << kNumMaxParallelDims;
   }
 
-  MLIRContext *context = exportOp.getContext();
+  MLIRContext *context = workgroupCountOp.getContext();
   OpBuilder builder(context);
-  Region &region = exportOp.workgroup_count();
-  Block *entryBlock = builder.createBlock(&region);
   // Add as many arguments as the number of loops
-  Location loc = exportOp.getLoc();
-  auto indexType = builder.getIndexType();
-  entryBlock->addArgument(builder.getType<IREE::HAL::DeviceType>(), loc);
+  Location loc = workgroupCountOp.getLoc();
 
   // AffineMap for the number of workgroups = ceilDiv(workload, tileSize)
   SmallVector<Value> numTiles;
-  numTiles.reserve(*numWorkloadValues);
-  builder.setInsertionPointToStart(entryBlock);
+  numTiles.reserve(workloadValues.size());
+  builder.setInsertionPoint(workgroupCountOp);
   Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
   llvm::DenseSet<unsigned> partitionableLoopsSet;
   partitionableLoopsSet.insert(partitionableLoops.begin(),
                                partitionableLoops.end());
-  for (auto loopNum : llvm::seq<unsigned>(0, *numWorkloadValues)) {
-    Value workload = entryBlock->addArgument(indexType, loc);
-    if (!partitionableLoopsSet.count(loopNum)) {
-      tileSizes[loopNum] = 0;
+  for (auto workload : llvm::enumerate(workloadValues)) {
+    if (!partitionableLoopsSet.count(workload.index())) {
+      tileSizes[workload.index()] = 0;
     }
-    if (tileSizes[loopNum] == 0) {
+    if (tileSizes[workload.index()] == 0) {
       numTiles.push_back(one);
       continue;
     }
-    if (tileSizes[loopNum] == 1) {
-      numTiles.push_back(workload);
+    if (tileSizes[workload.index()] == 1) {
+      numTiles.push_back(workload.value());
       continue;
     }
     AffineExpr s0;
-    bindSymbols(exportOp.getContext(), s0);
+    bindSymbols(workgroupCountOp.getContext(), s0);
     AffineMap numTilesMap =
-        AffineMap::get(0, 1, s0.ceilDiv(tileSizes[loopNum]));
-    Value nTiles = builder.create<AffineApplyOp>(loc, numTilesMap, workload);
+        AffineMap::get(0, 1, s0.ceilDiv(tileSizes[workload.index()]));
+    Value nTiles =
+        builder.create<AffineApplyOp>(loc, numTilesMap, workload.value());
     numTiles.push_back(nTiles);
   }
 
@@ -187,7 +178,8 @@ static LogicalResult defineWorkgroupCountRegion(
     workloadPerWorkgroup.push_back(tileSizes[partitionedLoop]);
   }
   numWorkgroups.resize(kNumMaxParallelDims, one);
-  builder.create<IREE::HAL::ReturnOp>(loc, numWorkgroups);
+  workgroupCountOp->replaceAllUsesWith(numWorkgroups);
+  workgroupCountOp.erase();
   return success();
 }
 
@@ -293,9 +285,6 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
     auto exportOp = entryPoints.lookup(funcOp.getName());
     if (!exportOp) continue;
 
-    // If there is already a region on the `exportOp` do nothing.
-    if (!exportOp.workgroup_count().empty()) continue;
-
     SmallVector<Operation *> computeOps;
     SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
     if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
@@ -310,9 +299,32 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
       continue;
     }
 
+    // Find the `flow.default_workgroup_count` operation in the
+    // `workgroup_count` region of `hal.executable.export`. Lower this to the
+    // actual computation that returns the `workgroup_count`.
+    // TODO(ravishankarm): Ideally this should be done using a pattern, but the
+    // `workload_per_workgroup` usage here makes it hard. That is to be
+    // deprecated. Rework this logic into a pattern when that is done.
+    Region &workgroupCountRegion = exportOp.workgroup_count();
+    if (!workgroupCountRegion.hasOneBlock()) {
+      exportOp.emitOpError(
+          "expected workgroup_count region to have a single block");
+      return signalPassFailure();
+    }
+    Block &workgroupCountBody = workgroupCountRegion.front();
+    auto ops = workgroupCountBody.getOps<IREE::Flow::DefaultWorkgroupCountOp>();
+    if (!llvm::hasSingleElement(ops)) {
+      // Do not modify the region since the default path expects only a single
+      // `flow.default_workgroup_count` op.
+      continue;
+    }
+    IREE::Flow::DefaultWorkgroupCountOp defaultWorkgroupCountOp =
+        *(ops.begin());
+
     SmallVector<int64_t> tileSizes, interchange, workloadPerWorkgroup;
-    if (failed(defineWorkgroupCountRegion(exportOp, computeOps, tileSizes,
-                                          interchange, workloadPerWorkgroup))) {
+    if (failed(lowerDefaultWorkgroupCountOp(defaultWorkgroupCountOp, computeOps,
+                                            tileSizes, interchange,
+                                            workloadPerWorkgroup))) {
       return signalPassFailure();
     }
     if (failed(updateTranslationInfoAttr(exportOp, workloadPerWorkgroup))) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/distribute_gpu_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/distribute_gpu_shared_memory.mlir
@@ -21,7 +21,7 @@ hal.executable private @shared_mem_cpy  {
       workgroup_size = [32: index, 4: index, 1:index]
     } {
     ^bb0(%arg0: !hal.device, %arg1 : index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/Common/test/distribute_gpu_shared_memory.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/distribute_gpu_shared_memory.mlir
@@ -17,8 +17,12 @@
 ]>
 hal.executable private @shared_mem_cpy  {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @shared_mem_cpy layout(#executable_layout) {
+    hal.executable.export @shared_mem_cpy layout(#executable_layout) attributes {
       workgroup_size = [32: index, 4: index, 1:index]
+    } {
+    ^bb0(%arg0: !hal.device, %arg1 : index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
       memref.global "private" @__shared_memory___1 : memref<3x512xf32, 3>

--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
@@ -10,8 +10,12 @@
 // CHECK-LABEL: func.func @dispatch_0()
 hal.executable private @dispatch_0  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @dispatch_0 layout(#executable_layout) {
+    hal.executable.export @dispatch_0 layout(#executable_layout) attributes {
       workgroup_size = [64: index, 1: index, 1:index]
+    } {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
     }
     builtin.module {
       func.func @dispatch_0() {
@@ -57,8 +61,13 @@ hal.executable private @dispatch_0  {
 #translation = #iree_codegen.translation_info<LLVMGPUDistribute workload_per_wg = [32]>
 hal.executable private @workgroup_tile_loop  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @workgroup_tile_loop layout(#executable_layout) {
+    hal.executable.export @workgroup_tile_loop layout(#executable_layout) attributes {
       translation_info = #translation
+    } {
+    ^bb0(%arg0 : !hal.device, %arg1 : index):
+      %c1 = arith.constant 1 : index
+      %0 = affine.apply affine_map<(d0) -> (d0 ceildiv 32)>(%arg1)
+      hal.return %0, %c1, %c1 : index, index, index
     }
     builtin.module {
       func.func @workgroup_tile_loop() {
@@ -91,8 +100,13 @@ hal.executable private @workgroup_tile_loop  {
 #translation = #iree_codegen.translation_info<LLVMGPUDistribute workload_per_wg = [16]>
 hal.executable private @workgroup_tile_loop_negative  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @workgroup_tile_loop_negative layout(#executable_layout)  {
+    hal.executable.export @workgroup_tile_loop_negative layout(#executable_layout) attributes {
       translation_info = #translation
+    } {
+    ^bb0(%arg0: !hal.device, %arg1 : index):
+      %c1 = arith.constant 1 : index
+      %0 = affine.apply affine_map<(d0) -> (d0 ceildiv 16)>(%arg1)
+      hal.return %0, %c1, %c1 : index, index, index
     }
     builtin.module {
       func.func @workgroup_tile_loop_negative() {
@@ -127,9 +141,14 @@ hal.executable private @workgroup_tile_loop_negative  {
 #translation = #iree_codegen.translation_info<LLVMGPUDistribute workload_per_wg = [32, 8, 1]>
 hal.executable private @both_workgroup_and_workitem  {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @both_workgroup_and_workitem layout(#executable_layout)  {
+    hal.executable.export @both_workgroup_and_workitem layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [8: index, 2: index, 1: index]
+    } {
+    ^bb0(%arg0 : !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %0 = affine.apply affine_map<(d0) -> (d0 ceildiv 8)>(%arg2)
+      %1 = affine.apply affine_map<(d0) -> (d0 ceildiv 32)>(%arg3)
+      hal.return %1, %0, %arg1 : index, index, index
     }
     builtin.module {
       func.func @both_workgroup_and_workitem() {
@@ -189,7 +208,7 @@ hal.executable private @both_workgroup_and_workitem  {
 module attributes {hal.device.targets = [#device_target_cpu]} {
   hal.executable private @simple_mul {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.export public @simple_mul ordinal(0) layout(#executable_layout) {translation_info = #translation} {
+      hal.executable.export public @simple_mul ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
       ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
         %c1 = arith.constant 1 : index
         %0 = affine.apply #map0()[%arg1]

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -19,7 +19,7 @@ hal.executable private @matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
     hal.executable.export public @matmul_tensors layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -118,7 +118,7 @@ hal.executable private @add {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @add layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -190,7 +190,7 @@ hal.executable private @add4D {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @add4D layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -265,7 +265,7 @@ hal.executable private @batch_matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
     hal.executable.export public @batch_matmul_tensors layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -332,7 +332,7 @@ hal.executable private @preset_config_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @preset_config layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -399,7 +399,7 @@ hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @copy_op layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -493,7 +493,7 @@ hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @static_1d_fft_stage2 layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -551,7 +551,7 @@ hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @static_3d_fft_stage3 layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -612,7 +612,7 @@ hal.executable private @outs_fusion {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @outs_fusion_fn layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -693,7 +693,7 @@ hal.executable private @conv {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @conv layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -775,7 +775,7 @@ hal.executable private @conv_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @conv_static layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -852,7 +852,7 @@ hal.executable private @generic_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
     hal.executable.export public @generic_static layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -915,7 +915,7 @@ hal.executable private @matmul_static {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
     hal.executable.export public @matmul_static layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -976,7 +976,7 @@ hal.executable private @restrict_num_workgroups {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
     hal.executable.export public @restrict_num_workgroups layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 :index, %arg4 : index, %arg5 : index, %arg6 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1042,7 +1042,7 @@ hal.executable private @reduction {
   hal.executable.variant public @reduction, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @reduction ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1114,7 +1114,7 @@ hal.executable private @gemm_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @gemm_unit_N ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1186,7 +1186,7 @@ hal.executable private @gemm_unit_M_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1249,7 +1249,7 @@ hal.executable private @generic_unit_dims {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @generic_unit_dims layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index, %arg8 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1326,7 +1326,7 @@ hal.executable private @reduce_to_scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @reduce_to_scalar layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1385,7 +1385,7 @@ hal.executable private @scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @scalar layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device):
-      %x, %y, %z = flow.default_workgroup_count
+      %x, %y, %z = flow.dispatch.default_workgroup_count
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1442,7 +1442,7 @@ hal.executable private @rank_reduced_slice {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
     hal.executable.export public @rank_reduced_slice layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -1510,7 +1510,7 @@ hal.executable private @matmul_interchange {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @matmul_interchange layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -17,7 +17,11 @@
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.export public @matmul_tensors layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_tensors layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @matmul_tensors() {
         %0 = hal.interface.constant.load[0] : index
@@ -112,7 +116,11 @@ hal.executable private @matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @add layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @add layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @add() {
         %0 = hal.interface.constant.load[0] : index
@@ -180,7 +188,11 @@ hal.executable private @add {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @add4D {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @add4D layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @add4D layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @add4D() {
         %0 = hal.interface.constant.load[0] : index
@@ -251,7 +263,11 @@ hal.executable private @add4D {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @batch_matmul_tensors {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.export public @batch_matmul_tensors layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @batch_matmul_tensors layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @batch_matmul_tensors() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -314,7 +330,11 @@ hal.executable private @batch_matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @preset_config_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @preset_config layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @preset_config layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @preset_config() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -377,7 +397,11 @@ hal.executable private @preset_config_matmul_tensors {
 #translation = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
 hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @copy_op layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @copy_op layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @copy_op() {
         %source_size_y = hal.interface.constant.load[0] : index
@@ -467,7 +491,11 @@ hal.executable public @copy_op {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @static_1d_fft_stage2 layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @static_1d_fft_stage2 layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @static_1d_fft_stage2() {
         %c2 = arith.constant 2 : index
@@ -521,7 +549,11 @@ hal.executable private @static_1d_fft_stage2 {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @static_3d_fft_stage3 layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @static_3d_fft_stage3 layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @static_3d_fft_stage3() {
         %c3 = arith.constant 3 : index
@@ -578,7 +610,11 @@ hal.executable private @static_3d_fft_stage3 {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @outs_fusion {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @outs_fusion_fn layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @outs_fusion_fn layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @outs_fusion_fn() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -655,7 +691,11 @@ hal.executable private @outs_fusion {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @conv layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @conv layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @conv() {
         %0 = hal.interface.constant.load[0] : index
@@ -733,7 +773,11 @@ hal.executable private @conv {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @conv_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @conv_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @conv_static layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @conv_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -806,7 +850,11 @@ hal.executable private @conv_static {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_static {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
-    hal.executable.export public @generic_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @generic_static layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @generic_static() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -865,7 +913,11 @@ hal.executable private @generic_static {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @matmul_static {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.export public @matmul_static layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_static layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @matmul_static() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -922,7 +974,11 @@ hal.executable private @matmul_static {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @restrict_num_workgroups {
   hal.executable.variant public @system_elf_arm_64, target = #executable_target_system_elf_arm_64_ {
-    hal.executable.export public @restrict_num_workgroups layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @restrict_num_workgroups layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 :index, %arg4 : index, %arg5 : index, %arg6 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @restrict_num_workgroups() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -984,7 +1040,11 @@ hal.executable private @restrict_num_workgroups {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduction {
   hal.executable.variant public @reduction, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @reduction ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @reduction ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @reduction(%arg0 : !flow.dispatch.tensor<readonly:7x7x2048xf32>,
           %arg1 : !flow.dispatch.tensor<writeonly:7xf32>) {
@@ -1052,7 +1112,11 @@ hal.executable private @reduction {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @gemm_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @gemm_unit_N ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @gemm_unit_N() {
         %c0 = arith.constant 0 : index
@@ -1120,7 +1184,11 @@ hal.executable private @gemm_unit_N {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @gemm_unit_M_unit_N {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @gemm_unit_M_unit_N ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @gemm_unit_M_unit_N() {
         %c0 = arith.constant 0 : index
@@ -1179,7 +1247,11 @@ hal.executable private @gemm_unit_M_unit_N {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @generic_unit_dims {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @generic_unit_dims layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @generic_unit_dims layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index, %arg8 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7, %arg8
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @generic_unit_dims() {
         %0 = hal.interface.constant.load[0] : index
@@ -1252,7 +1324,11 @@ hal.executable private @generic_unit_dims {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @reduce_to_scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @reduce_to_scalar layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @reduce_to_scalar layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @reduce_to_scalar() {
         %0 = hal.interface.constant.load[0] : index
@@ -1307,7 +1383,11 @@ hal.executable private @reduce_to_scalar {
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @scalar {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @scalar layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @scalar layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device):
+      %x, %y, %z = flow.default_workgroup_count
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @scalar() {
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -1360,7 +1440,11 @@ hal.executable private @scalar {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @rank_reduced_slice {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_arm_64_ {
-    hal.executable.export public @rank_reduced_slice layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @rank_reduced_slice layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @rank_reduced_slice() {
         %in_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
@@ -1424,7 +1508,11 @@ hal.executable private @rank_reduced_slice {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @matmul_interchange {
   hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @matmul_interchange layout(#executable_layout) {translation_info = #translation}
+    hal.executable.export public @matmul_interchange layout(#executable_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @matmul_interchange() {
         %0 = hal.interface.constant.load[0] : index

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
@@ -16,7 +16,7 @@
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [2]>
 hal.executable private @apply_scale_no_vector_feature {
   hal.executable.variant public @embedded_elf_riscv_64, target = #executable_target_embedded_elf_riscv_64_ {
-    hal.executable.export public @apply_scale_no_vector_feature ordinal(0) layout(#executable_layout) {translation_info = #translation} {
+    hal.executable.export public @apply_scale_no_vector_feature ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
@@ -64,7 +64,7 @@ hal.executable private @apply_scale_no_vector_feature {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [2]>
 hal.executable private @apply_scale_v {
   hal.executable.variant public @embedded_elf_riscv_64, target = #executable_target_embedded_elf_riscv_64_ {
-    hal.executable.export public @apply_scale_v ordinal(0) layout(#executable_layout) {translation_info = #translation} {
+    hal.executable.export public @apply_scale_v ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
@@ -110,7 +110,7 @@ hal.executable private @apply_scale_v {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [2]>
 hal.executable private @apply_scale_zve64x {
   hal.executable.variant public @embedded_elf_riscv_64, target = #executable_target_embedded_elf_riscv_64_ {
-    hal.executable.export public @apply_scale_zve64x ordinal(0) layout(#executable_layout) {translation_info = #translation} {
+    hal.executable.export public @apply_scale_zve64x ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]
@@ -156,7 +156,7 @@ hal.executable private @apply_scale_zve64x {
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [2]>
 hal.executable private @apply_scale_zve32x {
   hal.executable.variant public @embedded_elf_riscv_64, target = #executable_target_embedded_elf_riscv_64_ {
-    hal.executable.export public @apply_scale_zve32x ordinal(0) layout(#executable_layout) {translation_info = #translation} {
+    hal.executable.export public @apply_scale_zve32x ordinal(0) layout(#executable_layout) attributes {translation_info = #translation} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
       %c1 = arith.constant 1 : index
       %0 = affine.apply #map()[%arg1]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -11,9 +11,7 @@
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.export @illegal layout(#executable_layout)  {
-      translation_info = #translation
-    }
+    hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
         %c0 = arith.constant 0 : index
@@ -42,9 +40,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.export @illegal layout(#executable_layout)  {
-      translation_info = #translation
-    }
+    hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
         %c0 = arith.constant 0 : index
@@ -73,9 +69,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.export @illegal layout(#executable_layout)  {
-      translation_info = #translation
-    }
+    hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
         %c0 = arith.constant 0 : index
@@ -104,9 +98,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.export @illegal layout(#executable_layout)  {
-      translation_info = #translation
-    }
+    hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
         %c0 = arith.constant 0 : index
@@ -135,9 +127,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.export @illegal layout(#executable_layout)  {
-      translation_info = #translation
-    }
+    hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
         %c0 = arith.constant 0 : index
@@ -168,9 +158,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
-    hal.executable.export @illegal layout(#executable_layout)  {
-      translation_info = #translation
-    }
+    hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/peel_and_vectorize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/peel_and_vectorize.mlir
@@ -15,7 +15,11 @@
 ]>
 hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.export @no_peel_static_matmul layout(#executable_layout)
+    hal.executable.export @no_peel_static_matmul layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @no_peel_static_matmul() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -67,7 +71,11 @@ hal.executable private @preset_config_matmul  {
 ]>
 hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.export @peel_static_matmul layout(#executable_layout)
+    hal.executable.export @peel_static_matmul layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @peel_static_matmul() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -131,7 +139,11 @@ hal.executable private @preset_config_matmul  {
 ]>
 hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.export @peel_dynamic_matmul layout(#executable_layout)
+    hal.executable.export @peel_dynamic_matmul layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @peel_dynamic_matmul() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/peel_and_vectorize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/peel_and_vectorize.mlir
@@ -17,7 +17,7 @@ hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
     hal.executable.export @no_peel_static_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -73,7 +73,7 @@ hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
     hal.executable.export @peel_static_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -141,7 +141,7 @@ hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
     hal.executable.export @peel_dynamic_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -24,7 +24,7 @@ hal.executable private @check_no_cse {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @check_no_cse ordinal(0) layout(#executable_layout5) {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -83,7 +83,7 @@ hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
     hal.executable.export @preset_config_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -134,7 +134,7 @@ hal.executable private @batch_matmul_dynamic {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @batch_matmul_dynamic ordinal(0) layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -186,7 +186,7 @@ hal.executable private @check_buffer_ops_vectorization {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export public @check_buffer_ops_vectorization ordinal(0) layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -232,7 +232,7 @@ hal.executable private @vectorize_fill_conv2d_generic {
         >]>
       ) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -22,7 +22,11 @@
   >]>
 hal.executable private @check_no_cse {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @check_no_cse ordinal(0) layout(#executable_layout5)
+    hal.executable.export public @check_no_cse ordinal(0) layout(#executable_layout5) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @check_no_cse() {
         %cst = arith.constant 3.840000e+02 : f32
@@ -77,7 +81,11 @@ hal.executable private @check_no_cse {
 ]>
 hal.executable private @preset_config_matmul  {
   hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
-    hal.executable.export @preset_config_matmul layout(#executable_layout)
+    hal.executable.export @preset_config_matmul layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @preset_config_matmul() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -124,7 +132,11 @@ hal.executable private @preset_config_matmul  {
   >]>
 hal.executable private @batch_matmul_dynamic {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @batch_matmul_dynamic ordinal(0) layout(#executable_layout)
+    hal.executable.export public @batch_matmul_dynamic ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @batch_matmul_dynamic() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -172,7 +184,11 @@ hal.executable private @batch_matmul_dynamic {
   >]>
 hal.executable private @check_buffer_ops_vectorization {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @check_buffer_ops_vectorization ordinal(0) layout(#executable_layout)
+    hal.executable.export public @check_buffer_ops_vectorization ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @check_buffer_ops_vectorization() {
         %c0 = arith.constant 0 : index
@@ -214,7 +230,11 @@ hal.executable private @vectorize_fill_conv2d_generic {
           #hal.descriptor_set.binding<1, storage_buffer>,
           #hal.descriptor_set.binding<2, storage_buffer>]
         >]>
-      )
+      ) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @vectorize_fill_conv2d_generic() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
@@ -18,7 +18,11 @@
 
 hal.executable private @transpose_10_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export @transpose_10_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_10_8x8_pattern layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @transpose_10_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -72,7 +76,11 @@ hal.executable private @transpose_10_8x8_pattern {
 
 hal.executable private @transpose_021_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export @transpose_021_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_021_8x8_pattern layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @transpose_021_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -126,7 +134,11 @@ hal.executable private @transpose_021_8x8_pattern {
 
 hal.executable private @transpose_201_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export @transpose_201_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_201_8x8_pattern layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @transpose_201_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -180,7 +192,11 @@ hal.executable private @transpose_201_8x8_pattern {
 
 hal.executable private @transpose_210_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export @transpose_210_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_210_8x8_pattern layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @transpose_210_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -234,7 +250,11 @@ hal.executable private @transpose_210_8x8_pattern {
 
 hal.executable private @transpose_120_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export @transpose_120_8x8_pattern layout(#executable_layout)
+    hal.executable.export @transpose_120_8x8_pattern layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @transpose_120_8x8_pattern() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -288,7 +308,11 @@ hal.executable private @transpose_120_8x8_pattern {
 
 hal.executable private @transpose_102 {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export @transpose_102 layout(#executable_layout)
+    hal.executable.export @transpose_102 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @transpose_102() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -334,7 +358,11 @@ hal.executable private @transpose_102 {
 
 hal.executable private @test_no_avx2_feature {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export @test_no_avx2_feature layout(#executable_layout)
+    hal.executable.export @test_no_avx2_feature layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @test_no_avx2_feature() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
@@ -20,7 +20,7 @@ hal.executable private @transpose_10_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export @transpose_10_8x8_pattern layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -78,7 +78,7 @@ hal.executable private @transpose_021_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export @transpose_021_8x8_pattern layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -136,7 +136,7 @@ hal.executable private @transpose_201_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export @transpose_201_8x8_pattern layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -194,7 +194,7 @@ hal.executable private @transpose_210_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export @transpose_210_8x8_pattern layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -252,7 +252,7 @@ hal.executable private @transpose_120_8x8_pattern {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export @transpose_120_8x8_pattern layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -310,7 +310,7 @@ hal.executable private @transpose_102 {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export @transpose_102 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -360,7 +360,7 @@ hal.executable private @test_no_avx2_feature {
   hal.executable.variant @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
     hal.executable.export @test_no_avx2_feature layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -17,7 +17,7 @@
 #map4 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
 hal.executable private @dot_dispatch_0  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 1 : index, 1 : index]
     }
@@ -96,7 +96,7 @@ hal.executable private @dot_dispatch_0  {
 ]>
 hal.executable private @batch_matmul_func  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.export @batch_matmul_func layout(#executable_layout) {
+    hal.executable.export @batch_matmul_func layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [8 : index, 8 : index, 1 : index]
     }
@@ -176,7 +176,7 @@ builtin.module {
 #map4 = affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>
 hal.executable private @dot_dispatch_0  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 8 : index, 1 : index]
     }
@@ -258,7 +258,7 @@ hal.executable private @dot_dispatch_0  {
 // Pure reducion case, skip tiling.
 hal.executable @reduction_dispatch {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @predict_dispatch_153 layout(#executable_layout) {
+    hal.executable.export @predict_dispatch_153 layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [1: index, 1: index, 1: index]
     }
@@ -305,7 +305,7 @@ hal.executable @reduction_dispatch {
 ]>
 hal.executable private @conv_dispatch  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.export @conv_dispatch layout(#executable_layout) {
+    hal.executable.export @conv_dispatch layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 1 : index, 1 : index]
     }
@@ -376,7 +376,7 @@ hal.executable private @conv_dispatch  {
 ]>
 hal.executable private @contract_4d  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.export @contract_4d layout(#executable_layout) {
+    hal.executable.export @contract_4d layout(#executable_layout) attributes {
       workgroup_size = [64 : index, 8 : index, 1 : index]
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/illegal_configuration.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [32 : index, 8 : index, 8 : index]
     }
@@ -43,7 +43,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [32 : index, 8 : index, 2 : index]
     }
@@ -75,7 +75,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 10 : index]
     }
@@ -107,7 +107,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [48 : index, 2 : index, 1 : index]
     }
@@ -139,7 +139,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 2 : index]
     }
@@ -171,7 +171,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
@@ -203,7 +203,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [128 : index, 1 : index, 1 : index]
     }
@@ -235,7 +235,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
@@ -267,7 +267,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @matmul_tensors {
   hal.executable.variant @cuda, target = #hal.executable.target<"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }
@@ -300,7 +300,7 @@ hal.executable private @matmul_tensors {
 ]>
 hal.executable private @batch_matmul_func  {
   hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.export @illegal layout(#executable_layout) {
+    hal.executable.export @illegal layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [64 : index, 2 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -13,7 +13,11 @@
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.export @add_dispatch_0 layout(#executable_layout)
+  hal.executable.export @add_dispatch_0 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -53,7 +57,11 @@ hal.executable @simpleMath_ex_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @dot_dispatch_0 layout(#executable_layout)
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -120,7 +128,11 @@ hal.executable @dot_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-    hal.executable.export @dot_dispatch_0 layout(#executable_layout)
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32
@@ -169,7 +181,11 @@ hal.executable @dot_dispatch_0 {
 ]>
 hal.executable @conv2d_dispatch_0 {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.export @conv2d_dispatch_0 layout(#executable_layout)
+  hal.executable.export @conv2d_dispatch_0 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @conv2d_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -213,7 +229,11 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.export @add_dispatch_0 layout(#executable_layout)
+  hal.executable.export @add_dispatch_0 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -249,7 +269,11 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.export @reduction layout(#executable_layout)
+  hal.executable.export @reduction layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @reduction() {
       %c0 = arith.constant 0 : index
@@ -292,7 +316,11 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @vector_add_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.export @vector_add_dispatch layout(#executable_layout)
+  hal.executable.export @vector_add_dispatch layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @vector_add_dispatch() {
       %c0 = arith.constant 0 : index
@@ -341,7 +369,11 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @vector_reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.export @vector_reduction_dispatch layout(#executable_layout)
+  hal.executable.export @vector_reduction_dispatch layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @vector_reduction_dispatch() {
       %c0 = arith.constant 0 : index
@@ -384,7 +416,11 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 ]>
 hal.executable @mma_fused {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>)
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @_large_aligned_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -509,7 +545,11 @@ hal.executable @mma_fused {
 ]>
 hal.executable @mma_fused_fp16 {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>)
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @_large_aligned_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -634,7 +674,11 @@ hal.executable @mma_fused_fp16 {
 #map6 = affine_map<(d0)[s0] -> (-d0 + 64, s0)>
   hal.executable @large_dot_general_dispatch_0 {
     hal.executable.variant public @cuda, target = #executable_target_cuda_nvptx_fb {
-      hal.executable.export @large_dot_general_dispatch_0 layout(#executable_layout)
+      hal.executable.export @large_dot_general_dispatch_0 layout(#executable_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
+        %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+        hal.return %x, %y, %z : index, index, index
+      }
       builtin.module {
         func.func @large_dot_general_dispatch_0() {
           %c64 = arith.constant 64 : index
@@ -716,7 +760,11 @@ hal.executable @mma_fused_fp16 {
 #map6 = affine_map<(d0, d1, d2) -> (d2, d0, d1)>
   hal.executable public @split_k_gemm {
     hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
-      hal.executable.export public @split_k_gemm ordinal(0) layout(#executable_layout)
+      hal.executable.export public @split_k_gemm ordinal(0) layout(#executable_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
+        %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+        hal.return %x, %y, %z : index, index, index
+      }
       builtin.module {
         func.func @split_k_gemm() {
           %cst = arith.constant 0.000000e+00 : f32
@@ -775,7 +823,11 @@ hal.executable @mma_fused_fp16 {
 #executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>
   hal.executable public @pooling_dynamic {
     hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
-      hal.executable.export public @pooling_dynamic ordinal(0) layout(#executable_layout)
+      hal.executable.export public @pooling_dynamic ordinal(0) layout(#executable_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 :index, %arg4 : index, %arg5 : index, %arg6 : index):
+        %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+        hal.return %x, %y, %z : index, index, index
+      }
       builtin.module {
         func.func @pooling_dynamic() {
           %c1_i64 = arith.constant 1 : i64
@@ -816,7 +868,11 @@ hal.executable @mma_fused_fp16 {
 ]>
 hal.executable @warp_reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
-  hal.executable.export @warp_reduction_dispatch layout(#executable_layout)
+  hal.executable.export @warp_reduction_dispatch layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @warp_reduction_dispatch() {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -15,7 +15,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.export @add_dispatch_0 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {
@@ -59,7 +59,7 @@ hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
     hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -130,7 +130,7 @@ hal.executable @dot_dispatch_0 {
   hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
     hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -183,7 +183,7 @@ hal.executable @conv2d_dispatch_0 {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.export @conv2d_dispatch_0 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index, %arg6 : index, %arg7 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {
@@ -231,7 +231,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.export @add_dispatch_0 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {
@@ -271,7 +271,7 @@ hal.executable @reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.export @reduction layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {
@@ -318,7 +318,7 @@ hal.executable @vector_add_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.export @vector_add_dispatch layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {
@@ -371,7 +371,7 @@ hal.executable @vector_reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.export @vector_reduction_dispatch layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {
@@ -418,7 +418,7 @@ hal.executable @mma_fused {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
   hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
   ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-    %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
   builtin.module {
@@ -547,7 +547,7 @@ hal.executable @mma_fused_fp16 {
   hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
   hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
   ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-    %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
     hal.return %x, %y, %z : index, index, index
   }
   builtin.module {
@@ -676,7 +676,7 @@ hal.executable @mma_fused_fp16 {
     hal.executable.variant public @cuda, target = #executable_target_cuda_nvptx_fb {
       hal.executable.export @large_dot_general_dispatch_0 layout(#executable_layout) {
       ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
-        %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+        %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4
         hal.return %x, %y, %z : index, index, index
       }
       builtin.module {
@@ -762,7 +762,7 @@ hal.executable @mma_fused_fp16 {
     hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
       hal.executable.export public @split_k_gemm ordinal(0) layout(#executable_layout) {
       ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 : index):
-        %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4
+        %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4
         hal.return %x, %y, %z : index, index, index
       }
       builtin.module {
@@ -825,7 +825,7 @@ hal.executable @mma_fused_fp16 {
     hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
       hal.executable.export public @pooling_dynamic ordinal(0) layout(#executable_layout) {
       ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 :index, %arg4 : index, %arg5 : index, %arg6 : index):
-        %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
+        %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3, %arg4, %arg5, %arg6
         hal.return %x, %y, %z : index, index, index
       }
       builtin.module {
@@ -870,7 +870,7 @@ hal.executable @warp_reduction_dispatch {
 hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
   hal.executable.export @warp_reduction_dispatch layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -12,7 +12,11 @@
 ]>
 hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
-  hal.executable.export @add_dispatch_0 layout(#executable_layout)
+  hal.executable.export @add_dispatch_0 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index):
+      %x, %y, %z = flow.default_workgroup_count %arg1
+      hal.return %x, %y, %z : index, index, index
+    }
   builtin.module {
     func.func @add_dispatch_0() {
       %c0 = arith.constant 0 : index
@@ -52,7 +56,11 @@ hal.executable @simpleMath_ex_dispatch_0 {
 ]>
 hal.executable @dot_dispatch_0 {
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
-    hal.executable.export @dot_dispatch_0 layout(#executable_layout)
+    hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @dot_dispatch_0() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/rocdl_pipeline_test.mlir
@@ -14,7 +14,7 @@ hal.executable @simpleMath_ex_dispatch_0 {
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
   hal.executable.export @add_dispatch_0 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index):
-      %x, %y, %z = flow.default_workgroup_count %arg1
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1
       hal.return %x, %y, %z : index, index, index
     }
   builtin.module {
@@ -58,7 +58,7 @@ hal.executable @dot_dispatch_0 {
   hal.executable.variant @rocm, target = <"rocm", "rocm-hsaco-fb"> {
     hal.executable.export @dot_dispatch_0 layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_distribution.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_vector_distribution.mlir
@@ -11,7 +11,7 @@
 
 hal.executable private @reduce_dispatch_0 {
   hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
-    hal.executable.export public @reduce_dispatch_0 ordinal(0) layout(#executable_layout) { workgroup_size = [64: index, 1: index, 1: index] }
+    hal.executable.export public @reduce_dispatch_0 ordinal(0) layout(#executable_layout) attributes { workgroup_size = [64: index, 1: index, 1: index] }
     builtin.module {
       func.func @reduce_dispatch_0() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/convert_to_spirv.mlir
@@ -9,7 +9,7 @@
 hal.executable private @push_constant {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, #spv.resource_limits<>>}> {
-    hal.executable.export @push_constant layout(#executable_layout) {
+    hal.executable.export @push_constant layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -43,7 +43,7 @@ hal.executable private @push_constant {
 hal.executable private @resource_bindings_in_same_func {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, #spv.resource_limits<>>}> {
-    hal.executable.export @resource_bindings_in_same_func layout(#executable_layout) {
+    hal.executable.export @resource_bindings_in_same_func layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -98,10 +98,10 @@ hal.executable private @resource_bindings_in_same_func {
 hal.executable private @resource_bindings_in_multi_entry_func {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, #spv.resource_limits<>>}> {
-    hal.executable.export @resource_bindings_in_entry_func1 layout(#executable_layout) {
+    hal.executable.export @resource_bindings_in_entry_func1 layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
-    hal.executable.export @resource_bindings_in_entry_func2 layout(#executable_layout) {
+    hal.executable.export @resource_bindings_in_entry_func2 layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -154,7 +154,7 @@ hal.executable private @resource_bindings_in_multi_entry_func {
 hal.executable private @interface_binding {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, #spv.resource_limits<>>}> {
-    hal.executable.export @interface_binding layout(#executable_layout) {
+    hal.executable.export @interface_binding layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -197,7 +197,7 @@ hal.executable private @interface_binding {
 hal.executable private @interface_wg_id {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, #spv.resource_limits<>>}> {
-    hal.executable.export @interface_wg_id layout(#executable_layout) {
+    hal.executable.export @interface_wg_id layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {
@@ -232,7 +232,7 @@ hal.executable private @interface_wg_id {
 hal.executable private @interface_wg_count {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
       spv.target_env = #spv.target_env<#spv.vce<v1.3, [Shader], []>, #spv.resource_limits<>>}> {
-    hal.executable.export @interface_wg_count layout(#executable_layout) {
+    hal.executable.export @interface_wg_count layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index]
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -33,7 +33,11 @@ hal.executable public @matmul_256x1024x128_div_sub {
         max_compute_workgroup_size = [2147483647, 65535, 65535],
         subgroup_size = 32>
        >}> {
-    hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout)
+    hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module  {
       func.func @matmul_256x1024x128_div_sub() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -35,7 +35,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
        >}> {
     hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module  {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -17,7 +17,11 @@ hal.executable @matmul_128x256x64 {
       max_compute_workgroup_invocations = 1024,
       max_compute_workgroup_size = [65535, 65535, 65535],
       subgroup_size = 32>>}> {
-    hal.executable.export public @matmul_128x256x64 ordinal(0) layout(#executable_layout)
+    hal.executable.export public @matmul_128x256x64 ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @matmul_128x256x64() {
         %cst = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -19,7 +19,7 @@ hal.executable @matmul_128x256x64 {
       subgroup_size = 32>>}> {
     hal.executable.export public @matmul_128x256x64 ordinal(0) layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -17,7 +17,7 @@ hal.executable private @fuse_and_vectorize_fill_matmul {
     }> {
     hal.executable.export @fuse_and_vectorize_fill_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
@@ -68,7 +68,7 @@ hal.executable private @fuse_and_vectorize_matmul_add {
     }> {
     hal.executable.export @fuse_and_vectorize_matmul_add layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_vectorization.mlir
@@ -15,7 +15,11 @@ hal.executable private @fuse_and_vectorize_fill_matmul {
         max_compute_workgroup_size = [512, 512, 512],
        subgroup_size = 16>>
     }> {
-    hal.executable.export @fuse_and_vectorize_fill_matmul layout(#executable_layout)
+    hal.executable.export @fuse_and_vectorize_fill_matmul layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @fuse_and_vectorize_fill_matmul() {
         %c0 = arith.constant 0 : index
@@ -62,7 +66,11 @@ hal.executable private @fuse_and_vectorize_matmul_add {
         max_compute_workgroup_size = [512, 512, 512],
        subgroup_size = 16>>
     }> {
-    hal.executable.export @fuse_and_vectorize_matmul_add layout(#executable_layout)
+    hal.executable.export @fuse_and_vectorize_matmul_add layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.default_workgroup_count %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
     builtin.module {
       func.func @fuse_and_vectorize_matmul_add() {
         %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute.mlir
@@ -19,7 +19,7 @@
 ]>
 hal.executable private @matmul {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @matmul layout(#executable_layout) {
+    hal.executable.export @matmul layout(#executable_layout) attributes {
       workgroup_size = [16: index, 8: index, 1: index],
       translation_info = #translation
     }
@@ -89,7 +89,7 @@ hal.executable private @matmul {
 ]>
 hal.executable private @conv_1d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @conv_1d layout(#executable_layout) {
+    hal.executable.export @conv_1d layout(#executable_layout) attributes {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -169,7 +169,7 @@ hal.executable private @conv_1d {
 ]>
 hal.executable private @conv_2d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @conv_2d layout(#executable_layout) {
+    hal.executable.export @conv_2d layout(#executable_layout) attributes {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -284,7 +284,7 @@ hal.executable private @conv_2d {
 ]>
 hal.executable private @conv_3d {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @conv_3d layout(#executable_layout) {
+    hal.executable.export @conv_3d layout(#executable_layout) attributes {
       workgroup_size = [32: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -355,7 +355,7 @@ hal.executable private @conv_3d {
 module  {
   hal.executable private @pooling_nhwc_max {
     hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-      hal.executable.export @pooling_nhwc_max layout(#executable_layout) {
+      hal.executable.export @pooling_nhwc_max layout(#executable_layout) attributes {
         workgroup_size = [32: index, 4: index, 1: index],
         translation_info = #translation
       }
@@ -422,7 +422,7 @@ module  {
 
 hal.executable @matvec {
   hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export public @matvec ordinal(0) layout(#executable_layout) {
+    hal.executable.export public @matvec ordinal(0) layout(#executable_layout) attributes {
       workgroup_size = [32: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_scatter.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @static_scatter_update_slice  {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb"> {
-    hal.executable.export @static_scatter_update_slice layout(#executable_layout) {
+    hal.executable.export @static_scatter_update_slice layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_distribute_sort.mlir
@@ -10,7 +10,7 @@
 ]>
 hal.executable private @static_3d_sort  {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @static_3d_sort layout(#executable_layout) {
+    hal.executable.export @static_3d_sort layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [16 : index, 1 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_promote_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_promote_matmul.mlir
@@ -17,7 +17,7 @@ hal.executable @matmul_256x1024x128 {
       max_compute_workgroup_invocations = 1024,
       max_compute_workgroup_size = [65535, 65535, 65535],
       subgroup_size = 32>>}> {
-    hal.executable.export public @matmul_256x1024x128 ordinal(0) layout(#executable_layout) {
+    hal.executable.export public @matmul_256x1024x128 ordinal(0) layout(#executable_layout) attributes {
       translation_info = #iree_codegen.translation_info<SPIRVVectorizeWithWorkgroupMemory workload_per_wg = [128, 128]>,
       workgroup_size = [32 : index, 8 : index, 1 : index]
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_batch_matmul.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @fused_fill_batch_matmul {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @fused_fill_batch_matmul layout(#executable_layout) {
+    hal.executable.export @fused_fill_batch_matmul layout(#executable_layout) attributes {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @conv_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @conv_static_shape_f32 layout(#executable_layout) {
+    hal.executable.export @conv_static_shape_f32 layout(#executable_layout) attributes {
       workgroup_size = [4: index, 4: index, 1: index],
       translation_info = #translation
     }
@@ -99,7 +99,7 @@ hal.executable private @conv_static_shape_f32 {
 ]>
 hal.executable private @depthwise_conv_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @depthwise_conv_static_shape_f32 layout(#executable_layout) {
+    hal.executable.export @depthwise_conv_static_shape_f32 layout(#executable_layout) attributes {
       workgroup_size = [4: index, 4: index, 4: index],
       translation_info = #translation
     }
@@ -187,7 +187,7 @@ hal.executable private @depthwise_conv_static_shape_f32 {
 
 hal.executable private @low_padded_conv {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @low_padded_conv layout(#executable_layout) {
+    hal.executable.export @low_padded_conv layout(#executable_layout) attributes {
       workgroup_size = [8: index, 2: index, 1: index],
       translation_info = #translation
     }
@@ -299,7 +299,7 @@ hal.executable private @low_padded_conv {
 
 hal.executable private @low_high_padded_depthwise_conv {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @low_high_padded_depthwise_conv layout(#executable_layout) {
+    hal.executable.export @low_high_padded_depthwise_conv layout(#executable_layout) attributes {
       workgroup_size = [8: index, 2: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_matmul.mlir
@@ -11,7 +11,7 @@
 ]>
 hal.executable private @matmul_static_shape_f16 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @matmul_static_shape_f16 layout(#executable_layout) {
+    hal.executable.export @matmul_static_shape_f16 layout(#executable_layout) attributes {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }
@@ -73,7 +73,7 @@ hal.executable private @matmul_static_shape_f16 {
 ]>
 hal.executable private @matmul_static_shape_f32 {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
-    hal.executable.export @matmul_static_shape_f32 layout(#executable_layout) {
+    hal.executable.export @matmul_static_shape_f32 layout(#executable_layout) attributes {
       workgroup_size = [16: index, 1: index, 1: index],
       translation_info = #translation
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -34,7 +34,7 @@ hal.executable public @matmul_256x1024x128_div_sub {
         max_compute_workgroup_size = [2147483647, 65535, 65535],
         subgroup_size = 32>
        >}> {
-    hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout) {
+    hal.executable.export public @matmul_256x1024x128_div_sub layout(#executable_layout) attributes {
       translation_info = #translation,
       workgroup_size = [32 : index, 1 : index, 1 : index]
     } {

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -852,6 +852,13 @@ DispatchWorkgroupsOp::cloneReplacementExcludingOperandsAndResults(
   auto &newBody = newOp.getClosureBodyRegion();
   newBody.takeBody(getClosureBodyRegion());
 
+  // Copy the workgroup_count region.
+  auto &workgroupCountRegion = workgroup_count();
+  if (!workgroupCountRegion.empty()) {
+    auto &newWorkgroupCountRegion = newOp.workgroup_count();
+    newWorkgroupCountRegion.takeBody(workgroupCountRegion);
+  }
+
   // For dropped results, erase all the store-op uses. It is a pre-requisite
   // that the result can be dropped only if it is written within the dispatch
   // region op.

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1137,7 +1137,8 @@ def FLOW_TensorTraceOp : FLOW_Op<"tensor.trace", []> {
 // Parameterization Ops
 //===---------------------------------------------------------------------===//
 
-def Flow_DefaultWorkgroupCountOp : FLOW_PureOp<"default_workgroup_count"> {
+def Flow_DispatchDefaultWorkgroupCountOp :
+    FLOW_PureOp<"dispatch.default_workgroup_count"> {
   let summary = [{represents computation that returns workgroup count}];
   let description = [{
     During dispatch region formation, the `workload` captured is used

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1132,3 +1132,26 @@ def FLOW_TensorTraceOp : FLOW_Op<"tensor.trace", []> {
 }
 
 #endif  // IREE_DIALECT_FLOW_OPS
+
+//===---------------------------------------------------------------------===//
+// Parameterization Ops
+//===---------------------------------------------------------------------===//
+
+def Flow_DefaultWorkgroupCountOp : FLOW_PureOp<"default_workgroup_count"> {
+  let summary = [{represents computation that returns workgroup count}];
+  let description = [{
+    During dispatch region formation, the `workload` captured is used
+    by the backends to compute the number of workgroups. This operation
+    is a placeholder that represents the computation that takes the `workload`
+    as operands and returns the workgroup count as results.
+    The backends are expected to lower this operation into the actual computation
+    that returns the number of workgroups.
+  }];
+
+  let arguments = (ins Variadic<Index>:$operands);
+  let results = (outs Index:$x, Index:$y, Index:$z);
+
+  let assemblyFormat = [{
+    attr-dict $operands
+  }];
+}

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -398,6 +398,27 @@ buildOperandLessFlowDispatchWorkgroupOp(PatternRewriter &rewriter, Location loc,
       resultPos++;
     }
   }
+
+  LLVM_DEBUG(llvm::dbgs() << "After workgroup_body creation \n"
+                          << *dispatchOp << "\n");
+
+  // 4. Add a region for workgroup_count computation.
+  Region &workgroupCountRegion = dispatchOp.workgroup_count();
+  Block *body = rewriter.createBlock(&workgroupCountRegion);
+  // Assuming that there is an insertion guard in place already, change the
+  // insertion point to the body.
+  rewriter.setInsertionPointToStart(body);
+  SmallVector<Value> workloadArgs;
+  for (auto workload : llvm::enumerate(workload)) {
+    workloadArgs.push_back(body->addArgument(workload.value().getType(), loc));
+  }
+  auto numWorkgroupsOp =
+      rewriter.create<DefaultWorkgroupCountOp>(loc, workloadArgs);
+  rewriter.create<ReturnOp>(loc, numWorkgroupsOp.getResults());
+
+  LLVM_DEBUG(llvm::dbgs() << "After workgroup_count creation \n"
+                          << *dispatchOp << "\n");
+
   LLVM_DEBUG(llvm::dbgs() << "Created dispatchOp shell \n"
                           << *dispatchOp << "\n");
   return clonedOps;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -413,7 +413,7 @@ buildOperandLessFlowDispatchWorkgroupOp(PatternRewriter &rewriter, Location loc,
     workloadArgs.push_back(body->addArgument(workload.value().getType(), loc));
   }
   auto numWorkgroupsOp =
-      rewriter.create<DefaultWorkgroupCountOp>(loc, workloadArgs);
+      rewriter.create<DispatchDefaultWorkgroupCountOp>(loc, workloadArgs);
   rewriter.create<ReturnOp>(loc, numWorkgroupsOp.getResults());
 
   LLVM_DEBUG(llvm::dbgs() << "After workgroup_count creation \n"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -187,7 +187,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(IREE::Flow::createConvertConv2D1x1ToMatmulPass)
       .addPredicatedPass(clEnableConvToImg2Col,
                          IREE::Flow::createConvertConv2DToImg2ColPass)
-      .addPass(IREE::Flow::createDetachElementwiseFromNamedOpsPass)
+      .addPredicatedPass(clDispatchTransformFileName.empty(),
+                         IREE::Flow::createDetachElementwiseFromNamedOpsPass)
       // Input should now be legal.
       .addPass(IREE::Flow::createVerifyInputLegalityPass)
       // Catch matmul ops before we do anything else with them.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transformation_pipeline.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transformation_pipeline.mlir
@@ -16,8 +16,10 @@ func.func @elementwiseOps(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
 }
 
 // CHECK-LABEL: flow.executable private @elementwiseOps_dispatch_0 {
-//  CHECK-NEXT:   flow.executable.export public @elementwiseOps_dispatch_0
-//  CHECK-NEXT:   module {
+//  CHECK-NEXT:   flow.executable.export public @elementwiseOps_dispatch_0 workgroups(%[[ARG0:.+]]: index) -> (index, index, index) {
+//       CHECK:     %x, %y, %z = flow.dispatch.default_workgroup_count %[[ARG0]]
+//       CHECK:     flow.return %x, %y, %z
+//       CHECK:   module {
 //  CHECK-NEXT:     func.func @elementwiseOps_dispatch_0(%arg0: !flow.dispatch.tensor<readonly:4xf32>, %arg1: !flow.dispatch.tensor<writeonly:4xf32>) {
 //       CHECK:       %{{.+}} = linalg.generic
 //       CHECK:         %{{.+}} = arith.addf %{{.+}}, %{{.+}} : f32

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -113,7 +113,7 @@ func.func @cmdExecute(%arg0: !stream.resource<transient>, %arg1: index, %arg2: !
 ]>
 hal.executable private @ex {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-    hal.executable.export public @dispatch ordinal(0) layout(#executable_layout) {
+    hal.executable.export public @dispatch ordinal(0) layout(#executable_layout) attributes {
       translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
     } {
     ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -705,7 +705,7 @@ ParseResult ExecutableExportOp::parse(OpAsmParser &parser,
   if (failed(parser.parseKeyword("layout")) || failed(parser.parseLParen()) ||
       failed(parser.parseAttribute(layoutAttr)) ||
       failed(parser.parseRParen()) ||
-      failed(parser.parseOptionalAttrDict(result.attributes))) {
+      failed(parser.parseOptionalAttrDictWithKeyword(result.attributes))) {
     return failure();
   }
   result.addAttribute("layout", layoutAttr);
@@ -733,8 +733,9 @@ void ExecutableExportOp::print(OpAsmPrinter &p) {
   p << " layout(";
   p.printAttribute(layout());
   p << ")";
-  p.printOptionalAttrDict(op->getAttrs(),
-                          /*elidedAttrs=*/{"sym_name", "layout", "ordinal"});
+  p.printOptionalAttrDictWithKeyword(
+      op->getAttrs(),
+      /*elidedAttrs=*/{"sym_name", "layout", "ordinal"});
   if (workgroup_count().empty()) return;
   p << " ";
   p.printRegion(workgroup_count());

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/executable_ops.mlir
@@ -5,14 +5,14 @@
 hal.executable @ex {
   // CHECK: hal.executable.variant public @backend, target = #executable_target_format
   hal.executable.variant @backend, target = #executable_target_format {
-    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#executable_layout) {
+    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#executable_layout) attributes {
     // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
     hal.executable.export @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>
       ]>
-    ]>) {
+    ]>) attributes {
       workgroup_size = [4 : index, 1 : index, 1 : index]
     }
   }
@@ -33,14 +33,14 @@ hal.executable @ex {
 hal.executable @ex_with_workgroup_count_region {
   // CHECK: hal.executable.variant public @backend, target = #executable_target_format
   hal.executable.variant @backend, target = #executable_target_format {
-    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#executable_layout) {
+    // CHECK-DAG: hal.executable.export public @entry0 ordinal(0) layout(#executable_layout) attributes {
     // CHECK-SAME:     workgroup_size = [4 : index, 1 : index, 1 : index]
     hal.executable.export @entry0 ordinal(0) layout(#hal.executable.layout<push_constants = 0, sets = [
       #hal.descriptor_set.layout<0, bindings = [
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>
       ]>
-    ]>) {
+    ]>) attributes {
       workgroup_size = [4 : index, 1 : index, 1 : index]
     } {
     ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
@@ -14,7 +14,10 @@ module attributes {
 } {
 
 stream.executable public @add_dispatch_0 {
-  stream.executable.export @add_dispatch_0
+  stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module  {
     func.func @add_dispatch_0(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding, %arg2_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
@@ -13,7 +13,7 @@ module attributes {
 
 stream.executable public @add_dispatch_0 {
   stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module  {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
@@ -12,7 +12,10 @@ module attributes {
 } {
 
 stream.executable public @add_dispatch_0 {
-  stream.executable.export @add_dispatch_0
+  stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module  {
     func.func @add_dispatch_0(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding, %arg2_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
@@ -14,7 +14,10 @@ module attributes {
 } {
 
 stream.executable public @add_dispatch_0 {
-  stream.executable.export @add_dispatch_0
+  stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module  {
     func.func @add_dispatch_0(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding, %arg2_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
@@ -15,7 +15,7 @@ module attributes {
 
 stream.executable public @add_dispatch_0 {
   stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module  {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/test/smoketest.mlir
@@ -14,7 +14,7 @@ module attributes {
 
 stream.executable public @reduce_dispatch {
   stream.executable.export @reduce_dispatch workgroups(%arg0 : index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/test/smoketest.mlir
@@ -13,7 +13,10 @@ module attributes {
 } {
 
 stream.executable public @reduce_dispatch {
-  stream.executable.export @reduce_dispatch
+  stream.executable.export @reduce_dispatch workgroups(%arg0 : index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @reduce_dispatch(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/test/smoketest.mlir
@@ -12,7 +12,7 @@ module attributes {
 
 stream.executable public @add_dispatch_0 {
   stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module  {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/test/smoketest.mlir
@@ -11,7 +11,10 @@ module attributes {
 } {
 
 stream.executable public @add_dispatch_0 {
-  stream.executable.export @add_dispatch_0
+  stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module  {
     func.func @add_dispatch_0(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding, %arg2_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/linking.mlir
@@ -10,7 +10,11 @@
 
 hal.executable private @dispatch_0 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.export @dispatch_0 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_0 ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       vm.module @module {
         vm.func @dispatch_0() {
@@ -23,7 +27,11 @@ hal.executable private @dispatch_0 {
 }
 hal.executable private @dispatch_1 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.export @dispatch_1 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_1 ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       vm.module @module {
         vm.func @dispatch_1() {
@@ -36,7 +44,11 @@ hal.executable private @dispatch_1 {
 }
 hal.executable private @dispatch_2 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.export @dispatch_2 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_2 ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       vm.module @module {
         vm.func @dispatch_2() {
@@ -121,7 +133,11 @@ util.initializer {
 
 hal.executable private @dispatch_0 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.export @dispatch_0 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_0 ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       vm.module @module {
         vm.rodata public @rodata_a dense<[0]> : tensor<1xi32>
@@ -145,7 +161,11 @@ hal.executable private @dispatch_0 {
 }
 hal.executable private @dispatch_1 {
   hal.executable.variant @vmvx, target = #vmvx_target {
-    hal.executable.export @dispatch_1 ordinal(0) layout(#executable_layout)
+    hal.executable.export @dispatch_1 ordinal(0) layout(#executable_layout) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       vm.module @module {
         // Conflict with a public symbol, this should be renamed when linked.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -12,7 +12,7 @@ module attributes {
 
 stream.executable public @add_dispatch_0 {
   stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module  {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/smoketest.mlir
@@ -11,7 +11,10 @@ module attributes {
 } {
 
 stream.executable public @add_dispatch_0 {
-  stream.executable.export @add_dispatch_0
+  stream.executable.export @add_dispatch_0 workgroups(%arg0 : index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module  {
     func.func @add_dispatch_0(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding, %arg2_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/linking.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/linking.mlir
@@ -22,7 +22,11 @@
 
 hal.executable private @call_dispatch_0  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.export @call_dispatch_0 ordinal(0) layout(#executable_layout_0)
+    hal.executable.export @call_dispatch_0 ordinal(0) layout(#executable_layout_0) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_0() "None" {
@@ -36,7 +40,11 @@ hal.executable private @call_dispatch_0  {
 }
 hal.executable private @call_dispatch_1  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.export @call_dispatch_1 ordinal(0) layout(#executable_layout_1)
+    hal.executable.export @call_dispatch_1 ordinal(0) layout(#executable_layout_1) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_1() "None" {
@@ -50,7 +58,11 @@ hal.executable private @call_dispatch_1  {
 }
 hal.executable private @call_dispatch_2  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.export @call_dispatch_2 ordinal(0) layout(#executable_layout_0)
+    hal.executable.export @call_dispatch_2 ordinal(0) layout(#executable_layout_0) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_2() "None" {
@@ -64,7 +76,11 @@ hal.executable private @call_dispatch_2  {
 }
 hal.executable private @call_dispatch_3  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.export @call_dispatch_3 ordinal(0) layout(#executable_layout_1)
+    hal.executable.export @call_dispatch_3 ordinal(0) layout(#executable_layout_1) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_3() "None" {
@@ -78,7 +94,11 @@ hal.executable private @call_dispatch_3  {
 }
 hal.executable private @call_dispatch_4  {
   hal.executable.variant @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
-    hal.executable.export @call_dispatch_4 ordinal(0) layout(#executable_layout_1)
+    hal.executable.export @call_dispatch_4 ordinal(0) layout(#executable_layout_1) {
+    ^bb0(%arg0: !hal.device) :
+      %c1 = arith.constant 1 : index
+      hal.return %c1, %c1, %c1 : index, index, index
+    }
     builtin.module {
       spv.module Logical GLSL450 requires #spv.vce<v1.0, [Shader], [SPV_KHR_storage_buffer_storage_class]> {
         spv.func @call_dispatch_4() "None" {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest.mlir
@@ -14,7 +14,7 @@ module attributes {
 
 stream.executable public @reduce_dispatch {
   stream.executable.export @reduce_dispatch workgroups(%arg0 : index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/smoketest.mlir
@@ -13,7 +13,10 @@ module attributes {
 } {
 
 stream.executable public @reduce_dispatch {
-  stream.executable.export @reduce_dispatch
+  stream.executable.export @reduce_dispatch workgroups(%arg0 : index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @reduce_dispatch(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -20,7 +20,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK: hal.executable private @ex
   hal.executable private @ex {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.export public @dispatch ordinal(0) layout(#executable_layout) {
+      hal.executable.export public @dispatch ordinal(0) layout(#executable_layout) attributes {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -27,7 +27,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK: hal.executable private @ex0
   hal.executable private @ex0 {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.export public @dispatch0 ordinal(0) layout(#executable_layout_0) {
+      hal.executable.export public @dispatch0 ordinal(0) layout(#executable_layout_0) attributes {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):
@@ -41,7 +41,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
         }
       }
 
-      hal.executable.export public @dispatch1 ordinal(1) layout(#executable_layout_1) {
+      hal.executable.export public @dispatch1 ordinal(1) layout(#executable_layout_1) attributes {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
@@ -22,7 +22,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
     // We expect local outputs with attributes inlined:
     // CHECK-NEXT: hal.executable.variant {{.+}}, target = <"llvm"
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.export public @dispatch0 ordinal(0) layout(#executable_layout) {
+      hal.executable.export public @dispatch0 ordinal(0) layout(#executable_layout) attributes {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors
@@ -41,7 +41,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK: hal.executable private @ex1
   hal.executable private @ex1 {
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
-      hal.executable.export public @dispatch1 ordinal(0) layout(#executable_layout) {
+      hal.executable.export public @dispatch1 ordinal(0) layout(#executable_layout) attributes {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>
       } {
       ^bb0(%device: !hal.device, %arg0: index, %arg1: index, %arg2: index):  // no predecessors

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -122,13 +122,13 @@ module attributes {hal.device.targets = [#hal.device.target<"cpu">]} {
 //   - If there is no matching hal.executable.variant then the executable will not be cached
 hal.executable @exe {
   hal.executable.variant @vmvx, target = <"vmvx", "vmvx-bytecode-fb"> {
-    hal.executable.export @entry0 ordinal(0) layout(#executable_layout_0) {
+    hal.executable.export @entry0 ordinal(0) layout(#executable_layout_0) attributes {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
-    hal.executable.export @entry0_alias ordinal(0) layout(#executable_layout_0) {
+    hal.executable.export @entry0_alias ordinal(0) layout(#executable_layout_0) attributes {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
-    hal.executable.export @entry1 ordinal(1) layout(#executable_layout_1) {
+    hal.executable.export @entry1 ordinal(1) layout(#executable_layout_1) attributes {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/resolve_export_ordinals.mlir
@@ -7,7 +7,7 @@ hal.executable @exe {
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>
       ]>
-    ]>) {
+    ]>) attributes {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
   }
@@ -62,7 +62,7 @@ hal.executable @exe {
         #hal.descriptor_set.binding<0, storage_buffer>,
         #hal.descriptor_set.binding<1, storage_buffer>
       ]>
-    ]>) {
+    ]>) attributes {
       workgroup_size = [32 : index, 1 : index, 1 : index]
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Builtins/fill_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Builtins/fill_i64.mlir
@@ -9,7 +9,7 @@
 
 stream.executable private @__builtin_fill_i64 {
   stream.executable.export public @__builtin_fill_i64 workgroups(%arg0: index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/compiler/src/iree/compiler/Dialect/Stream/Builtins/fill_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Builtins/fill_i64.mlir
@@ -8,7 +8,10 @@
 // Writes the i64 %value %count times at byte %offset of %out_binding.
 
 stream.executable private @__builtin_fill_i64 {
-  stream.executable.export public @__builtin_fill_i64
+  stream.executable.export public @__builtin_fill_i64 workgroups(%arg0: index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @__builtin_fill_i64(%value: i64, %offset: index, %count: index, %out_binding: !stream.binding) {
       %out = stream.binding.subspan %out_binding[%offset] : !stream.binding -> !flow.dispatch.tensor<writeonly:?xi64>{%count}

--- a/compiler/src/iree/compiler/Dialect/Stream/Builtins/splat_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Builtins/splat_i64.mlir
@@ -8,7 +8,10 @@
 // Writes the i64 %value %count times at offset 0 of %out_binding.
 
 stream.executable private @__builtin_splat_i64 {
-  stream.executable.export public @__builtin_splat_i64
+  stream.executable.export public @__builtin_splat_i64 workgroups(%arg0: index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @__builtin_splat_i64(%value: i64, %count: index, %out_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/Stream/Builtins/splat_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Builtins/splat_i64.mlir
@@ -9,7 +9,7 @@
 
 stream.executable private @__builtin_splat_i64 {
   stream.executable.export public @__builtin_splat_i64 workgroups(%arg0: index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -1107,12 +1107,7 @@ LogicalResult BuiltinSplatI64Op::convertBuiltinOp(OpBuilder &builder) {
   auto c8 = builder.createOrFold<arith::ConstantIndexOp>(getLoc(), 8);
   auto count =
       builder.createOrFold<arith::DivUIOp>(getLoc(), result_size(), c8);
-  auto one = builder.create<arith::ConstantIndexOp>(getLoc(), 1);
-  Value workload[3] = {
-      count,
-      one,
-      one,
-  };
+  Value workload[] = {count};
   SmallVector<Value> operands = {
       value(),
       count,
@@ -1173,12 +1168,7 @@ LogicalResult BuiltinFillI64Op::convertBuiltinOp(OpBuilder &builder) {
   auto c8 = builder.createOrFold<arith::ConstantIndexOp>(getLoc(), 8);
   auto count =
       builder.createOrFold<arith::DivUIOp>(getLoc(), target_length(), c8);
-  auto one = builder.create<arith::ConstantIndexOp>(getLoc(), 1);
-  Value workload[3] = {
-      count,
-      one,
-      one,
-  };
+  Value workload[] = {count};
   SmallVector<Value> operands = {
       target(),
       value(),

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_builtins.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/materialize_builtins.mlir
@@ -7,7 +7,7 @@
 // CHECK-LABEL: @builtinSplatI64
 func.func @builtinSplatI64(%arg0: index, %arg1: i64) -> !stream.resource<*> {
   // CHECK: %[[COUNT:.+]] = arith.divui %arg0, %c8
-  // CHECK: %[[RET:.+]] = stream.async.dispatch @__builtin_splat_i64::@__builtin_splat_i64[%[[COUNT]], %c1, %c1](%arg1, %[[COUNT]]) : (i64, index) -> !stream.resource<*>{%arg0}
+  // CHECK: %[[RET:.+]] = stream.async.dispatch @__builtin_splat_i64::@__builtin_splat_i64[%[[COUNT]]](%arg1, %[[COUNT]]) : (i64, index) -> !stream.resource<*>{%arg0}
   %0 = stream.builtin.splat.i64 %arg1 : i64 -> !stream.resource<*>{%arg0}
   // CHECK: return %[[RET]]
   return %0 : !stream.resource<*>
@@ -23,7 +23,7 @@ func.func @builtinSplatI64(%arg0: index, %arg1: i64) -> !stream.resource<*> {
 // CHECK-SAME: (%[[RES:.+]]: !stream.resource<*>, %[[SIZE:.+]]: index, %[[VALUE:.+]]: i64, %[[BYTE_OFFSET:.+]]: index, %[[BYTE_LENGTH:.+]]: index)
 func.func @builtinFillI64(%res: !stream.resource<*>, %size: index, %value: i64, %byte_offset: index, %byte_length: index) -> !stream.resource<*> {
   // CHECK: %[[COUNT:.+]] = arith.divui %[[BYTE_LENGTH]], %c8
-  // CHECK: %[[RET:.+]] = stream.async.dispatch @__builtin_fill_i64::@__builtin_fill_i64[%[[COUNT]], %c1, %c1](%[[RES]], %[[VALUE]], %[[BYTE_OFFSET]], %[[COUNT]]) : (!stream.resource<*>{%[[SIZE]]}, i64, index, index) -> %[[RES]]{%[[SIZE]]}
+  // CHECK: %[[RET:.+]] = stream.async.dispatch @__builtin_fill_i64::@__builtin_fill_i64[%[[COUNT]]](%[[RES]], %[[VALUE]], %[[BYTE_OFFSET]], %[[COUNT]]) : (!stream.resource<*>{%[[SIZE]]}, i64, index, index) -> %[[RES]]{%[[SIZE]]}
   %0 = stream.builtin.fill.i64 %value, %res[%byte_offset to %byte_length for %byte_length] : i64 -> %arg0 as !stream.resource<*>{%size}
   // CHECK: return %[[RET]]
   return %0 : !stream.resource<*>

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
@@ -18,7 +18,10 @@
 
 
 stream.executable public @reduce_dispatch {
-  stream.executable.export @reduce_dispatch
+  stream.executable.export @reduce_dispatch workgroups(%arg0: index) -> (index, index, index) {
+    %x, %y, %z = flow.default_workgroup_count %arg0
+    stream.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @reduce_dispatch(%arg0_binding: !stream.binding, %arg1_binding: !stream.binding) {
       %c0 = arith.constant 0 : index

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
@@ -19,7 +19,7 @@
 
 stream.executable public @reduce_dispatch {
   stream.executable.export @reduce_dispatch workgroups(%arg0: index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
@@ -13,8 +13,11 @@
 ]>
 
 hal.executable.source public @executable {
-  hal.executable.export public @abs layout(#executable_layout)
-
+  hal.executable.export public @abs layout(#executable_layout) {
+  ^bb0(%arg0: !hal.device):
+    %x, %y, %z = flow.default_workgroup_count
+    hal.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @abs() {
       %c0 = arith.constant 0 : index

--- a/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/command_buffer_dispatch_test.mlir
@@ -15,7 +15,7 @@
 hal.executable.source public @executable {
   hal.executable.export public @abs layout(#executable_layout) {
   ^bb0(%arg0: !hal.device):
-    %x, %y, %z = flow.default_workgroup_count
+    %x, %y, %z = flow.dispatch.default_workgroup_count
     hal.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
@@ -13,8 +13,11 @@
 ]>
 
 hal.executable.source public @executable {
-  hal.executable.export public @abs layout(#executable_layout)
-
+  hal.executable.export public @abs layout(#executable_layout) {
+  ^bb0(%arg0: !hal.device):
+    %x, %y, %z = flow.default_workgroup_count
+    hal.return %x, %y, %z : index, index, index
+  }
   builtin.module {
     func.func @abs() {
       %c0 = arith.constant 0 : index

--- a/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
+++ b/runtime/src/iree/hal/cts/testdata/executable_cache_test.mlir
@@ -15,7 +15,7 @@
 hal.executable.source public @executable {
   hal.executable.export public @abs layout(#executable_layout) {
   ^bb0(%arg0: !hal.device):
-    %x, %y, %z = flow.default_workgroup_count
+    %x, %y, %z = flow.dispatch.default_workgroup_count
     hal.return %x, %y, %z : index, index, index
   }
   builtin.module {

--- a/tests/compiler_driver/streams.mlir
+++ b/tests/compiler_driver/streams.mlir
@@ -29,7 +29,7 @@ module @e2e {
 // CHECK: vm.rodata private @executable_0_vmvx_bytecode_fb
 stream.executable private @executable_0 {
   stream.executable.export public @dispatch workgroups(%arg0: index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {
@@ -77,7 +77,7 @@ module @inplace {
 // CHECK: vm.rodata private @executable_1_vmvx_bytecode_fb
 stream.executable private @executable_1 {
   stream.executable.export public @dispatch workgroups(%arg0: index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {
@@ -126,7 +126,7 @@ module @dynamic {
 // CHECK: vm.rodata private @executable_2_vmvx_bytecode_fb
 stream.executable private @executable_2 {
   stream.executable.export public @dispatch workgroups(%arg0: index) -> (index, index, index) {
-    %x, %y, %z = flow.default_workgroup_count %arg0
+    %x, %y, %z = flow.dispatch.default_workgroup_count %arg0
     stream.return %x, %y, %z : index, index, index
   }
   builtin.module {


### PR DESCRIPTION
This commit adds an operation `flow.default_workgroup_count` that
captures the relationship between the workload and workgroup_count at
the Flow level. This is populated now at the Flow level and carried
through to the HAL layer. There the backends lower this operation to
the actual computation that returns the workgroup count.

There could be many such ops. The current operation is just reflacting
the computation that is done today in the backend. In future more such
operations and corresponding lowerings in the backends could be added.

With this change, the backend expects the `workgroup_count` region to
be populated always.