### PR TITLE
Refactor matmul workgroup size computation and improve RISC-V default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -650,9 +650,10 @@ static void getDefaultMatmulWorkgroupSizes(linalg::LinalgOp op,
 }
 
 /// Main utility to compute the workgroup (vectorization/unrolling) tile sizes.
-static SmallVector<int64_t> getMatmulWorkgroupSizes(
-    func::FuncOp entryPointFn, linalg::LinalgOp op,
-    int64_t vectorSize, bool isQuantized) {
+static SmallVector<int64_t> getMatmulWorkgroupSizes(func::FuncOp entryPointFn,
+                                                    linalg::LinalgOp op,
+                                                    int64_t vectorSize,
+                                                    bool isQuantized) {
   SmallVector<int64_t> matmulTileSizes;
   auto variantOp = getExecutableVariantOp(entryPointFn);
   assert(succeeded(variantOp) && "ExecutableVariantOp not found");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
@@ -39,7 +39,7 @@ hal.executable private @matmul_riscv  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 64, 0], [8, 32, 0], [0, 0, 16]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 64, 0], [8, 32, 0], [0, 0, 1]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 //      CHECK: hal.executable.export public @matmul_riscv
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
This PR moves hard-coded workgroup tile sizes to an independent function
and pave the way for introducing more sophisticated tile size computation.
As part of this refactoring, we change the default tile sizes for RISC-V
to avoid vectorizing the dimension k, which resulted in very inefficient
code (see comments).