### PR TITLE
scf.foreach_thread lowering: Clone ops into dispatch regions

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/BUILD
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
     deps = [
         ":FlowExtensionsOpGen",
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
         "@llvm-project//mlir:ArithmeticDialect",

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/CMakeLists.txt
@@ -40,6 +40,7 @@ iree_cc_library(
     MLIRTransformDialect
     MLIRTransformUtils
     iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::Transforms
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -63,6 +63,7 @@ iree_compiler_cc_library(
         "VerifyInputLegality.cpp",
     ],
     hdrs = [
+        "DispatchLinalgOnTensors.h",
         "FusionUtils.h",
         "Passes.h",
         "Passes.h.inc",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
   NAME
     Transforms
   HDRS
+    "DispatchLinalgOnTensors.h"
     "FusionUtils.h"
     "Passes.h"
     "Passes.h.inc"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.h"
+
 #include <deque>
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
@@ -154,7 +156,7 @@ static bool isRootOp(Operation *op) {
 
 /// Operations that are cloned into dispatch regions formed with other
 /// operations as roots.
-static bool isClonableIntoDispatchOp(Operation *op) {
+bool isClonableIntoDispatchOp(Operation *op) {
   // TODO(#8637): `tensor.collapse_shape` and `tensor.expand_shape` are
   // trivially clonable too, but they cause problems
   // with bufferization. Make them clonable when fixed.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.h
@@ -1,0 +1,29 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_DISPATCHLINALGONTENSORS_H_
+#define IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_DISPATCHLINALGONTENSORS_H_
+
+namespace mlir {
+class Operation;
+
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+/// A heuristic that decides which ops should be cloned and fused into a
+/// dispatch region.
+///
+/// Note: This function returns `false` for ops that should be tiled and fused
+/// into a dispatch region.
+bool isClonableIntoDispatchOp(Operation *op);
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_DISPATCHLINALGONTENSORS_H_

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
@@ -2,13 +2,25 @@
 // RUN: FileCheck %s
 
 func.func @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
-             %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+                             %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
     outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
   return %1 : tensor<?x?xf32>
 }
 //      CHECK: func.func @tile_matmul_alone
 //      CHECK:   flow.dispatch.workgroups
+
+func.func @tile_matmul_with_constant(
+    %arg1 : tensor<5x10xf32>, %arg2 : tensor<10x10xf32>) -> tensor<10x10xf32> {
+  // The constant is cloned and fused into the dispatch region.
+  %a = arith.constant dense<1.0> : tensor<10x5xf32>
+  %1 = linalg.matmul ins(%a, %arg1 : tensor<10x5xf32>, tensor<5x10xf32>)
+    outs(%arg2 : tensor<10x10xf32>) -> tensor<10x10xf32>
+  return %1 : tensor<10x10xf32>
+}
+//      CHECK: func.func @tile_matmul_with_constant
+//      CHECK:   flow.dispatch.workgroups
+//      CHECK:     arith.constant dense<1.000000e+00> : tensor<10x5xf32>
 
 // Some dummy functions to exercise TSAN under parallelism.
 func.func @foo1() -> index {


### PR DESCRIPTION
When creating a flow.dispatch.workgroups op from an scf.foreach_thread
op, some ops are now cloned and fused into the dispatch region (as per
existing IREE heuristics).