### PR TITLE
Fix iree_task_pool_grow miscompilation on NDK r25

### DIFF
--- a/runtime/src/iree/task/pool.c
+++ b/runtime/src/iree/task/pool.c
@@ -91,7 +91,7 @@ static iree_status_t iree_task_pool_grow(iree_task_pool_t* pool,
   head->next_task = NULL;
   head->pool = pool;
 
-  // Work around a a loop vectorizer bug that causes memory corruption in this
+  // Work around a loop vectorizer bug that causes memory corruption in this
   // loop. Only Android NDK r25 is known to be affected. See
   // https://github.com/iree-org/iree/issues/9953 for details.
 #if defined(__NDK_MAJOR__) && __NDK_MAJOR__ == 25


### PR DESCRIPTION
Disable loop optimizations to avoid heap corruption.

Issue: https://github.com/iree-org/iree/issues/9953