### PR TITLE
[hal][cuda] Use the primary context if available in hal

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
@@ -6,6 +6,9 @@
 
 CU_PFN_DECL(cuCtxCreate, CUcontext*, unsigned int, CUdevice)
 CU_PFN_DECL(cuCtxDestroy, CUcontext)
+CU_PFN_DECL(cuDevicePrimaryCtxRetain, CUcontext*, CUdevice)
+CU_PFN_DECL(cuDevicePrimaryCtxRelease, CUdevice)
+CU_PFN_DECL(cuCtxSetCurrent, CUcontext)
 CU_PFN_DECL(cuDeviceGet, CUdevice*, int)
 CU_PFN_DECL(cuDeviceGetCount, int*)
 CU_PFN_DECL(cuDeviceGetName, char*, int, CUdevice)


### PR DESCRIPTION
Instead of creating a new context retain the primary context and use it.
This prevent running into problems if another library is using CUDA.
This may still fail if application using a context which is not the
primary context. We would need to scope the different iree entry point
to prevent that. This solution allows us to move forward in the meantime
and should cover most of the use cases.