### PR TITLE
Change some seq_cst to acquire/release in synchronization.c

### DIFF
--- a/runtime/src/iree/base/internal/synchronization.c
+++ b/runtime/src/iree/base/internal/synchronization.c
@@ -405,7 +405,7 @@ void iree_slim_mutex_initialize(iree_slim_mutex_t* out_mutex) {
 void iree_slim_mutex_deinitialize(iree_slim_mutex_t* mutex) {
   // Assert unlocked (callers must ensure the mutex is no longer in use).
   SYNC_ASSERT(
-      iree_atomic_load_int32(&mutex->value, iree_memory_order_seq_cst) == 0);
+      iree_atomic_load_int32(&mutex->value, iree_memory_order_acquire) == 0);
 }
 
 void iree_slim_mutex_lock(iree_slim_mutex_t* mutex)
@@ -683,7 +683,7 @@ void iree_notification_initialize(iree_notification_t* out_notification) {
 void iree_notification_deinitialize(iree_notification_t* notification) {
   // Assert no more waiters (callers must tear down waiters first).
   SYNC_ASSERT(
-      (iree_atomic_load_int64(&notification->value, iree_memory_order_seq_cst) &
+      (iree_atomic_load_int64(&notification->value, iree_memory_order_acquire) &
        IREE_NOTIFICATION_WAITER_MASK) == 0);
 }
 
@@ -732,7 +732,7 @@ bool iree_notification_commit_wait(iree_notification_t* notification,
   // the waiter count gets to 0 the less likely we'll wake on the futex.
   uint64_t previous_value = iree_atomic_fetch_add_int64(
       &notification->value, IREE_NOTIFICATION_WAITER_DEC,
-      iree_memory_order_seq_cst);
+      iree_memory_order_acq_rel);
   SYNC_ASSERT((previous_value & IREE_NOTIFICATION_WAITER_MASK) != 0);
 
   return result;
@@ -744,7 +744,7 @@ void iree_notification_cancel_wait(iree_notification_t* notification) {
   // the waiter count gets to 0 the less likely we'll wake on the futex.
   uint64_t previous_value = iree_atomic_fetch_add_int64(
       &notification->value, IREE_NOTIFICATION_WAITER_DEC,
-      iree_memory_order_seq_cst);
+      iree_memory_order_acq_rel);
   SYNC_ASSERT((previous_value & IREE_NOTIFICATION_WAITER_MASK) != 0);
 }
 

--- a/runtime/src/iree/base/internal/synchronization.h
+++ b/runtime/src/iree/base/internal/synchronization.h
@@ -57,9 +57,7 @@
 // https://github.com/llvm-mirror/compiler-rt/blob/master/include/sanitizer/tsan_interface.h
 #if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_EMSCRIPTEN) || \
     defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_WINDOWS)
-#if !defined(IREE_SANITIZER_THREAD)
 #define IREE_PLATFORM_HAS_FUTEX 1
-#endif  // !IREE_SANITIZER_THREAD
 #endif  // IREE_PLATFORM_*
 
 #if defined(IREE_PLATFORM_APPLE)

--- a/runtime/src/iree/base/internal/synchronization.h
+++ b/runtime/src/iree/base/internal/synchronization.h
@@ -52,9 +52,6 @@
 // to never need it. This removes our dependency on pthreads.
 #if !IREE_SYNCHRONIZATION_DISABLE_UNSAFE
 
-// NOTE: we only support futex when not using tsan as we need to add annotations
-// for tsan to understand what we are doing.
-// https://github.com/llvm-mirror/compiler-rt/blob/master/include/sanitizer/tsan_interface.h
 #if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_EMSCRIPTEN) || \
     defined(IREE_PLATFORM_LINUX) || defined(IREE_PLATFORM_WINDOWS)
 #define IREE_PLATFORM_HAS_FUTEX 1


### PR DESCRIPTION
The memory orders in this file were already mainly acquire/release. A few seq_cst looked kind of out of place, and were not clearly guaranteeing more than acq_rel given some concurrent accesses were acq_rel already.
    
The most significant change here is in iree_notification_commit_wait / iree_notification_cancel_wait. But note that iree_notification_post was acq_rel anyway.