### PR TITLE
[test] remove `private` from func.func

### DIFF
--- a/tests/e2e/regression/layernorm.mlir
+++ b/tests/e2e/regression/layernorm.mlir
@@ -21,7 +21,7 @@
 //   return
 // }
 
-func.func private @layernorm() {
+func.func @layernorm() {
   %cst = arith.constant 1.000000e+00 : f32
   %cst_0 = arith.constant 0.000000e+00 : f32
   %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x384xf32>
@@ -72,7 +72,7 @@ func.func private @layernorm() {
   return
 }
 
-func.func private @layernorm_dynamic() {
+func.func @layernorm_dynamic() {
   %cst = arith.constant 1.000000e+00 : f32
   %cst_0 = arith.constant 0.000000e+00 : f32
   %cst_1 = arith.constant dense<0.000000e+00> : tensor<128x384xf32>

--- a/tests/e2e/regression/softmax.mlir
+++ b/tests/e2e/regression/softmax.mlir
@@ -12,7 +12,7 @@
 //   return
 // }
 
-func.func private @softmax() {
+func.func @softmax() {
   %cst = arith.constant 1.000000e+00 : f32
   %cst_0 = arith.constant 0.000000e+00 : f32
   %cst_1 = arith.constant -3.40282347E+38 : f32
@@ -58,7 +58,7 @@ func.func private @softmax() {
   return
 }
 
-func.func private @softmax_dynamic() {
+func.func @softmax_dynamic() {
   %cst = arith.constant 1.000000e+00 : f32
   %cst_0 = arith.constant 0.000000e+00 : f32
   %cst_1 = arith.constant -3.40282347E+38 : f32


### PR DESCRIPTION
When a function is marked as private, an inlining pass removes it
and leaves the module empty, which is not desirable for testing.