### PR TITLE
Add transform dialect building blocks for dispatch region formation

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -9,6 +9,7 @@
 
 include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
+include "mlir/Dialect/Transform/IR/TransformEffects.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
@@ -45,6 +46,79 @@ def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreac
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::scf::ForeachThreadOp target,
         ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def WrapInDispatchRegionOp : Op<
+    Transform_Dialect, "iree.wrap_in_dispatch_region",
+    [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,
+     TransformOpInterface, TransformEachOpTrait]> {
+  let description = [{
+    Wrap the `target` op in a new `dispatch.region` op. All uses of target op
+    are replaces with the results of the newly generated `dispach.region` op.
+
+    #### Return modes
+
+    This transform consumes the `target` handle and produces the `transformed`
+    handle (i.e., the `dispatch.region` op).
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def ClonePrecedingOpIntoDispatchRegionOp : Op<
+    Transform_Dialect, "iree.clone_preceding_op_into_dispatch_region",
+    [TransformOpInterface]> {
+  let description = [{
+    Clone the `target` op into the given dispatch region op. The dispatch region
+    handle must be mapped to exactly one payload op.
+
+    All uses of the target inside of the dispatch region are replaced with the
+    results of the cloned op.
+
+    If `update_uses_outside_of_region` is set, all uses outside of the dispatch
+    region are also replaced: The results of the cloned target op are yielded
+    from the dispatch region and used in all uses outside of the dispatch
+    region. The transform fails if there are uses that appear before the
+    dispatch region.
+
+
+
+    TODO: Support multiple payload ops for the `target` handle. In that case,
+    the targets must be sorted topologically before cloning them.
+
+    #### Return modes
+
+    This transform consumes both the `target` handle and the `dispatch_region`
+    handle. It produces a new handle to the extended dispatch region.
+  }];
+
+  let arguments = (ins Arg<PDL_Operation, "",
+                           [TransformMappingRead,
+                            TransformMappingFree]>:$target,
+                       Arg<PDL_Operation, "",
+                           [TransformMappingRead,
+                            TransformMappingFree]>:$dispatch_region,
+                       DefaultValuedAttr<BoolAttr, "false">:$update_uses_outside_of_region);
+  let results = (outs Res<PDL_Operation, "",
+                           [TransformMappingAlloc,
+                            TransformMappingWrite]>:$transformed);
+  let assemblyFormat = "$target `into` $dispatch_region attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure apply(
+        ::mlir::transform::TransformResults &transformResults,
         ::mlir::transform::TransformState &state);
   }];
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -43,6 +43,7 @@ iree_lit_test_suite(
             "region_to_workgroups.mlir",
             "strip_and_splat_constant_variables.mlir",
             "strip_signedness.mlir",
+            "transform_dispatch_region_formation.mlir",
             "transformation_pipeline.mlir",
             "verify_input_ir.mlir",
         ],

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_lit_test_suite(
     "region_to_workgroups.mlir"
     "strip_and_splat_constant_variables.mlir"
     "strip_signedness.mlir"
+    "transform_dispatch_region_formation.mlir"
     "transformation_pipeline.mlir"
     "verify_input_ir.mlir"
   TOOLS

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dispatch_region_formation.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dispatch_region_formation.mlir
@@ -1,0 +1,89 @@
+// RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule -allow-unregistered-dialect -split-input-file | FileCheck %s
+
+// CHECK-LABEL: func @single_op(
+//  CHECK-SAME:   %[[arg0:.*]]: tensor<?x?xf32>, %[[s1:.*]]: index, %[[s2:.*]]: index
+func.func @single_op(%arg0: tensor<?x?xf32>, %s1: index, %s2: index) -> tensor<?x?xf32> {
+  // CHECK: %[[region:.*]] = flow.dispatch.region -> (tensor<?x?xf32>{%[[s1]], %[[s2]]}) {
+  // CHECK:   %[[slice:.*]] = tensor.extract_slice %[[arg0]]
+  // CHECK:   flow.return %[[slice]]
+  // CHECK: }
+  // CHECK: return %[[region]]
+  %0 = tensor.extract_slice %arg0 [0, 10] [%s1, %s2] [1, 1]
+      : tensor<?x?xf32> to tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1
+    transform.iree.wrap_in_dispatch_region %0
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func @clone_preceding(
+//  CHECK-SAME:   %[[arg0:.*]]: tensor<?x?xf32>, %[[arg1:.*]]: tensor<?x?xf32>, %[[s1:.*]]: index, %[[s2:.*]]: index
+func.func @clone_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: index, %s2: index) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+  // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[dim0:.*]] = tensor.dim %[[arg1]], %[[c0]]
+  // CHECK-DAG: %[[dim1:.*]] = tensor.dim %[[arg1]], %[[c1]]
+  // CHECK: %[[dummy:.*]] = "test.dummy"
+  // CHECK: %[[region:.*]] = flow.dispatch.region -> (tensor<?x?xf32>{%[[dim0]], %[[dim1]]}) {
+  // CHECK:   %[[dummy_clone:.*]] = "test.dummy"
+  // CHECK:   %[[insert:.*]] = tensor.insert_slice %[[dummy_clone]] into %[[arg1]]
+  // CHECK:   flow.return %[[insert]]
+  // CHECK: }
+  // CHECK: return %[[dummy]], %[[region]]
+  %0 = "test.dummy"() : () -> (tensor<?x?xf32>)
+  %1 = tensor.insert_slice %0 into %arg1 [5, 16] [%s1, %s2] [1, 1]
+      : tensor<?x?xf32> into tensor<?x?xf32>
+  return %0, %1 : tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1
+    %dispatch_op = transform.iree.wrap_in_dispatch_region %0
+    %1 = transform.structured.match ops{["test.dummy"]} in %arg1
+    transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op
+  }
+}
+
+// -----
+
+// CHECK-LABEL: func @move_preceding(
+//  CHECK-SAME:   %[[arg0:.*]]: tensor<?x?xf32>, %[[arg1:.*]]: tensor<?x?xf32>, %[[s1:.*]]: index, %[[s2:.*]]: index
+func.func @move_preceding(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>, %s1: index, %s2: index) -> (tensor<?x?xf32>, tensor<?x?xf32>) {
+  // CHECK-DAG: %[[c0:.*]] = arith.constant 0 : index
+  // CHECK-DAG: %[[c1:.*]] = arith.constant 1 : index
+  // CHECK-DAG: %[[dim0:.*]] = tensor.dim %[[arg1]], %[[c0]]
+  // CHECK-DAG: %[[dim1:.*]] = tensor.dim %[[arg1]], %[[c1]]
+  // CHECK: %[[region:.*]]:2 = flow.dispatch.region -> (tensor<?x?xf32>{%[[dim0]], %[[dim1]]}, tensor<?x?xf32>{%[[s1]], %[[s2]]}) {
+  // CHECK:   %[[slice:.*]] = tensor.extract_slice %[[arg0]]
+  // CHECK:   %[[insert:.*]] = tensor.insert_slice %[[slice]] into %[[arg1]]
+  // CHECK:   flow.return %[[insert]], %[[slice]]
+  // CHECK: }
+  // CHECK: return %[[region]]#0, %[[region]]#1
+  %0 = tensor.extract_slice %arg0 [0, 10] [%s1, %s2] [1, 1]
+      : tensor<?x?xf32> to tensor<?x?xf32>
+  %1 = tensor.insert_slice %0 into %arg1 [5, 16] [%s1, %s2] [1, 1]
+      : tensor<?x?xf32> into tensor<?x?xf32>
+  return %1, %0 : tensor<?x?xf32>, tensor<?x?xf32>
+}
+
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %0 = transform.structured.match ops{["tensor.insert_slice"]} in %arg1
+    %dispatch_op = transform.iree.wrap_in_dispatch_region %0
+    %1 = transform.structured.match ops{["tensor.extract_slice"]} in %arg1
+    transform.iree.clone_preceding_op_into_dispatch_region %1 into %dispatch_op {update_uses_outside_of_region = true}
+  }
+}


### PR DESCRIPTION
This commit adds two new transform dialect ops:
* WrapInDispatchRegionOp: Warp an arbitrary op in a new
  `dispatch.region` op.
* PullPrecedingOpIntoDispatchRegionOp: Move a preceding op into an
  existing `dispatch.region` op.

These ops will be used to build heuristics for dispatch region
formation.

The implementation of both ops is purpusely inside of static functions,
such the rewrite logic could be called from C++ without using the
transform dialect, if necessary.