### PR TITLE
Handle the missing results when posting comments

### DIFF
--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -5,8 +5,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import glob
 import os
 import argparse
+from typing import List, Sequence
 
 
 def build_common_argument_parser():
@@ -122,3 +124,20 @@ def build_common_argument_parser():
       "instead.")
 
   return parser
+
+
+def expand_and_check_file_paths(paths: Sequence[str]) -> List[str]:
+  """Expands the wildcards in the paths and check if they are files.
+    Returns:
+      List of expanded paths.
+  """
+
+  expanded_paths = []
+  for path in paths:
+    expanded_paths += glob.glob(path)
+
+  for path in expanded_paths:
+    if not os.path.isfile(path):
+      raise ValueError(f"{path} is not a file.")
+
+  return expanded_paths

--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -40,6 +40,7 @@ import markdown_strings as md
 
 from typing import Any, Dict, Optional, Sequence, Tuple
 
+from common.common_arguments import expand_and_check_file_paths
 from common.benchmark_definition import execute_cmd_and_get_output
 from common.benchmark_presentation import *
 
@@ -321,36 +322,29 @@ def update_comment_on_pr(comment_id: int, content: str, verbose: bool = False):
 def parse_arguments():
   """Parses command-line options."""
 
-  def check_file_path(path):
-    if os.path.isfile(path):
-      return path
-    else:
-      raise ValueError(path)
-
   parser = argparse.ArgumentParser()
   parser.add_argument(
       "--benchmark_files",
       metavar="<benchmark-json-files>",
-      type=check_file_path,
       default=[],
       nargs="+",
-      help="Paths to the JSON files containing benchmark results")
+      help=("Paths to the JSON files containing benchmark results, "
+            "accepts wildcards"))
   parser.add_argument(
       "--compile_stats_files",
       metavar="<compile-stats-json-files>",
-      type=check_file_path,
       default=[],
       nargs="+",
-      help="Paths to the JSON files containing compilation statistics")
+      help=("Paths to the JSON files containing compilation statistics, "
+            "accepts wildcards"))
   parser.add_argument("--dry-run",
                       action="store_true",
                       help="Print the comment instead of posting to GitHub")
   parser.add_argument(
       "--query-base",
       action="store_true",
-      help=
-      "Query the dashboard for the benchmark results of the targeting base branch"
-  )
+      help=("Query the dashboard for the benchmark results of the targeting "
+            "base branch"))
   parser.add_argument("--comment-title",
                       default=ABBR_PR_COMMENT_TITLE,
                       help="Title of the comment")
@@ -363,9 +357,11 @@ def parse_arguments():
 
 
 def main(args):
+  benchmark_files = expand_and_check_file_paths(args.benchmark_files)
+  compile_stats_files = expand_and_check_file_paths(args.compile_stats_files)
   full_md, abbr_md = get_benchmark_result_markdown(
-      args.benchmark_files,
-      args.compile_stats_files,
+      benchmark_files,
+      compile_stats_files,
       query_base=args.query_base,
       comment_title=args.comment_title,
       verbose=args.verbose)

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -115,18 +115,13 @@ steps:
         || grep -q "No artifacts found" ./bench-dl-log
       buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl-log \
         || grep -q "No artifacts found" ./stats-dl-log
-      # Check the downloaded artifacts and build the parameters.
-      if ls benchmark-results-*.json; then
-        PARAMS+=("--benchmark_files" benchmark-results-*.json)
-      fi
-      if ls compile-stats-results-*.json; then
-        PARAMS+=("--compile_stats_files" compile-stats-results-*.json)
-      fi
+      # The script will handle the wildcard patterns.
       python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py \
         --verbose \
         --query-base \
         --comment-title="Abbreviated Linux Benchmark Summary" \
-        $${PARAMS[@]}
+        --benchmark_files "benchmark-results-*.json" \
+        --compile_stats_files "compile-stats-results-*.json"
     if: >
       build.pull_request.id != null && (
         build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -109,15 +109,22 @@ steps:
   - label: ":lower_left_crayon: Comment benchmark results on pull request"
     key: "post-on-pr"
     commands: |
-      git clean -fdx
-      buildkite-agent artifact download "benchmark-results-*.json" ./
-      buildkite-agent artifact download "compile-stats-results-*.json" ./
+      set -euo pipefail
+      buildkite-agent artifact download "benchmark-results-*.json" ./ 2>&1 | tee bench-dl.log \
+        || { grep -q "No artifacts found" ./bench-dl.log; NOT_FOUND=1; }
+      if [[ -z "${NOT_FOUND:-}" ]]; then
+        PARAMS+=("--benchmark_files" benchmark-results-*.json)
+      fi
+      buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl.log \
+        || { grep -q "No artifacts found" ./stats-dl.log; NOT_FOUND=1; }
+      if [[ -z "${NOT_FOUND:-}" ]]; then
+        PARAMS+=("--compile_stats_files" compile-stats-results-*.json)
+      fi
       python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py \
         --verbose \
         --query-base \
         --comment-title="Abbreviated Linux Benchmark Summary" \
-        --benchmark_files benchmark-results-*.json \
-        --compile_stats_files compile-stats-results-*.json
+        ${PARAMS[@]}
     if: >
       build.pull_request.id != null && (
         build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -110,7 +110,7 @@ steps:
     key: "post-on-pr"
     commands: |
       set -euo pipefail
-      # Try to download the artifacts and not fail if not found.
+      # Try to download the artifacts, continuing with a message if not found.
       buildkite-agent artifact download "benchmark-results-*.json" ./ 2>&1 | tee bench-dl-log \
         || grep -q "No artifacts found" ./bench-dl-log
       buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl-log \

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -111,13 +111,13 @@ steps:
     commands: |
       set -euo pipefail
       buildkite-agent artifact download "benchmark-results-*.json" ./ 2>&1 | tee bench-dl.log \
-        || { grep -q "No artifacts found" ./bench-dl.log; NOT_FOUND=1; }
-      if [[ -z "$${NOT_FOUND:-}" ]]; then
+        || { grep -q "No artifacts found" ./bench-dl.log; BENCH_NOT_FOUND=1; }
+      if [[ -z "$${BENCH_NOT_FOUND:-}" ]]; then
         PARAMS+=("--benchmark_files" benchmark-results-*.json)
       fi
       buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl.log \
-        || { grep -q "No artifacts found" ./stats-dl.log; NOT_FOUND=1; }
-      if [[ -z "$${NOT_FOUND:-}" ]]; then
+        || { grep -q "No artifacts found" ./stats-dl.log; STATS_NOT_FOUND=1; }
+      if [[ -z "$${STATS_NOT_FOUND:-}" ]]; then
         PARAMS+=("--compile_stats_files" compile-stats-results-*.json)
       fi
       python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py \

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -110,14 +110,14 @@ steps:
     key: "post-on-pr"
     commands: |
       set -euo pipefail
-      buildkite-agent artifact download "benchmark-results-*.json" ./ 2>&1 | tee bench-dl.log \
-        || { grep -q "No artifacts found" ./bench-dl.log; BENCH_NOT_FOUND=1; }
-      if [[ -z "$${BENCH_NOT_FOUND:-}" ]]; then
+      buildkite-agent artifact download "benchmark-results-*.json" ./ 2>&1 | tee bench-dl-log \
+        || grep -q "No artifacts found" ./bench-dl-log
+      buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl-log \
+        || grep -q "No artifacts found" ./stats-dl-log
+      if ls benchmark-results-*.json; then
         PARAMS+=("--benchmark_files" benchmark-results-*.json)
       fi
-      buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl.log \
-        || { grep -q "No artifacts found" ./stats-dl.log; STATS_NOT_FOUND=1; }
-      if [[ -z "$${STATS_NOT_FOUND:-}" ]]; then
+      if ls compile-stats-results-*.json; then
         PARAMS+=("--compile_stats_files" compile-stats-results-*.json)
       fi
       python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py \

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -110,10 +110,12 @@ steps:
     key: "post-on-pr"
     commands: |
       set -euo pipefail
+      # Try to download the artifacts and not fail if not found.
       buildkite-agent artifact download "benchmark-results-*.json" ./ 2>&1 | tee bench-dl-log \
         || grep -q "No artifacts found" ./bench-dl-log
       buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl-log \
         || grep -q "No artifacts found" ./stats-dl-log
+      # Check the downloaded artifacts and build the parameters.
       if ls benchmark-results-*.json; then
         PARAMS+=("--benchmark_files" benchmark-results-*.json)
       fi

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -112,19 +112,19 @@ steps:
       set -euo pipefail
       buildkite-agent artifact download "benchmark-results-*.json" ./ 2>&1 | tee bench-dl.log \
         || { grep -q "No artifacts found" ./bench-dl.log; NOT_FOUND=1; }
-      if [[ -z "${NOT_FOUND:-}" ]]; then
+      if [[ -z "$${NOT_FOUND:-}" ]]; then
         PARAMS+=("--benchmark_files" benchmark-results-*.json)
       fi
       buildkite-agent artifact download "compile-stats-results-*.json" ./ 2>&1 | tee stats-dl.log \
         || { grep -q "No artifacts found" ./stats-dl.log; NOT_FOUND=1; }
-      if [[ -z "${NOT_FOUND:-}" ]]; then
+      if [[ -z "$${NOT_FOUND:-}" ]]; then
         PARAMS+=("--compile_stats_files" compile-stats-results-*.json)
       fi
       python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py \
         --verbose \
         --query-base \
         --comment-title="Abbreviated Linux Benchmark Summary" \
-        ${PARAMS[@]}
+        $${PARAMS[@]}
     if: >
       build.pull_request.id != null && (
         build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||


### PR DESCRIPTION
RISC-V benchmarks currently don't generate `benchmark-results-*.json`, so the comment step will fail because the artifacts can't be found.

This change stops the pipeline from failing if buildkite-agent can't find the artifacts and handles the wildcard in the scripts.

The dashboard upload step theoretically has the same issue, but since it only runs with full benchmarks, we don't have such a case right now. This fix is not very clean so I prefer to only fix the comment step for now.

Fix #9766