### PR TITLE
Exclude fragment_000.mlir.test from ASan build.

### DIFF
--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -124,6 +124,7 @@ label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 # TODO(#5715): Fix these
 declare -a excluded_tests=(
   "iree/samples/simple_embedding/simple_embedding_vulkan_test"
+  "iree/tests/e2e/models/fragment_000.mlir.test"
   "iree/tools/test/iree-benchmark-module.mlir.test"
   "iree/tools/test/iree-run-module.mlir.test"
   "iree/tools/test/multiple_exported_functions.mlir.test"


### PR DESCRIPTION
Looks like the ASan Vulkan/SwiftShader crash we have in a few other tests:

https://github.com/iree-org/iree/runs/7675754080?check_suite_focus=true

```
976/998 Test   #41: iree/tests/e2e/models/fragment_000.mlir.test .............................................................................***Failed    8.92 sec
-- Testing: 1 tests, 1 workers --
FAIL: IREE :: e2e/models/fragment_000.mlir (1 of 1)
******************** TEST 'IREE :: e2e/models/fragment_000.mlir' FAILED ********************
Script:
--
: 'RUN: at line 1';   iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=vmvx /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/fragment_000.mlir --function-input="f32=0" --function-input="5x1xf32=[1][-2][-3][4][-5]" --function-input="f32=1" --function-input="5x5xf32=[3.46499 -7.64389 -5.72249 5.98053 17.6892][2.9707 -6.20734 -4.25962 4.76055 13.8784][2.47641 -4.77079 -2.79675 3.54056 10.0675][1.98212 -3.33424 -1.33388 2.32058 6.25666][1.48783 -1.8977 0.12899 1.1006 2.4458]" --function-input="5xf32=0 0 0 0 0" | FileCheck /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/fragment_000.mlir
: 'RUN: at line 2';   iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=llvm-cpu /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/fragment_000.mlir --function-input="f32=0" --function-input="5x1xf32=[1][-2][-3][4][-5]" --function-input="f32=1" --function-input="5x5xf32=[3.46499 -7.64389 -5.72249 5.98053 17.6892][2.9707 -6.20734 -4.25962 4.76055 13.8784][2.47641 -4.77079 -2.79675 3.54056 10.0675][1.98212 -3.33424 -1.33388 2.32058 6.25666][1.48783 -1.8977 0.12899 1.1006 2.4458]" --function-input="5xf32=0 0 0 0 0" | FileCheck /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/fragment_000.mlir
: 'RUN: at line 3';   [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/fragment_000.mlir --function-input="f32=0" --function-input="5x1xf32=[1][-2][-3][4][-5]" --function-input="f32=1" --function-input="5x5xf32=[3.46499 -7.64389 -5.72249 5.98053 17.6892][2.9707 -6.20734 -4.25962 4.76055 13.8784][2.47641 -4.77079 -2.79675 3.54056 10.0675][1.98212 -3.33424 -1.33388 2.32058 6.25666][1.48783 -1.8977 0.12899 1.1006 2.4458]" --function-input="5xf32=0 0 0 0 0" | FileCheck /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/fragment_000.mlir)
--
Exit Code: 1

Command Output (stderr):
--
Tracer caught signal 11: addr=0x0 pc=0x6245f9 sp=0x7f055bc62d30
==47050==LeakSanitizer has encountered a fatal error.
==47050==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==47050==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
```