### PR TITLE
Make HalBufferView a VM Ref object in Python.

### DIFF
--- a/runtime/bindings/python/hal.h
+++ b/runtime/bindings/python/hal.h
@@ -11,6 +11,7 @@
 
 #include "./binding.h"
 #include "./status_utils.h"
+#include "./vm.h"
 #include "iree/hal/api.h"
 
 namespace iree {

--- a/runtime/bindings/python/iree/runtime/__init__.py
+++ b/runtime/bindings/python/iree/runtime/__init__.py
@@ -33,6 +33,7 @@ from ._binding import (
 from ._binding import (
     create_hal_module,
     Linkage,
+    VmBuffer,
     VmVariantList,
     VmFunction,
     VmInstance,

--- a/runtime/bindings/python/tests/function_test.py
+++ b/runtime/bindings/python/tests/function_test.py
@@ -515,7 +515,7 @@ class FunctionTest(unittest.TestCase):
           allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
           buffer=result_array,
           element_type=rt.HalElementType.SINT_32)
-      ret_list.push_buffer_view(buffer_view)
+      ret_list.push_ref(buffer_view)
 
     vm_context = MockVmContext(invoke)
     vm_function = MockVmFunction(reflection={
@@ -537,7 +537,7 @@ class FunctionTest(unittest.TestCase):
           allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
           buffer=result_array,
           element_type=rt.HalElementType.SINT_32)
-      ret_list.push_buffer_view(buffer_view)
+      ret_list.push_ref(buffer_view)
 
     vm_context = MockVmContext(invoke)
     vm_function = MockVmFunction(reflection={})
@@ -555,7 +555,7 @@ class FunctionTest(unittest.TestCase):
           allowed_usage=IMPLICIT_BUFFER_ARG_USAGE,
           buffer=result_array,
           element_type=rt.HalElementType.UINT_8)
-      ret_list.push_buffer_view(buffer_view)
+      ret_list.push_ref(buffer_view)
 
     vm_context = MockVmContext(invoke)
     vm_function = MockVmFunction(reflection={

--- a/runtime/bindings/python/tests/vm_types_test.py
+++ b/runtime/bindings/python/tests/vm_types_test.py
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import logging
+import numpy as np
 import unittest
 
 import iree.runtime as rt
@@ -28,6 +30,53 @@ class VmTypesTest(unittest.TestCase):
     self.assertNotEqual(lst1, False)
     self.assertTrue(ref.isinstance(rt.VmVariantList))
 
+  def test_variant_list(self):
+    l = rt.VmVariantList(5)
+    logging.info("variant_list: %s", l)
+    self.assertEqual(l.size, 0)
+
+  def test_variant_list_i64(self):
+    l = rt.VmVariantList(5)
+    # Push a value that exceeds 32-bit range.
+    l.push_int(10 * 1000 * 1000 * 1000)
+    self.assertEqual(str(l), "<VmVariantList(1): [10000000000]>")
+
+  def test_variant_list_buffers(self):
+    device = rt.get_device("local-sync")
+    ET = rt.HalElementType
+    for dt, et in ((np.int8, ET.SINT_8), (np.int16, ET.SINT_16),
+                   (np.int32, ET.SINT_32), (np.int64, ET.SINT_64),
+                   (np.uint8, ET.UINT_8), (np.uint16, ET.UINT_16),
+                   (np.uint32, ET.UINT_32), (np.uint64, ET.UINT_64),
+                   (np.float32, ET.FLOAT_32), (np.float64, ET.FLOAT_64)):
+      # TODO: Unimplemented: (np.float16, ET.FLOAT_16)
+      lst = rt.VmVariantList(5)
+      ary1 = np.asarray([1, 2, 3, 4], dtype=dt)
+      bv1 = device.allocator.allocate_buffer_copy(
+          memory_type=rt.MemoryType.DEVICE_LOCAL,
+          allowed_usage=(rt.BufferUsage.DEFAULT | rt.BufferUsage.MAPPING),
+          buffer=ary1,
+          element_type=et)
+      lst.push_ref(bv1)
+      ary2 = rt.DeviceArray(device,
+                            lst.get_as_object(0, rt.HalBufferView),
+                            override_dtype=dt,
+                            implicit_host_transfer=True)
+      np.testing.assert_array_equal(ary1, ary2)
+      with self.assertRaises(IndexError):
+        lst.get_as_object(1, rt.HalBufferView)
+
+  def test_variant_list_list(self):
+    lst1 = rt.VmVariantList(5)
+    lst2 = rt.VmVariantList(5)
+    lst1.push_list(lst2)
+    self.assertEqual("<VmVariantList(1): [List[]]>", str(lst1))
+    lstout = lst1.get_as_list(0)
+    self.assertEqual("<VmVariantList(0): []>", str(lstout))
+    with self.assertRaises(IndexError):
+      lst1.get_as_list(1)
+
 
 if __name__ == "__main__":
+  logging.basicConfig(level=logging.DEBUG)
   unittest.main()

--- a/runtime/bindings/python/tests/vm_types_test.py
+++ b/runtime/bindings/python/tests/vm_types_test.py
@@ -76,6 +76,19 @@ class VmTypesTest(unittest.TestCase):
     with self.assertRaises(IndexError):
       lst1.get_as_list(1)
 
+  def test_vm_buffer(self):
+    b1 = rt.VmBuffer(10, mutable=True)
+    print(b1)
+    contents = memoryview(b1)
+    contents[0:] = b'0123456789'
+    self.assertEqual(bytes(b1), b'0123456789')
+
+  def test_vm_buffer_ro(self):
+    b1 = rt.VmBuffer(10, mutable=False)
+    contents = memoryview(b1)
+    with self.assertRaises(TypeError):
+      contents[0:] = b'0123456789'
+
 
 if __name__ == "__main__":
   logging.basicConfig(level=logging.DEBUG)

--- a/runtime/bindings/python/vm.cc
+++ b/runtime/bindings/python/vm.cc
@@ -10,7 +10,9 @@
 #include "iree/base/api.h"
 #include "iree/base/status_cc.h"
 #include "iree/base/tracing.h"
-#include "iree/hal/api.h"
+// TODO: We shouldn't need the HAL API but it is used for direct printing
+// summaries of HAL objects in lists. We should have a better way of doing this
+// dynamically vs hard depending on a type switch here.
 #include "iree/modules/hal/module.h"
 #include "iree/vm/api.h"
 #include "pybind11/numpy.h"
@@ -19,15 +21,6 @@ namespace iree {
 namespace python {
 
 namespace {
-
-VmModule CreateHalModule(HalDevice* device) {
-  iree_vm_module_t* module;
-  CheckApiStatus(
-      iree_hal_module_create(device->raw_ptr(), IREE_HAL_MODULE_FLAG_NONE,
-                             iree_allocator_system(), &module),
-      "Error creating hal module");
-  return VmModule::StealFromRawPtr(module);
-}
 
 // RAII wrapper for a Py_buffer which calls PyBuffer_Release when it goes
 // out of scope.
@@ -182,8 +175,12 @@ const char* const VmRef::kRefAttr = "__iree_vm_ref__";
 const char* const VmRef::kCastAttr = "__iree_vm_cast__";
 const char* const VmRef::kTypeIdAttr = "__iree_vm_type_id__";
 
-py::object VmRef::Deref(py::object ref_object_class) {
-  return ref_object_class.attr(kCastAttr)(*this);
+py::object VmRef::Deref(py::object ref_object_class, bool optional) {
+  py::object casted = ref_object_class.attr(kCastAttr)(*this);
+  if (!optional && casted.is_none()) {
+    throw py::type_error("Cannot dereference to specific type");
+  }
+  return casted;
 }
 
 bool VmRef::IsInstance(py::object ref_object_class) {
@@ -229,11 +226,11 @@ void VmVariantList::PushList(VmVariantList& other) {
   iree_vm_list_push_ref_move(raw_ptr(), &retained);
 }
 
-void VmVariantList::PushBufferView(HalBufferView& buffer_view) {
-  iree_vm_ref_t buffer_view_ref =
-      iree_hal_buffer_view_retain_ref(buffer_view.raw_ptr());
-  CheckApiStatus(iree_vm_list_push_ref_move(raw_ptr(), &buffer_view_ref),
-                 "Error moving buffer view");
+void VmVariantList::PushRef(py::handle ref_or_object) {
+  py::object py_ref = ref_or_object.attr(VmRef::kRefAttr);
+  VmRef& ref = py::cast<VmRef&>(py_ref);
+  CheckApiStatus(iree_vm_list_push_ref_retain(raw_ptr(), &ref.ref()),
+                 "Failed to push ref");
 }
 
 py::object VmVariantList::GetAsList(int index) {
@@ -271,13 +268,10 @@ py::object VmVariantList::GetVariant(int index) {
     }
   } else if (v.type.ref_type == IREE_VM_REF_TYPE_NULL) {
     return py::none();
-  } else if (iree_vm_type_def_is_ref(&v.type)) {
-    // Convert reference type.
-    if (iree_vm_list_isa(v.ref)) {
-      return GetAsList(index);
-    } else if (iree_hal_buffer_view_isa(v.ref)) {
-      return GetAsBufferView(index);
-    }
+  } else if (iree_vm_variant_is_ref(v)) {
+    VmRef ref;
+    iree_vm_ref_retain(&v.ref, &ref.ref());
+    return py::cast(ref, py::return_value_policy::move);
   }
 
   throw RaiseValueError("Unsupported VM to Python Type Conversion");
@@ -387,16 +381,20 @@ py::object VmVariantList::GetAsSerializedTraceValue(int index) {
   throw RaiseValueError("Unsupported VM to Python Type Conversion");
 }
 
-py::object VmVariantList::GetAsBufferView(int index) {
+py::object VmVariantList::GetAsRef(int index) {
   iree_vm_variant_t v = iree_vm_variant_empty();
   CheckApiStatus(iree_vm_list_get_variant(raw_ptr(), index, &v),
                  "Could not access list element");
-  iree_hal_buffer_view_t* buffer_view = iree_hal_buffer_view_deref(v.ref);
-  if (!buffer_view) {
-    throw RaiseValueError("Could not deref result buffer view (wrong type?)");
+  if (!iree_vm_variant_is_ref(v)) {
+    throw std::invalid_argument("list element is not a ref");
   }
-  return py::cast(HalBufferView::BorrowFromRawPtr(buffer_view),
-                  py::return_value_policy::move);
+  VmRef ref;
+  iree_vm_ref_retain(&v.ref, &ref.ref());
+  return py::cast(ref, py::return_value_policy::move);
+}
+
+py::object VmVariantList::GetAsObject(int index, py::object clazz) {
+  return clazz.attr(VmRef::kCastAttr)(GetAsRef(index));
 }
 
 namespace {
@@ -514,10 +512,6 @@ std::string VmVariantList::DebugString() const {
 
 void SetupVmBindings(pybind11::module m) {
   IREE_CHECK_OK(iree_vm_register_builtin_types());
-  IREE_CHECK_OK(iree_hal_module_register_all_types());
-
-  // Built-in module creation.
-  m.def("create_hal_module", &CreateHalModule);
 
   py::enum_<enum iree_vm_function_linkage_e>(m, "Linkage")
       .value("INTERNAL", IREE_VM_FUNCTION_LINKAGE_INTERNAL)
@@ -529,13 +523,14 @@ void SetupVmBindings(pybind11::module m) {
   // Mutation and inspection of the variant list is mostly opaque to python.
   auto vm_list = py::class_<VmVariantList>(m, "VmVariantList");
   VmRef::BindRefProtocol(vm_list, iree_vm_list_type_id, iree_vm_list_retain_ref,
-                         iree_vm_list_check_deref);
+                         iree_vm_list_deref, iree_vm_list_isa);
   vm_list
       // User Methods.
       .def(py::init(&VmVariantList::Create))
       .def_property_readonly("size", &VmVariantList::size)
       .def("__len__", &VmVariantList::size)
-      .def("get_as_buffer_view", &VmVariantList::GetAsBufferView)
+      .def("get_as_ref", &VmVariantList::GetAsRef)
+      .def("get_as_object", &VmVariantList::GetAsObject)
       .def("get_as_list", &VmVariantList::GetAsList)
       .def("get_variant", &VmVariantList::GetVariant)
       .def("get_serialized_trace_value",
@@ -543,7 +538,7 @@ void SetupVmBindings(pybind11::module m) {
       .def("push_float", &VmVariantList::PushFloat)
       .def("push_int", &VmVariantList::PushInt)
       .def("push_list", &VmVariantList::PushList)
-      .def("push_buffer_view", &VmVariantList::PushBufferView)
+      .def("push_ref", &VmVariantList::PushRef)
       .def("__repr__", &VmVariantList::DebugString);
 
   py::class_<iree_vm_function_t>(m, "VmFunction")
@@ -650,8 +645,11 @@ void SetupVmBindings(pybind11::module m) {
 
   py::class_<VmRef>(m, "VmRef")
       .def("isinstance", &VmRef::IsInstance)
-      .def("deref", &VmRef::Deref)
+      .def("deref", &VmRef::Deref, py::arg("value"),
+           py::arg("optional") = false)
       .def("__repr__", &VmRef::ToString)
+      .def_property_readonly(VmRef::kRefAttr,
+                             [](py::object self) { return self; })
       .def("__eq__",
            [](VmRef& self, VmRef& other) {
              return self.ref().ptr == other.ref().ptr;

--- a/runtime/bindings/python/vm.h
+++ b/runtime/bindings/python/vm.h
@@ -10,7 +10,7 @@
 #include <optional>
 
 #include "./binding.h"
-#include "./hal.h"
+#include "./status_utils.h"
 #include "iree/base/api.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_module.h"
@@ -94,9 +94,10 @@ class VmVariantList : public ApiRefCounted<VmVariantList, iree_vm_list_t> {
   void PushFloat(double fvalue);
   void PushInt(int64_t ivalue);
   void PushList(VmVariantList& other);
-  void PushBufferView(HalBufferView& buffer_view);
+  void PushRef(py::handle ref_or_object);
   py::object GetAsList(int index);
-  py::object GetAsBufferView(int index);
+  py::object GetAsRef(int index);
+  py::object GetAsObject(int index, py::object clazz);
   py::object GetVariant(int index);
   py::object GetAsSerializedTraceValue(int index);
 };
@@ -174,7 +175,8 @@ class VmRef {
   //   [readonly property] __iree_vm_ref__ :
   //        Gets a VmRef from the object.
   //   __iree_vm_cast__(ref) :
-  //        Dereferences the VmRef to the concrete type.
+  //        Dereferences the VmRef to the concrete type. Returns None on cast
+  //        failure.
   //
   // In addition, a user attribute of "ref" will be added that is an alias of
   // __iree_vm_ref__.
@@ -191,10 +193,10 @@ class VmRef {
   static const char* const kCastAttr;
 
   template <typename PyClass, typename TypeIdFunctor, typename RetainRefFunctor,
-            typename CheckDerefFunctor>
+            typename DerefFunctor, typename IsaFunctor>
   static void BindRefProtocol(PyClass& cls, TypeIdFunctor type_id,
-                              RetainRefFunctor retain_ref,
-                              CheckDerefFunctor check_deref) {
+                              RetainRefFunctor retain_ref, DerefFunctor deref,
+                              IsaFunctor isa) {
     using WrapperType = typename PyClass::type;
     using RawPtrType = typename WrapperType::RawPtrType;
     auto ref_lambda = [=](WrapperType& self) {
@@ -203,10 +205,12 @@ class VmRef {
     cls.def_static(VmRef::kTypeIdAttr, [=]() { return type_id(); });
     cls.def_property_readonly(VmRef::kRefAttr, ref_lambda);
     cls.def_property_readonly("ref", ref_lambda);
-    cls.def_static(VmRef::kCastAttr, [=](VmRef& ref) {
-      RawPtrType casted;
-      CheckApiStatus(check_deref(ref.ref(), &casted), "Incompatible type");
-      return WrapperType::StealFromRawPtr(casted);
+    cls.def_static(VmRef::kCastAttr, [=](VmRef& ref) -> py::object {
+      if (!isa(ref.ref())) {
+        return py::none();
+      }
+      return py::cast(WrapperType::BorrowFromRawPtr(deref(ref.ref())),
+                      py::return_value_policy::move);
     });
     cls.def("__eq__", [](WrapperType& self, WrapperType& other) {
       return self.raw_ptr() == other.raw_ptr();
@@ -233,7 +237,7 @@ class VmRef {
 
   iree_vm_ref_t& ref() { return ref_; }
 
-  py::object Deref(py::object ref_object_class);
+  py::object Deref(py::object ref_object_class, bool optional);
   bool IsInstance(py::object ref_object_class);
 
   std::string ToString();

--- a/runtime/bindings/python/vm.h
+++ b/runtime/bindings/python/vm.h
@@ -26,6 +26,12 @@ class FunctionAbi;
 //------------------------------------------------------------------------------
 
 template <>
+struct ApiPtrAdapter<iree_vm_buffer_t> {
+  static void Retain(iree_vm_buffer_t* b) { iree_vm_buffer_retain(b); }
+  static void Release(iree_vm_buffer_t* b) { iree_vm_buffer_release(b); }
+};
+
+template <>
 struct ApiPtrAdapter<iree_vm_instance_t> {
   static void Retain(iree_vm_instance_t* b) { iree_vm_instance_retain(b); }
   static void Release(iree_vm_instance_t* b) { iree_vm_instance_release(b); }
@@ -66,6 +72,12 @@ struct ApiPtrAdapter<iree_vm_ref_t> {
   }
   static void Release(iree_vm_ref_t* b) { iree_vm_ref_release(b); }
 };
+
+//------------------------------------------------------------------------------
+// VmBuffer
+//------------------------------------------------------------------------------
+
+class VmBuffer : public ApiRefCounted<VmBuffer, iree_vm_buffer_t> {};
 
 //------------------------------------------------------------------------------
 // VmVariantList


### PR DESCRIPTION
Previously, the VM was depending on HAL, which made this impossible.
Severs the dependency and make VmVariantList operate on generic
reference types. Refactors call sites to cast explicitly to their
expected types.
    
Eliminates APIs:
    
* VmVariantList.get_as_buffer_view() (use get_as_ref() or
  get_as_object())
* VmVariantList.push_buffer_view() (use push_ref()).
    
Changed APIs:
    
* VmVariantList.get_variant() now returns a VmRef instead of a casted
  object.
    
All of these are fairly internal APIs that users should not have likely
used yet.

* Adds Python binding for an iree_vm_buffer.