### PR TITLE
Add CUDA support to benchmark tools

### DIFF
--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -33,6 +33,7 @@ GPU_NAME_TO_TARGET_ARCH_MAP = {
     "adreno-730": "gpu-adreno",
     "mali-g77": "gpu-mali-valhall",
     "mali-g78": "gpu-mali-valhall",
+    "tesla-v100-sxm2-16gb": "gpu-cuda-sm_70",
     "unknown": "gpu-unknown",
 }
 
@@ -71,6 +72,8 @@ IREE_DRIVERS_INFOS = {
         DriverInfo("IREE-VMVX-Sync", "CPU", "local-sync", "vmvx-module"),
     "iree-vulkan":
         DriverInfo("IREE-Vulkan", "GPU", "vulkan", ""),
+    "iree-cuda":
+        DriverInfo("IREE-CUDA", "GPU", "cuda", ""),
 }
 
 IREE_PRETTY_NAME_TO_DRIVER_NAME = {

--- a/build_tools/benchmarks/common/linux_device_utils.py
+++ b/build_tools/benchmarks/common/linux_device_utils.py
@@ -13,38 +13,54 @@ from .benchmark_definition import (execute_cmd_and_get_output, DeviceInfo,
                                    PlatformType)
 
 
-def _get_lscpu_field(field_name: str, verbose: bool = False) -> str:
-  output = execute_cmd_and_get_output(["lscpu"], verbose)
-  (value,) = re.findall(f"^{field_name}:\s*(.+)", output, re.MULTILINE)
+def _get_lscpu_field(lscpu_output: str, field_name: str) -> str:
+  (value,) = re.findall(f"^{field_name}:\s*(.+)", lscpu_output, re.MULTILINE)
   return value
 
 
-def get_linux_cpu_arch(verbose: bool = False) -> str:
+def get_linux_cpu_arch(lscpu_output: str) -> str:
   """Returns CPU Architecture, e.g., 'x86_64'."""
-  return _get_lscpu_field("Architecture", verbose)
+  return _get_lscpu_field(lscpu_output, "Architecture")
 
 
-def get_linux_cpu_features(verbose: bool = False) -> Sequence[str]:
+def get_linux_cpu_features(lscpu_output: str) -> Sequence[str]:
   """Returns CPU feature lists, e.g., ['mmx', 'fxsr', 'sse', 'sse2']."""
-  return _get_lscpu_field("Flags", verbose).split(" ")
+  return _get_lscpu_field(lscpu_output, "Flags").split(" ")
+
+
+def canonicalize_gpu_name(gpu_name: str) -> str:
+  # Replace all consecutive non-word characters with a single hypen.
+  return re.sub(r"\W+", "-", gpu_name)
 
 
 def get_linux_device_info(device_model: str = "Unknown",
                           cpu_uarch: Optional[str] = None,
+                          gpu_id: str = "0",
                           verbose: bool = False) -> DeviceInfo:
   """Returns device info for the Linux device.
 
     Args:
     - device_model: the device model name, e.g., 'ThinkStation P520'
     - cpu_uarch: the CPU microarchitecture, e.g., 'CascadeLake'
+    - gpu_id: the target GPU ID, e.g., '0' or 'GPU-<UUID>'
   """
+  lscpu_output = execute_cmd_and_get_output(["lscpu"], verbose)
+
+  try:
+    gpu_name = execute_cmd_and_get_output([
+        "nvidia-smi", "--query-gpu=name", "--format=csv,noheader",
+        f"--id={gpu_id}"
+    ], verbose)
+  except FileNotFoundError:
+    # Set GPU name to Unknown if the tool "nvidia-smi" doesn't exist.
+    gpu_name = "Unknown"
+
   return DeviceInfo(
       PlatformType.LINUX,
       # Includes CPU model as it is the key factor of the device performance.
       model=device_model,
       # Currently we only have x86, so CPU ABI = CPU arch.
-      cpu_abi=get_linux_cpu_arch(verbose),
+      cpu_abi=get_linux_cpu_arch(lscpu_output),
       cpu_uarch=cpu_uarch,
-      cpu_features=get_linux_cpu_features(verbose),
-      # We don't yet support GPU benchmark on Linux devices.
-      gpu_name="Unknown")
+      cpu_features=get_linux_cpu_features(lscpu_output),
+      gpu_name=canonicalize_gpu_name(gpu_name))

--- a/build_tools/benchmarks/common/linux_device_utils_test.py
+++ b/build_tools/benchmarks/common/linux_device_utils_test.py
@@ -10,39 +10,25 @@ import unittest
 from unittest import mock
 
 from common.benchmark_definition import DeviceInfo, PlatformType
-from common.linux_device_utils import get_linux_cpu_arch, get_linux_cpu_features, get_linux_device_info
+from common.linux_device_utils import canonicalize_gpu_name, get_linux_cpu_arch, get_linux_cpu_features
+
+LSCPU_OUTPUT = ("Architecture:                    x86_64\n"
+                "Vendor ID:                       AuthenticAMD\n"
+                "Flags:                           fpu vme de pse tsc\n")
 
 
 class LinuxDeviceUtilsTest(unittest.TestCase):
 
-  def setUp(self):
-    self.execute_cmd_patch = mock.patch(
-        "common.linux_device_utils.execute_cmd_and_get_output")
-    self.execute_cmd_mock = self.execute_cmd_patch.start()
-    self.execute_cmd_mock.return_value = (
-        "Architecture:                    x86_64\n"
-        "Vendor ID:                       AuthenticAMD\n"
-        "Flags:                           fpu vme de pse tsc\n")
-
-  def tearDown(self):
-    self.execute_cmd_patch.stop()
-
   def test_get_linux_cpu_arch(self):
-    self.assertEqual(get_linux_cpu_arch(), "x86_64")
+    self.assertEqual(get_linux_cpu_arch(LSCPU_OUTPUT), "x86_64")
 
   def test_get_linux_cpu_features(self):
-    self.assertEqual(get_linux_cpu_features(),
+    self.assertEqual(get_linux_cpu_features(LSCPU_OUTPUT),
                      ["fpu", "vme", "de", "pse", "tsc"])
 
-  def test_get_linux_device_info(self):
-    self.assertEqual(
-        get_linux_device_info("Dummy", "Zen2"),
-        DeviceInfo(platform_type=PlatformType.LINUX,
-                   model="Dummy",
-                   cpu_abi="x86_64",
-                   cpu_uarch="Zen2",
-                   cpu_features=["fpu", "vme", "de", "pse", "tsc"],
-                   gpu_name="Unknown"))
+  def test_canonicalize_gpu_name(self):
+    self.assertEqual(canonicalize_gpu_name("Tesla  V100-SXM2-16GB"),
+                     "Tesla-V100-SXM2-16GB")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add CUDA support to the linux benchmark tool.

The tool has a new option `--gpu_id` to specify the target GPU. It reads the GPU info from `nvidia-smi` and gets the compute capability. Only the benchmarks match the GPU's compute capability will be run.