### PR TITLE
Change default multi-reduction lowering from innerparallel to innerreduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -57,6 +57,17 @@ static llvm::cl::opt<bool> clEnableMicrokernels(
 extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectFileName;
 
 //===---------------------------------------------------------------------===//
+// Default Linalg code generation options for CPU backend
+//===---------------------------------------------------------------------===//
+
+struct LinalgCPUVectorLoweringPassOptions : LinalgVectorLoweringPassOptions {
+  LinalgCPUVectorLoweringPassOptions() : LinalgVectorLoweringPassOptions() {
+    lowerVectorTransposeTo = "shuffle";
+  }
+};
+
+
+//===---------------------------------------------------------------------===//
 // Default allocation functions for CPU backend
 //===---------------------------------------------------------------------===//
 
@@ -239,7 +250,7 @@ void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager) {
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
   }
@@ -331,7 +342,7 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
   }
@@ -392,7 +403,7 @@ void addMultiTilingExpertPassPipeline(OpPassManager &passManager,
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.lowerVectorTransposeToAVX2 = lowerToAVX2;
     options.splitVectorTransfersTo = "linalg-copy";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
@@ -455,7 +466,7 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
   // Add the vector lowering expert.
   {
     OpPassManager &nestedFuncPassManager = nestedModulePM.nest<func::FuncOp>();
-    LinalgVectorLoweringPassOptions options;
+    LinalgCPUVectorLoweringPassOptions options;
     options.splitVectorTransfersTo = "shuffle";
     addLowerToVectorTransforms(nestedFuncPassManager, options);
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -63,6 +63,7 @@ extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectFileName;
 struct LinalgCPUVectorLoweringPassOptions : LinalgVectorLoweringPassOptions {
   LinalgCPUVectorLoweringPassOptions() : LinalgVectorLoweringPassOptions() {
     lowerVectorTransposeTo = "shuffle";
+    lowerVectorMultiReductionTo = "innerreduction";
   }
 };
 


### PR DESCRIPTION
The 'innerparallel' multi-reduction lowering transposes the innermost
reduction dimension with an outer parallel dimension so that the innestmost
dimension becomes parallel and each vector lane can compute an independent
reduction. The 'innerreduction' multi-reduction lowering keeps the
reduction dimension in its innermost position and generates vector
horizontal reductions as part of the computation. The horizontal
reductions are not generated very efficiently right now but transposing
a 2D vector *should* always be less efficient than computing a
horizontal reduction. If that is not the case, we should investigate
why.
    
This PR changes the reduction policy from 'innerparallel' to
'innerreduction'.
    
This PR is part of a set of changes aimed at improving reductions and
transpositions on RISC-V.