### PR TITLE
Add mlir loading to the iree-import-tflite tool

### DIFF
--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
@@ -66,6 +66,7 @@ class ImportOptions(CompilerOptions):
   save_temp_tfl_input: Optional[str] = None
   save_temp_iree_input: Optional[str] = None
   input_type: Optional[str] = "tosa"
+  import_from_mlir: bool = False
 
 
 def build_import_command_line(input_path: str, tfs: TempFileSaver,
@@ -90,6 +91,9 @@ def build_import_command_line(input_path: str, tfs: TempFileSaver,
     output_file = tfs.alloc_optional("tflite-output.mlir",
                                      export_as=options.output_file)
     cl.append(f"-o={options.output_file}")
+
+  if options.import_from_mlir:
+    cl.append('-import-from-mlir')
 
   # Input arrays.
   if options.input_arrays:
@@ -157,30 +161,33 @@ def compile_file(fb_path: str, **kwargs):
     return result
 
 
-def compile_str(fb_content: bytes, **kwargs):
+def compile_str(input_bytes: bytes, **kwargs):
   """Compiles in-memory TFLite FlatBuffer to an IREE binary.
 
   Args:
-    fb_content: Flatbuffer content as bytes.
+    input_bytes: Flatbuffer content as bytes or IR string.
     **kwargs: Keyword args corresponding to ImportOptions or CompilerOptions.
   Returns:
     A bytes-like object with the compiled output or None if output_file=
     was specified.
   """
+  input_bytes = input_bytes.encode("utf-8") if isinstance(input_bytes, str) else input_bytes
   with TempFileSaver.implicit() as tfs:
     options = ImportOptions(**kwargs)
     import_cl = build_import_command_line("-", tfs, options)
     if options.import_only:
       # One stage tool pipeline.
-      result = invoke_immediate(import_cl, immediate_input=fb_content)
+
+      result = invoke_immediate(import_cl, immediate_input=input_bytes)
       if options.output_file:
         return None
+      result = result.decode("utf-8")
       return result
 
     # Full compilation pipeline.
     compile_cl = build_compile_command_line("-", tfs, options)
     result = invoke_pipeline([import_cl, compile_cl],
-                             immediate_input=fb_content)
+                             immediate_input=input_bytes)
     if options.output_file:
       return None
-    return result
+    return result.decode("utf-8")

--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
@@ -171,7 +171,8 @@ def compile_str(input_bytes: bytes, **kwargs):
     A bytes-like object with the compiled output or None if output_file=
     was specified.
   """
-  input_bytes = input_bytes.encode("utf-8") if isinstance(input_bytes, str) else input_bytes
+  input_bytes = input_bytes.encode("utf-8") if isinstance(input_bytes,
+                                                          str) else input_bytes
   with TempFileSaver.implicit() as tfs:
     options = ImportOptions(**kwargs)
     import_cl = build_import_command_line("-", tfs, options)
@@ -190,4 +191,4 @@ def compile_str(input_bytes: bytes, **kwargs):
                              immediate_input=input_bytes)
     if options.output_file:
       return None
-    return result.decode("utf-8")
+    return result.decode("utf-8") if result is not None else result

--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/tflite.py
@@ -66,7 +66,6 @@ class ImportOptions(CompilerOptions):
   save_temp_tfl_input: Optional[str] = None
   save_temp_iree_input: Optional[str] = None
   input_type: Optional[str] = "tosa"
-  import_from_mlir: bool = False
 
 
 def build_import_command_line(input_path: str, tfs: TempFileSaver,
@@ -91,9 +90,6 @@ def build_import_command_line(input_path: str, tfs: TempFileSaver,
     output_file = tfs.alloc_optional("tflite-output.mlir",
                                      export_as=options.output_file)
     cl.append(f"-o={options.output_file}")
-
-  if options.import_from_mlir:
-    cl.append('-import-from-mlir')
 
   # Input arrays.
   if options.input_arrays:

--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -96,6 +96,7 @@ cc_binary(
         "//iree_tf_compiler/TFL",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TosaDialect",

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -17,6 +17,7 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OperationSupport.h"
+#include "mlir/Parser/Parser.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "tensorflow/compiler/mlir/lite/flatbuffer_import.h"
@@ -31,6 +32,9 @@ int main(int argc, char **argv) {
 
   static cl::opt<std::string> inputPath(
       cl::Positional, cl::desc("<TFLite FlatBuffer>"), cl::Required);
+  static cl::opt<bool> loadMlirFile(
+    "import-from-mlir",
+    cl::desc("Import should come from an mlir file"));
   static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
                                              cl::value_desc("filename"),
                                              cl::init("-"));
@@ -91,15 +95,24 @@ int main(int argc, char **argv) {
                                         outputArrayFlag.end());
   auto loc = mlir::FileLineColLoc::get(&context,
                                        inputFile->getBufferIdentifier(), 0, 0);
-  OwningOpRef<mlir::ModuleOp> module = tflite::FlatBufferToMlir(
-      absl::string_view(inputFile->getBufferStart(),
-                        inputFile->getBufferSize()),
-      &context, loc,
-      /*use_external_constant=*/false, inputArrays, outputArrays);
-  if (!module) {
-    // Error should have emitted.
-    llvm::errs() << "Unable to import TFLite FlatBuffer to MLIR Module\n";
-    return 2;
+  OwningOpRef<mlir::ModuleOp> module;
+  if (loadMlirFile) {
+    module = ModuleOp::create(mlir::UnknownLoc::get(&context));
+    std::string errorMessage;
+    sourceMgr.AddNewSourceBuffer(std::move(inputFile), SMLoc());
+    module = parseSourceFile<ModuleOp>(sourceMgr, &context);
+    if (!module) return 2;
+  } else {
+    module = tflite::FlatBufferToMlir(
+        absl::string_view(inputFile->getBufferStart(),
+                          inputFile->getBufferSize()),
+        &context, loc,
+        /*use_external_constant=*/false, inputArrays, outputArrays);
+    if (!module) {
+      // Error should have emitted.
+      llvm::errs() << "Unable to import TFLite FlatBuffer to MLIR Module\n";
+      return 2;
+    }
   }
 
   // Save.

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -93,12 +93,12 @@ int main(int argc, char **argv) {
   auto loc = mlir::FileLineColLoc::get(&context,
                                        inputFile->getBufferIdentifier(), 0, 0);
   OwningOpRef<mlir::ModuleOp> module;
-  auto contents = absl::string_view(
-    inputFile->getBufferStart(), inputFile->getBufferSize());
+  auto contents = absl::string_view(inputFile->getBufferStart(),
+                                    inputFile->getBufferSize());
   if ((contents.substr(4, 4) == "TFL3")) {
-    module = tflite::FlatBufferToMlir(
-        contents, &context, loc,
-        /*use_external_constant=*/false, inputArrays, outputArrays);
+    module = tflite::FlatBufferToMlir(contents, &context, loc,
+                                      /*use_external_constant=*/false,
+                                      inputArrays, outputArrays);
   } else {
     module = ModuleOp::create(mlir::UnknownLoc::get(&context));
     sourceMgr.AddNewSourceBuffer(MemoryBuffer::getMemBuffer(contents), SMLoc());

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -33,8 +33,7 @@ int main(int argc, char **argv) {
   static cl::opt<std::string> inputPath(
       cl::Positional, cl::desc("<TFLite FlatBuffer>"), cl::Required);
   static cl::opt<bool> loadMlirFile(
-    "import-from-mlir",
-    cl::desc("Import should come from an mlir file"));
+      "import-from-mlir", cl::desc("Import should come from an mlir file"));
   static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
                                              cl::value_desc("filename"),
                                              cl::init("-"));


### PR DESCRIPTION
It can be useful to load IR for debugging purposes. Include loading from
IR to allow for this easier debugging.