### PR TITLE
Change default transpose lowering from eltwise to shuffle

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -57,6 +57,17 @@ static llvm::cl::opt<bool> clEnableMicrokernels(
 extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectFileName;
 
 //===---------------------------------------------------------------------===//
+// Default Linalg code generation options for CPU backend
+//===---------------------------------------------------------------------===//
+
+struct LinalgCPUVectorLoweringPassOptions : LinalgVectorLoweringPassOptions {
+  LinalgCPUVectorLoweringPassOptions() : LinalgVectorLoweringPassOptions() {
+    lowerVectorTransposeTo = "shuffle";
+  }
+};
+
+
+//===---------------------------------------------------------------------===//
 // Default allocation functions for CPU backend
 //===---------------------------------------------------------------------===//
 
@@ -239,7 +250,7 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
   }
@@ -331,7 +342,7 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
   }
@@ -392,7 +403,7 @@ void addMultiTilingExpertPassPipeline(OpPassManager &passManager,
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.lowerVectorTransposeToAVX2 = lowerToAVX2;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
@@ -455,7 +466,7 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "shuffle";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -66,7 +66,6 @@ struct LinalgCPUVectorLoweringPassOptions : LinalgVectorLoweringPassOptions {
   }
 };
 
-
 //===---------------------------------------------------------------------===//
 // Default allocation functions for CPU backend
 //===---------------------------------------------------------------------===//


### PR DESCRIPTION
This *should* improve the performance a bit on all the CPUs since
we go from generating an extract/insert pair of operations for each
element to generating complex shuffle that *should* be lowered to a
smarter sequence of instructions by the backend.

This PR is part of a set of changes aimed at improving reductions and
transpositions on RISC-V.