### PR TITLE
Support multiple target ops in clone_succeeding_op_into_dispatch_region

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -159,9 +159,6 @@ def CloneSucceedingOpIntoDispatchRegionOp : Op<
     are yielded from the dispatch region and used instead of results of the
     original target op.
 
-    TODO: Support multiple payload ops for the `target` handle. In that case,
-    the targets must be sorted topologically before cloning them.
-
     #### Return modes
 
     This transform consumes both the `target` handle and the `dispatch_region`


### PR DESCRIPTION
Support multiple target ops in clone_succeeding_op_into_dispatch_region

The target ops are sorted topologically before cloning them one-by-one.
This is to ensure that there are no dominance violations. (Same logic as
with the existing dispatch region formation.)

This PR depends on #10022. Only review the last commit.