### PR TITLE
Support multiple target ops in clone_preceding_op_into_dispatch_region

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -119,11 +119,6 @@ def ClonePrecedingOpIntoDispatchRegionOp : Op<
     region. The transform fails if there are uses that appear before the
     dispatch region.
 
-
-
-    TODO: Support multiple payload ops for the `target` handle. In that case,
-    the targets must be sorted topologically before cloning them.
-
     #### Return modes
 
     This transform consumes both the `target` handle and the `dispatch_region`


### PR DESCRIPTION
Support multiple target ops in clone_preceding_op_into_dispatch_region

The target ops are sorted topoloically before cloning them one-by-one.
This is to ensure that there are no dominance violations. (Same logic as
with the existing dispatch region formation.)

This PR depends on #9985. Only review the second change.