### PR TITLE
Don't explicitly set MLIR_TABLEGEN_EXE

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -428,7 +428,6 @@ endif()
 # Third party: llvm-project
 #-------------------------------------------------------------------------------
 if(IREE_BUILD_COMPILER)
-  set(MLIR_TABLEGEN_EXE mlir-tblgen)
   set(MLIR_PDLL_TABLEGEN_EXE mlir-pdll)
   # iree-tblgen is not defined using the add_tablegen mechanism as other TableGen
   # tools in LLVM.

--- a/integrations/tensorflow/iree-dialects/CMakeLists.txt
+++ b/integrations/tensorflow/iree-dialects/CMakeLists.txt
@@ -42,7 +42,6 @@ endfunction()
 # Configure CMake and tablegen.
 list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
 list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
-set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
 include(TableGen)
 include(AddLLVM)

--- a/llvm-external-projects/iree-dialects/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/CMakeLists.txt
@@ -42,7 +42,6 @@ endfunction()
 # Configure CMake and tablegen.
 list(APPEND CMAKE_MODULE_PATH ${MLIR_MAIN_SRC_DIR}/cmake/modules)
 list(APPEND CMAKE_MODULE_PATH ${LLVM_MAIN_SRC_DIR}/cmake)
-set(MLIR_TABLEGEN_EXE mlir-tblgen)
 
 include(TableGen)
 include(AddLLVM)


### PR DESCRIPTION
With llvm/llvm-project@112499f landed, `MLIR_TABLEGEN_EXE` is now set as
a cache variable by the MLIR core project. Hence, there is no need to
set it explicitly and doing so indeed breaks cross-compiling.

It might be necessary to wait for the integrate commit that lands commit
llvm/llvm-project@112499f, before this one can be merged.