### PR TITLE
Access worker->state with acquire/release, not seq_cst.

### DIFF
--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -493,7 +493,7 @@ static iree_task_t* iree_task_executor_try_steal_task_from_affinity_set(
     mask = iree_shr(mask, offset + 1);
     iree_task_worker_t* victim_worker = &executor->workers[victim_index];
     if (iree_atomic_load_int32(&victim_worker->state,
-                               iree_memory_order_seq_cst) !=
+                               iree_memory_order_acquire) !=
         IREE_TASK_WORKER_STATE_RUNNING) {
       return NULL;
     }


### PR DESCRIPTION
Actually one place was already acquire/release, inconsistently with the
rest that was seq_cst. That was likely a bug, though it hadn't
manifested itself so far under TSan.

We had to standardize one way or the other: either all seq_cst or
all acquire/release.

I thought about why we might need this to be seq_cst and though actually
we probably don't. Changing to weakly ordered means that the order in
which different workers change state may be seen differently by
different threads, but that doens't seem to matter. It would have move
consequences if there were other atomics that we are accessing seq_cst
in conjunction with worker->state and we actually relied on sequential
consistency, but there don't really seem to be.

The comment in worker.h points to worker->wake_notification, and the
implementation in synchronization.c has its own issues with inconsistent
memory orders (seq_cst in iree_notification_deinitialize vs acq_rel in
iree_notification_post) so it doesn't seem that we would rely on the
seq_cst there being actually sequentially consistent with worker->state
changes.