### PR TITLE
Ignore certain filepaths in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,49 @@ name: CI
 on:
   workflow_dispatch:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'experimental/**'
+      - 'build_tools/kokoro/**'
+      - 'build_tools/buildkite/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**.cff'
+      - '**.clang-format'
+      - '**.git-ignore'
+      - '**.md'
+      - '**.natvis'
+      - '**.pylintrc'
+      - '**.rst'
+      - '**.toml'
+      - '**.yamllint.yml'
+      - '**.yapf'
+      - '**CODEOWNERS'
+      - '**AUTHORS'
+      - '**LICENSE'
   push:
     branches:
       - main
+    # Keep this in sync with the above. Once more, the lack of variables means
+    # this whole thing has to be repeated.
+    paths-ignore:
+      - 'docs/**'
+      - 'experimental/**'
+      - 'build_tools/kokoro/**'
+      - 'build_tools/buildkite/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '**.cff'
+      - '**.clang-format'
+      - '**.git-ignore'
+      - '**.md'
+      - '**.natvis'
+      - '**.pylintrc'
+      - '**.rst'
+      - '**.toml'
+      - '**.yamllint.yml'
+      - '**.yapf'
+      - '**CODEOWNERS'
+      - '**AUTHORS'
+      - '**LICENSE'
 
 env:
   BUCKET: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: "Print labels"
         run: |
           cat <<EOF | jq -c
-            ${{ toJson(github.event.labels.*.name) }}
+            ${{ toJson(github.event) }}
           EOF
 
   ################################### Basic ####################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
   # Jobs that build all of IREE "normally"
   ##############################################################################
   build_all:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -110,7 +110,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   build_test_all_bazel:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -136,7 +136,7 @@ jobs:
             ./build_tools/bazel/build_core.sh
 
   test_all:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -166,7 +166,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -209,7 +209,7 @@ jobs:
   # Jobs that build some subset of IREE
   ##############################################################################
   build_runtime:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
@@ -240,7 +240,7 @@ jobs:
           path: "${{ env.BUILD_DIR }}.tar"
 
   test_runtime:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: build_runtime
     runs-on: ubuntu-20.04
     env:
@@ -265,7 +265,7 @@ jobs:
             "${BUILD_DIR}"
 
   host_tools_assertions:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     uses: ./.github/workflows/host_tools.yml
     with:
       host-binary-root: host-tools-assertions
@@ -275,7 +275,7 @@ jobs:
   # Jobs that build the IREE-Tensorflow integrations
   ##############################################################################
   build_tf_integrations:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -321,7 +321,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   test_tf_integrations:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -360,7 +360,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_tf_integrations_gpu:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -407,7 +407,7 @@ jobs:
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
   asan:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -426,7 +426,7 @@ jobs:
             ./build_tools/cmake/build_and_test_asan.sh
 
   tsan:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -445,7 +445,7 @@ jobs:
             ./build_tools/cmake/build_and_test_tsan.sh
 
   build_benchmarks:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: [build_all, build_tf_integrations]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -488,7 +488,7 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
   android_arm64:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: [host_tools_assertions]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -522,7 +522,7 @@ jobs:
             build_tools/build_android.sh
 
   riscv32:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: host_tools_assertions
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -558,7 +558,7 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: false
     needs: [build_all, host_tools_assertions, build_tf_integrations]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -619,7 +619,7 @@ jobs:
   summary:
     # Even if you have an explicit if condition, you still need to override
     # GitHub's default behavior of not running if any dependencies failed.
-    if: always() && github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: always() && false
     runs-on: ubuntu-20.04
     needs:
       # Basic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
   # Jobs that build all of IREE "normally"
   ##############################################################################
   build_all:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -101,7 +101,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   build_test_all_bazel:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -127,7 +127,7 @@ jobs:
             ./build_tools/bazel/build_core.sh
 
   test_all:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -157,7 +157,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -200,7 +200,7 @@ jobs:
   # Jobs that build some subset of IREE
   ##############################################################################
   build_runtime:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
@@ -231,7 +231,7 @@ jobs:
           path: "${{ env.BUILD_DIR }}.tar"
 
   test_runtime:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: build_runtime
     runs-on: ubuntu-20.04
     env:
@@ -256,7 +256,7 @@ jobs:
             "${BUILD_DIR}"
 
   host_tools_assertions:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     uses: ./.github/workflows/host_tools.yml
     with:
       host-binary-root: host-tools-assertions
@@ -266,7 +266,7 @@ jobs:
   # Jobs that build the IREE-Tensorflow integrations
   ##############################################################################
   build_tf_integrations:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -312,7 +312,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   test_tf_integrations:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -351,7 +351,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_tf_integrations_gpu:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -398,7 +398,7 @@ jobs:
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
   asan:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -417,7 +417,7 @@ jobs:
             ./build_tools/cmake/build_and_test_asan.sh
 
   tsan:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -436,7 +436,7 @@ jobs:
             ./build_tools/cmake/build_and_test_tsan.sh
 
   build_benchmarks:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: [build_all, build_tf_integrations]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -479,7 +479,7 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
   android_arm64:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: [host_tools_assertions]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -513,7 +513,7 @@ jobs:
             build_tools/build_android.sh
 
   riscv32:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: host_tools_assertions
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -549,7 +549,7 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
-    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     needs: [build_all, host_tools_assertions, build_tf_integrations]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -610,7 +610,7 @@ jobs:
   summary:
     # Even if you have an explicit if condition, you still need to override
     # GitHub's default behavior of not running if any dependencies failed.
-    if: always() && github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
+    if: always() && github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     needs:
       # Basic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
   # Jobs that build all of IREE "normally"
   ##############################################################################
   build_all:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -110,7 +110,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   build_test_all_bazel:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -136,7 +136,7 @@ jobs:
             ./build_tools/bazel/build_core.sh
 
   test_all:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -166,7 +166,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -209,7 +209,7 @@ jobs:
   # Jobs that build some subset of IREE
   ##############################################################################
   build_runtime:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
@@ -240,7 +240,7 @@ jobs:
           path: "${{ env.BUILD_DIR }}.tar"
 
   test_runtime:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: build_runtime
     runs-on: ubuntu-20.04
     env:
@@ -265,7 +265,7 @@ jobs:
             "${BUILD_DIR}"
 
   host_tools_assertions:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     uses: ./.github/workflows/host_tools.yml
     with:
       host-binary-root: host-tools-assertions
@@ -275,7 +275,7 @@ jobs:
   # Jobs that build the IREE-Tensorflow integrations
   ##############################################################################
   build_tf_integrations:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -321,7 +321,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   test_tf_integrations:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -360,7 +360,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_tf_integrations_gpu:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -407,7 +407,7 @@ jobs:
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
   asan:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -426,7 +426,7 @@ jobs:
             ./build_tools/cmake/build_and_test_asan.sh
 
   tsan:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -445,7 +445,7 @@ jobs:
             ./build_tools/cmake/build_and_test_tsan.sh
 
   build_benchmarks:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_all, build_tf_integrations]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -488,7 +488,7 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
   android_arm64:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [host_tools_assertions]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -522,7 +522,7 @@ jobs:
             build_tools/build_android.sh
 
   riscv32:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: host_tools_assertions
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -558,7 +558,7 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
-    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_all, host_tools_assertions, build_tf_integrations]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -619,7 +619,7 @@ jobs:
   summary:
     # Even if you have an explicit if condition, you still need to override
     # GitHub's default behavior of not running if any dependencies failed.
-    if: always() && ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
+    if: always() && github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     needs:
       # Basic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,15 @@ env:
 
 # Jobs are organized into groups and topologically sorted by dependencies
 jobs:
+  gcmn_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: "Print labels"
+        run: |
+          cat <<EOF | jq -c
+            ${{ toJson(github.event.labels.*.name) }}
+          EOF
+
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"
   ##############################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: "Print labels"
         run: |
           cat <<EOF | jq -c
-            ${{ toJson(github.event) }}
+            ${{ toJson(github.event.labels.*.name) }}
           EOF
 
   ################################### Basic ####################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
   # Jobs that build all of IREE "normally"
   ##############################################################################
   build_all:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -110,7 +110,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   build_test_all_bazel:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -136,7 +136,7 @@ jobs:
             ./build_tools/bazel/build_core.sh
 
   test_all:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -166,7 +166,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -209,7 +209,7 @@ jobs:
   # Jobs that build some subset of IREE
   ##############################################################################
   build_runtime:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
@@ -240,7 +240,7 @@ jobs:
           path: "${{ env.BUILD_DIR }}.tar"
 
   test_runtime:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: build_runtime
     runs-on: ubuntu-20.04
     env:
@@ -265,7 +265,7 @@ jobs:
             "${BUILD_DIR}"
 
   host_tools_assertions:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     uses: ./.github/workflows/host_tools.yml
     with:
       host-binary-root: host-tools-assertions
@@ -275,7 +275,7 @@ jobs:
   # Jobs that build the IREE-Tensorflow integrations
   ##############################################################################
   build_tf_integrations:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -321,7 +321,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   test_tf_integrations:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -360,7 +360,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_tf_integrations_gpu:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -407,7 +407,7 @@ jobs:
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
   asan:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -426,7 +426,7 @@ jobs:
             ./build_tools/cmake/build_and_test_asan.sh
 
   tsan:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -445,7 +445,7 @@ jobs:
             ./build_tools/cmake/build_and_test_tsan.sh
 
   build_benchmarks:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_all, build_tf_integrations]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -488,7 +488,7 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
   android_arm64:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [host_tools_assertions]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -522,7 +522,7 @@ jobs:
             build_tools/build_android.sh
 
   riscv32:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: host_tools_assertions
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -558,7 +558,7 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
-    if: false
+    if: github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_all, host_tools_assertions, build_tf_integrations]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -619,7 +619,7 @@ jobs:
   summary:
     # Even if you have an explicit if condition, you still need to override
     # GitHub's default behavior of not running if any dependencies failed.
-    if: always() && false
+    if: always() && github.event_name != 'pull_request' || ! contains(github.event.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     needs:
       # Basic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
   # Jobs that build all of IREE "normally"
   ##############################################################################
   build_all:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -101,7 +101,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   build_test_all_bazel:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -127,7 +127,7 @@ jobs:
             ./build_tools/bazel/build_core.sh
 
   test_all:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -157,7 +157,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -200,7 +200,7 @@ jobs:
   # Jobs that build some subset of IREE
   ##############################################################################
   build_runtime:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
@@ -231,7 +231,7 @@ jobs:
           path: "${{ env.BUILD_DIR }}.tar"
 
   test_runtime:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: build_runtime
     runs-on: ubuntu-20.04
     env:
@@ -256,7 +256,7 @@ jobs:
             "${BUILD_DIR}"
 
   host_tools_assertions:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     uses: ./.github/workflows/host_tools.yml
     with:
       host-binary-root: host-tools-assertions
@@ -266,7 +266,7 @@ jobs:
   # Jobs that build the IREE-Tensorflow integrations
   ##############################################################################
   build_tf_integrations:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -312,7 +312,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   test_tf_integrations:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -351,7 +351,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_tf_integrations_gpu:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -398,7 +398,7 @@ jobs:
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
   asan:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -417,7 +417,7 @@ jobs:
             ./build_tools/cmake/build_and_test_asan.sh
 
   tsan:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -436,7 +436,7 @@ jobs:
             ./build_tools/cmake/build_and_test_tsan.sh
 
   build_benchmarks:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: [build_all, build_tf_integrations]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -479,7 +479,7 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
   android_arm64:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: [host_tools_assertions]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -513,7 +513,7 @@ jobs:
             build_tools/build_android.sh
 
   riscv32:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: host_tools_assertions
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -549,7 +549,7 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
-    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     needs: [build_all, host_tools_assertions, build_tf_integrations]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -610,7 +610,7 @@ jobs:
   summary:
     # Even if you have an explicit if condition, you still need to override
     # GitHub's default behavior of not running if any dependencies failed.
-    if: always() && github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
+    if: always() && ! (github.event_name == 'pull_request' && contains(github.event.labels.*.name, 'skip-ci'))
     runs-on: ubuntu-20.04
     needs:
       # Basic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,15 +45,6 @@ env:
 
 # Jobs are organized into groups and topologically sorted by dependencies
 jobs:
-  gcmn_test:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: "Print labels"
-        run: |
-          cat <<EOF | jq -c
-            ${{ toJson(github.event.labels.*.name) }}
-          EOF
-
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"
   ##############################################################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
   # Jobs that build all of IREE "normally"
   ##############################################################################
   build_all:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -100,6 +101,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   build_test_all_bazel:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -125,6 +127,7 @@ jobs:
             ./build_tools/bazel/build_core.sh
 
   test_all:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -154,6 +157,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: build_all
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -196,6 +200,7 @@ jobs:
   # Jobs that build some subset of IREE
   ##############################################################################
   build_runtime:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
@@ -226,6 +231,7 @@ jobs:
           path: "${{ env.BUILD_DIR }}.tar"
 
   test_runtime:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: build_runtime
     runs-on: ubuntu-20.04
     env:
@@ -250,6 +256,7 @@ jobs:
             "${BUILD_DIR}"
 
   host_tools_assertions:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     uses: ./.github/workflows/host_tools.yml
     with:
       host-binary-root: host-tools-assertions
@@ -259,6 +266,7 @@ jobs:
   # Jobs that build the IREE-Tensorflow integrations
   ##############################################################################
   build_tf_integrations:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -304,6 +312,7 @@ jobs:
           echo "::set-output name=gcs-artifact::${GCS_ARTIFACT}"
 
   test_tf_integrations:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -342,6 +351,7 @@ jobs:
             "${BUILD_DIR}"
 
   test_tf_integrations_gpu:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_tf_integrations, build_all]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -388,6 +398,7 @@ jobs:
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
   asan:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -406,6 +417,7 @@ jobs:
             ./build_tools/cmake/build_and_test_asan.sh
 
   tsan:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -424,6 +436,7 @@ jobs:
             ./build_tools/cmake/build_and_test_tsan.sh
 
   build_benchmarks:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_all, build_tf_integrations]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -466,6 +479,7 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
   android_arm64:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: [host_tools_assertions]
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
@@ -499,6 +513,7 @@ jobs:
             build_tools/build_android.sh
 
   riscv32:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: host_tools_assertions
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -534,6 +549,7 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
+    if: github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     needs: [build_all, host_tools_assertions, build_tf_integrations]
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -592,6 +608,9 @@ jobs:
   # Depends on all the other jobs to provide a single anchor that indicates the
   # final status. Status reporting will become more sophisticated in the future.
   summary:
+    # Even if you have an explicit if condition, you still need to override
+    # GitHub's default behavior of not running if any dependencies failed.
+    if: always() && github.event_name != 'pull_request' || contains(github.event.labels.*.name, 'skip-ci')
     runs-on: ubuntu-20.04
     needs:
       # Basic
@@ -618,7 +637,6 @@ jobs:
       - android_arm64
       - riscv32
       - riscv64
-    if: always()
     steps:
       - name: Getting combined job status
         run: |


### PR DESCRIPTION
Part of https://github.com/iree-org/iree/issues/10042.
https://github.com/iree-org/iree/pull/10055 lets someone manually skip
CI for their PRs, but this will make it automatic for a big chunk of
things that can't possibly (famous last words) affect the build. Note 
that this doesn't apply to lint checks.