### PR TITLE
[NFC] Replace pdl.pattern with structured.match

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
@@ -10,17 +10,9 @@ func.func @select_cmp_eq_select(%arg0: i64, %arg1: i64) -> i64 {
 
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_fun_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "func.func"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_fun_target in %arg1
+    %0 = transform.structured.match ops{["func.func"]} in %arg1
     transform.iree.apply_patterns %0 { canonicalization }
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
@@ -35,17 +35,8 @@ hal.executable private @pad_matmul_static_dispatch_0 {
 
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_matmul_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_matmul_target in %arg1
     transform.iree.bufferize
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
@@ -26,17 +26,8 @@ func.func @pad_matmul_static_dispatch_0(%arg0: tensor<250x500xf32>, %arg1: tenso
 
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_matmul_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_matmul_target in %arg1
     transform.iree.bufferize { target_gpu }
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
@@ -1,16 +1,7 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_matmul_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_matmul_target in %arg1
     transform.iree.bufferize
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -1,32 +1,17 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_fill_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.fill"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-  pdl.pattern @pdl_matmul_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_fill_target in %arg1
+    %0 = transform.structured.match ops{["linalg.fill"]} in %arg1
     %foreach_thread, %tiled_fill = tile_to_foreach_thread_op %0 {num_threads = [5, 1], thread_dim_mapping = [1, 0, 2]}
 
-    %1 = pdl_match @pdl_matmul_target in %arg1
+    %1 = transform.structured.match ops{["linalg.matmul"]} in %arg1
     %foreach_thread_2, %tiled_matmul = tile_to_foreach_thread_op %1 {num_threads = [7, 9]}
 
     transform.iree.bufferize
 
     // Get the function to which to apply to.
-    %2 = pdl_match @pdl_matmul_target in %arg1
+    %2 = transform.structured.match ops{["linalg.matmul"]} in %arg1
     %func = transform.get_closest_isolated_parent %2
     transform.iree.foreach_thread_to_gpu_and_translation_info %func { workgroup_size = [10, 11]}
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
@@ -1,18 +1,8 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-
-  pdl.pattern @pdl_if_op_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "scf.if"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %if_op = pdl_match @pdl_if_op_target in %arg1
+    %if_op = transform.structured.match ops{["scf.if"]} in %arg1
     %warp = transform.iree.vector.warp_execute_on_lane_0 %if_op { warp_size = 32 }
     %isolated = transform.get_closest_isolated_parent %warp
     transform.iree.vector.warp_distribute %isolated

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
@@ -1,18 +1,8 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-
-  pdl.pattern @pdl_if_op_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "scf.if"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %if_op = pdl_match @pdl_if_op_target in %arg1
+    %if_op = transform.structured.match ops{["scf.if"]} in %arg1
     transform.iree.vector.warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
@@ -1,16 +1,8 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_matmul_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_matmul_target in %arg1
+    %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
     %foreach_op, %tiled_op = tile_to_foreach_thread_op %0 {num_threads = [42, 67]}
     %dispatch_op = transform.iree.foreach_thread_to_flow %foreach_op
   }

--- a/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
@@ -1,16 +1,7 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_matmul_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_matmul_target in %arg1
     transform.iree.bufferize
   }
 }

--- a/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
@@ -1,16 +1,8 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
-  pdl.pattern @pdl_matmul_target : benefit(1) {
-    %args = operands
-    %results = types
-    %0 = operation "linalg.matmul"(%args : !pdl.range<value>) -> (%results : !pdl.range<type>)
-    // TODO: we don't want this, but it is the required terminator for pdl.pattern
-    rewrite %0 with "transform.dialect"
-  }
-
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @pdl_matmul_target in %arg1
+    %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
     %foreach_op, %tiled_op = tile_to_foreach_thread_op %0 {num_threads = [13, 33]}
     %dispatch_op = transform.iree.foreach_thread_to_flow %foreach_op
   }


### PR DESCRIPTION
This is a more lightweight way of matching for ops in the transform
dialect.