### PR TITLE
[NFC] Remove LinalgTransformationFilter from dispatch region formation

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -458,12 +458,14 @@ static SmallVector<Operation *> orderOperations(ArrayRef<Operation *> ops) {
   // results. Also compute the operations that form the leafs of the DAG of
   // operations in `ops`.
   for (auto op : ops) {
-    for (auto operand : op->getOperands()) {
-      auto definingOp = operand.getDefiningOp();
-      if (!definingOp || !opSet.count(definingOp)) continue;
-      insertAfterMap[definingOp].push_back(op);
-      if (leafOps.count(op)) leafOps.remove(op);
-    }
+    op->walk([&](Operation *opOrNestedOp) {
+      for (auto operand : opOrNestedOp->getOperands()) {
+        auto definingOp = operand.getDefiningOp();
+        if (!definingOp || !opSet.count(definingOp)) continue;
+        insertAfterMap[definingOp].push_back(op);
+        if (leafOps.count(op)) leafOps.remove(op);
+      }
+    });
   }
 
   // The leaves are at the head of the ordered list.
@@ -561,6 +563,23 @@ static void getUsedValuesDefinedAboveAfterCloningOps(
     }
     clonedOps.push_back(definingOp);
     worklist.append(definingOp->operand_begin(), definingOp->operand_end());
+    // Add operands of ops that are directly nested to the worklist if they are
+    // defined outside of the op.
+    for (Region &r : definingOp->getRegions()) {
+      for (Block &b : r.getBlocks()) {
+        for (Operation &op : b) {
+          for (Value v : op.getOperands()) {
+            if (auto bbArg = v.dyn_cast<BlockArgument>()) {
+              if (bbArg.getOwner()->getParentOp() != &op)
+                worklist.push_back(bbArg);
+            } else {
+              if (v.getDefiningOp()->getParentOp() != &op)
+                worklist.push_back(v);
+            }
+          }
+        }
+      }
+    }
   }
   // The cloned operations form a DAG. Return the cloned operations so the
   // leaves come first, and can be cloned in-order into the dispatch region.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -662,7 +662,6 @@ static void tryToTieOperandsAndResults(
     IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
   Block *block = dispatchOp.getBody(0);
 
-  SmallVector<unsigned> eraseArguments;
   // Go over each result to tie operand when possible, by:
   // 1. Update the tied operand argument to take readwrite tensors.
   // 2. Erase the result argument.
@@ -680,11 +679,10 @@ static void tryToTieOperandsAndResults(
         IREE::Flow::TensorAccess::ReadWrite, oldType.getShape(),
         oldType.getElementType()));
     outputArgument.replaceAllUsesWith(tiedOperandArgument);
-    eraseArguments.push_back(outputArgument.getArgNumber());
+    block->eraseArgument(outputArgument.getArgNumber());
     dispatchOp.setTiedResultOperandIndex(result.index(),
                                          tiedOperandArgument.getArgNumber());
   }
-  block->eraseArguments(eraseArguments);
 }
 
 // After outlining in dispatch region we can rewrite the dispatch ops with


### PR DESCRIPTION
This change is NFC and simplifies the code base. `LinalgTransformationFilter` was previously used to ensure that the pattern that creates dispatch regions is not applied in certain places. This change replaces the pattern with a simpler walk over the IR. (The greedy pattern rewriter is no longer used for this purpose.)