### PR TITLE
Test to disable -iree-flow-demote-f64-to-f32 and check correctness of f64-based computations

### DIFF
--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -55,6 +55,7 @@ iree_lit_test_suite(
             "layernorm.mlir",
             "linalg_quantized_matmul_vs_linalg_matmul.mlir",
             "lowering_config.mlir",
+            "disable_demote_f64_to_f32",
         ] + BACKEND_TESTS,
     ),
     cfg = "//tests:lit.cfg.py",
@@ -128,4 +129,14 @@ iree_check_single_backend_test_suite(
         "requires-gpu-nvidia",
     ],
     target_backend = "cuda",
+)
+
+iree_check_single_backend_test_suite(
+    name = "disable_demote_f64_to_f32",
+    srcs = [
+        "disable_demote_f64_to_f32.mlir",
+    ],
+    compiler_flags = ["-iree-flow-demote-f64-to-f32=false"],
+    driver = "local-task",
+    target_backend = "llvm-cpu",
 )

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -19,6 +19,7 @@ package(
 )
 
 BACKEND_TESTS = [
+    "disable_demote_f64_to_f32",
     "dynamic_abs.mlir",
     "dynamic_add.mlir",
     "dynamic_dot.mlir",
@@ -51,11 +52,11 @@ iree_lit_test_suite(
         # TODO(#5897): enable these for codegen linalg on tensors/etc.
         exclude = [
             "associative_reordering.mlir",
+            "disable_demote_f64_to_f32",
             "large_reduction.mlir",
             "layernorm.mlir",
             "linalg_quantized_matmul_vs_linalg_matmul.mlir",
             "lowering_config.mlir",
-            "disable_demote_f64_to_f32",
         ] + BACKEND_TESTS,
     ),
     cfg = "//tests:lit.cfg.py",

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -19,7 +19,6 @@ package(
 )
 
 BACKEND_TESTS = [
-    "disable_demote_f64_to_f32",
     "dynamic_abs.mlir",
     "dynamic_add.mlir",
     "dynamic_dot.mlir",
@@ -52,7 +51,7 @@ iree_lit_test_suite(
         # TODO(#5897): enable these for codegen linalg on tensors/etc.
         exclude = [
             "associative_reordering.mlir",
-            "disable_demote_f64_to_f32",
+            "disable_demote_f64_to_f32.mlir",
             "large_reduction.mlir",
             "layernorm.mlir",
             "linalg_quantized_matmul_vs_linalg_matmul.mlir",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -155,4 +155,17 @@ iree_check_single_backend_test_suite(
     "requires-gpu-nvidia"
 )
 
+iree_check_single_backend_test_suite(
+  NAME
+    disable_demote_f64_to_f32
+  SRCS
+    "disable_demote_f64_to_f32.mlir"
+  TARGET_BACKEND
+    "llvm-cpu"
+  DRIVER
+    "local-task"
+  COMPILER_FLAGS
+    "-iree-flow-demote-f64-to-f32=false"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/regression/disable_demote_f64_to_f32.mlir
+++ b/tests/e2e/regression/disable_demote_f64_to_f32.mlir
@@ -1,0 +1,23 @@
+#map0 = affine_map<(d1) -> (d1)>
+#map1 = affine_map<(d1) -> (0)>
+
+func.func @demote() {
+  %input = util.unfoldable_constant dense<3.0> : tensor<8388608xf32>
+  %cst_0 = arith.constant 0.000000e+00 : f64
+  %init = linalg.init_tensor [1] : tensor<1xf64>
+  %zeros = linalg.fill ins(%cst_0 : f64) outs(%init : tensor<1xf64>) -> tensor<1xf64>
+  %accum = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["reduction"]} ins(%input : tensor<8388608xf32>) outs(%init : tensor<1xf64>) {
+  ^bb0(%arg1: f32, %arg2: f64):
+    %ext = arith.extf %arg1 : f32 to f64
+    %add = arith.addf %ext, %arg2 : f64
+    linalg.yield %add : f64
+  } -> tensor<1xf64>
+  %init2 = linalg.init_tensor [1] : tensor<1xf32>
+  %result = linalg.generic {indexing_maps = [#map0, #map0], iterator_types = ["parallel"]} ins(%accum : tensor<1xf64>) outs(%init2 : tensor<1xf32>) {
+  ^bb0(%arg1: f64, %arg2: f32):
+    %res = arith.truncf %arg1 : f64 to f32
+    linalg.yield %res : f32
+  } -> tensor<1xf32>
+  check.expect_almost_eq_const(%result, dense<[25165824.0]> : tensor<1xf32>) : tensor<1xf32>
+  return
+}


### PR DESCRIPTION
Adding a test to ensure -iree-flow-demote-f64-to-f32=false flag stops demoting f64 promotions and computations to f32. This is to close https://github.com/iree-org/iree/issues/9961