### PR TITLE
Show executable sources via source locs in Tracy if available.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.h
@@ -27,7 +27,8 @@ namespace HAL {
 //
 // Usage:
 //  LibraryBuilder builder(&module);
-//  builder.addExport("hello", "", DispatchAttrs{}, &helloFunc);
+//  builder.addExport(
+//     "hello", "source.mlir", 123, "test tag", DispatchAttrs{}, &helloFunc);
 //  ...
 //  auto *queryFunc = builder.build("_query_library_foo");
 //  // call queryFunc, export it, etc
@@ -110,11 +111,13 @@ class LibraryBuilder {
   }
 
   // Defines a new entry point on the library implemented by |func|.
-  // |name| will be used as the library export and an optional |tag| will be
-  // attached.
-  void addExport(StringRef name, StringRef tag, DispatchAttrs attrs,
-                 llvm::Function *func) {
-    exports.push_back({name.str(), tag.str(), attrs, func});
+  // |name| will be used as the library export
+  // |sourceFile| and |sourceLoc| are optional source information
+  // |tag| is an optional attachment
+  void addExport(StringRef name, StringRef sourceFile, uint32_t sourceLoc,
+                 StringRef tag, DispatchAttrs attrs, llvm::Function *func) {
+    exports.push_back(
+        {name.str(), sourceFile.str(), sourceLoc, tag.str(), attrs, func});
   }
 
   // Builds a `iree_hal_executable_library_query_fn_t` with the given
@@ -148,6 +151,8 @@ class LibraryBuilder {
 
   struct Dispatch {
     std::string name;
+    std::string sourceFile;
+    uint32_t sourceLoc;
     std::string tag;
     DispatchAttrs attrs;
     llvm::Function *func;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -216,6 +216,8 @@ class TargetBackend {
     std::string dumpIntermediatesPath;
     // Optional path to write serialized binary results into.
     std::string dumpBinariesPath;
+    // Optional path that executable sources were already written to.
+    std::string dumpedSourcesPath;
   };
 
   // Serializes the given |variantOp| executable produced by this backend to one

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -227,7 +227,8 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
     passManager.addNestedPass<IREE::HAL::ExecutableOp>(
         createSerializeExecutablesPass(
             targetOptions.executableIntermediatesPath,
-            targetOptions.executableBinariesPath));
+            targetOptions.executableBinariesPath,
+            targetOptions.sourceListingPath));
 
     // NOTE: symbol DCE will destroy executable target contents, so only run it
     // if we serialized things.

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -124,13 +124,15 @@ createResolveExportOrdinalsPass();
 // Converts hal.executable.variants to one or more hal.executable.binary ops.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
 createSerializeExecutablesPass(std::string dumpIntermediatesPath = "",
-                               std::string dumpBinariesPath = "");
+                               std::string dumpBinariesPath = "",
+                               std::string dumpedSourcesPath = "");
 
 // Serializes executables for the specified |target| backend.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableOp>>
 createSerializeTargetExecutablesPass(StringRef target,
                                      std::string dumpIntermediatesPath = "",
-                                     std::string dumpBinariesPath = "");
+                                     std::string dumpBinariesPath = "",
+                                     std::string dumpedSourcesPath = "");
 
 //===----------------------------------------------------------------------===//
 // Resource initialization, caching, and optimization

--- a/runtime/src/iree/hal/local/executable_library.h
+++ b/runtime/src/iree/hal/local/executable_library.h
@@ -408,6 +408,13 @@ typedef struct iree_hal_executable_export_table_v0_t {
   // verbose logging. The string values, when present, may be attached to
   // tracing/debugging events related to the entry point.
   const char* const* tags;
+
+  // Optional table of source files which src_locs index into, 1:1 with ptrs.
+  const char* const* src_files;
+
+  // Optional table of source location line numbers, 1:1 with ptrs.
+  // Used to map back to locations in src_file.
+  const uint32_t* src_locs;
 } iree_hal_executable_export_table_v0_t;
 
 // A table declaring the executable-level constants that can be used to

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -263,9 +263,23 @@ static iree_status_t iree_hal_elf_executable_issue_call(
   if (iree_string_view_is_empty(entry_point_name)) {
     entry_point_name = iree_make_cstring_view("unknown_elf_call");
   }
-  IREE_TRACE_ZONE_BEGIN_EXTERNAL(
-      z0, executable->identifier.data, executable->identifier.size, ordinal,
-      entry_point_name.data, entry_point_name.size, NULL, 0);
+  const char* source_file = NULL;
+  size_t source_file_length = 0;
+  uint32_t source_loc;
+  if (library->exports.src_files != NULL && library->exports.src_locs != NULL) {
+    // We have source location data, so use it.
+    source_file = library->exports.src_files[ordinal];
+    source_file_length = strlen(source_file);
+    source_loc = library->exports.src_locs[ordinal];
+  } else {
+    // No source location data, so make do with what we have.
+    source_file = executable->identifier.data;
+    source_file_length = executable->identifier.size;
+    source_loc = ordinal;
+  }
+  IREE_TRACE_ZONE_BEGIN_EXTERNAL(z0, source_file, source_file_length,
+                                 source_loc, entry_point_name.data,
+                                 entry_point_name.size, NULL, 0);
   if (library->exports.tags != NULL) {
     const char* tag = library->exports.tags[ordinal];
     if (tag) {

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -134,11 +134,25 @@ static iree_status_t iree_hal_static_executable_issue_call(
     entry_point_name = iree_make_cstring_view(library->exports.names[ordinal]);
   }
   if (iree_string_view_is_empty(entry_point_name)) {
-    entry_point_name = iree_make_cstring_view("unknown_dylib_call");
+    entry_point_name = iree_make_cstring_view("unknown_static_call");
   }
-  IREE_TRACE_ZONE_BEGIN_EXTERNAL(
-      z0, executable->identifier.data, executable->identifier.size, ordinal,
-      entry_point_name.data, entry_point_name.size, NULL, 0);
+  const char* source_file = NULL;
+  size_t source_file_length = 0;
+  uint32_t source_loc;
+  if (library->exports.src_files != NULL && library->exports.src_locs != NULL) {
+    // We have source location data, so use it.
+    source_file = library->exports.src_files[ordinal];
+    source_file_length = strlen(source_file);
+    source_loc = library->exports.src_locs[ordinal];
+  } else {
+    // No source location data, so make do with what we have.
+    source_file = executable->identifier.data;
+    source_file_length = executable->identifier.size;
+    source_loc = ordinal;
+  }
+  IREE_TRACE_ZONE_BEGIN_EXTERNAL(z0, source_file, source_file_length,
+                                 source_loc, entry_point_name.data,
+                                 entry_point_name.size, NULL, 0);
   if (library->exports.tags != NULL) {
     const char* tag = library->exports.tags[ordinal];
     if (tag) {

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -383,9 +383,23 @@ static iree_status_t iree_hal_system_executable_issue_call(
   if (iree_string_view_is_empty(entry_point_name)) {
     entry_point_name = iree_make_cstring_view("unknown_dylib_call");
   }
-  IREE_TRACE_ZONE_BEGIN_EXTERNAL(
-      z0, executable->identifier.data, executable->identifier.size, ordinal,
-      entry_point_name.data, entry_point_name.size, NULL, 0);
+  const char* source_file = NULL;
+  size_t source_file_length = 0;
+  uint32_t source_loc;
+  if (library->exports.src_files != NULL && library->exports.src_locs != NULL) {
+    // We have source location data, so use it.
+    source_file = library->exports.src_files[ordinal];
+    source_file_length = strlen(source_file);
+    source_loc = library->exports.src_locs[ordinal];
+  } else {
+    // No source location data, so make do with what we have.
+    source_file = executable->identifier.data;
+    source_file_length = executable->identifier.size;
+    source_loc = ordinal;
+  }
+  IREE_TRACE_ZONE_BEGIN_EXTERNAL(z0, source_file, source_file_length,
+                                 source_loc, entry_point_name.data,
+                                 entry_point_name.size, NULL, 0);
   if (library->exports.tags != NULL) {
     const char* tag = library->exports.tags[ordinal];
     if (tag) {


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/7211 😄 

Tracy captures of `iree-run-module` (and other runtime binaries) can now reference source information for dispatch regions. This lets developers see what computation is running in each dispatch without having to cross-reference between the UI and an IR dump:

![image](https://user-images.githubusercontent.com/4010439/182487590-a6b1fbae-9a04-482d-b9c8-c7da05c9c47d.png)

There are many points at which we _could_ snapshot the IR and consider it the source (mhlo, linalg, after lowering to LLVM, etc.). I opted to piggyback off of the existing `DumpExecutableSourcesPass` so that these debugging tools could work together. If you set `--iree-hal-dump-executable-sources-to={path}` while `--iree-llvm-debug-symbols` is also set (the default), the absolute paths to the dumped executable sources will be plumbed through the executable libraries and into Tracy.
* Note that these absolute paths are not portable, so if you compile on one machine (e.g. Linux) and then run on another (e.g. Android), the source file paths will not match up. There are a few things we can try to improve that once this works at all.

Currently supported in the llvm-cpu target only, but other targets could add their own information in a similar way.