### PR TITLE
Add time unit option to iree-benchmark-module

### DIFF
--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -179,7 +179,7 @@ static std::pair<bool, benchmark::TimeUnit> FLAG_time_unit = {
     false, benchmark::kNanosecond};
 IREE_FLAG_CALLBACK(
     parse_time_unit, print_time_unit, &FLAG_time_unit, time_unit,
-    "The time unit to be printed in the results. Can be ms, us, or ns.");
+    "The time unit to be printed in the results. Can be 'ms', 'us', or 'ns'.");
 
 namespace iree {
 namespace {

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -169,7 +169,7 @@ static void print_time_unit(iree_string_view_t flag_name, void* storage,
   fprintf(file, "--%.*s=\"%s\"\n", (int)flag_name.size, flag_name.data,
           unit_string.c_str());
 }
-// Time unit to printed. If the first field is false, each place will use its
+// Time unit to be printed. If the first field is false, each place will use its
 // default time unit.
 static std::pair<bool, benchmark::TimeUnit> FLAG_time_unit = {
     false, benchmark::kNanosecond};

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -75,6 +75,10 @@
 #include "iree/vm/bytecode_module.h"
 #include "iree/vm/ref_cc.h"
 
+constexpr char kNanosecondsUnitString[] = "ns";
+constexpr char kMicrosecondsUnitString[] = "us";
+constexpr char kMillisecondsUnitString[] = "ms";
+
 IREE_FLAG(string, module_file, "-",
           "File containing the module to load that contains the entry "
           "function. Defaults to stdin.");
@@ -133,13 +137,13 @@ static iree_status_t parse_time_unit(iree_string_view_t flag_name,
                                      void* storage, iree_string_view_t value) {
   auto* unit = (std::pair<bool, benchmark::TimeUnit>*)storage;
   auto unit_string = std::string(value.data, value.size);
-  if (unit_string == "ms") {
+  if (unit_string == kMillisecondsUnitString) {
     *unit = {true, benchmark::kMillisecond};
     return iree_ok_status();
-  } else if (unit_string == "us") {
+  } else if (unit_string == kMicrosecondsUnitString) {
     *unit = {true, benchmark::kMicrosecond};
     return iree_ok_status();
-  } else if (unit_string == "ns") {
+  } else if (unit_string == kNanosecondsUnitString) {
     *unit = {true, benchmark::kNanosecond};
     return iree_ok_status();
   }
@@ -155,13 +159,13 @@ static void print_time_unit(iree_string_view_t flag_name, void* storage,
   std::string unit_string;
   switch (unit->second) {
     case benchmark::kMillisecond:
-      unit_string = "ms";
+      unit_string = kMillisecondsUnitString;
       break;
     case benchmark::kMicrosecond:
-      unit_string = "us";
+      unit_string = kMicrosecondsUnitString;
       break;
     case benchmark::kNanosecond:
-      unit_string = "ns";
+      unit_string = kNanosecondsUnitString;
       break;
     default:
       assert(false && "Unexpected time unit.");


### PR DESCRIPTION
Now we have some benchmarks (x86, CUDA) that take less than 10ms to run. This means the default milliseconds unit isn't precise enough to show the difference (the console output only shows 2 digits after decimal point).

This change adds a new option to specify the desired time unit: nanoseconds, microseconds, and milliseconds.