### PR TITLE
Tweak Tracy CMake config so release build works again.

### DIFF
--- a/build_tools/third_party/tracy/CMakeLists.txt
+++ b/build_tools/third_party/tracy/CMakeLists.txt
@@ -136,19 +136,6 @@ target_link_libraries(IREETracyServer
 )
 
 #-------------------------------------------------------------------------------
-# IMGUI library
-#-------------------------------------------------------------------------------
-
-file(GLOB IMGUI_SOURCES
-  ${TRACY_SOURCE_DIR}/imgui/*.cpp
-  ${TRACY_SOURCE_DIR}/profiler/src/imgui/*.cpp
-)
-add_library(IREETracyIMGUI
-  ${IMGUI_SOURCES}
-)
-setup_cxx_options(IREETracyIMGUI)
-
-#-------------------------------------------------------------------------------
 # Standalone capture server
 #-------------------------------------------------------------------------------
 
@@ -171,6 +158,19 @@ target_link_libraries(IREETracyCaptureServer
 #-------------------------------------------------------------------------------
 
 if(TRACY_GTK_DEPS_FOUND)
+  #-----------------------------------------------------------------------------
+  # IMGUI library
+  #-----------------------------------------------------------------------------
+
+  file(GLOB IMGUI_SOURCES
+    ${TRACY_SOURCE_DIR}/imgui/*.cpp
+    ${TRACY_SOURCE_DIR}/profiler/src/imgui/*.cpp
+  )
+  add_library(IREETracyIMGUI
+    ${IMGUI_SOURCES}
+  )
+  setup_cxx_options(IREETracyIMGUI)
+
   #-----------------------------------------------------------------------------
   # NFD library
   #-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes the build with `IREE_BUILD_TRACY` on our release Docker image. See a sample failure here: https://github.com/iree-org/iree/actions/runs/2817051970

Tested with `override_python_versions="cp39-cp39" packages="iree-runtime-instrumented" output_dir="/tmp/wheelhouse" ./build_tools/python_deploy/build_linux_packages.sh` before and after.

This check fails:
```
  pkg_check_modules(TRACY_GTK_DEPS
    freetype2
    glfw3
    gtk+-3.0
    dbus-1
  )
```
but we were still building the imgui sources that use `glfw3`:
```
 FAILED: tracy/CMakeFiles/IREETracyIMGUI.dir/__/__/__/third_party/tracy/profiler/src/imgui/imgui_impl_glfw.cpp.o
  /opt/rh/devtoolset-10/root/usr/bin/c++  -I/main_checkout/iree/build_tools/third_party/tracy/../../../third_party/tracy/imgui -I/usr/include/capstone -I/usr/include/capstone/capstone -O3 -DNDEBUG -fPIC -Wno-unused-result -std=gnu++17 -MD -MT tracy/CMakeFiles/IREETracyIMGUI.dir/__/__/__/third_party/tracy/profiler/src/imgui/imgui_impl_glfw.cpp.o -MF tracy/CMakeFiles/IREETracyIMGUI.dir/__/__/__/third_party/tracy/profiler/src/imgui/imgui_impl_glfw.cpp.o.d -o tracy/CMakeFiles/IREETracyIMGUI.dir/__/__/__/third_party/tracy/profiler/src/imgui/imgui_impl_glfw.cpp.o -c /main_checkout/iree/third_party/tracy/profiler/src/imgui/imgui_impl_glfw.cpp
  /main_checkout/iree/third_party/tracy/profiler/src/imgui/imgui_impl_glfw.cpp:73:10: fatal error: GLFW/glfw3.h: No such file or directory
     73 | #include <GLFW/glfw3.h>
        |          ^~~~~~~~~~~~~~
```

---

Separately, I looked into building the Tracy tools on presubmit (like https://github.com/iree-org/iree/pull/9992), but I found that Ubuntu 18.04 includes versions of glfw and zstd that are too old to build Tracy (3.2.1 < 3.3, 1.3.3 < 1.4.0). glfw is just needed for the GUI components, but zstd is necessary for trace compression. We could build those libraries from source rather than install them via apt, but since this is an optional utility in IREE I don't want to jump through those hoops. We could add a new presubmit that uses the release Docker image, or create a newer image based on Ubuntu 20+, if we find ourselves needing this tested on presubmit.