### PR TITLE
Removing the need for the ririririri fields in vmvx arg structs.

### DIFF
--- a/runtime/src/iree/modules/vmvx/exports.inl
+++ b/runtime/src/iree/modules/vmvx/exports.inl
@@ -19,13 +19,13 @@
 // name in a way compatible with iree_string_view_compare.
 //
 // Users are meant to `#define EXPORT_FN` to be able to access the information.
-// #define EXPORT_FN(name, arg_type, ret_type, target_fn)
+// #define EXPORT_FN(name, target_fn, arg_struct, arg_type, ret_type)
 
 // clang-format off
 
-EXPORT_FN("add.2d.f32", iree_vmvx_add2d_f32, rIIIrIIIrIIIII, v)
-EXPORT_FN("copy.2d.x32", iree_vmvx_copy2d_x32, rIIIrIIIII, v)
-EXPORT_FN("fill.2d.x32", iree_vmvx_fill2d_x32, irIIII, v)
-EXPORT_FN("matmul.f32f32f32", iree_vmvx_matmul_f32f32f32, rIIrIIrIIIIIffi, v)
+EXPORT_FN("add.2d.f32", iree_vmvx_add2d_f32, binary2d, rIIIrIIIrIIIII, v)
+EXPORT_FN("copy.2d.x32", iree_vmvx_copy2d_x32, unary2d, rIIIrIIIII, v)
+EXPORT_FN("fill.2d.x32", iree_vmvx_fill2d_x32, fill2d_x32, irIIII, v)
+EXPORT_FN("matmul.f32f32f32", iree_vmvx_matmul_f32f32f32, matmul_f32, rIIrIIrIIIIIffi, v)
 
 // clang-format on

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -61,143 +61,8 @@ iree_vmvx_module_free_state(void* self, iree_vm_module_state_t* module_state) {
 }
 
 //===----------------------------------------------------------------------===//
-// Private shims not needed by anything else.
+// Argument validation and marshalling
 //===----------------------------------------------------------------------===//
-
-IREE_VM_ABI_FIXED_STRUCT(irIIII, {
-  union {
-    struct {
-      int32_t fill_value;
-      iree_vm_ref_t out_ref;
-      int64_t out_offset;
-      int64_t out_row_stride;
-      int64_t size0;
-      int64_t size1;
-    } IREE_ATTRIBUTE_PACKED fill2d_x32;
-    struct {
-      int32_t i0;
-      iree_vm_ref_t r1;
-      int64_t i2;
-      int64_t i3;
-      int64_t i4;
-      int64_t i5;
-    } IREE_ATTRIBUTE_PACKED raw;
-  };
-});
-
-IREE_VM_ABI_FIXED_STRUCT(rIIrIIrIIIIIffi, {
-  union {
-    struct {
-      iree_vm_ref_t lhs_ref;
-      int64_t lhs_offset;
-      int64_t lhs_row_stride;
-      iree_vm_ref_t rhs_ref;
-      int64_t rhs_offset;
-      int64_t rhs_row_stride;
-      iree_vm_ref_t out_ref;
-      int64_t out_offset;
-      int64_t out_row_stride;
-      int64_t m;
-      int64_t n;
-      int64_t k;
-      float alpha;
-      float beta;
-      int32_t flags;
-    } IREE_ATTRIBUTE_PACKED matmul_f32;
-    struct {
-      iree_vm_ref_t r0;
-      int64_t i1;
-      int64_t i2;
-      iree_vm_ref_t r3;
-      int64_t i4;
-      int64_t i5;
-      iree_vm_ref_t r6;
-      int64_t i7;
-      int64_t i8;
-      int64_t i9;
-      int64_t i10;
-      int64_t i11;
-      float i12;
-      float i13;
-      int32_t flags;
-    } IREE_ATTRIBUTE_PACKED raw;
-  };
-});
-
-IREE_VM_ABI_FIXED_STRUCT(rIIIrIIIII, {
-  union {
-    struct {
-      iree_vm_ref_t in_ref;
-      int64_t in_offset;
-      int64_t in_stride0;
-      int64_t in_stride1;
-      iree_vm_ref_t out_ref;
-      int64_t out_offset;
-      int64_t out_stride0;
-      int64_t out_stride1;
-      int64_t size0;
-      int64_t size1;
-    } IREE_ATTRIBUTE_PACKED unary2d;
-    struct {
-      iree_vm_ref_t r0;
-      int64_t i1;
-      int64_t i2;
-      int64_t i3;
-      iree_vm_ref_t r4;
-      int64_t i5;
-      int64_t i6;
-      int64_t i7;
-      int64_t i8;
-      int64_t i9;
-    } IREE_ATTRIBUTE_PACKED raw;
-  };
-});
-
-// Binary elementwise ops all have the same signature:
-// rIIIrIIIII
-IREE_VM_ABI_FIXED_STRUCT(rIIIrIIIrIIIII, {
-  union {
-    struct {
-      iree_vm_ref_t lhs_ref;
-      int64_t lhs_offset;
-      int64_t lhs_stride0;
-      int64_t lhs_stride1;
-      iree_vm_ref_t rhs_ref;
-      int64_t rhs_offset;
-      int64_t rhs_stride0;
-      int64_t rhs_stride1;
-      iree_vm_ref_t out_ref;
-      int64_t out_offset;
-      int64_t out_stride0;
-      int64_t out_stride1;
-      int64_t size0;
-      int64_t size1;
-    } IREE_ATTRIBUTE_PACKED binary2d;
-    struct {
-      iree_vm_ref_t r0;
-      int64_t i1;
-      int64_t i2;
-      int64_t i3;
-      iree_vm_ref_t r4;
-      int64_t i5;
-      int64_t i6;
-      int64_t i7;
-      iree_vm_ref_t r8;
-      int64_t i9;
-      int64_t i10;
-      int64_t i11;
-      int64_t i12;
-      int64_t i13;
-    } IREE_ATTRIBUTE_PACKED raw;
-  };
-});
-
-// Since these are private/unlikely to be general, mark as static. If there
-// ever becomes one of these in the common set, the compiler will complain.
-static IREE_VM_ABI_DEFINE_SHIM(irIIII, v);
-static IREE_VM_ABI_DEFINE_SHIM(rIIIrIIIII, v);
-static IREE_VM_ABI_DEFINE_SHIM(rIIrIIrIIIIIffi, v);
-static IREE_VM_ABI_DEFINE_SHIM(rIIIrIIIrIIIII, v);
 
 static iree_host_size_t iree_vmvx_2d_length_bound(
     iree_host_size_t element_size, uint64_t size0, uint64_t size1,
@@ -276,53 +141,76 @@ static iree_host_size_t iree_vmvx_cast_host_size(int64_t value,
   dtype* name = (dtype*)name##_span.data
 
 //===----------------------------------------------------------------------===//
-// Exported
-// function
-// definitions
+// Shared argument shims
 //===----------------------------------------------------------------------===//
 
-IREE_VM_ABI_EXPORT(iree_vmvx_add2d_f32, iree_vmvx_module_state_t,
-                   rIIIrIIIrIIIII, v) {
+#define IREE_VMVX_ABI_EXPORT(function_name, arg_types, ret_types)        \
+  IREE_VM_ABI_EXPORT(function_name, iree_vmvx_module_state_t, arg_types, \
+                     ret_types)
+#define IREE_VMVX_ABI_FIXED_STRUCT(name, types, body) \
+  IREE_VM_ABI_FIXED_STRUCT(name, body)
+#define IREE_VMVX_ABI_DEFINE_SHIM(arg_types, ret_types) \
+  static IREE_VM_ABI_DEFINE_SHIM(arg_types, ret_types)
+
+IREE_VMVX_ABI_FIXED_STRUCT(unary2d, rIIIrIIIII, {
+  iree_vm_ref_t in_ref;
+  int64_t in_offset;
+  int64_t in_stride0;
+  int64_t in_stride1;
+  iree_vm_ref_t out_ref;
+  int64_t out_offset;
+  int64_t out_stride0;
+  int64_t out_stride1;
+  int64_t size0;
+  int64_t size1;
+});
+IREE_VMVX_ABI_DEFINE_SHIM(unary2d, v);
+
+IREE_VMVX_ABI_FIXED_STRUCT(binary2d, rIIIrIIIrIIIII, {
+  iree_vm_ref_t lhs_ref;
+  int64_t lhs_offset;
+  int64_t lhs_stride0;
+  int64_t lhs_stride1;
+  iree_vm_ref_t rhs_ref;
+  int64_t rhs_offset;
+  int64_t rhs_stride0;
+  int64_t rhs_stride1;
+  iree_vm_ref_t out_ref;
+  int64_t out_offset;
+  int64_t out_stride0;
+  int64_t out_stride1;
+  int64_t size0;
+  int64_t size1;
+});
+IREE_VMVX_ABI_DEFINE_SHIM(binary2d, v);
+
+//===----------------------------------------------------------------------===//
+// Exported function definitions
+//===----------------------------------------------------------------------===//
+
+IREE_VMVX_ABI_EXPORT(iree_vmvx_add2d_f32, binary2d, v) {
   IREE_TRACE_ZONE_BEGIN(z0);
   MAP_BUFFER_2D_RO(lhs, float,
-                   /*buffer_ref=*/
-                   args->binary2d.lhs_ref,
-                   /*offset=*/
-                   args->binary2d.lhs_offset,
-                   /*stride0=*/
-                   args->binary2d.lhs_stride0,
-                   /*stride1=*/
-                   args->binary2d.lhs_stride1,
-                   /*size0=*/
-                   args->binary2d.size0,
-                   /*size1=*/
-                   args->binary2d.size1);
+                   /*buffer_ref=*/args->lhs_ref,
+                   /*offset=*/args->lhs_offset,
+                   /*stride0=*/args->lhs_stride0,
+                   /*stride1=*/args->lhs_stride1,
+                   /*size0=*/args->size0,
+                   /*size1=*/args->size1);
   MAP_BUFFER_2D_RO(rhs, float,
-                   /*buffer_ref=*/
-                   args->binary2d.rhs_ref,
-                   /*offset=*/
-                   args->binary2d.rhs_offset,
-                   /*stride0=*/
-                   args->binary2d.rhs_stride0,
-                   /*stride1=*/
-                   args->binary2d.rhs_stride1,
-                   /*size0=*/
-                   args->binary2d.size0,
-                   /*size1=*/
-                   args->binary2d.size1);
+                   /*buffer_ref=*/args->rhs_ref,
+                   /*offset=*/args->rhs_offset,
+                   /*stride0=*/args->rhs_stride0,
+                   /*stride1=*/args->rhs_stride1,
+                   /*size0=*/args->size0,
+                   /*size1=*/args->size1);
   MAP_BUFFER_2D_RW(out, float,
-                   /*buffer_ref=*/
-                   args->binary2d.out_ref,
-                   /*offset=*/
-                   args->binary2d.out_offset,
-                   /*stride0=*/
-                   args->binary2d.out_stride0,
-                   /*stride1=*/
-                   args->binary2d.out_stride1,
-                   /*size0=*/
-                   args->binary2d.size0,
-                   /*size1=*/
-                   args->binary2d.size1);
+                   /*buffer_ref=*/args->out_ref,
+                   /*offset=*/args->out_offset,
+                   /*stride0=*/args->out_stride0,
+                   /*stride1=*/args->out_stride1,
+                   /*size0=*/args->size0,
+                   /*size1=*/args->size1);
 
   for (iree_host_size_t i = 0; i < out_size0; ++i) {
     for (iree_host_size_t j = 0; j < out_size1; ++j) {
@@ -336,35 +224,22 @@ IREE_VM_ABI_EXPORT(iree_vmvx_add2d_f32, iree_vmvx_module_state_t,
   return iree_ok_status();
 }
 
-IREE_VM_ABI_EXPORT(iree_vmvx_copy2d_x32, iree_vmvx_module_state_t, rIIIrIIIII,
-                   v) {
+IREE_VMVX_ABI_EXPORT(iree_vmvx_copy2d_x32, unary2d, v) {
   IREE_TRACE_ZONE_BEGIN(z0);
   MAP_BUFFER_2D_RO(in, int32_t,
-                   /*buffer_ref=*/
-                   args->unary2d.in_ref,
-                   /*offset=*/
-                   args->unary2d.in_offset,
-                   /*stride0=*/
-                   args->unary2d.in_stride0,
-                   /*stride1=*/
-                   args->unary2d.in_stride1,
-                   /*size0=*/
-                   args->unary2d.size0,
-                   /*size1=*/
-                   args->unary2d.size1);
+                   /*buffer_ref=*/args->in_ref,
+                   /*offset=*/args->in_offset,
+                   /*stride0=*/args->in_stride0,
+                   /*stride1=*/args->in_stride1,
+                   /*size0=*/args->size0,
+                   /*size1=*/args->size1);
   MAP_BUFFER_2D_RW(out, int32_t,
-                   /*buffer_ref=*/
-                   args->unary2d.out_ref,
-                   /*offset=*/
-                   args->unary2d.out_offset,
-                   /*stride0=*/
-                   args->unary2d.out_stride0,
-                   /*stride1=*/
-                   args->unary2d.out_stride1,
-                   /*size0=*/
-                   args->unary2d.size0,
-                   /*size1=*/
-                   args->unary2d.size1);
+                   /*buffer_ref=*/args->out_ref,
+                   /*offset=*/args->out_offset,
+                   /*stride0=*/args->out_stride0,
+                   /*stride1=*/args->out_stride1,
+                   /*size0=*/args->size0,
+                   /*size1=*/args->size1);
 
   for (iree_host_size_t j = 0; j < out_size0; ++j) {
     for (iree_host_size_t i = 0; i < out_size1; ++i) {
@@ -377,25 +252,28 @@ IREE_VM_ABI_EXPORT(iree_vmvx_copy2d_x32, iree_vmvx_module_state_t, rIIIrIIIII,
   return iree_ok_status();
 }
 
-IREE_VM_ABI_EXPORT(iree_vmvx_fill2d_x32, iree_vmvx_module_state_t, irIIII, v) {
+IREE_VMVX_ABI_FIXED_STRUCT(fill2d_x32, irIIII, {
+  int32_t fill_value;
+  iree_vm_ref_t out_ref;
+  int64_t out_offset;
+  int64_t out_row_stride;
+  int64_t size0;
+  int64_t size1;
+});
+IREE_VMVX_ABI_DEFINE_SHIM(fill2d_x32, v);
+IREE_VMVX_ABI_EXPORT(iree_vmvx_fill2d_x32, fill2d_x32, v) {
   IREE_TRACE_ZONE_BEGIN(z0);
   MAP_BUFFER_2D_RW(out, int32_t,
-                   /*buffer_ref=*/
-                   args->fill2d_x32.out_ref,
-                   /*offset=*/
-                   args->fill2d_x32.out_offset,
-                   /*stride0=*/
-                   args->fill2d_x32.out_row_stride,
-                   /*stride1=*/
-                   1,
-                   /*size0=*/
-                   args->fill2d_x32.size0,
-                   /*size1=*/
-                   args->fill2d_x32.size1);
+                   /*buffer_ref=*/args->out_ref,
+                   /*offset=*/args->out_offset,
+                   /*stride0=*/args->out_row_stride,
+                   /*stride1=*/1,
+                   /*size0=*/args->size0,
+                   /*size1=*/args->size1);
 
   for (iree_host_size_t i = 0; i < out_size0; ++i) {
     for (iree_host_size_t j = 0; j < out_size1; ++j) {
-      out[i * out_stride0 + j] = args->fill2d_x32.fill_value;
+      out[i * out_stride0 + j] = args->fill_value;
     }
   }
 
@@ -403,64 +281,61 @@ IREE_VM_ABI_EXPORT(iree_vmvx_fill2d_x32, iree_vmvx_module_state_t, irIIII, v) {
   return iree_ok_status();
 }
 
-IREE_VM_ABI_EXPORT(iree_vmvx_matmul_f32f32f32, iree_vmvx_module_state_t,
-                   rIIrIIrIIIIIffi, v) {
+IREE_VMVX_ABI_FIXED_STRUCT(matmul_f32, rIIrIIrIIIIIffi, {
+  iree_vm_ref_t lhs_ref;
+  int64_t lhs_offset;
+  int64_t lhs_row_stride;
+  iree_vm_ref_t rhs_ref;
+  int64_t rhs_offset;
+  int64_t rhs_row_stride;
+  iree_vm_ref_t out_ref;
+  int64_t out_offset;
+  int64_t out_row_stride;
+  int64_t m;
+  int64_t n;
+  int64_t k;
+  float alpha;
+  float beta;
+  int32_t flags;
+});
+IREE_VMVX_ABI_DEFINE_SHIM(matmul_f32, v);
+IREE_VMVX_ABI_EXPORT(iree_vmvx_matmul_f32f32f32, matmul_f32, v) {
   IREE_TRACE_ZONE_BEGIN(z0);
   MAP_BUFFER_2D_RO(lhs, float,
-                   /*buffer_ref=*/
-                   args->matmul_f32.lhs_ref,
-                   /*offset=*/
-                   args->matmul_f32.lhs_offset,
-                   /*stride0=*/
-                   args->matmul_f32.lhs_row_stride,
-                   /*stride1=*/
-                   1,
-                   /*size0=*/
-                   args->matmul_f32.m,
-                   /*size1=*/
-                   args->matmul_f32.k);
+                   /*buffer_ref=*/args->lhs_ref,
+                   /*offset=*/args->lhs_offset,
+                   /*stride0=*/args->lhs_row_stride,
+                   /*stride1=*/1,
+                   /*size0=*/args->m,
+                   /*size1=*/args->k);
   MAP_BUFFER_2D_RO(rhs, float,
-                   /*buffer_ref=*/
-                   args->matmul_f32.rhs_ref,
-                   /*offset=*/
-                   args->matmul_f32.rhs_offset,
-                   /*stride0=*/
-                   args->matmul_f32.rhs_row_stride,
-                   /*stride1=*/
-                   1,
-                   /*size0=*/
-                   args->matmul_f32.k,
-                   /*size1=*/
-                   args->matmul_f32.n);
+                   /*buffer_ref=*/args->rhs_ref,
+                   /*offset=*/args->rhs_offset,
+                   /*stride0=*/args->rhs_row_stride,
+                   /*stride1=*/1,
+                   /*size0=*/args->k,
+                   /*size1=*/args->n);
   MAP_BUFFER_2D_RW(out, float,
-                   /*buffer_ref=*/
-                   args->matmul_f32.out_ref,
-                   /*offset=*/
-                   args->matmul_f32.out_offset,
-                   /*stride0=*/
-                   args->matmul_f32.out_row_stride,
-                   /*stride1=*/
-                   1,
-                   /*size0=*/
-                   args->matmul_f32.m,
-                   /*size1=*/
-                   args->matmul_f32.n);
+                   /*buffer_ref=*/args->out_ref,
+                   /*offset=*/args->out_offset,
+                   /*stride0=*/args->out_row_stride,
+                   /*stride1=*/1,
+                   /*size0=*/args->m,
+                   /*size1=*/args->n);
 
-  iree_host_size_t M = (iree_host_size_t)args->matmul_f32.m;
-  iree_host_size_t N = (iree_host_size_t)args->matmul_f32.n;
-  iree_host_size_t K = (iree_host_size_t)args->matmul_f32.k;
+  iree_host_size_t M = (iree_host_size_t)args->m;
+  iree_host_size_t N = (iree_host_size_t)args->n;
+  iree_host_size_t K = (iree_host_size_t)args->k;
 
-  // TODO: Define
-  // flags more
-  // robustly.
-  if (args->matmul_f32.flags == 0) {
+  // TODO: define flags more robustly.
+  if (args->flags == 0) {
     // Row major.
     for (iree_host_size_t i = 0; i < M; ++i) {
       for (iree_host_size_t k = 0; k < K; ++k) {
-        float apart = args->matmul_f32.alpha * lhs[i * lhs_stride0 + k];
+        float apart = args->alpha * lhs[i * lhs_stride0 + k];
         for (iree_host_size_t j = 0; j < N; ++j) {
           out[i * out_stride0 + j] +=
-              args->matmul_f32.beta * apart * rhs[k * rhs_stride0 + j];
+              args->beta * apart * rhs[k * rhs_stride0 + j];
         }
       }
     }
@@ -468,7 +343,7 @@ IREE_VM_ABI_EXPORT(iree_vmvx_matmul_f32f32f32, iree_vmvx_module_state_t,
     IREE_TRACE_ZONE_END(z0);
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "unsupported matmul flags: %x",
-                            (unsigned)args->matmul_f32.flags);
+                            (unsigned)args->flags);
   }
 
   IREE_TRACE_ZONE_END(z0);
@@ -481,30 +356,27 @@ IREE_VM_ABI_EXPORT(iree_vmvx_matmul_f32f32f32, iree_vmvx_module_state_t,
 
 // NOTE: this must match the ordering of the iree_vmvx_module_exports_table.
 static const iree_vm_native_function_ptr_t iree_vmvx_module_funcs_[] = {
-#define EXPORT_FN(name, target_fn, arg_types, ret_types)       \
-  {                                                            \
-      .shim = (iree_vm_native_function_shim_t)                 \
-          iree_vm_shim_##arg_types##_##ret_types,              \
-      .target = (iree_vm_native_function_target_t)(target_fn), \
+#define EXPORT_FN(name, target_fn, arg_struct, arg_types, ret_types) \
+  {                                                                  \
+      .shim = (iree_vm_native_function_shim_t)                       \
+          iree_vm_shim_##arg_struct##_##ret_types,                   \
+      .target = (iree_vm_native_function_target_t)(target_fn),       \
   },
 #include "iree/modules/vmvx/exports.inl"  // IWYU pragma: keep
 #undef EXPORT_FN
 };
 
-// NOTE: 0 length,
-// but can't
-// express that in
-// C.
+// NOTE: 0 length, but can't express that in C.
 static const iree_vm_native_import_descriptor_t iree_vmvx_module_imports_[1];
 
 static const iree_vm_native_export_descriptor_t iree_vmvx_module_exports_[] = {
-#define EXPORT_FN(name, target_fn, arg_types, ret_types)           \
-  {                                                                \
-      .local_name = iree_string_view_literal(name),                \
-      .calling_convention =                                        \
-          iree_string_view_literal("0" #arg_types "_" #ret_types), \
-      .attr_count = 0,                                             \
-      .attrs = NULL,                                               \
+#define EXPORT_FN(name, target_fn, arg_struct, arg_types, ret_types) \
+  {                                                                  \
+      .local_name = iree_string_view_literal(name),                  \
+      .calling_convention =                                          \
+          iree_string_view_literal("0" #arg_types "_" #ret_types),   \
+      .attr_count = 0,                                               \
+      .attrs = NULL,                                                 \
   },
 #include "iree/modules/vmvx/exports.inl"  // IWYU pragma: keep
 #undef EXPORT_FN
@@ -518,11 +390,7 @@ static const iree_vm_native_module_descriptor_t iree_vmvx_module_descriptor_ = {
                                             "x"),
     .module_attr_count = 0,
     .module_attrs = NULL,
-    .import_count = 0,  // workaround
-                        // for
-                        // 0-length
-                        // C
-                        // struct
+    .import_count = 0,  // workaround for 0-length C struct
     .imports = iree_vmvx_module_imports_,
     .export_count = IREE_ARRAYSIZE(iree_vmvx_module_exports_),
     .exports = iree_vmvx_module_exports_,
@@ -535,25 +403,15 @@ IREE_API_EXPORT iree_status_t iree_vmvx_module_create(
   IREE_ASSERT_ARGUMENT(out_module);
   *out_module = NULL;
 
-  // Setup the
-  // interface with
-  // the functions
-  // we implement
-  // ourselves. Any
-  // function we
-  // omit will be
-  // handled by the
-  // base native
-  // module.
+  // Setup the interface with the functions we implement ourselves. Any function
+  // we omit will be handled by the base native module.
   static const iree_vm_module_t interface = {
       .destroy = iree_vmvx_module_destroy,
       .alloc_state = iree_vmvx_module_alloc_state,
       .free_state = iree_vmvx_module_free_state,
   };
 
-  // Allocate
-  // shared module
-  // state.
+  // Allocate shared module state.
   iree_host_size_t total_size =
       iree_vm_native_module_size() + sizeof(iree_vmvx_module_t);
   iree_vm_module_t* base_module = NULL;

--- a/runtime/src/iree/vm/shims.h
+++ b/runtime/src/iree/vm/shims.h
@@ -27,13 +27,13 @@
 #define IREE_VM_ABI_TYPE_NAME(types) iree_vm_abi_##types##_t
 
 #define IREE_VM_ABI_FIXED_STRUCT(types, body) \
-  IREE_VM_ABI_FIXED_STRUCT_IMPL(types, IREE_VM_ABI_TYPE_NAME(types), body)
+  IREE_VM_ABI_FIXED_STRUCT_IMPL(IREE_VM_ABI_TYPE_NAME(types), types, body)
 
 #define IREE_VM_ABI_VLA_STRUCT(types, vla_count, vla_field, body) \
   IREE_VM_ABI_VLA_STRUCT_IMPL(types, vla_count, vla_field,        \
                               IREE_VM_ABI_TYPE_NAME(types), body)
 
-#define IREE_VM_ABI_FIXED_STRUCT_IMPL(types, struct_type, body)        \
+#define IREE_VM_ABI_FIXED_STRUCT_IMPL(struct_type, types, body)        \
   typedef struct iree_vm_abi_##types##_t body IREE_ATTRIBUTE_PACKED    \
       struct_type;                                                     \
   static inline struct_type* iree_vm_abi_##types##_checked_deref(      \


### PR DESCRIPTION
This gets us to a single declaration of the argument fields and
closer to what the vm.import-generated stuff will look like.

I think there's still some simplification that can be done here by
reusing the cconv signature declared on the structs to provide the
full cconv signature for the EXPORT_FN decls but I didn't try to do
that here. There's other ergonomics/cleanliness improvements that
could be done but these changes at least get us to a state of only
marginally 🤮-inducing.