### PR TITLE
Add ConvertRegionToWorkgroups pass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -288,6 +288,11 @@ LogicalResult DispatchRegionOp::verify() {
       return term->emitOpError()
              << "operand types do not match with parent results";
 
+  // Make sure that all returned values are ranked tensors.
+  for (Type t : getResultTypes())
+    if (!t.isa<RankedTensorType>())
+      return emitOpError() << "only ranked tensor results are allowed";
+
   return success();
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -14,17 +14,17 @@ include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
 def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreach_thread_to_flow",
-    [FunctionalStyleTransformOpTrait, 
+    [FunctionalStyleTransformOpTrait,
      MemoryEffectsOpInterface,
      TransformOpInterface,
      TransformEachOpTrait]> {
   let description = [{
     Rewrite an scf.foreach_thread to Flow::DispatchWorkgroups.
-    
-    
+
+
     Return modes:
     =============
-    This operation ignores non-scf::ForeachThread ops and drops them in the 
+    This operation ignores non-scf::ForeachThread ops and drops them in the
     return.
 
     If any rewrite fails, the transform definitely fails.
@@ -32,7 +32,7 @@ def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreac
     If all the operations referred to by the `target` PDLOperation generalize
     properly, the transform succeeds. Otherwise the transform silently fails.
 
-    The return handle points to only the subset of successfully produced 
+    The return handle points to only the subset of successfully produced
     equivalent flow::DispatchWorkgroups operations, which can be empty.
   }];
 
@@ -43,10 +43,10 @@ def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreac
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
-        ::mlir::scf::ForeachThreadOp target, 
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::scf::ForeachThreadOp target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
         ::mlir::transform::TransformState &state);
   }];
 }
- 
+
 #endif // IREE_COMPILER_DIALECT_FLOW_TRANSFORMEXTENSIONS_FLOWEXTENSIONS

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
         "ConvertConv2D1x1ToMatmul.cpp",
         "ConvertConv2DToImg2Col.cpp",
         "ConvertLinalgMatmulToMmt4D.cpp",
+        "ConvertRegionToWorkgroups.cpp",
         "DeduplicateExecutables.cpp",
         "DetachElementwiseFromNamedOps.cpp",
         "DispatchLinalgOnTensors.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     "ConvertConv2D1x1ToMatmul.cpp"
     "ConvertConv2DToImg2Col.cpp"
     "ConvertLinalgMatmulToMmt4D.cpp"
+    "ConvertRegionToWorkgroups.cpp"
     "DeduplicateExecutables.cpp"
     "DetachElementwiseFromNamedOps.cpp"
     "DispatchLinalgOnTensors.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -1,0 +1,233 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/BlockAndValueMapping.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/RegionUtils.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+
+/// Compute the dynamic dims of the given value and add them to the vector.
+static void appendDynamicDims(OpBuilder &b, Location loc,
+                              SmallVector<Value> &argumentDims, Value tensor) {
+  auto tensorType = tensor.getType().cast<RankedTensorType>();
+
+  // Fast-path for if the value comes from ops that support our dynamic
+  // shape interfaces. Otherwise we have to insert tensor.dim ops.
+  auto availableDims = IREE::Util::findDynamicDims(tensor);
+  if (availableDims.hasValue()) {
+    argumentDims.append(availableDims->begin(), availableDims->end());
+    assert(tensorType.getNumDynamicDims() == availableDims->size() &&
+           "not enough dynamic dims found");
+    return;
+  }
+
+  for (auto dim : llvm::enumerate(tensorType.getShape())) {
+    if (dim.value() != ShapedType::kDynamicSize) continue;
+    argumentDims.push_back(
+        b.createOrFold<tensor::DimOp>(loc, tensor, dim.index()));
+  }
+}
+
+/// Follow the reverse SSA use-def chain of the given value (always taking the
+/// tied operand) and return the first value outside of `regionOp`.
+static Optional<Value> findFirstTiedValueOutsideOfRegionOp(
+    Flow::DispatchRegionOp regionOp, Value value) {
+  // Check if `v` is defined outside of `regionOp`.
+  auto isOutside = [&](Value v) {
+    if (v.isa<OpResult>()) return !regionOp->isAncestor(v.getDefiningOp());
+    assert(v.isa<BlockArgument>() && "expected bbArg");
+    // DispatchRegionOp does not have block arguments.
+    return true;
+  };
+
+  while (!isOutside(value)) {
+    auto tiedOpInterface = value.getDefiningOp<IREE::Util::TiedOpInterface>();
+    if (!tiedOpInterface)
+      // Reached an op that does not implement the interface.
+      return llvm::None;
+    value = tiedOpInterface.getTiedResultOperand(value);
+    if (!value)
+      // Nothing is tied here.
+      return llvm::None;
+  }
+
+  return value;
+}
+
+/// Rewrite the DispatchRegionOp into a DispatchWorkgroupsOp. The
+/// DispatchRegionOp is not isolated from above and may capture any SSA value
+/// that is in scope. The generated DispatchWorkgroupsOp captures all SSA values
+/// explicitly and makes them available inside the region via block arguments.
+static FailureOr<Flow::DispatchWorkgroupsOp>
+rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
+    Flow::DispatchRegionOp regionOp, RewriterBase &rewriter) {
+  // Only ops with a single block are supported.
+  Region &region = regionOp.getBody();
+  if (!region.hasOneBlock()) return failure();
+  Block &body = region.front();
+  auto terminator = cast<Flow::ReturnOp>(body.getTerminator());
+  unsigned numResults = terminator->getNumOperands();
+
+  // Prepare rewriter.
+  OpBuilder::InsertionGuard guard(rewriter);
+  Location loc = regionOp.getLoc();
+  rewriter.setInsertionPoint(regionOp);
+
+  // Compute arguments of the dispatch region.
+  llvm::SetVector<Value> argumentsSet;
+  mlir::getUsedValuesDefinedAbove(region, argumentsSet);
+  // Unranked tensors are not supported.
+  assert(!llvm::any_of(argumentsSet, [](Value v) {
+    return v.getType().isa<UnrankedTensorType>();
+  }) && "unranked tensors are not supported");
+
+  // Compute dimensions of tensor args.
+  SmallVector<Value> argumentDims;
+  for (Value tensor : argumentsSet) {
+    auto tensorType = tensor.getType().dyn_cast<RankedTensorType>();
+    if (!tensorType) continue;
+    appendDynamicDims(rewriter, loc, argumentDims, tensor);
+  }
+
+  // Find tied results.
+  DenseSet<Value> tiedArgumentsSet;
+  SmallVector<int64_t> tiedArguments(numResults,
+                                     IREE::Util::TiedOpInterface::kUntiedIndex);
+  for (const auto &it : llvm::enumerate(terminator->getOperands())) {
+    auto tiedArgument =
+        findFirstTiedValueOutsideOfRegionOp(regionOp, it.value());
+    if (!tiedArgument.hasValue()) continue;
+    assert(argumentsSet.contains(*tiedArgument) &&
+           "expected that tiedArgument is already an argument");
+    // Do not tie an argument to multiple results.
+    if (tiedArgumentsSet.contains(*tiedArgument)) continue;
+    tiedArgumentsSet.insert(*tiedArgument);
+    tiedArguments[it.index()] = std::distance(
+        argumentsSet.begin(), llvm::find(argumentsSet, *tiedArgument));
+  }
+
+  // Create empty dispatch region.
+  SmallVector<Value> arguments(argumentsSet.begin(), argumentsSet.end());
+  arguments.append(argumentDims);
+  for (unsigned i = 0; i < numResults; ++i) {
+    // Tied arguments already have their dynamic result dims in `arguments`. Do
+    // not add them again.
+    if (tiedArguments[i] == IREE::Util::TiedOpInterface::kUntiedIndex) {
+      ValueRange dims = regionOp.getResultDynamicDims(i);
+      arguments.append(dims.begin(), dims.end());
+    }
+  }
+  auto workgroupsOp = rewriter.create<IREE::Flow::DispatchWorkgroupsOp>(
+      loc, /*workload=*/ValueRange(), regionOp.getResultTypes(),
+      regionOp.getResultDims(), arguments, argumentDims, tiedArguments);
+  BlockAndValueMapping bvm;
+  bvm.map(arguments, workgroupsOp.getInputBlockArguments());
+
+  // Create DispatchTensorLoadOp for all tensor arguments.
+  assert(workgroupsOp.getWorkgroupBody().hasOneBlock() &&
+         "expected one block after constructor");
+  Block &newBody = workgroupsOp.getWorkgroupBody().getBlocks().front();
+  assert(newBody.empty() && "expected empty block after constructor");
+  rewriter.setInsertionPointToStart(&newBody);
+  for (const auto &it : llvm::enumerate(arguments)) {
+    auto tensorType = it.value().getType().dyn_cast<RankedTensorType>();
+    if (!tensorType) continue;
+    auto inputBbArg = workgroupsOp.getInputBlockArgument(it.index());
+    auto dims =
+        Util::findVariadicDynamicDims(it.index(), arguments, argumentDims);
+    assert(dims.size() == tensorType.getNumDynamicDims() &&
+           "dynamic dims not found among arguments");
+    SmallVector<Value> bbArgDims = llvm::to_vector(
+        llvm::map_range(dims, [&](Value v) { return bvm.lookup(v); }));
+    Value loadedTensor = rewriter.create<IREE::Flow::DispatchTensorLoadOp>(
+        loc, tensorType, inputBbArg, bbArgDims);
+    bvm.map(it.value(), loadedTensor);
+  }
+
+  // Move regionOp body into the workgroupsOp.
+  newBody.getOperations().splice(newBody.end(), body.getOperations());
+  for (Value argument : arguments) {
+    argument.replaceUsesWithIf(bvm.lookup(argument), [&](OpOperand &operand) {
+      return workgroupsOp->isProperAncestor(operand.getOwner());
+    });
+  }
+
+  // Update terminator.
+  rewriter.setInsertionPoint(terminator);
+  for (const auto &it : llvm::enumerate(terminator->getOperands())) {
+    auto outputBbArg = workgroupsOp.getOutputBlockArgument(it.index());
+    ValueRange dims;
+    if (tiedArguments[it.index()] ==
+        IREE::Util::TiedOpInterface::kUntiedIndex) {
+      dims = regionOp.getResultDynamicDims(it.index());
+    } else {
+      // This assumes that the number of dynamic dims does not change when
+      // following an SSA use-def chain of tied values.
+      dims = Util::findVariadicDynamicDims(tiedArguments[it.index()], arguments,
+                                           argumentDims);
+    }
+#ifndef NDEBUG
+    auto tensorType = it.value().getType().cast<RankedTensorType>();
+    assert(dims.size() == tensorType.getNumDynamicDims() &&
+           "mismatching number of dynamic dims");
+#endif  // NDEBUG
+    SmallVector<Value> bbArgDims = llvm::to_vector(
+        llvm::map_range(dims, [&](Value v) { return bvm.lookup(v); }));
+    rewriter.create<IREE::Flow::DispatchTensorStoreOp>(loc, it.value(),
+                                                       outputBbArg, bbArgDims);
+  }
+
+  // Delete the old terminator and create a new one.
+  rewriter.create<IREE::Flow::ReturnOp>(loc);
+  rewriter.eraseOp(terminator);
+
+  rewriter.replaceOp(regionOp, workgroupsOp.getResults());
+  return workgroupsOp;
+}
+
+struct ConvertRegionToWorkgroupsPass
+    : public ConvertRegionToWorkgroupsBase<ConvertRegionToWorkgroupsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<Flow::FlowDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    SmallVector<Flow::DispatchRegionOp> ops;
+    getOperation()->walk([&](Flow::DispatchRegionOp op) { ops.push_back(op); });
+
+    IRRewriter rewriter(getOperation()->getContext());
+    for (Flow::DispatchRegionOp regionOp : ops) {
+      if (failed(rewriteFlowDispatchRegionToFlowDispatchWorkgroups(regionOp,
+                                                                   rewriter))) {
+        signalPassFailure();
+        return;
+      }
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<Pass> createConvertRegionToWorkgroupsPass() {
+  return std::make_unique<ConvertRegionToWorkgroupsPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -79,6 +79,9 @@ std::unique_ptr<Pass> createConvertConv2D1x1ToMatmulPass();
 // using im2col tranformation.
 std::unique_ptr<Pass> createConvertConv2DToImg2ColPass();
 
+// Creates a pass to convert dispatch.region ops to dispatch.workgroups ops.
+std::unique_ptr<Pass> createConvertRegionToWorkgroupsPass();
+
 // Pass to convert a linalg.pad_tensor operation into a linalg.fill +
 // subtensor_insert. This allows lowering the operation into a single kernel.
 std::unique_ptr<Pass> createPadTensorToTensorInsertSlicePass();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -38,6 +38,12 @@ def ConvertConv2DToImg2Col :
   let constructor = "mlir::iree_compiler::IREE::Flow::createConvertConv2DToImg2ColPass()";
 }
 
+def ConvertRegionToWorkgroups :
+    Pass<"iree-flow-convert-region-to-workgroups", ""> {
+  let summary = "Convert DispatchRegion ops to Workgroups ops.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createConvertRegionToWorkgroupsPass()";
+}
+
 def ConvertToFlow :
     Pass<"iree-flow-convert-to-flow", ""> {
   let summary = "Convert operations to flow. Currently just a test pass.";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -41,6 +41,7 @@ iree_lit_test_suite(
             "outline_dispatch_regions.mlir",
             "pad_linalg_ops.mlir",
             "pad_tensor_to_tensor.mlir",
+            "region_to_workgroups.mlir",
             "strip_and_splat_constant_variables.mlir",
             "strip_signedness.mlir",
             "transformation_pipeline.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -38,6 +38,7 @@ iree_lit_test_suite(
     "outline_dispatch_regions.mlir"
     "pad_linalg_ops.mlir"
     "pad_tensor_to_tensor.mlir"
+    "region_to_workgroups.mlir"
     "strip_and_splat_constant_variables.mlir"
     "strip_signedness.mlir"
     "transformation_pipeline.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/region_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/region_to_workgroups.mlir
@@ -1,0 +1,45 @@
+// RUN: iree-opt %s --iree-flow-convert-region-to-workgroups -canonicalize -cse -split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @foo(
+//       CHECK:   %[[argA:.*]]: tensor<?x?xf32>, %[[argB:.*]]: tensor<5x10xf32>, %[[argC:.*]]: tensor<10x11xf32>
+func.func @foo(%argA: tensor<?x?xf32>, %argB: tensor<5x10xf32>, %argC: tensor<10x11xf32>) -> (tensor<?x?xf32>, tensor<5x11xf32>) {
+  //  CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+  //  CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
+  //  CHECK-DAG: %[[dim_argA_0:.*]] = tensor.dim %[[argA]], %[[c0]]
+  //  CHECK-DAG: %[[dim_argA_1:.*]] = tensor.dim %[[argA]], %[[c1]]
+  //      CHECK: %[[r0:.*]] = flow.dispatch.workgroups(%[[argA]], %[[dim_argA_0]], %[[dim_argA_1]]) : (tensor<?x?xf32>{%[[dim_argA_0]], %[[dim_argA_1]]}, index, index) -> %[[argA]]{%[[dim_argA_0]], %[[dim_argA_1]]} =
+  // CHECK-NEXT: (%[[arg1:.*]]: !flow.dispatch.tensor<readwrite:?x?xf32>, %[[arg2:.*]]: index, %[[arg3:.*]]: index) {
+  //      CHECK:   %[[load:.*]] = flow.dispatch.tensor.load %[[arg1]], offsets = [0, 0], sizes = [%[[arg2]], %[[arg3]]], strides = [1, 1] : !flow.dispatch.tensor<readwrite:?x?xf32>{%[[arg2]], %[[arg3]]} -> tensor<?x?xf32>
+  //      CHECK:   flow.dispatch.tensor.store %[[load]], %[[arg1]], offsets = [0, 0], sizes = [%[[arg2]], %[[arg3]]], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<readwrite:?x?xf32>{%[[arg2]], %[[arg3]]}
+  //      CHECK:   flow.return
+  //      CHECK: }
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %dimA0 = tensor.dim %argA, %c0 : tensor<?x?xf32>
+  %dimA1 = tensor.dim %argA, %c1 : tensor<?x?xf32>
+  %r0 = flow.dispatch.region -> (tensor<?x?xf32>{%dimA0, %dimA1}) {
+    flow.return %argA : tensor<?x?xf32>
+  }
+
+  //      CHECK: %[[r1:.*]] = flow.dispatch.workgroups(%[[argB]], %[[argC]]) : (tensor<5x10xf32>, tensor<10x11xf32>) -> tensor<5x11xf32> =
+  // CHECK-NEXT: (%[[arg3:.*]]: !flow.dispatch.tensor<readonly:5x10xf32>, %[[arg4:.*]]: !flow.dispatch.tensor<readonly:10x11xf32>, %[[arg5:.*]]: !flow.dispatch.tensor<writeonly:5x11xf32>)
+  //  CHECK-DAG:   %[[loadB:.*]] = flow.dispatch.tensor.load %[[arg3]], offsets = [0, 0], sizes = [5, 10], strides = [1, 1] : !flow.dispatch.tensor<readonly:5x10xf32> -> tensor<5x10xf32>
+  //  CHECK-DAG:   %[[loadC:.*]] = flow.dispatch.tensor.load %[[arg4]], offsets = [0, 0], sizes = [10, 11], strides = [1, 1] : !flow.dispatch.tensor<readonly:10x11xf32> -> tensor<10x11xf32>
+  //      CHECK:   %[[init_tensor:.*]] = linalg.init_tensor [5, 11] : tensor<5x11xf32>
+  //      CHECK:   %[[fill:.*]] = linalg.fill ins(%{{.*}} : f32) outs(%[[init_tensor]] : tensor<5x11xf32>) -> tensor<5x11xf32>
+  //      CHECK:   %[[matmul:.*]] = linalg.matmul ins(%[[loadB]], %[[loadC]] : tensor<5x10xf32>, tensor<10x11xf32>) outs(%[[fill]] : tensor<5x11xf32>) -> tensor<5x11xf32>
+  //      CHECK:   flow.dispatch.tensor.store %[[matmul]], %[[arg5]], offsets = [0, 0], sizes = [5, 11], strides = [1, 1] : tensor<5x11xf32> -> !flow.dispatch.tensor<writeonly:5x11xf32>
+  //      CHECK:   flow.return
+  //      CHECK: }
+  %r1 = flow.dispatch.region -> (tensor<5x11xf32>) {
+    %zero = arith.constant 0.0 : f32
+    %0 = linalg.init_tensor [5, 11] : tensor<5x11xf32>
+    %1 = linalg.fill ins(%zero : f32) outs(%0 : tensor<5x11xf32>) -> tensor<5x11xf32>
+    %2 = linalg.matmul ins(%argB, %argC : tensor<5x10xf32>, tensor<10x11xf32>)
+        outs(%1 : tensor<5x11xf32>) -> tensor<5x11xf32>
+    flow.return %2 : tensor<5x11xf32>
+  }
+
+  //      CHECK: return %[[r0]], %[[r1]]
+  return %r0, %r1 : tensor<?x?xf32>, tensor<5x11xf32>
+}


### PR DESCRIPTION
This pass converts `dispatch.region` ops into `dispatch.workgroups` ops. This can eventually replace the part of DispatchLinalgOnTensors that builds the `workgroups` ops. The op is built in one step, and there is no need for dropping operands/block arguments due to tieing etc.

What is still missing a transform that builds the `region` op based on a heuristic such as the one in DispatchLinalgOnTensors. This heuristic should put all ops that are needed in the dispatch region into the region. I.e., this transform should handle both fusion and cloning.
