### PR TITLE
Canonicalize offset, sizes and strides for `flow.dispatch.tensor.store`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -238,13 +238,12 @@ hal.executable private @add4D {
 //  CHECK-DAG:    %[[D2:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_3]]]
 //      CHECK:    hal.return %[[D2]], %[[D1]], %[[D0]] : index, index, index
 //      CHECK: func.func @add4D()
-//      CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
 //      CHECK:       scf.for %[[IV2:.+]] =
 //  CHECK-NOT:         scf.for
 //      CHECK:         %[[GENERIC:.+]] = linalg.generic
-//      CHECK:         flow.dispatch.tensor.store %[[GENERIC]], %{{.+}}, offsets = [%[[C0]], %[[IV0]], %[[IV1]], %[[IV2]]]
+//      CHECK:         flow.dispatch.tensor.store %[[GENERIC]], %{{.+}}, offsets = [0, %[[IV0]], %[[IV1]], %[[IV2]]]
 
 // -----
 
@@ -746,7 +745,6 @@ hal.executable private @conv {
 //  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_3]]]
 //      CHECK:   hal.return %[[D2]], %[[D1]], %[[D0]] : index, index, index
 //      CHECK: func.func @conv()
-//      CHECK:   %[[C0:.+]] = arith.constant 0
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
 //      CHECK:       scf.for %[[IV2:.+]] =
@@ -754,7 +752,7 @@ hal.executable private @conv {
 //  CHECK-DAG:         %[[FILTER:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [0, 0, 0, %[[IV2]]]
 //  CHECK-DAG:         %[[INIT:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [0, %[[IV0]], %[[IV1]], %[[IV2]]]
 //      CHECK:         %[[RESULT:.+]] = linalg.conv_2d_nhwc_hwcf
-//      CHECK:         flow.dispatch.tensor.store %[[RESULT]], %{{.+}}, offsets = [%[[C0]], %[[IV0]], %[[IV1]], %[[IV2]]]
+//      CHECK:         flow.dispatch.tensor.store %[[RESULT]], %{{.+}}, offsets = [0, %[[IV0]], %[[IV1]], %[[IV2]]]
 
 // -----
 
@@ -821,7 +819,6 @@ hal.executable private @conv_static {
 //  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP2]]()[%[[WORKLOAD_3]]]
 //      CHECK:   hal.return %[[D2]], %[[D1]], %[[D0]] : index, index, index
 //      CHECK: func.func @conv_static()
-//      CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
 //      CHECK:       scf.for %[[IV2:.+]] =
@@ -830,7 +827,7 @@ hal.executable private @conv_static {
 // CHECK-SAME:             outs(%[[INIT]] :
 //      CHECK:         %[[RESULT:.+]] = linalg.depthwise_conv_2d_nhwc_hwc
 // CHECK-SAME:             outs(%[[FILL]] :
-//      CHECK:         flow.dispatch.tensor.store %[[RESULT]], %{{.+}}, offsets = [%[[C0]], %[[IV0]], %[[IV1]], %[[IV2]]], sizes = [1, 20, 40, 48]
+//      CHECK:         flow.dispatch.tensor.store %[[RESULT]], %{{.+}}, offsets = [0, %[[IV0]], %[[IV1]], %[[IV2]]], sizes = [1, 20, 40, 48]
 
 // -----
 
@@ -1156,7 +1153,6 @@ hal.executable private @gemm_unit_N {
 //  CHECK-DAG:   %[[D0:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_0]]]
 //      CHECK:   hal.return %[[D0]], %[[C1]], %[[C1]] : index, index, index
 //      CHECK: func.func @gemm_unit_N()
-//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0]
 //  CHECK-DAG:   %[[WG_ID_X:.+]] = hal.interface.workgroup.id[0]
 //  CHECK-DAG:   %[[WG_COUNT_X:.+]] = hal.interface.workgroup.count[0]
@@ -1166,7 +1162,7 @@ hal.executable private @gemm_unit_N {
 //  CHECK-NOT:     scf.for
 //      CHECK:     %[[GEMM:.+]] = linalg.matmul
 //      CHECK:     flow.dispatch.tensor.store %[[GEMM]],
-// CHECK-SAME:         offsets = [%[[IV0]], %[[C0]]]
+// CHECK-SAME:         offsets = [%[[IV0]], 0]
 
 // -----
 #config = #iree_codegen.lowering_config<tile_sizes = [[0, 0, 0], [0, 0, 0], [0, 0, 16]]>
@@ -1298,13 +1294,12 @@ hal.executable private @generic_unit_dims {
 //  CHECK-DAG:   %[[D2:.+]] = affine.apply #[[MAP0]]()[%[[WORKLOAD_7]]]
 //      CHECK:   hal.return %[[D2]], %[[D1]], %[[D0]] : index, index, index
 //      CHECK: func.func @generic_unit_dims()
-//      CHECK:   %[[C0:.+]] = arith.constant 0 : index
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
 //      CHECK:       scf.for %[[IV2:.+]] =
 //      CHECK:         %[[GENERIC:.+]] = linalg.generic
 //      CHECK:         flow.dispatch.tensor.store %[[GENERIC]],
-// CHECK-SAME:             offsets = [%[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[IV0]], %[[IV1]], %[[C0]], %[[IV2]]]
+// CHECK-SAME:             offsets = [0, 0, 0, 0, %[[IV0]], %[[IV1]], 0, %[[IV2]]]
 
 // -----
 #config = #iree_codegen.lowering_config<tile_sizes = [[0], [0], [4]]>

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -107,6 +107,9 @@ static llvm::SmallBitVector getDroppedDimsImpl(
     RankedTensorType slicedObjectType, ArrayRef<OpFoldResult> mixedSizes) {
   ArrayRef<int64_t> resultShape = slicedObjectType.getShape();
   llvm::SmallBitVector droppedDims(mixedSizes.size());
+  if (slicedObjectType.getRank() == mixedSizes.size()) {
+    return droppedDims;
+  }
   unsigned shapePos = 0;
   for (const auto &size : llvm::enumerate(mixedSizes)) {
     Optional<int64_t> sizeVal = getConstantIntValue(size.value());

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -536,6 +536,9 @@ def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [
       return {resultRank, resultRank, resultRank};
     }
 
+    /// Return the type of the value type as a RankedTensorType.
+    RankedTensorType getValueType() { return getValue().getType().cast<RankedTensorType>(); }
+
     /// Return the number of leading operands before the `offsets`, `sizes` and
     /// and `strides` operands.
     static unsigned getOffsetSizeAndStrideStartOperandIndex() { return 3; }

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_tensor_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/test/dispatch_tensor_folding.mlir
@@ -81,3 +81,51 @@ func.func @canonicalizeDimOfTensorTile(%arg0: !flow.dispatch.tensor<readonly:250
 // CHECK: %[[ARG0:.+]]: !flow.dispatch.tensor<readonly:250x1024xf32>, %[[ARG1:.+]]: index, %[[ARG2:.+]]: index
 // CHECK: %[[DIM:.+]] = affine.min #[[MAP]]()[%[[ARG1]]]
 // CHECK: "test.sink"(%[[DIM]]) : (index) -> ()
+
+// -----
+
+func.func @canonicalizeStaticOperandsForStore(%arg0: !flow.dispatch.tensor<writeonly:?x?x?xf32>,
+    %arg1 : tensor<3x?xf32>, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index) {
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %c3 = arith.constant 3 : index
+  %c4 = arith.constant 4 : index
+  %d = tensor.dim %arg1, %c1 : tensor<3x?xf32>
+  flow.dispatch.tensor.store %arg1, %arg0, offsets = [%c2, %c4, %arg2], sizes = [%c3, 1, %d], strides = [%c1, %c2, %c1]
+      : tensor<3x?xf32> -> !flow.dispatch.tensor<writeonly:?x?x?xf32>{%arg3, %arg4, %arg5}
+  return
+}
+//      CHECK: func @canonicalizeStaticOperandsForStore
+// CHECK-SAME:     %[[ARG0:.+]]: !flow.dispatch.tensor<writeonly:?x?x?xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<3x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9]+]]: index
+//      CHECK:   %[[C1:.+]] = arith.constant 1 : index
+//      CHECK:   %[[D:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//      CHECK:   flow.dispatch.tensor.store %[[ARG1]], %[[ARG0]]
+// CHECK-SAME:       offsets = [2, 4, %[[ARG2]]]
+// CHECK-SAME:       sizes = [3, 1, %[[D]]]
+// CHECK-SAME:       strides = [1, 2, 1]
+// CHECK-SAME:       tensor<3x?xf32> -> !flow.dispatch.tensor<writeonly:?x?x?xf32>{%[[ARG3]], %[[ARG4]], %[[ARG5]]}
+
+// -----
+
+func.func @foldCastIntoStore(%arg0: !flow.dispatch.tensor<writeonly:?x?x?xf32>,
+    %arg1 : tensor<3x?xf32>, %arg2 : index, %arg3 : index, %arg4 : index, %arg5 : index) {
+  %0 = tensor.cast %arg1 : tensor<3x?xf32> to tensor<?x?xf32>
+  flow.dispatch.tensor.store %0, %arg0, offsets = [3, 4, 5], sizes = [3, 1, %arg2], strides = [1, 1, 1]
+      : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:?x?x?xf32>{%arg3, %arg4, %arg5}
+  return
+}
+//      CHECK: func @foldCastIntoStore
+// CHECK-SAME:     %[[ARG0:.+]]: !flow.dispatch.tensor<writeonly:?x?x?xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<3x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG4:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG5:[a-zA-Z0-9]+]]: index
+//      CHECK:   flow.dispatch.tensor.store %[[ARG1]], %[[ARG0]]
+// CHECK-SAME:       sizes = [3, 1, %[[ARG2]]]
+// CHECK-SAME:       tensor<3x?xf32> -> !flow.dispatch.tensor<writeonly:?x?x?xf32>{%[[ARG3]], %[[ARG4]], %[[ARG5]]}


### PR DESCRIPTION
When the values in these operand lists are defined by an
`arith.constant`, the value is replaced with the integer
directly. This also fixes the `tensor.cast` ->
`flow.dispatch.tensor.store` operation folding to only fold if the
target of the cast is more dynamic than the source.