### PR TITLE
Switch transform.iree.match op to custom assembly format

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -136,12 +136,8 @@ def MatchOp : Op<Transform_Dialect, "iree.match",
   // TODO: veriadic results when needed.
   let results = (outs PDL_Operation:$results);
 
-  let assemblyFormat = [{
-    (`ops` `{` $match_op^ `}`)? 
-    (`interface` `{` $match_interface^ `}`)? 
-    `in` $target attr-dict
-  }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 }
 


### PR DESCRIPTION
This is in preparation of adding a region (with a custom printer that
elides the region if it is empty).