### PR TITLE
[LLVMGPU] Support more cases in warp reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -470,9 +470,10 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
     return failure();
   if (op.getRegionOutputArgs().size() != 1) return failure();
 
-  // Disallow transposition for now, to be enabled.
+  // Only support projected permutation, this could be extended to projected
+  // permutated with broadcast.
   if (llvm::any_of(op.getInputOperands(), [&](OpOperand *input) {
-        return !op.getTiedIndexingMap(input).isMinorIdentity();
+        return !op.getTiedIndexingMap(input).isProjectedPermutation();
       }))
     return failure();
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
@@ -83,8 +83,10 @@ static void populateVectorUnrollPatterns(RewritePatternSet &patterns,
 namespace {
 struct LLVMGPUVectorizationPass
     : public LLVMGPUVectorizationBase<LLVMGPUVectorizationPass> {
-  LLVMGPUVectorizationPass(int64_t nativeVector, bool generateContract)
-      : nativeVector(nativeVector), generateContract(generateContract) {}
+  LLVMGPUVectorizationPass(int64_t nativeVector, bool generateContract) {
+    this->nativeVector = nativeVector;
+    this->generateContract = generateContract;
+  }
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<vector::VectorDialect>();
   }
@@ -163,11 +165,6 @@ struct LLVMGPUVectorizationPass
       });
     }
   }
-
- private:
-  int64_t nativeVector;
-  // Try to convert reduction to contraction op.
-  bool generateContract;
 };
 }  // namespace
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -200,7 +200,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
   const int64_t nativeVector = 32;
   // Linalg -> vector
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createLLVMGPUVectorizationPass(nativeVector));
+      createLLVMGPUVectorizationPass(nativeVector, /*generateContract=*/false));
   nestedModulePM.addNestedPass<func::FuncOp>(
       createLoopInvariantCodeMotionPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -370,8 +370,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 
 //   CHECK-LABEL: hal.executable public @vector_reduction_dispatch
 //         CHECK:   hal.executable.variant public @cuda
-//         CHECK:   llvm.fadd %{{.*}}, %{{.*}} : vector<4xf32>
-//         CHECK:   llvm.store %{{.*}} : !llvm.ptr<vector<4xf32>>
+// CHECK-COUNT-5:     nvvm.shfl.sync  bfly
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -341,7 +341,7 @@ createLLVMGPULowerExecutableTargetPass();
 
 /// Convert Linalg ops to Vector.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorizationPass(
-    int64_t nativeVector = 4);
+    int64_t nativeVector = 4, bool generateContract = true);
 
 /// Convert Linalg ops to Vector and prepare converstion to GPU MMA ops.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -288,6 +288,14 @@ def LLVMGPUVectorization :
     Pass<"iree-llvmgpu-vectorization", "func::FuncOp"> {
   let summary = "Pass to convert linalg into Vector.";
   let constructor = "mlir::iree_compiler::createLLVMGPUVectorizationPass()";
+  let options = [
+    Option<"nativeVector", "native-vector", "int64_t",
+            /*default=*/"4",
+           "Pick the native size being targeted.">,
+    Option<"generateContract", "generate-contract", "bool",
+            /*default=*/"true",
+           "Try to convert reduction to vector.contract.">,
+  ];
 }
 
 def LLVMGPUTensorCoreVectorization :


### PR DESCRIPTION
Allow more broadcast and transpose support for warp reduction. Note that
the memory access patterns for transpose case may not be optimal but it
is still faster than serializing the reduction.