### PR TITLE
Expand on documentation for IREE_ENABLE_LLD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,8 @@ set(IREE_USE_LINKER "" CACHE STRING "")
 # Note that unlike LLVM's LLVM_ENABLE_LLD, this does _not_ build lld. You will
 # need to either install a recent version of lld or build it from source prior
 # to setting this option. See also: https://lld.llvm.org/#using-lld.
-option(IREE_ENABLE_LLD "Override the system's default linker to lld" OFF)
+# This option is disabled on Apple platforms, where lld is not supported.
+cmake_dependent_option(IREE_ENABLE_LLD "Override the system's default linker to lld" OFF "NOT APPLE" OFF)
 
 include(iree_setup_toolchain)
 

--- a/build_tools/cmake/iree_setup_toolchain.cmake
+++ b/build_tools/cmake/iree_setup_toolchain.cmake
@@ -18,7 +18,7 @@ if(IREE_ENABLE_LLD)
   set(IREE_USE_LINKER "lld")
 endif()
 
-if(IREE_USE_LINKER AND NOT APPLE)
+if(IREE_USE_LINKER)
   set(IREE_LINKER_FLAG "-fuse-ld=${IREE_USE_LINKER}")
 
   # Depending on how the C compiler is invoked, it may trigger an unused
@@ -56,7 +56,4 @@ if(IREE_USE_LINKER AND NOT APPLE)
   if(NOT CC_SUPPORTS_CUSTOM_LINKER)
     message(FATAL_ERROR "Compiler '${CMAKE_C_COMPILER}' does not support '${IREE_LINKER_FLAG}'")
   endif()
-
-elseif(IREE_USE_LINKER)
-  message(WARNING "On Apple OSX use the system linker. IREE_USE_LINKER is set to '${IREE_USE_LINKER}', ignoring it")
 endif()


### PR DESCRIPTION
Revisiting some of the work in https://github.com/iree-org/iree/pull/2098.

I tried setting `IREE_ENABLE_LLD`, expecting it to build a supported version lld as needed, as `LLVM_ENABLE_LLD` [claims to do](https://llvm.org/docs/CMake.html#llvm-use-linker:~:text=LLVM_ENABLE_LLD%3ABOOL):
> `LLVM_ENABLE_LLD:BOOL`
> This option is equivalent to `-DLLVM_USE_LINKER=lld`, except during a 2-stage build where a dependency is added from the first stage to the second ensuring that lld is built before stage2 begins.

However, our option does _not_ do that. I'm tempted to drop `IREE_ENABLE_LLD` entirely, since we can't realistically do that sort of 2-stage build as just a downstream user of LLVM and other libraries.

Short of removing the misleading option (then updating our scripts and docs and asking developers to switch to the explicit option), I opted to add more comments to help future developers with troubleshooting.

Also mixed up in this are https://github.com/iree-org/iree/issues/7473 and https://github.com/iree-org/iree/pull/7474, which tried to set/use `IREE_ENABLE_LLD` on a platform (OSX) where lld is not actually supported (?). I moved that check from CMake branches to `cmake_dependent_option`.