### PR TITLE
Replace tensorflow::StatusOr::ConsumeValueOrDie with StatusOr::ValueOrDie().

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
@@ -73,7 +73,7 @@ static OwningOpRef<mlir::ModuleOp> importSavedModelV2(
     return nullptr;
   }
 
-  return loadedModule.ConsumeValueOrDie();
+  return std::move(loadedModule).ValueOrDie();
 }
 
 static OwningOpRef<mlir::ModuleOp> importSavedModelV1(
@@ -117,7 +117,7 @@ static OwningOpRef<mlir::ModuleOp> importSavedModelV1(
     return nullptr;
   }
 
-  return loadedModule.ConsumeValueOrDie();
+  return std::move(loadedModule).ValueOrDie();
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This is to align tensorflow::StatusOr with absl::StatusOr in preparation
for upstream changes.
