### PR TITLE
Fix submodule checkout for buildkite pipeline

### DIFF
--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -12,6 +12,8 @@ steps:
   - label: ":hammer_and_wrench: Build host tools"
     key: "build-host-tools"
     commands: |
+      git submodule sync
+      git submodule update --init --jobs 8 --depth 1
       docker run --user=$(id -u):$(id -g) \
         --volume="$${HOME?}:$${HOME?}" \
         --volume="/etc/passwd:/etc/passwd:ro" \


### PR DESCRIPTION
#9845 removed the submodule update from `build_host_tools.sh` in favor of Github runner. Buildkite disabled the submodule checkout, so we need to manually do it in the Buildkite pipelines.