### PR TITLE
Adding extern C around embedded data toc impl.

### DIFF
--- a/build_tools/embed_data/generate_embed_data_main.cc
+++ b/build_tools/embed_data/generate_embed_data_main.cc
@@ -179,9 +179,11 @@ static bool GenerateImpl(const std::string& identifier,
   }
   f << "  {NULL, NULL, 0},\n";
   f << "};\n";
+  GenerateExternCOpen(f);
   f << "const struct iree_file_toc_t* " << identifier << "_create() {\n";
   f << "  return &toc[0];\n";
   f << "}\n";
+  GenerateExternCClose(f);
   f.close();
   return f.good();
 }


### PR DESCRIPTION
If the compiler is misconfigured to compile the .c file as C++ this will
ensure the symbol name matches the declaration in the header.

Fixes #7327.