### PR TITLE
Summarize presubmit in single PR check

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -29,12 +29,8 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build_runtime, test_runtime, tsan]
     if: always()
-    env:
-      # This has to be injected as an env variable. If the substitution is done
-      # within a step, its meaning changes to whether any previous step has
-      # failed.
-      FAILURE: ${{ failure() }}
     steps:
       - name: Getting combined job status
         run: |
-          [[ "${FAILURE}" == "false" ]]
+          echo '${{ toJson(needs.*.result) }}' \
+            | jq --exit-status 'all(.=="success")'

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -30,6 +30,9 @@ jobs:
     needs: [build_runtime, test_runtime, tsan]
     if: always()
     env:
+      # This has to be injected as an env variable. If the substitution is done
+      # within a step, its meaning changes to whether any previous step has
+      # failed.
       FAILURE: ${{ failure() }}
     steps:
       - name: Getting combined job status

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -25,22 +25,13 @@ jobs:
   tsan:
     uses: ./.github/workflows/tsan.yml
 
-  presubmit:
+  summary:
     runs-on: ubuntu-20.04
     needs: [build_runtime, test_runtime, tsan]
     if: always()
     steps:
-      - run: |
-          echo "### Summary of Presubmit results" >> "${GITHUB_STEP_SUMMARY}"
-          echo ""                                 >> "${GITHUB_STEP_SUMMARY}"
-          echo "| job | result |"                 >> "${GITHUB_STEP_SUMMARY}"
-          echo "| --- | --- |"                    >> "${GITHUB_STEP_SUMMARY}"
-
-          echo '${{ toJson(needs) }}' \
-            | jq --raw-output \
-                'to_entries | .[] | @text "| \(.key) | \(.value.result) |"' \
-            >> "${GITHUB_STEP_SUMMARY}"
-
+      - name: Getting combined job status
+        run: |
           echo '${{ toJson(needs) }}' \
             | jq --exit-status \
                 '[to_entries | .[] | select(.value.result != "success")] | length == 0'

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Getting combined job status
         run: |
           echo '${{ toJson(needs.*.result) }}' \
-            | jq --exit-status 'all(.=="success")'
+            | jq --exit-status 'all(.=="success")' > /dev/null

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -29,9 +29,9 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [build_runtime, test_runtime, tsan]
     if: always()
+    env:
+      FAILURE: ${{ failure() }}
     steps:
       - name: Getting combined job status
         run: |
-          echo '${{ toJson(needs) }}' \
-            | jq --exit-status \
-                '[to_entries | .[] | select(.value.result != "success")] | length == 0'
+          [[ "${FAILURE}" == "false" ]]

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -24,3 +24,23 @@ jobs:
 
   tsan:
     uses: ./.github/workflows/tsan.yml
+
+  presubmit:
+    runs-on: ubuntu-20.04
+    needs: [build_runtime, test_runtime, tsan]
+    if: always()
+    steps:
+      - run: |
+          echo "### Summary of Presubmit results" >> "${GITHUB_STEP_SUMMARY}"
+          echo ""                                 >> "${GITHUB_STEP_SUMMARY}"
+          echo "| job | result |"                 >> "${GITHUB_STEP_SUMMARY}"
+          echo "| --- | --- |"                    >> "${GITHUB_STEP_SUMMARY}"
+
+          echo '${{ toJson(needs) }}' \
+            | jq --raw-output \
+                'to_entries | .[] | @text "| \(.key) | \(.value.result) |"' \
+            >> "${GITHUB_STEP_SUMMARY}"
+
+          echo '${{ toJson(needs) }}' \
+            | jq --exit-status \
+                '[to_entries | .[] | select(.value.result != "success")] | length == 0'

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -30,6 +30,8 @@ jobs:
       - cpu
       - os-family=Linux
     steps:
+      - name: "Fail"
+        run: exit 1
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -30,9 +30,6 @@ jobs:
       - cpu
       - os-family=Linux
     steps:
-      # DO NOT SUBMIT: DELETE
-      - name: "Fail"
-        run: exit 1
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -30,8 +30,6 @@ jobs:
       - cpu
       - os-family=Linux
     steps:
-      - name: "Fail"
-        run: exit 1
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:

--- a/.github/workflows/tsan.yml
+++ b/.github/workflows/tsan.yml
@@ -30,6 +30,9 @@ jobs:
       - cpu
       - os-family=Linux
     steps:
+      # DO NOT SUBMIT: DELETE
+      - name: "Fail"
+        run: exit 1
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
         with:


### PR DESCRIPTION
Add a job that aggregates the results of all other presubmit jobs
into a single "Check Run" (different from the "Status" API and from
PR "checks". Very confusing). We can use this job's  to hook into the
GitHub "required checks" functionality and therefore enable dynamic
determination about which jobs need to pass before a PR can be
merged.

Demo: https://github.com/iree-org/iree/actions/runs/2694279081
