### PR TITLE
Add CUDA benchmark pipeline for MiniLM

### DIFF
--- a/benchmarks/TF/CMakeLists.txt
+++ b/benchmarks/TF/CMakeLists.txt
@@ -34,3 +34,4 @@ set(MINILM_L12_H384_UNCASED_INT32_MODULE
 # Add benchmarks for all platforms.                                            #
 ################################################################################
 include(linux-x86_64.cmake)
+include(linux-cuda.cmake)

--- a/benchmarks/TF/linux-cuda.cmake
+++ b/benchmarks/TF/linux-cuda.cmake
@@ -16,12 +16,12 @@
 #                                                                              #
 ################################################################################
 
-set(LINUX_CUDA_SM_70_GPU_COMPILATION_FLAGS
+set(LINUX_CUDA_SM_80_GPU_COMPILATION_FLAGS
   "--iree-input-type=mhlo"
-  "--iree-hal-cuda-llvm-target-arch=sm_70"
+  "--iree-hal-cuda-llvm-target-arch=sm_80"
 )
 
-# GPU, CUDA, SM_70, full-inference
+# GPU, CUDA, SM_80, full-inference
 iree_benchmark_suite(
   GROUP_NAME
     "linux-cuda"
@@ -34,9 +34,9 @@ iree_benchmark_suite(
   TARGET_BACKEND
     "cuda"
   TARGET_ARCHITECTURE
-    "GPU-CUDA-SM_70"
+    "GPU-CUDA-SM_80"
   COMPILATION_FLAGS
-    ${LINUX_CUDA_SM_70_GPU_COMPILATION_FLAGS}
+    ${LINUX_CUDA_SM_80_GPU_COMPILATION_FLAGS}
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG

--- a/benchmarks/TF/linux-cuda.cmake
+++ b/benchmarks/TF/linux-cuda.cmake
@@ -1,0 +1,46 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+################################################################################
+#                                                                              #
+# Default benchmark configurations                                             #
+#                                                                              #
+# Each suite benchmarks a list of modules with configurations specifying a     #
+# target architecture and runtime characteristics (e.g. threads/cores). These  #
+# benchmarks only configure IREE compilation and runtime flags for the target  #
+# architecture and do *not* include any non-default flags. No non-default      #
+# flags should be added here.                                                  #
+#                                                                              #
+################################################################################
+
+set(LINUX_CUDA_SM_70_GPU_COMPILATION_FLAGS
+  "--iree-input-type=mhlo"
+  "--iree-hal-cuda-llvm-target-arch=sm_70"
+)
+
+# GPU, CUDA, SM_70, full-inference
+iree_benchmark_suite(
+  GROUP_NAME
+    "linux-cuda"
+
+  MODULES
+    "${MINILM_L12_H384_UNCASED_INT32_MODULE}"
+
+  BENCHMARK_MODES
+    "full-inference,default-flags"
+  TARGET_BACKEND
+    "cuda"
+  TARGET_ARCHITECTURE
+    "GPU-CUDA-SM_70"
+  COMPILATION_FLAGS
+    ${LINUX_CUDA_SM_70_GPU_COMPILATION_FLAGS}
+  BENCHMARK_TOOL
+    iree-benchmark-module
+  CONFIG
+    "iree-cuda"
+  DRIVER
+    "cuda"
+)

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -35,6 +35,7 @@ CONST_COMPONENT_NAME = "_const.bin"
 DISPATCH_COMPONENT_PATTERNS = [
     r".+_embedded_elf_.+\.so",
     r".+_vulkan_spirv_fb\.fb",
+    r".+_cuda_nvptx_fb\.fb",
     r".+_vmvx_bytecode_fb\.bin",
 ]
 

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -43,8 +43,10 @@ class CollectCompilationStatistics(unittest.TestCase):
     with zipfile.ZipFile(module_file, "w") as zip:
       zip.writestr(VM_COMPONENT_NAME, b"abcd")
       zip.writestr(CONST_COMPONENT_NAME, b"123")
-      zip.writestr("main_dispatch_0_vulkan_spirv_fb.fb", b"bindata1")
-      zip.writestr("main_dispatch_1_vulkan_spirv_fb.fb", b"bindata2")
+      zip.writestr("main_dispatch_0_vulkan_spirv_fb.fb", b"bindata0")
+      zip.writestr("main_dispatch_1_vulkan_spirv_fb.fb", b"bindata1")
+      zip.writestr("predict_dispatch_2_cuda_nvptx_fb.fb", b"bindata2")
+      zip.writestr("dispatch_3_embedded_elf_x86_64.so", b"bindata3")
     module_file_data = module_file.getvalue()
 
     component_sizes = get_module_component_info(BytesIO(module_file_data),
@@ -55,7 +57,7 @@ class CollectCompilationStatistics(unittest.TestCase):
         ModuleComponentSizes(file_bytes=len(module_file_data),
                              vm_component_bytes=4,
                              const_component_bytes=3,
-                             total_dispatch_component_bytes=16))
+                             total_dispatch_component_bytes=32))
 
   def test_get_module_component_info_unknown_components(self):
     module_file = BytesIO()

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -34,6 +34,7 @@ GPU_NAME_TO_TARGET_ARCH_MAP = {
     "mali-g77": "gpu-mali-valhall",
     "mali-g78": "gpu-mali-valhall",
     "tesla-v100-sxm2-16gb": "gpu-cuda-sm_70",
+    "nvidia-a100-sxm4-40gb": "gpu-cuda-sm_80",
     "unknown": "gpu-unknown",
 }
 

--- a/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
@@ -46,7 +46,7 @@ steps:
         build-targets/linux-cuda
     agents:
       - "gcp:machine-type=a2-highgpu-1g"
-      - "queue=benchmark-cuda-a100"
+      - "queue=benchmark-cuda"
     artifact_paths:
       - "benchmark-results-gcp-gpu-a100-${BUILDKITE_BUILD_NUMBER}.json"
     timeout_in_minutes: "10"

--- a/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
@@ -6,7 +6,7 @@
 
 steps:
   - label: ":hammer_and_wrench: Build linux-cuda benchmark tools"
-    key: "build-benchmark-tools"
+    key: "build-cuda-benchmark-tools"
     commands: |
       docker run --user=$(id -u):$(id -g) \
         --volume="$${HOME?}:$${HOME?}" \
@@ -25,10 +25,9 @@ steps:
     artifact_paths:
       - "iree-linux-cuda-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
 
-  - wait
-
   - label: ":stopwatch: Benchmark on Nvidia A100 (GCP-a2-highgpu-1g)"
-    key: "run-benchmark-gcp-gpu-a100"
+    key: "run-cuda-benchmark-gcp-gpu-a100"
+    depends_on: "build-cuda-benchmark-tools"
     commands: |
       git clean -fdx
       buildkite-agent artifact download \

--- a/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
@@ -1,0 +1,52 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+steps:
+  - label: ":hammer_and_wrench: Build linux-cuda benchmark tools"
+    key: "build-benchmark-tools"
+    commands: |
+      docker run --user=$(id -u):$(id -g) \
+        --volume="$${HOME?}:$${HOME?}" \
+        --volume="/etc/passwd:/etc/passwd:ro" \
+        --volume="/etc/group:/etc/group:ro" \
+        --volume="$$PWD:$$IREE_DOCKER_WORKDIR" \
+        --workdir="$$IREE_DOCKER_WORKDIR" \
+        --rm \
+        $${DOCKER_IMAGE} \
+        build_tools/cmake/build_linux_benchmark_tools.sh linux-cuda
+      tar -czvf iree-linux-cuda-tools-${BUILDKITE_BUILD_NUMBER}.tgz \
+        build-targets/linux-cuda/tools/iree-benchmark-module \
+        build-targets/linux-cuda/tools/build_config.txt
+    agents:
+      - "queue=build"
+    artifact_paths:
+      - "iree-linux-cuda-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
+
+  - wait
+
+  - label: ":stopwatch: Benchmark on Nvidia A100 (GCP-a2-highgpu-1g)"
+    key: "run-benchmark-gcp-gpu-a100"
+    commands: |
+      git clean -fdx
+      buildkite-agent artifact download \
+        "benchmark-suites-linux-cuda-$${BUILDKITE_BUILD_NUMBER}.tgz" ./
+      buildkite-agent artifact download \
+        "iree-linux-cuda-tools-$${BUILDKITE_BUILD_NUMBER}.tgz" ./
+      tar -xzvf "benchmark-suites-linux-cuda-$${BUILDKITE_BUILD_NUMBER}.tgz"
+      tar -xzvf "iree-linux-cuda-tools-$${BUILDKITE_BUILD_NUMBER}.tgz"
+      python3 build_tools/benchmarks/run_benchmarks_on_linux.py \
+        --device_model=GCP-a2-highgpu-1g \
+        --normal_benchmark_tool_dir=build-targets/linux-cuda/tools/ \
+        --driver_filter_regex=cuda \
+        -o "benchmark-results-gcp-gpu-a100-$${BUILDKITE_BUILD_NUMBER}.json" \
+        --verbose \
+        build-targets/linux-cuda
+    agents:
+      - "gcp:machine-type=a2-highgpu-1g"
+      - "queue=benchmark-cuda-a100"
+    artifact_paths:
+      - "benchmark-results-gcp-gpu-a100-${BUILDKITE_BUILD_NUMBER}.json"
+    timeout_in_minutes: "10"

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -27,7 +27,8 @@ steps:
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||
-      build.pull_request.labels includes 'buildkite:benchmark-riscv'
+      build.pull_request.labels includes 'buildkite:benchmark-riscv' ||
+      build.pull_request.labels includes 'buildkite:benchmark-cuda'
     agents:
       - "queue=build"
     artifact_paths:
@@ -66,7 +67,8 @@ steps:
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||
-      build.pull_request.labels includes 'buildkite:benchmark-riscv'
+      build.pull_request.labels includes 'buildkite:benchmark-riscv' ||
+      build.pull_request.labels includes 'buildkite:benchmark-cuda'
     agents:
       - "queue=build"
     artifact_paths:
@@ -82,6 +84,14 @@ steps:
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-x86_64'
+
+  - label: ":arrow_forward: Execute linux-cuda benchmark pipeline"
+    commands: |
+      buildkite-agent pipeline upload \
+        build_tools/buildkite/cmake/linux/cuda/benchmark.yml
+    if: >
+      build.pull_request.id == null ||
+      build.pull_request.labels includes 'buildkite:benchmark-cuda'
 
   - label: ":recycle: Collect compilation statistics"
     key: "collect-compilation-statistics"
@@ -99,7 +109,8 @@ steps:
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||
-      build.pull_request.labels includes 'buildkite:benchmark-riscv'
+      build.pull_request.labels includes 'buildkite:benchmark-riscv' ||
+      build.pull_request.labels includes 'buildkite:benchmark-cuda'
     agents:
       - "queue=build"
     artifact_paths:
@@ -127,7 +138,8 @@ steps:
     if: >
       build.pull_request.id != null && (
         build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||
-        build.pull_request.labels includes 'buildkite:benchmark-riscv'
+        build.pull_request.labels includes 'buildkite:benchmark-riscv' ||
+        build.pull_request.labels includes 'buildkite:benchmark-cuda'
       )
     agents:
       - "queue=report"

--- a/build_tools/buildkite/cmake/linux/x86_64/benchmark2.yml
+++ b/build_tools/buildkite/cmake/linux/x86_64/benchmark2.yml
@@ -6,7 +6,7 @@
 
 steps:
   - label: ":hammer_and_wrench: Build linux-x86_64 benchmark tools"
-    key: "build-benchmark-tools"
+    key: "build-x86_64-benchmark-tools"
     commands: |
       docker run --user=$(id -u):$(id -g) \
         --volume="$${HOME?}:$${HOME?}" \
@@ -25,10 +25,9 @@ steps:
     artifact_paths:
       - "iree-linux-x86_64-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
 
-  - wait
-
   - label: ":stopwatch: Benchmark on Intel Cascade Lake CPU (GCP-c2-standard-16)"
-    key: "run-benchmark-gcp-cpu"
+    key: "run-x86_64-benchmark-gcp-cpu"
+    depends_on: "build-x86_64-benchmark-tools"
     commands: |
       git clean -fdx
       buildkite-agent artifact download \

--- a/build_tools/cmake/build_host_tools.sh
+++ b/build_tools/cmake/build_host_tools.sh
@@ -34,13 +34,24 @@ fi
 mkdir -p "${INSTALL_DIR}"
 
 # Configure, build, install.
-"${CMAKE_BIN}" -G Ninja -B "${BUILD_DIR}" \
-  -DCMAKE_INSTALL_PREFIX="$(realpath ${INSTALL_DIR})" \
-  -DIREE_ENABLE_LLD=ON \
-  -DIREE_ENABLE_ASSERTIONS="${IREE_ENABLE_ASSERTIONS}" \
-  -DIREE_BUILD_COMPILER=ON \
-  -DIREE_BUILD_TESTS=OFF \
-  -DIREE_BUILD_SAMPLES=OFF \
-  "${ROOT_DIR}"
+declare -a CMAKE_ARGS=(
+  "-G" "Ninja"
+  "-B" "${BUILD_DIR}"
+
+  "-DCMAKE_INSTALL_PREFIX=$(realpath ${INSTALL_DIR})"
+  "-DIREE_ENABLE_LLD=ON"
+  "-DIREE_ENABLE_ASSERTIONS=${IREE_ENABLE_ASSERTIONS}"
+  "-DIREE_BUILD_COMPILER=ON"
+  "-DIREE_BUILD_TESTS=OFF"
+  "-DIREE_BUILD_SAMPLES=OFF"
+
+  # Enable CUDA compiler and runtime builds unconditionally. Our CI images all
+  # have enough deps to at least build CUDA support and compile CUDA binaries
+  # (but not necessarily test on real hardware).
+  "-DIREE_HAL_DRIVER_CUDA=ON"
+  "-DIREE_TARGET_BACKEND_CUDA=ON"
+)
+
+"${CMAKE_BIN}" "${CMAKE_ARGS[@]}"
 "${CMAKE_BIN}" --build "${BUILD_DIR}" --target install -- -k 0
 # --------------------------------------------------------------------------- #

--- a/build_tools/cmake/build_linux_benchmark_modules.sh
+++ b/build_tools/cmake/build_linux_benchmark_modules.sh
@@ -94,3 +94,28 @@ cd build-targets/linux-riscv
 
 "${CMAKE_BIN}" --build . --target iree-benchmark-suites-linux-riscv -- -k 0
 # --------------------------------------------------------------------------- #
+
+# --------------------------------------------------------------------------- #
+# Build for the target (linux-cuda).
+
+cd "${ROOT_DIR}"
+
+if [ -d "build-targets/linux-cuda" ]
+then
+  echo "linux-cuda directory already exists. Will use cached results there."
+else
+  echo "linux-cuda directory does not already exist. Creating a new one."
+  mkdir -p build-targets/linux-cuda
+fi
+cd build-targets/linux-cuda
+
+"${CMAKE_BIN}" -G Ninja ../.. \
+  -DIREE_HOST_BINARY_ROOT="${HOST_BINARY_ROOT}" \
+  -DIREE_BUILD_COMPILER=OFF \
+  -DIREE_BUILD_TESTS=OFF \
+  -DIREE_BUILD_SAMPLES=OFF \
+  -DIREE_BUILD_BENCHMARKS=ON \
+  -DIREE_ENABLE_COMPILATION_BENCHMARKS=ON
+
+"${CMAKE_BIN}" --build . --target iree-benchmark-suites-linux-cuda -- -k 0
+# --------------------------------------------------------------------------- #

--- a/build_tools/cmake/build_linux_benchmark_tools.sh
+++ b/build_tools/cmake/build_linux_benchmark_tools.sh
@@ -56,3 +56,30 @@ cd build-targets/linux-x86_64
 
 fi
 # --------------------------------------------------------------------------- #
+
+# --------------------------------------------------------------------------- #
+# Build for the target (linux-cuda).
+if [[ "${TARGETS}" == *"linux-cuda"* ]] || [[ "${TARGETS}" == *"all"* ]]
+then
+
+cd "${ROOT_DIR}"
+
+if [ -d "build-targets/linux-cuda" ]
+then
+  echo "linux-cuda directory already exists. Will use cached results there."
+else
+  echo "linux-cuda directory does not already exist. Creating a new one."
+  mkdir -p build-targets/linux-cuda
+fi
+cd build-targets/linux-cuda
+
+"${CMAKE_BIN}" -G Ninja ../.. \
+  -DIREE_BUILD_COMPILER=OFF \
+  -DIREE_BUILD_TESTS=OFF \
+  -DIREE_BUILD_SAMPLES=OFF \
+  -DIREE_HAL_DRIVER_CUDA=ON
+
+"${CMAKE_BIN}" --build . --target iree-benchmark-module -- -k 0
+
+fi
+# --------------------------------------------------------------------------- #

--- a/build_tools/cmake/build_linux_benchmark_tools.sh
+++ b/build_tools/cmake/build_linux_benchmark_tools.sh
@@ -33,53 +33,47 @@ cd "${ROOT_DIR}"
 
 # --------------------------------------------------------------------------- #
 # Build for the target (linux-x86_64).
-if [[ "${TARGETS}" == *"linux-x86_64"* ]] || [[ "${TARGETS}" == *"all"* ]]
-then
+if [[ "${TARGETS}" =~ linux-x86_64|all ]]; then
+  cd "${ROOT_DIR}"
 
-cd "${ROOT_DIR}"
+  if [ -d "build-targets/linux-x86_64" ]
+  then
+    echo "linux-x86_64 directory already exists. Will use cached results there."
+  else
+    echo "linux-x86_64 directory does not already exist. Creating a new one."
+    mkdir -p build-targets/linux-x86_64
+  fi
+  cd build-targets/linux-x86_64
 
-if [ -d "build-targets/linux-x86_64" ]
-then
-  echo "linux-x86_64 directory already exists. Will use cached results there."
-else
-  echo "linux-x86_64 directory does not already exist. Creating a new one."
-  mkdir -p build-targets/linux-x86_64
-fi
-cd build-targets/linux-x86_64
+  "${CMAKE_BIN}" -G Ninja ../.. \
+    -DIREE_BUILD_COMPILER=OFF \
+    -DIREE_BUILD_TESTS=OFF \
+    -DIREE_BUILD_SAMPLES=OFF
 
-"${CMAKE_BIN}" -G Ninja ../.. \
-  -DIREE_BUILD_COMPILER=OFF \
-  -DIREE_BUILD_TESTS=OFF \
-  -DIREE_BUILD_SAMPLES=OFF
-
-"${CMAKE_BIN}" --build . --target iree-benchmark-module -- -k 0
-
+  "${CMAKE_BIN}" --build . --target iree-benchmark-module -- -k 0
 fi
 # --------------------------------------------------------------------------- #
 
 # --------------------------------------------------------------------------- #
 # Build for the target (linux-cuda).
-if [[ "${TARGETS}" == *"linux-cuda"* ]] || [[ "${TARGETS}" == *"all"* ]]
-then
+if [[ "${TARGETS}" =~ linux-cuda|all ]]; then
+  cd "${ROOT_DIR}"
 
-cd "${ROOT_DIR}"
+  if [ -d "build-targets/linux-cuda" ]
+  then
+    echo "linux-cuda directory already exists. Will use cached results there."
+  else
+    echo "linux-cuda directory does not already exist. Creating a new one."
+    mkdir -p build-targets/linux-cuda
+  fi
+  cd build-targets/linux-cuda
 
-if [ -d "build-targets/linux-cuda" ]
-then
-  echo "linux-cuda directory already exists. Will use cached results there."
-else
-  echo "linux-cuda directory does not already exist. Creating a new one."
-  mkdir -p build-targets/linux-cuda
-fi
-cd build-targets/linux-cuda
+  "${CMAKE_BIN}" -G Ninja ../.. \
+    -DIREE_BUILD_COMPILER=OFF \
+    -DIREE_BUILD_TESTS=OFF \
+    -DIREE_BUILD_SAMPLES=OFF \
+    -DIREE_HAL_DRIVER_CUDA=ON
 
-"${CMAKE_BIN}" -G Ninja ../.. \
-  -DIREE_BUILD_COMPILER=OFF \
-  -DIREE_BUILD_TESTS=OFF \
-  -DIREE_BUILD_SAMPLES=OFF \
-  -DIREE_HAL_DRIVER_CUDA=ON
-
-"${CMAKE_BIN}" --build . --target iree-benchmark-module -- -k 0
-
+  "${CMAKE_BIN}" --build . --target iree-benchmark-module -- -k 0
 fi
 # --------------------------------------------------------------------------- #

--- a/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
+++ b/build_tools/kokoro/gcp_ubuntu/cmake/android/build.sh
@@ -78,7 +78,11 @@ cd build-host
 
 "${CMAKE_BIN}" --build . --target install -- -k 0
 # Also make sure that we can generate artifacts for benchmarking on Android.
-"${CMAKE_BIN}" --build . --target iree-benchmark-suites -- -k 0
+"${CMAKE_BIN}" --build . --target \
+  iree-benchmark-suites-android-arm64-v8a \
+  iree-benchmark-suites-android-adreno \
+  iree-benchmark-suites-android-mali \
+  -- -k 0
 # --------------------------------------------------------------------------- #
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Add a new pipeline for CUDA benchmarks on A100. Also add a new CUDA benchmark for MiniLM.

Fix #9318