### PR TITLE
Format our yaml files

### DIFF
--- a/.github/workflows/advance_upstream_forks.yml
+++ b/.github/workflows/advance_upstream_forks.yml
@@ -9,7 +9,7 @@ name: Advance Upstream Forks
 on:
   schedule:
     # Every hour
-    - cron: '0 * * * *'
+    - cron: "0 * * * *"
 
   workflow_dispatch:
 
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: iree-org/iree-llvm-fork
@@ -32,7 +32,7 @@ jobs:
           git remote add upstream https://github.com/llvm/llvm-project.git
           git pull --ff-only upstream main
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: main
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: iree-org/iree-mhlo-fork
@@ -56,7 +56,7 @@ jobs:
           git remote add upstream https://github.com/tensorflow/mlir-hlo.git
           git pull --ff-only upstream master
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: master
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           repository: iree-org/iree-tf-fork
@@ -80,7 +80,7 @@ jobs:
           git remote add upstream https://github.com/tensorflow/tensorflow.git
           git pull --ff-only upstream master
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: master

--- a/.github/workflows/android_tflite_oneshot_build.yml
+++ b/.github/workflows/android_tflite_oneshot_build.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       ANDROID_CONTAINER: "gcr.io/iree-oss/gradle-android@sha256:5da3d6281618ac840a00e667afd97b4484d97d676c0a0d75fa74c84e392084a9"
     steps:
-      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: Execute Android Build
@@ -21,7 +21,7 @@ jobs:
           -v $PWD:/work \
           "${ANDROID_CONTAINER}" \
           bash -c build_tools/gradle/build_tflite_android_library.sh
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2  # v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           path: ./runtime/bindings/tflite/java/build/outputs/aar/*.aar
           retention-days: 1

--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -11,19 +11,19 @@ on:
   workflow_dispatch:
     inputs:
       package_suffix:
-        description: 'Suffix to append to package names'
+        description: "Suffix to append to package names"
         required: false
-        default: ''
+        default: ""
       package_version:
-        description: 'Version of the package'
+        description: "Version of the package"
         required: true
-        default: '0.1a1'
+        default: "0.1a1"
       release_id:
-        description: 'Release id to upload artifacts to'
-        default: ''
+        description: "Release id to upload artifacts to"
+        default: ""
       commit:
-        description: 'Commit to check out'
-        default: ''
+        description: "Commit to check out"
+        default: ""
 
 jobs:
   build_core:
@@ -65,9 +65,9 @@ jobs:
       MANYLINUX_X86_64_IMAGE: gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:2c6a9120a5f96bcf3b1dda4086d807682705b51fb9c6ee5b48a8756c436220bc
 
     steps:
-      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
-          path: 'main_checkout'
+          path: "main_checkout"
           submodules: true
           ref: ${{ github.event.inputs.commit }}
 
@@ -79,7 +79,6 @@ jobs:
         shell: bash
         run: |
           sudo ./main_checkout/build_tools/python_deploy/install_macos_deps.sh
-
 
       ##########################################################################
       # Write version_info.json
@@ -177,7 +176,7 @@ jobs:
             "${MANYLINUX_X86_64_IMAGE}" \
             bash -c 'export PATH=/opt/python/cp39-cp39/bin:$PATH; python ./main_checkout/build_tools/github_actions/build_dist.py py-tf-compiler-tools-pkg'
 
-      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2  # v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2
         with:
           # We upload all wheels (which includes deps so that subsequent
           # steps can run without further fetching).
@@ -188,7 +187,7 @@ jobs:
       - name: Upload Release Assets
         if: github.event.inputs.release_id != ''
         id: upload-release-assets
-        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148  # v1
+        uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
@@ -202,7 +201,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: "Invoke workflow :: Validate and Publish Release"
-        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7  # v1
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1
         with:
           workflow: Validate and Publish Release
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       build-dir: ${{ env.BUILD_DIR }}
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: "Building runtime"
@@ -65,7 +65,7 @@ jobs:
       # do our own.
       - name: "Create build dir archive"
         run: tar -cf ${BUILD_DIR}.tar ${BUILD_DIR}
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: "${{ env.BUILD_DIR }}.tar"
           path: "${{ env.BUILD_DIR }}.tar"
@@ -77,11 +77,11 @@ jobs:
       BUILD_DIR: ${{ needs.build_runtime.outputs.build-dir }}
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: "Downloading runtime build directory"
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
         with:
           name: "${{ env.BUILD_DIR }}.tar"
       - name: "Extracting archive"
@@ -111,7 +111,7 @@ jobs:
       gcs-artifact: ${{ steps.upload.outputs.gcs-artifact }}
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: "Building IREE"
@@ -159,7 +159,7 @@ jobs:
       GCS_ARTIFACT: ${{ needs.build_all.outputs.gcs-artifact }}
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: "Downloading build dir archive"
@@ -189,7 +189,7 @@ jobs:
       GCS_ARTIFACT: ${{ needs.build_all.outputs.gcs-artifact }}
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: Querying GPU information
@@ -221,7 +221,7 @@ jobs:
       - os-family=Linux
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: "Building and testing with ThreadSanitizer"
@@ -251,11 +251,11 @@ jobs:
       HOST_BINARY_ARCHIVE: ${{ needs.host_tools_assertions.outputs.host-binary-root }}.tar
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: "Downloading host tools"
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741  # v3.0.0
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # v3.0.0
         with:
           name: "${{ env.HOST_BINARY_ARCHIVE }}"
       - name: "Extracting host tools archive"

--- a/.github/workflows/host_tools.yml
+++ b/.github/workflows/host_tools.yml
@@ -12,7 +12,7 @@ on:
         type: string
       enable-assertions:
         required: false
-        type: string  # Thanks CMake and Bash for not having proper booleans
+        type: string # Thanks CMake and Bash for not having proper booleans
         default: "OFF"
     outputs:
       host-binary-root:
@@ -50,7 +50,7 @@ jobs:
       host-binary-root: ${{ inputs.host-binary-root }}
     steps:
       - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
       - name: "Building host tools"
@@ -65,7 +65,7 @@ jobs:
       # do our own.
       - name: "Creating host tools archive"
         run: tar -cvf "${HOST_BINARY_ARCHIVE}" "${HOST_BINARY_ROOT}"
-      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8  # v3.1.0
+      - uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: "${{ env.HOST_BINARY_ARCHIVE }}"
           path: "${{ env.HOST_BINARY_ARCHIVE }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
       - name: Running bazel_to_cmake for IREE core
         run: ./build_tools/bazel_to_cmake/bazel_to_cmake.py --verbosity=2
       - name: Running bazel_to_cmake for IREE TF Integration Tests
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -53,9 +53,9 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
       - name: Setting up python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -76,12 +76,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
       - name: Setting up python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # v2
         with:
           # Pytype does not support python3.9, which this action defaults to.
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -98,7 +98,7 @@ jobs:
           wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format -O /tmp/git-clang-format
           chmod +x /tmp/git-clang-format
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"
@@ -122,7 +122,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
       - name: Fetching Base Branch
         # We have to explicitly fetch the base branch as well
         run: git fetch --no-tags --prune --depth=1 origin "${GITHUB_BASE_REF?}:${GITHUB_BASE_REF?}"

--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
 
@@ -26,7 +26,7 @@ jobs:
           git tag "${tag_name}"
 
       - name: Pushing changes
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref_name }}
@@ -34,7 +34,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
@@ -46,7 +46,7 @@ jobs:
           prerelease: true
 
       - name: "Invoke workflow :: Build Native Release Packages"
-        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7  # v1
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1
         with:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -11,7 +11,7 @@ jobs:
     name: Adding issue to the IREE GitHub project
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/add-to-project@7a0820f97673dfefc999713a9a6d6b7ee128bba5  # v0.0.3
+      - uses: actions/add-to-project@7a0820f97673dfefc999713a9a6d6b7ee128bba5 # v0.0.3
         with:
           project-url: https://github.com/orgs/iree-org/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -24,14 +24,14 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
       - name: Fetching base gh-pages branch
         # We have to explicitly fetch the gh-pages branch as well to preserve history
         run: git fetch --no-tags --prune --depth=1 origin "gh-pages:gh-pages"
       - name: Setting up Python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # v2
         with:
           python-version: 3.x
       - name: Installing Material for MkDocs

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -2,7 +2,7 @@ name: Schedule candidate release
 
 on:
   schedule:
-    - cron: '0 10 * * *'
+    - cron: "0 10 * * *"
 
   workflow_dispatch:
 
@@ -20,7 +20,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           ref: ${{ steps.last_green_commit.outputs.result }}
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
@@ -54,7 +54,7 @@ jobs:
           prerelease: true
 
       - name: "Invoke workflow :: Build Native Release Packages"
-        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7  # v1
+        uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1
         with:
           workflow: Build Native Release Packages
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -6,13 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       release_id:
-        description: 'Release id to publish'
+        description: "Release id to publish"
         required: true
       package_version:
-        description: 'Version of the package'
+        description: "Version of the package"
         required: true
       build_run_id:
-        description: 'Run ID for the build_package.yml workflow that triggered this workflow'
+        description: "Run ID for the build_package.yml workflow that triggered this workflow"
         required: true
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
     steps:
       - name: Download packages
         id: download_packages
-        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39  # v2
+        uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39 # v2
         with:
           github_token: ${{secrets.WRITE_ACCESS_TOKEN}}
           workflow: build_package.yml
@@ -35,9 +35,9 @@ jobs:
           ls -R
       - name: Set up python
         id: set_up_python
-        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a  # v2
+        uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # v2
         with:
-          python-version: '3.8'
+          python-version: "3.8"
       - name: Install python packages
         id: install_python_packages
         run: |
@@ -77,14 +77,14 @@ jobs:
     steps:
       - name: Publish Release
         id: publish_release
-        uses: eregon/publish-release@d6aee8c288e653387d895ee64d559fc0dd63339d  # v1.0.3
+        uses: eregon/publish-release@d6aee8c288e653387d895ee64d559fc0dd63339d # v1.0.3
         env:
           GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
         with:
           release_id: ${{ github.event.inputs.release_id }}
 
       - name: Checking out repository
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e  # v2
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           # Get all history. Otherwise the latest-snapshot branch can't be
@@ -92,7 +92,7 @@ jobs:
           fetch-depth: 0
 
       - name: Updating latest-snapshot branch
-        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
         with:
           github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
           branch: latest-snapshot

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -16,6 +16,9 @@ rules:
   truthy: disable
   # We have lots of long strings and command lines.
   line-length: disable
+  comments:
+    # Formatters may do this (e.g. Prettier does) and it seems like the most
+    # trivial thing to get a failing check for.
+    min-spaces-from-content: 1
 
-ignore:
-  /third_party/*
+ignore: /third_party/*

--- a/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/pipeline.yml
@@ -42,7 +42,7 @@ steps:
       - "find build-android/ -name '*.cmake' -exec sed -i \"s!\\$IREE_DOCKER_WORKDIR/!\\$PWD/!g\" {} \\;"
       # Pixel 4 ships an old Adreno GPU driver. There are quite a few bugs triggered by our tests.
       # Disable running tests entirely on Pixel 4. Moto Edge X30 gets us covered on Adreno GPU.
-      - "ctest -j 4 --test-dir build-android/ --timeout 900 --output-on-failure --no-tests=error --label-exclude \"vulkan\""
+      - 'ctest -j 4 --test-dir build-android/ --timeout 900 --output-on-failure --no-tests=error --label-exclude "vulkan"'
     agents:
       - "android-soc=snapdragon-855"
       - "queue=test-android"

--- a/build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
+++ b/build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
@@ -27,8 +27,8 @@ steps:
     env:
       MUST_BOOTSTRAP: "false"
     commands: |
-        buildkite-agent pipeline upload --replace \
-          build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
+      buildkite-agent pipeline upload --replace \
+        build_tools/buildkite/pipelines/fragment/bootstrap-trusted.yml
 
   - wait
 
@@ -39,8 +39,8 @@ steps:
     env:
       CONFIG_FETCH_REF: ${BUILDKITE_COMMIT}
     commands: |
-        buildkite-agent pipeline upload \
-          build_tools/buildkite/pipelines/trusted/${BUILDKITE_PIPELINE_SLUG}.yml
+      buildkite-agent pipeline upload \
+        build_tools/buildkite/pipelines/trusted/${BUILDKITE_PIPELINE_SLUG}.yml
 
   # If we're coming from a fork, pipelines will be checked out from the main
   # branch
@@ -55,5 +55,5 @@ steps:
     env:
       CONFIG_FETCH_REF: "main"
     commands: |
-        buildkite-agent pipeline upload \
-          build_tools/buildkite/pipelines/trusted/${BUILDKITE_PIPELINE_SLUG}.yml
+      buildkite-agent pipeline upload \
+        build_tools/buildkite/pipelines/trusted/${BUILDKITE_PIPELINE_SLUG}.yml

--- a/build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
+++ b/build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
@@ -10,7 +10,6 @@ agents:
   queue: "orchestration"
   security: "untrusted"
 
-
 steps:
   # Bootstrap the checked-in bootstrap pipeline. This replaces the rest of the
   # steps (which are waiting on this one).
@@ -25,12 +24,12 @@ steps:
     env:
       MUST_BOOTSTRAP: "false"
     commands: |
-        buildkite-agent pipeline upload --replace \
-          build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
+      buildkite-agent pipeline upload --replace \
+        build_tools/buildkite/pipelines/fragment/bootstrap-untrusted.yml
 
   - wait
 
   - label: ":pipeline: Uploading pipeline from '${BUILDKITE_COMMIT:0:7}'"
     commands: |
-        buildkite-agent pipeline upload \
-          build_tools/buildkite/pipelines/untrusted/${BUILDKITE_PIPELINE_SLUG}.yml
+      buildkite-agent pipeline upload \
+        build_tools/buildkite/pipelines/untrusted/${BUILDKITE_PIPELINE_SLUG}.yml

--- a/build_tools/buildkite/pipelines/untrusted/test-runtime-cmake.yml
+++ b/build_tools/buildkite/pipelines/untrusted/test-runtime-cmake.yml
@@ -19,7 +19,6 @@ steps:
         "build-runtime-cmake-build-id" \
         "$(cat build.json | python3 -c "import json,sys;print(json.load(sys.stdin)['id'])")"
 
-
   # TODO: better emoji here
   - label: ":hammer_and_wrench: Test the runtime only"
     agents:

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -10,10 +10,10 @@ theme:
   custom_dir: overrides
 
   features:
-    - navigation.instant  # Faster loading
+    - navigation.instant # Faster loading
 
     # TODO(scotttodd): join mkdocs-material insiders for this
-    - navigation.tracking  # Update URL in address bar with the active anchor
+    - navigation.tracking # Update URL in address bar with the active anchor
 
     # TODO(scotttodd): decide if we want this
     #     these move sections from the left nav to tabs below the header
@@ -21,11 +21,11 @@ theme:
     # - navigation.tabs.sticky  # insiders only
 
     # TODO(scotttodd): remove this if the number of pages grows too much
-    - navigation.sections  # Group sections without collapsible buttons
+    - navigation.sections # Group sections without collapsible buttons
 
-    - navigation.top  # Back to top button
+    - navigation.top # Back to top button
 
-    - navigation.indexes  # section names can link to index.md pages
+    - navigation.indexes # section names can link to index.md pages
 
   palette:
     # Light mode
@@ -47,7 +47,7 @@ theme:
 
 repo_url: https://github.com/iree-org/iree
 repo_name: iree-org/iree
-edit_uri: ""  # Omit edit button (linking to GitHub) from each document
+edit_uri: "" # Omit edit button (linking to GitHub) from each document
 
 extra:
   social:
@@ -60,7 +60,7 @@ extra:
     - icon: fontawesome/solid/users
       link: https://groups.google.com/forum/#!forum/iree-discuss
       name: IREE Discuss Google Group
-  generator: false  # TODO(scotttodd): join mkdocs-material insiders for this
+  generator: false # TODO(scotttodd): join mkdocs-material insiders for this
 
 extra_css:
   - assets/stylesheets/extra.css
@@ -87,44 +87,44 @@ markdown_extensions:
       custom_checkbox: true
   - tables
   - toc:
-      permalink: true  # TODO(scotttodd): icon: https://fonts.google.com/icons?selected=Material+Icons+Outlined:link
+      permalink: true # TODO(scotttodd): icon: https://fonts.google.com/icons?selected=Material+Icons+Outlined:link
 
 # Navigation with explicit ordering and nesting.
 # https://www.mkdocs.org/user-guide/configuration/#nav
 # Note: may include external links and titles are optional for internal links
 nav:
-  - Home: 'index.md'
-  - 'Getting Started':
-      - 'getting-started/index.md'
-      - TensorFlow: 'getting-started/tensorflow.md'
-      - TensorFlow Lite: 'getting-started/tflite.md'
-      - JAX: 'getting-started/jax.md'
-  - 'Deployment configurations':
-      - 'deployment-configurations/index.md'
-      - CPU: 'deployment-configurations/cpu.md'
-      - CPU - Bare-Metal: 'deployment-configurations/bare-metal.md'
-      - GPU - Vulkan: 'deployment-configurations/gpu-vulkan.md'
-      - GPU - CUDA/ROCm: 'deployment-configurations/gpu-cuda-rocm.md'
-  - 'Building from source':
-      - 'building-from-source/index.md'
-      - 'building-from-source/getting-started.md'
-      - 'building-from-source/python-bindings-and-importers.md'
-      - 'building-from-source/android.md'
-      - 'building-from-source/riscv.md'
-  - 'Bindings':
-      - 'bindings/index.md'
-      - C API: 'bindings/c-api.md'
-      - Python: 'bindings/python.md'
-      - TensorFlow Lite: 'bindings/tensorflow-lite.md'
-  - 'Extensions':
-      - 'extensions/index.md'
-  - 'Blog':
-      - 'blog/index.md'
-      - CUDA backend: 'blog/2021-10-15-cuda-backend.md'
-      - Work in progress on Matrix Multiplication on CPU: 'blog/2021-10-13-mmt4d.md'
-      - TFLite Support via TOSA: 'blog/2021-07-19-tflite-tosa.md'
-  - 'Reference':
-      - Glossary: 'reference/glossary.md'
-      - Optimization Options: 'reference/optimization-options.md'
-  - 'Community':
-      - 'community/index.md'
+  - Home: "index.md"
+  - "Getting Started":
+      - "getting-started/index.md"
+      - TensorFlow: "getting-started/tensorflow.md"
+      - TensorFlow Lite: "getting-started/tflite.md"
+      - JAX: "getting-started/jax.md"
+  - "Deployment configurations":
+      - "deployment-configurations/index.md"
+      - CPU: "deployment-configurations/cpu.md"
+      - CPU - Bare-Metal: "deployment-configurations/bare-metal.md"
+      - GPU - Vulkan: "deployment-configurations/gpu-vulkan.md"
+      - GPU - CUDA/ROCm: "deployment-configurations/gpu-cuda-rocm.md"
+  - "Building from source":
+      - "building-from-source/index.md"
+      - "building-from-source/getting-started.md"
+      - "building-from-source/python-bindings-and-importers.md"
+      - "building-from-source/android.md"
+      - "building-from-source/riscv.md"
+  - "Bindings":
+      - "bindings/index.md"
+      - C API: "bindings/c-api.md"
+      - Python: "bindings/python.md"
+      - TensorFlow Lite: "bindings/tensorflow-lite.md"
+  - "Extensions":
+      - "extensions/index.md"
+  - "Blog":
+      - "blog/index.md"
+      - CUDA backend: "blog/2021-10-15-cuda-backend.md"
+      - Work in progress on Matrix Multiplication on CPU: "blog/2021-10-13-mmt4d.md"
+      - TFLite Support via TOSA: "blog/2021-07-19-tflite-tosa.md"
+  - "Reference":
+      - Glossary: "reference/glossary.md"
+      - Optimization Options: "reference/optimization-options.md"
+  - "Community":
+      - "community/index.md"


### PR DESCRIPTION
This formats all our yaml files with [Prettier](https://prettier.io/).
I don't think this is a really important property, but the RedHat YAML
language server, which appears to back the only YAML VSCode extension
uses this formatter and I'm really tired of getting random edits from
running the formatter. In particular, yamllint wants there to be two
spaces between code and a comment and Prettier adds only one. This is
extremely annoying and I cannot imagine why anyone would care whether
there are one or two spaces there (other than the Google Python style
guide and linter). So I've updated our yamllint config to also stop
complaining about this trivial thing.

I don't propose that we start mandating Prettier now (though we might
consider it at some point), but this formatting does increase the
consistency in our YAML files (in particular, with which types of
quotes we use).