### PR TITLE
Fix shutdown deadlock

### DIFF
--- a/runtime/src/iree/task/poller.c
+++ b/runtime/src/iree/task/poller.c
@@ -418,13 +418,13 @@ static void iree_task_poller_wake_task(iree_task_poller_t* poller,
 // wait handles were resolved.
 static void iree_task_poller_commit_wait(iree_task_poller_t* poller,
                                          iree_time_t deadline_ns) {
-  IREE_TRACE_ZONE_BEGIN(z0);
-
   if (iree_atomic_load_int32(&poller->state, iree_memory_order_seq_cst) ==
       IREE_TASK_POLLER_STATE_EXITING) {
     // Thread exit requested - don't block shutdown.
     return;
   }
+
+  IREE_TRACE_ZONE_BEGIN(z0);
 
   // Enter the system wait API.
   iree_wait_handle_t wake_handle = iree_wait_handle_immediate();

--- a/runtime/src/iree/task/poller.c
+++ b/runtime/src/iree/task/poller.c
@@ -420,6 +420,12 @@ static void iree_task_poller_commit_wait(iree_task_poller_t* poller,
                                          iree_time_t deadline_ns) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  if (iree_atomic_load_int32(&poller->state, iree_memory_order_seq_cst) ==
+      IREE_TASK_POLLER_STATE_EXITING) {
+    // Thread exit requested - don't block shutdown.
+    return;
+  }
+
   // Enter the system wait API.
   iree_wait_handle_t wake_handle = iree_wait_handle_immediate();
   iree_status_t status =


### PR DESCRIPTION
The issue was that iree_task_poller_pump_until_exit only checked
for IREE_TASK_POLLER_STATE_EXITING at the beginning of each loop
iteration, then reset wake_event, then called
iree_task_poller_commit_wait.

Meanwhile, on the main thread, iree_task_poller_request_exit could
change state to IREE_TASK_POLLER_STATE_EXITING and set wake_event.

So in a race, iree_task_poller_pump_until_exit would reset the
wake_event set by iree_task_poller_request_exit, and that would leave
iree_task_poller_commit_wait waiting infinitely.

Fixes #9723