### PR TITLE
Finish rationalizing atomics in remaining `runtime/` code

### DIFF
--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -92,8 +92,10 @@ static iree_status_t iree_dynamic_library_make_temp_file_path(
   // process. We combine this with the _mktemp path that should be unique to the
   // process itself.
   static iree_atomic_int32_t next_unique_id = IREE_ATOMIC_VAR_INIT(0);
+  // relaxed because we only care about uniqueness, we don't care about ordering
+  // of accesses to unique_id w.r.t. other memory operations.
   uint32_t unique_id = (uint32_t)iree_atomic_fetch_add_int32(
-      &next_unique_id, 1, iree_memory_order_seq_cst);
+      &next_unique_id, 1, iree_memory_order_relaxed);
 
   // Allocate storage for the full file path and format it in.
   int file_path_length =

--- a/runtime/src/iree/hal/drivers/vulkan/native_semaphore.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_semaphore.cc
@@ -201,7 +201,8 @@ static void iree_hal_vulkan_native_semaphore_fail(
   iree_status_t old_status = iree_ok_status();
   if (!iree_atomic_compare_exchange_strong_intptr(
           &semaphore->failure_status, (intptr_t*)&old_status, (intptr_t)status,
-          iree_memory_order_seq_cst, iree_memory_order_seq_cst)) {
+          iree_memory_order_acq_rel,
+          iree_memory_order_relaxed /* old_status is unused */)) {
     // Previous status was not OK; drop our new status.
     IREE_IGNORE_ERROR(status);
     return;

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -147,6 +147,7 @@ iree_status_t iree_task_executor_create(
       worker_local_memory += worker_local_memory_size;
       if (!iree_status_is_ok(status)) break;
     }
+    // The masks are accessed with 'relaxed' order because they are just hints.
     iree_atomic_task_affinity_set_store(&executor->worker_suspend_mask,
                                         worker_suspend_mask,
                                         iree_memory_order_relaxed);
@@ -535,6 +536,7 @@ iree_task_t* iree_task_executor_try_steal_task(
     iree_task_queue_t* local_task_queue) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  // The masks are accessed with 'relaxed' order because they are just hints.
   iree_task_affinity_set_t worker_live_mask =
       iree_atomic_task_affinity_set_load(&executor->worker_live_mask,
                                          iree_memory_order_relaxed);

--- a/runtime/src/iree/task/poller.c
+++ b/runtime/src/iree/task/poller.c
@@ -34,7 +34,7 @@ iree_status_t iree_task_poller_initialize(
   // check in enqueue to see if the wait thread needs to be resumed.
   // initial_state = IREE_TASK_POLLER_STATE_SUSPENDED;
   iree_atomic_store_int32(&out_poller->state, initial_state,
-                          iree_memory_order_seq_cst);
+                          iree_memory_order_release);
 
   // Acquire an event we can use to wake the wait thread from other threads.
   iree_status_t status = iree_event_pool_acquire(

--- a/runtime/src/iree/task/post_batch.c
+++ b/runtime/src/iree/task/post_batch.c
@@ -34,6 +34,7 @@ iree_host_size_t iree_task_post_batch_worker_count(
 
 static iree_host_size_t iree_task_post_batch_select_random_worker(
     iree_task_post_batch_t* post_batch, iree_task_affinity_set_t affinity_set) {
+  // The masks are accessed with 'relaxed' order because they are just hints.
   iree_task_affinity_set_t worker_live_mask =
       iree_atomic_task_affinity_set_load(
           &post_batch->executor->worker_live_mask, iree_memory_order_relaxed);
@@ -68,6 +69,7 @@ iree_host_size_t iree_task_post_batch_select_worker(
   // worker's queue to finish. Note that we only consider workers idle if we
   // ourselves in this batch haven't already queued work for them (as then they
   // aren't going to be idle).
+  // The masks are accessed with 'relaxed' order because they are just hints.
   iree_task_affinity_set_t worker_idle_mask =
       iree_atomic_task_affinity_set_load(
           &post_batch->executor->worker_idle_mask, iree_memory_order_relaxed);
@@ -103,6 +105,7 @@ static void iree_task_post_batch_wake_workers(
   // Wake workers that may be suspended. We fetch the set of workers we need to
   // wake (hopefully none in the common case) and mark that we've woken them so
   // that we don't double-resume.
+  // The masks are accessed with 'relaxed' order because they are just hints.
   iree_task_affinity_set_t resume_mask =
       iree_atomic_task_affinity_set_fetch_and(&executor->worker_suspend_mask,
                                               ~wake_mask,

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -282,6 +282,7 @@ static void iree_task_worker_pump_until_exit(iree_task_worker_t* worker) {
     // structures we use.
     iree_wait_token_t wait_token =
         iree_notification_prepare_wait(&worker->wake_notification);
+    // The masks are accessed with 'relaxed' order because they are just hints.
     iree_atomic_task_affinity_set_fetch_and(&worker->executor->worker_idle_mask,
                                             ~worker->worker_bit,
                                             iree_memory_order_relaxed);

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -45,8 +45,10 @@ static void iree_vm_context_destroy(iree_vm_context_t* context);
 // Allocates a process-unique ID for a context to use.
 static iree_vm_context_id_t iree_vm_context_allocate_id(void) {
   static iree_atomic_int32_t next_context_id = IREE_ATOMIC_VAR_INIT(1);
+  // relaxed because we only care about atomic increments, not ordering w.r.t.
+  // other memory accesses.
   uint32_t context_id = iree_atomic_fetch_add_int32(&next_context_id, 1,
-                                                    iree_memory_order_seq_cst);
+                                                    iree_memory_order_relaxed);
 #if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_FIBERS
   // This is what we pass to Tracy as the fiber name.
   // The string must remain live for the lifetime of the process.

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -206,7 +206,7 @@ static iree_vm_invocation_id_t iree_vm_invoke_allocate_id(
     // TODO(benvanik): name it based on the function?
     static iree_atomic_int32_t next_invocation_id = IREE_ATOMIC_VAR_INIT(1);
     uint32_t invocation_id = iree_atomic_fetch_add_int32(
-        &next_invocation_id, 1, iree_memory_order_seq_cst);
+        &next_invocation_id, 1, iree_memory_order_relaxed);
     IREE_LEAK_CHECK_DISABLE_PUSH();
     char* name = (char*)malloc(32);
     snprintf(name, 32, "invoke-%04d", invocation_id - 1);


### PR DESCRIPTION
Similar to other PRs from today (#9834, #9835, #9836) this is the rest of the "audit" on all remaining `runtime/` code.

With this, there are no remaining sequentially-consistent atomics in non-test IREE code. That wasn't a goal in itself: seq_cst atomics are fine (though expensive). But it happened that as many accesses were acquire/release anyway, making remaining accesses acquire/release was not only a potential optimization, it also makes the overall code easier to reason about and more self-documenting. One good thing about acquire and release orders is that they convey intent. By contrast, seq_cst and relaxed don't convey as much information about intent, so an audit of all uses was sure to find at least some cases that were using them for no particular reason.

Some places are changed all the way from seq_cst to relaxed, when that was correct. Comments are added to justify relaxed, also at existing places that were already using relaxed. Relaxed is the most aggressive order and doesn't generally self-document intent (unlike acquire/release), so uses should generally be justified by a comment.