### PR TITLE
Remove unnecessary visibility

### DIFF
--- a/compiler/src/iree/compiler/API/test/BUILD
+++ b/compiler/src/iree/compiler/API/test/BUILD
@@ -7,7 +7,6 @@
 load("//build_tools/bazel:native_binary.bzl", "native_test")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Bindings/TFLite/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Bindings/TFLite/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Codegen/Sandbox/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Sandbox/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/ConstEval/test/BUILD
+++ b/compiler/src/iree/compiler/ConstEval/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StandardToHAL/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/UtilToHAL/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/UtilToHAL/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Modules/Check/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Modules/Check/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/HALToStream/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/StandardToStream/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/UtilToStream/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Util/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/Analysis/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Analysis/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/MathToVM/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/test/BUILD
@@ -9,7 +9,6 @@ load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/StandardToVMVX/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/StandardToVMVX/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VMVX/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/IR/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Vulkan/IR/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/IR/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/BUILD
@@ -9,7 +9,6 @@ load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/InputConversion/Common/test/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/InputConversion/TMTensor/test/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/TMTensor/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/compiler/src/iree/compiler/InputConversion/TOSA/test/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/TOSA/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/integrations/tensorflow/iree_tf_compiler/MHLO/test/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/MHLO/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/integrations/tensorflow/iree_tf_compiler/TF/test/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TF/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/integrations/tensorflow/iree_tf_compiler/TFL/test/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/test/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/integrations/tensorflow/iree_tf_compiler/TFL/test/import/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/test/import/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/base/testing/BUILD
+++ b/runtime/src/iree/base/testing/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_test")
 load("//build_tools/embed_data:build_defs.bzl", "c_embed_data")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/hal/BUILD
+++ b/runtime/src/iree/hal/BUILD
@@ -68,7 +68,6 @@ iree_runtime_cc_library(
     hdrs = [
         "api.h",
     ],
-    visibility = ["//visibility:public"],
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",

--- a/runtime/src/iree/modules/check/test/BUILD
+++ b/runtime/src/iree/modules/check/test/BUILD
@@ -9,7 +9,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/vm/test/BUILD
+++ b/runtime/src/iree/vm/test/BUILD
@@ -9,7 +9,7 @@ load("//build_tools/bazel:iree_bytecode_module.bzl", "iree_bytecode_module")
 load("//build_tools/embed_data:build_defs.bzl", "c_embed_data")
 
 package(
-    default_visibility = ["//visibility:public"],
+    default_visibility = ["//runtime/src/iree/vm:__subpackages__"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/runtime/src/iree/vm/test/emitc/BUILD
+++ b/runtime/src/iree/vm/test/emitc/BUILD
@@ -8,7 +8,6 @@ load("//build_tools/bazel:build_defs.oss.bzl", "iree_runtime_cc_test")
 load("//build_tools/bazel:iree_c_module.bzl", "iree_c_module")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -10,7 +10,6 @@ load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 
 package(
-    default_visibility = ["//visibility:public"],
     features = ["layering_check"],
     licenses = ["notice"],  # Apache 2.0
 )


### PR DESCRIPTION
In general, tests shouldn't be visible. If someone's depending on your
test, it's usually a bad sign. There were a few other places where
things were unnecessarily marked as visible.

We're generally pretty loose about visibility and make things public
because it doesn't function very well outside of a monorepo, but tests
are usually an exception.