### PR TITLE
Add an e2e CUDA transform dialect example.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -46,7 +46,7 @@
 #include "mlir/Support/FileUtilities.h"
 
 #define DEBUG_TYPE "iree-transform-dialect-interpreter"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE << "]: ")
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 using namespace mlir;
 
@@ -120,6 +120,7 @@ class TransformDialectInterpreterPass
     if (failed(transform::parseTransformModuleFromFile(
             context, transformFileName, module)))
       return failure();
+
     sharedTransformModule =
         std::make_shared<OwningOpRef<ModuleOp>>(std::move(module));
     return success();

--- a/compiler/transform_dialect/gpu/reduction/reduction.mlir
+++ b/compiler/transform_dialect/gpu/reduction/reduction.mlir
@@ -1,0 +1,81 @@
+// RUN: iree-compile %s --iree-hal-target-backends=cuda |\
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/transform_dialect_dispatch_spec.mlir |\
+// RUN:     --iree-hal-dump-executable-sources-to=- | \
+// RUN: iree-opt %s --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' |\
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/transform_dialect_codegen_spec.mlir |\
+// RUN: FileCheck %s
+
+// RUN: iree-run-compile %s --iree-hal-target-backends=cuda |\
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/transform_dialect_dispatch_spec.mlir |\
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/transform_dialect_codegen_spec.mlir |\
+// RUN: iree-run-module --entry_function=reduce --device=cuda |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+func.func @reduce() -> (tensor<8xf32>) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  // Note: arith.constant is good for our purposes here but it may be useful to use
+  // util.unfoldable_constant. However that would not bufferize with just iree-opt 
+  // for now and only bufferizes via iree-run-mlir.
+  %arg = arith.constant dense<1.0> : tensor<8x64xf32>
+  %0 = linalg.init_tensor [8] : tensor<8xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<8xf32>) ->   tensor<8xf32>
+
+  //     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  //     CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  //     CHECK-DAG: %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<1xf32>
+  //     CHECK-DAG: %[[TIDX:.]] = gpu.thread_id  x
+  //     CHECK-DAG: %[[TIDY:.]] = gpu.thread_id  y
+  //     CHECK-DAG: %[[TIDZ:.]] = gpu.thread_id  z
+  //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 128 : i64} : memref<8x2xf32, 3>
+  //         CHECK: %[[SHMEM_VIEW:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]
+  //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.expand_shape %[[SHMEM_VIEW]] [] : memref<f32, {{.*}}> into memref<1x1xf32, {{.*}}>
+  //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+
+  // Distributed fill to shared memory, only threadIdx.x == 0 writes.
+  //         CHECK: scf.if %[[CONDXIS0]]
+  //         CHECK:   vector.transfer_write %[[F0]], %[[SHMEM_VIEW_EXPANDED]][%[[C0]], %[[C0]]]
+  //         CHECK: gpu.barrier
+
+  // Distributed reduction: everyone loads then 5 xor + addf expected
+  //         CHECK: vector.transfer_read %{{.*}}[%[[C0]], %[[C0]], %[[TIDX]]]
+  // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+  // Note some inefficiencies here: all threads read + addf but only threadIdx.x==0 commits.
+  // So only threadIdx.x == 0 could do that.
+  // Additionally, the value read is exactly the "Distributed fill to shared memory" from above
+  // and there is no interleaved read/write so we could fold this read into only
+  // %[[F0]] and only write back to shared memory.
+  //
+  // Note: This will probably happen once the fill is fused into the split op at the linalg level.
+  //         CHECK: %[[NEUTRAL:.*]] = vector.transfer_read %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]
+  //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}, %[[NEUTRAL]]
+  //         CHECK: scf.if %[[CONDXIS0]]
+  //         CHECK:   vector.transfer_write %[[RES]], %[[SHMEM_VIEW_EXPANDED]][%[[C0]], %[[C0]]]
+  //         CHECK: gpu.barrier
+
+  // Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
+  //         CHECK: %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
+  //          TODO: cond eq 0 and cond ult 1 do not CSE atm.
+  //         CHECK: %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
+  //         CHECK: scf.if %[[CONXANDYARE0]] {
+  // CHECK-COUNT-2:   vector.transfer_read
+  //         CHECK:   vector.reduction <add>
+  //         CHECK:   arith.addf
+  //         CHECK:   vector.transfer_write
+  //         CHECK: gpu.barrier
+  //         CHECK: memref.dealloc %[[SHMEM_ALLOC]] : memref<8x2xf32, 3>
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : tensor<8x64xf32>) outs(%1 : tensor<8xf32>) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> tensor<8xf32>
+  return %2 : tensor<8xf32>
+}
+
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 8xf32=64 64 64 64 64 64 64 64

--- a/compiler/transform_dialect/gpu/reduction/transform_dialect_codegen_spec.mlir
+++ b/compiler/transform_dialect/gpu/reduction/transform_dialect_codegen_spec.mlir
@@ -1,0 +1,58 @@
+// RUN: iree-opt %s
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  pdl.pattern @pdl_generic_target : benefit(1) {
+    %args = operands
+    %results = types
+    %0 = operation "linalg.generic"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+    // TODO: we don't want this, but it is the required terminator for pdl.pattern
+    rewrite %0 with "transform.dialect"
+  }
+
+  pdl.pattern @pdl_if_op_target : benefit(1) {
+    %args = operands
+    %results = types
+    %0 = operation "scf.if"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
+    // TODO: we don't want this, but it is the required terminator for pdl.pattern
+    rewrite %0 with "transform.dialect"
+  }
+
+  transform.structured.canonicalized_sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    
+    // Note: split by 32 to vector-distribute the tail combiner_op, but
+    // split by 2 to vector-distribute the meaty %more_parallel_op
+    %init_or_alloc_op, %fill_op, %more_parallel_op, %combiner_op = 
+      transform.structured.split_reduction %0 
+        { split_factor = 2, insert_split_dimension = 1, use_alloc }
+    
+    %1 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    %foreach_thread_1, %tiled_fill = 
+      tile_to_foreach_thread_op %fill_op 
+        {num_threads = [8, 2], thread_dim_mapping = [2, 1, 0]}
+    %foreach_thread_2, %tiled_more_parallel_op = 
+       tile_to_foreach_thread_op %more_parallel_op 
+         {num_threads = [8, 2], thread_dim_mapping = [2, 1, 0]}
+    %foreach_thread_3, %tiled_combiner_op = 
+      tile_to_foreach_thread_op %combiner_op 
+        {num_threads = [8], thread_dim_mapping = [2, 1, 0]}
+
+    %isolated_handle_1 = transform.get_closest_isolated_parent %foreach_thread_2
+    %isolated_handle_2 = transform.structured.vectorize %isolated_handle_1
+    %isolated_handle_3 = transform.iree.apply_patterns %isolated_handle_2 { rank_reducing }
+
+    transform.iree.bufferize { target_gpu }
+    %isolated_handle_4 = 
+      transform.iree.foreach_thread_to_gpu_and_translation_info %isolated_handle_3 
+        { workgroup_size = [32, 2, 8] }
+    
+    // Vector distribution needs to happen on buffers.
+    %if_op = transform.structured.match ops{["scf.if"]} in %arg1
+    %warp = transform.iree.vector.warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    transform.iree.vector.warp_distribute %isolated_handle_4
+    
+    // transform.print { name = "after codegen"}
+  }
+}

--- a/compiler/transform_dialect/gpu/reduction/transform_dialect_dispatch_spec.mlir
+++ b/compiler/transform_dialect/gpu/reduction/transform_dialect_dispatch_spec.mlir
@@ -1,0 +1,11 @@
+// RUN: iree-opt %s
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.structured.canonicalized_sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    %foreach_thread, %tiled_generic = tile_to_foreach_thread_op %0 {num_threads = [2]}
+    transform.iree.foreach_thread_to_flow %foreach_thread
+  }
+}


### PR DESCRIPTION
Add and e2e CUDA transform dialect example.

This shows an example of e2e codegen driven by fine-grained transform dialect strategies.
The target is controlled warp distribution of a reduction op.

This exhibits the need to have a place to put such transform dialect IR such that we can from a
centralized place and with the same tooling:
    1. write an iree-opt test that checks expectes IR without having to write HAL abstractions.
    2. write an e2e execution test to check results w/ accuracy etc.
    3. selectively import as an expert strategy and use without surprises in IREE, when the time comes.

A first tentative location for this is in `compiler/transform_dialect/`.

The GPU-specific transforms are relaxed to allow targeting either hal.executable or hal.executable.variant
which lets them apply with either an iree-run-mlir or iree-opt flow.
