### PR TITLE
Force CMAKE_CXX_STANDARD to 17 to override LLVM's mechanism.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 project(IREE ASM C CXX)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
+# LLVM defines this as a CACHE property and uses a policy that causes the
+# cache value to take precedence. This is causing us to mix 17/14 across
+# the boundary.
+# TODO: Remove this once the LLVM mechanism is updated. See:
+#   https://discourse.llvm.org/t/important-new-toolchain-requirements-to-build-llvm-will-most-likely-be-landing-within-a-week-prepare-your-buildbots/61447/9
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to" FORCE)
 set(IREE_IDE_FOLDER IREE)
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
This should work around a GCC bug that is causing multiple definition
errors when standards mismatch.