### PR TITLE
Switch to zstd for compression of artifacts passed between jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    if: github.event_name != 'pull_request'
+    # DO NOT SUBMIT. Restore this. if: github.event_name != 'pull_request'
     needs: build_all
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,10 +130,10 @@ jobs:
       - name: "Creating build dir archive"
         id: archive
         env:
-          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.xz
+          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
         run: |
           tar --exclude '*.a' --exclude '*.o' \
-            -I 'xz -3 -T0' \
+            -I 'zstd -T0' \
             -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
           echo "::set-output name=build-dir-archive::${BUILD_DIR_ARCHIVE}"
       - name: "Uploading build dir archive"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,7 +223,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    # DO NOT SUBMIT. Restore this. if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     needs: build_all
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.


### PR DESCRIPTION
This is faster for compression and *way* faster for decompression. I
didn't use it before because it wasn't installed on the CI VMs, but
I've updated the image to include it.

This brings compression + upload + download + decompression time from
over 5 minutes to about 1.5 minutes.

I temporarily enabled GPU testing to ensure extraction worked there
too: https://github.com/iree-org/iree/runs/7570456284

Part of https://github.com/iree-org/iree/9855
