### PR TITLE
Fix UB in iree_string_view_append_to_buffer

### DIFF
--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -272,7 +272,12 @@ IREE_API_EXPORT bool iree_string_view_match_pattern(
 IREE_API_EXPORT iree_host_size_t iree_string_view_append_to_buffer(
     iree_string_view_t source_value, iree_string_view_t* target_value,
     char* buffer) {
-  memcpy(buffer, source_value.data, source_value.size);
+  // Do not copy zero-sized values to avoid passing NULLs to memcpy. The source
+  // and destination pointers are required to be valid and non-NULL by the C
+  // standard.
+  if (source_value.size > 0) {
+    memcpy(buffer, source_value.data, source_value.size);
+  }
   target_value->data = buffer;
   target_value->size = source_value.size;
   return source_value.size;

--- a/runtime/src/iree/base/string_view_test.cc
+++ b/runtime/src/iree/base/string_view_test.cc
@@ -369,6 +369,42 @@ TEST(StringViewTest, ReplaceChar) {
   EXPECT_EQ(replace_char("axbxc", 'x', 'y'), "aybyc");
 }
 
+TEST(StringViewTest, AppendToBuffer) {
+  char buffer[6] = {0, 1, 2, 3, 4, 5};
+  iree_string_view_t source = iree_make_cstring_view("test");
+  iree_string_view_t target = {};
+  const iree_host_size_t size =
+      iree_string_view_append_to_buffer(source, &target, buffer);
+  EXPECT_EQ(size, source.size);
+  EXPECT_EQ(target.size, source.size);
+  EXPECT_EQ(target.data, buffer);
+  // Make sure we did not write past the source size.
+  EXPECT_THAT(buffer, ElementsAre('t', 'e', 's', 't', 4, 5));
+}
+
+TEST(StringViewTest, AppendToBufferEmptySource) {
+  char buffer[4] = {0, 1, 2, 3};
+  iree_string_view_t source = iree_make_string_view(nullptr, 0);
+  iree_string_view_t target = {};
+  const iree_host_size_t size =
+      iree_string_view_append_to_buffer(source, &target, buffer);
+  EXPECT_EQ(size, 0u);
+  EXPECT_EQ(target.size, 0u);
+  EXPECT_EQ(target.data, buffer);
+  // Make sure we did not write to the buffer.
+  EXPECT_THAT(buffer, ElementsAre(0, 1, 2, 3));
+}
+
+TEST(StringViewTest, AppendToBufferEmptySourceAndBuffer) {
+  iree_string_view_t source = iree_make_string_view(nullptr, 0);
+  iree_string_view_t target = {};
+  const iree_host_size_t size =
+      iree_string_view_append_to_buffer(source, &target, nullptr);
+  EXPECT_EQ(size, 0u);
+  EXPECT_EQ(target.size, 0u);
+  EXPECT_EQ(target.data, nullptr);
+}
+
 template <size_t N>
 static iree::StatusOr<std::array<uint8_t, N>> ParseHex(const char* value) {
   std::array<uint8_t, N> buffer;


### PR DESCRIPTION
Do not pass null pointers to memcpy. Found with `-DIREE_ENABLE_UBSAN=1`.