### PR TITLE
Add `linalg.generic` op canonicalization after decomposition.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/DecomposeLinalgGeneric.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/DecomposeLinalgGeneric.cpp
@@ -23,8 +23,10 @@ class DecomposeLinalgGenericPass
     registry.insert<AffineDialect, linalg::LinalgDialect>();
   }
   void runOnOperation() override {
-    RewritePatternSet patterns(&getContext());
+    MLIRContext *context = &getContext();
+    RewritePatternSet patterns(context);
     linalg::populateDecomposeLinalgOpsPattern(patterns);
+    linalg::GenericOp::getCanonicalizationPatterns(patterns, context);
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {
       return signalPassFailure();


### PR DESCRIPTION
The upstream decompose ops pattern is intended to work with
`linalg.generic` canonicalization pattern. So pull the
`linalg.generic` op canonicalization pattern with the decompose
operation pattern.