### PR TITLE
Replace mhlo ops with core dialect ops in type conversion tests.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f32_to_f16.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f32_to_f16.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file -iree-util-demote-f32-to-f16 %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-util-demote-f32-to-f16 %s | FileCheck %s
 
 // NOTE: for more comprehensive tests see demote_i64_to_i32.mlir.
 
@@ -20,17 +20,16 @@ func.func @simple_f32() -> (tensor<4xf32>) {
 // CHECK-NOT: f32
 // CHECK-LABEL: func.func @nested_region_f32()
 // CHECK-NOT: f32
-// CHECK: return %{{.*}} : tensor<4xf16>
+// CHECK: return %{{.*}} : tensor<?xf16>
 util.global private @"__global" = dense<[1.000000e+01, 5.000000e+00, 1.000000e+01, 5.000000e+00]> : tensor<4xf32>
-func.func @nested_region_f32() -> (tensor<4xf32>) {
+func.func @nested_region_f32() -> (tensor<?xf32>) {
   %0 = util.global.address @"__global" : !util.ptr<tensor<4xf32>>
   %1 = util.global.load.indirect %0 : !util.ptr<tensor<4xf32>> -> tensor<4xf32>
-  %2 = "mhlo.broadcast_in_dim"(%1) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<4xf32>) -> tensor<4x4xf32>
-  %4 = mhlo.constant dense<0xFF800000> : tensor<f32>
-  %3 = "mhlo.reduce"(%2, %4) ( {
-  ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):
-    %5393 = mhlo.maximum %arg3, %arg4 : tensor<f32>
-    "mhlo.return"(%5393) : (tensor<f32>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<4x4xf32>, tensor<f32>) -> tensor<4xf32>
-  return %3 : tensor<4xf32>
+  %c4 = arith.constant 4 : index
+  %2 = tensor.generate %c4 {
+  ^bb0(%arg0: index) :
+    %element = tensor.extract %1[%arg0] : tensor<4xf32>
+    tensor.yield %element : f32
+  } : tensor<?xf32>
+  return %2 : tensor<?xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/demote_f64_to_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file -iree-util-demote-f64-to-f32 %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-util-demote-f64-to-f32 %s | FileCheck %s
 
 // NOTE: for more comprehensive tests see demote_i64_to_i32.mlir.
 
@@ -39,19 +39,18 @@ func.func @simple_f64() -> (tensor<4xf64>) {
 // CHECK-NOT: f64
 // CHECK-LABEL: func.func @nested_region_f64()
 // CHECK-NOT: f64
-// CHECK: return %{{.*}} : tensor<4xf32>
+// CHECK: return %{{.*}} : tensor<?xf32>
 util.global private @"__global" = dense<[1.000000e+01, 5.000000e+00, 1.000000e+01, 5.000000e+00]> : tensor<4xf64>
-func.func @nested_region_f64() -> (tensor<4xf64>) {
+func.func @nested_region_f64() -> (tensor<?xf64>) {
   %0 = util.global.address @"__global" : !util.ptr<tensor<4xf64>>
   %1 = util.global.load.indirect %0 : !util.ptr<tensor<4xf64>> -> tensor<4xf64>
-  %2 = "mhlo.broadcast_in_dim"(%1) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<4xf64>) -> tensor<4x4xf64>
-  %4 = mhlo.constant dense<0xFF800000> : tensor<f64>
-  %3 = "mhlo.reduce"(%2, %4) ( {
-  ^bb0(%arg3: tensor<f64>, %arg4: tensor<f64>):
-    %5393 = mhlo.maximum %arg3, %arg4 : tensor<f64>
-    "mhlo.return"(%5393) : (tensor<f64>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<4x4xf64>, tensor<f64>) -> tensor<4xf64>
-  return %3 : tensor<4xf64>
+  %c4 = arith.constant 4 : index
+  %2 = tensor.generate %c4 {
+  ^bb0(%arg0: index) :
+    %element = tensor.extract %1[%arg0] : tensor<4xf64>
+    tensor.yield %element : f64
+  } : tensor<?xf64>
+  return %2 : tensor<?xf64>
 }
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/promote_f16_to_f32.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/promote_f16_to_f32.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file -iree-util-promote-f16-to-f32 %s | FileCheck %s
+// RUN: iree-opt --split-input-file --iree-util-promote-f16-to-f32 %s | FileCheck %s
 
 // NOTE: for more comprehensive tests see demote_i64_to_i32.mlir.
 
@@ -20,17 +20,16 @@ func.func @simple_f16() -> (tensor<4xf16>) {
 // CHECK-NOT: f16
 // CHECK-LABEL: func.func @nested_region_f16()
 // CHECK-NOT: f16
-// CHECK: return %{{.*}} : tensor<4xf32>
+// CHECK: return %{{.*}} : tensor<?xf32>
 util.global private @"__global" = dense<[1.000000e+01, 5.000000e+00, 1.000000e+01, 5.000000e+00]> : tensor<4xf16>
-func.func @nested_region_f16() -> (tensor<4xf16>) {
+func.func @nested_region_f16() -> (tensor<?xf16>) {
   %0 = util.global.address @"__global" : !util.ptr<tensor<4xf16>>
   %1 = util.global.load.indirect %0 : !util.ptr<tensor<4xf16>> -> tensor<4xf16>
-  %2 = "mhlo.broadcast_in_dim"(%1) {broadcast_dimensions = dense<0> : tensor<1xi64>} : (tensor<4xf16>) -> tensor<4x4xf16>
-  %4 = mhlo.constant dense<0xFC00> : tensor<f16>
-  %3 = "mhlo.reduce"(%2, %4) ( {
-  ^bb0(%arg3: tensor<f16>, %arg4: tensor<f16>):
-    %5393 = mhlo.maximum %arg3, %arg4 : tensor<f16>
-    "mhlo.return"(%5393) : (tensor<f16>) -> ()
-  }) {dimensions = dense<1> : tensor<1xi64>} : (tensor<4x4xf16>, tensor<f16>) -> tensor<4xf16>
-  return %3 : tensor<4xf16>
+  %c4 = arith.constant 4 : index
+  %2 = tensor.generate %c4 {
+  ^bb0(%arg0: index) :
+    %element = tensor.extract %1[%arg0] : tensor<4xf16>
+    tensor.yield %element : f16
+  } : tensor<?xf16>
+  return %2 : tensor<?xf16>
 }


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/9667

`mhlo.reduce` was being used as a simple op with a nested region. I considered using `linalg.generic` in its place, but found that `tensor.generate` was simpler. Maybe a custom op would be even simpler (if we're trying to test something purely structural and don't care about a particular op's semantics)?