### PR TITLE
Simplifying vm call interface.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -341,9 +341,7 @@ vm.module @my_module {
   // Create the call to the imported function.
   // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTPTR:.+]] = emitc.apply "&"(%[[ARGSTRUCT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]])
+  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
   // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Check that we don't unpack anything from the result struct.
@@ -442,9 +440,7 @@ vm.module @my_module {
   // Create the call to the imported function.
   // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTPTR:.+]] = emitc.apply "&"(%[[ARGSTRUCT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]])
+  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
   // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.
@@ -527,22 +523,12 @@ vm.module @my_module {
   // CHECK-NEXT: %[[A1SIZE:.+]] = emitc.call "sizeof"() {args = [i32]} : () -> !emitc.opaque<"iree_host_size_t">
   // CHECK-NEXT: %[[A2PTR:.+]] = emitc.apply "&"(%arg3) : (i32) -> !emitc.ptr<i32>
   // CHECK-NEXT: emitc.call "memcpy"(%[[A1ADDR]], %[[A2PTR]], %[[A1SIZE]])
-  
+
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[EXECRESULT:.+]] = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_execution_result_t">
-  // CHECK-NEXT: %[[EXECRESULTPTR1:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %[[EXECRESULTSIZE:.+]] = emitc.call "sizeof"(%[[EXECRESULT]]) : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call "memset"(%[[EXECRESULTPTR1]], %[[EXECRESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
   // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTPTR:.+]] = emitc.apply "&"(%[[ARGSTRUCT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[EXECRESULTPTR:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]], %[[EXECRESULTPTR]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index, 3 : index]}
+  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
+  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.
   //      CHECK: %[[RES:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
@@ -616,9 +602,7 @@ vm.module @my_module {
   // Create the call to the imported function.
   // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
-  // CHECK-NEXT: %[[ARGSTRUCTPTR:.+]] = emitc.apply "&"(%[[ARGSTRUCT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]])
+  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCT]])
   // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/control_flow_ops.mlir
@@ -339,21 +339,12 @@ vm.module @my_module {
   // CHECK-NOT: %[[ARGSPTR:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%{{.+}}) {args = [0 : index, #emitc.opaque<"data">]}
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[EXECRESULT:.+]] = "emitc.variable"() {value = #emitc.opaque<"">}
-  // CHECK-SAME:     : () -> !emitc.opaque<"iree_vm_execution_result_t">
-  // CHECK-NEXT: %[[EXECRESULTPTR1:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %[[EXECRESULTSIZE:.+]] = emitc.call "sizeof"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call "memset"(%[[EXECRESULTPTR1]], %[[EXECRESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
   // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
   // CHECK-NEXT: %[[ARGSTRUCTPTR:.+]] = emitc.apply "&"(%[[ARGSTRUCT]])
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[EXECRESULTPTR:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]], %[[EXECRESULTPTR]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index, 3 : index]}
+  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]])
+  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Check that we don't unpack anything from the result struct.
   // CHECK-NOT: emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
@@ -449,20 +440,12 @@ vm.module @my_module {
   // CHECK-NEXT: emitc.call "memcpy"(%[[A3ADDR]], %[[A4PTR]], %[[A3SIZE:.+]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[EXECRESULT:.+]] = "emitc.variable"() {value = #emitc.opaque<"">} : () -> !emitc.opaque<"iree_vm_execution_result_t">
-  // CHECK-NEXT: %[[EXECRESULTPTR1:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %[[EXECRESULTSIZE:.+]] = emitc.call "sizeof"(%[[EXECRESULT]]) : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call "memset"(%[[EXECRESULTPTR1]], %[[EXECRESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
-  // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>, !emitc.opaque<"iree_host_size_t">) -> ()
   // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
   // CHECK-NEXT: %[[ARGSTRUCTPTR:.+]] = emitc.apply "&"(%[[ARGSTRUCT]])
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[EXECRESULTPTR:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]], %[[EXECRESULTPTR]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index, 3 : index]}
+  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]])
+  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.
   //      CHECK: %[[RES:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
@@ -631,21 +614,12 @@ vm.module @my_module {
   // CHECK-NEXT: emitc.call "iree_vm_ref_assign"(%arg2, %[[ARG]])
 
   // Create the call to the imported function.
-  // CHECK-NEXT: %[[EXECRESULT:.+]] = "emitc.variable"() {value = #emitc.opaque<"">}
-  // CHECK-SAME:     : () -> !emitc.opaque<"iree_vm_execution_result_t">
-  // CHECK-NEXT: %[[EXECRESULTPTR1:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %[[EXECRESULTSIZE:.+]] = emitc.call "sizeof"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.opaque<"iree_host_size_t">
-  // CHECK-NEXT: emitc.call "memset"(%[[EXECRESULTPTR1]], %[[EXECRESULTSIZE]]) {args = [0 : index, 0 : ui32, 1 : index]}
   // CHECK-NEXT: %[[IMPORTMOD:.+]] = emitc.call "EMITC_STRUCT_PTR_MEMBER"(%arg1) {args = [0 : index, #emitc.opaque<"module">]}
   // CHECK-SAME:     : (!emitc.ptr<!emitc.opaque<"iree_vm_function_t">>) -> !emitc.ptr<!emitc.opaque<"iree_vm_module_t">>
   // CHECK-NEXT: %[[ARGSTRUCTPTR:.+]] = emitc.apply "&"(%[[ARGSTRUCT]])
   // CHECK-SAME:     : (!emitc.opaque<"iree_vm_function_call_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_function_call_t">>
-  // CHECK-NEXT: %[[EXECRESULTPTR:.+]] = emitc.apply "&"(%[[EXECRESULT]])
-  // CHECK-SAME:     : (!emitc.opaque<"iree_vm_execution_result_t">) -> !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>
-  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]], %[[EXECRESULTPTR]])
-  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index, 3 : index]}
+  // CHECK-NEXT: %{{.+}} = emitc.call "EMITC_STRUCT_PTR_MEMBER_CALL"(%[[IMPORTMOD]], %arg0, %[[ARGSTRUCTPTR]])
+  // CHECK-SAME:     {args = [0 : index, #emitc.opaque<"begin_call">, 0 : index, 1 : index, 2 : index]}
 
   // Unpack the function results.
   //      CHECK: %[[RES:.+]] = emitc.call "EMITC_STRUCT_MEMBER"(%[[ARGSTRUCT]]) {args = [0 : index, #emitc.opaque<"results">]}
@@ -676,7 +650,7 @@ vm.module @my_module {
 
   // Create a new function to export with the adapted signature.
   //      CHECK: func.func @my_module_fn_export_shim(%arg0: !emitc.ptr<!emitc.opaque<"iree_vm_stack_t">>, %arg1: !emitc.opaque<"uint32_t">, %arg2: !emitc.opaque<"iree_byte_span_t">, %arg3: !emitc.opaque<"iree_byte_span_t">,
-  // CHECK-SAME:                                %arg4: !emitc.ptr<!emitc.opaque<"void">>, %arg5: !emitc.ptr<!emitc.opaque<"void">>, %arg6: !emitc.ptr<!emitc.opaque<"iree_vm_execution_result_t">>)
+  // CHECK-SAME:                                %arg4: !emitc.ptr<!emitc.opaque<"void">>, %arg5: !emitc.ptr<!emitc.opaque<"void">>)
   // CHECK-SAME:     -> !emitc.opaque<"iree_status_t"> attributes {emitc.static, vm.calling_convention = "0i_i", vm.export_name = "fn"}
 
   // Cast module and module state structs.

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -419,9 +419,8 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
   call.function = entry_fn;
   call.arguments = iree_make_byte_span(&call_args, sizeof(call_args));
   call.results = iree_make_byte_span(NULL, 0);
-  iree_vm_execution_result_t result;
   iree_status_t status =
-      entry_fn.module->begin_call(entry_fn.module->self, stack, &call, &result);
+      entry_fn.module->begin_call(entry_fn.module->self, stack, &call);
 
   iree_vm_stack_deinitialize(stack);
 

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -420,7 +420,7 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
   call.arguments = iree_make_byte_span(&call_args, sizeof(call_args));
   call.results = iree_make_byte_span(NULL, 0);
   iree_status_t status =
-      entry_fn.module->begin_call(entry_fn.module->self, stack, &call);
+      entry_fn.module->begin_call(entry_fn.module->self, stack, call);
 
   iree_vm_stack_deinitialize(stack);
 

--- a/runtime/src/iree/runtime/session.c
+++ b/runtime/src/iree/runtime/session.c
@@ -300,9 +300,8 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_call_direct(
                                   iree_runtime_session_host_allocator(session));
 
   // Issue the call.
-  iree_vm_execution_result_t result;
   iree_status_t status = call->function.module->begin_call(
-      call->function.module->self, stack, call, &result);
+      call->function.module->self, stack, call);
 
   // Cleanup the stack.
   iree_vm_stack_deinitialize(stack);

--- a/runtime/src/iree/runtime/session.c
+++ b/runtime/src/iree/runtime/session.c
@@ -288,9 +288,8 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_call_by_name(
 }
 
 IREE_API_EXPORT iree_status_t iree_runtime_session_call_direct(
-    iree_runtime_session_t* session, const iree_vm_function_call_t* call) {
+    iree_runtime_session_t* session, const iree_vm_function_call_t call) {
   IREE_ASSERT_ARGUMENT(session);
-  IREE_ASSERT_ARGUMENT(call);
   IREE_TRACE_ZONE_BEGIN(z0);
 
   // Allocate a VM stack on the host stack and initialize it.
@@ -300,8 +299,8 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_call_direct(
                                   iree_runtime_session_host_allocator(session));
 
   // Issue the call.
-  iree_status_t status = call->function.module->begin_call(
-      call->function.module->self, stack, call);
+  iree_status_t status =
+      call.function.module->begin_call(call.function.module->self, stack, call);
 
   // Cleanup the stack.
   iree_vm_stack_deinitialize(stack);

--- a/runtime/src/iree/runtime/session.h
+++ b/runtime/src/iree/runtime/session.h
@@ -217,7 +217,7 @@ IREE_API_EXPORT iree_status_t iree_runtime_session_call_by_name(
 //
 // See iree_vm_function_call_t for more information.
 IREE_API_EXPORT iree_status_t iree_runtime_session_call_direct(
-    iree_runtime_session_t* session, const iree_vm_function_call_t* call);
+    iree_runtime_session_t* session, const iree_vm_function_call_t call);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/vm/bytecode_dispatch.c
+++ b/runtime/src/iree/vm/bytecode_dispatch.c
@@ -484,8 +484,8 @@ static iree_status_t iree_vm_bytecode_issue_import_call(
     iree_vm_stack_frame_t** out_caller_frame,
     iree_vm_registers_t* out_caller_registers) {
   // Call external function.
-  iree_status_t call_status = call.function.module->begin_call(
-      call.function.module->self, stack, &call);
+  iree_status_t call_status =
+      call.function.module->begin_call(call.function.module->self, stack, call);
   if (iree_status_is_deferred(call_status)) {
     return call_status;  // deferred for future resume
   } else if (IREE_UNLIKELY(!iree_status_is_ok(call_status))) {
@@ -655,7 +655,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
 
 iree_status_t iree_vm_bytecode_dispatch_begin(
     iree_vm_stack_t* stack, iree_vm_bytecode_module_t* module,
-    const iree_vm_function_call_t* call, iree_string_view_t cconv_arguments,
+    const iree_vm_function_call_t call, iree_string_view_t cconv_arguments,
     iree_string_view_t cconv_results) {
   // Enter function (as this is the initial call).
   // The callee's return will take care of storing the output registers when it
@@ -663,11 +663,11 @@ iree_status_t iree_vm_bytecode_dispatch_begin(
   iree_vm_stack_frame_t* current_frame = NULL;
   iree_vm_registers_t regs;
   IREE_RETURN_IF_ERROR(iree_vm_bytecode_external_enter(
-      stack, call->function, cconv_arguments, call->arguments, cconv_results,
+      stack, call.function, cconv_arguments, call.arguments, cconv_results,
       &current_frame, &regs));
 
   return iree_vm_bytecode_dispatch(stack, module, current_frame, regs,
-                                   call->results);
+                                   call.results);
 }
 
 iree_status_t iree_vm_bytecode_dispatch_resume(

--- a/runtime/src/iree/vm/bytecode_dispatch_async_test.cc
+++ b/runtime/src/iree/vm/bytecode_dispatch_async_test.cc
@@ -80,26 +80,24 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldSequence) {
   call.function = function;
   call.arguments = iree_make_byte_span(&arg_value, sizeof(arg_value));
   call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
-  iree_vm_execution_result_t result;
 
   // 0/3
-  ASSERT_THAT(
-      function.module->begin_call(function.module->self, stack, &call, &result),
-      StatusIs(StatusCode::kDeferred));
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, &call),
+              StatusIs(StatusCode::kDeferred));
 
   // 1/3
-  ASSERT_THAT(function.module->resume_call(function.module->self, stack,
-                                           call.results, &result),
-              StatusIs(StatusCode::kDeferred));
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
 
   // 2/3
-  ASSERT_THAT(function.module->resume_call(function.module->self, stack,
-                                           call.results, &result),
-              StatusIs(StatusCode::kDeferred));
+  ASSERT_THAT(
+      function.module->resume_call(function.module->self, stack, call.results),
+      StatusIs(StatusCode::kDeferred));
 
   // 3/3
-  IREE_ASSERT_OK(function.module->resume_call(function.module->self, stack,
-                                              call.results, &result));
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
 
   ASSERT_EQ(ret_value, arg_value + 3);
 
@@ -137,24 +135,21 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldDivergent) {
   call.function = function;
   call.arguments = iree_make_byte_span(&arg_values, sizeof(arg_values));
   call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
-  iree_vm_execution_result_t result;
 
   // arg0=0: result = %arg0 ? %arg1 : %arg2 => %arg2
   arg_values.arg0 = 0;
-  ASSERT_THAT(
-      function.module->begin_call(function.module->self, stack, &call, &result),
-      StatusIs(StatusCode::kDeferred));
-  IREE_ASSERT_OK(function.module->resume_call(function.module->self, stack,
-                                              call.results, &result));
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, &call),
+              StatusIs(StatusCode::kDeferred));
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
   ASSERT_EQ(ret_value, arg_values.arg2);
 
   // arg0=1: result = %arg0 ? %arg1 : %arg2 => %arg1
   arg_values.arg0 = 1;
-  ASSERT_THAT(
-      function.module->begin_call(function.module->self, stack, &call, &result),
-      StatusIs(StatusCode::kDeferred));
-  IREE_ASSERT_OK(function.module->resume_call(function.module->self, stack,
-                                              call.results, &result));
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, &call),
+              StatusIs(StatusCode::kDeferred));
+  IREE_ASSERT_OK(
+      function.module->resume_call(function.module->self, stack, call.results));
   ASSERT_EQ(ret_value, arg_values.arg1);
 
   iree_vm_stack_deinitialize(stack);

--- a/runtime/src/iree/vm/bytecode_dispatch_async_test.cc
+++ b/runtime/src/iree/vm/bytecode_dispatch_async_test.cc
@@ -82,7 +82,7 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldSequence) {
   call.results = iree_make_byte_span(&ret_value, sizeof(ret_value));
 
   // 0/3
-  ASSERT_THAT(function.module->begin_call(function.module->self, stack, &call),
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
               StatusIs(StatusCode::kDeferred));
 
   // 1/3
@@ -138,7 +138,7 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldDivergent) {
 
   // arg0=0: result = %arg0 ? %arg1 : %arg2 => %arg2
   arg_values.arg0 = 0;
-  ASSERT_THAT(function.module->begin_call(function.module->self, stack, &call),
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
               StatusIs(StatusCode::kDeferred));
   IREE_ASSERT_OK(
       function.module->resume_call(function.module->self, stack, call.results));
@@ -146,7 +146,7 @@ TEST_F(VMBytecodeDispatchAsyncTest, YieldDivergent) {
 
   // arg0=1: result = %arg0 ? %arg1 : %arg2 => %arg1
   arg_values.arg0 = 1;
-  ASSERT_THAT(function.module->begin_call(function.module->self, stack, &call),
+  ASSERT_THAT(function.module->begin_call(function.module->self, stack, call),
               StatusIs(StatusCode::kDeferred));
   IREE_ASSERT_OK(
       function.module->resume_call(function.module->self, stack, call.results));

--- a/runtime/src/iree/vm/bytecode_module.c
+++ b/runtime/src/iree/vm/bytecode_module.c
@@ -1024,13 +1024,10 @@ static iree_status_t IREE_API_PTR iree_vm_bytecode_module_notify(
 }
 
 static iree_status_t iree_vm_bytecode_module_begin_call(
-    void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call,
-    iree_vm_execution_result_t* out_result) {
+    void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call) {
   // NOTE: any work here adds directly to the invocation time. Avoid doing too
   // much work or touching too many unlikely-to-be-cached structures (such as
   // walking the FlatBuffer, which may cause page faults).
-  IREE_ASSERT_ARGUMENT(out_result);
-  memset(out_result, 0, sizeof(iree_vm_execution_result_t));
 
   // Map the (potentially) export ordinal into the internal function ordinal in
   // the function descriptor table.
@@ -1071,21 +1068,15 @@ static iree_status_t iree_vm_bytecode_module_begin_call(
 
   // Jump into the dispatch routine to execute bytecode until the function
   // either returns (synchronous) or yields (asynchronous).
-  return iree_vm_bytecode_dispatch_begin(stack, module, &internal_call,
-                                         cconv_arguments, cconv_results,
-                                         out_result);  // tail
+  return iree_vm_bytecode_dispatch_begin(
+      stack, module, &internal_call, cconv_arguments, cconv_results);  // tail
 }
 
 static iree_status_t iree_vm_bytecode_module_resume_call(
-    void* self, iree_vm_stack_t* stack, iree_byte_span_t call_results,
-    iree_vm_execution_result_t* out_result) {
-  IREE_ASSERT_ARGUMENT(out_result);
-  memset(out_result, 0, sizeof(iree_vm_execution_result_t));
-
+    void* self, iree_vm_stack_t* stack, iree_byte_span_t call_results) {
   // Resume the call by jumping back into the bytecode dispatch.
   iree_vm_bytecode_module_t* module = (iree_vm_bytecode_module_t*)self;
-  return iree_vm_bytecode_dispatch_resume(stack, module, call_results,
-                                          out_result);  // tail
+  return iree_vm_bytecode_dispatch_resume(stack, module, call_results);  // tail
 }
 
 IREE_API_EXPORT iree_status_t iree_vm_bytecode_module_create(

--- a/runtime/src/iree/vm/bytecode_module_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode_module_benchmark.cc
@@ -114,7 +114,7 @@ static iree_status_t RunFunction(benchmark::State& state,
       reinterpret_cast<int32_t*>(call.arguments.data)[i] = i32_args[i];
     }
     IREE_CHECK_OK(
-        bytecode_module->begin_call(bytecode_module->self, stack, &call));
+        bytecode_module->begin_call(bytecode_module->self, stack, call));
   }
   iree_vm_stack_deinitialize(stack);
 

--- a/runtime/src/iree/vm/bytecode_module_benchmark.cc
+++ b/runtime/src/iree/vm/bytecode_module_benchmark.cc
@@ -25,7 +25,7 @@ static iree_status_t native_import_module_add_1(
     iree_vm_stack_t* stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
     iree_vm_native_function_target_t target_fn, void* module,
-    void* module_state, iree_vm_execution_result_t* out_result) {
+    void* module_state) {
   // Add 1 to arg0 and return.
   int32_t arg0 = *reinterpret_cast<int32_t*>(args_storage.data);
   int32_t ret0 = arg0 + 1;
@@ -113,10 +113,8 @@ static iree_status_t RunFunction(benchmark::State& state,
     for (iree_host_size_t i = 0; i < i32_args.size(); ++i) {
       reinterpret_cast<int32_t*>(call.arguments.data)[i] = i32_args[i];
     }
-
-    iree_vm_execution_result_t result;
-    IREE_CHECK_OK(bytecode_module->begin_call(bytecode_module->self, stack,
-                                              &call, &result));
+    IREE_CHECK_OK(
+        bytecode_module->begin_call(bytecode_module->self, stack, &call));
   }
   iree_vm_stack_deinitialize(stack);
 

--- a/runtime/src/iree/vm/bytecode_module_impl.h
+++ b/runtime/src/iree/vm/bytecode_module_impl.h
@@ -139,19 +139,17 @@ typedef struct iree_vm_bytecode_module_state_t {
 } iree_vm_bytecode_module_state_t;
 
 // Begins execution of the current frame and continues until either a yield or
-// return. |out_result| will contain the result status for continuation, if
-// needed.
+// return.
 iree_status_t iree_vm_bytecode_dispatch_begin(
     iree_vm_stack_t* stack, iree_vm_bytecode_module_t* module,
     const iree_vm_function_call_t* call, iree_string_view_t cconv_arguments,
-    iree_string_view_t cconv_results, iree_vm_execution_result_t* out_result);
+    iree_string_view_t cconv_results);
 
 // Resumes execution of an in-progress frame and continues until either a yield
-// or return. |out_result| will contain the result status for continuation, if
-// needed.
+// or return.
 iree_status_t iree_vm_bytecode_dispatch_resume(
     iree_vm_stack_t* stack, iree_vm_bytecode_module_t* module,
-    iree_byte_span_t call_results, iree_vm_execution_result_t* out_result);
+    iree_byte_span_t call_results);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/vm/bytecode_module_impl.h
+++ b/runtime/src/iree/vm/bytecode_module_impl.h
@@ -142,7 +142,7 @@ typedef struct iree_vm_bytecode_module_state_t {
 // return.
 iree_status_t iree_vm_bytecode_dispatch_begin(
     iree_vm_stack_t* stack, iree_vm_bytecode_module_t* module,
-    const iree_vm_function_call_t* call, iree_string_view_t cconv_arguments,
+    const iree_vm_function_call_t call, iree_string_view_t cconv_arguments,
     iree_string_view_t cconv_results);
 
 // Resumes execution of an in-progress frame and continues until either a yield

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -83,8 +83,7 @@ static iree_status_t iree_vm_context_run_function(
   }
 
   IREE_TRACE_FIBER_ENTER(context->context_id);
-  iree_vm_execution_result_t result;
-  status = module->begin_call(module->self, stack, &call, &result);
+  status = module->begin_call(module->self, stack, &call);
   IREE_TRACE_FIBER_LEAVE();
   if (!iree_status_is_ok(status)) {
     status = IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, status);
@@ -549,8 +548,7 @@ static iree_status_t iree_vm_context_call_module_notify(
   }
 
   // Call the resolved function.
-  iree_vm_execution_result_t result;
-  status = module->begin_call(module->self, stack, &call, &result);
+  status = module->begin_call(module->self, stack, &call);
   if (!iree_status_is_ok(status)) {
     status = IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, status);
   }

--- a/runtime/src/iree/vm/context.c
+++ b/runtime/src/iree/vm/context.c
@@ -83,7 +83,7 @@ static iree_status_t iree_vm_context_run_function(
   }
 
   IREE_TRACE_FIBER_ENTER(context->context_id);
-  status = module->begin_call(module->self, stack, &call);
+  status = module->begin_call(module->self, stack, call);
   IREE_TRACE_FIBER_LEAVE();
   if (!iree_status_is_ok(status)) {
     status = IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, status);
@@ -548,7 +548,7 @@ static iree_status_t iree_vm_context_call_module_notify(
   }
 
   // Call the resolved function.
-  status = module->begin_call(module->self, stack, &call);
+  status = module->begin_call(module->self, stack, call);
   if (!iree_status_is_ok(status)) {
     status = IREE_VM_STACK_ANNOTATE_BACKTRACE_IF_ENABLED(stack, status);
   }

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -453,7 +453,7 @@ IREE_API_EXPORT iree_status_t iree_vm_begin_invoke(
   // completes. A result of OK indicates successful completion while DEFERRED
   // indicates that the invocation needs to be resumed/waited again.
   state->status =
-      function.module->begin_call(function.module->self, stack, &call);
+      function.module->begin_call(function.module->self, stack, call);
 
   // The call may have yielded, either for cooperative scheduling purposes or
   // for a wait operation (in which case the top of the stack will have a wait

--- a/runtime/src/iree/vm/invocation.c
+++ b/runtime/src/iree/vm/invocation.c
@@ -452,9 +452,8 @@ IREE_API_EXPORT iree_status_t iree_vm_begin_invoke(
   // Execute the target function until the first yield point is reached or it
   // completes. A result of OK indicates successful completion while DEFERRED
   // indicates that the invocation needs to be resumed/waited again.
-  iree_vm_execution_result_t result;
   state->status =
-      function.module->begin_call(function.module->self, stack, &call, &result);
+      function.module->begin_call(function.module->self, stack, &call);
 
   // The call may have yielded, either for cooperative scheduling purposes or
   // for a wait operation (in which case the top of the stack will have a wait
@@ -504,9 +503,8 @@ iree_vm_resume_invoke(iree_vm_invoke_state_t* state) {
     // Call into the VM to resume the function. It may complete (returning OK),
     // defer to be waited/resumed later, or fail.
     iree_vm_function_t resume_function = resume_frame->function;
-    iree_vm_execution_result_t result;
     state->status = resume_function.module->resume_call(
-        resume_function.module->self, state->stack, state->results, &result);
+        resume_function.module->self, state->stack, state->results);
 
     // If the call yielded then return that so the user knows to resume again.
     if (iree_status_is_deferred(state->status)) {

--- a/runtime/src/iree/vm/module.h
+++ b/runtime/src/iree/vm/module.h
@@ -398,7 +398,7 @@ typedef struct iree_vm_module_t {
   // resumed. Depending on the program it may be unsafe to begin any other calls
   // without first completing prior ones.
   iree_status_t(IREE_API_PTR* begin_call)(void* self, iree_vm_stack_t* stack,
-                                          const iree_vm_function_call_t* call);
+                                          iree_vm_function_call_t call);
 
   // Resumes execution of a previously-yielded call.
   //

--- a/runtime/src/iree/vm/module.h
+++ b/runtime/src/iree/vm/module.h
@@ -240,16 +240,6 @@ IREE_API_EXPORT iree_status_t iree_vm_function_call_compute_cconv_fragment_size(
     const iree_vm_register_list_t* segment_size_list,
     iree_host_size_t* out_required_size);
 
-// Results of an iree_vm_module_execute request.
-typedef struct iree_vm_execution_result_t {
-  // TODO(benvanik): yield information.
-  // Yield modes:
-  // - yield (yield instruction)
-  // - await (with 1+ wait handles)
-  // - break
-  int reserved;
-} iree_vm_execution_result_t;
-
 //===----------------------------------------------------------------------===//
 // Source locations
 //===----------------------------------------------------------------------===//
@@ -406,11 +396,9 @@ typedef struct iree_vm_module_t {
   //
   // Returns IREE_STATUS_DEFERRED if execution yielded and the call needs to be
   // resumed. Depending on the program it may be unsafe to begin any other calls
-  // without first completing prior ones. |out_result| will contain information
-  // for when to reschedule the call.
-  iree_status_t(IREE_API_PTR* begin_call)(
-      void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call,
-      iree_vm_execution_result_t* out_result);
+  // without first completing prior ones.
+  iree_status_t(IREE_API_PTR* begin_call)(void* self, iree_vm_stack_t* stack,
+                                          const iree_vm_function_call_t* call);
 
   // Resumes execution of a previously-yielded call.
   //
@@ -419,11 +407,9 @@ typedef struct iree_vm_module_t {
   //
   // Returns IREE_STATUS_DEFERRED if execution yielded and the call needs to be
   // resumed. Depending on the program it may be unsafe to begin any other calls
-  // without first completing prior ones. |out_result| will contain information
-  // for when to reschedule the call.
-  iree_status_t(IREE_API_PTR* resume_call)(
-      void* self, iree_vm_stack_t* stack, iree_byte_span_t call_results,
-      iree_vm_execution_result_t* out_result);
+  // without first completing prior ones.
+  iree_status_t(IREE_API_PTR* resume_call)(void* self, iree_vm_stack_t* stack,
+                                           iree_byte_span_t call_results);
 } iree_vm_module_t;
 
 // Initializes the interface of a module handle.

--- a/runtime/src/iree/vm/native_module.c
+++ b/runtime/src/iree/vm/native_module.c
@@ -333,15 +333,14 @@ static iree_status_t iree_vm_native_module_issue_call(
 }
 
 static iree_status_t IREE_API_PTR iree_vm_native_module_begin_call(
-    void* self, iree_vm_stack_t* stack, const iree_vm_function_call_t* call) {
+    void* self, iree_vm_stack_t* stack, iree_vm_function_call_t call) {
   iree_vm_native_module_t* module = (iree_vm_native_module_t*)self;
-  if (IREE_UNLIKELY(call->function.linkage !=
-                    IREE_VM_FUNCTION_LINKAGE_EXPORT) ||
-      IREE_UNLIKELY(call->function.ordinal >=
+  if (IREE_UNLIKELY(call.function.linkage != IREE_VM_FUNCTION_LINKAGE_EXPORT) ||
+      IREE_UNLIKELY(call.function.ordinal >=
                     module->descriptor->export_count)) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "function ordinal out of bounds: 0 < %u < %zu",
-                            call->function.ordinal,
+                            call.function.ordinal,
                             module->descriptor->export_count);
   }
   if (module->user_interface.begin_call) {
@@ -354,13 +353,13 @@ static iree_status_t IREE_API_PTR iree_vm_native_module_begin_call(
 
   iree_vm_stack_frame_t* callee_frame = NULL;
   IREE_RETURN_IF_ERROR(iree_vm_stack_function_enter(
-      stack, &call->function, IREE_VM_STACK_FRAME_NATIVE, frame_size,
+      stack, &call.function, IREE_VM_STACK_FRAME_NATIVE, frame_size,
       /*frame_cleanup_fn=*/NULL, &callee_frame));
 
   // Begin call with fresh callee frame.
   return iree_vm_native_module_issue_call(
       module, stack, callee_frame, IREE_VM_NATIVE_FUNCTION_CALL_BEGIN,
-      call->arguments, call->results);  // tail
+      call.arguments, call.results);  // tail
 }
 
 static iree_status_t IREE_API_PTR iree_vm_native_module_resume_call(

--- a/runtime/src/iree/vm/native_module.h
+++ b/runtime/src/iree/vm/native_module.h
@@ -63,7 +63,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_shim_t)(
     iree_vm_stack_t* stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
     iree_vm_native_function_target_t target_fn, void* module,
-    void* module_state, iree_vm_execution_result_t* out_result);
+    void* module_state);
 
 // An entry in the function pointer table.
 typedef struct iree_vm_native_function_ptr_t {

--- a/runtime/src/iree/vm/native_module_cc.h
+++ b/runtime/src/iree/vm/native_module_cc.h
@@ -215,16 +215,16 @@ class NativeModule {
   }
 
   static iree_status_t ModuleBeginCall(void* self, iree_vm_stack_t* stack,
-                                       const iree_vm_function_call_t* call) {
+                                       iree_vm_function_call_t call) {
     auto* module = FromModulePointer(self);
-    if (IREE_UNLIKELY(call->function.ordinal >=
+    if (IREE_UNLIKELY(call.function.ordinal >=
                       module->dispatch_table_.size())) {
       return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                               "function ordinal out of bounds: 0 < %u < %zu",
-                              call->function.ordinal,
+                              call.function.ordinal,
                               module->dispatch_table_.size());
     }
-    const auto& info = module->dispatch_table_[call->function.ordinal];
+    const auto& info = module->dispatch_table_[call.function.ordinal];
 
     // NOTE: VM stack is currently unused. We could stash things here for the
     // debugger or use it for coroutine state.
@@ -232,7 +232,7 @@ class NativeModule {
 
     iree_vm_stack_frame_t* callee_frame = NULL;
     IREE_RETURN_IF_ERROR(iree_vm_stack_function_enter(
-        stack, &call->function, IREE_VM_STACK_FRAME_NATIVE, frame_size,
+        stack, &call.function, IREE_VM_STACK_FRAME_NATIVE, frame_size,
         /*frame_cleanup_fn=*/nullptr, &callee_frame));
 
     auto* state = FromStatePointer(callee_frame->module_state);

--- a/runtime/src/iree/vm/native_module_cc.h
+++ b/runtime/src/iree/vm/native_module_cc.h
@@ -215,10 +215,7 @@ class NativeModule {
   }
 
   static iree_status_t ModuleBeginCall(void* self, iree_vm_stack_t* stack,
-                                       const iree_vm_function_call_t* call,
-                                       iree_vm_execution_result_t* out_result) {
-    IREE_ASSERT_ARGUMENT(out_result);
-    std::memset(out_result, 0, sizeof(*out_result));
+                                       const iree_vm_function_call_t* call) {
     auto* module = FromModulePointer(self);
     if (IREE_UNLIKELY(call->function.ordinal >=
                       module->dispatch_table_.size())) {
@@ -239,7 +236,7 @@ class NativeModule {
         /*frame_cleanup_fn=*/nullptr, &callee_frame));
 
     auto* state = FromStatePointer(callee_frame->module_state);
-    iree_status_t status = info.call(info.ptr, state, stack, call, out_result);
+    iree_status_t status = info.call(info.ptr, state, stack, call);
     if (IREE_UNLIKELY(!iree_status_is_ok(status))) {
       status = iree_status_annotate_f(
           status, "while invoking C++ function %s.%.*s", module->name_,

--- a/runtime/src/iree/vm/native_module_packing.h
+++ b/runtime/src/iree/vm/native_module_packing.h
@@ -621,8 +621,7 @@ struct DispatchFunctor {
   using FnPtr = StatusOr<Results> (Owner::*)(Params...);
 
   static Status Call(void (Owner::*ptr)(), Owner* self, iree_vm_stack_t* stack,
-                     const iree_vm_function_call_t* call,
-                     iree_vm_execution_result_t* out_result) {
+                     const iree_vm_function_call_t* call) {
     // Marshal arguments into types/locals we can forward to the function.
     IREE_ASSIGN_OR_RETURN(
         auto params, impl::Unpacker::LoadSequence<Params...>(call->arguments));
@@ -653,8 +652,7 @@ struct DispatchFunctorVoid {
   using FnPtr = Status (Owner::*)(Params...);
 
   static Status Call(void (Owner::*ptr)(), Owner* self, iree_vm_stack_t* stack,
-                     const iree_vm_function_call_t* call,
-                     iree_vm_execution_result_t* out_result) {
+                     const iree_vm_function_call_t* call) {
     IREE_ASSIGN_OR_RETURN(
         auto params, impl::Unpacker::LoadSequence<Params...>(call->arguments));
     return ApplyFn(reinterpret_cast<FnPtr>(ptr), self, std::move(params),
@@ -677,8 +675,7 @@ struct NativeFunction {
   void (Owner::*const ptr)();
   Status (*const call)(void (Owner::*ptr)(), Owner* self,
                        iree_vm_stack_t* stack,
-                       const iree_vm_function_call_t* call,
-                       iree_vm_execution_result_t* out_result);
+                       const iree_vm_function_call_t* call);
 };
 
 template <typename Owner, typename Result, typename... Params>

--- a/runtime/src/iree/vm/native_module_test.h
+++ b/runtime/src/iree/vm/native_module_test.h
@@ -28,10 +28,7 @@ static iree_status_t call_import_i32_i32(iree_vm_stack_t* stack,
   call.function = *import;
   call.arguments = iree_make_byte_span(&arg0, sizeof(arg0));
   call.results = iree_make_byte_span(out_ret0, sizeof(*out_ret0));
-
-  iree_vm_execution_result_t result;
-  memset(&result, 0, sizeof(result));
-  return import->module->begin_call(import->module, stack, &call, &result);
+  return import->module->begin_call(import->module, stack, &call);
 }
 
 typedef iree_status_t (*call_i32_i32_t)(iree_vm_stack_t* stack,
@@ -49,8 +46,7 @@ static iree_status_t call_shim_i32_i32(iree_vm_stack_t* stack,
                                        iree_byte_span_t args_storage,
                                        iree_byte_span_t rets_storage,
                                        call_i32_i32_t target_fn, void* module,
-                                       void* module_state,
-                                       iree_vm_execution_result_t* out_result) {
+                                       void* module_state) {
   // We can use structs to allow compiler-controlled indexing optimizations,
   // though this won't work for variadic cases.
   // TODO(benvanik): packed attributes.

--- a/runtime/src/iree/vm/native_module_test.h
+++ b/runtime/src/iree/vm/native_module_test.h
@@ -28,7 +28,7 @@ static iree_status_t call_import_i32_i32(iree_vm_stack_t* stack,
   call.function = *import;
   call.arguments = iree_make_byte_span(&arg0, sizeof(arg0));
   call.results = iree_make_byte_span(out_ret0, sizeof(*out_ret0));
-  return import->module->begin_call(import->module, stack, &call);
+  return import->module->begin_call(import->module, stack, call);
 }
 
 typedef iree_status_t (*call_i32_i32_t)(iree_vm_stack_t* stack,

--- a/runtime/src/iree/vm/shims.h
+++ b/runtime/src/iree/vm/shims.h
@@ -79,8 +79,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
       iree_vm_native_function_flags_t flags, iree_byte_span_t args_storage,    \
       iree_byte_span_t rets_storage,                                           \
       iree_vm_native_function_target2_t target_fn, void* IREE_RESTRICT module, \
-      void* IREE_RESTRICT module_state,                                        \
-      iree_vm_execution_result_t* IREE_RESTRICT out_result);
+      void* IREE_RESTRICT module_state);
 
 #define IREE_VM_ABI_DEFINE_SHIM(arg_types, ret_types)                          \
   iree_status_t iree_vm_shim_##arg_types##_##ret_types(                        \
@@ -88,8 +87,7 @@ typedef iree_status_t(IREE_API_PTR* iree_vm_native_function_target2_t)(
       iree_vm_native_function_flags_t flags, iree_byte_span_t args_storage,    \
       iree_byte_span_t rets_storage,                                           \
       iree_vm_native_function_target2_t target_fn, void* IREE_RESTRICT module, \
-      void* IREE_RESTRICT module_state,                                        \
-      iree_vm_execution_result_t* IREE_RESTRICT out_result) {                  \
+      void* IREE_RESTRICT module_state) {                                      \
     const IREE_VM_ABI_TYPE_NAME(arg_types)* args =                             \
         iree_vm_abi_##arg_types##_checked_deref(args_storage);                 \
     IREE_VM_ABI_TYPE_NAME(ret_types)* rets =                                   \

--- a/runtime/src/iree/vm/shims_emitc.h
+++ b/runtime/src/iree/vm/shims_emitc.h
@@ -14,17 +14,15 @@
 typedef iree_status_t (*iree_vm_native_function_target_emitc_t)(
     iree_vm_stack_t* IREE_RESTRICT stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
-    void* IREE_RESTRICT module, void* IREE_RESTRICT module_state,
-    iree_vm_execution_result_t* IREE_RESTRICT);
+    void* IREE_RESTRICT module, void* IREE_RESTRICT module_state);
 
 static iree_status_t iree_emitc_shim(
     iree_vm_stack_t* IREE_RESTRICT stack, iree_vm_native_function_flags_t flags,
     iree_byte_span_t args_storage, iree_byte_span_t rets_storage,
     iree_vm_native_function_target_emitc_t target_fn,
-    void* IREE_RESTRICT module, void* IREE_RESTRICT module_state,
-    iree_vm_execution_result_t* IREE_RESTRICT out_result) {
+    void* IREE_RESTRICT module, void* IREE_RESTRICT module_state) {
   return target_fn(stack, flags, args_storage, rets_storage, module,
-                   module_state, out_result);
+                   module_state);
 }
 
 #endif  // IREE_VM_SHIMS_EMITC_H_


### PR DESCRIPTION
This removes the unused `iree_vm_execution_result_t` that needed to be passed in to each call and changes the `iree_vm_function_call_t` struct to be passed by-value to improve compiler analysis.