### PR TITLE
Web sample tweaks for showing demos.

### DIFF
--- a/experimental/web/sample_dynamic/CMakeLists.txt
+++ b/experimental/web/sample_dynamic/CMakeLists.txt
@@ -30,6 +30,7 @@ target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
 target_link_libraries(${_NAME}
   iree_runtime_runtime
   iree_hal_local_loaders_system_library_loader
+  iree_hal_local_loaders_vmvx_module_loader
   iree_hal_drivers_local_sync_sync_driver
 )
 

--- a/experimental/web/sample_dynamic/benchmarks.html
+++ b/experimental/web/sample_dynamic/benchmarks.html
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <meta charset="utf-8" />
   <title>IREE Dynamic Web Benchmarks</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/ghost.svg" type="image/svg+xml">
+  <link rel="icon" href="./ghost.svg" type="image/svg+xml">
 
   <style>
     body {

--- a/experimental/web/sample_dynamic/device_sync.c
+++ b/experimental/web/sample_dynamic/device_sync.c
@@ -6,19 +6,25 @@
 
 #include "iree/hal/drivers/local_sync/sync_device.h"
 #include "iree/hal/local/loaders/system_library_loader.h"
+#include "iree/hal/local/loaders/vmvx_module_loader.h"
 
-iree_status_t create_device_with_wasm_loader(iree_allocator_t host_allocator,
-                                             iree_hal_device_t** out_device) {
+iree_status_t create_device_with_loaders(iree_allocator_t host_allocator,
+                                         iree_hal_device_t** out_device) {
   iree_hal_sync_device_params_t params;
   iree_hal_sync_device_params_initialize(&params);
 
   iree_status_t status = iree_ok_status();
 
-  iree_hal_executable_loader_t* loaders[1] = {NULL};
+  iree_hal_executable_loader_t* loaders[2] = {NULL, NULL};
   iree_host_size_t loader_count = 0;
   if (iree_status_is_ok(status)) {
     status = iree_hal_system_library_loader_create(
         iree_hal_executable_import_provider_null(), host_allocator,
+        &loaders[loader_count++]);
+  }
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_vmvx_module_loader_create_isolated(
+        /*user_module_count=*/0, /*user_modules=*/NULL, host_allocator,
         &loaders[loader_count++]);
   }
 

--- a/experimental/web/sample_dynamic/index.html
+++ b/experimental/web/sample_dynamic/index.html
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <meta charset="utf-8" />
   <title>IREE Dynamic Web Sample</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/ghost.svg" type="image/svg+xml">
+  <link rel="icon" href="./ghost.svg" type="image/svg+xml">
 
   <style>
     body {

--- a/experimental/web/sample_dynamic/main.c
+++ b/experimental/web/sample_dynamic/main.c
@@ -71,8 +71,8 @@ typedef struct iree_program_state_t {
   iree_vm_module_t* module;
 } iree_program_state_t;
 
-extern iree_status_t create_device_with_wasm_loader(
-    iree_allocator_t host_allocator, iree_hal_device_t** out_device);
+extern iree_status_t create_device_with_loaders(iree_allocator_t host_allocator,
+                                                iree_hal_device_t** out_device);
 
 iree_sample_state_t* setup_sample() {
   iree_sample_state_t* sample_state = NULL;
@@ -91,8 +91,8 @@ iree_sample_state_t* setup_sample() {
   }
 
   if (iree_status_is_ok(status)) {
-    status = create_device_with_wasm_loader(iree_allocator_system(),
-                                            &sample_state->device);
+    status = create_device_with_loaders(iree_allocator_system(),
+                                        &sample_state->device);
   }
 
   if (!iree_status_is_ok(status)) {

--- a/experimental/web/sample_static/index.html
+++ b/experimental/web/sample_static/index.html
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <meta charset="utf-8" />
   <title>IREE Static Web Sample</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/ghost.svg" type="image/svg+xml">
+  <link rel="icon" href="./ghost.svg" type="image/svg+xml">
 
   <script src="./easeljs.min.js"></script>
   <script src="./iree_api.js"></script>

--- a/experimental/web/testing/index_template.html
+++ b/experimental/web/testing/index_template.html
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <meta charset="utf-8" />
   <title>IREE Tests</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/experimental/web/testing/ghost.svg" type="image/svg+xml">
+  <link rel="icon" href="./ghost.svg" type="image/svg+xml">
 
   <style>
     html, body, .full-height {

--- a/experimental/web/testing/test-runner.html
+++ b/experimental/web/testing/test-runner.html
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
   <meta charset="utf-8" />
   <title>IREE Tests</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/experimental/web/testing/ghost.svg" type="image/svg+xml">
+  <link rel="icon" href="./ghost.svg" type="image/svg+xml">
 
   <style>
     .test-output {


### PR DESCRIPTION
* Use a relative path to the favicon (stable across serving from a different root)
* Add VMVX loader to dynamic sample