### PR TITLE
Fixing util.buffer.size -> vm.buffer.size result type conversion.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/BUILD
@@ -29,6 +29,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/VM/Conversion",
         "//compiler/src/iree/compiler/Dialect/VM/IR",
+        "@llvm-project//mlir:ArithmeticDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
     "ConvertStatusOps.cpp"
     "ConvertUtilToVM.cpp"
   DEPS
+    MLIRArithmeticDialect
     MLIRFuncDialect
     MLIRIR
     MLIRPass

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/buffer_ops.mlir
@@ -63,9 +63,12 @@ func.func @buffer_slice(%arg0: !util.buffer, %arg1: index, %arg2: index, %arg3: 
 
 // CHECK-LABEL: @buffer_size
 func.func @buffer_size(%arg0: !util.buffer) -> index {
-  // CHECK-32: %[[SIZE:.+]] = vm.buffer.length %arg0 : !vm.buffer -> i64
+  // CHECK-32: %[[SIZE_I64:.+]] = vm.buffer.length %arg0 : !vm.buffer -> i64
+  // CHECK-32: %[[SIZE_I32:.+]] = vm.trunc.i64.i32 %[[SIZE_I64]]
+  // CHECK-64: %[[SIZE_I64:.+]] = vm.buffer.length %arg0 : !vm.buffer -> i64
   %0 = util.buffer.size %arg0 : !util.buffer
-  // CHECK-32: return %[[SIZE]]
+  // CHECK-32: return %[[SIZE_I32]]
+  // CHECK-64: return %[[SIZE_I64]]
   return %0 : index
 }
 


### PR DESCRIPTION
Previously this would result in a mistyped size i64 even when index
was lowered to i32 in other parts of the program.