### PR TITLE
Don't report compiler specifics if not built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,15 +219,17 @@ cmake_dependent_option(IREE_INPUT_MHLO "Builds support for compiling MHLO progra
 cmake_dependent_option(IREE_INPUT_TORCH "Builds support for compiling Torch MLIR programs" ON ${IREE_BUILD_COMPILER} OFF)
 cmake_dependent_option(IREE_INPUT_TOSA "Builds support for compiling TOSA programs" ON ${IREE_BUILD_COMPILER} OFF)
 
-message(STATUS "IREE compiler input dialects:")
-if(IREE_INPUT_MHLO)
-  message(STATUS "  - MHLO")
-endif()
-if(IREE_INPUT_TORCH)
-  message(STATUS "  - Torch MLIR")
-endif()
-if(IREE_INPUT_TOSA)
-  message(STATUS "  - TOSA")
+if(IREE_BUILD_COMPILER)
+  message(STATUS "IREE compiler input dialects:")
+  if(IREE_INPUT_MHLO)
+    message(STATUS "  - MHLO")
+  endif()
+  if(IREE_INPUT_TORCH)
+    message(STATUS "  - Torch MLIR")
+  endif()
+  if(IREE_INPUT_TOSA)
+    message(STATUS "  - TOSA")
+  endif()
 endif()
 
 #-------------------------------------------------------------------------------
@@ -236,13 +238,15 @@ endif()
 
 cmake_dependent_option(IREE_OUTPUT_FORMAT_C "Enables the 'vm-c' output format, using MLIR EmitC" ON ${IREE_BUILD_COMPILER} OFF)
 
-message(STATUS "IREE compiler output formats:")
-if(IREE_OUTPUT_FORMAT_C)
-  message(STATUS "  - C source module")
+if(IREE_BUILD_COMPILER)
+  message(STATUS "IREE compiler output formats:")
+  if(IREE_OUTPUT_FORMAT_C)
+    message(STATUS "  - C source module")
+  endif()
+  # The 'vm-bytecode' and 'vm-asm' formats are always enabled.
+  message(STATUS "  - VM Bytecode")
+  message(STATUS "  - VM MLIR Assembly")
 endif()
-# The 'vm-bytecode' and 'vm-asm' formats are always enabled.
-message(STATUS "  - VM Bytecode")
-message(STATUS "  - VM MLIR Assembly")
 
 #-------------------------------------------------------------------------------
 # IREE compilation toolchain configuration


### PR DESCRIPTION
With #9474 the compiler inputs and outputs are always reported even
though the compiler might not be built (e.g. when only building the
runtime). This can be confusing for example when using a snapshot
install of the compiler that generates the workload (especially if it
should generate a C source module) which is than cross-compiled together
with the runtime (this the case in iree-bare-metal for example). With
this patch inputs and outputs (non at all in the example given before)
are only reported when building the compiler.