### PR TITLE
Add clone_succeeding_op_into_dispatch_region transform op

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -739,6 +739,123 @@ transform_dialect::ClonePrecedingOpIntoDispatchRegionOp::apply(
   return DiagnosedSilenceableFailure(success());
 }
 
+// Clone a `target` op that is succeeding the given dispatch region op into the
+// dispatch region.
+//
+// All operands of the target are replaced with values defined inside of the
+// dispatch region when possible.
+//
+// If `updateUsesOutsideOfRegion` is set, all uses of the target op after the
+// dispatch region, are updated: The target op's results are returned from the
+// the dispatch region an used in those places.
+//
+// Example when `updateUsesOutsideOfRegion` is set:
+//
+// %r = flow.dispatch.region -> (tensor<?xf32>{%d0}) {
+//   %1 = "another_op"() : () -> (tensor<?xf32>)
+//   flow.return %1 : tensor<?xf32>
+// }
+// %0 = "some_op"(%r) : (tensor<?xf32>) -> (tensor<?xf32>)
+// %2 = "yet_another_use"(%0) : (tensor<?xf32>) -> (tensor<?xf32>)
+//
+// In this example, "some_op" will be cloned into the dispatch region and the
+// OpOperand of "yet_another_use" will be replaced:
+//
+// %r:2 = flow.dispatch.region -> (tensor<?xf32>{%d0}) {
+//   %1 = "another_op"() : () -> (tensor<?xf32>)
+//   %0_clone = "some_op"(%1) : (tensor<?xf32>) -> (tensor<?xf32>)
+//   flow.return %1, %0_clone : tensor<?xf32>, tensor<?xf32>
+// }
+// %2 = "yet_another_use"(%r#1) : (tensor<?xf32>) -> (tensor<?xf32>)
+static FailureOr<Flow::DispatchRegionOp> cloneSucceedingOpIntoDispatchRegion(
+    RewriterBase &rewriter, Operation *target, Flow::DispatchRegionOp regionOp,
+    bool updateUsesOutsideOfRegion) {
+  assert(regionOp->isBeforeInBlock(target) &&
+         "expected that region op comes first");
+  Block &body = regionOp.getBody().front();
+
+  // Gather all uses of `target`.
+  SmallVector<OpOperand *> usesOutsideOfRegion;
+  for (OpOperand &use : target->getUses()) usesOutsideOfRegion.push_back(&use);
+
+  // Clone op into dispatch region.
+  auto returnOp = cast<Flow::ReturnOp>(body.getTerminator());
+  Operation *newTargetOp;
+  if (updateUsesOutsideOfRegion) {
+    // Optimization: If all uses outside of the region are updated, the target
+    // can simply be moved instead of cloned.
+    target->moveBefore(returnOp);
+    newTargetOp = target;
+  } else {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(returnOp);
+    newTargetOp = rewriter.clone(*target);
+  }
+
+  // Replace all operands that are results of the regionOp.
+  for (OpOperand &operand : newTargetOp->getOpOperands()) {
+    if (operand.get().getDefiningOp() == regionOp) {
+      unsigned resultNumber = operand.get().cast<OpResult>().getResultNumber();
+      operand.set(returnOp->getOperand(resultNumber));
+    }
+  }
+
+  // Replace all uses outside of the dispatch region.
+  if (updateUsesOutsideOfRegion) {
+    unsigned previousNumResults = regionOp->getNumResults();
+
+    // Note: Appending results one-by-one here so that this can be extended to
+    // specific results in the future. Many ops have just one result, so this
+    // should not be a large overhead.
+    for (Value v : newTargetOp->getResults()) {
+      auto newRegionOp = appendDispatchRegionResult(rewriter, regionOp, v);
+      if (failed(newRegionOp)) return failure();
+      regionOp = *newRegionOp;
+    }
+
+    // Replace uses of `target` after the dispatch region.
+    for (OpOperand *use : usesOutsideOfRegion) {
+      rewriter.updateRootInPlace(use->getOwner(), [&]() {
+        use->set(
+            regionOp->getResult(previousNumResults +
+                                use->get().cast<OpResult>().getResultNumber()));
+      });
+    }
+  }
+
+  return regionOp;
+}
+
+DiagnosedSilenceableFailure
+transform_dialect::CloneSucceedingOpIntoDispatchRegionOp::apply(
+    transform::TransformResults &transformResults,
+    transform::TransformState &state) {
+  ArrayRef<Operation *> targetOps = state.getPayloadOps(getTarget());
+  ArrayRef<Operation *> dispatchRegion =
+      state.getPayloadOps(getDispatchRegion());
+
+  // TODO: Multiple targetOps could be allowed.
+  if (targetOps.size() != 1 || dispatchRegion.size() != 1)
+    return DiagnosedSilenceableFailure(this->emitOpError(
+        "requires exactly one target/dispatch region handle"));
+
+  auto regionOp = dyn_cast<Flow::DispatchRegionOp>(dispatchRegion.front());
+  if (!regionOp)
+    return DiagnosedSilenceableFailure(
+        this->emitOpError("expected 'dispatch.region' operand"));
+
+  IRRewriter rewriter(regionOp->getContext());
+  auto newRegionOp = cloneSucceedingOpIntoDispatchRegion(
+      rewriter, targetOps.front(), regionOp, getUpdateUsesOutsideOfRegion());
+  if (failed(newRegionOp))
+    return DiagnosedSilenceableFailure(
+        reportUnknownTransformError(targetOps.front()));
+
+  transformResults.set(getTransformed().cast<OpResult>(),
+                       newRegionOp->getOperation());
+  return DiagnosedSilenceableFailure(success());
+}
+
 static Flow::DispatchRegionOp makeEmptyDispatchRegion(RewriterBase &rewriter,
                                                       Location loc) {
   OpBuilder::InsertionGuard guard(rewriter);

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -113,11 +113,11 @@ def ClonePrecedingOpIntoDispatchRegionOp : Op<
     All uses of the target inside of the dispatch region are replaced with the
     results of the cloned op.
 
-    If `update_uses_outside_of_region` is set, all uses outside of the dispatch
-    region are also replaced: The results of the cloned target op are yielded
-    from the dispatch region and used in all uses outside of the dispatch
-    region. The transform fails if there are uses that appear before the
-    dispatch region.
+    If `update_uses_outside_of_region` is set (default value: `false`), all
+    uses outside of the dispatch region are also replaced: The results of the
+    cloned target op are yielded from the dispatch region and used in all uses
+    outside of the dispatch region. The transform fails if there are uses that
+    appear before the dispatch region.
 
     #### Return modes
 
@@ -132,6 +132,49 @@ def ClonePrecedingOpIntoDispatchRegionOp : Op<
                            [TransformMappingRead,
                             TransformMappingFree]>:$dispatch_region,
                        DefaultValuedAttr<BoolAttr, "false">:$update_uses_outside_of_region);
+  let results = (outs Res<PDL_Operation, "",
+                           [TransformMappingAlloc,
+                            TransformMappingWrite]>:$transformed);
+  let assemblyFormat = "$target `into` $dispatch_region attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure apply(
+        ::mlir::transform::TransformResults &transformResults,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
+def CloneSucceedingOpIntoDispatchRegionOp : Op<
+    Transform_Dialect, "iree.clone_succeeding_op_into_dispatch_region",
+    [TransformOpInterface]> {
+  let description = [{
+    Clone the `target` op into the given dispatch region op. The dispatch region
+    handle must be mapped to exactly one payload op.
+
+    All operands of the target are replaced with values that are defined inside
+    of the dispatch region when possible. 
+
+    If `update_uses_outside_of_region` is set (default value: `true`), all uses
+    of the original target op are replaced: The results of the cloned target op
+    are yielded from the dispatch region and used instead of results of the
+    original target op.
+
+    TODO: Support multiple payload ops for the `target` handle. In that case,
+    the targets must be sorted topologically before cloning them.
+
+    #### Return modes
+
+    This transform consumes both the `target` handle and the `dispatch_region`
+    handle. It produces a new handle to the extended dispatch region.
+  }];
+
+  let arguments = (ins Arg<PDL_Operation, "",
+                           [TransformMappingRead,
+                            TransformMappingFree]>:$target,
+                       Arg<PDL_Operation, "",
+                           [TransformMappingRead,
+                            TransformMappingFree]>:$dispatch_region,
+                       DefaultValuedAttr<BoolAttr, "true">:$update_uses_outside_of_region);
   let results = (outs Res<PDL_Operation, "",
                            [TransformMappingAlloc,
                             TransformMappingWrite]>:$transformed);


### PR DESCRIPTION
This op is symmetric to `clone_preceding_op_into_dispatch_region` and
can be used to build heuristics for dispatch region formation.

This PR depends on #9985. Only review the second commit.