### PR TITLE
Split the alignment flag for 64-bit types

### DIFF
--- a/runtime/src/iree/base/alignment.h
+++ b/runtime/src/iree/base/alignment.h
@@ -117,26 +117,9 @@ static inline uint32_t iree_unaligned_load_le_u32(const uint32_t* ptr) {
          ((uint32_t)p[IREE_LE_IDX_4(2)] << 16) |
          ((uint32_t)p[IREE_LE_IDX_4(3)] << 24);
 }
-static inline uint64_t iree_unaligned_load_le_u64(const uint64_t* ptr) {
-  const uint8_t* p = (const uint8_t*)ptr;
-  return ((uint64_t)p[IREE_LE_IDX_8(0)]) |
-         ((uint64_t)p[IREE_LE_IDX_8(1)] << 8) |
-         ((uint64_t)p[IREE_LE_IDX_8(2)] << 16) |
-         ((uint64_t)p[IREE_LE_IDX_8(3)] << 24) |
-         ((uint64_t)p[IREE_LE_IDX_8(4)] << 32) |
-         ((uint64_t)p[IREE_LE_IDX_8(5)] << 40) |
-         ((uint64_t)p[IREE_LE_IDX_8(6)] << 48) |
-         ((uint64_t)p[IREE_LE_IDX_8(7)] << 56);
-}
 static inline float iree_unaligned_load_le_f32(const float* ptr) {
   uint32_t uint_value = iree_unaligned_load_le_u32((const uint32_t*)ptr);
   float value;
-  memcpy(&value, &uint_value, sizeof(value));
-  return value;
-}
-static inline double iree_unaligned_load_le_f64(const double* ptr) {
-  uint64_t uint_value = iree_unaligned_load_le_u64((const uint64_t*)ptr);
-  double value;
   memcpy(&value, &uint_value, sizeof(value));
   return value;
 }
@@ -156,6 +139,54 @@ static inline void iree_unaligned_store_le_u32(uint32_t* ptr, uint32_t value) {
   p[IREE_LE_IDX_4(2)] = value >> 16;
   p[IREE_LE_IDX_4(3)] = value >> 24;
 }
+static inline void iree_unaligned_store_le_f32(float* ptr, float value) {
+  uint32_t uint_value;
+  memcpy(&uint_value, &value, sizeof(value));
+  iree_unaligned_store_le_u32((uint32_t*)ptr, uint_value);
+}
+
+#else
+
+#if defined(IREE_ENDIANNESS_LITTLE)
+
+#define iree_unaligned_load_le_u8(ptr) *(ptr)
+#define iree_unaligned_load_le_u16(ptr) *(ptr)
+#define iree_unaligned_load_le_u32(ptr) *(ptr)
+#define iree_unaligned_load_le_f32(ptr) *(ptr)
+
+#define iree_unaligned_store_le_u8(ptr, value) *(ptr) = (value)
+#define iree_unaligned_store_le_u16(ptr, value) *(ptr) = (value)
+#define iree_unaligned_store_le_u32(ptr, value) *(ptr) = (value)
+#define iree_unaligned_store_le_f32(ptr, value) *(ptr) = (value)
+
+#else
+
+#error "TODO(benvanik): little-endian load/store for big-endian archs"
+
+#endif  // IREE_ENDIANNESS_*
+
+#endif  // IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED
+
+#if IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64
+
+static inline uint64_t iree_unaligned_load_le_u64(const uint64_t* ptr) {
+  const uint8_t* p = (const uint8_t*)ptr;
+  return ((uint64_t)p[IREE_LE_IDX_8(0)]) |
+         ((uint64_t)p[IREE_LE_IDX_8(1)] << 8) |
+         ((uint64_t)p[IREE_LE_IDX_8(2)] << 16) |
+         ((uint64_t)p[IREE_LE_IDX_8(3)] << 24) |
+         ((uint64_t)p[IREE_LE_IDX_8(4)] << 32) |
+         ((uint64_t)p[IREE_LE_IDX_8(5)] << 40) |
+         ((uint64_t)p[IREE_LE_IDX_8(6)] << 48) |
+         ((uint64_t)p[IREE_LE_IDX_8(7)] << 56);
+}
+static inline double iree_unaligned_load_le_f64(const double* ptr) {
+  uint64_t uint_value = iree_unaligned_load_le_u64((const uint64_t*)ptr);
+  double value;
+  memcpy(&value, &uint_value, sizeof(value));
+  return value;
+}
+
 static inline void iree_unaligned_store_le_u64(uint64_t* ptr, uint64_t value) {
   uint8_t* p = (uint8_t*)ptr;
   p[IREE_LE_IDX_8(0)] = value;
@@ -167,11 +198,6 @@ static inline void iree_unaligned_store_le_u64(uint64_t* ptr, uint64_t value) {
   p[IREE_LE_IDX_8(6)] = value >> 48;
   p[IREE_LE_IDX_8(7)] = value >> 56;
 }
-static inline void iree_unaligned_store_le_f32(float* ptr, float value) {
-  uint32_t uint_value;
-  memcpy(&uint_value, &value, sizeof(value));
-  iree_unaligned_store_le_u32((uint32_t*)ptr, uint_value);
-}
 static inline void iree_unaligned_store_le_f64(double* ptr, double value) {
   uint64_t uint_value;
   memcpy(&uint_value, &value, sizeof(value));
@@ -182,18 +208,10 @@ static inline void iree_unaligned_store_le_f64(double* ptr, double value) {
 
 #if defined(IREE_ENDIANNESS_LITTLE)
 
-#define iree_unaligned_load_le_u8(ptr) *(ptr)
-#define iree_unaligned_load_le_u16(ptr) *(ptr)
-#define iree_unaligned_load_le_u32(ptr) *(ptr)
 #define iree_unaligned_load_le_u64(ptr) *(ptr)
-#define iree_unaligned_load_le_f32(ptr) *(ptr)
 #define iree_unaligned_load_le_f64(ptr) *(ptr)
 
-#define iree_unaligned_store_le_u8(ptr, value) *(ptr) = (value)
-#define iree_unaligned_store_le_u16(ptr, value) *(ptr) = (value)
-#define iree_unaligned_store_le_u32(ptr, value) *(ptr) = (value)
 #define iree_unaligned_store_le_u64(ptr, value) *(ptr) = (value)
-#define iree_unaligned_store_le_f32(ptr, value) *(ptr) = (value)
 #define iree_unaligned_store_le_f64(ptr, value) *(ptr) = (value)
 
 #else
@@ -202,7 +220,7 @@ static inline void iree_unaligned_store_le_f64(double* ptr, double value) {
 
 #endif  // IREE_ENDIANNESS_*
 
-#endif  // IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED
+#endif  // IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64
 
 // clang-format off
 

--- a/runtime/src/iree/base/target_platform.h
+++ b/runtime/src/iree/base/target_platform.h
@@ -31,6 +31,7 @@
 // IREE_ENDIANNESS_BIG
 //
 // IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED (0/1)
+// IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64 (0/1)
 //
 // IREE_COMPILER_CLANG
 // IREE_COMPILER_GCC
@@ -155,6 +156,10 @@ static_assert(sizeof(void*) == sizeof(uintptr_t),
 #define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 0
 #endif  // !__ARM_FEATURE_UNALIGNED
 
+// Unaligned support is only available for singles on Armv7-M.
+// Therefore, aligned memory access is enforced for 64-bit data types.
+#define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64 1
+
 #elif defined(IREE_ARCH_RISCV_32) || defined(IREE_ARCH_RISCV_64)
 
 // Though unaligned access is part of the base spec it is allowed to be
@@ -168,6 +173,13 @@ static_assert(sizeof(void*) == sizeof(uintptr_t),
 #else
 #define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED 0
 #endif  // !IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED
+
+// Set IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64 to the value of
+// IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED if the former was not set before.
+#if !defined(IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64)
+#define IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64 \
+  IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED
+#endif  // !IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64
 
 //==============================================================================
 // IREE_COMPILER_*


### PR DESCRIPTION
Splits out the ops for 64-bit types from the
`IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED` flag and introduces a
`IREE_MEMORY_ACCESS_ALIGNMENT_REQUIRED_64` flag. The new flag is enabled
for Arm targets if the alignment requirements aren't specified by the
user. If the user specifies alignment requirements but doesn't
explicitly for 64-bit types, the new flag defaults to the general
alignment settings.

Fixes #9593.