### PR TITLE
Update reduction_broadcast test to use arith.maxf

### DIFF
--- a/tests/e2e/regression/reduction_broadcast_elementwise.mlir
+++ b/tests/e2e/regression/reduction_broadcast_elementwise.mlir
@@ -18,9 +18,8 @@ func.func @max_sub_exp() {
   %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<12x128xf32>) -> tensor<12x128xf32>
   %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%0 : tensor<12x128x128xf32>) outs(%2 : tensor<12x128xf32>) {
   ^bb0(%arg0: f32, %arg1: f32):
-    %8 = arith.cmpf ogt, %arg0, %arg1 : f32
-    %9 = arith.select %8, %arg0, %arg1 : f32
-    linalg.yield %9 : f32
+    %8 = arith.maxf %arg0, %arg1 : f32
+    linalg.yield %8 : f32
   } -> tensor<12x128xf32>
   %4 = linalg.init_tensor [12, 128, 128] : tensor<12x128x128xf32>
   %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%0, %3 : tensor<12x128x128xf32>, tensor<12x128xf32>) outs(%4 : tensor<12x128x128xf32>) {
@@ -52,9 +51,8 @@ func.func @max_sub_exp_dynamic() {
   %2 = linalg.fill ins(%cst : f32) outs(%1 : tensor<?x?xf32>) -> tensor<?x?xf32>
   %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%cst_1 : tensor<?x?x?xf32>) outs(%2 : tensor<?x?xf32>) {
   ^bb0(%arg0: f32, %arg1: f32):
-    %8 = arith.cmpf ogt, %arg0, %arg1 : f32
-    %9 = arith.select %8, %arg0, %arg1 : f32
-    linalg.yield %9 : f32
+    %8 = arith.maxf %arg0, %arg1 : f32
+    linalg.yield %8 : f32
   } -> tensor<?x?xf32>
   %4 = linalg.init_tensor [%dim_0, %dim_1, %dim_2] : tensor<?x?x?xf32>
   %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%cst_1, %3 : tensor<?x?x?xf32>, tensor<?x?xf32>) outs(%4 : tensor<?x?x?xf32>) {


### PR DESCRIPTION
As Tosa lowering is getting uppdated (https://reviews.llvm.org/D131426) we
should use maxf to hit the interesting case in IREE.