### PR TITLE
Consistently treat worker_*_masks as loose hints with relaxed accesses

### DIFF
--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -494,8 +494,9 @@ static iree_task_t* iree_task_executor_try_steal_task_from_affinity_set(
     iree_task_worker_t* victim_worker = &executor->workers[victim_index];
     if (iree_atomic_load_int32(&victim_worker->state,
                                iree_memory_order_seq_cst) !=
-        IREE_TASK_WORKER_STATE_RUNNING)
+        IREE_TASK_WORKER_STATE_RUNNING) {
       return NULL;
+    }
 
     // Policy: steal a chunk of tasks at the tail of the victim queue.
     // This will steal multiple tasks from the victim up to the specified max

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -155,7 +155,7 @@ iree_status_t iree_task_executor_create(
                                         iree_memory_order_relaxed);
     iree_atomic_task_affinity_set_store(&executor->worker_live_mask,
                                         worker_live_mask,
-                                        iree_memory_order_release);
+                                        iree_memory_order_relaxed);
   }
 
   if (!iree_status_is_ok(status)) {
@@ -492,6 +492,10 @@ static iree_task_t* iree_task_executor_try_steal_task_from_affinity_set(
     worker_index += offset + 1;
     mask = iree_shr(mask, offset + 1);
     iree_task_worker_t* victim_worker = &executor->workers[victim_index];
+    if (iree_atomic_load_int32(&victim_worker->state,
+                               iree_memory_order_seq_cst) !=
+        IREE_TASK_WORKER_STATE_RUNNING)
+      return NULL;
 
     // Policy: steal a chunk of tasks at the tail of the victim queue.
     // This will steal multiple tasks from the victim up to the specified max
@@ -532,7 +536,7 @@ iree_task_t* iree_task_executor_try_steal_task(
 
   iree_task_affinity_set_t worker_live_mask =
       iree_atomic_task_affinity_set_load(&executor->worker_live_mask,
-                                         iree_memory_order_acquire);
+                                         iree_memory_order_relaxed);
   iree_task_affinity_set_t worker_idle_mask =
       iree_atomic_task_affinity_set_load(&executor->worker_idle_mask,
                                          iree_memory_order_relaxed);

--- a/runtime/src/iree/task/post_batch.c
+++ b/runtime/src/iree/task/post_batch.c
@@ -36,7 +36,7 @@ static iree_host_size_t iree_task_post_batch_select_random_worker(
     iree_task_post_batch_t* post_batch, iree_task_affinity_set_t affinity_set) {
   iree_task_affinity_set_t worker_live_mask =
       iree_atomic_task_affinity_set_load(
-          &post_batch->executor->worker_live_mask, iree_memory_order_acquire);
+          &post_batch->executor->worker_live_mask, iree_memory_order_relaxed);
   iree_task_affinity_set_t valid_worker_mask = affinity_set & worker_live_mask;
   if (!valid_worker_mask) {
     // No valid workers as desired; for now just bail to worker 0.
@@ -106,7 +106,7 @@ static void iree_task_post_batch_wake_workers(
   iree_task_affinity_set_t resume_mask =
       iree_atomic_task_affinity_set_fetch_and(&executor->worker_suspend_mask,
                                               ~wake_mask,
-                                              iree_memory_order_acquire);
+                                              iree_memory_order_relaxed);
   resume_mask &= wake_mask;
   if (IREE_UNLIKELY(resume_mask)) {
     int resume_count = iree_task_affinity_set_count_ones(resume_mask);


### PR DESCRIPTION
This makes worker_*_mask accesses use memory_order_relaxed, making them be only fast and loose hints, and not play a role in ordering other accesses.

Some of these used to be relaxed until https://github.com/iree-org/iree/pull/8854 which made worker_live_mask use acquire/release to fix a specific race reported by TSan. This PR re-solves that in a different way: the missing ordering is now provided instead by an atomic access to worker->state.

Some accesses (in worker.c) were seq_cst even before https://github.com/iree-org/iree/pull/8854, so this new PR makes more things relaxed than were even back then.

This is part of a more general, consistent move towards this design:
* worker->state is the only memory-ordering, coherent view of workers'
  state.
* worker_*_mask is only fast and loose hints.

In https://github.com/iree-org/iree/pull/9560 I was questioning the need for those hints, but they really serve a purpose: for callers that favor performance over getting the most up-to-date information and that need to iterate over all workers, worker_*_mask allows to get that information in just 1 atomic load instead of N, and that atomic load is now relaxed.

The rationale in #9560 was "it's not sane to have two different atomics tracking overlapping state information, we'll never manage to keep that consistent". The resolution here is that they're really not two state atomics on an equal footing.  `worker->state` is the true state, while the masks become mere hints/approximations.