### PR TITLE
Add iree-import-tf as requirements in the doc

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -85,7 +85,8 @@ These steps help reproduce the failures in TFLite models.
 
 ### Running benchmark suites locally
 
-First you need to have [`iree-import-tflite`](https://iree-org.github.io/iree/getting-started/tflite/)
+First you need to have [`iree-import-tflite`](https://iree-org.github.io/iree/getting-started/tflite/),
+[`iree-import-tf`](https://iree-org.github.io/iree/getting-started/tensorflow/),
 and `requests` in your python environment. Then you can build the target
 `iree-benchmark-suites` to generate the required files:
 


### PR DESCRIPTION
With the new MiniLM TF models, the `iree-import-tf` is one of the requirements to build benchmark suite.