### PR TITLE
Added TosaToTensor after TosaToLinalg

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -49,7 +49,7 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
 
   tosa::addTosaToLinalgPasses(passManager);
 
-  // Sometimes we generate more TOSA operaitons post linalg.
+  // Sometimes we generate more TOSA operations during the lowering to linalg.
   passManager.addNestedPass<func::FuncOp>(tosa::createTosaToArith());
   passManager.addNestedPass<func::FuncOp>(tosa::createTosaToTensor());
 

--- a/compiler/src/iree/compiler/InputConversion/TOSA/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/TOSA/Passes.cpp
@@ -48,7 +48,10 @@ void buildTOSAInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
 
   tosa::addTosaToLinalgPasses(passManager);
+
+  // Sometimes we generate more TOSA operaitons post linalg.
   passManager.addNestedPass<func::FuncOp>(tosa::createTosaToArith());
+  passManager.addNestedPass<func::FuncOp>(tosa::createTosaToTensor());
 
   passManager.addNestedPass<func::FuncOp>(
       IREE::Flow::createStripSignednessPass());


### PR DESCRIPTION
TosaToLinalg can now add a tosa.slice operation due to changes to
tosa.transpose_conv. We include another TosaToTensor lowering to ensure
it is lowered away from the TOSA dialect.