### PR TITLE
Add ins/outs to ForeachThreadToFlowDispatchWorkgroupsOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -363,20 +363,12 @@ rewriteForeachThreadToFlowDispatchWorkgroups(
 // IREE-specific transformations defined outside of iree_linalg_transform.
 //===---------------------------------------------------------------------===//
 
-DiagnosedSilenceableFailure
-transform_dialect::ForeachThreadToFlowDispatchWorkgroupsOp::apply(
-    transform::TransformResults &results, transform::TransformState &state) {
-  if (state.getTopLevel()
-          ->walk<WalkOrder::PostOrder>([&](scf::ForeachThreadOp op) {
-            SimplePatternRewriter rewriter(op);
-            if (failed(
-                    rewriteForeachThreadToFlowDispatchWorkgroups(op, rewriter)))
-              return WalkResult::interrupt();
-            return WalkResult::advance();
-          })
-          .wasInterrupted())
-    return DiagnosedSilenceableFailure::definiteFailure();
-  return DiagnosedSilenceableFailure::success();
+FailureOr<Flow::DispatchWorkgroupsOp>
+transform_dialect::ForeachThreadToFlowDispatchWorkgroupsOp::applyToOne(
+    scf::ForeachThreadOp foreachThreadOp, transform::TransformState &state) {
+  SimplePatternRewriter rewriter(foreachThreadOp->getContext());
+  return rewriteForeachThreadToFlowDispatchWorkgroups(foreachThreadOp,
+                                                      rewriter);
 }
 
 #define GET_OP_CLASSES

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h
@@ -7,14 +7,29 @@
 #ifndef IREE_COMPILER_CODEGEN_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS_H_
 #define IREE_COMPILER_CODEGEN_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS_H_
 
+#include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
+
+namespace mlir {
+class DialectRegistry;
+
+namespace scf {
+class ForeachThreadOp;
+}  // namespace scf
+
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+class DispatchWorkgroupsOp;
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
 
 #define GET_OP_CLASSES
 #include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.h.inc"
 
 namespace mlir {
-class DialectRegistry;
-
 namespace iree_compiler {
 
 /// Registers Flow transformations that require IREE-specific information into

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_DIALECT_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS
 #define IREE_COMPILER_DIALECT_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS
 
+include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
@@ -15,14 +16,20 @@ include "mlir/IR/OpBase.td"
 def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreach_thread_to_flow",
     [FunctionalStyleTransformOpTrait, 
      MemoryEffectsOpInterface,
-     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+     TransformOpInterface,
+     TransformEachOpTrait]> {
   let description = [{Rewrite an scf.foreach_thread to Flow::DispatchWorkgroups.}];
 
-  let arguments = (ins);
-  let results = (outs);
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$transformed);
 
-  let assemblyFormat = "attr-dict";
+  let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::FailureOr<::mlir::iree_compiler::IREE::Flow::DispatchWorkgroupsOp> applyToOne(
+      ::mlir::scf::ForeachThreadOp foreachThreadOp, ::mlir::transform::TransformState &state);
+  }];
 }
  
 #endif // IREE_COMPILER_DIALECT_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
@@ -11,7 +11,7 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %0 = pdl_match @pdl_matmul_target in %arg1
-    %tiling_1_result:2 = tile_to_foreach_thread_op %0 {num_threads = [42, 67]}
-    transform.iree.foreach_thread_to_flow
+    %foreach_op, %tiled_op = tile_to_foreach_thread_op %0 {num_threads = [42, 67]}
+    %dispatch_op = transform.iree.foreach_thread_to_flow %foreach_op
   }
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
@@ -45,8 +45,8 @@ def TileToForeachOp :
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$num_threads,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$thread_dim_mapping);
-  let results = (outs PDL_Operation:$tiled_op,
-                      PDL_Operation:$tile_op);
+  let results = (outs PDL_Operation:$tile_op,
+                      PDL_Operation:$tiled_op);
 
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";

--- a/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
@@ -11,7 +11,7 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %0 = pdl_match @pdl_matmul_target in %arg1
-    %tiling_1_result:2 = tile_to_foreach_thread_op %0 {num_threads = [13, 33]}
-    transform.iree.foreach_thread_to_flow
+    %foreach_op, %tiled_op = tile_to_foreach_thread_op %0 {num_threads = [13, 33]}
+    %dispatch_op = transform.iree.foreach_thread_to_flow %foreach_op
   }
 }


### PR DESCRIPTION
Also fixes a bug in TileToForeachOp where the outs were returned in the
wrong order.