### PR TITLE
Add convert-tensor-to-flow pass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -38,6 +38,7 @@ iree_compiler_cc_library(
         "ConvertConv2DToImg2Col.cpp",
         "ConvertLinalgMatmulToMmt4D.cpp",
         "ConvertRegionToWorkgroups.cpp",
+        "ConvertTensorToFlow.cpp",
         "DeduplicateExecutables.cpp",
         "DetachElementwiseFromNamedOps.cpp",
         "DispatchLinalgOnTensors.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_cc_library(
     "ConvertConv2DToImg2Col.cpp"
     "ConvertLinalgMatmulToMmt4D.cpp"
     "ConvertRegionToWorkgroups.cpp"
+    "ConvertTensorToFlow.cpp"
     "DeduplicateExecutables.cpp"
     "DetachElementwiseFromNamedOps.cpp"
     "DispatchLinalgOnTensors.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertTensorToFlow.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertTensorToFlow.cpp
@@ -1,0 +1,53 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/ConvertTensorToFlow.h"
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+struct ConvertTensorToFlowPass
+    : public ConvertTensorToFlowBase<ConvertTensorToFlowPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<Flow::FlowDialect, tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override {
+    MLIRContext *ctx = getOperation()->getContext();
+    RewritePatternSet convertToFlowPatterns(ctx);
+    populateTensorToFlowConversionPatterns(ctx, convertToFlowPatterns);
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(
+        convertToFlowPatterns);
+    IREE::Flow::TensorReshapeOp::getCanonicalizationPatterns(
+        convertToFlowPatterns, ctx);
+    if (failed(applyPatternsAndFoldGreedily(
+            getOperation(), std::move(convertToFlowPatterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<Pass> createConvertTensorToFlowPass() {
+  return std::make_unique<ConvertTensorToFlowPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -82,6 +82,9 @@ std::unique_ptr<Pass> createConvertConv2DToImg2ColPass();
 // Creates a pass to convert dispatch.region ops to dispatch.workgroups ops.
 std::unique_ptr<Pass> createConvertRegionToWorkgroupsPass();
 
+// Creates a pass to convert tensor dialect ops to Flow dialect ops.
+std::unique_ptr<Pass> createConvertTensorToFlowPass();
+
 // Pass to convert a linalg.pad_tensor operation into a linalg.fill +
 // subtensor_insert. This allows lowering the operation into a single kernel.
 std::unique_ptr<Pass> createPadTensorToTensorInsertSlicePass();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -44,6 +44,12 @@ def ConvertRegionToWorkgroups :
   let constructor = "mlir::iree_compiler::IREE::Flow::createConvertRegionToWorkgroupsPass()";
 }
 
+def ConvertTensorToFlow :
+    Pass<"iree-flow-convert-tensor-to-flow", ""> {
+  let summary = "Convert tensor dialect ops to Flow dialect ops.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createConvertTensorToFlowPass()";
+}
+
 def ConvertToFlow :
     Pass<"iree-flow-convert-to-flow", ""> {
   let summary = "Convert operations to flow. Currently just a test pass.";


### PR DESCRIPTION
Add a pass to convert tensor dialect ops to Flow dialect ops. This
functionality is copied from DispatchLinalgOnTensors.cpp. This change is
in preparation of decomposing the DispatchLinalgOnTensors.cpp into
smaller pieces.