### PR TITLE
shark model testing for iree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,58 @@ jobs:
               ./build_tools/scripts/check_vulkan.sh
               build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
 
+  test_shark_model_suite:
+    needs: [build_tf_integrations, build_all]
+    runs-on:
+      # Pseudo-ternary hack and order matters. See comment at top of file.
+      - self-hosted
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - gpu 
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.gcs-artifact }}
+      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        with:
+          submodules: true
+      - name: "Downloading TF binaries archive"
+        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+      - name: "Extracting TF binaries archive"
+        run: tar -xf "${TF_BINARIES_ARCHIVE}"
+      - name: "Symlinking TF binaries"
+        run: |
+          ./integrations/tensorflow/symlink_binaries.sh "$(realpath "${TF_BINARIES_DIR}")"
+        run: gcloud alpha storage cp "${GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Downloading SHARK"
+        id: download_shark
+        uses: actions/checkout@64424877aca820469cfb91591c29fdf7be764084  # v2
+        with:
+          repository: nod-ai/SHARK
+          path: ${{ github.workspace }}/SHARK
+      - name: "Testing Shark Model Suite"
+        run: |
+          cd "${GITHUB_WORKSPACE}/SHARK"
+          NO_BACKEND=1 ./setup_venv.sh
+          source shark.venv/bin/activate
+          export TFPYBASE="${GITHUB_WORKSPACE}/integrations/tensorflow/python_projects"
+          export PYTHONPATH="${PYTHONPATH}:${BUILD_DIR}/compiler/bindings/python:${BUILD_DIR}/runtime/bindings/python"
+          export PYTHONPATH="${PYTHONPATH}:$TFPYBASE/iree_tf:$TFPYBASE/iree_tflite"
+          export SHARK_SKIP_TESTS="--ignore=shark/tests/test_shark_importer.py \
+            --ignore=benchmarks/tests/test_hf_benchmark.py \
+            --ignore=benchmarks/tests/test_benchmark.py"
+          pytest -k 'cpu' $SHARK_SKIP_TESTS
+          pytest -k 'vulkan' $SHARK_SKIP_TESTS
+          pytest -k "gpu" $SHARK_SKIP_TESTS
+
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration
   ##############################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,9 +502,10 @@ jobs:
           export SHARK_SKIP_TESTS="--ignore=shark/tests/test_shark_importer.py \
             --ignore=benchmarks/tests/test_hf_benchmark.py \
             --ignore=benchmarks/tests/test_benchmark.py"
-          pytest tank/test_models.py -k 'cpu' $SHARK_SKIP_TESTS
-          pytest tank/test_models.py -k 'vulkan' $SHARK_SKIP_TESTS
-          pytest tank/test_models.py -k "cuda" $SHARK_SKIP_TESTS
+          export MODEL_LIST="bert_base_cased or mobilebert_uncased or MiniLM_L12_H384_uncased or module_resnet50 or mobilenet_v3 or squeezenet1_0 or vit_base_patch16_224"
+          pytest tank/test_models.py -k "cpu and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+          pytest tank/test_models.py -k "vulkan and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+          pytest tank/test_models.py -k "cuda and ($MODEL_LIST)" $SHARK_SKIP_TESTS
 
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,9 +499,9 @@ jobs:
           export SHARK_SKIP_TESTS="--ignore=shark/tests/test_shark_importer.py \
             --ignore=benchmarks/tests/test_hf_benchmark.py \
             --ignore=benchmarks/tests/test_benchmark.py"
-          pytest -k 'cpu' $SHARK_SKIP_TESTS
-          pytest -k 'vulkan' $SHARK_SKIP_TESTS
-          pytest -k "cuda" $SHARK_SKIP_TESTS
+          pytest tank/test_models.py -k 'cpu' $SHARK_SKIP_TESTS
+          pytest tank/test_models.py -k 'vulkan' $SHARK_SKIP_TESTS
+          pytest tank/test_models.py -k "cuda" $SHARK_SKIP_TESTS
 
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -451,6 +451,7 @@ jobs:
 
   test_shark_model_suite:
     needs: [build_tf_integrations, build_all]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,7 @@ jobs:
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Downloading SHARK"
         id: download_shark
-        uses: actions/checkout@64424877aca820469cfb91591c29fdf7be764084  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:
           repository: nod-ai/SHARK
           path: ${{ github.workspace }}/SHARK

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,7 +456,7 @@ jobs:
       - self-hosted
       - runner-group=${{ needs.setup.outputs.runner-group }}
       - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu 
+      - gpu
       - os-family=Linux
     env:
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
@@ -477,6 +477,7 @@ jobs:
       - name: "Symlinking TF binaries"
         run: |
           ./integrations/tensorflow/symlink_binaries.sh "$(realpath "${TF_BINARIES_DIR}")"
+      - name: "Downloading build archive"
         run: gcloud alpha storage cp "${GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -449,6 +449,9 @@ jobs:
               ./build_tools/scripts/check_vulkan.sh
               build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
 
+  ############################# Model Coverage #################################
+  # Jobs that test IREE performance on a set of models.
+  ##############################################################################
   test_shark_model_suite:
     needs: [setup, build_all, build_tf_integrations]
     if: needs.setup.outputs.should-run == 'true'
@@ -701,6 +704,9 @@ jobs:
       - build_tf_integrations
       - test_tf_integrations
       - test_tf_integrations_gpu
+
+      # Model Coverage
+      - test_shark_model_suite
 
       # Configurations
       - asan

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,7 +450,7 @@ jobs:
               build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
 
   test_shark_model_suite:
-    needs: [build_tf_integrations, build_all]
+    needs: [setup, build_all, build_tf_integrations]
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
             --ignore=benchmarks/tests/test_benchmark.py"
           pytest -k 'cpu' $SHARK_SKIP_TESTS
           pytest -k 'vulkan' $SHARK_SKIP_TESTS
-          pytest -k "gpu" $SHARK_SKIP_TESTS
+          pytest -k "cuda" $SHARK_SKIP_TESTS
 
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -462,10 +462,10 @@ jobs:
     env:
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.gcs-artifact }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
       TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
       TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.gcs-artifact }}
+      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
@@ -478,9 +478,9 @@ jobs:
       - name: "Symlinking TF binaries"
         run: |
           ./integrations/tensorflow/symlink_binaries.sh "$(realpath "${TF_BINARIES_DIR}")"
-      - name: "Downloading build archive"
-        run: gcloud alpha storage cp "${GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting archive"
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Downloading SHARK"
         id: download_shark


### PR DESCRIPTION
Attempts to address #9537 

Has the same workflow inputs as validate_and_publish_release.yml, but I wasn't sure what the intended place in the existing workflows this was meant to plug into.  All it currently does is download the generated packages from the build_package.yml workflow and use them to run shark model zoo. Happy to configure to spec.

I think the custom runners are still up in the air per #9432 , so this will have to be edited later to account for how those are used. 

