### PR TITLE
[vulkan] Disable layernorm while fixing failures on Pixel 6

### DIFF
--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -58,6 +58,7 @@ iree_lit_test_suite(
             "dynamic_linalg_matmul_on_tensors_fuse_1.mlir",
             "dynamic_linalg_matmul_on_tensors_fuse_2.mlir",
             "large_reduction.mlir",
+            "layernorm.mlir",
             "linalg_quantized_matmul_vs_linalg_matmul.mlir",
             "lowering_config.mlir",
         ] + BACKEND_TESTS,

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -28,7 +28,6 @@ BACKEND_TESTS = [
     "dynamic_torch_index_select_scalar.mlir",
     "dynamic_torch_index_select_vector.mlir",
     "i1_inlined_constant.mlir",
-    "layernorm.mlir",
     "linalg_ops.mlir",
     "reduction_broadcast_elementwise.mlir",
     "softmax.mlir",
@@ -77,6 +76,7 @@ iree_check_single_backend_test_suite(
     name = "check_regression_llvm-cpu",
     srcs = [
         "associative_reordering.mlir",
+        "layernorm.mlir",
         "lowering_config.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=mhlo"],
@@ -99,7 +99,9 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_regression_vmvx",
-    srcs = BACKEND_TESTS,
+    srcs = [
+        "layernorm.mlir",
+    ] + BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=mhlo"],
     driver = "local-task",
     target_backend = "vmvx",
@@ -107,6 +109,7 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
     name = "check_regression_vulkan-spirv",
+    # TODO(#10024): Fix layernorm.mlir on Pixel 6 and put in BACKEND_TESTS.
     srcs = BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=mhlo"],
     driver = "vulkan",
@@ -117,6 +120,7 @@ iree_check_single_backend_test_suite(
     name = "check_regression_cuda",
     srcs = [
         "large_reduction.mlir",
+        "layernorm.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=mhlo"],
     driver = "cuda",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -110,7 +110,6 @@ iree_check_single_backend_test_suite(
     "dynamic_torch_index_select_scalar.mlir"
     "dynamic_torch_index_select_vector.mlir"
     "i1_inlined_constant.mlir"
-    "layernorm.mlir"
     "linalg_ops.mlir"
     "reduction_broadcast_elementwise.mlir"
     "softmax.mlir"


### PR DESCRIPTION
Tracking issue: https://github.com/iree-org/iree/issues/10024