### PR TITLE
lockless atomic_slist

### DIFF
--- a/runtime/src/iree/base/internal/atomic_slist.h
+++ b/runtime/src/iree/base/internal/atomic_slist.h
@@ -17,7 +17,6 @@
 
 #include "iree/base/alignment.h"
 #include "iree/base/internal/atomics.h"
-#include "iree/base/internal/synchronization.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,7 +28,7 @@ typedef void* iree_atomic_slist_intrusive_ptr_t;
 
 // DO NOT USE: implementation detail.
 typedef struct iree_atomic_slist_entry_t {
-  struct iree_atomic_slist_entry_t* next;
+  iree_atomic_intptr_t next;
 } iree_atomic_slist_entry_t;
 
 // Lightweight contention-avoiding singly linked list.
@@ -79,8 +78,7 @@ typedef struct iree_atomic_slist_entry_t {
 // single heavily tested implementation seems more worthwhile than several.
 typedef iree_alignas(iree_max_align_t) struct {
   // TODO(benvanik): spend some time golfing this. Unblocking myself for now :)
-  iree_slim_mutex_t mutex;
-  iree_atomic_slist_entry_t* head;
+  iree_atomic_intptr_t head;
 } iree_atomic_slist_t;
 
 // Initializes an slist handle to an empty list.
@@ -186,68 +184,72 @@ bool iree_atomic_slist_flush(iree_atomic_slist_t* list,
 //  my_type_t* entry = allocate_my_type(123);
 //  my_type_slist_push(&list, entry);
 //  entry = my_type_slist_pop(&list);
-#define IREE_TYPED_ATOMIC_SLIST_WRAPPER(name, type, next_offset)               \
-  static inline iree_atomic_slist_entry_t* name##_slist_entry_from_ptr(        \
-      type* entry) {                                                           \
-    return entry                                                               \
-               ? ((iree_atomic_slist_entry_t*)((uint8_t*)entry + next_offset)) \
-               : NULL;                                                         \
-  }                                                                            \
-  static inline type* name##_slist_entry_to_ptr(                               \
-      iree_atomic_slist_entry_t* entry) {                                      \
-    return entry ? (type*)(((uint8_t*)entry) - next_offset) : NULL;            \
-  }                                                                            \
-                                                                               \
-  static inline type* name##_slist_get_next(type* entry) {                     \
-    if (!entry) return NULL;                                                   \
-    return name##_slist_entry_to_ptr(                                          \
-        ((iree_atomic_slist_entry_t*)((uint8_t*)entry + next_offset))->next);  \
-  }                                                                            \
-  static inline void name##_slist_set_next(type* entry, type* next) {          \
-    name##_slist_entry_from_ptr(entry)->next =                                 \
-        name##_slist_entry_from_ptr(next);                                     \
-  }                                                                            \
-                                                                               \
-  typedef iree_alignas(iree_max_align_t) struct {                              \
-    iree_atomic_slist_t impl;                                                  \
-  } name##_slist_t;                                                            \
-                                                                               \
-  static inline void name##_slist_initialize(name##_slist_t* out_list) {       \
-    iree_atomic_slist_initialize(&out_list->impl);                             \
-  }                                                                            \
-  static inline void name##_slist_deinitialize(name##_slist_t* list) {         \
-    iree_atomic_slist_deinitialize(&list->impl);                               \
-  }                                                                            \
-                                                                               \
-  static inline void name##_slist_push(name##_slist_t* list, type* entry) {    \
-    iree_atomic_slist_push(&list->impl, name##_slist_entry_from_ptr(entry));   \
-  }                                                                            \
-  static inline void name##_slist_push_unsafe(name##_slist_t* list,            \
-                                              type* entry) {                   \
-    iree_atomic_slist_push_unsafe(&list->impl,                                 \
-                                  name##_slist_entry_from_ptr(entry));         \
-  }                                                                            \
-  static inline void name##_slist_concat(name##_slist_t* list, type* head,     \
-                                         type* tail) {                         \
-    iree_atomic_slist_concat(&list->impl, name##_slist_entry_from_ptr(head),   \
-                             name##_slist_entry_from_ptr(tail));               \
-  }                                                                            \
-  static inline type* name##_slist_pop(name##_slist_t* list) {                 \
-    return name##_slist_entry_to_ptr(iree_atomic_slist_pop(&list->impl));      \
-  }                                                                            \
-                                                                               \
-  static inline bool name##_slist_flush(                                       \
-      name##_slist_t* list, iree_atomic_slist_flush_order_t flush_order,       \
-      type** out_head, type** out_tail) {                                      \
-    iree_atomic_slist_entry_t* head = NULL;                                    \
-    iree_atomic_slist_entry_t* tail = NULL;                                    \
-    if (!iree_atomic_slist_flush(&list->impl, flush_order, &head,              \
-                                 out_tail ? &tail : NULL)) {                   \
-      return false; /* empty list */                                           \
-    }                                                                          \
-    *out_head = name##_slist_entry_to_ptr(head);                               \
-    if (out_tail) *out_tail = name##_slist_entry_to_ptr(tail);                 \
-    return true;                                                               \
+#define IREE_TYPED_ATOMIC_SLIST_WRAPPER(name, type, next_offset)             \
+  static inline iree_atomic_slist_entry_t* name##_slist_entry_from_ptr(      \
+      type* ptr) {                                                           \
+    return ptr ? ((iree_atomic_slist_entry_t*)((uint8_t*)ptr + next_offset)) \
+               : NULL;                                                       \
+  }                                                                          \
+  static inline type* name##_slist_entry_to_ptr(                             \
+      iree_atomic_slist_entry_t* entry) {                                    \
+    return entry ? (type*)(((uint8_t*)entry) - next_offset) : NULL;          \
+  }                                                                          \
+                                                                             \
+  static inline type* name##_slist_get_next(type* ptr) {                     \
+    iree_atomic_slist_entry_t* entry = name##_slist_entry_from_ptr(ptr);     \
+    if (!entry) return NULL;                                                 \
+    iree_atomic_slist_entry_t* next =                                        \
+        (iree_atomic_slist_entry_t*)iree_atomic_load_intptr(                 \
+            &entry->next, iree_memory_order_relaxed);                        \
+    return name##_slist_entry_to_ptr(next);                                  \
+  }                                                                          \
+  static inline void name##_slist_set_next(type* ptr, type* next) {          \
+    iree_atomic_slist_entry_t* entry = name##_slist_entry_from_ptr(ptr);     \
+    iree_atomic_store_intptr(&entry->next,                                   \
+                             (intptr_t)name##_slist_entry_from_ptr(next),    \
+                             iree_memory_order_relaxed);                     \
+  }                                                                          \
+                                                                             \
+  typedef iree_alignas(iree_max_align_t) struct {                            \
+    iree_atomic_slist_t impl;                                                \
+  } name##_slist_t;                                                          \
+                                                                             \
+  static inline void name##_slist_initialize(name##_slist_t* out_list) {     \
+    iree_atomic_slist_initialize(&out_list->impl);                           \
+  }                                                                          \
+  static inline void name##_slist_deinitialize(name##_slist_t* list) {       \
+    iree_atomic_slist_deinitialize(&list->impl);                             \
+  }                                                                          \
+                                                                             \
+  static inline void name##_slist_push(name##_slist_t* list, type* entry) {  \
+    iree_atomic_slist_push(&list->impl, name##_slist_entry_from_ptr(entry)); \
+  }                                                                          \
+  static inline void name##_slist_push_unsafe(name##_slist_t* list,          \
+                                              type* entry) {                 \
+    iree_atomic_slist_push_unsafe(&list->impl,                               \
+                                  name##_slist_entry_from_ptr(entry));       \
+  }                                                                          \
+  static inline void name##_slist_concat(name##_slist_t* list, type* head,   \
+                                         type* tail) {                       \
+    iree_atomic_slist_concat(&list->impl, name##_slist_entry_from_ptr(head), \
+                             name##_slist_entry_from_ptr(tail));             \
+  }                                                                          \
+  static inline type* name##_slist_pop(name##_slist_t* list) {               \
+    return name##_slist_entry_to_ptr(iree_atomic_slist_pop(&list->impl));    \
+  }                                                                          \
+                                                                             \
+  static inline bool name##_slist_flush(                                     \
+      name##_slist_t* list, iree_atomic_slist_flush_order_t flush_order,     \
+      type** out_head, type** out_tail) {                                    \
+    iree_atomic_slist_entry_t* head = NULL;                                  \
+    iree_atomic_slist_entry_t* tail = NULL;                                  \
+    if (!iree_atomic_slist_flush(&list->impl, flush_order, &head,            \
+                                 out_tail ? &tail : NULL)) {                 \
+      return false; /* empty list */                                         \
+    }                                                                        \
+    *out_head = name##_slist_entry_to_ptr(head);                             \
+    if (out_tail) *out_tail = name##_slist_entry_to_ptr(tail);               \
+    return true;                                                             \
   }
 
 #ifdef __cplusplus

--- a/runtime/src/iree/task/queue.h
+++ b/runtime/src/iree/task/queue.h
@@ -135,14 +135,6 @@ void iree_task_queue_push_front(iree_task_queue_t* queue, iree_task_t* task);
 void iree_task_queue_append_from_lifo_list_unsafe(iree_task_queue_t* queue,
                                                   iree_task_list_t* list);
 
-// Flushes the |source_slist| LIFO mailbox into the task queue in FIFO order.
-// Returns the first task in the queue upon success; the task may be
-// pre-existing or from the newly flushed tasks.
-//
-// Must only be called from the owning worker's thread.
-iree_task_t* iree_task_queue_flush_from_lifo_slist(
-    iree_task_queue_t* queue, iree_atomic_task_slist_t* source_slist);
-
 // Pops a task from the front of the queue if any are available.
 //
 // Must only be called from the owning worker's thread.

--- a/runtime/src/iree/task/queue_test.cc
+++ b/runtime/src/iree/task/queue_test.cc
@@ -117,7 +117,7 @@ TEST(QueueTest, FlushSlistEmpty) {
   iree_atomic_task_slist_initialize(&slist);
 
   EXPECT_TRUE(iree_task_queue_is_empty(&queue));
-  EXPECT_FALSE(iree_task_queue_flush_from_lifo_slist(&queue, &slist));
+  iree_task_list_append_from_fifo_slist(&queue.list, &slist);
   EXPECT_TRUE(iree_task_queue_is_empty(&queue));
 
   iree_atomic_task_slist_deinitialize(&slist);
@@ -135,7 +135,8 @@ TEST(QueueTest, FlushSlist1) {
   iree_atomic_task_slist_push(&slist, &task_a);
 
   EXPECT_TRUE(iree_task_queue_is_empty(&queue));
-  EXPECT_EQ(&task_a, iree_task_queue_flush_from_lifo_slist(&queue, &slist));
+  iree_task_list_append_from_fifo_slist(&queue.list, &slist);
+  EXPECT_EQ(&task_a, iree_task_queue_pop_front(&queue));
   EXPECT_TRUE(iree_task_queue_is_empty(&queue));
 
   iree_atomic_task_slist_deinitialize(&slist);
@@ -160,7 +161,8 @@ TEST(QueueTest, FlushSlistOrdered) {
   // Flush the list to the queue; it should swap LIFO->FIFO and return the
   // first task in the queue.
   EXPECT_TRUE(iree_task_queue_is_empty(&queue));
-  EXPECT_EQ(&task_a, iree_task_queue_flush_from_lifo_slist(&queue, &slist));
+  iree_task_list_append_from_fifo_slist(&queue.list, &slist);
+  EXPECT_EQ(&task_a, iree_task_queue_pop_front(&queue));
   EXPECT_FALSE(iree_task_queue_is_empty(&queue));
 
   // Pop list and ensure order: [a->]b->c.

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -168,7 +168,18 @@ iree_task_t* iree_task_worker_try_steal_task(iree_task_worker_t* worker,
   if (task) return task;
 
   // If we still didn't steal any tasks then let's try the slist instead.
+  //
+  // Locking worker->local_task_queue.mutex looks out of place here as this is
+  // atomic list pop, but the problem is that we may be racing here against
+  // another thread calling iree_task_queue_flush_from_lifo_slist, copying
+  // linked list elements out of the atomic list, into a plain linked list,
+  // then doing a plain non-atomic pop on that. Fortunately,
+  // iree_task_queue_flush_from_lifo_slist locks worker->local_task_queue.mutex
+  // around that non-atomic operation, so we can avoid the race by also locking
+  // it here.
+  iree_slim_mutex_lock(&worker->local_task_queue.mutex);
   task = iree_atomic_task_slist_pop(&worker->mailbox_slist);
+  iree_slim_mutex_unlock(&worker->local_task_queue.mutex);
   if (task) return task;
 
   return NULL;


### PR DESCRIPTION
Now working (previous attempt: #9581).

The snag we ran into in #9581 was a key difficulty: it isn't trivial to have an intrusive linked list element structure that's used in BOTH atomic and non-atomic linked lists, with shallow copies between the two making `->next` dereferences potentially racing between the two.

For a while I was tempted to sweep that under the rug by having the non-atomic side do relaxed atomic ops, and that did silence TSan errors, but on closer inspection I believe that that was actually potentially leaving data structures in an inconsistent state.

So this instead uses a mutex at the place that was racy. If there are more races to be discovered, at least we should get a TSan report, we haven't silenced anything.

See the diff/comment in `worker.c`.