### PR TITLE
Use helper methods to get block arguments for output during tie-ing of operands/results.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -697,7 +697,6 @@ static BlockArgument getTiedOperandBlockArgument(BlockArgument resultArg) {
 static void tryToTieOperandsAndResults(
     IREE::Flow::DispatchWorkgroupsOp dispatchOp) {
   Block *block = dispatchOp.getBody(0);
-  unsigned numOperands = dispatchOp.getODSOperandIndexAndLength(1).second;
 
   SmallVector<unsigned> eraseArguments;
   // Go over each result to tie operand when possible, by:
@@ -707,7 +706,7 @@ static void tryToTieOperandsAndResults(
   for (auto result : llvm::enumerate(dispatchOp.getResults())) {
     if (dispatchOp.getTiedResultOperand(result.value())) continue;
     BlockArgument outputArgument =
-        block->getArgument(numOperands + result.index());
+        dispatchOp.getOutputBlockArgument(result.index());
     BlockArgument tiedOperandArgument =
         getTiedOperandBlockArgument(outputArgument);
     if (!tiedOperandArgument) continue;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1444,3 +1444,26 @@ func.func @multi_use_producer_fusion(%arg0 : tensor<?x8xf32>, %arg1 : tensor<8x?
 //  CHECK-DAG:     flow.dispatch.tensor.store %[[GENERIC]], %[[RESULT0]]
 //  CHECK-DAG:     flow.dispatch.tensor.store %[[MATMUL]], %[[RESULT1]]
 //      CHECK:   return %[[DISPATCH]]#1, %[[DISPATCH]]#0
+
+// -----
+
+func.func @fft_cst_output(%arg0 : tensor<3x2190x1x512xf32>) -> (tensor<3x2190x1x512xf32>, tensor<3x2190x1x512xf32>) {
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant dense<1.000000e+00> : tensor<1xf32>
+  %cst_0 = arith.constant dense<-0.000000e+00> : tensor<1xf32>
+  %cst_1 = arith.constant dense<0.000000e+00> : tensor<3x2190x1x512xf32>
+  %0:2 = iree_linalg_ext.fft ins(%c1, %cst, %cst_0 : index, tensor<1xf32>, tensor<1xf32>)
+      outs(%arg0, %cst_1 : tensor<3x2190x1x512xf32>, tensor<3x2190x1x512xf32>) : tensor<3x2190x1x512xf32>, tensor<3x2190x1x512xf32>
+  return %0#0, %0#1 : tensor<3x2190x1x512xf32>, tensor<3x2190x1x512xf32>
+}
+//      CHECK: func @fft_cst_output
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<3x2190x1x512xf32>
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups
+// CHECK-SAME:       (%[[ARG0]]) : (tensor<3x2190x1x512xf32>) -> (%[[ARG0]], tensor<3x2190x1x512xf32>)
+// CHECK-NEXT:     %[[ARG1:.+]]: !flow.dispatch.tensor<readwrite
+// CHECK-SAME:     %[[ARG2:.+]]: !flow.dispatch.tensor<writeonly
+//      CHECK:       %[[OUT:.+]] = flow.dispatch.tensor.load %[[ARG1]]
+//      CHECK:       %[[FFT:.+]]:2 = iree_linalg_ext.fft
+// CHECK-SAME:           outs(%[[OUT]],
+//  CHECK-DAG:       flow.dispatch.tensor.store %[[FFT]]#0, %[[ARG1]]
+//  CHECK-DAG:       flow.dispatch.tensor.store %[[FFT]]#1, %[[ARG2]]


### PR DESCRIPTION
Use the recently added method to get block arguments for a result to
avoid invalid out-of-bounds accesses.

Issue #9896 