### PR TITLE
Fixes for upstream: Retire LinalgPromotion pattern @5a0011360c9cea0fd…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -46,6 +46,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialectPasses",
         "@llvm-project//llvm:Support",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_library(
   DEPS
     IREELinalgExtDialect
     IREELinalgExtPasses
+    IREELinalgExtTransforms
     IREELinalgTransformDialect
     IREELinalgTransformDialectPasses
     LLVMSupport

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -6,6 +6,7 @@
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree-dialects/Dialect/LinalgExt/Passes/Transforms.h"
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Codegen/LLVMGPU/KernelConfig.h"
 #include "iree/compiler/Codegen/PassDetail.h"
@@ -186,12 +187,15 @@ static LogicalResult copyToWorkgroupMemory(OpBuilder &b, Value src, Value dst) {
   return success();
 }
 
+template <typename T>
+using LinalgPromotionPattern =
+    mlir::iree_compiler::IREE::LinalgExt::LinalgPromotionPattern<T>;
 static void populatePromotionPatterns(MLIRContext *context,
                                       RewritePatternSet &patterns,
                                       ArrayRef<int64_t> operandsToPromote) {
-  patterns.insert<linalg::LinalgPromotionPattern<linalg::MatmulOp>,
-                  linalg::LinalgPromotionPattern<linalg::BatchMatmulOp>,
-                  linalg::LinalgPromotionPattern<linalg::GenericOp>>(
+  patterns.insert<LinalgPromotionPattern<linalg::MatmulOp>,
+                  LinalgPromotionPattern<linalg::BatchMatmulOp>,
+                  LinalgPromotionPattern<linalg::GenericOp>>(
       context,
       linalg::LinalgPromotionOptions()
           .setAllocationDeallocationFns(allocateWorkgroupMemory,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD
@@ -53,6 +53,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:AffineDialect",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_library(
   DEPS
     IREELinalgExtDialect
     IREELinalgExtPasses
+    IREELinalgExtTransforms
     LLVMSupport
     MLIRAffineAnalysis
     MLIRAffineDialect

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -11,6 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
@@ -96,6 +97,9 @@ LogicalResult copyToWorkgroupMemory(OpBuilder &builder, Value src, Value dst) {
   return success();
 }
 
+template <typename T>
+using LinalgPromotionPattern =
+    mlir::iree_compiler::IREE::LinalgExt::LinalgPromotionPattern<T>;
 static void populatePromotionPatterns(RewritePatternSet &patterns,
                                       StringAttr replaceMarker) {
   MLIRContext *context = patterns.getContext();
@@ -116,14 +120,14 @@ static void populatePromotionPatterns(RewritePatternSet &patterns,
   linalg::LinalgTransformationFilter promoteBothFilter(
       {StringAttr::get(context, promoteBothMarker)}, replaceMarker);
 
-  patterns.insert<linalg::LinalgPromotionPattern<linalg::MatmulOp>,
-                  linalg::LinalgPromotionPattern<linalg::BatchMatmulOp>>(
+  patterns.insert<LinalgPromotionPattern<linalg::MatmulOp>,
+                  LinalgPromotionPattern<linalg::BatchMatmulOp>>(
       patterns.getContext(), promoteLHSOptions, promoteLHSFilter);
-  patterns.insert<linalg::LinalgPromotionPattern<linalg::MatmulOp>,
-                  linalg::LinalgPromotionPattern<linalg::BatchMatmulOp>>(
+  patterns.insert<LinalgPromotionPattern<linalg::MatmulOp>,
+                  LinalgPromotionPattern<linalg::BatchMatmulOp>>(
       patterns.getContext(), promoteRHSOptions, promoteRHSFilter);
-  patterns.insert<linalg::LinalgPromotionPattern<linalg::MatmulOp>,
-                  linalg::LinalgPromotionPattern<linalg::BatchMatmulOp>>(
+  patterns.insert<LinalgPromotionPattern<linalg::MatmulOp>,
+                  LinalgPromotionPattern<linalg::BatchMatmulOp>>(
       patterns.getContext(), promoteBothOptions, promoteBothFilter);
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Transforms.h
@@ -4,8 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#ifndef IREE_DIALECTS_DIALECT_LINALGEXT_TRANSFORMS_TRANSFORMS_H_
-#define IREE_DIALECTS_DIALECT_LINALGEXT_TRANSFORMS_TRANSFORMS_H_
+#ifndef IREE_DIALECTS_DIALECT_LINALGEXT_PASSES_TRANSFORMS_H_
+#define IREE_DIALECTS_DIALECT_LINALGEXT_PASSES_TRANSFORMS_H_
 
 #include "iree-dialects/Dialect/LinalgExt/IR/TiledOpInterface.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -90,4 +90,4 @@ struct TiledOpInterfaceTilingPattern
 } // namespace iree_compiler
 } // namespace mlir
 
-#endif // IREE_DIALECTS_DIALECT_LINALGEXT_TRANSFORMS_TRANSFORMS_H_
+#endif // IREE_DIALECTS_DIALECT_LINALGEXT_PASSES_TRANSFORMS_H_


### PR DESCRIPTION
…c182c8c66ed3bc774a50835

This revision makes a copy of the LinalgPromotionPattern in IREE as it is slated to be removed upstream.
Since this breaks the dependence on the upstream pattern, this can be merged now and the integrate can happen later.

Context: https://discourse.llvm.org/t/psa-retire-linalg-filter-based-patterns/63785