### PR TITLE
Move ref vs retain when stealing pointer for structured args.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,10 +292,8 @@ jobs:
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Running TF integrations tests"
-        # TODO(#9936): Enable Vulkan
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_DISABLE=1 \
             gcr.io/iree-oss/frontends-swiftshader@sha256:41e516b8c1b432e3c02896c4bf4b7f06df6a67371aa167b88767b8d4d2018ea6 \
             build_tools/cmake/run_tf_tests.sh \
             "${BUILD_DIR}"

--- a/runtime/bindings/python/invoke.cc
+++ b/runtime/bindings/python/invoke.cc
@@ -250,7 +250,7 @@ class InvokeStatics {
 
           // Push the sub list.
           iree_vm_ref_t retained =
-              iree_vm_list_retain_ref(item_list.steal_raw_ptr());
+              iree_vm_list_move_ref(item_list.steal_raw_ptr());
           iree_vm_list_push_ref_move(list, &retained);
         };
       } else if (compound_type.equal(kSdictTag)) {
@@ -295,7 +295,7 @@ class InvokeStatics {
 
           // Push the sub list.
           iree_vm_ref_t retained =
-              iree_vm_list_retain_ref(item_list.steal_raw_ptr());
+              iree_vm_list_move_ref(item_list.steal_raw_ptr());
           iree_vm_list_push_ref_move(list, &retained);
         };
       } else {
@@ -452,8 +452,7 @@ class InvokeStatics {
         sub_packer(c, item_list.raw_ptr(), py_item);
       }
       // Push the sub list.
-      iree_vm_ref_t retained =
-          iree_vm_list_retain_ref(item_list.steal_raw_ptr());
+      iree_vm_ref_t retained = iree_vm_list_move_ref(item_list.steal_raw_ptr());
       iree_vm_list_push_ref_move(list, &retained);
     };
     AddPackCallback(py::type::of(py::list{}), sequence_callback);
@@ -482,8 +481,7 @@ class InvokeStatics {
         sub_packer(c, item_list.raw_ptr(), py_item);
       }
       // Push the sub list.
-      iree_vm_ref_t retained =
-          iree_vm_list_retain_ref(item_list.steal_raw_ptr());
+      iree_vm_ref_t retained = iree_vm_list_move_ref(item_list.steal_raw_ptr());
       iree_vm_list_push_ref_move(list, &retained);
     };
     AddPackCallback(py::type::of(py::dict{}), dict_callback);


### PR DESCRIPTION
This was a bit tricky to track down. It only affects structured argument
packing/unpacking. We were leaking a reference to the sub-list, which,
given that it usually contains buffers, was causing a leak of any
contained device backed memory buffers. Then much later, with asserts
enabled, the vulkan driver would notice that not all allocated memory
was freed and assert.

I am not completely sure on the cause of the non-determinism. Since the
problem manifests on shutdown, I'm (just guessing) that the normal
shutdown process may be bypassed sometimes? This does only affect a
subset of TF-specific invocation schemes, and until that was obvious, it
was difficult to see the pattern.

Fixes #9936