### PR TITLE
Clean up RISC-V CI RVV config

### DIFF
--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -150,7 +150,7 @@ tools/iree-compile \
   --iree-llvm-target-cpu=generic-rv64 \
   --iree-llvm-target-abi=lp64d \
   --iree-llvm-target-cpu-features="+m,+a,+f,+d,+v" \
-  --riscv-v-vector-bits-min=256 --riscv-v-fixed-length-vector-lmul-max=8 \
+  --riscv-v-vector-bits-min=512 --riscv-v-fixed-length-vector-lmul-max=8 \
   iree_input.mlir -o mobilenet_cpu.vmfb
 ```
 
@@ -158,7 +158,7 @@ Then run on the RISC-V QEMU:
 
 ```shell hl_lines="2 5"
 ${QEMU_BIN} \
-  -cpu rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
+  -cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0 \
   -L ${RISCV_TOOLCHAIN_ROOT}/sysroot/ \
   ../iree-build-riscv/tools/iree-run-module \
   --device=local-task \

--- a/tests/riscv32/smoke.sh
+++ b/tests/riscv32/smoke.sh
@@ -16,17 +16,14 @@ export PS4='[$(date -u "+%T %Z")] '
 # Run the embedded_library module loader and simple_embedding under QEMU.
 echo "Test elf_module_test_binary"
 pushd "${BUILD_RISCV_DIR}/runtime/src/iree/hal/local/elf" > /dev/null
-"${QEMU_RV32_BIN}" -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
-elf_module_test_binary
+"${QEMU_RV32_BIN}" -cpu rv32 elf_module_test_binary
 popd > /dev/null
 
 echo "Test simple_embedding binaries"
 pushd "${BUILD_RISCV_DIR}/samples/simple_embedding" > /dev/null
 
-"${QEMU_RV32_BIN}" -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
-simple_embedding_embedded_sync
+"${QEMU_RV32_BIN}" -cpu rv32 simple_embedding_embedded_sync
 
-"${QEMU_RV32_BIN}" -cpu rv32,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0 \
-simple_embedding_vmvx_sync
+"${QEMU_RV32_BIN}" -cpu rv32 simple_embedding_vmvx_sync
 
 popd > /dev/null

--- a/tests/riscv64/lit.cfg.py
+++ b/tests/riscv64/lit.cfg.py
@@ -16,7 +16,7 @@ config.environment["BUILD_RISCV_DIR"] = BUILD_RISCV_DIR
 test_cmd = [
     os.environ["QEMU_RV64_BIN"],
     "-cpu",
-    "rv64,x-v=true,x-k=true,vlen=256,elen=64,vext_spec=v1.0",
+    "rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0",
     "-L",
     os.path.join(os.environ["RISCV_TOOLCHAIN_ROOT"], "sysroot"),
 ]

--- a/tests/riscv64/smoke.sh
+++ b/tests/riscv64/smoke.sh
@@ -50,7 +50,7 @@ function generate_llvm_cpu_vmfb {
       --iree-input-type=tosa
       --iree-llvm-target-cpu-features="+m,+a,+f,+d,+c,+v"
       --riscv-v-fixed-length-vector-lmul-max=8
-      --riscv-v-vector-bits-min=256
+      --riscv-v-vector-bits-min=512
       "${BUILD_RISCV_DIR}/tosa.mlir"
     )
   fi
@@ -61,7 +61,7 @@ generate_llvm_cpu_vmfb mhlo \
   "${ROOT_DIR}/tools/test/iree-run-module.mlir" \
   -o "${BUILD_RISCV_DIR}/iree-run-module-llvm_aot.vmfb"
 
-wget -P "${BUILD_RISCV_DIR}/" https://github.com/tensorflow/tflite-micro/raw/aeac6f39e5c7475cea20c54e86d41e3a38312546/tensorflow/lite/micro/models/person_detect.tflite
+wget -P "${BUILD_RISCV_DIR}/" "https://storage.googleapis.com/iree-model-artifacts/person_detect.tflite"
 
 generate_llvm_cpu_vmfb tosa \
   "${BUILD_RISCV_DIR}/person_detect.tflite" \


### PR DESCRIPTION
* Remove QEMU vector setting for non-vector emulation in rv32
* Use vlen=512 for v-ext emulation to align with `benchmarks/` setup
* Update the e2e model path to align with `benchmarks/` setup