### PR TITLE
Remove unnecessary `--iree-input-type=mhlo` flag uses.

### DIFF
--- a/runtime/bindings/tflite/testdata/BUILD
+++ b/runtime/bindings/tflite/testdata/BUILD
@@ -18,7 +18,6 @@ iree_bytecode_module(
     src = "add_dynamic.mlir",
     c_identifier = "iree_tflite_testdata_add_dynamic",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-native-bindings-support=false",
         "--iree-tflite-bindings-support",
         "--iree-hal-target-backends=vmvx",
@@ -31,7 +30,6 @@ iree_bytecode_module(
     src = "add_multi.mlir",
     c_identifier = "iree_tflite_testdata_add_multi",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-native-bindings-support=false",
         "--iree-tflite-bindings-support",
         "--iree-hal-target-backends=vmvx",
@@ -44,7 +42,6 @@ iree_bytecode_module(
     src = "add_static.mlir",
     c_identifier = "iree_tflite_testdata_add_static",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-native-bindings-support=false",
         "--iree-tflite-bindings-support",
         "--iree-hal-target-backends=vmvx",

--- a/runtime/bindings/tflite/testdata/CMakeLists.txt
+++ b/runtime/bindings/tflite/testdata/CMakeLists.txt
@@ -18,7 +18,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_tflite_testdata_add_dynamic"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-native-bindings-support=false"
     "--iree-tflite-bindings-support"
     "--iree-hal-target-backends=vmvx"
@@ -34,7 +33,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_tflite_testdata_add_multi"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-native-bindings-support=false"
     "--iree-tflite-bindings-support"
     "--iree-hal-target-backends=vmvx"
@@ -50,7 +48,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_tflite_testdata_add_static"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-native-bindings-support=false"
     "--iree-tflite-bindings-support"
     "--iree-hal-target-backends=vmvx"

--- a/runtime/src/iree/modules/check/test/BUILD
+++ b/runtime/src/iree/modules/check/test/BUILD
@@ -37,12 +37,10 @@ iree_lit_test_suite(
 iree_check_test_suite(
     name = "check",
     srcs = ["success.mlir"],
-    compiler_flags = ["--iree-input-type=mhlo"],
 )
 
 iree_check_test_suite(
     name = "check_failure",
     srcs = ["failure.mlir"],
-    compiler_flags = ["--iree-input-type=mhlo"],
     runner_args = ["--expect_failure"],
 )

--- a/runtime/src/iree/modules/check/test/CMakeLists.txt
+++ b/runtime/src/iree/modules/check/test/CMakeLists.txt
@@ -31,8 +31,6 @@ iree_check_test_suite(
     check
   SRCS
     "success.mlir"
-  COMPILER_FLAGS
-    "--iree-input-type=mhlo"
 )
 
 iree_check_test_suite(
@@ -40,8 +38,6 @@ iree_check_test_suite(
     check_failure
   SRCS
     "failure.mlir"
-  COMPILER_FLAGS
-    "--iree-input-type=mhlo"
   RUNNER_ARGS
     "--expect_failure"
 )

--- a/runtime/src/iree/modules/check/test/failure.mlir
+++ b/runtime/src/iree/modules/check/test/failure.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-check-module --expect_failure - | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --device=vulkan --expect_failure - | FileCheck %s)
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-check-module --expect_failure - | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --device=vulkan --expect_failure - | FileCheck %s)
 
 // CHECK-LABEL: expect_failure.expect_true_of_false
 // CHECK: Expected 0 to be nonzero

--- a/runtime/src/iree/modules/check/test/success.mlir
+++ b/runtime/src/iree/modules/check/test/success.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-check-module --device=local-task -
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --device=vulkan -)
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-check-module --device=local-task -
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-check-module --device=vulkan -)
 
 func.func @expect_true() {
   %true = util.unfoldable_constant 1 : i32

--- a/runtime/src/iree/modules/check/test/unavailable.mlir
+++ b/runtime/src/iree/modules/check/test/unavailable.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-run-module --module_file=- --entry_function=expect_true_of_false | FileCheck %s
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --module_file=- --entry_function=expect_true_of_false | FileCheck %s
 
 // Tests that even if the check module is not available (in this case because
 // we are running with iree-run-module instead of iree-check-module) the

--- a/runtime/src/iree/runtime/testdata/BUILD
+++ b/runtime/src/iree/runtime/testdata/BUILD
@@ -27,7 +27,6 @@ iree_bytecode_module(
     src = "simple_mul.mlir",
     c_identifier = "iree_runtime_testdata_simple_mul_module",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=vmvx",
     ],
 )

--- a/runtime/src/iree/runtime/testdata/CMakeLists.txt
+++ b/runtime/src/iree/runtime/testdata/CMakeLists.txt
@@ -22,7 +22,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_runtime_testdata_simple_mul_module"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=vmvx"
   PUBLIC
 )

--- a/samples/simple_embedding/BUILD
+++ b/samples/simple_embedding/BUILD
@@ -46,7 +46,6 @@ iree_bytecode_module(
     src = "simple_embedding_test.mlir",
     c_identifier = "iree_samples_simple_embedding_test_module_vmvx",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=vmvx",
     ],
 )
@@ -99,7 +98,6 @@ iree_bytecode_module(
     src = "simple_embedding_test.mlir",
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_x86_64",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=x86_64-pc-linux-elf",
         "--iree-llvm-debug-symbols=false",
@@ -113,7 +111,6 @@ iree_bytecode_module(
     src = "simple_embedding_test.mlir",
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_riscv_32",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=riscv32-pc-linux-elf",
         "--iree-llvm-target-cpu=generic-rv32",
@@ -130,7 +127,6 @@ iree_bytecode_module(
     src = "simple_embedding_test.mlir",
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_riscv_64",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=riscv64-pc-linux-elf",
         "--iree-llvm-target-cpu=generic-rv64",
@@ -147,7 +143,6 @@ iree_bytecode_module(
     src = "simple_embedding_test.mlir",
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_32",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=armv7a-pc-linux-elf",
         "--iree-llvm-target-float-abi=hard",
@@ -162,7 +157,6 @@ iree_bytecode_module(
     src = "simple_embedding_test.mlir",
     c_identifier = "iree_samples_simple_embedding_test_module_dylib_arm_64",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=dylib-llvm-aot",
         "--iree-llvm-target-triple=aarch64-pc-linux-elf",
         "--iree-llvm-debug-symbols=false",
@@ -249,7 +243,6 @@ iree_bytecode_module(
     src = "simple_embedding_test.mlir",
     c_identifier = "iree_samples_simple_embedding_test_module_vulkan",
     flags = [
-        "--iree-input-type=mhlo",
         "--iree-hal-target-backends=vulkan-spirv",
         "--iree-llvm-debug-symbols=false",
     ],
@@ -299,7 +292,6 @@ endif()
 #     src = "simple_embedding_test.mlir",
 #     c_identifier = "iree_samples_simple_embedding_test_module_cuda",
 #     flags = [
-#         "--iree-input-type=mhlo",
 #         "--iree-hal-target-backends=cuda",
 #         "--iree-llvm-debug-symbols=false",
 #     ],

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -39,7 +39,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_samples_simple_embedding_test_module_vmvx"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=vmvx"
   PUBLIC
 )
@@ -86,7 +85,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_samples_simple_embedding_test_module_dylib_x86_64"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=x86_64-pc-linux-elf"
     "--iree-llvm-debug-symbols=false"
@@ -103,7 +101,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_samples_simple_embedding_test_module_dylib_riscv_32"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=riscv32-pc-linux-elf"
     "--iree-llvm-target-cpu=generic-rv32"
@@ -123,7 +120,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_samples_simple_embedding_test_module_dylib_riscv_64"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=riscv64-pc-linux-elf"
     "--iree-llvm-target-cpu=generic-rv64"
@@ -143,7 +139,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_samples_simple_embedding_test_module_dylib_arm_32"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=armv7a-pc-linux-elf"
     "--iree-llvm-target-float-abi=hard"
@@ -161,7 +156,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_samples_simple_embedding_test_module_dylib_arm_64"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=dylib-llvm-aot"
     "--iree-llvm-target-triple=aarch64-pc-linux-elf"
     "--iree-llvm-debug-symbols=false"
@@ -238,7 +232,6 @@ iree_bytecode_module(
   C_IDENTIFIER
     "iree_samples_simple_embedding_test_module_vulkan"
   FLAGS
-    "--iree-input-type=mhlo"
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-llvm-debug-symbols=false"
   PUBLIC

--- a/tools/test/benchmark_flags.txt
+++ b/tools/test/benchmark_flags.txt
@@ -2,18 +2,18 @@
 // HELP: --module_file
 // HELP: --benchmark_list_tests
 
-// RUN: ( iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-benchmark-module --benchmark_list_tests --device=local-task --benchmark_list_tests ) | FileCheck --check-prefix=LIST-BENCHMARKS %s
+// RUN: ( iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --benchmark_list_tests --device=local-task --benchmark_list_tests ) | FileCheck --check-prefix=LIST-BENCHMARKS %s
 module {
   // LIST-BENCHMARKS: BM_foo1
   func.func @foo1() -> tensor<4xf32> {
     %input = util.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf32>
-    %result = "mhlo.exponential"(%input) : (tensor<4xf32>) -> tensor<4xf32>
+    %result = math.exp %input : tensor<4xf32>
     return %result : tensor<4xf32>
   }
   // LIST-BENCHMARKS: BM_foo2
   func.func @foo2() -> tensor<4xf32> {
     %input = util.unfoldable_constant dense<[0.0, 1.0, 2.0, 4.0]> : tensor<4xf32>
-    %result = "mhlo.abs"(%input) : (tensor<4xf32>) -> tensor<4xf32>
+    %result = math.abs %input : tensor<4xf32>
     return %result : tensor<4xf32>
   }
 }

--- a/tools/test/multiple_exported_functions.mlir
+++ b/tools/test/multiple_exported_functions.mlir
@@ -1,5 +1,5 @@
-// RUN: iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vmvx %s | iree-benchmark-module --device=local-task | FileCheck %s
-// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv %s | iree-benchmark-module --device=vulkan | FileCheck %s)
+// RUN: iree-compile --iree-hal-target-backends=vmvx %s | iree-benchmark-module --device=local-task | FileCheck %s
+// RUN: [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-compile --iree-hal-target-backends=vulkan-spirv %s | iree-benchmark-module --device=vulkan | FileCheck %s)
 
 module {
   func.func @foo1() -> tensor<4xf32> {


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/9667 - nearly done!

I'm now able to build and test `all` using `-DIREE_INPUT_DIALECTS_MHLO=OFF -DIREE_INPUT_DIALECTS_TORCH=OFF -DIREE_INPUT_DIALECTS_TOSA=OFF` from https://github.com/iree-org/iree/pull/9474. I haven't tried `iree-test-deps` yet, but it will take more work to get passing in that configuration (if we care).

One drawback of this is that the `--iree-input-type=` flag might be harder to discover for users/developers who browse through the repository. We should improve error messages and ergonomics anyway (see https://github.com/iree-org/iree/discussions/9759 for a recent discussion about that).