### PR TITLE
Fix compile errors in atomics_disabled

### DIFF
--- a/runtime/src/iree/base/internal/atomics_disabled.h
+++ b/runtime/src/iree/base/internal/atomics_disabled.h
@@ -37,8 +37,8 @@ typedef int64_t iree_atomic_int64_t;
 // typedef __int128 iree_atomic_int128_t;
 typedef intptr_t iree_atomic_intptr_t;
 
-#define iree_atomic_load_int32(object, order) *(object)
-#define iree_atomic_store_int32(object, desired, order) *(object) = (desired)
+#define iree_atomic_load_int32(object, order) (*(object))
+#define iree_atomic_store_int32(object, desired, order) (*(object) = (desired))
 #define iree_atomic_fetch_add_int32(object, operand, order)                 \
   iree_atomic_fetch_add_int32_impl((volatile iree_atomic_int32_t*)(object), \
                                    (int32_t)(operand))
@@ -65,8 +65,8 @@ typedef intptr_t iree_atomic_intptr_t;
 #define iree_atomic_compare_exchange_weak_int32 \
   iree_atomic_compare_exchange_strong_int32
 
-#define iree_atomic_load_int64(object, order) *(object)
-#define iree_atomic_store_int64(object, desired, order) *(object) = (desired)
+#define iree_atomic_load_int64(object, order) (*(object))
+#define iree_atomic_store_int64(object, desired, order) (*(object) = (desired))
 #define iree_atomic_fetch_add_int64(object, operand, order)                 \
   iree_atomic_fetch_add_int64_impl((volatile iree_atomic_int64_t*)(object), \
                                    (int64_t)(operand))


### PR DESCRIPTION
iree_atomic_store_intptr(x, y) expanded to

```
(intptr_t) * (iree_atomic_int32_t*) (x) = (y)
```

The (intptr_t) cast on the left hand side had higher precedence than the
assignment operator so the entire expression

```
  (intptr_t) * (iree_atomic_int32_t*) (x)
```
was interpreted as a lvalue being assigned to, and that resulted in
compilation error. This showed up only on riscv CI on #9777.

* Why only on RISCV: presumably because it's the only place where we use atomics_disabled.
* Why only on that PR: presumably because it introduces a use of iree_atomic_store_intptr.
