### PR TITLE
Add conversion tests for vm.abs ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops.mlir
@@ -88,6 +88,17 @@ vm.module @my_module {
 
 // -----
 
+// CHECK-LABEL: @my_module_abs_i32
+vm.module @my_module {
+  vm.func @abs_i32(%arg0 : i32) -> i32 {
+    // CHECK: %0 = emitc.call "vm_abs_i32"(%arg3) : (i32) -> i32
+    %0 = vm.abs.i32 %arg0 : i32
+    vm.return %0 : i32
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @my_module_not_i32
 vm.module @my_module {
   vm.func @not_i32(%arg0 : i32) -> i32 {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/arithmetic_ops_i64.mlir
@@ -88,6 +88,17 @@ vm.module @my_module {
 
 // -----
 
+// CHECK-LABEL: @my_module_abs_i64
+vm.module @my_module {
+  vm.func @abs_i64(%arg0 : i64) -> i64 {
+    // CHECK: %0 = emitc.call "vm_abs_i64"(%arg3) : (i64) -> i64
+    %0 = vm.abs.i64 %arg0 : i64
+    vm.return %0 : i64
+  }
+}
+
+// -----
+
 // CHECK-LABEL: @my_module_not_i64
 vm.module @my_module {
   vm.func @not_i64(%arg0 : i64) -> i64 {


### PR DESCRIPTION
This adds VM to EmitC tests for the ops added with commit ca51bc6.