### PR TITLE
Update docs to use "llvm-cpu" and "local-task" names consistently.

### DIFF
--- a/docs/developers/debugging/tf_integrations_test_repro.md
+++ b/docs/developers/debugging/tf_integrations_test_repro.md
@@ -41,7 +41,7 @@ Note that the command can only be run under `integrations/tensorflow/test/python
 
 ```
 iree-compile \
-  --iree-hal-target-backends=dylib-llvm-aot \
+  --iree-hal-target-backends=llvm-cpu \
   --iree-input-type=mhlo \
   iree_input.mlir
 ```

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -145,7 +145,7 @@ with the additional command-line flags
 
 ```shell hl_lines="3 4 5 6 7 8"
 tools/iree-compile \
-  --iree-hal-target-backends=dylib-llvm-aot \
+  --iree-hal-target-backends=llvm-cpu \
   --iree-llvm-target-triple=riscv64 \
   --iree-llvm-target-cpu=generic-rv64 \
   --iree-llvm-target-abi=lp64d \

--- a/docs/website/docs/deployment-configurations/bare-metal.md
+++ b/docs/website/docs/deployment-configurations/bare-metal.md
@@ -29,7 +29,7 @@ The model can be compiled with the following command (assuming the path to
 ```shell
 iree-compile \
     --iree-stream-partitioning-favor=min-peak-memory \
-    --iree-hal-target-backends=dylib-llvm-aot \
+    --iree-hal-target-backends=llvm-cpu \
     --iree-llvm-target-triple=x86_64-pc-linux-elf \
     --iree-llvm-debug-symbols=false \
     samples/models/simple_abs.mlir \
@@ -42,8 +42,7 @@ In which
 *   `-iree-stream-partitioning-favor=min-peak-memory`: Optimize for minimum peak
     memory usage at the cost of concurrency - include when targeting
     single-threaded execution to reduce memory consumption.
-*   `iree-hal-target-backends=dylib-llvm-aot`: Build the model for the dynamic
-    library CPU HAL driver
+*   `iree-hal-target-backends=llvm-cpu`: Compile using the LLVM CPU target
 *   `iree-llvm-target-triple`: Use the `<arch>-pc-linux-elf` LLVM target triple
     so the artifact has a fixed ABI to be rendered by the
     [elf_module library](https://github.com/iree-org/iree/tree/main/iree/hal/local/elf)

--- a/docs/website/docs/deployment-configurations/cpu.md
+++ b/docs/website/docs/deployment-configurations/cpu.md
@@ -88,7 +88,7 @@ system's `PATH`):
 
 ``` shell hl_lines="3"
 iree-compile \
-    --iree-hal-target-backends=cpu \
+    --iree-hal-target-backends=llvm-cpu \
     iree_input.mlir -o mobilenet_cpu.vmfb
 ```
 

--- a/docs/website/docs/getting-started/tflite.md
+++ b/docs/website/docs/getting-started/tflite.md
@@ -43,7 +43,7 @@ iree-import-tflite ${TFLITE_PATH} -o ${IMPORT_PATH}
 # Compile for the CPU backend
 iree-compile \
     --iree-input-type=tosa \
-    --iree-hal-target-backends=cpu \
+    --iree-hal-target-backends=llvm-cpu \
     ${IMPORT_PATH} \
     -o ${MODULE_PATH}
 ```
@@ -75,7 +75,7 @@ tfliteIR = "/".join([workdir, "tflite.mlir"])
 tosaIR = "/".join([workdir, "tosa.mlir"])
 bytecodeModule = "/".join([workdir, "iree.vmfb"])
 
-backends = ["dylib-llvm-aot"]
+backends = ["llvm-cpu"]
 config = "local-task"
 ```
 
@@ -103,7 +103,7 @@ iree_tflite_compile.compile_file(
   import_only=False)
 ```
 
-After compilation is completed we configure the VmModule using the dylib configuration and compiled
+After compilation is completed we configure the VmModule using the local-task configuration and compiled
 IREE module.
 
 ```python

--- a/runtime/src/iree/hal/local/executable_library_benchmark.md
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.md
@@ -84,7 +84,7 @@ iree-compile \
     --compile-mode=hal-executable \
     iree/hal/local/testdata/elementwise_mul.mlir \
     -o=elementwise_mul.so \
-    --iree-hal-target-backends=dylib-llvm-aot \
+    --iree-hal-target-backends=llvm-cpu \
     --iree-llvm-debug-symbols=false \
     --iree-llvm-target-triple=x86_64-pc-linux-elf
 ```
@@ -117,7 +117,7 @@ iree-compile \
     --iree-input-type=mhlo \
     iree/samples/simple_embedding/simple_embedding_test.mlir \
     -o=module.vmfb \
-    --iree-hal-target-backends=dylib-llvm-aot \
+    --iree-hal-target-backends=llvm-cpu \
     --iree-llvm-debug-symbols=false \
     --iree-llvm-target-triple=x86_64-pc-linux-elf \
     --mlir-print-ir-after-all \


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/9930