### PR TITLE
[LLVMGPU] Improve reduction flow and support handled fused broadcast

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -184,11 +184,13 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
 }
 
 void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
-  tileAndBufferize(pm);
-
-  // Don't tile to warp or thread and use vector distribution instead.
-
+  pm.addPass(createTileAndDistributeToWorkgroupsPass());
   auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createConvertToDestinationPassingStylePass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
@@ -202,6 +204,12 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
       createLoopInvariantCodeMotionPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+
+  addBufferizePasses(nestedModulePM);
+
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -191,9 +191,6 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
-  nestedModulePM.addPass(createCanonicalizerPass());
-  nestedModulePM.addPass(createCSEPass());
-
   nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/VectorReductionToGPU.cpp
@@ -85,7 +85,7 @@ static Value groupReduction(Location loc, OpBuilder &builder, Value input,
 
 /// Hoist uniform operations as well as special hal operations that have side
 /// effect but are safe to move out of the warp single lane region.
-void static moveScalarAndBindingUniformCode(
+static void moveScalarAndBindingUniformCode(
     vector::WarpExecuteOnLane0Op warpOp) {
   /// Hoist ops without side effect as well as special binding ops.
   auto canBeHoisted = [](Operation *op,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/VectorReductionToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/VectorReductionToGPU.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Vector/Transforms/VectorDistribution.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
+#include "mlir/Transforms/SideEffectUtils.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -82,23 +83,40 @@ static Value groupReduction(Location loc, OpBuilder &builder, Value input,
   return laneVal;
 }
 
-/// Special case to hoist hal operations that have side effect but are safe to
-/// move out of the warp single lane region.
-static void hoistHalBindingOps(vector::WarpExecuteOnLane0Op warpOp) {
+/// Hoist uniform operations as well as special hal operations that have side
+/// effect but are safe to move out of the warp single lane region.
+void static moveScalarAndBindingUniformCode(
+    vector::WarpExecuteOnLane0Op warpOp) {
+  /// Hoist ops without side effect as well as special binding ops.
+  auto canBeHoisted = [](Operation *op,
+                         function_ref<bool(Value)> definedOutside) {
+    return llvm::all_of(op->getOperands(), definedOutside) &&
+           (isSideEffectFree(op) ||
+            isa<IREE::HAL::InterfaceBindingSubspanOp,
+                IREE::HAL::InterfaceConstantLoadOp, memref::AssumeAlignmentOp>(
+                op)) &&
+           op->getNumRegions() == 0;
+  };
   Block *body = warpOp.getBody();
 
   // Keep track of the ops we want to hoist.
   llvm::SmallSetVector<Operation *, 8> opsToMove;
 
+  // Helper to check if a value is or will be defined outside of the region.
+  auto isDefinedOutsideOfBody = [&](Value value) {
+    auto *definingOp = value.getDefiningOp();
+    return (definingOp && opsToMove.count(definingOp)) ||
+           warpOp.isDefinedOutsideOfRegion(value);
+  };
+
   // Do not use walk here, as we do not want to go into nested regions and hoist
   // operations from there.
   for (auto &op : body->without_terminator()) {
-    if (!isa<IREE::HAL::InterfaceBindingSubspanOp>(&op)) continue;
-    if (llvm::any_of(op.getOperands(), [&](Value operand) {
-          return !warpOp.isDefinedOutsideOfRegion(operand);
-        }))
-      continue;
-    opsToMove.insert(&op);
+    bool hasVectorResult = llvm::any_of(op.getResults(), [](Value result) {
+      return result.getType().isa<VectorType>();
+    });
+    if (!hasVectorResult && canBeHoisted(&op, isDefinedOutsideOfBody))
+      opsToMove.insert(&op);
   }
 
   // Move all the ops marked as uniform outside of the region.
@@ -166,9 +184,7 @@ struct LLVMGPUReduceToGPUPass
     builder.create<vector::YieldOp>(loc);
 
     // 3. Hoist the scalar code outside of the warp region.
-    vector::moveScalarUniformCode(warpOp);
-    hoistHalBindingOps(warpOp);
-    vector::moveScalarUniformCode(warpOp);
+    moveScalarAndBindingUniformCode(warpOp);
 
     // 4. Distribute transfer write operations.
     {
@@ -196,7 +212,7 @@ struct LLVMGPUReduceToGPUPass
       (void)applyPatternsAndFoldGreedily(getOperation(), std::move(patterns));
     }
 
-    // 4. Lower the remaining WarpExecuteOnLane0 ops.
+    // 5. Lower the remaining WarpExecuteOnLane0 ops.
     {
       RewritePatternSet patterns(ctx);
       vector::WarpExecuteOnLane0LoweringOptions options;


### PR DESCRIPTION
Move buferization to after vectorization for group reduction pipeline.
This will allow better register level fusion. Also improve distribution
interaction with hal operations and add a test to make sure this can
handle fusion with broadcast.