### PR TITLE
Cherry-pick LLVM changes related to SubViewOp::inferRankReducedType and Transform::applyToOne

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -33,6 +33,18 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
       registered dialects and ops.
       - rank_reducing: adds patterns that results in rank-reducing behavior on
       subset-based operations.
+
+    Return modes:
+    =============
+    This operation applies a number of patterns to rewrite vector IR into 
+    distributed warp form. To apply these patterns, this operation must target 
+    an operation that is isolated from above, otherwise the transform definitely
+    fails.
+  
+    If the pattern application fails, or if the underlying listener fails to 
+    capture op handles, the transformation definitely fails.
+
+    Otherwise the transformation is successful and no result is returned.
   }];
 
   let arguments = (ins PDL_Operation:$target,
@@ -44,8 +56,10 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::Operation *> applyToOne(
-      ::mlir::Operation *target, ::mlir::transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -148,7 +148,7 @@ struct DispatchTensorLoadOpInterface
 
     // Bufferize to subview.
     auto subviewMemRefType = memref::SubViewOp::inferRankReducedResultType(
-        loadOp.getType().getRank(), source.getType().cast<MemRefType>(),
+        loadOp.getType().getShape(), source.getType().cast<MemRefType>(),
         loadOp.getMixedOffsets(), loadOp.getMixedSizes(),
         loadOp.getMixedStrides());
     replaceOpWithNewBufferizedOp<memref::SubViewOp>(
@@ -193,7 +193,7 @@ struct DispatchTensorStoreOpInterface
       // Writing to a part of the tensor.
       auto subviewMemRefType =
           memref::SubViewOp::inferRankReducedResultType(
-              storeOp.value().getType().cast<ShapedType>().getRank(),
+              storeOp.value().getType().cast<ShapedType>().getShape(),
               target.getType().cast<MemRefType>(), storeOp.getMixedOffsets(),
               storeOp.getMixedSizes(), storeOp.getMixedStrides())
               .cast<MemRefType>();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -196,8 +196,8 @@ struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
       subViewStrides.push_back(rewriter.getIndexAttr(1));
     }
     MemRefType resultType = memref::SubViewOp::inferRankReducedResultType(
-                                rankOfCollapsedVector, sourceType,
-                                subViewOffsets, subViewSizes, subViewStrides)
+                                vectorShapeCollapse, sourceType, subViewOffsets,
+                                subViewSizes, subViewStrides)
                                 .cast<MemRefType>();
     Value subView = rewriter.create<memref::SubViewOp>(
         loc, resultType, source, subViewOffsets, subViewSizes, subViewStrides);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -35,7 +35,20 @@ def ForeachThreadToGpuAndTranslationInfo :
    
     Barriers are inserted after each scf.foreach_thread op for now.
 
+    Return modes:
+    =============
+    This operation ignores non-Func ops and drops them in the return.
+
+    If all the scf::ForeachThread operations contained within the FuncOp 
+    referred to by the `target` PDLOperation lower to GPU properly, the 
+    transform succeeds. Otherwise the transform definitely fails.
+    
+    The returned handle points to the same FuncOp operand, consuming it and
+    producing a new SSA value to satisfy chaining and linearity of the IR 
+    properties.
+
     Example:
+    ========
 
     ```
     hal.executable {
@@ -76,9 +89,10 @@ def ForeachThreadToGpuAndTranslationInfo :
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::func::FuncOp> applyToOne(
-      ::mlir::func::FuncOp target,
-      ::mlir::transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::func::FuncOp target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 
@@ -103,7 +117,29 @@ def VectorWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.warp_execute
     This is the first of two step towards apply vector distribution to a single
     warp.
 
+
+    Return modes:
+    =============
+    This operation ignores non-scf::IfOp ops and drops them in the return.
+
+    If all the operations referred to by the `target` PDLOperation are properly
+    properly, the transform succeeds. Otherwise the transform silently fails.
+    
+    If the transform is anchored at a top-level that is not isolated from above,
+    the transform definitely fails.
+
+    If the transform cannot find a proper HAL::ExecutableExportOp with a 
+    well-formed workgroup_size 3-entry attribute such that the threadIdx.x 
+    component is a multiple of warp_size, the transform silently fails.
+    If the scf::ForOp predicate does not predicate on threadIdx.x == 0, the 
+    transform silently fails.
+
+    Otherwise the transformation succeeds and the returned handle points to the
+    produced vector::WarpExecuteOnThread0Op.
+
+
     Example:
+    ========
 
     ```
     hal.executable.export public @foo ... { workgroup_size = [64: index, 1: index, 1: index] }
@@ -155,8 +191,10 @@ def VectorWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.warp_execute
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::vector::WarpExecuteOnLane0Op> applyToOne(
-      ::mlir::scf::IfOp ifOp, ::mlir::transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::scf::IfOp target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 
@@ -175,7 +213,28 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
     This is the second step of two for applying vector distribution to a single
     warp.
 
+            
+    Return modes:
+    =============
+    This operation applies a number of patterns to rewrite vector IR into 
+    distributed warp form. To apply these patterns, this operation must target 
+    an operation that is isolated from above, otherwise the transform definitely
+    fails.
+  
+    Patterns sets are applied in the following order:
+      - applyMultiReductionLoweringPatterns
+      - applyVectorTransferWriteDistribution
+      - applyPropagateVectorDistribution
+      - applyWarpExecuteOnLane0ToScf
+
+    If any of the pattern sets fail to apply, the transformation definitely
+    fails.
+
+    Otherwise the transformation is successful and no result is returned.
+
+
     Example:
+    ========
 
     ```
     hal.executable.export public @foo ... { workgroup_size = [64: index, 1: index, 1: index] }
@@ -237,8 +296,10 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
-    ::mlir::LogicalResult applyToOne(
-      ::mlir::Operation *target, ::mlir::transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
@@ -143,7 +143,7 @@ func.func @ksplitmatmul_4D_allone(%a: memref<128x16x32x256xf32>) -> vector<1x1x1
   return %0 : vector<1x1x1x1xf32>
 }
 
-//   CHECK-DAG:#[[$MAP:.*]] = affine_map<(d0, d1) -> (d0 * 256 + d1 + 287749)>
+//   CHECK-DAG:#[[$MAP:.*]] = affine_map<(d0, d1) -> (d0 * 131072 + d1 * 8192 + 287749)>
 // CHECK-LABEL: func.func @ksplitmatmul_4D_allone
 //   CHECK-DAG: %[[ID:.*]] = arith.constant 0 : index
 //   CHECK-DAG: %[[CST:.*]] = arith.constant 0.000000e+00 : f32

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -663,7 +663,7 @@ void replaceMemrefUsesAndPropagateType(Operation *oldOp, Value val,
     }
     builder.setInsertionPoint(subviewUse);
     Type newType = memref::SubViewOp::inferRankReducedResultType(
-        subviewUse.getType().getRank(), val.getType().cast<MemRefType>(),
+        subviewUse.getType().getShape(), val.getType().cast<MemRefType>(),
         extractFromI64ArrayAttr(subviewUse.static_offsets()),
         extractFromI64ArrayAttr(subviewUse.static_sizes()),
         extractFromI64ArrayAttr(subviewUse.static_strides()));

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -367,11 +367,6 @@ def FLOW_DispatchTensorLoadOp : FLOW_PureOp<"dispatch.tensor.load", [
         (IREE::Flow::DispatchTensorType sourceType,
          ArrayRef<OpFoldResult> mixedSizes);
 
-    /// Returns the type of the result based on the sizes.
-    static RankedTensorType inferRankReducedResultType
-        (unsigned resultRank, IREE::Flow::DispatchTensorType sourceType,
-         ArrayRef<OpFoldResult> mixedSizes);
-
     /// Returns the list of dimensions that are dropped if the
     /// !flow.dispatch.tensor.load is rank-reducing.
     llvm::SmallBitVector getDroppedDims();

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -18,17 +18,34 @@ def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreac
      MemoryEffectsOpInterface,
      TransformOpInterface,
      TransformEachOpTrait]> {
-  let description = [{Rewrite an scf.foreach_thread to Flow::DispatchWorkgroups.}];
+  let description = [{
+    Rewrite an scf.foreach_thread to Flow::DispatchWorkgroups.
+    
+    
+    Return modes:
+    =============
+    This operation ignores non-scf::ForeachThread ops and drops them in the 
+    return.
+
+    If any rewrite fails, the transform definitely fails.
+
+    If all the operations referred to by the `target` PDLOperation generalize
+    properly, the transform succeeds. Otherwise the transform silently fails.
+
+    The return handle points to only the subset of successfully produced 
+    equivalent flow::DispatchWorkgroups operations, which can be empty.
+  }];
 
   let arguments = (ins PDL_Operation:$target);
   let results = (outs PDL_Operation:$transformed);
 
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
-
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::iree_compiler::IREE::Flow::DispatchWorkgroupsOp> applyToOne(
-      ::mlir::scf::ForeachThreadOp foreachThreadOp, ::mlir::transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::scf::ForeachThreadOp target, 
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
  

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
@@ -35,12 +35,25 @@ def TileToForeachOp :
        MemoryEffectsOpInterface,
        TransformEachOpTrait,
        TransformOpInterface]> {
-  let description = [{Tile a tileable op to `scf.foreach_thread`.}];
-
-  let summary = [{
+  let description = [{
+    Tile a linalg op to `scf.foreach_thread`.
+    
     0 should be used as a tile size to skip tiling a particular dimension.
     This is a commonly used convention in Linalg.
-    }];
+    
+    Return modes:
+    =============
+    This operation ignores non-Linalg ops and drops them in the return.
+
+    If all the operations referred to by the `target` PDLOperation tile
+    properly, the transform succeeds. Otherwise the transform silently fails.
+    
+    The 2 returned handles points to only the subset of successfully produced 
+    tiled operations, which can all be empty.
+    This 2 returned handles point to:
+      - the new scf.foreach_thread op,
+      - the tiled linalg op used.
+  }];
 
   let arguments = (ins PDL_Operation:$target,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$num_threads,
@@ -52,8 +65,10 @@ def TileToForeachOp :
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::llvm::SmallVector<::mlir::Operation *>> applyToOne(
-      ::mlir::TilingInterface target, transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::linalg::LinalgOp target, 
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 
@@ -85,6 +100,18 @@ def RewriteForeachThreadToAsyncOp :
 
   let description = [{
     Rewrite a bufferized scf.foreach_thread op to the async dialect.
+        
+    Return modes:
+    =============
+    This operation ignores non-Linalg ops and drops them in the return.
+    This transform is currently only implemented for 1-D scf.foreach_thread that
+    have been bufferized and definitely fail for the rest.
+
+    If all the operations referred to by the `target` PDLOperation lower
+    properly, the transform succeeds. Otherwise the transform silently fails.
+    
+    The returned handle points to only the subset of successfully produced 
+    async operations, which can all be empty.
   }];
   let arguments = (ins PDL_Operation:$target);
   let results = (outs PDL_Operation:$transformed);
@@ -93,8 +120,10 @@ def RewriteForeachThreadToAsyncOp :
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::Operation *> applyToOne(
-      ::mlir::scf::ForeachThreadOp target, transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::scf::ForeachThreadOp target, 
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 
@@ -107,6 +136,18 @@ def RewriteForeachThreadToScfForOp :
 
   let description = [{
     Rewrite a bufferized scf.foreach_thread to a sequential scf.for.
+            
+    Return modes:
+    =============
+    This operation ignores non-Linalg ops and drops them in the return.
+    This transform is currently only implemented for 1-D scf.foreach_thread that
+    have been bufferized and definitely fail for the rest.
+
+    If all the operations referred to by the `target` PDLOperation lower
+    properly, the transform succeeds. Otherwise the transform silently fails.
+    
+    The returned handle points to only the subset of successfully produced 
+    scf.for operations, which can all be empty.
   }];
   let arguments = (ins PDL_Operation:$target);
   let results = (outs PDL_Operation:$transformed);
@@ -115,8 +156,10 @@ def RewriteForeachThreadToScfForOp :
   let cppNamespace = "mlir::iree_compiler::IREE::LinalgExt";
 
   let extraClassDeclaration = [{
-    ::mlir::FailureOr<::mlir::scf::ForOp> applyToOne(
-        ::mlir::scf::ForeachThreadOp target, transform::TransformState &state);
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::scf::ForeachThreadOp target, 
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
   }];
 }
 


### PR DESCRIPTION
Also provide fixes required for those changes.