### PR TITLE
[NVVM] Drop Dealloc of shared memory buffers in conversion to NVVM

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -113,6 +113,8 @@ static LogicalResult cpuComprehensiveBufferizeCopyFn(OpBuilder &builder,
 static FailureOr<Value> gpuComprehensiveBufferizeAllocationFn(
     OpBuilder &builder, Location loc, MemRefType memRefType,
     ValueRange dynamicSizes, unsigned alignment) {
+  // TODO: use gpu::GPUDialect::getWorkgroupAddressSpace() but this requires
+  // moving out of CommonExtensions.
   MemRefType allocType = MemRefType::get(memRefType.getShape(),
                                          memRefType.getElementType(), {}, 3);
   return builder


### PR DESCRIPTION
Shared memory does not have traditional alloc/dealloc semantics but rather a semantics tht is closer to alloca with block-wide visibility and addressability (i.e. not thread-local stack visibility).
Dealloc ops of shared memory may serve the purpose of annotations for computing live ranges to better reuse limited shared memory space but cannot be lowered to NVVM as there is no abstraction to represent this.

This revision simply drops such deallocs when converting to NVVM.