### PR TITLE
Tweaks to atomics in `iree_thread_*` - use acquire/release consistently

### DIFF
--- a/runtime/src/iree/base/internal/threading_darwin.c
+++ b/runtime/src/iree/base/internal/threading_darwin.c
@@ -240,8 +240,8 @@ void iree_thread_resume(iree_thread_t* thread) {
   // debuggers/profilers that may be suspending threads for their own uses.
   int32_t expected = 1;
   if (iree_atomic_compare_exchange_strong_int32(
-          &thread->is_suspended, &expected, 0, iree_memory_order_seq_cst,
-          iree_memory_order_seq_cst)) {
+          &thread->is_suspended, &expected, 0, iree_memory_order_acq_rel,
+          iree_memory_order_relaxed /* expected is unused */)) {
     thread_resume(thread->mach_port);
   }
 

--- a/runtime/src/iree/base/internal/threading_pthreads.c
+++ b/runtime/src/iree/base/internal/threading_pthreads.c
@@ -59,7 +59,7 @@ static void iree_thread_set_priority_class(
 static bool iree_thread_resumed_predicate(void* arg) {
   iree_thread_t* thread = (iree_thread_t*)arg;
   return iree_atomic_load_int32(&thread->suspend_count,
-                                iree_memory_order_seq_cst) == 0;
+                                iree_memory_order_acquire) == 0;
 }
 
 #if defined(IREE_PLATFORM_EMSCRIPTEN)
@@ -107,7 +107,7 @@ static void* iree_thread_start_routine(void* param) {
 
   // Wait until we resume if we were created suspended.
   while (iree_atomic_load_int32(&thread->suspend_count,
-                                iree_memory_order_seq_cst) > 0) {
+                                iree_memory_order_acquire) > 0) {
     iree_notification_await(&thread->suspend_barrier,
                             iree_thread_resumed_predicate, thread,
                             iree_infinite_timeout());
@@ -346,7 +346,7 @@ void iree_thread_resume(iree_thread_t* thread) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
   if (iree_atomic_exchange_int32(&thread->suspend_count, 0,
-                                 iree_memory_order_seq_cst) == 1) {
+                                 iree_memory_order_acq_rel) == 1) {
     iree_notification_post(&thread->suspend_barrier, IREE_ALL_WAITERS);
   }
 

--- a/runtime/src/iree/base/internal/threading_win32.c
+++ b/runtime/src/iree/base/internal/threading_win32.c
@@ -317,8 +317,8 @@ void iree_thread_resume(iree_thread_t* thread) {
   // debuggers/profilers that may be suspending threads for their own uses.
   int32_t expected = 1;
   if (iree_atomic_compare_exchange_strong_int32(
-          &thread->is_suspended, &expected, 0, iree_memory_order_seq_cst,
-          iree_memory_order_seq_cst)) {
+          &thread->is_suspended, &expected, 0, iree_memory_order_acq_rel,
+          iree_memory_order_relaxed /* expected is unused */)) {
     ResumeThread(thread->handle);
   }
 


### PR DESCRIPTION
This is mostly changing some unnecessary seq_cst to acquire/release consistently with what other accesses were already doing.

In some compare_exchange, the compare-failure case could use relaxed because we didn't rely on ordering in that case.