### PR TITLE
Replace mhlo ops with core dialect ops in more tests.

### DIFF
--- a/compiler/src/iree/compiler/API/python/test/tools/compiler_core_test.py
+++ b/compiler/src/iree/compiler/API/python/test/tools/compiler_core_test.py
@@ -15,8 +15,8 @@ import iree.compiler.tools
 
 SIMPLE_MUL_ASM = """
 func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-    %0 = "mhlo.multiply"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
-    return %0 : tensor<4xf32>
+  %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+  return %0 : tensor<4xf32>
 }
 """
 
@@ -35,7 +35,6 @@ class CompilerTest(unittest.TestCase):
   def testCompileStr(self):
     binary = iree.compiler.tools.compile_str(
         SIMPLE_MUL_ASM,
-        input_type="mhlo",
         target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
     logging.info("Flatbuffer size = %d", len(binary))
     self.assertTrue(binary)
@@ -45,7 +44,6 @@ class CompilerTest(unittest.TestCase):
   # specifically. See: https://github.com/iree-org/iree/issues/4439
   def testCompileStrLLVMAOT(self):
     binary = iree.compiler.tools.compile_str(SIMPLE_MUL_ASM,
-                                             input_type="mhlo",
                                              target_backends=["dylib-llvm-aot"])
     logging.info("Flatbuffer size = %d", len(binary))
     self.assertTrue(binary)
@@ -56,7 +54,6 @@ class CompilerTest(unittest.TestCase):
   def testCompileMultipleBackends(self):
     binary = iree.compiler.tools.compile_str(
         SIMPLE_MUL_ASM,
-        input_type="mhlo",
         target_backends=["dylib-llvm-aot", "vulkan-spirv"])
     logging.info("Flatbuffer size = %d", len(binary))
     self.assertTrue(binary)
@@ -68,7 +65,6 @@ class CompilerTest(unittest.TestCase):
         f.close()
         binary = iree.compiler.tools.compile_file(
             f.name,
-            input_type="mhlo",
             target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
       finally:
         os.remove(f.name)
@@ -81,7 +77,6 @@ class CompilerTest(unittest.TestCase):
         f.close()
         output = iree.compiler.tools.compile_str(
             SIMPLE_MUL_ASM,
-            input_type="mhlo",
             output_file=f.name,
             target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
         self.assertIsNone(output)
@@ -96,7 +91,6 @@ class CompilerTest(unittest.TestCase):
   def testOutputFbText(self):
     text = iree.compiler.tools.compile_str(
         SIMPLE_MUL_ASM,
-        input_type="mhlo",
         output_format=iree.compiler.tools.OutputFormat.FLATBUFFER_TEXT,
         target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS).decode(
             "utf-8")
@@ -119,7 +113,6 @@ class CompilerTest(unittest.TestCase):
         "FLATBUFFER_BINARY, FLATBUFFER_TEXT, MLIR_TEXT"):
       _ = iree.compiler.tools.compile_str(
           SIMPLE_MUL_ASM,
-          input_type="mhlo",
           output_format="foobar",
           target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
 
@@ -136,7 +129,6 @@ class CompilerTest(unittest.TestCase):
   def testOutputMlirText(self):
     text = iree.compiler.tools.compile_str(
         SIMPLE_MUL_ASM,
-        input_type="mhlo",
         output_format=iree.compiler.tools.OutputFormat.MLIR_TEXT,
         target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS).decode(
             "utf-8")
@@ -148,7 +140,6 @@ class CompilerTest(unittest.TestCase):
     with io.StringIO() as buf, contextlib.redirect_stderr(buf):
       iree.compiler.tools.compile_str(
           SIMPLE_MUL_ASM,
-          input_type="mhlo",
           extra_args=["--mlir-timing"],
           target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
       stderr = buf.getvalue()
@@ -157,7 +148,6 @@ class CompilerTest(unittest.TestCase):
   def testAllOptions(self):
     binary = iree.compiler.tools.compile_str(
         SIMPLE_MUL_ASM,
-        input_type="mhlo",
         optimize=False,
         strip_debug_ops=True,
         strip_source_map=True,
@@ -179,7 +169,6 @@ class CompilerTest(unittest.TestCase):
     with iree.compiler.tools.TempFileSaver(temp_dir.name):
       output = iree.compiler.tools.compile_str(
           SIMPLE_MUL_ASM,
-          input_type="mhlo",
           output_file=output_file.name,
           target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
       self.assertIsNone(output)
@@ -202,7 +191,6 @@ class CompilerTest(unittest.TestCase):
     with iree.compiler.tools.TempFileSaver(temp_dir.name):
       output = iree.compiler.tools.compile_str(
           SIMPLE_MUL_ASM,
-          input_type="mhlo",
           target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
       self.assertIsNotNone(output)
       self.assertGreater(len(output), 0)
@@ -226,7 +214,6 @@ class CompilerTest(unittest.TestCase):
     with iree.compiler.tools.TempFileSaver(temp_dir.name):
       output = iree.compiler.tools.compile_str(
           SIMPLE_MUL_ASM,
-          input_type="mhlo",
           target_backends=iree.compiler.tools.DEFAULT_TESTING_BACKENDS)
       self.assertIsNotNone(output)
       self.assertGreater(len(output), 0)

--- a/compiler/src/iree/compiler/API/python/test/transforms/ireec/compile_sample_module.py
+++ b/compiler/src/iree/compiler/API/python/test/transforms/ireec/compile_sample_module.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import io
-import subprocess
 
 from iree.compiler import ir
 from iree.compiler import passmanager
@@ -33,16 +32,14 @@ with ir.Context() as ctx:
 
   input_module = ir.Module.parse(r"""
     builtin.module  {
-      func.func @fabs(%arg0: tensor<1x4xf32>, %arg1: tensor<4x1xf32>) -> tensor<4x4xf32> {
-        %0 = chlo.broadcast_add %arg0, %arg1 : (tensor<1x4xf32>, tensor<4x1xf32>) -> tensor<4x4xf32>
-        %1 = "mhlo.abs"(%0) : (tensor<4x4xf32>) -> tensor<4x4xf32>
-        return %1 : tensor<4x4xf32>
+      func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+        %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+        return %0 : tensor<4xf32>
       }
     }
   """)
 
-  options = ireec.CompilerOptions("--iree-hal-target-backends=cpu",
-                                  "--iree-input-type=mhlo")
+  options = ireec.CompilerOptions("--iree-hal-target-backends=cpu")
   print(options)
   pm = passmanager.PassManager()
   ireec.build_iree_vm_pass_pipeline(options, pm)

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -700,7 +700,7 @@ def FLOW_TensorConstantOp : FLOW_Op<"tensor.constant"> {
 
     ```mlir
     %c = flow.tensor.constant tensor<2x2xf32> -> tensor<?x?xf32>
-    %res = "mhlo.abs"(%c) : (tensor<?x?xf32>) -> tensor<?x?xf32>
+    %res = math.abs %c : tensor<?x?xf32>
     ```
   }];
   let arguments = (ins ElementsAttr:$value);

--- a/runtime/bindings/python/tests/system_api_test.py
+++ b/runtime/bindings/python/tests/system_api_test.py
@@ -22,12 +22,11 @@ def create_simple_mul_module():
       """
       module @arithmetic {
         func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
-            %0 = "mhlo.multiply"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
-            return %0 : tensor<4xf32>
+          %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
+          return %0 : tensor<4xf32>
         }
       }
       """,
-      input_type="mhlo",
       target_backends=iree.compiler.core.DEFAULT_TESTING_BACKENDS,
   )
   m = iree.runtime.VmModule.from_flatbuffer(binary)

--- a/runtime/src/iree/runtime/demo/README.md
+++ b/runtime/src/iree/runtime/demo/README.md
@@ -7,9 +7,8 @@ The module used has a single exported function `@simple_mul` that multiplies two
 tensors and returns the result:
 
 ```mlir
-func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32>
-    {
-  %0 = "mhlo.multiply"(%arg0, %arg1) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 ```

--- a/samples/static_library/README.md
+++ b/samples/static_library/README.md
@@ -9,10 +9,8 @@ The model compiled into the static library exports a single function
 `simple_mul` that returns the multiplication of two tensors:
 
 ```mlir
-func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32>
-{
-  %0 = "mhlo.multiply"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>,
-    tensor<4xf32>) -> tensor<4xf32>
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = "arith.mulf"(%arg0, %arg1) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }
 ```

--- a/samples/static_library/simple_mul.mlir
+++ b/samples/static_library/simple_mul.mlir
@@ -1,5 +1,4 @@
-func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32>
-{
-  %0 = "arith.mulf"(%arg0, %arg1) {name = "mul.1"} : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+  %0 = "arith.mulf"(%arg0, %arg1) : (tensor<4xf32>, tensor<4xf32>) -> tensor<4xf32>
   return %0 : tensor<4xf32>
 }


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/9667, working towards removing MHLO and other input dialects from the "core" parts of the IREE compiler. Any tests using input dialects should be organized under the relevant `compiler/InputConversion/*` or `tests/e2e/*_ops/` directories.

Notable remaining tests using mhlo in the "core" of the compiler:
* [demote_f32_to_f16.mlir](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f32_to_f16.mlir)
* [demote_f64_to_f32.mlir](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir)
* [demote_i64_to_i32.mlir](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_i64_to_i32.mlir)
* [promote_f16_to_f32.mlir](https://github.com/iree-org/iree/blob/main/compiler/src/iree/compiler/Dialect/Util/Transforms/test/promote_f16_to_f32.mlir)