### PR TITLE
Use custom script to determine whether to run CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,19 +55,33 @@ jobs:
   should_run:
     runs-on: ubuntu-20.04
     env:
-      SHOULD_RUN: ${{ github.event_name != 'pull_request' || ! contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      # The commit being checked out is the merge commit for the PR. Its first
+      # parent will be the tip of main.
+      BASE_REF: HEAD^
+      LABELS: join(${{ github.event.pull_request.labels.*.name }})
     outputs:
-      should-run: ${{ env.SHOULD_RUN }}
+      should-run: ${{ steps.should-run.outputs.should-run }}
     steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          # We need the parent commit to do a diff
+          fetch-depth: 2
       - name: "Computing whether CI should run"
+        id: should-run
         run: |
-          echo "EVENT_IS_PR=${{ github.event_name == 'pull_request' }}"
-          echo "SKIP_LABEL=${{ contains(github.event.pull_request.labels.*.name, 'skip-ci') }}"
-          echo LABELS:
-          cat <<EOF | jq -c
-            ${{ toJson(github.event.pull_request.labels.*.name) }}
-          EOF
-          echo "SHOULD_RUN=${SHOULD_RUN}"
+          git log --oneline --graph
+          ret=0
+          ./build_tools/github_actions/should_ci_run.py || ret=$?
+          if (( ret==0 )); then
+            echo "::set-output name=should-run::true"
+            exit 0
+          elif (( ret==2 )); then
+            echo "::set-output name=should-run::false"
+            exit 0
+          fi
+          exit "${ret}"
+
 
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"

--- a/build_tools/github_actions/should_ci_run.py
+++ b/build_tools/github_actions/should_ci_run.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Determines whether CI should run on a given PR.
+
+Exit code 0 indicates that it should and exit code 2 indicates that it should
+not.
+"""
+
+import fnmatch
+import os
+import subprocess
+import sys
+
+SKIP_CI_LABEL = "skip-ci"
+
+# Note that these are fnmatch patterns, which are not the same as gitignore
+# patterns because they don't treat '/' specially. The standard library doesn't
+# contain a function for gitignore style "wildmatch". There's a third-party
+# library pathspec (https://pypi.org/project/pathspec/), but it doesn't seem
+# worth the dependency.
+SKIP_PATH_PATTERNS = [
+    "docs/*",
+    "experimental/*",
+    "build_tools/kokoro/*",
+    "build_tools/buildkite/*",
+    ".github/ISSUE_TEMPLATE/*",
+    "*.cff",
+    "*.clang-format",
+    "*.git-ignore",
+    "*.md",
+    "*.natvis",
+    "*.pylintrc",
+    "*.rst",
+    "*.toml",
+    "*.yamllint.yml",
+    "*.yapf",
+    "*CODEOWNERS",
+    "*AUTHORS",
+    "*LICENSE",
+]
+
+
+def skip_path(path):
+  return any(fnmatch.fnmatch(path, pattern) for pattern in SKIP_PATH_PATTERNS)
+
+
+def get_modified_paths(base_ref):
+  return subprocess.run(["git", "diff", "--name-only", base_ref],
+                        stdout=subprocess.PIPE,
+                        check=True,
+                        text=True,
+                        timeout=20).stdout.splitlines()
+
+
+def modifies_included_path(base_ref):
+  return any(not skip_path(p) for p in get_modified_paths(base_ref))
+
+
+def should_run_ci():
+  event_name = os.environ["GITHUB_EVENT_NAME"]
+  base_ref = os.environ["BASE_REF"]
+  labels = os.environ["LABELS"].split(",")
+
+  if event_name != "pull_request":
+    print("Running CI independent of diff because run was not triggered by a"
+          "pull request event.")
+    return True
+
+  if SKIP_CI_LABEL in labels:
+    print(f"Not running CI because PR has label '{SKIP_CI_LABEL}'.")
+    return False
+
+  if not modifies_included_path(base_ref):
+    print("Skipping CI because all modified files are marked as excluded.")
+    return False
+
+  return True
+
+
+def main():
+  if should_run_ci():
+    print("CI should run")
+    sys.exit(0)
+  print("CI should not run")
+  sys.exit(2)
+
+
+if __name__ == "__main__":
+  main()

--- a/build_tools/github_actions/should_ci_run.py
+++ b/build_tools/github_actions/should_ci_run.py
@@ -54,7 +54,7 @@ def get_modified_paths(base_ref):
                         stdout=subprocess.PIPE,
                         check=True,
                         text=True,
-                        timeout=20).stdout.splitlines()
+                        timeout=60).stdout.splitlines()
 
 
 def modifies_included_path(base_ref):
@@ -75,7 +75,13 @@ def should_run_ci():
     print(f"Not running CI because PR has label '{SKIP_CI_LABEL}'.")
     return False
 
-  if not modifies_included_path(base_ref):
+  try:
+    modifies = modifies_included_path(base_ref)
+  except TimeoutError as e:
+    print("Computing modified files timed out. Running the CI")
+    return True
+
+  if not modifies:
     print("Skipping CI because all modified files are marked as excluded.")
     return False
 


### PR DESCRIPTION
As noted in https://github.com/iree-org/iree/pull/10062, we can't use
the GitHub actions built-in paths-ignore feature because it doesn't
work well with required checks. Instead, we use a custom script and a
job to determine whether to run CI. This could later be extended to
determining which other jobs to run.