### PR TITLE
Nuke macos zstd cmake files in GHA

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -159,6 +159,7 @@ jobs:
           # libzstd on GitHub Action bots is not compatible with MacOS universal.
           # https://github.com/iree-org/iree/issues/9955
           sudo rm -rf /usr/local/lib/libzstd.*.dylib
+          sudo rm -rf /usr/local/lib/cmake/zstd/*
 
           packages="iree-compiler" \
           output_dir="$PWD/bindist" \


### PR DESCRIPTION
Github macos runners have non-universal binary zstd that breaks
our macos universal builds. We have to remove the cmake files too.