### PR TITLE
Add a workflow for building and testing the runtime post-submit

### DIFF
--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -33,6 +33,8 @@ jobs:
             gcr.io/iree-oss/base@sha256:9d742e01507c292def852cbfebfae71412cff94df0ab2619f61f9a5a2a98f651 \
             ./build_tools/cmake/build_runtime.sh \
             "${{ inputs.build-dir }}"
+      # Using a tar archive is necessary to preserve file permissions. See
+      # https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
       - name: "Create build dir archive"
         run: tar -cf ${{ inputs.build-dir }}.tar ${{ inputs.build-dir }}
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -33,7 +33,9 @@ jobs:
             gcr.io/iree-oss/base@sha256:9d742e01507c292def852cbfebfae71412cff94df0ab2619f61f9a5a2a98f651 \
             ./build_tools/cmake/build_runtime.sh \
             "${{ inputs.build-dir }}"
+      - name: "Create build dir archive"
+        run: tar -cf ${{ inputs.build-dir }}.tar ${{ inputs.build-dir }}
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
-          name: ${{ inputs.build-dir }}
-          path: ${{ inputs.build-dir }}
+          name: "${{ inputs.build-dir }}.tar"
+          path: "${{ inputs.build-dir }}.tar"

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -13,7 +13,6 @@ on:
 
 
 env:
-  BUILD_DIR: ${{ inputs.build-dir }}
   IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
 
 jobs:
@@ -31,8 +30,8 @@ jobs:
             --rm \
             gcr.io/iree-oss/base@sha256:9d742e01507c292def852cbfebfae71412cff94df0ab2619f61f9a5a2a98f651 \
             ./build_tools/cmake/build_runtime.sh \
-            "${BUILD_DIR}"
+            "${{ inputs.build-dir }}"
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
-          name: ${{ env.BUILD_DIR }}
-          path: ${{ env.BUILD_DIR }}
+          name: ${{ inputs.build-dir }}
+          path: ${{ inputs.build-dir }}

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -35,6 +35,9 @@ jobs:
             "${{ inputs.build-dir }}"
       # Using a tar archive is necessary to preserve file permissions. See
       # https://github.com/actions/upload-artifact#maintaining-file-permissions-and-case-sensitive-files
+      # The upload action already does its own gzip compression, so it's likely
+      # unnecessary (and perhaps harmful) to do our own, though that hasn't been
+      # investigated.
       - name: "Create build dir archive"
         run: tar -cf ${{ inputs.build-dir }}.tar ${{ inputs.build-dir }}
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -11,7 +11,6 @@ on:
         required: true
         type: string
 
-
 env:
   IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
 

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        with:
+          submodules: true
       - name: "Building runtime"
         run: |
           docker run --user="$(id -u):$(id -g)" \

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -32,7 +32,7 @@ jobs:
             gcr.io/iree-oss/base@sha256:9d742e01507c292def852cbfebfae71412cff94df0ab2619f61f9a5a2a98f651 \
             ./build_tools/cmake/build_runtime.sh \
             "${BUILD_DIR}"
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
           name: ${{ env.BUILD_DIR }}
           path: ${{ env.BUILD_DIR }}

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build_runtime:
-    name: "Build runtime"
     runs-on: ubuntu-20.04
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/build_runtime_cmake.yml
+++ b/.github/workflows/build_runtime_cmake.yml
@@ -1,0 +1,38 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+on:
+  workflow_call:
+    inputs:
+      build-dir:
+        required: true
+        type: string
+
+
+env:
+  BUILD_DIR: ${{ inputs.build-dir }}
+  IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+
+jobs:
+  build_runtime:
+    name: "Build runtime"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+      - name: "Building runtime"
+        run: |
+          docker run --user="$(id -u):$(id -g)" \
+            --volume="$PWD:$IREE_DOCKER_WORKDIR" \
+            --workdir="$IREE_DOCKER_WORKDIR" \
+            --rm \
+            gcr.io/iree-oss/base@sha256:9d742e01507c292def852cbfebfae71412cff94df0ab2619f61f9a5a2a98f651 \
+            ./build_tools/cmake/build_runtime.sh \
+            "${BUILD_DIR}"
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: ${{ env.BUILD_DIR }}
+          path: ${{ env.BUILD_DIR }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@
 
 name: Lint
 
-# on: [pull_request] DO NOT SUBMIT. Undo this!
+on: [pull_request]
 
 jobs:
   bazel_to_cmake:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@
 
 name: Lint
 
-on: [pull_request]
+# on: [pull_request] DO NOT SUBMIT. Undo this!
 
 jobs:
   bazel_to_cmake:

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -20,6 +20,7 @@ jobs:
       build-dir: build-runtime
 
   test_runtime:
+    needs: build_runtime
     uses: ./.github/workflows/test_runtime.yml
     with:
       build-dir: build-runtime

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
           name: some-dir
+          path: some-dir
       - name: "Explore"
         run: ls -R
 

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -21,6 +21,6 @@ jobs:
 
   test_runtime:
     needs: build_runtime
-    uses: ./.github/workflows/test_runtime.yml
+    uses: ./.github/workflows/test_runtime_cmake.yml
     with:
       build-dir: build-runtime

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -14,13 +14,35 @@ on: [pull_request]
   # pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
-  build_runtime:
-    uses: ./.github/workflows/build_runtime_cmake.yml
-    with:
-      build-dir: build-runtime
+  upload_dir:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Create artifacts"
+        run: |
+          mkdir some-dir
+          touch some-dir/foo.txt
+          touch some-dir/bar.txt
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
+        with:
+          name: some-dir
+          path: some-dir
+  download_dir:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Downloading runtime build directory"
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
+        with:
+          name: some-dir
+      - name: "Explore"
+        run: ls -R
 
-  test_runtime:
-    needs: build_runtime
-    uses: ./.github/workflows/test_runtime_cmake.yml
-    with:
-      build-dir: build-runtime
+  # build_runtime:
+  #   uses: ./.github/workflows/build_runtime_cmake.yml
+  #   with:
+  #     build-dir: build-runtime
+
+  # test_runtime:
+  #   needs: build_runtime
+  #   uses: ./.github/workflows/test_runtime_cmake.yml
+  #   with:
+  #     build-dir: build-runtime

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -14,37 +14,13 @@ on: [pull_request]
   # pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
-  upload_dir:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Create artifacts"
-        run: |
-          mkdir some-dir
-          echo "foo" > some-dir/foo.txt
-          echo "bar" > some-dir/bar.txt
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
-        with:
-          name: some-dir
-          path: some-dir
-  download_dir:
-    runs-on: ubuntu-20.04
-    needs: [upload_dir]
-    steps:
-      - name: "Downloading runtime build directory"
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
-        with:
-          name: some-dir
-          path: some-dir
-      - name: "Explore"
-        run: ls -R
+  build_runtime:
+    uses: ./.github/workflows/build_runtime_cmake.yml
+    with:
+      build-dir: build-runtime
 
-  # build_runtime:
-  #   uses: ./.github/workflows/build_runtime_cmake.yml
-  #   with:
-  #     build-dir: build-runtime
-
-  # test_runtime:
-  #   needs: build_runtime
-  #   uses: ./.github/workflows/test_runtime_cmake.yml
-  #   with:
-  #     build-dir: build-runtime
+  test_runtime:
+    needs: build_runtime
+    uses: ./.github/workflows/test_runtime_cmake.yml
+    with:
+      build-dir: build-runtime

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -20,8 +20,8 @@ jobs:
       - name: "Create artifacts"
         run: |
           mkdir some-dir
-          touch some-dir/foo.txt
-          touch some-dir/bar.txt
+          echo "foo" > some-dir/foo.txt
+          echo "bar" > some-dir/bar.txt
       - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
         with:
           name: some-dir

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -11,7 +11,6 @@ on:
     branches:
       - main
   workflow_dispatch:
-  pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
   build_runtime:

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -6,12 +6,12 @@
 
 name: Postsubmit
 
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
-  pull_request:  # TODO: DO NOT SUBMIT. remove this
+on: [pull_request]
+  # push:
+  #   branches:
+  #     - main
+  # workflow_dispatch:
+  # pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
   build_runtime:

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -28,12 +28,13 @@ jobs:
           path: some-dir
   download_dir:
     runs-on: ubuntu-20.04
+    needs: [upload_dir]
     steps:
       - name: "Downloading runtime build directory"
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
           name: some-dir
-          # path: some-dir
+          path: some-dir
       - name: "Explore"
         run: ls -R
 

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -1,0 +1,25 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Postsubmit
+
+on:
+  push:
+    branches:
+     - main
+  workflow_dispatch:
+  pull_request: # TODO: remove this
+
+jobs:
+  build_runtime:
+    uses: ./.github/workflows/build_runtime_cmake.yml
+    with:
+      build-dir: build-runtime
+
+  test_runtime:
+    uses:  ./.github/workflows/test_runtime.yml
+    with:
+      build-dir: build-runtime

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -14,40 +14,13 @@ on: [pull_request]
   # pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
-  upload:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Create artifacts
-        run: |
-          mkdir some-dir
-          touch some-dir/foo.txt
-          touch some-dir/bar.sh
-          chmod +x some-dir/bar.sh
-          tar -cf some-dir.tar some-dir
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
-        with:
-          name: some-dir.tar
-          path: some-dir.tar
+  build_runtime:
+    uses: ./.github/workflows/build_runtime_cmake.yml
+    with:
+      build-dir: build-runtime
 
-  download:
-    runs-on: ubuntu-20.04
-    needs: upload
-    steps:
-      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
-        with:
-          name: some-dir.tar
-      - name: Extract
-        run: tar -xf some-dir.tar
-      - name: Explore
-        run: ls -lhtR
-
-  # build_runtime:
-  #   uses: ./.github/workflows/build_runtime_cmake.yml
-  #   with:
-  #     build-dir: build-runtime
-
-  # test_runtime:
-  #   needs: build_runtime
-  #   uses: ./.github/workflows/test_runtime_cmake.yml
-  #   with:
-  #     build-dir: build-runtime
+  test_runtime:
+    needs: build_runtime
+    uses: ./.github/workflows/test_runtime_cmake.yml
+    with:
+      build-dir: build-runtime

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -6,12 +6,12 @@
 
 name: Postsubmit
 
-on: [pull_request]
-  # push:
-  #   branches:
-  #     - main
-  # workflow_dispatch:
-  # pull_request:  # TODO: DO NOT SUBMIT. remove this
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
   build_runtime:

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -14,13 +14,40 @@ on: [pull_request]
   # pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
-  build_runtime:
-    uses: ./.github/workflows/build_runtime_cmake.yml
-    with:
-      build-dir: build-runtime
+  upload:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Create artifacts
+        run: |
+          mkdir some-dir
+          touch some-dir/foo.txt
+          touch some-dir/bar.sh
+          chmod +x some-dir/bar.sh
+          tar -cf some-dir.tar some-dir
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
+        with:
+          name: some-dir.tar
+          path: some-dir.tar
 
-  test_runtime:
-    needs: build_runtime
-    uses: ./.github/workflows/test_runtime_cmake.yml
-    with:
-      build-dir: build-runtime
+  download:
+    runs-on: ubuntu-20.04
+    needs: upload
+    steps:
+      - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
+        with:
+          name: some-dir.tar
+      - name: Extract
+        run: tar -xf some-dir.tar
+      - name: Explore
+        run: ls -lhtR
+
+  # build_runtime:
+  #   uses: ./.github/workflows/build_runtime_cmake.yml
+  #   with:
+  #     build-dir: build-runtime
+
+  # test_runtime:
+  #   needs: build_runtime
+  #   uses: ./.github/workflows/test_runtime_cmake.yml
+  #   with:
+  #     build-dir: build-runtime

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
           name: some-dir
-          path: some-dir
+          # path: some-dir
       - name: "Explore"
         run: ls -R
 

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -9,9 +9,9 @@ name: Postsubmit
 on:
   push:
     branches:
-     - main
+      - main
   workflow_dispatch:
-  pull_request: # TODO: remove this
+  pull_request:  # TODO: DO NOT SUBMIT. remove this
 
 jobs:
   build_runtime:
@@ -20,6 +20,6 @@ jobs:
       build-dir: build-runtime
 
   test_runtime:
-    uses:  ./.github/workflows/test_runtime.yml
+    uses: ./.github/workflows/test_runtime.yml
     with:
       build-dir: build-runtime

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -17,7 +17,6 @@ env:
 
 jobs:
   build_runtime:
-    name: "Test runtime"
     runs-on: ubuntu-20.04
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -28,7 +28,6 @@ jobs:
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
           name: "${{ inputs.build-dir }}.tar"
-          path: "${{ inputs.build-dir }}.tar"
       - name: "Extract archive"
         run: tar -xf ${{ inputs.build-dir }}.tar ${{ inputs.build-dir }}
       - name: "Testing runtime"

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -16,7 +16,7 @@ env:
   IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
 
 jobs:
-  build_runtime:
+  test_runtime:
     runs-on: ubuntu-20.04
     steps:
       - name: "Checking out repository"

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -27,8 +27,10 @@ jobs:
       - name: "Downloading runtime build directory"
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
-          name: ${{ inputs.build-dir }}
-          path: ${{ inputs.build-dir }}
+          name: "${{ inputs.build-dir }}.tar"
+          path: "${{ inputs.build-dir }}.tar"
+      - name: "Extract archive"
+        run: tar -xf ${{ inputs.build-dir }}.tar ${{ inputs.build-dir }}
       - name: "Testing runtime"
         run: |
           docker run --user="$(id -u):$(id -g)" \

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        with:
+          submodules: true
       - name: "Downloading runtime build directory"
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
       - name: "Downloading runtime build directory"
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
           name: ${{ env.BUILD_DIR }}
       - name: "Testing runtime"

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -28,6 +28,7 @@ jobs:
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
           name: ${{ inputs.build-dir }}
+          path: ${{ inputs.build-dir }}
       - name: "Testing runtime"
         run: |
           docker run --user="$(id -u):$(id -g)" \

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -11,7 +11,6 @@ on:
         required: true
         type: string
 
-
 env:
   IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
 

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -1,0 +1,39 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+on:
+  workflow_call:
+    inputs:
+      build-dir:
+        required: true
+        type: string
+
+
+env:
+  BUILD_DIR: ${{ inputs.build-dir }}
+  IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
+
+jobs:
+  build_runtime:
+    name: "Test runtime"
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+      - name: "Downloading runtime build directory"
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
+        with:
+          name: ${{ env.BUILD_DIR }}
+      - name: "Testing runtime"
+        run: |
+          docker run --user="$(id -u):$(id -g)" \
+            --volume="$PWD:$IREE_DOCKER_WORKDIR" \
+            --workdir="$IREE_DOCKER_WORKDIR" \
+            --env IREE_VULKAN_DISABLE=1 \
+            --rm \
+            gcr.io/iree-oss/base@sha256:9d742e01507c292def852cbfebfae71412cff94df0ab2619f61f9a5a2a98f651 \
+            ./build_tools/cmake/ctest_all.sh \
+            "${BUILD_DIR}"

--- a/.github/workflows/test_runtime_cmake.yml
+++ b/.github/workflows/test_runtime_cmake.yml
@@ -13,7 +13,6 @@ on:
 
 
 env:
-  BUILD_DIR: ${{ inputs.build-dir }}
   IREE_DOCKER_WORKDIR: "/usr/src/github/iree"
 
 jobs:
@@ -26,7 +25,7 @@ jobs:
       - name: "Downloading runtime build directory"
         uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
         with:
-          name: ${{ env.BUILD_DIR }}
+          name: ${{ inputs.build-dir }}
       - name: "Testing runtime"
         run: |
           docker run --user="$(id -u):$(id -g)" \
@@ -36,4 +35,4 @@ jobs:
             --rm \
             gcr.io/iree-oss/base@sha256:9d742e01507c292def852cbfebfae71412cff94df0ab2619f61f9a5a2a98f651 \
             ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+            "${{ inputs.build-dir }}"


### PR DESCRIPTION
This uses GitHub's hosted runners, since they are sufficient when only
building the runtime. It mostly a step towards migrating our initial
Buildkite workflows and finding parity with those. Note that this is
not doing anything to make the entire workflow idempotent. We will
likely need to move to our own artifact storage scheme (backed by GCS)
to make that work. We definitely incur a cost from having to upload and
download the build directory rather than building and testing in the
same directory (1.5 minutes to upload. download is negligible), but I
think the modularity is worth it and we can find a way to speed it up.