### PR TITLE
Fix bug in FlattenMemRefSubspanPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -472,7 +472,7 @@ struct FoldMemRefReshape final : public OpConversionPattern<ReshapeOpTy> {
       rewriter.replaceOp(op, adaptor.getSrc());
       return success();
     } else if (isRankOneMemRef(neededResultType)) {
-      rewriter.replaceOpWithNewOp<memref::CastOp>(op, op.getResult().getType(),
+      rewriter.replaceOpWithNewOp<memref::CastOp>(op, neededResultType,
                                                   adaptor.getSrc());
       return success();
     }


### PR DESCRIPTION
The newly added test case was lowered to an invalid memref::CastOp.