### PR TITLE
Added mhlo shape lowerings pass to mhlo input conversion

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -96,6 +96,10 @@ EXPLICIT_TARGET_MAPPING = {
         "tensorflow::external_mhlo_includes",
         "MhloPasses",
     ],
+    "@mlir-hlo//:legalize_shape_computations": [
+        "tensorflow::external_mhlo_includes",
+        "MhloPasses",
+    ],
     "@mlir-hlo//:legalize_to_linalg": [
         "tensorflow::external_mhlo_includes",
         "MhloToLinalg",

--- a/compiler/src/iree/compiler/InputConversion/MHLO/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/BUILD
@@ -101,6 +101,7 @@ iree_compiler_cc_library(
         "@mlir-hlo//:legalize_control_flow",
         "@mlir-hlo//:legalize_einsum_to_dot_general",
         "@mlir-hlo//:legalize_gather_to_torch_index_select",
+        "@mlir-hlo//:legalize_shape_computations",
         "@mlir-hlo//:legalize_to_linalg",
         "@mlir-hlo//:legalize_to_standard",
         "@mlir-hlo//:map_lmhlo_to_scalar_op",

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -92,7 +92,8 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(mlir::createCSEPass());
 
   // Convert to Linalg. After this point, MHLO will be eliminated.
-  passManager.addNestedPass<func::FuncOp>(mhlo::createLegalizeShapeComputationsPass());
+  passManager.addNestedPass<func::FuncOp>(
+      mhlo::createLegalizeShapeComputationsPass());
   passManager.addNestedPass<func::FuncOp>(createConvertMHLOToLinalgExtPass());
   passManager.addNestedPass<func::FuncOp>(createMHLOToLinalgOnTensorsPass());
   // Ensure conversion completed.

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -92,6 +92,7 @@ void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<func::FuncOp>(mlir::createCSEPass());
 
   // Convert to Linalg. After this point, MHLO will be eliminated.
+  passManager.addNestedPass<func::FuncOp>(mhlo::createLegalizeShapeComputationsPass());
   passManager.addNestedPass<func::FuncOp>(createConvertMHLOToLinalgExtPass());
   passManager.addNestedPass<func::FuncOp>(createMHLOToLinalgOnTensorsPass());
   // Ensure conversion completed.


### PR DESCRIPTION
Shape op on mhlo dynamic operations is missing lowerings.

https://github.com/iree-org/iree/issues/7897