### PR TITLE
Making executable layouts optional for local executables.

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -868,6 +868,12 @@ static iree_status_t iree_hal_task_command_buffer_build_dispatch(
 
   iree_hal_local_executable_t* local_executable =
       iree_hal_local_executable_cast(executable);
+  if (IREE_UNLIKELY(!local_executable->executable_layouts)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "layouts not provided during executable creation; cannot dispatch");
+  }
+
   iree_hal_local_executable_layout_t* local_layout =
       (iree_hal_local_executable_layout_t*)
           local_executable->executable_layouts[entry_point];

--- a/runtime/src/iree/hal/local/inline_command_buffer.c
+++ b/runtime/src/iree/hal/local/inline_command_buffer.c
@@ -404,6 +404,12 @@ static iree_status_t iree_hal_inline_command_buffer_dispatch(
 
   iree_hal_local_executable_t* local_executable =
       iree_hal_local_executable_cast(executable);
+  if (IREE_UNLIKELY(!local_executable->executable_layouts)) {
+    return iree_make_status(
+        IREE_STATUS_FAILED_PRECONDITION,
+        "layouts not provided during executable creation; cannot dispatch");
+  }
+
   iree_hal_local_executable_layout_t* local_layout =
       (iree_hal_local_executable_layout_t*)
           local_executable->executable_layouts[entry_point];

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -185,11 +185,14 @@ static iree_status_t iree_hal_elf_executable_create(
         iree_hal_elf_executable_resolve_imports(executable, import_provider);
   }
 
+  // TODO(benvanik): move alloc and verification to an executable_library_util.
   const bool disable_verification =
       iree_all_bits_set(executable_params->caching_mode,
                         IREE_HAL_EXECUTABLE_CACHING_MODE_DISABLE_VERIFICATION);
-  if (iree_status_is_ok(status) && !disable_verification) {
-    // Check to make sure that the entry point count matches the layout count.
+  if (iree_status_is_ok(status) &&
+      (!disable_verification &&
+       executable_params->executable_layout_count > 0)) {
+    // NOTE: executable layouts are optional but if provided must be consistent.
     if (executable->library.v0->exports.count !=
         executable_params->executable_layout_count) {
       status =

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -305,11 +305,14 @@ static iree_status_t iree_hal_system_executable_create(
         iree_hal_system_executable_resolve_imports(executable, import_provider);
   }
 
+  // TODO(benvanik): move alloc and verification to an executable_library_util.
   const bool disable_verification =
       iree_all_bits_set(executable_params->caching_mode,
                         IREE_HAL_EXECUTABLE_CACHING_MODE_DISABLE_VERIFICATION);
-  if (iree_status_is_ok(status) && !disable_verification) {
-    // Check to make sure that the entry point count matches the layout count.
+  if (iree_status_is_ok(status) &&
+      (!disable_verification &&
+       executable_params->executable_layout_count > 0)) {
+    // NOTE: executable layouts are optional but if provided must be consistent.
     if (executable->library.v0->exports.count !=
         executable_params->executable_layout_count) {
       status =

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -149,9 +149,11 @@ static iree_status_t iree_hal_vmvx_executable_create(
   *out_executable = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  // NOTE: executable layouts are optional but if provided must be consistent.
   iree_host_size_t entry_count =
       iree_vm_module_signature(bytecode_module).export_function_count;
-  if (entry_count != executable_params->executable_layout_count) {
+  if (executable_params->executable_layout_count > 0 &&
+      entry_count != executable_params->executable_layout_count) {
     return iree_make_status(IREE_STATUS_FAILED_PRECONDITION,
                             "executable provides %zu entry points but caller "
                             "provided %zu; must match",

--- a/runtime/src/iree/hal/local/local_executable.h
+++ b/runtime/src/iree/hal/local/local_executable.h
@@ -18,6 +18,14 @@ extern "C" {
 typedef struct iree_hal_local_executable_t {
   iree_hal_resource_t resource;
   iree_allocator_t host_allocator;
+
+  // Optional executable layouts.
+  // Not all users require the layouts (such as when directly calling executable
+  // functions) and in those cases they can be omitted. Users routing through
+  // the HAL command buffer APIs will usually require them.
+  //
+  // TODO(benvanik): make this a flag we set and can query instead - poking into
+  // this from dispatch code is a layering violation.
   iree_host_size_t executable_layout_count;
   iree_hal_executable_layout_t** executable_layouts;
 


### PR DESCRIPTION
The inline HAL does not need them and they were always somewhat
optional for tooling like executable_library_benchmark given that
the packing of bindings is well-defined. We still need them for the
full HAL which may have sparse bindings as part of one or more
descriptor sets that are shared across many dispatches.

Part of #9945.