### PR TITLE
Fix android_symbolize script

### DIFF
--- a/build_tools/scripts/android_symbolize.sh
+++ b/build_tools/scripts/android_symbolize.sh
@@ -58,7 +58,7 @@ do
   then
     adb pull "$file" "$pulled_file" 1>/dev/null 2>/dev/null
   fi
-  llvm_symbolizer_output="$($ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-symbolizer -obj "$pulled_file" "$address")"
+  llvm_symbolizer_output="$($ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-symbolizer --obj "$pulled_file" "$address")"
   if [ -z "$llvm_symbolizer_output" ]
   then
     echo "$line"


### PR DESCRIPTION
The symbolizer from the newest NDK treats `-obj` as 3 separate short
options.