### PR TITLE
gitignore archives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ docs/website/site/
 
 # Temporary files
 iree/builtins/**/bin/*.ll
+
+# Archive files
+*.tar
+*.tar.*


### PR DESCRIPTION
We don't want these getting checked in to the repository. The
particular motivation is that the Cuda on-demand download drops the
archives in the repository root and I've been carrying them around as
untracked files. That's theoretically supposed to change, but I think
ignoring archives is probably good anyway.