### PR TITLE
Fixing flag argv truncation.

### DIFF
--- a/runtime/src/iree/base/internal/flags.c
+++ b/runtime/src/iree/base/internal/flags.c
@@ -305,7 +305,7 @@ IREE_FLAG_CALLBACK(iree_flags_parse_help, iree_flags_print_help, NULL, help,
 static void iree_flags_remove_arg(int arg, int* argc_ptr, char*** argv_ptr) {
   int argc = *argc_ptr;
   char** argv = *argv_ptr;
-  memmove(&argv[arg], &argv[arg + 1], (argc - arg) * sizeof(char*));
+  memmove(&argv[arg], &argv[arg + 1], (argc - arg - 1) * sizeof(char*));
   *argc_ptr = argc - 1;
 }
 

--- a/runtime/src/iree/base/testing/BUILD
+++ b/runtime/src/iree/base/testing/BUILD
@@ -31,6 +31,12 @@ c_embed_data(
 iree_runtime_cc_test(
     name = "dynamic_library_test",
     srcs = ["dynamic_library_test.cc"],
+    tags = [
+        # Disabled because of unknown CI failures only with bazel on the CI.
+        # This passes locally and with cmake.
+        # See #10034 for more information.
+        "nokokoro",
+    ],
     deps = [
         ":dynamic_library_test_library",
         "//runtime/src/iree/base",

--- a/runtime/src/iree/base/testing/dynamic_library_test.cc
+++ b/runtime/src/iree/base/testing/dynamic_library_test.cc
@@ -67,7 +67,7 @@ class DynamicLibraryTest : public ::testing::Test {
         iree_make_const_byte_span(file_toc->data, file_toc->size)));
 
     std::cout << "Embedded test library written to temp path: "
-              << library_temp_path_;
+              << library_temp_path_ << "\n";
   }
 
   static std::string library_temp_path_;


### PR DESCRIPTION
This wasn't caught before as most flag parsing happens on the libc heap
allocations but in future changes to iree-run-mlir we parse from an
std::vector with proper instrumentation and asan catches it.

For unknown reasons the bazel CI fails the dynamic_library_test with this
change, even though the updated function is never called (confirmed with
an `abort()` in the function) and with the entire gtest->flags dependency cut 👻 