### PR TITLE
Add support for lowering memref.alloca to VM dialect.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
@@ -118,6 +118,8 @@ class ConvertMemRefGetGlobalOp
   }
 };
 
+// TODO(#9165): Support alignment for vm.buffer.alloc. So far we ignore the
+// alignment attribute when lowering the op to VM dialect.
 class ConvertMemRefAllocaOp : public OpConversionPattern<memref::AllocaOp> {
  public:
   using OpConversionPattern::OpConversionPattern;

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
@@ -139,7 +139,7 @@ class ConvertMemRefAllocaOp : public OpConversionPattern<memref::AllocaOp> {
     auto oldType = allocaOp.getType();
     auto newType = getTypeConverter()->convertType(oldType);
     Value size =
-        rewriter.create<IREE::VM::ConstI32Op>(allocaOp.getLoc(), length);
+        rewriter.create<IREE::VM::ConstI64Op>(allocaOp.getLoc(), length);
     rewriter.replaceOpWithNewOp<IREE::VM::BufferAllocOp>(allocaOp, newType,
                                                          size);
     return success();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
@@ -132,10 +132,6 @@ class ConvertMemRefAllocaOp : public OpConversionPattern<memref::AllocaOp> {
     }
 
     int64_t length = type.getSizeInBits();
-    if (adaptor.alignment()) {
-      int64_t alignmentInBits = *adaptor.alignment() * 8;
-      length = llvm::divideCeil(length, alignmentInBits) * alignmentInBits;
-    }
     length = llvm::divideCeil(length, 8);
 
     auto oldType = allocaOp.getType();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/ConvertMemRefToVM.cpp
@@ -128,7 +128,7 @@ class ConvertMemRefAllocaOp : public OpConversionPattern<memref::AllocaOp> {
     auto type = allocaOp.getType().cast<ShapedType>();
     if (!type.hasStaticShape()) {
       return rewriter.notifyMatchFailure(
-          "unable to create buffers for dynamic shapes");
+          allocaOp, "unable to create buffers for dynamic shapes");
     }
 
     int64_t length = type.getSizeInBits();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/BUILD
@@ -17,7 +17,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
-            "load_store_ops.mlir",
+            "memref_ops.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/CMakeLists.txt
@@ -14,7 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
-    "load_store_ops.mlir"
+    "memref_ops.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/memref_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/memref_ops.mlir
@@ -3,8 +3,8 @@
 module {
   // CHECK-LABEL: vm.func private @alloca() -> !vm.buffer
   func.func @alloca() -> memref<16xi32> {
-    // CHECK: %[[LEN:.+]] = vm.const.i32 64
-    // CHECK: %[[BUF:.+]] = vm.buffer.alloc %[[LEN]] : !vm.buffer
+    // CHECK: %[[LEN_64:.+]] = vm.const.i64 64
+    // CHECK: %[[BUF:.+]] = vm.buffer.alloc %[[LEN_64]] : !vm.buffer
     // return %[[BUF]]
     %0 = memref.alloca() : memref<16xi32>
     return %0 : memref<16xi32>

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/memref_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MemRefToVM/test/memref_ops.mlir
@@ -1,6 +1,19 @@
 // RUN: iree-opt --split-input-file --iree-vm-conversion %s | FileCheck %s
 
 module {
+  // CHECK-LABEL: vm.func private @alloca() -> !vm.buffer
+  func.func @alloca() -> memref<16xi32> {
+    // CHECK: %[[LEN:.+]] = vm.const.i32 64
+    // CHECK: %[[BUF:.+]] = vm.buffer.alloc %[[LEN]] : !vm.buffer
+    // return %[[BUF]]
+    %0 = memref.alloca() : memref<16xi32>
+    return %0 : memref<16xi32>
+  }
+}
+
+// -----
+
+module {
   // CHECK-LABEL: vm.func private @load_store
   // CHECK-SAME: (%[[BUFFER:.+]]: !vm.buffer, %[[IDX0:.+]]: i32, %[[IDX1:.+]]: i32) -> f32 {
   func.func @load_store(%buffer: memref<?xf32>, %idx0: index, %idx1: index) -> f32 {


### PR DESCRIPTION
Rebasing #9163 and updating to 64-bit VM sizes.

Fixes #9155.