### PR TITLE
[EmitC] Fix conversion for zero argument variadic calls

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2550,8 +2550,6 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
               .getResult();
     }
 
-    // TODO(simon-camp): Insert numSpansOperand right before the varidic
-    // arguments start.
     for (auto pair : llvm::enumerate(operands)) {
       Value operand = pair.value();
       size_t index = pair.index();
@@ -2598,6 +2596,12 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
       } else {
         updatedOperands.push_back(operand);
       }
+    }
+
+    // If the variadic part of the arguments is repeated zero times, we need to
+    // add the span count argument to the end.
+    if (numSpansOperand && !llvm::count(updatedOperands, numSpansOperand)) {
+      updatedOperands.push_back(numSpansOperand);
     }
 
     // Create a variable for every result and a pointer to it as output


### PR DESCRIPTION
The generated import shims contain an argument for the number of variadic arguments. This argument was missing in the generated call in the case the variadic part had zero arguments.