### PR TITLE
Replace config string with DriverInfo

### DIFF
--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -341,15 +341,15 @@ class BenchmarkInfo:
     model_tags = model_tags.strip("[]").split(",")
     bench_mode = bench_mode.split(",")
 
-    runner = IREE_PRETTY_NAME_TO_DRIVER_NAME.get(runner)
-    if not runner:
+    driver = IREE_PRETTY_NAME_TO_DRIVER_NAME.get(runner)
+    if not driver:
       raise ValueError(f"Unrecognized runner: {runner}")
 
     return BenchmarkInfo(model_name=model_name,
                          model_tags=model_tags,
                          model_source=model_source,
                          bench_mode=bench_mode,
-                         driver_info=IREE_DRIVERS_INFOS[runner],
+                         driver_info=IREE_DRIVERS_INFOS[driver],
                          device_info=device_info)
 
   def to_json_object(self) -> Dict[str, Any]:

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -73,7 +73,7 @@ IREE_DRIVERS_INFOS = {
         DriverInfo("IREE-Vulkan", "GPU", "vulkan", ""),
 }
 
-IREE_PRETTY_NAMES_TO_DRIVERS = {
+IREE_PRETTY_NAME_TO_DRIVER_NAME = {
     v.pretty_name: k for k, v in IREE_DRIVERS_INFOS.items()
 }
 
@@ -123,11 +123,11 @@ def get_git_commit_hash(commit: str) -> str:
 
 def get_iree_benchmark_module_arguments(
     results_filename: str,
-    config: str,
+    driver_info: DriverInfo,
     benchmark_min_time: Optional[float] = None):
   """Returns the common arguments to run iree-benchmark-module."""
 
-  if config == "iree-vmvx" or config == "iree-vmvx-sync":
+  if driver_info.loader_name == "vmvx-module":
     # VMVX is very unoptimized for now and can take a long time to run.
     # Decrease the repetition for it until it's reasonably fast.
     repetitions = 3
@@ -299,24 +299,19 @@ class BenchmarkInfo:
   model_tags: Sequence[str]
   model_source: str
   bench_mode: Sequence[str]
-  runner: str
+  driver_info: DriverInfo
   device_info: DeviceInfo
 
   def __str__(self):
     # Get the target architecture and better driver name depending on the runner.
-    driver_info = IREE_DRIVERS_INFOS.get(self.runner)
-    if not driver_info:
-      raise ValueError(
-          f"Unrecognized runner '{self.runner}'; need to update the list")
-
     target_arch = None
-    if driver_info.device_type == 'GPU':
+    if self.driver_info.device_type == 'GPU':
       target_arch = "GPU-" + self.device_info.gpu_name
-    elif driver_info.device_type == 'CPU':
+    elif self.driver_info.device_type == 'CPU':
       target_arch = "CPU-" + self.device_info.get_detailed_cpu_arch_name()
     else:
       raise ValueError(
-          f"Unrecognized device type '{driver_info.device_type}' of the runner '{self.runner}'"
+          f"Unrecognized device type '{self.driver_info.device_type}' of the driver '{self.driver_info.pretty_name}'"
       )
 
     if self.model_tags:
@@ -327,7 +322,7 @@ class BenchmarkInfo:
     device_part = f"{self.device_info.model} ({target_arch})"
     mode = ",".join(self.bench_mode)
 
-    return f"{model_part} {mode} with {driver_info.pretty_name} @ {device_part}"
+    return f"{model_part} {mode} with {self.driver_info.pretty_name} @ {device_part}"
 
   @staticmethod
   def from_device_info_and_name(device_info: DeviceInfo, name: str):
@@ -345,9 +340,17 @@ class BenchmarkInfo:
     model_source = model_source.strip("()")
     model_tags = model_tags.strip("[]").split(",")
     bench_mode = bench_mode.split(",")
-    runner = IREE_PRETTY_NAMES_TO_DRIVERS.get(runner)
-    return BenchmarkInfo(model_name, model_tags, model_source, bench_mode,
-                         runner, device_info)
+
+    runner = IREE_PRETTY_NAME_TO_DRIVER_NAME.get(runner)
+    if not runner:
+      raise ValueError(f"Unrecognized runner: {runner}")
+
+    return BenchmarkInfo(model_name=model_name,
+                         model_tags=model_tags,
+                         model_source=model_source,
+                         bench_mode=bench_mode,
+                         driver_info=IREE_DRIVERS_INFOS[runner],
+                         device_info=device_info)
 
   def to_json_object(self) -> Dict[str, Any]:
     return {
@@ -355,17 +358,22 @@ class BenchmarkInfo:
         "model_tags": self.model_tags,
         "model_source": self.model_source,
         "bench_mode": self.bench_mode,
-        "runner": self.runner,
+        # Get the "iree-*" driver name from the DriverInfo.
+        "runner": IREE_PRETTY_NAME_TO_DRIVER_NAME[self.driver_info.pretty_name],
         "device_info": self.device_info.to_json_object(),
     }
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
+    driver_info = IREE_DRIVERS_INFOS.get(json_object["runner"])
+    if not driver_info:
+      raise ValueError(f"Unrecognized runner: {json_object['runner']}")
+
     return BenchmarkInfo(model_name=json_object["model_name"],
                          model_tags=json_object["model_tags"],
                          model_source=json_object["model_source"],
                          bench_mode=json_object["bench_mode"],
-                         runner=json_object["runner"],
+                         driver_info=driver_info,
                          device_info=DeviceInfo.from_json_object(
                              json_object["device_info"]))
 

--- a/build_tools/benchmarks/common/benchmark_driver.py
+++ b/build_tools/benchmarks/common/benchmark_driver.py
@@ -210,7 +210,7 @@ class BenchmarkDriver(object):
                          model_tags=benchmark_case.model_tags,
                          model_source=category,
                          bench_mode=benchmark_case.bench_mode,
-                         runner=benchmark_case.config,
+                         driver_info=benchmark_case.driver_info,
                          device_info=self.device_info)
 
   def __get_available_drivers_and_loaders(

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -13,7 +13,7 @@ from typing import Optional
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
 from common.benchmark_driver import BenchmarkDriver
 from common.benchmark_config import BENCHMARK_RESULTS_REL_PATH, CAPTURES_REL_PATH, BenchmarkConfig, TraceCaptureConfig
-from common.benchmark_definition import DeviceInfo, PlatformType
+from common.benchmark_definition import IREE_DRIVERS_INFOS, DeviceInfo, PlatformType
 
 
 class FakeBenchmarkDriver(BenchmarkDriver):
@@ -77,14 +77,14 @@ class BenchmarkDriverTest(unittest.TestCase):
                           model_tags=[],
                           bench_mode=["1-thread", "full-inference"],
                           target_arch="CPU-ARM64-v8A",
-                          config="iree-dylib",
+                          driver_info=IREE_DRIVERS_INFOS["iree-dylib"],
                           benchmark_case_dir="case1",
                           benchmark_tool_name="tool")
     case2 = BenchmarkCase(model_name="DeepNetv2",
                           model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="CPU-ARM64-v8A",
-                          config="iree-dylib-sync",
+                          driver_info=IREE_DRIVERS_INFOS["iree-dylib-sync"],
                           benchmark_case_dir="case2",
                           benchmark_tool_name="tool")
     self.benchmark_suite = BenchmarkSuite({

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -35,7 +35,7 @@ import re
 
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Sequence, Tuple
-from common.benchmark_definition import IREE_DRIVERS_INFOS
+from common.benchmark_definition import IREE_DRIVERS_INFOS, DriverInfo
 
 # All benchmarks' relative path against root build directory.
 BENCHMARK_SUITE_REL_PATH = "benchmark_suites"
@@ -52,7 +52,7 @@ class BenchmarkCase:
     model_tags: the source model tags, e.g., ['f32'].
     bench_mode: the benchmark mode, e.g., '1-thread,big-core'.
     target_arch: the target CPU/GPU architature, e.g., 'GPU-Adreno'.
-    config: the IREE runtime configuration, e.g., 'dylib'.
+    driver_info: the IREE driver configuration.
     benchmark_case_dir: the path to benchmark case directory.
     benchmark_tool_name: the benchmark tool, e.g., 'iree-benchmark-module'.
   """
@@ -61,7 +61,7 @@ class BenchmarkCase:
   model_tags: Sequence[str]
   bench_mode: Sequence[str]
   target_arch: str
-  config: str
+  driver_info: DriverInfo
   benchmark_case_dir: str
   benchmark_tool_name: str
 
@@ -122,17 +122,17 @@ class BenchmarkSuite(object):
 
     chosen_cases = []
     for benchmark_case in self.suite_map[category_dir]:
-      config_info = IREE_DRIVERS_INFOS[benchmark_case.config.lower()]
+      driver_info = benchmark_case.driver_info
 
-      driver_name = config_info.driver_name
+      driver_name = driver_info.driver_name
       matched_available_driver = (available_drivers is None or
                                   driver_name in available_drivers)
       matched_drivler_filter = driver_filter is None or re.match(
           driver_filter, driver_name) is not None
       matched_driver = matched_available_driver and matched_drivler_filter
 
-      matched_loader = not config_info.loader_name or available_loaders is None or (
-          config_info.loader_name in available_loaders)
+      matched_loader = not driver_info.loader_name or available_loaders is None or (
+          driver_info.loader_name in available_loaders)
 
       target_arch = benchmark_case.target_arch.lower()
       matched_cpu_arch = (cpu_target_arch_filter is not None and re.match(
@@ -197,7 +197,7 @@ class BenchmarkSuite(object):
                         model_tags=model_tags,
                         bench_mode=bench_mode,
                         target_arch=target_arch,
-                        config=config,
+                        driver_info=IREE_DRIVERS_INFOS[config.lower()],
                         benchmark_case_dir=benchmark_case_dir,
                         benchmark_tool_name=tool_name))
 

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import unittest
 from typing import Sequence
+from common.benchmark_definition import IREE_DRIVERS_INFOS
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
 
 
@@ -28,21 +29,21 @@ class BenchmarkSuiteTest(unittest.TestCase):
                           model_tags=[],
                           bench_mode=["1-thread", "full-inference"],
                           target_arch="CPU-ARMv8",
-                          config="iree-dylib",
+                          driver_info=IREE_DRIVERS_INFOS["iree-dylib"],
                           benchmark_case_dir="case1",
                           benchmark_tool_name="tool")
     case2 = BenchmarkCase(model_name="deepnetv2",
                           model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="GPU-Mali",
-                          config="iree-vulkan",
+                          driver_info=IREE_DRIVERS_INFOS["iree-vulkan"],
                           benchmark_case_dir="case2",
                           benchmark_tool_name="tool")
     case3 = BenchmarkCase(model_name="deepnetv3",
                           model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="CPU-x86_64",
-                          config="iree-dylib-sync",
+                          driver_info=IREE_DRIVERS_INFOS["iree-dylib-sync"],
                           benchmark_case_dir="case3",
                           benchmark_tool_name="tool")
     suite = BenchmarkSuite({
@@ -142,7 +143,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
                          model_tags=model_tags,
                          bench_mode=bench_mode,
                          target_arch=target_arch,
-                         config=config,
+                         driver_info=IREE_DRIVERS_INFOS[config],
                          benchmark_case_dir=bench_path,
                          benchmark_tool_name=tool)
 

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -40,7 +40,7 @@ import sys
 from typing import Optional, Sequence
 from common.benchmark_config import BenchmarkConfig
 from common.benchmark_driver import BenchmarkDriver
-from common.benchmark_definition import (execute_cmd,
+from common.benchmark_definition import (DriverInfo, execute_cmd,
                                          execute_cmd_and_get_output,
                                          get_git_commit_hash,
                                          get_iree_benchmark_module_arguments,
@@ -204,7 +204,7 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     if benchmark_results_filename is not None:
       self.__run_benchmark(android_case_dir=android_case_dir,
                            tool_name=benchmark_case.benchmark_tool_name,
-                           config=benchmark_case.config,
+                           driver_info=benchmark_case.driver_info,
                            results_filename=benchmark_results_filename,
                            taskset=taskset)
 
@@ -214,8 +214,9 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
                          capture_filename=capture_filename,
                          taskset=taskset)
 
-  def __run_benchmark(self, android_case_dir: str, tool_name: str, config: str,
-                      results_filename: str, taskset: str):
+  def __run_benchmark(self, android_case_dir: str, tool_name: str,
+                      driver_info: DriverInfo, results_filename: str,
+                      taskset: str):
     host_tool_path = os.path.join(self.config.normal_benchmark_tool_dir,
                                   tool_name)
     android_tool = self.__check_and_push_file(host_tool_path,
@@ -227,7 +228,7 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
       cmd.extend(
           get_iree_benchmark_module_arguments(
               results_filename=f"'{os.path.basename(results_filename)}'",
-              config=config,
+              driver_info=driver_info,
               benchmark_min_time=self.config.benchmark_min_time))
 
     result_json = adb_execute_and_get_output(cmd,


### PR DESCRIPTION
Convert the driver config string to `DriverInfo` from the inputs and only use `DriverInfo` internally.

After the recent changes on the IREE driver, there are more options to config the driver. The original "driver name" string becomes an alias of a specific config. `DriverInfo` contains the structured data and makes other places easier to get the detailed info.