### PR TITLE
Add unit support in benchmark tools

### DIFF
--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -189,7 +189,7 @@ def main(args: argparse.Namespace):
       compilation_statistics = CompilationStatistics(
           compilation_info=compilation_info,
           module_component_sizes=module_component_sizes,
-          compilation_time=compilation_time)
+          compilation_time_ms=compilation_time)
       compilation_statistics_list.append(compilation_statistics)
 
   commit = get_git_commit_hash("HEAD")

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -80,19 +80,19 @@ def parse_compilation_time_from_ninja_log(log: TextIO) -> Dict[str, int]:
 
 
 def get_module_component_info(module: BinaryIO,
-                              module_file_size: int) -> ModuleComponentSizes:
+                              module_file_bytes: int) -> ModuleComponentSizes:
   with zipfile.ZipFile(module) as module_zipfile:
     size_map = dict(
         (info.filename, info.file_size) for info in module_zipfile.infolist())
 
-  vm_component_size = size_map[VM_COMPONENT_NAME]
-  const_component_size = size_map[CONST_COMPONENT_NAME]
+  vm_component_bytes = size_map[VM_COMPONENT_NAME]
+  const_component_bytes = size_map[CONST_COMPONENT_NAME]
   identified_names = {VM_COMPONENT_NAME, CONST_COMPONENT_NAME}
-  total_dispatch_component_size = 0
+  total_dispatch_component_bytes = 0
   for filename, size in size_map.items():
     for pattern in DISPATCH_COMPONENT_PATTERNS:
       if re.match(pattern, filename):
-        total_dispatch_component_size += size
+        total_dispatch_component_bytes += size
         identified_names.add(filename)
         break
 
@@ -101,10 +101,10 @@ def get_module_component_info(module: BinaryIO,
         f"Unrecognized components in the module: {size_map.keys()}.")
 
   return ModuleComponentSizes(
-      file_size=module_file_size,
-      vm_component_size=vm_component_size,
-      const_component_size=const_component_size,
-      total_dispatch_component_size=total_dispatch_component_size)
+      file_bytes=module_file_bytes,
+      vm_component_bytes=vm_component_bytes,
+      const_component_bytes=const_component_bytes,
+      total_dispatch_component_bytes=total_dispatch_component_bytes)
 
 
 def get_module_path(flag_file: TextIO) -> Optional[str]:
@@ -179,7 +179,7 @@ def main(args: argparse.Namespace):
       if cmake_target is None:
         raise RuntimeError(
             f"Module path isn't a module cmake target: {module_path}")
-      compilation_time = target_build_time_map[cmake_target]
+      compilation_time_ms = target_build_time_map[cmake_target]
 
       compilation_info = CompilationInfo(model_name=benchmark_case.model_name,
                                          model_tags=benchmark_case.model_tags,
@@ -189,7 +189,7 @@ def main(args: argparse.Namespace):
       compilation_statistics = CompilationStatistics(
           compilation_info=compilation_info,
           module_component_sizes=module_component_sizes,
-          compilation_time_ms=compilation_time)
+          compilation_time_ms=compilation_time_ms)
       compilation_statistics_list.append(compilation_statistics)
 
   commit = get_git_commit_hash("HEAD")

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -52,10 +52,10 @@ class CollectCompilationStatistics(unittest.TestCase):
 
     self.assertEqual(
         component_sizes,
-        ModuleComponentSizes(file_size=len(module_file_data),
-                             vm_component_size=4,
-                             const_component_size=3,
-                             total_dispatch_component_size=16))
+        ModuleComponentSizes(file_bytes=len(module_file_data),
+                             vm_component_bytes=4,
+                             const_component_bytes=3,
+                             total_dispatch_component_bytes=16))
 
   def test_get_module_component_info_unknown_components(self):
     module_file = BytesIO()

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -492,14 +492,10 @@ class CompilationInfo(object):
 
 @dataclass(frozen=True)
 class ModuleComponentSizes(object):
-  # File size in bytes.
-  file_size: int
-  # VM component size in bytes.
-  vm_component_size: int
-  # Const component size in bytes.
-  const_component_size: int
-  # Total dispatch size in bytes.
-  total_dispatch_component_size: int
+  file_bytes: int
+  vm_component_bytes: int
+  const_component_bytes: int
+  total_dispatch_component_bytes: int
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -492,9 +492,13 @@ class CompilationInfo(object):
 
 @dataclass(frozen=True)
 class ModuleComponentSizes(object):
+  # File size in bytes.
   file_size: int
+  # VM component size in bytes.
   vm_component_size: int
+  # Const component size in bytes.
   const_component_size: int
+  # Total dispatch size in bytes.
   total_dispatch_component_size: int
 
   @staticmethod
@@ -508,7 +512,7 @@ class CompilationStatistics(object):
   # Module file and component sizes.
   module_component_sizes: ModuleComponentSizes
   # Module compilation time in ms.
-  compilation_time: int
+  compilation_time_ms: int
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
@@ -517,7 +521,7 @@ class CompilationStatistics(object):
             json_object["compilation_info"]),
         module_component_sizes=ModuleComponentSizes.from_json_object(
             json_object["module_component_sizes"]),
-        compilation_time=json_object["compilation_time"])
+        compilation_time_ms=json_object["compilation_time_ms"])
 
 
 @dataclass(frozen=True)

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -437,13 +437,16 @@ class BenchmarkResults(object):
       - benchmark_index: the benchmark's index.
       - kind: what kind of aggregate time to get; choices:
         'mean', 'median', 'stddev'.
+      Returns:
+        Time in nanoseconds.
       """
     time = None
     for bench_case in self.benchmarks[benchmark_index].results:
       if bench_case["name"].endswith(f"real_time_{kind}"):
         if bench_case["time_unit"] != "ms":
           raise ValueError(f"Expected ms as time unit")
-        time = int(round(bench_case["real_time"]))
+        # Convert into nanoseconds.
+        time = int(round(bench_case["real_time"] * 10**6))
         break
     if time is None:
       raise ValueError(f"Cannot found real_time_{kind} in benchmark results")

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -138,6 +138,7 @@ def get_iree_benchmark_module_arguments(
     repetitions = 10
 
   cmd = [
+      "--time_unit=ns",
       "--benchmark_format=json",
       "--benchmark_out_format=json",
       f"--benchmark_out={results_filename}",
@@ -443,10 +444,9 @@ class BenchmarkResults(object):
     time = None
     for bench_case in self.benchmarks[benchmark_index].results:
       if bench_case["name"].endswith(f"real_time_{kind}"):
-        if bench_case["time_unit"] != "ms":
-          raise ValueError(f"Expected ms as time unit")
-        # Convert into nanoseconds.
-        time = int(round(bench_case["real_time"] * 10**6))
+        if bench_case["time_unit"] != "ns":
+          raise ValueError(f"Expected ns as time unit")
+        time = int(round(bench_case["real_time"]))
         break
     if time is None:
       raise ValueError(f"Cannot found real_time_{kind} in benchmark results")

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -329,7 +329,7 @@ def _categorize_on_single_metric(
     elif similar_threshold.unit.value == metric_unit:
       ratio = abs(current - base)
     else:
-      raise ValueError("Doesn't support mismatch threshold unit yet.")
+      raise ValueError(f"Mismatch between metric unit '{metric_unit}' and threshold unit '{similar_threshold.unit.value}'")
 
     if ratio <= similar_threshold.threshold:
       similar_map[name] = metrics_obj

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -341,7 +341,7 @@ def _categorize_on_single_metric(
   return (regressed_map, improved_map, similar_map, raw_map)
 
 
-def _get_compare_text(current: int, base: Optional[int]) -> str:
+def _get_compare_text(current: float, base: Optional[int]) -> str:
   """Generates the text of comparison between current and base value. Returns
     the current value if the base value is None.
   """

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -351,7 +351,7 @@ def _get_compare_text(current: float, base: Optional[int]) -> str:
 
   ratio = abs(current - base) / base
   direction = "↑" if current > base else ("↓" if current < base else "")
-  return f"{current} (vs. {base}, {ratio:.2%}{direction})"
+  return f"{current:.3f} (vs. {base:.3f}, {ratio:.2%}{direction})"
 
 
 def _sort_benchmarks_and_get_table(benchmarks: Dict[str,
@@ -372,8 +372,8 @@ def _sort_benchmarks_and_get_table(benchmarks: Dict[str,
     str_mean = _get_compare_text(current, base)
     clickable_name = _make_series_link(name)
     sorted_rows.append(
-        (ratio, (clickable_name, str_mean, benchmark.median_time / 1e6,
-                 benchmark.stddev_time / 1e6)))
+        (ratio, (clickable_name, str_mean, f"{benchmark.median_time / 1e6:.3f}",
+                 f"{benchmark.stddev_time / 1e6:.3f}")))
   sorted_rows.sort(key=lambda row: row[0], reverse=True)
 
   return _add_header_and_get_markdown_table(
@@ -412,8 +412,9 @@ def categorize_benchmarks_into_tables(benchmarks: Dict[
     tables.append(_sort_benchmarks_and_get_table(similar, size_cut))
   if raw:
     tables.append(md.header("Raw Latencies", 3))
-    raw_list = [(_make_series_link(k), v.mean_time / 1e6, v.median_time / 1e6,
-                 v.stddev_time / 1e6) for k, v in raw.items()]
+    raw_list = [(_make_series_link(k), f"{v.mean_time / 1e6:.3f}",
+                 f"{v.median_time / 1e6:.3f}", f"{v.stddev_time / 1e6:.3f}")
+                for k, v in raw.items()]
     tables.append(
         _add_header_and_get_markdown_table(BENCHMARK_RESULTS_HEADERS,
                                            raw_list,

--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -12,8 +12,8 @@ from enum import Enum
 
 
 class ThresholdUnit(Enum):
-  PERCENTAGE = 0  # Percentage
-  VALUE_MS = 1  # Absolute value in milliseconds
+  PERCENTAGE = "%"  # Percentage
+  VALUE_MS = "ms"  # Absolute value in milliseconds
 
 
 @dataclass

--- a/build_tools/benchmarks/common/benchmark_thresholds.py
+++ b/build_tools/benchmarks/common/benchmark_thresholds.py
@@ -13,7 +13,7 @@ from enum import Enum
 
 class ThresholdUnit(Enum):
   PERCENTAGE = "%"  # Percentage
-  VALUE_MS = "ms"  # Absolute value in milliseconds
+  VALUE_NS = "ns"  # Absolute value in nanoseconds
 
 
 @dataclass
@@ -64,15 +64,15 @@ BENCHMARK_THRESHOLDS = [
 
     # Fluctuating benchmarks on GPUs.
     BenchmarkThreshold(
-        re.compile(r"^MobileNetV3Small.*full-inference.*GPU-Mali"), 2,
-        ThresholdUnit.VALUE_MS),
+        re.compile(r"^MobileNetV3Small.*full-inference.*GPU-Mali"), 2 * 10**6,
+        ThresholdUnit.VALUE_NS),
 
     # Benchmarks that complete around 10ms on GPUs; using percentage is not
     # suitable anymore.
-    BenchmarkThreshold(re.compile(r"^DeepLabV3.*GPU-Mali"), 1,
-                       ThresholdUnit.VALUE_MS),
-    BenchmarkThreshold(re.compile(r"^MobileNet.*GPU"), 1,
-                       ThresholdUnit.VALUE_MS),
+    BenchmarkThreshold(re.compile(r"^DeepLabV3.*GPU-Mali"), 1 * 10**6,
+                       ThresholdUnit.VALUE_NS),
+    BenchmarkThreshold(re.compile(r"^MobileNet.*GPU"), 1 * 10**6,
+                       ThresholdUnit.VALUE_NS),
 
     # Default threshold for all benchmarks: 5%.
     BenchmarkThreshold(re.compile(r".*"), 5, ThresholdUnit.PERCENTAGE),

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Optional
 
 from common.common_arguments import expand_and_check_file_paths
 from common.benchmark_presentation import COMPILATION_METRICS_TO_TABLE_MAPPERS, collect_all_compilation_metrics
-from common.benchmark_definition import (BenchmarkInfo, BenchmarkResults,
+from common.benchmark_definition import (BenchmarkResults,
                                          execute_cmd_and_get_output)
 from common.benchmark_thresholds import BENCHMARK_THRESHOLDS
 
@@ -253,7 +253,7 @@ def add_new_iree_build(build_id: int,
 
 def add_new_sample(series_id: str,
                    build_id: int,
-                   sample_unit: int,
+                   sample_unit: str,
                    sample_value: int,
                    override: bool = False,
                    dry_run: bool = False,
@@ -372,11 +372,7 @@ def main(args):
     for mapper in COMPILATION_METRICS_TO_TABLE_MAPPERS:
       sample_value, _ = mapper.get_current_and_base_value(compile_metrics)
       series_id = mapper.get_series_name(name)
-
-      if 'compilation-time' in series_id:
-        series_unit = "ms"
-      elif 'total-dispatch-size' in series_id:
-        series_unit = "bytes"
+      series_unit = mapper.get_unit()
 
       # Override by default to allow updates to the series.
       add_new_iree_series(series_id=series_id,
@@ -386,10 +382,9 @@ def main(args):
                           dry_run=args.dry_run,
                           verbose=args.verbose)
       add_new_sample(series_id=series_id,
-                     commit_count=commit_count,
+                     build_id=commit_count,
                      sample_unit=series_unit,
                      sample_value=sample_value,
-                     override=True,
                      dry_run=args.dry_run,
                      verbose=args.verbose)
 

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -111,6 +111,7 @@ def get_git_commit_info(commit: str, verbose: bool = False) -> Dict[str, str]:
 
 def compose_series_payload(project_id: str,
                            series_id: str,
+                           series_unit: str,
                            series_description: bool = None,
                            average_range: str = '5%',
                            average_min_count: int = 3,
@@ -120,6 +121,7 @@ def compose_series_payload(project_id: str,
   payload = {
       'projectId': project_id,
       'serieId': series_id,
+      'serieUnit': series_unit,
       'analyse': {
           'benchmark': {
               'range': average_range,
@@ -155,12 +157,14 @@ def compose_build_payload(project_id: str,
 def compose_sample_payload(project_id: str,
                            series_id: str,
                            build_id: int,
+                           sample_unit: str,
                            sample_value: int,
                            override: bool = False) -> Dict[str, Any]:
   """Composes the payload dictionary for a sample."""
   return {
       'projectId': project_id,
       'serieId': series_id,
+      'sampleUnit': sample_unit,
       'sample': {
           'buildId': build_id,
           'value': sample_value
@@ -199,10 +203,11 @@ def post_to_dashboard(url: str,
   code = response.status_code
   if code != 200:
     raise requests.RequestException(
-        f'Failed to post to dashboard server with status code {code}')
+        f'Failed to post to dashboard server with {code} - {response.text}')
 
 
 def add_new_iree_series(series_id: str,
+                        series_unit: str,
                         series_description: Optional[str] = None,
                         override: bool = False,
                         dry_run: bool = False,
@@ -220,10 +225,11 @@ def add_new_iree_series(series_id: str,
 
   payload = compose_series_payload(IREE_PROJECT_ID,
                                    series_id,
+                                   series_unit,
                                    series_description,
                                    average_range=average_range,
                                    override=override)
-  post_to_dashboard(f'{url}/apis/addSerie',
+  post_to_dashboard(f'{url}/apis/v2/addSerie',
                     payload,
                     dry_run=dry_run,
                     verbose=verbose)
@@ -247,6 +253,7 @@ def add_new_iree_build(build_id: int,
 
 def add_new_sample(series_id: str,
                    build_id: int,
+                   sample_unit: int,
                    sample_value: int,
                    override: bool = False,
                    dry_run: bool = False,
@@ -254,8 +261,8 @@ def add_new_sample(series_id: str,
   """Posts a new sample to the dashboard."""
   url = get_required_env_var('IREE_DASHBOARD_URL')
   payload = compose_sample_payload(IREE_PROJECT_ID, series_id, build_id,
-                                   sample_value, override)
-  post_to_dashboard(f'{url}/apis/addSample',
+                                   sample_unit, sample_value, override)
+  post_to_dashboard(f'{url}/apis/v2/addSample',
                     payload,
                     dry_run=dry_run,
                     verbose=verbose)
@@ -339,14 +346,16 @@ def main(args):
     description += COMMON_DESCRIIPTION
 
     # Override by default to allow updates to the series.
-    add_new_iree_series(series_id,
-                        description,
+    add_new_iree_series(series_id=series_id,
+                        series_unit="ns",
+                        series_description=description,
                         override=True,
                         dry_run=args.dry_run,
                         verbose=args.verbose)
-    add_new_sample(series_id,
-                   commit_count,
-                   sample_value,
+    add_new_sample(series_id=series_id,
+                   build_id=commit_count,
+                   sample_unit="ns",
+                   sample_value=sample_value,
                    dry_run=args.dry_run,
                    verbose=args.verbose)
 
@@ -363,15 +372,24 @@ def main(args):
     for mapper in COMPILATION_METRICS_TO_TABLE_MAPPERS:
       sample_value, _ = mapper.get_current_and_base_value(compile_metrics)
       series_id = mapper.get_series_name(name)
+
+      if 'compilation-time' in series_id:
+        series_unit = "ms"
+      elif 'total-dispatch-size' in series_id:
+        series_unit = "bytes"
+
       # Override by default to allow updates to the series.
-      add_new_iree_series(series_id,
-                          description,
+      add_new_iree_series(series_id=series_id,
+                          series_unit=series_unit,
+                          series_description=description,
                           override=True,
                           dry_run=args.dry_run,
                           verbose=args.verbose)
-      add_new_sample(series_id,
-                     commit_count,
-                     sample_value,
+      add_new_sample(series_id=series_id,
+                     commit_count=commit_count,
+                     sample_unit=series_unit,
+                     sample_value=sample_value,
+                     override=True,
                      dry_run=args.dry_run,
                      verbose=args.verbose)
 


### PR DESCRIPTION
The x86 and CUDA benchmarks need sub-milliseconds data to show the improvements/regressions.
This change uploads the latencies in nanoseconds to the dashboard with the new API.

It still shows milliseconds (wtih 3 digits) in the summary report.

Fix https://github.com/iree-org/iree/issues/9418