### PR TITLE
Added path to merge widen mhlo.convert to mhlo.{dot, dot_generals, conv}

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -747,7 +747,7 @@ struct FuseWidenOperands : public OpRewritePattern<Op> {
   using OpRewritePattern<Op>::OpRewritePattern;
 
   LogicalResult matchAndRewrite(Op op,
-                                PatternRewriter& rewriter) const override {
+                                PatternRewriter &rewriter) const override {
     llvm::SmallVector<Value> operands;
     for (Value operand : op->getOperands()) {
       auto convertOp =

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -738,6 +738,46 @@ class ReorderBroadcastInDimOpAndElementwiseOp
   }
 };
 
+// Identifies cases where a dense operation has inputs that come from widening
+// operations. For instance, a dot product widening from FP16 to FP32 is better
+// to have the casting operation fused into the dot operation. This decreases
+// the loading required during a dense computation.
+template <class Op>
+struct FuseWidenOperands : public OpRewritePattern<Op> {
+  using OpRewritePattern<Op>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(Op op,
+                                PatternRewriter& rewriter) const override {
+    llvm::SmallVector<Value> operands;
+    for (Value operand : op->getOperands()) {
+      auto convertOp =
+          dyn_cast_or_null<mhlo::ConvertOp>(operand.getDefiningOp());
+      if (convertOp) {
+        auto inputType = getElementTypeOrSelf(convertOp.operand().getType());
+        auto castedType = getElementTypeOrSelf(convertOp.getResult().getType());
+        bool isSameCast =
+            (inputType.isa<IntegerType>() && castedType.isa<IntegerType>()) ||
+            (inputType.isa<FloatType>() && castedType.isa<FloatType>());
+        if (isSameCast && inputType.getIntOrFloatBitWidth() <
+                              castedType.getIntOrFloatBitWidth()) {
+          operands.push_back(convertOp.getOperand());
+          continue;
+        }
+      }
+      operands.push_back(operand);
+    }
+
+    if (llvm::all_of(llvm::zip(operands, op->getOperands()), [](auto pair) {
+          return std::get<0>(pair) == std::get<1>(pair);
+        }))
+      return failure();
+
+    rewriter.replaceOpWithNewOp<Op>(op, op->getResultTypes(), operands,
+                                    op->getAttrs());
+    return success();
+  }
+};
+
 struct MHLOToMHLOPreprocessingPass
     : public MHLOToMHLOPreprocessingBase<MHLOToMHLOPreprocessingPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -774,6 +814,11 @@ struct MHLOToMHLOPreprocessingPass
     // dot_general canoncalization patterns.
     mhlo::populateGeneralDotOpLoweringPatterns(&patterns, context);
     patterns.insert<TransposeReshapeGenericDotGeneral>(context);
+
+    // Fusion operations.
+    patterns.insert<FuseWidenOperands<mhlo::DotOp>,
+                    FuseWidenOperands<mhlo::DotGeneralOp>,
+                    FuseWidenOperands<mhlo::ConvolutionOp>>(context);
 
     // Unary elementwise op.
     patterns.insert<

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
@@ -299,3 +299,62 @@ func.func @mul_float_bool_cast_dyn_broadcast(%arg0: tensor<?xi1>, %arg1: tensor<
 
 // CHECK-LABEL: @mul_float_bool_cast_dyn_broadcast
 // CHECK: mhlo.select
+
+// -----
+
+// CHECK-LABEL: @dot_general_fuse_both_with_attrs
+func.func @dot_general_fuse_both_with_attrs(%arg0: tensor<16x64x128xf16>, %arg1: tensor<16x128x3072xf16>) -> tensor<16x64x3072xf32> {
+  %0 = mhlo.convert(%arg0) : (tensor<16x64x128xf16>) -> tensor<16x64x128xf32>
+  %1 = mhlo.convert(%arg1) : (tensor<16x128x3072xf16>) -> tensor<16x128x3072xf32>
+  // CHECK: "mhlo.dot_general"(%arg0, %arg1)
+    // CHECK-SAME: dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>,
+    // CHECK-SAME: precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>]
+    // CHECK-SAME: -> tensor<16x64x3072xf32>
+  %2 = "mhlo.dot_general"(%0, %1) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>, precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>]} : (tensor<16x64x128xf32>, tensor<16x128x3072xf32>) -> tensor<16x64x3072xf32>
+  return %2 : tensor<16x64x3072xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @dot_general_fuse_one
+func.func @dot_general_fuse_one(%arg0: tensor<16x64x128xf64>, %arg1: tensor<16x128x3072xf16>) -> tensor<16x64x3072xf32> {
+  %0 = mhlo.convert(%arg0) : (tensor<16x64x128xf64>) -> tensor<16x64x128xf32>
+  %1 = mhlo.convert(%arg1) : (tensor<16x128x3072xf16>) -> tensor<16x128x3072xf32>
+  // CHECK: %[[CONVERT:.+]] = mhlo.convert(%arg0)
+  // CHECK: "mhlo.dot_general"(%[[CONVERT]], %arg1)
+  %2 = "mhlo.dot_general"(%0, %1) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>, precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>]} : (tensor<16x64x128xf32>, tensor<16x128x3072xf32>) -> tensor<16x64x3072xf32>
+  return %2 : tensor<16x64x3072xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @dot_basic
+func.func @dot_basic(%arg0: tensor<4x4xf16>, %arg1: tensor<4x4xf16>) -> tensor<4x4xf32> {
+  %0 = mhlo.convert(%arg0) : (tensor<4x4xf16>) -> tensor<4x4xf32>
+  %1 = mhlo.convert(%arg1) : (tensor<4x4xf16>) -> tensor<4x4xf32>
+  // CHECK: %[[DOT:.+]] = "mhlo.dot"(%arg0, %arg1)
+  %2 = "mhlo.dot"(%0, %1) {precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>]} : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+  // CHECK: return %[[DOT]]
+  return %2 : tensor<4x4xf32>
+}
+
+// -----
+
+// CHECK-LABEL: @convolution
+func.func @convolution(%arg0: tensor<16x32x256xbf16>, %arg1: tensor<1x256x256xbf16>) -> tensor<16x32x256xf32> {
+  %cast = mhlo.convert(%arg0) : (tensor<16x32x256xbf16>) -> tensor<16x32x256xf32>
+  // CHECK: %[[CONV:.+]] = mhlo.convolution(%arg0, %arg1)
+  // CHECK-SAME: -> tensor<16x32x256xf32>
+  %0 = "mhlo.convolution"(%cast, %arg1) {
+     batch_group_count = 1 : i64,
+     dimension_numbers = #mhlo.conv<[b, 0, f]x[0, i, o]->[b, 0, f]>,
+     feature_group_count = 1 : i64,
+     lhs_dilation = dense<1> : tensor<1xi64>,
+     padding = dense<0> : tensor<1x2xi64>,
+     precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>],
+     rhs_dilation = dense<1> : tensor<1xi64>,
+     window_strides = dense<1> : tensor<1xi64>
+   } : (tensor<16x32x256xf32>, tensor<1x256x256xbf16>) -> tensor<16x32x256xf32>
+  // CHECK: return %[[CONV]]
+  func.return %0 : tensor<16x32x256xf32>
+}


### PR DESCRIPTION
Convert operations fusing into dense mhlo fusion operations. This case
substantially decrease the amount of memory loading in a dense
operation.