### PR TITLE
Remove unused results from DispatchRegionOps

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.h
@@ -30,6 +30,7 @@ namespace mlir {
 namespace iree_compiler {
 namespace IREE {
 namespace Flow {
+class DispatchRegionOp;
 
 // Returns the `combinedOffsets`, `combinedSizes` and `combinedStrides` to use
 // when folding a "producer" **into** a "consumer" op that implement
@@ -57,6 +58,11 @@ void populateTensorSliceOpWithDispatchTensorOpFoldingPatterns(
 
 // Verifies the flow.dispatch.workgroup.size/id/count operations.
 LogicalResult verifyDispatchWorkgroupInfoOp(Operation *op, uint64_t dimension);
+
+// Drop unused results of the given dispatch region. Return `true` if the IR
+// was modified.
+bool dropUnusedDispatchRegionResults(RewriterBase &rewriter,
+                                     Flow::DispatchRegionOp regionOp);
 
 }  // namespace Flow
 }  // namespace IREE

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -43,6 +43,7 @@ def FLOW_DispatchRegionOp : FLOW_PureOp<"dispatch.region", [
   let arguments = (ins FLOW_ShapeDynamicDims:$result_dims);
   let results = (outs Variadic<AnyType>:$result);
   let regions = (region AnyRegion:$body);
+  let hasCanonicalizer = 1;
   let hasCustomAssemblyFormat = 1;
   let hasVerifier = 1;
 


### PR DESCRIPTION
Add a canonicalization pattern that removes unused results from dispatch
regions. Also exposes this canonicalization as a transform dialect ops,
such that the canonicalization can be applied without running the
GreedyPatternRewriter.