### PR TITLE
Implement TiedOpInterface for InsertSliceOp, LinalgOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -455,6 +455,19 @@ LogicalResult DispatchTensorLoadOp::reifyResultShapes(
   return success();
 }
 
+Value DispatchTensorLoadOp::getTiedResult(unsigned resultIndex) {
+  return IREE::Util::TiedOpInterface::findTiedBaseValue(getSource());
+}
+
+::llvm::Optional<unsigned> DispatchTensorLoadOp::getTiedResultOperandIndex(
+    unsigned resultIndex) {
+  return {0};  // source
+}
+
+SmallVector<int64_t, 4> DispatchTensorLoadOp::getTiedResultOperandIndices() {
+  return {0};  // source
+}
+
 //===----------------------------------------------------------------------===//
 // flow.dispatch.tensor.store
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -290,6 +290,11 @@ def FLOW_DispatchTensorLoadOp : FLOW_PureOp<"dispatch.tensor.load", [
   AttrSizedOperandSegments,
   OffsetSizeAndStrideOpInterface,
   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+  DeclareOpInterfaceMethods<Util_TiedOpInterface, [
+      "getTiedResult",
+      "getTiedResultOperandIndex",
+      "getTiedResultOperandIndices",
+  ]>,
   Util_ShapeAwareOp,
 ]> {
   let summary = [{loads a tensor from a dispatch input placeholder}];

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -362,7 +362,7 @@ func.func @keep_original_producer_uses(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>,
 //  CHECK-DAG: %[[D4:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG: %[[D5:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //      CHECK: %[[origCC:.+]]:2 = flow.dispatch.workgroups[%[[D0]], %[[D1]], %[[C1]]]
-// CHECK-SAME:     (%[[ARG2]], %[[D2]], %[[D3]], %[[ARG0]], %[[D0]], %[[D4]], %[[ARG1]], %[[D5]], %[[D1]])
+// CHECK-SAME:     (%[[ARG2]], %[[D2]], %[[D3]], %[[ARG0]], %[[D0]], %[[D4]], %[[ARG1]], %[[D5]], %[[D1]]) : ({{.*}}) -> (%[[ARG2]]{{{.*}}}, tensor<?x?xf32>{{{.*}}})
 // CHECK-NEXT:   %[[ARG2_CAPTURE:.+]]: !flow.dispatch.tensor<readwrite:?x?xf32>
 // CHECK-SAME:   %[[RESULT_CAPTURE:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:?x?xf32>
 //      CHECK:   %[[LOAD:.+]] = flow.dispatch.tensor.load %[[ARG2_CAPTURE]]
@@ -370,8 +370,8 @@ func.func @keep_original_producer_uses(%A: tensor<?x?xf32>, %B: tensor<?x?xf32>,
 // CHECK-SAME:     outs(%[[LOAD]] : tensor<?x?xf32>)
 //      CHECK:   %[[GEMM:.+]] = linalg.matmul
 // CHECK-SAME:     outs(%[[STOREVAL]] : tensor<?x?xf32>)
-//  CHECK-DAG:   flow.dispatch.tensor.store %[[STOREVAL]], %[[ARG2_CAPTURE]]
-//  CHECK-DAG:   flow.dispatch.tensor.store %[[GEMM]], %[[RESULT_CAPTURE]]
+//  CHECK-DAG:   flow.dispatch.tensor.store %[[STOREVAL]], %[[RESULT_CAPTURE]]
+//  CHECK-DAG:   flow.dispatch.tensor.store %[[GEMM]], %[[ARG2_CAPTURE]]
 //      CHECK: return %[[origCC]]#0, %[[origCC]]#1
 
 // -----

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Attributes/Range.cpp
@@ -191,8 +191,11 @@ ChangeStatus FloatRangeValueElement::updateValue(Value value,
           auto inner = solver.getElementFor<FloatRangeValueElement>(
               *this, Position::forValue(loopBodyValue),
               DFX::Resolution::REQUIRED);
-
           newState ^= inner;
+          // Stop traversal if tied OpOperand is not used in the op body.
+          if (!linalgOp.payloadUsesValueFromOperand(
+                  linalgOp.getOutputOperand(result.getResultNumber())))
+            return WalkResult::skip();
           return WalkResult::advance();
         } else if (auto minfOp = dyn_cast<arith::MinFOp>(definingOp)) {
           auto lhs = solver.getElementFor<FloatRangeValueElement>(

--- a/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Analysis/Explorer.cpp
@@ -720,7 +720,9 @@ TraversalResult Explorer::walkDefiningOps(Value value, ResultWalkFn fn) {
     auto resultValue = work.cast<OpResult>();
     LLVM_DEBUG(llvm::dbgs() << "  == emitting op "
                             << definingOp->getName().getStringRef() << "\n");
-    if (fn(resultValue).wasInterrupted()) break;
+    auto fnResult = fn(resultValue);
+    if (fnResult.wasInterrupted()) break;
+    if (fnResult.wasSkipped()) continue;
 
     // If the op is tied we may need to walk up to the operand the result is
     // tied to.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/BUILD
@@ -42,6 +42,24 @@ td_library(
 )
 
 iree_compiler_cc_library(
+    name = "ExternalModels",
+    srcs = [
+        "UtilExternalModels.cpp",
+    ],
+    hdrs = [
+        "UtilExternalModels.h",
+    ],
+    deps = [
+        ":IR",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
+        "@llvm-project//mlir:ArithmeticDialect",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LinalgStructuredOpsIncGen",
+        "@llvm-project//mlir:TensorDialect",
+    ],
+)
+
+iree_compiler_cc_library(
     name = "IR",
     srcs = [
         "ClosureOpUtils.cpp",

--- a/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/CMakeLists.txt
@@ -12,6 +12,23 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
+    ExternalModels
+  HDRS
+    "UtilExternalModels.h"
+  SRCS
+    "UtilExternalModels.cpp"
+  DEPS
+    ::IR
+    IREELinalgExtDialect
+    MLIRArithmeticDialect
+    MLIRLinalgDialect
+    MLIRLinalgStructuredOpsIncGenLib
+    MLIRTensorDialect
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     IR
   HDRS
     "ClosureOpUtils.h"

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilDialect.h
@@ -1,4 +1,4 @@
-// Copyright 2019 The IREE Authors
+// Copyright 2022 The IREE Authors
 //
 // Licensed under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -35,8 +35,6 @@ class UtilDialect : public Dialect {
   void registerAttributes();
   void registerTypes();
 };
-
-void registerUtilExternalModels(DialectRegistry& registry);
 
 }  // namespace Util
 }  // namespace IREE

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
@@ -1,0 +1,150 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Util/IR/UtilExternalModels.h"
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Util {
+
+namespace {
+
+// Since all details of the interface are provided via default implementations,
+// we can just have one templated external model to apply per op, vs one
+// explicit model per op.
+struct GenericNumericCastExternalModel {
+  template <typename OpTy>
+  struct ExternalModel
+      : public NumericCastOpInterface::ExternalModel<ExternalModel<OpTy>,
+                                                     OpTy> {};
+
+  template <typename OpTy>
+  static void add(MLIRContext *ctx) {
+    OpTy::template attachInterface<ExternalModel<OpTy>>(*ctx);
+  }
+
+  template <typename OpTy1, typename OpTy2, typename... More>
+  static void add(MLIRContext *ctx) {
+    add<OpTy1>(ctx);
+    add<OpTy2, More...>(ctx);
+  }
+};
+
+struct InsertSliceOpTiedOpInterface
+    : public TiedOpInterface::ExternalModel<InsertSliceOpTiedOpInterface,
+                                            tensor::InsertSliceOp> {
+  Value getTiedResult(Operation *op, unsigned resultIndex) const {
+    auto insertSliceOp = cast<tensor::InsertSliceOp>(op);
+    return IREE::Util::TiedOpInterface::findTiedBaseValue(
+        insertSliceOp.getDest());
+  }
+
+  ::llvm::Optional<unsigned> getTiedResultOperandIndex(
+      Operation *op, unsigned resultIndex) const {
+    return {1};  // dest
+  }
+
+  SmallVector<int64_t, 4> getTiedResultOperandIndices(Operation *op) const {
+    return {1};  // dest
+  }
+};
+
+template <typename OpTy>
+struct LinalgOpTiedOpInterface
+    : public TiedOpInterface::ExternalModel<LinalgOpTiedOpInterface<OpTy>,
+                                            OpTy> {
+  Value getTiedResult(Operation *op, unsigned resultIndex) const {
+    auto linalgOp = cast<OpTy>(op);
+    return IREE::Util::TiedOpInterface::findTiedBaseValue(
+        linalgOp.getOutputTensorOperands()[resultIndex]->get());
+  }
+
+  ::llvm::Optional<unsigned> getTiedResultOperandIndex(
+      Operation *op, unsigned resultIndex) const {
+    auto linalgOp = cast<OpTy>(op);
+    return {
+        linalgOp.getOutputTensorOperands()[resultIndex]->getOperandNumber()};
+  }
+
+  SmallVector<int64_t, 4> getTiedResultOperandIndices(Operation *op) const {
+    SmallVector<int64_t, 4> result;
+    for (unsigned i = 0; i < op->getNumResults(); ++i)
+      result.push_back(*getTiedResultOperandIndex(op, i));
+    return result;
+  }
+};
+
+/// Helper structure that iterates over all LinalgOps in `OpTys` and registers
+/// the `TiedOpInterface` with each of them.
+template <typename... Ops>
+struct LinalgOpTiedOpInterfaceHelper {
+  static void registerOpInterface(MLIRContext *ctx) {
+    (void)std::initializer_list<int>{
+        0, (Ops::template attachInterface<LinalgOpTiedOpInterface<Ops>>(*ctx),
+            0)...};
+  }
+};
+
+}  // namespace
+
+void registerUtilExternalModels(DialectRegistry &registry) {
+  // Must ensure that any dependent dialects are registered.
+  registry.insert<arith::ArithmeticDialect, linalg::LinalgDialect,
+                  tensor::TensorDialect>();
+
+  registry.addExtension(+[](MLIRContext *ctx,
+                            arith::ArithmeticDialect *dialect) {
+    GenericNumericCastExternalModel::add<
+        arith::BitcastOp, arith::ExtFOp, arith::ExtUIOp, arith::ExtSIOp,
+        arith::FPToSIOp, arith::FPToUIOp, arith::IndexCastOp, arith::TruncFOp,
+        arith::TruncIOp, arith::SIToFPOp, arith::UIToFPOp>(ctx);
+  });
+
+  registry.addExtension(+[](MLIRContext *ctx, tensor::TensorDialect *dialect) {
+    tensor::InsertSliceOp::attachInterface<InsertSliceOpTiedOpInterface>(*ctx);
+  });
+
+  registry.addExtension(+[](MLIRContext *ctx, linalg::LinalgDialect *dialect) {
+    // Register all Linalg structured ops. `LinalgOp` is an interface and it is
+    // not possible to attach an external interface to an existing interface.
+    // Therefore, attach the `TiedOpInterface` to all ops one-by-one.
+    LinalgOpTiedOpInterfaceHelper<
+#define GET_OP_LIST
+#include "mlir/Dialect/Linalg/IR/LinalgStructuredOps.cpp.inc"
+        >::registerOpInterface(ctx);
+  });
+
+  // TODO(matthias-springer): Use a helper instead of listing all ops. This is
+  // tricky because LinalgExtOps.td includes YieldOp.
+  registry.addExtension(
+      +[](MLIRContext *ctx, LinalgExt::IREELinalgExtDialect *dialect) {
+        LinalgExt::ScatterOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::ScatterOp>>(*ctx);
+        LinalgExt::SortOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::SortOp>>(*ctx);
+        LinalgExt::FftOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::FftOp>>(*ctx);
+        LinalgExt::ScanOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::ScanOp>>(*ctx);
+        LinalgExt::ReverseOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::ReverseOp>>(*ctx);
+        LinalgExt::TopkOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::TopkOp>>(*ctx);
+      });
+}
+
+}  // namespace Util
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.h
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.h
@@ -1,0 +1,24 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_UTIL_IR_UTILEXTERNALMODELS_H_
+#define IREE_COMPILER_DIALECT_UTIL_IR_UTILEXTERNALMODELS_H_
+
+namespace mlir {
+class DialectRegistry;
+
+namespace iree_compiler {
+namespace IREE {
+namespace Util {
+
+void registerUtilExternalModels(DialectRegistry& registry);
+
+}  // namespace Util
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_UTIL_IR_UTILEXTERNALMODELS_H_

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilInterfaces.td
@@ -317,7 +317,8 @@ def Util_TiedOpInterface : OpInterface<"TiedOpInterface"> {
       /*methodBody=*/[{}],
       /*defaultImplementation=*/[{
         auto resultIndex = result.cast<mlir::OpResult>().getResultNumber();
-        auto operandIndex = $_op.getTiedResultOperandIndex(resultIndex);
+        auto operandIndex = cast<TiedOpInterface>($_op.getOperation())
+            .getTiedResultOperandIndex(resultIndex);
         return operandIndex.hasValue() ?
             $_op.getOperand(operandIndex.getValue()) :
             nullptr;

--- a/compiler/src/iree/compiler/Tools/BUILD
+++ b/compiler/src/iree/compiler/Tools/BUILD
@@ -29,6 +29,7 @@ cc_library(
         "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//compiler/src/iree/compiler/Dialect/Stream/Transforms",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
+        "//compiler/src/iree/compiler/Dialect/Util/IR:ExternalModels",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
         "//compiler/src/iree/compiler/Dialect/VM/Analysis",
         "//compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC",

--- a/compiler/src/iree/compiler/Tools/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Tools/CMakeLists.txt
@@ -66,6 +66,7 @@ iree_cc_library(
     iree::compiler::Dialect::Stream::IR
     iree::compiler::Dialect::Stream::Transforms
     iree::compiler::Dialect::Util::IR
+    iree::compiler::Dialect::Util::IR::ExternalModels
     iree::compiler::Dialect::Util::Transforms
     iree::compiler::Dialect::VM::Analysis
     iree::compiler::Dialect::VM::IR

--- a/compiler/src/iree/compiler/Tools/init_iree_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_iree_dialects.h
@@ -25,6 +25,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
 #include "iree/compiler/Dialect/Stream/IR/StreamDialect.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
+#include "iree/compiler/Dialect/Util/IR/UtilExternalModels.h"
 #include "iree/compiler/Dialect/VM/IR/VMDialect.h"
 #include "iree/compiler/Dialect/VMVX/IR/VMVXDialect.h"
 #include "iree/compiler/Dialect/Vulkan/IR/VulkanDialect.h"


### PR DESCRIPTION
The purpose of this change is to address a TODO in `DispatchLinalgOnTensors.cpp`:

```
  // TODO(antiagainst): use TiedOpInterface here instead of hardcoding ops
  // when it's available in MLIR core in some form.
```
