### PR TITLE
Fix setting IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED

### DIFF
--- a/runtime/src/iree/base/target_platform.h
+++ b/runtime/src/iree/base/target_platform.h
@@ -163,10 +163,9 @@ static_assert(sizeof(void*) == sizeof(uintptr_t),
 // every load/store.
 #define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 1
 
-#endif  // IREE_ARCH_*
-
 #else
 #define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 0
+#endif  // IREE_ARCH_*
 #endif  // !IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED
 
 //==============================================================================


### PR DESCRIPTION
Even if `IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED` was defined it was
always set to 0. However, it is only valid to set it to 0 if
`IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED` isn't defined.

Makes progress on #9593 and allows to control the alignment behavior
via `IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED` instead of being
forced to pass `-mno-unaligned-access`.