### PR TITLE
Adding custom_module sample.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -23,8 +23,270 @@ namespace iree_compiler {
 namespace IREE {
 namespace ABI {
 
+// Populates attributes on |wrapperOp| to support runtime reflection.
+static void populateReflectionAttrs(func::FuncOp exportOp,
+                                    func::FuncOp wrapperOp) {
+  SmallVector<NamedAttribute, 4> attrs;
+  auto abiAttr = exportOp->getAttr("iree.abi");
+  if (abiAttr) {
+    attrs.emplace_back(StringAttr::get(exportOp.getContext(), "iree.abi"),
+                       abiAttr);
+  }
+  if (!attrs.empty()) {
+    auto reflectionAttr = DictionaryAttr::get(exportOp.getContext(), attrs);
+    wrapperOp->setAttr("iree.reflection", reflectionAttr);
+  }
+}
+
+// Maps a source type to the native ABI type.
+static Type mapToABIType(Type type) {
+  if (type.isa<TensorType>()) {
+    return IREE::HAL::BufferViewType::get(type.getContext());
+  }
+  return type;
+}
+
+// Creates the corresponding wrapper function for the given import function.
+static func::FuncOp createImportWrapperFunc(func::FuncOp importOp,
+                                            FunctionType oldImportType,
+                                            FunctionType newImportType,
+                                            StringRef privateName) {
+  // Create the internal wrapper function with the original import signature.
+  auto wrapperOp =
+      func::FuncOp::create(importOp.getLoc(), privateName, oldImportType);
+  wrapperOp.setPrivate();
+
+  // Copy arg/result attrs from the import op to the wrapper function.
+  // We may want to remove them from the import but would need to filter.
+  SmallVector<DictionaryAttr, 4> argAttrDict;
+  importOp.getAllArgAttrs(argAttrDict);
+  wrapperOp.setAllArgAttrs(argAttrDict);
+  SmallVector<DictionaryAttr, 4> resultAttrDict;
+  importOp.getAllResultAttrs(resultAttrDict);
+  wrapperOp.setAllResultAttrs(resultAttrDict);
+
+  auto *entryBlock = wrapperOp.addEntryBlock();
+  auto entryBuilder = OpBuilder::atBlockBegin(entryBlock);
+
+  // Marshal arguments.
+  SmallVector<Value> arguments;
+  for (auto arg : llvm::enumerate(entryBlock->getArguments())) {
+    auto oldType = oldImportType.getInput(arg.index());
+    auto newType = newImportType.getInput(arg.index());
+    if (oldType.isa<TensorType>()) {
+      // This is where we could perform type casting or in-place storage binding
+      // if the user had any attrs specifying it.
+      auto argLoc = arg.value().getLoc();
+      auto exportOp = entryBuilder.create<IREE::HAL::TensorExportOp>(
+          argLoc, newType, arg.value());
+      arguments.push_back(exportOp.getTarget());
+    } else {
+      arguments.push_back(arg.value());
+    }
+  }
+
+  // Make the call with the updated types.
+  auto callOp =
+      entryBuilder.create<func::CallOp>(importOp.getLoc(), importOp, arguments);
+
+  // Marshal results.
+  SmallVector<Value> results;
+  for (auto result : llvm::enumerate(callOp.getResults())) {
+    auto oldType = oldImportType.getResult(result.index());
+    if (oldType.isa<TensorType>()) {
+      results.push_back(entryBuilder.create<IREE::HAL::TensorImportOp>(
+          importOp.getLoc(), oldType, result.value()));
+    } else {
+      results.push_back(result.value());
+    }
+  }
+
+  entryBuilder.create<func::ReturnOp>(importOp.getLoc(), results);
+  return wrapperOp;
+}
+
+// Updates |importOp| to use the native ABI and creates a wrapper function that
+// preserves the original behavior. All callers will be updated to point at the
+// new wrapper function.
+static LogicalResult wrapImportFunc(mlir::ModuleOp moduleOp,
+                                    func::FuncOp importOp,
+                                    SymbolTable &symbolTable) {
+  // Replace all existing calls to the import to instead call the wrapper.
+  auto publicName = importOp.getName().str();
+  auto privateName = "_" + publicName;
+  auto privateNameAttr =
+      mlir::StringAttr::get(importOp.getContext(), privateName);
+  if (failed(symbolTable.replaceAllSymbolUses(importOp, privateNameAttr,
+                                              moduleOp))) {
+    return importOp.emitError() << "unknown symbol table op encountered; "
+                                   "cannot fix up symbol names";
+  }
+
+  // Convert import signature types to those required by the binding ABI.
+  //
+  // NOTE: this is where we could change our signature to provide additional
+  // values from the runtime bindings as may be required - like semaphores for
+  // async behavior or cancellation.
+  auto oldImportType = importOp.getFunctionType();
+  SmallVector<Type> inputTypes;
+  for (auto oldType : oldImportType.getInputs()) {
+    inputTypes.push_back(mapToABIType(oldType));
+  }
+  SmallVector<Type> resultTypes;
+  for (auto oldType : oldImportType.getResults()) {
+    resultTypes.push_back(mapToABIType(oldType));
+  }
+  auto newImportType =
+      FunctionType::get(importOp.getContext(), inputTypes, resultTypes);
+
+  // Update the import to the new type and mark it as being converted so we
+  // don't try to convert it again.
+  importOp.setType(newImportType);
+  importOp->setAttr("iree.abi.stub", UnitAttr::get(importOp.getContext()));
+
+  // Create the wrapper function that matches the original internal types but
+  // calls out to the updated import using ABI types.
+  auto wrapperOp = createImportWrapperFunc(importOp, oldImportType,
+                                           newImportType, privateName);
+  if (!wrapperOp) return failure();
+  moduleOp.insert(++Block::iterator(importOp), wrapperOp);
+
+  return success();
+}
+
+// Creates the corresponding wrapper function for the given export function.
+static func::FuncOp createExportWrapperFunc(func::FuncOp exportOp,
+                                            StringRef publicName) {
+  // Convert argument types to those required by the binding ABI.
+  //
+  // NOTE: this is where we could change our signature to provide additional
+  // values from the runtime bindings as may be required - like semaphores for
+  // async behavior or cancellation.
+  auto oldExportType = exportOp.getFunctionType();
+  SmallVector<Type> inputTypes;
+  for (auto oldType : oldExportType.getInputs()) {
+    inputTypes.push_back(mapToABIType(oldType));
+  }
+  SmallVector<Type> resultTypes;
+  for (auto oldType : oldExportType.getResults()) {
+    resultTypes.push_back(mapToABIType(oldType));
+  }
+  auto newExportType =
+      FunctionType::get(exportOp.getContext(), inputTypes, resultTypes);
+
+  // Update the import to the new type and mark it as being converted so we
+  // don't try to convert it again.
+  auto wrapperOp =
+      func::FuncOp::create(exportOp.getLoc(), publicName, newExportType);
+  wrapperOp.setPublic();
+  wrapperOp->setAttr("iree.abi.stub", UnitAttr::get(exportOp.getContext()));
+
+  // Copy arg/result attrs from the import op to the wrapper function.
+  // We may want to remove them from the import but would need to filter.
+  SmallVector<DictionaryAttr, 4> argAttrDict;
+  exportOp.getAllArgAttrs(argAttrDict);
+  wrapperOp.setAllArgAttrs(argAttrDict);
+  SmallVector<DictionaryAttr, 4> resultAttrDict;
+  exportOp.getAllResultAttrs(resultAttrDict);
+  wrapperOp.setAllResultAttrs(resultAttrDict);
+
+  // Populate the reflection attrs based on the original types.
+  populateReflectionAttrs(exportOp, wrapperOp);
+
+  auto *entryBlock = wrapperOp.addEntryBlock();
+  auto entryBuilder = OpBuilder::atBlockBegin(entryBlock);
+
+  // Build a map of result value to the argument that has its backing storage.
+  SmallVector<Value> resultStorages;
+  resultStorages.resize(resultTypes.size());
+  for (unsigned i = 0; i < inputTypes.size(); ++i) {
+    auto outputAttr =
+        exportOp.getArgAttrOfType<IntegerAttr>(i, "iree.abi.output");
+    if (!outputAttr) continue;
+    // Today all outputs need to be a !hal.buffer - we could change this
+    // in the future to be something more generalized.
+    auto storageArg = entryBlock->getArgument(i);
+    if (!storageArg.getType().isa<IREE::HAL::BufferType>()) {
+      exportOp.emitError() << "storage argument " << i
+                           << " has an invalid type " << storageArg.getType()
+                           << "; must be a !hal.buffer";
+      return {};
+    }
+    resultStorages[outputAttr.getInt()] = storageArg;
+  }
+
+  // Marshal arguments.
+  SmallVector<Value> arguments;
+  for (auto arg : llvm::enumerate(entryBlock->getArguments())) {
+    auto oldType = oldExportType.getInput(arg.index());
+    if (oldType.isa<TensorType>()) {
+      auto argLoc = arg.value().getLoc();
+      auto importOp = entryBuilder.create<IREE::HAL::TensorImportOp>(
+          argLoc, oldType, arg.value());
+      arguments.push_back(importOp.getTarget());
+    } else {
+      arguments.push_back(arg.value());
+    }
+  }
+
+  // Make the call with the original types.
+  auto callOp =
+      entryBuilder.create<func::CallOp>(exportOp.getLoc(), exportOp, arguments);
+
+  // Marshal results.
+  SmallVector<Value> results;
+  for (auto result : llvm::enumerate(callOp.getResults())) {
+    auto oldType = oldExportType.getResult(result.index());
+    auto newType = newExportType.getResult(result.index());
+    if (oldType.isa<TensorType>()) {
+      auto dynamicDims = IREE::Util::buildDynamicDimsForValue(
+          exportOp.getLoc(), result.value(), entryBuilder);
+      results.push_back(entryBuilder.create<IREE::HAL::TensorExportOp>(
+          exportOp.getLoc(), newType, result.value(),
+          TypeAttr::get(result.value().getType()), dynamicDims,
+          resultStorages[result.index()]));
+    } else {
+      results.push_back(result.value());
+    }
+  }
+
+  entryBuilder.create<func::ReturnOp>(exportOp.getLoc(), results);
+  return wrapperOp;
+}
+
+// Replaces |exportOp| with a wrapper function that exports the native ABI.
+// The original function will be made private and be renamed.
+// This allows us to support multiple binding schemes as transforms from other
+// bindings can also perform their own equivalent wrapping.
+static LogicalResult wrapExportFunc(mlir::ModuleOp moduleOp,
+                                    func::FuncOp exportOp,
+                                    SymbolTable &symbolTable) {
+  // Rename the original function so that our wrapper can use the original
+  // name in its public definition.
+  auto publicName = exportOp.getName().str();
+  auto privateName = "_" + publicName;
+  auto privateNameAttr =
+      mlir::StringAttr::get(exportOp.getContext(), privateName);
+  if (failed(symbolTable.replaceAllSymbolUses(exportOp, privateNameAttr,
+                                              moduleOp))) {
+    return exportOp.emitError() << "unknown symbol table op encountered; "
+                                   "cannot fix up symbol names";
+  }
+  exportOp.setName(privateNameAttr);
+  exportOp.setPrivate();
+
+  // Create the wrapper function that conforms to the IREE native ABI and
+  // marshals arguments/results to the original function.
+  auto wrapperOp = createExportWrapperFunc(exportOp, publicName);
+  if (!wrapperOp) return failure();
+  moduleOp.insert(Block::iterator(exportOp), wrapperOp);
+
+  return success();
+}
+
 // Wraps all entry points in a function that is compatible with the
 // expected invocation semantics of bindings following the native IREE ABI.
+// Imports are also handled as they are entry points in another module.
 class WrapEntryPointsPass
     : public PassWrapper<WrapEntryPointsPass, OperationPass<ModuleOp>> {
  public:
@@ -46,166 +308,39 @@ class WrapEntryPointsPass
   void runOnOperation() override {
     auto moduleOp = getOperation();
 
-    SmallVector<func::FuncOp, 4> entryFuncOps;
+    // Gather functions that need wrapping.
+    SmallVector<func::FuncOp> importOps;
+    SmallVector<func::FuncOp> exportOps;
     for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
-      if (funcOp.isPublic() && !funcOp->hasAttr("iree.abi.stub")) {
-        entryFuncOps.push_back(funcOp);
+      // Ignore functions already marked as having their ABI goo handled.
+      if (funcOp->hasAttr("iree.abi.stub")) continue;
+      if (funcOp.isExternal()) {
+        // Imported function.
+        importOps.push_back(funcOp);
+      } else if (funcOp.isPublic()) {
+        // Exported function.
+        exportOps.push_back(funcOp);
       }
     }
 
     SymbolTable symbolTable(moduleOp);
 
-    // Create a wrapper function for each entry point.
-    for (auto entryFuncOp : entryFuncOps) {
-      // Rename the original function so that our wrapper can use the original
-      // name in its public definition.
-      auto publicName = entryFuncOp.getName().str();
-      auto privateName = "_" + publicName;
-      auto privateNameAttr =
-          mlir::StringAttr::get(entryFuncOp.getContext(), privateName);
-      if (failed(symbolTable.replaceAllSymbolUses(entryFuncOp, privateNameAttr,
-                                                  moduleOp))) {
-        entryFuncOp.emitError() << "unknown symbol table op encountered; "
-                                   "cannot fix up symbol names";
+    // Create a wrapper function for each imported function.
+    // This will preserve the internal types (tensors/etc) but change the import
+    // to taking the ABI types and rewrite calls.
+    for (auto importOp : importOps) {
+      if (failed(wrapImportFunc(moduleOp, importOp, symbolTable))) {
         return signalPassFailure();
       }
-      entryFuncOp.setName(privateNameAttr);
-      entryFuncOp.setPrivate();
-
-      // Create the wrapper function that conforms to the IREE native ABI and
-      // marshals arguments/results to the original function.
-      auto wrapperFuncOp = createWrapperFunc(entryFuncOp);
-      if (!wrapperFuncOp) return signalPassFailure();
-      wrapperFuncOp.setPublic();
-      wrapperFuncOp.setName(
-          mlir::StringAttr::get(entryFuncOp.getContext(), publicName));
-      moduleOp.insert(Block::iterator(entryFuncOp), wrapperFuncOp);
-
-      wrapperFuncOp.getOperation()->setAttr("iree.abi.stub",
-                                            UnitAttr::get(&getContext()));
     }
-  }
 
- private:
-  Type mapToABIType(Type type) {
-    if (type.isa<TensorType>()) {
-      return IREE::HAL::BufferViewType::get(type.getContext());
-    }
-    return type;
-  }
-
-  // Creates the corresponding wrapper function for the given entry point.
-  //
-  // We do this by creating a new function just for the bindings and calling the
-  // existing entry point. This allows us to support multiple binding schemes as
-  // transforms from other bindings can also perform their own equivalent
-  // wrapping.
-  //
-  // NOTE: today we only support a single entry point; with minor tweaks we
-  // could fix this up to support multiple if we wanted.
-  func::FuncOp createWrapperFunc(func::FuncOp entryFuncOp) {
-    // Convert argument types to those required by the binding ABI.
-    //
-    // NOTE: this is where we could change our signature to provide additional
-    // values from the runtime bindings as may be required - like semaphores for
-    // async behavior or cancellation.
-    auto entryFuncType = entryFuncOp.getFunctionType();
-    SmallVector<Type> inputTypes;
-    for (auto oldType : entryFuncType.getInputs()) {
-      inputTypes.push_back(mapToABIType(oldType));
-    }
-    SmallVector<Type> resultTypes;
-    for (auto oldType : entryFuncType.getResults()) {
-      resultTypes.push_back(mapToABIType(oldType));
-    }
-    auto wrapperFuncType =
-        FunctionType::get(entryFuncOp.getContext(), inputTypes, resultTypes);
-
-    auto wrapperFuncOp = func::FuncOp::create(
-        entryFuncOp.getLoc(), entryFuncOp.getName(), wrapperFuncType);
-
-    SmallVector<DictionaryAttr, 4> argAttrDict;
-    entryFuncOp.getAllArgAttrs(argAttrDict);
-    wrapperFuncOp.setAllArgAttrs(argAttrDict);
-    SmallVector<DictionaryAttr, 4> resultAttrDict;
-    entryFuncOp.getAllResultAttrs(resultAttrDict);
-    wrapperFuncOp.setAllResultAttrs(resultAttrDict);
-
-    populateReflectionAttrs(entryFuncOp, wrapperFuncOp);
-
-    auto *entryBlock = wrapperFuncOp.addEntryBlock();
-    auto entryBuilder = OpBuilder::atBlockBegin(entryBlock);
-
-    // Build a map of result value to the argument that has its backing storage.
-    SmallVector<Value> resultStorages;
-    resultStorages.resize(resultTypes.size());
-    for (unsigned i = 0; i < inputTypes.size(); ++i) {
-      auto outputAttr =
-          entryFuncOp.getArgAttrOfType<IntegerAttr>(i, "iree.abi.output");
-      if (!outputAttr) continue;
-      // Today all outputs need to be a !hal.buffer - we could change this
-      // in the future to be something more generalized.
-      auto storageArg = entryBlock->getArgument(i);
-      if (!storageArg.getType().isa<IREE::HAL::BufferType>()) {
-        entryFuncOp.emitError()
-            << "storage argument " << i << " has an invalid type "
-            << storageArg.getType() << "; must be a !hal.buffer";
-        return {};
+    // Create a wrapper function for each exported function.
+    // This will change the export to taking the ABI types and preserve the
+    // internal types.
+    for (auto exportOp : exportOps) {
+      if (failed(wrapExportFunc(moduleOp, exportOp, symbolTable))) {
+        return signalPassFailure();
       }
-      resultStorages[outputAttr.getInt()] = storageArg;
-    }
-
-    // Marshal arguments.
-    SmallVector<Value> arguments;
-    for (auto arg : llvm::enumerate(entryBlock->getArguments())) {
-      auto oldType = entryFuncType.getInput(arg.index());
-      if (auto tensorType = oldType.dyn_cast<RankedTensorType>()) {
-        auto argLoc = arg.value().getLoc();
-        auto importOp = entryBuilder.create<IREE::HAL::TensorImportOp>(
-            argLoc, oldType, arg.value());
-        arguments.push_back(importOp.getTarget());
-      } else {
-        arguments.push_back(arg.value());
-      }
-    }
-
-    // Make the call with the original types.
-    auto callOp = entryBuilder.create<func::CallOp>(entryFuncOp.getLoc(),
-                                                    entryFuncOp, arguments);
-
-    // Marshal results.
-    SmallVector<Value> results;
-    for (auto result : llvm::enumerate(callOp.getResults())) {
-      auto oldType = entryFuncType.getResult(result.index());
-      auto newType = wrapperFuncType.getResult(result.index());
-      if (oldType.isa<TensorType>()) {
-        auto dynamicDims = IREE::Util::buildDynamicDimsForValue(
-            entryFuncOp.getLoc(), result.value(), entryBuilder);
-        results.push_back(entryBuilder.create<IREE::HAL::TensorExportOp>(
-            entryFuncOp.getLoc(), newType, result.value(),
-            TypeAttr::get(result.value().getType()), dynamicDims,
-            resultStorages[result.index()]));
-      } else {
-        results.push_back(result.value());
-      }
-    }
-    entryBuilder.create<func::ReturnOp>(entryFuncOp.getLoc(), results);
-
-    return wrapperFuncOp;
-  }
-
-  // Populates attributes on |wrapperFuncOp| to support runtime reflection.
-  void populateReflectionAttrs(func::FuncOp entryFuncOp,
-                               func::FuncOp wrapperFuncOp) {
-    SmallVector<NamedAttribute, 4> attrs;
-    auto abiAttr = entryFuncOp->getAttr("iree.abi");
-    if (abiAttr) {
-      attrs.emplace_back(StringAttr::get(entryFuncOp.getContext(), "iree.abi"),
-                         abiAttr);
-    }
-    if (!attrs.empty()) {
-      auto reflectionAttr = DictionaryAttr::get(&getContext(), attrs);
-      wrapperFuncOp->setAttr("iree.reflection", reflectionAttr);
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExecutableOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/ConvertExecutableOps.cpp
@@ -132,9 +132,8 @@ class ExecutableCreateOpConversion
         createOp.getLoc(), rodataOp);
 
     // Get format string as a rodata blob.
-    auto executableFormatStr = createStringTableValue(
-        createOp.getLoc(), executableBinaryOp.getFormatAttr(),
-        importOp.getFunctionType().getInput(1), rewriter);
+    auto executableFormatStr = rewriter.create<IREE::VM::RodataInlineOp>(
+        createOp.getLoc(), executableBinaryOp.getFormatAttr());
 
     // Pack constants, if any.
     auto constantBuffer = createPackedConstantBuffer(

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ElideAsyncCopies.cpp
@@ -307,7 +307,9 @@ class LastUseAnalysis {
   LogicalResult run() {
     // Seed all block arguments throughout the program.
     for (auto callableOp : getTopLevelOps()) {
-      for (auto &block : *callableOp.getCallableRegion()) {
+      auto *region = callableOp.getCallableRegion();
+      if (!region) continue;
+      for (auto &block : *region) {
         for (auto arg : block.getArguments()) {
           if (arg.getType().isa<IREE::Stream::ResourceType>()) {
             solver.getOrCreateElementFor<ArgumentSemantics>(
@@ -499,9 +501,9 @@ class ElideAsyncCopiesPass : public ElideAsyncCopiesBase<ElideAsyncCopiesPass> {
       // If we can't elide any we'll consider the iteration complete and exit.
       bool didChange = false;
       for (auto callableOp : analysis.getTopLevelOps()) {
-        didChange = tryElideAsyncCopiesInRegion(*callableOp.getCallableRegion(),
-                                                analysis) ||
-                    didChange;
+        auto *region = callableOp.getCallableRegion();
+        if (!region) continue;
+        didChange = tryElideAsyncCopiesInRegion(*region, analysis) || didChange;
       }
       if (!didChange) break;
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/MaterializeBuiltins.cpp
@@ -53,7 +53,9 @@ using BuiltinUsageMap =
 static BuiltinUsageMap findBuiltinOps(mlir::ModuleOp moduleOp) {
   BuiltinUsageMap results;
   for (auto callableOp : moduleOp.getOps<CallableOpInterface>()) {
-    for (auto &block : *callableOp.getCallableRegion()) {
+    auto *region = callableOp.getCallableRegion();
+    if (!region) continue;
+    for (auto &block : *region) {
       for (auto &op : block.getOperations()) {
         if (auto builtinOp = dyn_cast<IREE::Stream::BuiltinOpInterface>(op)) {
           auto name = builtinOp->getName();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/OutlineConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/OutlineConstants.cpp
@@ -46,7 +46,9 @@ struct ConstantDef {
 static SmallVector<ConstantDef> findConstantsInModule(mlir::ModuleOp moduleOp) {
   SmallVector<ConstantDef> results;
   for (auto callableOp : moduleOp.getOps<CallableOpInterface>()) {
-    for (auto &block : *callableOp.getCallableRegion()) {
+    auto *region = callableOp.getCallableRegion();
+    if (!region) continue;
+    for (auto &block : *region) {
       for (auto &op : block.getOperations()) {
         if (auto constantOp = dyn_cast<arith::ConstantOp>(op)) {
           if (isOutlinableValue(constantOp.getValue())) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/RefineUsage.cpp
@@ -210,6 +210,10 @@ struct ApplyFuncOp : public UsageRefinementPattern<mlir::func::FuncOp> {
   using UsageRefinementPattern<mlir::func::FuncOp>::UsageRefinementPattern;
   LogicalResult matchAndRewrite(mlir::func::FuncOp op,
                                 PatternRewriter &rewriter) const override {
+    if (op.isExternal()) {
+      return rewriter.notifyMatchFailure(op, "external funcs not supported");
+    }
+
     bool didChange = false;
 
     // Arguments:

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/propagate_subviews.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/propagate_subviews.mlir
@@ -13,7 +13,7 @@
 util.global private mutable @constantGlobal : !stream.resource<constant>
 
 // CHECK-LABEL: @globalLoad
-func.func @globalLoad() {
+func.func private @globalLoad() {
   // CHECK-NEXT: %[[RESOURCE:.+]] = util.global.load @constantGlobal : !stream.resource<constant>
   // CHECK-NEXT: %[[STORAGE_SIZE:.+]] = util.global.load @constantGlobal__storage_size : index
   // CHECK-NEXT: %[[OFFSET:.+]] = util.global.load @constantGlobal__offset : index
@@ -39,7 +39,7 @@ util.global private mutable @mutableGlobal : !stream.resource<variable>
 
 // CHECK-LABEL: @globalStore
 // CHECK-SAME: (%[[RESOURCE:.+]]: !stream.resource<variable>, %[[STORAGE_SIZE:.+]]: index, %[[OFFSET:.+]]: index, %[[LENGTH:.+]]: index)
-func.func @globalStore(%resource: !stream.resource<variable>) {
+func.func private @globalStore(%resource: !stream.resource<variable>) {
   // CHECK: util.global.store %[[RESOURCE]], @mutableGlobal : !stream.resource<variable>
   // CHECK: util.global.store %[[STORAGE_SIZE]], @mutableGlobal__storage_size : index
   // CHECK: util.global.store %[[OFFSET]], @mutableGlobal__offset : index
@@ -57,7 +57,7 @@ func.func @globalStore(%resource: !stream.resource<variable>) {
 
 // CHECK-LABEL: @funcArgs
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !stream.resource<external>, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !stream.resource<transient>, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
-func.func @funcArgs(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) {
+func.func private @funcArgs(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) {
   // CHECK-NEXT: %[[SUBVIEW0:.+]] = stream.resource.subview %[[RESOURCE0]][%[[OFFSET0]]] : !stream.resource<external>{%[[STORAGE_SIZE0]]} -> !stream.resource<external>{%[[LENGTH0]]}
   // CHECK-NEXT: %[[SUBVIEW1:.+]] = stream.resource.subview %[[RESOURCE1]][%[[OFFSET1]]] : !stream.resource<transient>{%[[STORAGE_SIZE1]]} -> !stream.resource<transient>{%[[LENGTH1]]}
 
@@ -78,7 +78,7 @@ func.func @funcArgs(%resource0: !stream.resource<external>, %resource1: !stream.
 // CHECK-LABEL: @funcResults
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !stream.resource<external>, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !stream.resource<transient>, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
 // CHECK-SAME: -> (!stream.resource<external>, index, index, index, !stream.resource<transient>, index, index, index)
-func.func @funcResults(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>) {
+func.func private @funcResults(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>) {
   // NOTE: there will be extra stuff here from the arg insertion. Since the
   // return should consume the subview that was inserted we expect to directly
   // use the function arguments.
@@ -97,7 +97,7 @@ func.func @funcResults(%resource0: !stream.resource<external>, %resource1: !stre
 
 // CHECK-LABEL: @caller
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !stream.resource<external>, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !stream.resource<transient>, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
-func.func @caller(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) {
+func.func private @caller(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) {
   // NOTE: there will be extra stuff here from the arg insertion. The call
   // consumes the subviews and we expect the args to be passed directly.
 
@@ -117,7 +117,9 @@ func.func @caller(%resource0: !stream.resource<external>, %resource1: !stream.re
   return
 }
 
-func.func private @callee(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>)
+func.func private @callee(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>) {
+  return %arg0, %arg1 : !stream.resource<external>, !stream.resource<transient>
+}
 
 // -----
 
@@ -128,7 +130,7 @@ func.func private @callee(%arg0: !stream.resource<external>, %arg1: !stream.reso
 
 // CHECK-LABEL: @br
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !stream.resource<external>, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !stream.resource<transient>, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
-func.func @br(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) {
+func.func private @br(%resource0: !stream.resource<external>, %resource1: !stream.resource<transient>) {
   // NOTE: there will be extra stuff here from the arg insertion. The branch
   // consumes the unready resources and we expect the args to be passed directly
   // to the cf.br.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/propagate_timepoints.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/propagate_timepoints.mlir
@@ -35,7 +35,7 @@ util.global private mutable @mutableGlobal : !stream.resource<variable>
 
 // CHECK-LABEL: @globalStore
 // CHECK-SAME: (%[[TIMEPOINT:.+]]: !stream.timepoint, %[[UNREADY:.+]]: !stream.resource<variable>)
-func.func @globalStore(%arg0: !stream.resource<variable>) {
+func.func private @globalStore(%arg0: !stream.resource<variable>) {
   //      CHECK: util.global.store %[[TIMEPOINT]], @mutableGlobal__timepoint : !stream.timepoint
   // CHECK-NEXT: util.global.store %[[UNREADY]], @mutableGlobal : !stream.resource<variable>
   util.global.store %arg0, @mutableGlobal : !stream.resource<variable>
@@ -52,7 +52,7 @@ func.func @globalStore(%arg0: !stream.resource<variable>) {
 // CHECK-LABEL: @funcArgs
 // CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
 // CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
-func.func @funcArgs(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+func.func private @funcArgs(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
   // CHECK-NEXT: %[[SIZE0:.+]] = stream.resource.size %[[UNREADY0]] : !stream.resource<external>
   // CHECK-NEXT: %[[READY0:.+]] = stream.timepoint.await %[[TIMEPOINT0]] => %[[UNREADY0]] : !stream.resource<external>{%[[SIZE0]]}
   // CHECK-NEXT: %[[SIZE1:.+]] = stream.resource.size %[[UNREADY1]] : !stream.resource<transient>
@@ -75,7 +75,7 @@ func.func @funcArgs(%arg0: !stream.resource<external>, %arg1: !stream.resource<t
 // CHECK-LABEL: @funcResults
 // CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
 // CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
-func.func @funcResults(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>) {
+func.func private @funcResults(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>) {
   // NOTE: there will be extra stuff here from the arg insertion. Since the
   // return should consume the await that was inserted we expect to directly use
   // the function arguments.
@@ -96,7 +96,7 @@ func.func @funcResults(%arg0: !stream.resource<external>, %arg1: !stream.resourc
 // CHECK-LABEL: @caller
 // CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
 // CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
-func.func @caller(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+func.func private @caller(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
   // NOTE: there will be extra stuff here from the arg insertion. The call
   // consumes the unready resources and we expect the args to be passed
   // directly.
@@ -117,7 +117,9 @@ func.func @caller(%arg0: !stream.resource<external>, %arg1: !stream.resource<tra
   return
 }
 
-func.func private @callee(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>)
+func.func private @callee(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) -> (!stream.resource<external>, !stream.resource<transient>) {
+  return %arg0, %arg1 : !stream.resource<external>, !stream.resource<transient>
+}
 
 // -----
 
@@ -129,7 +131,7 @@ func.func private @callee(%arg0: !stream.resource<external>, %arg1: !stream.reso
 // CHECK-LABEL: @br
 // CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
 // CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
-func.func @br(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+func.func private @br(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
   // NOTE: there will be extra stuff here from the arg insertion. The branch
   // consumes the unready resources and we expect the args to be passed directly
   // to the cf.br.
@@ -163,7 +165,7 @@ func.func @br(%arg0: !stream.resource<external>, %arg1: !stream.resource<transie
 // CHECK-LABEL: @asyncExecuteConsume
 // CHECK-SAME: (%[[TIMEPOINT0:.+]]: !stream.timepoint, %[[UNREADY0:.+]]: !stream.resource<external>,
 // CHECK-SAME:  %[[TIMEPOINT1:.+]]: !stream.timepoint, %[[UNREADY1:.+]]: !stream.resource<transient>)
-func.func @asyncExecuteConsume(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
+func.func private @asyncExecuteConsume(%arg0: !stream.resource<external>, %arg1: !stream.resource<transient>) {
   // NOTE: there will be extra stuff here from the arg insertion. The execution
   // region consumes the unready resources and we expect the args to be captured
   // directly.

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/buffer_ops.mlir
@@ -9,6 +9,15 @@ func.func @buffer_constant() -> !util.buffer {
 
 // -----
 
+// CHECK-LABEL: @buffer_constant_string
+func.func @buffer_constant_string() -> !util.buffer {
+  // CHECK: = util.buffer.constant : !util.buffer = "hello"
+  %0 = util.buffer.constant : !util.buffer = "hello"
+  return %0 : !util.buffer
+}
+
+// -----
+
 // CHECK-LABEL: @buffer_alloc
 func.func @buffer_alloc(%arg0: index) -> !util.buffer {
   // CHECK: = util.buffer.alloc uninitialized {alignment = 16 : index} : !util.buffer{%arg0}

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/FuseGlobals.cpp
@@ -129,7 +129,9 @@ class FuseGlobalsPass
     for (auto callableOp : moduleOp.getOps<CallableOpInterface>()) {
       LLVM_DEBUG(llvm::dbgs()
                  << "FuseGlobals: analyzing " << callableOp << ":\n");
-      for (auto &block : *callableOp.getCallableRegion()) {
+      auto *region = callableOp.getCallableRegion();
+      if (!region) continue;
+      for (auto &block : *region) {
         DenseMap<Value, SmallVector<IREE::Util::GlobalStoreOp>> valueStores;
         for (auto storeOp : block.getOps<IREE::Util::GlobalStoreOp>()) {
           auto &global = globalTable.globalMap[storeOp.getGlobal()];

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/propagate_subranges.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/propagate_subranges.mlir
@@ -11,7 +11,7 @@
 util.global private mutable @constantGlobal : !util.buffer
 
 // CHECK-LABEL: @globalLoad
-func.func @globalLoad() {
+func.func private @globalLoad() {
   // CHECK-NEXT: %[[RESOURCE:.+]] = util.global.load @constantGlobal : !util.buffer
   // CHECK-NEXT: %[[STORAGE_SIZE:.+]] = util.global.load @constantGlobal__storage_size : index
   // CHECK-NEXT: %[[OFFSET:.+]] = util.global.load @constantGlobal__offset : index
@@ -37,7 +37,7 @@ util.global private mutable @mutableGlobal : !util.buffer
 
 // CHECK-LABEL: @globalStore
 // CHECK-SAME: (%[[RESOURCE:.+]]: !util.buffer, %[[STORAGE_SIZE:.+]]: index, %[[OFFSET:.+]]: index, %[[LENGTH:.+]]: index)
-func.func @globalStore(%resource: !util.buffer) {
+func.func private @globalStore(%resource: !util.buffer) {
   // CHECK: util.global.store %[[RESOURCE]], @mutableGlobal : !util.buffer
   // CHECK: util.global.store %[[STORAGE_SIZE]], @mutableGlobal__storage_size : index
   // CHECK: util.global.store %[[OFFSET]], @mutableGlobal__offset : index
@@ -55,7 +55,7 @@ func.func @globalStore(%resource: !util.buffer) {
 
 // CHECK-LABEL: @funcArgs
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !util.buffer, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !util.buffer, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
-func.func @funcArgs(%resource0: !util.buffer, %resource1: !util.buffer) {
+func.func private @funcArgs(%resource0: !util.buffer, %resource1: !util.buffer) {
   // CHECK-NEXT: %[[SUBRANGE0:.+]] = util.buffer.subspan %[[RESOURCE0]][%[[OFFSET0]]] : !util.buffer{%[[STORAGE_SIZE0]]} -> !util.buffer{%[[LENGTH0]]}
   // CHECK-NEXT: %[[SUBRANGE1:.+]] = util.buffer.subspan %[[RESOURCE1]][%[[OFFSET1]]] : !util.buffer{%[[STORAGE_SIZE1]]} -> !util.buffer{%[[LENGTH1]]}
 
@@ -76,7 +76,7 @@ func.func @funcArgs(%resource0: !util.buffer, %resource1: !util.buffer) {
 // CHECK-LABEL: @funcResults
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !util.buffer, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !util.buffer, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
 // CHECK-SAME: -> (!util.buffer, index, index, index, !util.buffer, index, index, index)
-func.func @funcResults(%resource0: !util.buffer, %resource1: !util.buffer) -> (!util.buffer, !util.buffer) {
+func.func private @funcResults(%resource0: !util.buffer, %resource1: !util.buffer) -> (!util.buffer, !util.buffer) {
   // NOTE: there will be extra stuff here from the arg insertion. Since the
   // return should consume the subrange that was inserted we expect to directly
   // use the function arguments.
@@ -95,7 +95,7 @@ func.func @funcResults(%resource0: !util.buffer, %resource1: !util.buffer) -> (!
 
 // CHECK-LABEL: @caller
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !util.buffer, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !util.buffer, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
-func.func @caller(%resource0: !util.buffer, %resource1: !util.buffer) {
+func.func private @caller(%resource0: !util.buffer, %resource1: !util.buffer) {
   // NOTE: there will be extra stuff here from the arg insertion. The call
   // consumes the subranges and we expect the args to be passed directly.
 
@@ -115,7 +115,9 @@ func.func @caller(%resource0: !util.buffer, %resource1: !util.buffer) {
   return
 }
 
-func.func private @callee(%arg0: !util.buffer, %arg1: !util.buffer) -> (!util.buffer, !util.buffer)
+func.func private @callee(%arg0: !util.buffer, %arg1: !util.buffer) -> (!util.buffer, !util.buffer) {
+  return %arg0, %arg1 : !util.buffer, !util.buffer
+}
 
 // -----
 
@@ -125,7 +127,7 @@ func.func private @callee(%arg0: !util.buffer, %arg1: !util.buffer) -> (!util.bu
 
 // CHECK-LABEL: @callerInSCF
 // CHECK-SAME: (%[[RESOURCE:.+]]: !util.buffer, %[[STORAGE_SIZE:.+]]: index, %[[OFFSET:.+]]: index, %[[LENGTH:.+]]: index, %[[COND:.+]]: i1)
-func.func @callerInSCF(%resource: !util.buffer, %cond: i1) {
+func.func private @callerInSCF(%resource: !util.buffer, %cond: i1) {
   // NOTE: there will be extra stuff here from the arg insertion. The call
   // consumes the subranges and we expect the args to be passed directly.
 
@@ -138,7 +140,9 @@ func.func @callerInSCF(%resource: !util.buffer, %cond: i1) {
   return
 }
 
-func.func private @callee(%arg0: !util.buffer)
+func.func private @callee(%arg0: !util.buffer) {
+  return
+}
 
 // -----
 
@@ -149,7 +153,7 @@ func.func private @callee(%arg0: !util.buffer)
 
 // CHECK-LABEL: @callerWithSubrange
 // CHECK-SAME: (%[[ARG_RESOURCE:.+]]: !util.buffer, %[[ARG_SIZE:.+]]: index, %[[ARG_OFFSET:.+]]: index, %[[ARG_LENGTH:.+]]: index)
-func.func @callerWithSubrange(%arg: !util.buffer) {
+func.func private @callerWithSubrange(%arg: !util.buffer) {
   // NOTE: there will be extra stuff here from the arg insertion. The call
   // consumes the subranges and we expect the args to be passed directly.
 
@@ -182,7 +186,9 @@ func.func @callerWithSubrange(%arg: !util.buffer) {
   return
 }
 
-func.func private @callee(%arg0: !util.buffer) -> (!util.buffer)
+func.func private @callee(%arg0: !util.buffer) -> !util.buffer {
+  return %arg0 : !util.buffer
+}
 
 // -----
 
@@ -193,7 +199,7 @@ func.func private @callee(%arg0: !util.buffer) -> (!util.buffer)
 
 // CHECK-LABEL: @br
 // CHECK-SAME: (%[[RESOURCE0:.+]]: !util.buffer, %[[STORAGE_SIZE0:.+]]: index, %[[OFFSET0:.+]]: index, %[[LENGTH0:.+]]: index, %[[RESOURCE1:.+]]: !util.buffer, %[[STORAGE_SIZE1:.+]]: index, %[[OFFSET1:.+]]: index, %[[LENGTH1:.+]]: index)
-func.func @br(%resource0: !util.buffer, %resource1: !util.buffer) {
+func.func private @br(%resource0: !util.buffer, %resource1: !util.buffer) {
   // NOTE: there will be extra stuff here from the arg insertion. The branch
   // consumes the unready resources and we expect the args to be passed directly
   // to the cf.br.

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/ImportUtils.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/ImportUtils.h
@@ -37,11 +37,6 @@ Optional<SmallVector<Value, 4>> rewriteAttrToOperands(
     ConversionPatternRewriter &rewriter);
 }  // namespace detail
 
-// Creates a module-level vm.rodata containing the string contents and returns
-// the dereferenced byte buffer.
-Value createStringTableValue(Location loc, StringAttr attrValue, Type inputType,
-                             OpBuilder &builder);
-
 // Casts |value| to |targetType| ala static_cast for when the declared type
 // differs from the type provided by the input dialect.
 Value castToImportType(Value value, Type targetType,

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/buffer_ops.mlir
@@ -11,6 +11,16 @@ func.func @buffer_constant() -> !util.buffer {
 
 // -----
 
+// CHECK-LABEL: @buffer_constant_string
+func.func @buffer_constant_string() -> !util.buffer {
+  // CHECK-64: %[[BUFFER:.+]] = vm.rodata.inline : !vm.buffer = "hello"
+  %0 = util.buffer.constant : !util.buffer = "hello"
+  // CHECK-64: return %[[BUFFER]]
+  return %0 : !util.buffer
+}
+
+// -----
+
 // CHECK-LABEL: @buffer_alloc
 func.func @buffer_alloc(%arg0: index) -> !util.buffer {
   // CHECK-32: %[[SIZE_64:.+]] = vm.ext.i32.i64.u %arg0 : i32 -> i64

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -265,7 +265,6 @@ ParseResult ImportOp::parse(OpAsmParser &parser, OperationState &result) {
   result.addAttribute(mlir::function_interface_impl::getTypeAttrName(),
                       TypeAttr::get(functionType));
 
-  // No clue why this is required.
   result.addRegion();
 
   return success();
@@ -321,7 +320,6 @@ void ImportOp::build(OpBuilder &builder, OperationState &result, StringRef name,
                                                   /*resultAttrs=*/llvm::None);
   }
 
-  // No clue why this is required.
   result.addRegion();
 }
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -823,6 +823,46 @@ void ConstRefRodataOp::getAsmResultNames(OpAsmSetValueNameFn setNameFn) {
   setResultName(setNameFn, getResult(), getRodata());
 }
 
+// Makes a human-readable symbol name for the given string value.
+// This is not uniqued and may need uniquing before being added to the symbol
+// table.
+//
+// For example:
+//   'Some string!' -> '_utf8_some_string'
+//   'I'm a really long'... -> '_utf8_im_a_really_long'
+static std::string makeSafeIdentifier(StringRef unsafeIdentifier) {
+  std::string result = "_utf8_";
+  llvm::raw_string_ostream os(result);
+  bool lastUnderscore = true;
+  for (char c : unsafeIdentifier) {
+    if (!llvm::isPrint(c)) continue;
+    if (llvm::isAlnum(c)) {
+      os << llvm::toLower(c);
+      lastUnderscore = false;
+    } else if (!lastUnderscore) {
+      os << "_";
+      lastUnderscore = true;
+    }
+  }
+  std::string prefix = os.str().substr(0, 32);
+  if (!StringRef(prefix).endswith("_")) {
+    prefix += "_";
+  }
+  return prefix + llvm::utohexstr(static_cast<uint64_t>(
+                      llvm::hash_value(unsafeIdentifier)));
+}
+
+void RodataInlineOp::build(OpBuilder &builder, OperationState &result,
+                           StringAttr value) {
+  // Make an identifier-friendly version of the string so that the value is
+  // more readable in IR (so "I'm some string" becomes "im_some_string", etc).
+  auto safeIdentifier = makeSafeIdentifier(value.getValue());
+  build(builder, result,
+        IREE::VM::RefType::get(IREE::VM::BufferType::get(builder.getContext())),
+        builder.getStringAttr(safeIdentifier), value,
+        /*alignment=*/builder.getI64IntegerAttr(1));
+}
+
 //===----------------------------------------------------------------------===//
 // Lists
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -181,6 +181,8 @@ def VM_ImportOp : VM_Op<"import", [
     OptionalAttr<UnitAttr>:$is_optional
   );
 
+  // Required because FunctionOpInterface and CallableOpInterface disagree with
+  // each other about the requirement for regions. We don't use this region.
   let regions = (region AnyRegion:$body);
 
   let skipDefaultBuilders = 1;

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.td
@@ -1048,7 +1048,8 @@ def VM_RodataInlineOp : VM_PureOp<"rodata.inline", [
     [{
       $_state.addTypes({resultType});
       $_state.addAttribute("value", value);
-    }]>
+    }]>,
+    OpBuilder<(ins "StringAttr":$value)>
   ];
 }
 

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.cpp
@@ -105,9 +105,12 @@ void buildIREEVMTransformPassPipeline(
       (IREE::Stream::DumpOutputFormat)schedulingOptions.dumpStatisticsFormat;
   streamOptions.dumpStatisticsFile = schedulingOptions.dumpStatisticsFile;
 
+  // TODO(benvanik): only run these pipelines if there are tensors in the
+  // program that we need to convert.
   IREE::Flow::buildFlowTransformPassPipeline(passManager, flowOptions);
   IREE::Stream::buildStreamTransformPassPipeline(passManager, streamOptions);
   IREE::HAL::buildHALTransformPassPipeline(passManager, executableOptions);
+
   IREE::VM::buildVMTransformPassPipeline(passManager, targetOptions);
   passManager.addPass(IREE::Util::createDropCompilerHintsPass());
 }

--- a/samples/custom_module/CMakeLists.txt
+++ b/samples/custom_module/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+set(_NAME "iree_samples_custom_module_run")
+add_executable(${_NAME} "")
+target_sources(${_NAME}
+  PRIVATE
+    main.c
+    module.cc
+    module.h
+)
+
+set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "custom-module-run")
+
+target_link_libraries(${_NAME}
+  iree_base_base
+  iree_base_cc
+  iree_base_internal_file_io
+  iree_vm_vm
+  iree_vm_bytecode_module
+)
+
+add_subdirectory(test)

--- a/samples/custom_module/CMakeLists.txt
+++ b/samples/custom_module/CMakeLists.txt
@@ -15,6 +15,11 @@ target_sources(${_NAME}
 
 set_target_properties(${_NAME} PROPERTIES OUTPUT_NAME "custom-module-run")
 
+# TODO(benvanik): make iree_status_annotate_f always available as a function
+# instead of defining it empty? otherwise optimized builds of the runtime won't
+# export it but external libraries may pull it in.
+target_compile_options(${_NAME} PRIVATE ${IREE_DEFAULT_COPTS})
+
 target_link_libraries(${_NAME}
   iree_base_base
   iree_base_cc

--- a/samples/custom_module/README.md
+++ b/samples/custom_module/README.md
@@ -1,0 +1,260 @@
+# "Custom Module" sample
+
+This sample shows how to
+
+1. Create a custom module in C++ that can be used with the IREE runtime
+2. Author an MLIR input that uses a custom module including a custom type
+3. Compile that program to an IREE VM bytecode module
+4. Load the compiled program using a low-level VM interface
+5. Call exported functions on the loaded program to exercise the custom module
+
+The custom module is declared in [`module.h`](./module.h), implemented using a
+C++ module wrapper layer in [`module.cc`](./module.cc), and called by example in
+[`main.c`](./main.c).
+
+This document uses terminology that can be found in the documentation of
+[IREE's execution model](https://github.com/iree-org/iree/blob/main/docs/developers/design_docs/execution_model.md).
+See [IREE's extensibility mechanisms](https://iree-org.github.io/iree/extensions/)
+documentation for more information specific to extenting IREE and
+alternative approaches to doing so.
+
+## Background
+
+IREE's VM is used to dynamically link modules of various types together at
+runtime (C, C++, IREE's VM bytecode, etc). Via this mechanism any number of
+modules containing exported functions and types that can be used across modules
+can extend IREE's base functionality. In most IREE programs the HAL module is
+used to provide a hardware abstraction layer for execution and both the HAL
+module itself and the types it exposes (`!hal.buffer`, `!hal.executable`, etc)
+are implemented using this mechanism.
+
+## Instructions
+
+1. Build or install the `iree-compile` binary:
+
+    ```
+    python -m pip install iree-compiler
+    ```
+
+    [See here](https://iree-org.github.io/iree/getting-started/)
+    for general instructions on installing the compiler.
+
+3. Compile the [example module](./test/example.mlir) to a .vmfb file:
+
+    ```
+    # TODO(benvanik): remove requirement of hal backend for non-HAL modules.
+    iree-compile samples/custom_module/test/example.mlir -o=/tmp/example.vmfb -iree-hal-target-backends=vmvx
+    ```
+
+3. Build the `iree_samples_custom_module_run` CMake target :
+
+    ```
+    cmake -B ../iree-build/ -DCMAKE_BUILD_TYPE=RelWithDebInfo . \
+        -DCMAKE_C_FLAGS=-DIREE_VM_EXECUTION_TRACING_FORCE_ENABLE=1
+    cmake --build ../iree-build/ --target iree_samples_custom_module_run
+    ```
+    (here we force runtime execution tracing for demonstration purposes)
+
+    [See here](https://iree-org.github.io/iree/building-from-source/getting-started/)
+    for general instructions on building using CMake.
+
+4. Run the example program to call the main function:
+
+   ```
+   ../iree-build/samples/custom_module/custom-module-run \
+       /tmp/example.vmfb example.main
+   ```
+
+## Defining Custom Modules in C++
+
+Modules are exposed to applications and the IREE VM via the `iree_vm_module_t`
+interface. IREE canonically uses C headers to expose module and type functions
+but the implementation of the module can be anything the user is able to work
+with (C, C++, rust, etc).
+
+A C++ wrapper is provided to ease implementation when minimal code size and overhead is not a focus and provides easy definition of exports and marshaling
+of types. Utilities such as `iree::Status` and `iree::vm::ref<T>` add safety for
+managing reference counted resources and can be used within the modules.
+
+General flow:
+
+1. Expose module via a C API ([`module.h`](./module.h)):
+
+```c
+// Ideally all allocations performed by the module should use |allocator|.
+// The returned module in |out_module| should have a ref count of 1 to transfer
+// ownership to the caller.
+iree_status_t iree_table_module_create(iree_allocator_t allocator,
+                                       iree_vm_module_t** out_module);
+```
+
+2. Implement the module using C/C++/etc ([`module.cc`](./module.cc)):
+
+Modules have two parts: a shared module and instantiated state.
+
+The `iree::vm::NativeModule` helper is used to handle the shared module
+declaration and acts as a factory for per-context instantiated state and the
+methods exported by the module:
+
+```c++
+// Any mutable state stored on the module may be accessed from multiple threads
+// if the module is instantiated in multiple contexts and must be thread-safe.
+struct TableModule final : public vm::NativeModule<TableModuleState> {
+  // Each time the module is instantiated this will be called to allocate the
+  // context-specific state. The returned state must only be thread-compatible
+  // as invocations within a context will not be made from multiple threads but
+  // the thread on which they are made may change over time; this means no TLS!
+  StatusOr<std::unique_ptr<TableModuleState>> CreateState(
+      iree_allocator_t allocator) override;
+};
+```
+
+The module implementation is done on the state object so that methods may use
+`this` to access context-local state:
+
+```c++
+struct TableModuleState final {
+  // Local to the context the module was instantiated in and thread-compatible.
+  std::unordered_map<std::string, std::string> mutable_state;
+
+  // Exported functions must return Status or StatusOr. Failures will result in
+  // program termination and will be propagated up to the top-level invoker.
+  // If a module wants to provide non-fatal errors it can return results to the
+  // program: here we return a 0/1 indicating whether the key was found as well
+  // as the result or null.
+  //
+  // MLIR declaration:
+  //   func.func private @table.lookup(!util.buffer) -> (i1, !util.buffer)
+  StatusOr<std::tuple<int32_t, vm::ref<iree_vm_buffer_t>>> Lookup(
+      const vm::ref<iree_vm_buffer_t> key);
+};
+```
+
+Finally the exported methods are registered and marshaling code is expanded:
+
+```c++
+static const vm::NativeFunction<TableModuleState> kTableModuleFunctions[] = {
+    vm::MakeNativeFunction("lookup", &TableModuleState::Lookup),
+};
+extern "C" iree_status_t iree_table_module_create(
+    iree_allocator_t allocator, iree_vm_module_t** out_module) {
+  auto module = std::make_unique<TableModule>(
+      "table", allocator,
+      iree::span<const vm::NativeFunction<CustomModuleState>>
+      (kTableModuleFunctions));
+  *out_module = module.release()->interface();
+  return iree_ok_status();
+}
+```
+
+## Registering Custom Modules at Runtime
+
+Once a custom module is defined it needs to be provided to any context that it
+is going to be used in. Each context may have its own unique mix of modules and
+it's the hosting application's responsibility to inject the available modules.
+See [`main.c`](./main.c) for an example showing the entire end-to-end lifetime
+of loading a compiled bytecode module and providing a custom module for runtime
+dynamic linking.
+
+Since modules themselves can be reused across contexts it can be a way of
+creating shared caches (requires thread-safety!) that span contexts while the
+module state is context specific and isolated.
+
+Import resolution happens in reverse registration order: the most recently
+registered modules override previous ones. This combined with optional imports
+allows overriding behavior and version compatibility shims (though there is
+still some trickiness involved).
+
+```c
+// Ensure custom types are registered before loading modules that use them.
+// This only needs to be done once.
+IREE_CHECK_OK(iree_custom_module_register_types());
+
+// Create the custom module that can be reused across contexts.
+iree_vm_module_t* custom_module = NULL;
+IREE_CHECK_OK(iree_custom_module_create(allocator, &custom_module));
+
+// Create the context for this invocation reusing the loaded modules.
+// Contexts hold isolated state and can be reused for multiple calls.
+// Note that the module order matters: the input user module is dependent on
+// the custom module.
+iree_vm_module_t* modules[] = {custom_module, bytecode_module};
+iree_vm_context_t* context = NULL;
+IREE_CHECK_OK(iree_vm_context_create_with_modules(
+    instance, IREE_VM_CONTEXT_FLAG_NONE, IREE_ARRAYSIZE(modules), modules,
+    allocator, &context));
+```
+
+## Calling Custom Modules from Compiled Programs
+
+The IREE compiler allows for external functions that are resolved at runtime
+using the [MLIR `func` dialect](https://mlir.llvm.org/docs/Dialects/Func/). Some
+optional attributes are used to allow for customization where required but in
+many cases no additional IREE-specific work is required in the compiled program.
+A few advanced features of the VM FFI are not currently exposed via this
+mechanism such as variadic arguments and tuples but the advantage is that users
+need not customize the IREE compiler in order to use their modules.
+
+Prior to passing input programs to the IREE compiler users can insert the
+imported functions as external
+[`func.func`](https://mlir.llvm.org/docs/Dialects/Func/#funcfunc-mlirfuncfuncop)
+ops and calls to those functions using
+[`func.call`](https://mlir.llvm.org/docs/Dialects/Func/#funccall-mlirfunccallop):
+
+```mlir
+// An external function declaration.
+// `custom` is the runtime module and `string.create` is the exported method.
+// This call uses both IREE types (`!util.buffer`) and custom ones not known to
+// the compiler but available at runtime (`!custom.string`).
+func.func private @custom.string.create(!util.buffer) -> !custom.string
+```
+
+```mlir
+// Call the imported function.
+%buffer = util.buffer.constant : !util.buffer = "hello world!"
+%result = func.call @custom.string.create(%buffer) : (!util.buffer) -> !custom.string
+```
+
+Users with custom dialects and ops can use
+[MLIR's dialect conversion](https://mlir.llvm.org/docs/DialectConversion/)
+framework to rewrite their custom ops to this form and perform additional
+marshaling logic. For example, the above could have started as this program
+before the user ran their dialect conversion and passed it in to `iree-compile`:
+
+```mlir
+%result = custom.string.create "hello world!" : !custom.string
+```
+
+See this samples [`example.mlir`](./test/example.mlir) for examples of features
+such as signature specification and optional import fallback support.
+
+### Interoperating with the HAL
+
+Currently only HAL types with synchronous behavior are supported in custom
+modules but deeper integration with the HAL is planned.
+This means that today all custom module operations are executed on the host and
+synchronous with other host behavior. Future extensions will allow for custom
+device-specific command buffer operations and asynchronous scheduling that fit
+within the
+[IREE execution model](https://github.com/iree-org/iree/blob/main/docs/developers/design_docs/execution_model.md).
+
+The same ABI mechanisms used to call in to IREE with HAL resources can be used
+to call in to custom modules:
+
+```mlir
+// Perform work on tensors using tensor dialects. This will run using IREE's
+// asynchronous execution model.
+%src = call @produce_tensor() : () -> tensor<?x3xf32>
+
+// Make the custom call synchronously on the host. The call can use the
+// `iree_hal_buffer_view_t` APIs to access the metadata and contents and
+// allocate a new buffer view to return to the program.
+%dst = func.call @custom.process(%src) : (tensor<?x3xf32>) -> tensor<3x?xi32>
+
+// Continue using the tensor as normal.
+call @consume_tensor(%dst) : (tensor<3x?xi32>) -> ()
+```
+
+Future extensions will allow for `!hal.fence` and `!hal.buffer` to be used to
+allow for chaining asynchronous submissions and assign storage for in-place
+operations.

--- a/samples/custom_module/main.c
+++ b/samples/custom_module/main.c
@@ -1,0 +1,115 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdio.h>
+
+// Low-level IREE VM APIs.
+// The higher-level iree/runtime/api.h can be used for more complete ML-like
+// programs using the hardware abstraction layer (HAL). This simple sample just
+// uses base VM types.
+#include "iree/base/api.h"
+#include "iree/vm/api.h"
+#include "iree/vm/bytecode_module.h"
+
+// HACK: this pokes in to private APIs for IO helpers while we expect
+// applications to bring their own IO.
+#include "iree/base/internal/file_io.h"
+
+// Custom native module used in the sample.
+// Modules may be linked in from native code or other bytecode modules loaded at
+// runtime: there's no difference.
+#include "module.h"
+
+// NOTE: CHECKs are dangerous but this is a sample; a real application would
+// want to handle errors gracefully. We know in this constrained case that
+// these won't fail unless something is catastrophically wrong (out of memory,
+// solar flares, etc).
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    fprintf(stderr,
+            "Usage:\n"
+            "  custom-module-run - <entry.point> # read from stdin\n"
+            "  custom-module-run </path/to/say_hello.vmfb> <entry.point>\n");
+    fprintf(stderr, "  (See the README for this sample for details)\n ");
+    return -1;
+  }
+
+  // Internally IREE does not (in general) use malloc and instead uses the
+  // provided allocator to allocate and free memory. Applications can integrate
+  // their own allocator as-needed.
+  iree_allocator_t allocator = iree_allocator_system();
+
+  // Create the root isolated VM instance that we can create contexts within.
+  iree_vm_instance_t* instance = NULL;
+  IREE_CHECK_OK(iree_vm_instance_create(allocator, &instance));
+
+  // Ensure custom types are registered before loading modules that use them.
+  // This only needs to be done once.
+  // TODO(benvanik): move to instance-based registration.
+  IREE_CHECK_OK(iree_custom_module_register_types());
+
+  // Create the custom module that can be reused across contexts.
+  iree_vm_module_t* custom_module = NULL;
+  IREE_CHECK_OK(iree_custom_module_create(allocator, &custom_module));
+
+  // Load the module from stdin or a file on disk.
+  // Applications can ship and load modules however they want (such as mapping
+  // them into memory instead of allocating like this). Modules can also be
+  // embedded in the binary but in those cases it makes more sense to use emitc
+  // to avoid the bytecode entirely and have a fully static build (see
+  // samples/emitc_modules/ for some examples).
+  const char* module_path = argv[1];
+  iree_file_contents_t* module_contents = NULL;
+  if (strcmp(module_path, "-") == 0) {
+    IREE_CHECK_OK(iree_stdin_read_contents(allocator, &module_contents));
+  } else {
+    IREE_CHECK_OK(
+        iree_file_read_contents(module_path, allocator, &module_contents));
+  }
+
+  // Load the bytecode module from the vmfb.
+  // This module can be reused across multiple contexts.
+  // Note that we let the module retain the file contents for as long as needed.
+  iree_vm_module_t* bytecode_module = NULL;
+  IREE_CHECK_OK(iree_vm_bytecode_module_create(
+      module_contents->const_buffer,
+      iree_file_contents_deallocator(module_contents), allocator,
+      &bytecode_module));
+
+  // Create the context for this invocation reusing the loaded modules.
+  // Contexts hold isolated state and can be reused for multiple calls.
+  // Note that the module order matters: the input user module is dependent on
+  // the custom module.
+  iree_vm_module_t* modules[] = {custom_module, bytecode_module};
+  iree_vm_context_t* context = NULL;
+  IREE_CHECK_OK(iree_vm_context_create_with_modules(
+      instance, IREE_VM_CONTEXT_FLAG_NONE, IREE_ARRAYSIZE(modules), modules,
+      allocator, &context));
+
+  // Lookup the function by fully-qualified name (module.func).
+  iree_vm_function_t function;
+  IREE_CHECK_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view(argv[2]), &function));
+
+  fprintf(stdout, "INVOKE BEGIN %s\n", argv[2]);
+  fflush(stdout);
+
+  // Synchronously invoke the requested function.
+  // We don't pass in/out anything in these simple examples so the I/O lists
+  // are not needed.
+  IREE_CHECK_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                               /*policy=*/NULL, /*inputs=*/NULL,
+                               /*outputs=*/NULL, allocator));
+
+  fprintf(stdout, "INVOKE END\n");
+  fflush(stdout);
+
+  iree_vm_context_release(context);
+  iree_vm_module_release(bytecode_module);
+  iree_vm_module_release(custom_module);
+  iree_vm_instance_release(instance);
+  return 0;
+}

--- a/samples/custom_module/module.cc
+++ b/samples/custom_module/module.cc
@@ -1,0 +1,197 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "module.h"
+
+#include <cstdio>
+
+#include "iree/base/api.h"
+#include "iree/base/status_cc.h"
+#include "iree/vm/native_module_cc.h"
+#include "iree/vm/ref_cc.h"
+
+// NOTE: this module is written in C++ using the native module wrapper and uses
+// template magic to handle marshaling arguments. For a lot of uses this is a
+// much friendlier way of exposing modules to the IREE VM and if performance and
+// code size are not a concern is a fine route to take. Here we do it for
+// brevity but all of the internal IREE modules are implemented in C.
+
+//===----------------------------------------------------------------------===//
+// !custom.string type
+//===----------------------------------------------------------------------===//
+
+// Runtime type descriptor for the !custom.string describing how to manage it
+// and destroy it. The type ID is allocated at runtime and does not need to
+// match the compiler ID.
+static iree_vm_ref_type_descriptor_t iree_custom_string_descriptor = {0};
+
+// The "string" type we use to store and retain string data.
+// This could be arbitrarily complex or simply wrap another user-defined type.
+// The descriptor that is registered at startup defines how to manage the
+// lifetime of the type (such as which destruction function is called, if any).
+// See ref.h for more information and additional utilities.
+typedef struct iree_custom_string_t {
+  // Must be the first field; used to track the reference count of the object.
+  iree_vm_ref_object_t ref_object;
+  // Allocator the string data was allocated from.
+  // Ideally pools and nested allocators would be used to avoid needing to store
+  // the allocator with every object.
+  iree_allocator_t allocator;
+  // Non-NUL-terminated string value.
+  iree_string_view_t value;
+} iree_custom_string_t;
+
+IREE_VM_DEFINE_TYPE_ADAPTERS(iree_custom_string, iree_custom_string_t);
+
+extern "C" iree_status_t iree_custom_string_create(
+    iree_string_view_t value, iree_allocator_t allocator,
+    iree_custom_string_t** out_string) {
+  IREE_ASSERT_ARGUMENT(out_string);
+  // Note that we allocate the string and the string value together.
+  iree_custom_string_t* string = NULL;
+  IREE_RETURN_IF_ERROR(iree_allocator_malloc(
+      allocator, sizeof(*string) + value.size, (void**)&string));
+  string->ref_object.counter = IREE_ATOMIC_VAR_INIT(1);
+  string->allocator = allocator;
+  string->value.data = ((const char*)string) + sizeof(iree_custom_string_t);
+  string->value.size = value.size;
+  memcpy((void*)string->value.data, value.data, string->value.size);
+  *out_string = string;
+  return iree_ok_status();
+}
+
+extern "C" void iree_custom_string_destroy(void* ptr) {
+  iree_custom_string_t* string = (iree_custom_string_t*)ptr;
+  iree_allocator_free(string->allocator, ptr);
+}
+
+extern "C" iree_status_t iree_custom_module_register_types(void) {
+  if (iree_custom_string_descriptor.type) {
+    return iree_ok_status();  // Already registered.
+  }
+  iree_custom_string_descriptor.type_name =
+      iree_make_cstring_view("custom.string");
+  iree_custom_string_descriptor.offsetof_counter =
+      offsetof(iree_custom_string_t, ref_object.counter);
+  iree_custom_string_descriptor.destroy = iree_custom_string_destroy;
+  return iree_vm_ref_register_type(&iree_custom_string_descriptor);
+}
+
+//===----------------------------------------------------------------------===//
+// VM module interface implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+using namespace iree;
+
+// Per-context module state.
+// This can contain "globals" and other arbitrary state.
+//
+// Thread-compatible; the runtime will not issue multiple calls at the same
+// time using the same state. If the implementation uses external threads then
+// it must synchronize itself.
+class CustomModuleState final {
+ public:
+  explicit CustomModuleState(iree_allocator_t allocator)
+      : allocator_(allocator) {}
+  ~CustomModuleState() = default;
+
+  // Creates a new string with a copy of the given string data.
+  // No NUL terminator is required.
+  StatusOr<vm::ref<iree_custom_string_t>> StringCreate(
+      iree_string_view_t data) {
+    vm::ref<iree_custom_string_t> string;
+    IREE_RETURN_IF_ERROR(iree_custom_string_create(data, allocator_, &string));
+    fprintf(stdout, "CREATE %.*s\n", static_cast<int>(string->value.size),
+            string->value.data);
+    fflush(stdout);
+    return std::move(string);
+  }
+
+  // Returns the length of the string in characters.
+  StatusOr<int64_t> StringLength(const vm::ref<iree_custom_string_t> string) {
+    if (!string) {
+      // Passed in refs may be null.
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT, "null string arg");
+    }
+    fprintf(stdout, "LENGTH %.*s = %zu\n", static_cast<int>(string->value.size),
+            string->value.data, string->value.size);
+    fflush(stdout);
+    return static_cast<int64_t>(string->value.size);
+  }
+
+  // Prints the contents of the string to stdout.
+  Status StringPrint(const vm::ref<iree_custom_string_t> string) {
+    if (!string) return OkStatus();  // no-op
+    fprintf(stdout, "PRINT %.*s\n", static_cast<int>(string->value.size),
+            string->value.data);
+    fflush(stdout);
+    return OkStatus();
+  }
+
+  // Prints the contents of the string; only exported in debug mode.
+  Status StringDPrint(const vm::ref<iree_custom_string_t> string) {
+    if (!string) return OkStatus();  // no-op
+    return StringPrint(std::move(string));
+  }
+
+ private:
+  // Allocator that the caller requested we use for any allocations we need to
+  // perform during operation.
+  iree_allocator_t allocator_ = iree_allocator_system();
+};
+
+// Function table mapping imported function names to their implementation.
+static const vm::NativeFunction<CustomModuleState> kCustomModuleFunctions[] = {
+    vm::MakeNativeFunction("string.create", &CustomModuleState::StringCreate),
+    vm::MakeNativeFunction("string.length", &CustomModuleState::StringLength),
+    vm::MakeNativeFunction("string.print", &CustomModuleState::StringPrint),
+
+#if !NDEBUG
+    // This is an optional method that we purposefully compile out in release
+    // builds to demonstrate fallback paths. Consuming modules can query as to
+    // whether the function exists at runtime and call fallbacks/change their
+    // behavior.
+    vm::MakeNativeFunction("string.dprint", &CustomModuleState::StringDPrint),
+#endif  // !NDEBUG
+};
+
+// The module instance that will be allocated and reused across contexts.
+// Any context-specific state must be stored in a state structure such as
+// CustomModuleState.
+//
+// Assumed thread-safe (by construction here, as it's immutable), though if any
+// mutable state is stored here it will need to be synchronized by the
+// implementation.
+class CustomModule final : public vm::NativeModule<CustomModuleState> {
+ public:
+  using vm::NativeModule<CustomModuleState>::NativeModule;
+
+  // Creates per-context state when the module is added to a new context.
+  // May be called from any thread.
+  StatusOr<std::unique_ptr<CustomModuleState>> CreateState(
+      iree_allocator_t allocator) override {
+    auto state = std::make_unique<CustomModuleState>(allocator);
+    return state;
+  }
+};
+
+}  // namespace
+
+// Note that while we are using C++ bindings internally we still expose the
+// module as a C instance. This hides the details of our implementation.
+extern "C" iree_status_t iree_custom_module_create(
+    iree_allocator_t allocator, iree_vm_module_t** out_module) {
+  IREE_ASSERT_ARGUMENT(out_module);
+  *out_module = NULL;
+  auto module = std::make_unique<CustomModule>(
+      "custom", allocator,
+      iree::span<const vm::NativeFunction<CustomModuleState>>(
+          kCustomModuleFunctions));
+  *out_module = module.release()->interface();
+  return iree_ok_status();
+}

--- a/samples/custom_module/module.h
+++ b/samples/custom_module/module.h
@@ -1,0 +1,50 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_SAMPLES_CUSTOM_MODULE_MODULE_H_
+#define IREE_SAMPLES_CUSTOM_MODULE_MODULE_H_
+
+#include <stdint.h>
+
+#include "iree/base/api.h"
+#include "iree/vm/api.h"
+
+// A non-NUL-terminated string.
+typedef struct iree_custom_string_t iree_custom_string_t;
+IREE_VM_DECLARE_TYPE_ADAPTERS(iree_custom_string, iree_custom_string_t);
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// Creates a new !custom.string object with a copy of the given |value|.
+// Applications could use this and any other methods we wanted to expose to
+// interop with the loaded VM modules - such as passing in/out the objects.
+// We don't need this for the demo but creating the custom object, appending it
+// to the invocation input list, and then consuming it in the compiled module
+// is straightforward.
+iree_status_t iree_custom_string_create(iree_string_view_t value,
+                                        iree_allocator_t allocator,
+                                        iree_custom_string_t** out_string);
+
+// Registers types provided by the custom module.
+// TODO(benvanik): move to instance-based type registration (this would take
+// a iree_vm_instance_t).
+iree_status_t iree_custom_module_register_types(void);
+
+// Creates a native custom module that can be reused in multiple contexts.
+// The module itself may hold state that can be shared by all instantiated
+// copies but it will require the module to provide synchronization; usually
+// it's safer to just treat the module as immutable and keep state within the
+// instantiated module states instead.
+iree_status_t iree_custom_module_create(iree_allocator_t allocator,
+                                        iree_vm_module_t** out_module);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_SAMPLES_CUSTOM_MODULE_MODULE_H_

--- a/samples/custom_module/test/CMakeLists.txt
+++ b/samples/custom_module/test/CMakeLists.txt
@@ -1,0 +1,18 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_lit_test_suite(
+  NAME
+    lit
+  SRCS
+    "example.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+    iree_samples_custom_module_run
+  LABELS
+    "hostonly"
+)

--- a/samples/custom_module/test/example.mlir
+++ b/samples/custom_module/test/example.mlir
@@ -1,0 +1,75 @@
+// RUN: iree-compile %s -iree-hal-target-backends=vmvx | custom-module-run - example.main | FileCheck %s
+
+module @example {
+  //===--------------------------------------------------------------------===//
+  // Imports
+  //===--------------------------------------------------------------------===//
+  // External function declarations for the methods implemented in the custom
+  // module C++ file. Note that they are prefixed with the `custom.` module
+  // name.
+
+  // Creates a new string with a copy of the given string data.
+  // No NUL terminator is required.
+  func.func private @custom.string.create(!util.buffer) -> !custom.string
+
+  // Returns the length of the string in characters.
+  func.func private @custom.string.length(!custom.string) -> index attributes {
+    // Explicitly force the returned type to be i64 regardless of whether the
+    // VM is in 32 or 64 bit mode and what conversion would make index.
+    vm.signature = (!vm.ref<!custom.string>) -> i64
+  }
+
+  // Prints the contents of the string to stdout.
+  func.func private @custom.string.print(!custom.string)
+
+  // Prints the contents of the string only in debug mode and otherwise prints
+  // "optimized".
+  func.func private @custom.string.dprint(!custom.string) attributes {
+    // Indicates the import is optional and if not present the specified
+    // fallback method will be called instead.
+    vm.fallback = @custom_string_dprint
+  }
+  func.func private @custom_string_dprint(%ignored: !custom.string) {
+    // Called when the import is not available at runtime (in this case when the
+    // runtime is compiled in release mode). This is a silly example but makes
+    // it easier to test.
+    %data = util.buffer.constant : !util.buffer = "optimized"
+    %str = call @custom.string.create(%data) : (!util.buffer) -> !custom.string
+    call @custom.string.print(%str) : (!custom.string) -> ()
+    return
+  }
+
+  //===--------------------------------------------------------------------===//
+  // Sample methods
+  //===--------------------------------------------------------------------===//
+  // Note that there can be any number of publicly-exported methods; this simple
+  // sample just has one to keep things simple.
+
+  // CHECK-LABEL: INVOKE BEGIN example.main
+  func.func @main() {
+    // Create string from a byte buffer encoding the characters.
+    %hello_data = util.buffer.constant : !util.buffer = "hello"
+    // CHECK-NEXT: CREATE hello
+    %hello_str = call @custom.string.create(%hello_data) : (!util.buffer) -> !custom.string
+
+    // Print the string to stdout.
+    // CHECK-NEXT: PRINT hello
+    call @custom.string.print(%hello_str) : (!custom.string) -> ()
+
+    // Query the length of the string.
+    // We don't do anything with it here but just demonstrate how index works.
+    // CHECK-NEXT: LENGTH hello = 5
+    %strlen = call @custom.string.length(%hello_str) : (!custom.string) -> index
+    util.do_not_optimize(%strlen) : index
+
+    // Print "debug" if the runtime is compiled in debug mode and otherwise
+    // prints "optimized".
+    // CHECK: PRINT {{debug|optimized}}
+    %debug_data = util.buffer.constant : !util.buffer = "debug"
+    %debug_str = call @custom.string.create(%debug_data) : (!util.buffer) -> !custom.string
+    call @custom.string.dprint(%debug_str) : (!custom.string) -> ()
+
+    return
+  }
+  // CHECK-NEXT: INVOKE END
+}


### PR DESCRIPTION
This demonstrates how a user out-of-tree can use custom modules and
types with the IREE VM and includes some basic guided documentation.
There are still a lot of ergonomics improvements to be done (especially
with the C++ wrappers) but it's enough to implement the old custom
module sample but without needing any compiler changes at all (can
do all of this from a pip install of iree-compile).