### PR TITLE
Add dispatch.region op to Flow dialect

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -272,6 +272,16 @@ static void printDispatchWorkgroupsCountRegion(OpAsmPrinter &p, Operation *op,
 }
 
 //===----------------------------------------------------------------------===//
+// flow.dispatch.region
+//===----------------------------------------------------------------------===//
+
+LogicalResult DispatchRegionOp::verify() {
+  if (!getBody().getArguments().empty())
+    return emitOpError() << "expected no block arguments";
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
 // flow.dispatch.tie_shape
 //===----------------------------------------------------------------------===//
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -24,6 +24,27 @@ class FLOW_PureOp<string mnemonic, list<Trait> traits = []> :
 // Partitioned regions
 //===----------------------------------------------------------------------===//
 
+def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
+    SingleBlockImplicitTerminator<"IREE::Flow::ReturnOp">]> {
+  let summary = [{a group of ops}];
+  let description = [{
+    This op is a container/grouping of ops. It represents a fusion group before
+    being lowered to a dispatch region. Ops are collected inside of the region
+    body of the op. Values from parent regions can be captured. Results are
+    yielded with a `return` terminator and returned from this op.
+
+    `dispatch.region` ops are lowered to `dispatch.workgroups` ops. Workgroups
+    isolated from above. `dispatch.region` ops are a more lightweight
+    abstraction for implementing fusion heuristics, i.e., the process of
+    deciding which ops should form a dispatch region.
+  }];
+
+  let results = (outs Variadic<AnyType>:$result);
+  let regions = (region AnyRegion:$body);
+  let assemblyFormat = "attr-dict `:` type($result) $body";
+  let hasVerifier = 1;
+}
+
 def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [
   IsolatedFromAbove,
   AttrSizedOperandSegments,

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -25,6 +25,7 @@ class FLOW_PureOp<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 
 def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
+    Util_ShapeAwareOp,
     SingleBlockImplicitTerminator<"IREE::Flow::ReturnOp">]> {
   let summary = [{a group of ops}];
   let description = [{
@@ -39,10 +40,16 @@ def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
     deciding which ops should form a dispatch region.
   }];
 
+  let arguments = (ins FLOW_ShapeDynamicDims:$result_dims);
   let results = (outs Variadic<AnyType>:$result);
   let regions = (region AnyRegion:$body);
-  let assemblyFormat = "attr-dict `:` type($result) $body";
+  let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    ValueRange getOperandDynamicDims(unsigned idx) { return ValueRange{}; }
+    ValueRange getResultDynamicDims(unsigned idx);
+  }];
 }
 
 def FLOW_DispatchWorkgroupsOp : FLOW_PureOp<"dispatch.workgroups", [

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
@@ -117,12 +117,31 @@ func.func @inplaceTypeChange(%arg0: tensor<4x?xf32>) -> tensor<?x4xf32> {
 // CHECK-LABEL: @region
 // CHECK-SAME: (%[[ARG0:.+]]: tensor<?x?xf32>)
 func.func @region(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // CHECK: %[[R:.*]] = flow.dispatch.region : tensor<?x?xf32> {
+  // CHECK: %[[R:.*]] = flow.dispatch.region -> (tensor<?x?xf32>{%{{.*}}, %{{.*}}}) {
   // CHECK:   flow.return %[[ARG0]] : tensor<?x?xf32>
   // CHECK: }
-  %r = flow.dispatch.region : tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %r = flow.dispatch.region -> (tensor<?x?xf32>{%d0, %d1}) {
     flow.return %arg0 : tensor<?x?xf32>
   }
   // CHECK: return %[[R]]
   return %r : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @regionStaticShape
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<5x10xf32>)
+func.func @regionStaticShape(%arg0: tensor<5x10xf32>) -> tensor<5x10xf32> {
+  // CHECK: %[[R:.*]] = flow.dispatch.region -> (tensor<5x10xf32>) {
+  // CHECK:   flow.return %[[ARG0]] : tensor<5x10xf32>
+  // CHECK: }
+  %r = flow.dispatch.region -> (tensor<5x10xf32>) {
+    flow.return %arg0 : tensor<5x10xf32>
+  }
+  // CHECK: return %[[R]]
+  return %r : tensor<5x10xf32>
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_ops.mlir
@@ -111,3 +111,18 @@ func.func @inplaceTypeChange(%arg0: tensor<4x?xf32>) -> tensor<?x4xf32> {
   %0 = flow.dispatch @ex0::@dispatch_fn[%cst](%arg0) : (tensor<4x?xf32>{%dim0}) -> %arg0 as tensor<?x4xf32>{%dim0}
   return %0 : tensor<?x4xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @region
+// CHECK-SAME: (%[[ARG0:.+]]: tensor<?x?xf32>)
+func.func @region(%arg0: tensor<?x?xf32>) -> tensor<?x?xf32> {
+  // CHECK: %[[R:.*]] = flow.dispatch.region : tensor<?x?xf32> {
+  // CHECK:   flow.return %[[ARG0]] : tensor<?x?xf32>
+  // CHECK: }
+  %r = flow.dispatch.region : tensor<?x?xf32> {
+    flow.return %arg0 : tensor<?x?xf32>
+  }
+  // CHECK: return %[[R]]
+  return %r : tensor<?x?xf32>
+}


### PR DESCRIPTION
A `region` op contains all ops that form a dispatch region. Fusion
heuristics should generate `region` ops. These can then be
lowered to a dispatch region, at which point the op becomes isolated
from above.