### PR TITLE
Add a more intuitive transform.iree.match op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
@@ -41,6 +41,14 @@ iree_gentbl_cc_library(
             ["--gen-op-defs"],
             "CommonExtensionsOps.cpp.inc",
         ),
+        (
+            ["--gen-enum-decls"],
+            "CommonExtensionsAttrs.h.inc",
+        ),
+        (
+            ["--gen-enum-defs"],
+            "CommonExtensionsAttrs.cpp.inc",
+        ),
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "CommonExtensionsOps.td",
@@ -51,10 +59,12 @@ iree_compiler_cc_library(
     name = "CommonExtensions",
     srcs = [
         "CommonExtensions.cpp",
+        "CommonExtensionsAttrs.cpp.inc",
         "CommonExtensionsOps.cpp.inc",
     ],
     hdrs = [
         "CommonExtensions.h",
+        "CommonExtensionsAttrs.h.inc",
         "CommonExtensionsOps.h.inc",
     ],
     deps = [
@@ -63,6 +73,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Interfaces:BufferizationInterfaces",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "@llvm-project//llvm:Support",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:BufferizationTransforms",
         "@llvm-project//mlir:Pass",

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
@@ -18,6 +18,8 @@ iree_tablegen_library(
   OUTS
     --gen-op-decls CommonExtensionsOps.h.inc
     --gen-op-defs CommonExtensionsOps.cpp.inc
+    --gen-enum-decls CommonExtensionsAttrs.h.inc
+    --gen-enum-defs CommonExtensionsAttrs.cpp.inc
 )
 
 iree_cc_library(
@@ -25,14 +27,17 @@ iree_cc_library(
     CommonExtensions
   HDRS
     "CommonExtensions.h"
+    "CommonExtensionsAttrs.h.inc"
     "CommonExtensionsOps.h.inc"
   SRCS
     "CommonExtensions.cpp"
+    "CommonExtensionsAttrs.cpp.inc"
     "CommonExtensionsOps.cpp.inc"
   DEPS
     ::CommonExtensionsOpGen
     IREEDialectsTransforms
     IREELinalgTransformDialect
+    LLVMSupport
     MLIRBufferizationDialect
     MLIRBufferizationTransforms
     MLIRPass

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -10,6 +10,9 @@
 #include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 
+// Do not hoist this include!
+#include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsAttrs.h.inc"
+
 #define GET_OP_CLASSES
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.h.inc"
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -11,6 +11,7 @@ include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 
 def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
@@ -73,6 +74,19 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
     By default, CPU allocations are emitted. This behavior can be modified by 
     using the following attributes:
       - target_gpu: if set, GPU allocations are emitted.
+
+    Return modes:
+    =============
+    This operation calls the upstream one-shot bufferization pass with extra
+    registered patterns for IREE.
+  
+    The pass is ran on all the ModuleOp nested under the top-level op on which
+    the transform dialect interpreter pass is applied.
+
+    If any of the pass on any of the ModuleOp fails, the transformation 
+    definitely fails. Otherwise the transformation succeeds.
+
+    No handles are consumed or produced.
   }];
 
   let arguments = (ins UnitAttr:$target_gpu);
@@ -80,6 +94,55 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
 
   let assemblyFormat = "attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
+def MatchInterfaceEnum : I32EnumAttr<"MatchInterfaceEnum", "An interface to match",
+    [
+      I32EnumAttrCase<"LinalgOp", 0>,
+      I32EnumAttrCase<"TilingInterface", 1>
+    ]>{
+  let cppNamespace = "::mlir::iree_compiler::IREE::transform_dialect";
+}
+
+def MatchOp : Op<Transform_Dialect, "iree.match",
+    [MemoryEffectsOpInterface,
+     NavigationTransformOpTrait,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{
+    Match op with the specified constraints, within the target op.
+
+    The following constraints are supported:
+      - interface: an optional MatchInterfaceEnum specifying an enum
+      representation for an interface to target.
+      - ops: an optional StrArrayAttr specifying the concrete name of an op. 
+      
+      Note: either `ops` or `interface` must be specified.
+
+    Return modes:
+    =============
+    This op traverses the ops nested under `target` and returns the handles to
+    all the operations that match the requirements.
+
+    This op fails if the target is not a handle to exactly one operation. 
+    Otherwise it succeeds.
+  
+    This operation does not consume the target handle and produces new handles:
+    it is a navigation op.
+  }];
+
+  let arguments = (ins PDL_Operation:$target,
+                       OptionalAttr<StrArrayAttr>:$match_op,
+                       OptionalAttr<MatchInterfaceEnum>:$match_interface);
+  // TODO: veriadic results when needed.
+  let results = (outs PDL_Operation:$results);
+
+  let assemblyFormat = [{
+    (`ops` `{` $match_op^ `}`)? 
+    (`interface` `{` $match_interface^ `}`)? 
+    `in` $target attr-dict
+  }];
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let hasVerifier = 1;
 }
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "test_partitionable_loops_interface.mlir",
             "tile_and_distribute_to_workgroups.mlir",
             "transform_dialect_apply_pattern_op.mlir",
+            "transform_dialect_match_op.mlir",
             "transpose_canonicalization.mlir",
             "type_propagation.mlir",
             "vectorize_linalg_conv.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_to_workgroups.mlir"
     "transform_dialect_apply_pattern_op.mlir"
+    "transform_dialect_match_op.mlir"
     "transpose_canonicalization.mlir"
     "type_propagation.mlir"
     "vectorize_linalg_conv.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_match_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_match_op.mlir
@@ -1,0 +1,50 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule -split-input-file | FileCheck %s
+
+func.func @test_match(%arg0: tensor<250x500xf32>, %arg1: tensor<500x1020xf32>) -> tensor<250x1020xf32> {
+  %0 = linalg.init_tensor [250, 1020] : tensor<250x1020xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%1 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+  return %2: tensor<250x1020xf32>
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.iree.match ops{["linalg.matmul", "linalg.init_tensor"]} in %arg1 
+
+    //     CHECK: linalg.init_tensor
+    // CHECK-NOT: linalg.fill
+    //     CHECK: linalg.matmul
+    transform.print %0 { name = "Matched Ops" }
+  }
+}
+
+// The printing of the func comes after the transform.print
+//         CHECK: @test_match
+
+// -----
+
+func.func @test_match(%arg0: tensor<250x500xf32>, %arg1: tensor<500x1020xf32>) -> tensor<250x1020xf32> {
+  %0 = linalg.init_tensor [250, 1020] : tensor<250x1020xf32>
+  %cst = arith.constant 0.000000e+00 : f32
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%1 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+  return %2: tensor<250x1020xf32>
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.iree.match interface{LinalgOp} in %arg1 
+
+    // CHECK: linalg.fill ins(%{{.*}} : f32) outs(%{{.*}} : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+    // CHECK: linalg.matmul ins(%{{.*}}, %{{.*}} : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%{{.*}} : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+    transform.print %0 { name = "Matched Interfaces" }
+  }
+}
+
+// The printing of the func comes after the transform.print
+//         CHECK: @test_match

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -957,9 +957,10 @@ transform_ext::PrintOp::apply(mlir::transform::TransformResults &results,
     return DiagnosedSilenceableFailure::success();
   }
 
-  llvm::outs() << "[[[ IR printer: " << getName() << " single op ]]]\n";
+  llvm::outs() << "[[[ IR printer: " << getName() << " ]]]\n";
   ArrayRef<Operation *> targets = state.getPayloadOps(getTarget());
-  targets.front()->dump();
+  for (Operation *target : targets)
+    llvm::outs() << *target << "\n";
   return DiagnosedSilenceableFailure::success();
 }
 


### PR DESCRIPTION
This revision adds a less general but more customizable match op that is easier to use than PDL's.
The feature set should grow up towards idiomatic use cases for high-level codegen.

Each feature should be carefully weighed in to ensure it does provide significantly usability gains, otherwise we should just use the PDL match op.
