### PR TITLE
Build script improvements

### DIFF
--- a/build_tools/cmake/build_and_test_tsan.sh
+++ b/build_tools/cmake/build_and_test_tsan.sh
@@ -22,6 +22,13 @@ if [[ -z "${BUILD_DIR}" ]]; then
   BUILD_DIR="${IREE_TSAN_BUILD_DIR:-build-tsan}"
 fi
 
+# Enable CUDA compiler and runtime builds unless disabled. Our CI images all
+# have enough deps to at least build CUDA support and compile CUDA binaries.
+# We will skip running GPU tests below but this still yields a bit more TSan
+# coverage, at least in the compiler, and regarding the runtime it's at
+# least checking that it builds with TSan.
+export IREE_CUDA_BUILD=${IREE_CUDA_BUILD:-1}
+
 source "${SCRIPT_DIR}/setup_build.sh"
 
 CMAKE_ARGS=(
@@ -50,13 +57,8 @@ CMAKE_ARGS=(
   "-DIREE_BUILD_SAMPLES=OFF"
 )
 
-if [[ -z "${IREE_CUDA_DISABLE_BUILD}" ]]; then
+if [[ "${IREE_CUDA_BUILD}" == 1 ]]; then
   CMAKE_ARGS+=(
-    # Enable CUDA compiler and runtime builds unless disabled. Our CI images all
-    # have enough deps to at least build CUDA support and compile CUDA binaries.
-    # We will skip running GPU tests below but this still yields a bit more TSan
-    # coverage, at least in the compiler, and regarding the runtime it's at
-    # least checking that it builds with TSan.
     "-DIREE_HAL_DRIVER_CUDA=ON"
     "-DIREE_TARGET_BACKEND_CUDA=ON"
   )

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -13,6 +13,10 @@ set -e
 
 ROOT_DIR=$(git rev-parse --show-toplevel)
 
+# Enable CUDA compiler and runtime builds unless disabled. Our CI images all
+# have enough deps to at least build CUDA support and compile CUDA binaries.
+export IREE_CUDA_BUILD=${IREE_CUDA_BUILD:-1}
+
 CMAKE_BIN=${CMAKE_BIN:-$(which cmake)}
 
 "$CMAKE_BIN" --version
@@ -49,10 +53,8 @@ CMAKE_ARGS=(
   "-DIREE_ENABLE_ASSERTIONS=ON"
 )
 
-if [[ -z "${IREE_CUDA_DISABLE_BUILD}" ]]; then
+if [[ "${IREE_CUDA_BUILD}" == 1 ]]; then
   CMAKE_ARGS+=(
-    # Enable CUDA compiler and runtime builds unless disabled. Our CI images all
-    # have enough deps to at least build CUDA support and compile CUDA binaries.
     "-DIREE_HAL_DRIVER_CUDA=ON"
     "-DIREE_TARGET_BACKEND_CUDA=ON"
   )


### PR DESCRIPTION
* Build all targets in one command (should parallelize better)
* Allow not building CUDA (helps running locally)

With that, anyone can build and test TSan like follows and reproduce exactly (up to TSan nondeterminism) what CI does. Before, one had to either install CUDA (never going to be easy for everyone) or edit that script to disable it.

```
IREE_CUDA_DISABLE_BUILD=1 ./build_tools/cmake/build_and_test_tsan.sh
```