### PR TITLE
Add lowering from canonicalize dot general to mul

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -840,6 +840,79 @@ struct DotToMul : public OpRewritePattern<mhlo::DotOp> {
   }
 };
 
+
+// Similar to DotIsMul, this finds the case where a canonical dot general
+// can be represented using a mul operation. This includes possibly making
+// an implicit cast explicit prior the mul.
+struct DotGeneralIsMul : public OpRewritePattern<mhlo::DotGeneralOp> {
+  using OpRewritePattern<mhlo::DotGeneralOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mhlo::DotGeneralOp op,
+                                PatternRewriter &rewriter) const override {
+    auto lhs = op.lhs();
+    auto rhs = op.rhs();
+    auto lhsTy = lhs.getType().dyn_cast<RankedTensorType>();
+    auto rhsTy = rhs.getType().dyn_cast<RankedTensorType>();
+    auto resultTy = op.getType().dyn_cast<RankedTensorType>();
+
+    if (!lhsTy || !rhsTy || !resultTy) return failure();
+
+    auto dNums = op.dot_dimension_numbers();
+    auto batchDimsL = dNums.getLhsBatchingDimensions();
+    auto batchDimsR = dNums.getRhsBatchingDimensions();
+    auto contractDimsL = dNums.getLhsContractingDimensions();
+    auto contractDimsR = dNums.getRhsContractingDimensions();
+
+    // Check there are canonical number of dimensions.
+    if (batchDimsL.size() != 1 || batchDimsR.size() != 1 ||
+        contractDimsL.size() != 1 || contractDimsR.size() != 1)
+      return failure();
+
+    // Check the dimensions are the valid members.
+    if (batchDimsL.front() != 0 || batchDimsR.front() != 0 ||
+        contractDimsL.front() != 2 || contractDimsR.front() != 1)
+      return failure();
+
+    // Check that the contraction dimension is degenerate.
+    if (lhsTy.getDimSize(2) != 1) return failure();
+    if (rhsTy.getDimSize(1) != 1) return failure();
+
+    // Determine the output size of the result.
+    auto batchSize = rewriter.create<mhlo::GetDimensionSizeOp>(
+        op.getLoc(), RankedTensorType::get({1}, rewriter.getI32Type()), lhs, 0);
+    auto leftSize = rewriter.create<mhlo::GetDimensionSizeOp>(
+        op.getLoc(), RankedTensorType::get({1}, rewriter.getI32Type()), lhs, 1);
+    auto rightSize = rewriter.create<mhlo::GetDimensionSizeOp>(
+        op.getLoc(), RankedTensorType::get({1}, rewriter.getI32Type()), rhs, 2);
+    auto dynSize = rewriter.create<mhlo::ConcatenateOp>(
+        op.getLoc(), RankedTensorType::get({3}, rewriter.getI32Type()),
+        ValueRange{batchSize, leftSize, rightSize}, 0);
+
+    auto lhsBroadcastTy =
+        RankedTensorType::get(resultTy.getShape(), lhsTy.getElementType());
+    lhs = rewriter.create<mhlo::DynamicBroadcastInDimOp>(
+        op.getLoc(), lhsBroadcastTy, lhs, dynSize,
+        rewriter.getI64TensorAttr({0, 1, 2}));
+
+    auto rhsBroadcastTy =
+        RankedTensorType::get(resultTy.getShape(), rhsTy.getElementType());
+    rhs = rewriter.create<mhlo::DynamicBroadcastInDimOp>(
+        op.getLoc(), rhsBroadcastTy, rhs, dynSize,
+        rewriter.getI64TensorAttr({0, 1, 2}));
+
+    if (lhsBroadcastTy != resultTy) {
+      lhs = rewriter.create<mhlo::ConvertOp>(op.getLoc(), resultTy, lhs);
+    }
+
+    if (rhsBroadcastTy != resultTy) {
+      rhs = rewriter.create<mhlo::ConvertOp>(op.getLoc(), resultTy, rhs);
+    }
+
+    rewriter.replaceOpWithNewOp<mhlo::MulOp>(op, resultTy, lhs, rhs);
+    return success();
+  }
+};
+
 struct MHLOToMHLOPreprocessingPass
     : public MHLOToMHLOPreprocessingBase<MHLOToMHLOPreprocessingPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -876,6 +949,7 @@ struct MHLOToMHLOPreprocessingPass
     // dot_general canoncalization patterns.
     mhlo::populateGeneralDotOpLoweringPatterns(&patterns, context);
     patterns.insert<TransposeReshapeGenericDotGeneral>(context);
+    patterns.insert<DotGeneralIsMul>(context);
 
     // Fusion operations.
     patterns.insert<FuseWidenOperands<mhlo::DotOp>,

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -894,13 +894,13 @@ struct DotGeneralIsMul : public OpRewritePattern<mhlo::DotGeneralOp> {
     auto i64Iota = builder.getI64TensorAttr({0, 1, 2});
     auto lhsBroadcastTy =
         RankedTensorType::get(resultTy.getShape(), lhsTy.getElementType());
-    lhs = builder.createOrFold<mhlo::DynamicBroadcastInDimOp>(lhsBroadcastTy, lhs,
-                                                        dynSize, i64Iota);
+    lhs = builder.createOrFold<mhlo::DynamicBroadcastInDimOp>(
+        lhsBroadcastTy, lhs, dynSize, i64Iota);
 
     auto rhsBroadcastTy =
         RankedTensorType::get(resultTy.getShape(), rhsTy.getElementType());
-    rhs = builder.createOrFold<mhlo::DynamicBroadcastInDimOp>(rhsBroadcastTy, rhs,
-                                                        dynSize, i64Iota);
+    rhs = builder.createOrFold<mhlo::DynamicBroadcastInDimOp>(
+        rhsBroadcastTy, rhs, dynSize, i64Iota);
 
     lhs = builder.createOrFold<mhlo::ConvertOp>(resultTy, lhs);
     rhs = builder.createOrFold<mhlo::ConvertOp>(resultTy, rhs);

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -840,7 +840,6 @@ struct DotToMul : public OpRewritePattern<mhlo::DotOp> {
   }
 };
 
-
 // Similar to DotIsMul, this finds the case where a canonical dot general
 // can be represented using a mul operation. This includes possibly making
 // an implicit cast explicit prior the mul.

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing_canoncalize_dot_general.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing_canoncalize_dot_general.mlir
@@ -188,6 +188,7 @@ func.func @dot_general_1d_batching_1d_contracting(%arg0: tensor<64x155x4x36xf32>
 
 // -----
 
+// CHECK-LABEL: @dot_general_fuse
 func.func @dot_general_fuse(%arg0: tensor<64x155x4x36xf16>, %arg1: tensor<309x4x36xf16>) -> tensor<4x64x155x309xf32> {
   %0 = "mhlo.convert"(%arg0) : (tensor<64x155x4x36xf16>) -> tensor<64x155x4x36xf32>
   %1 = "mhlo.convert"(%arg1) : (tensor<309x4x36xf16>) -> tensor<309x4x36xf32>
@@ -218,4 +219,50 @@ func.func @dot_is_mul(%arg0: tensor<?x1xf16>, %arg1: tensor<1x?xf16>) -> tensor<
   %0 = "mhlo.dot"(%arg0, %arg1) {precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>]} : (tensor<?x1xf16>, tensor<1x?xf16>) -> tensor<?x?xf32>
   // CHECK: return %[[RESULT]]
   return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dot_general_to_mul_static
+func.func @dot_general_to_mul_static(%arg0: tensor<4x17x1xf32>, %arg1: tensor<4x1x309xf32>) -> tensor<4x17x309xf32> {
+  // CHECK: %[[SHP:.+]] = mhlo.constant dense<[4, 17, 309]> : tensor<3xi32>
+  // CHECK: %[[LEFT:.+]] = "mhlo.dynamic_broadcast_in_dim"(%arg0, %[[SHP]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>}
+  // CHECK: %[[RIGHT:.+]] = "mhlo.dynamic_broadcast_in_dim"(%arg1, %[[SHP]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>}
+  // CHECK: %[[MUL:.+]] = mhlo.multiply %[[LEFT]], %[[RIGHT]]
+  %0 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<4x17x1xf32>, tensor<4x1x309xf32>) -> tensor<4x17x309xf32>
+  // CHECK: return %[[MUL]]
+  return %0 : tensor<4x17x309xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dot_general_to_mul_dynamic
+func.func @dot_general_to_mul_dynamic(%arg0: tensor<4x?x1xf32>, %arg1: tensor<4x1x309xf32>) -> tensor<4x?x309xf32> {
+  // CHECK-DAG: %[[BATCH:.+]] = mhlo.constant dense<4> : tensor<1xi32>
+  // CHECK-DAG: %[[ELEMENTS:.+]] = "mhlo.get_dimension_size"(%arg0) {dimension = 1 : i64}
+  // CHECK-DAG: %[[FEATURES:.+]] = mhlo.constant dense<309> : tensor<1xi32>
+  // CHECK-DAG: %[[SHAPE:.+]] = "mhlo.concatenate"(%[[BATCH]], %[[ELEMENTS]], %[[FEATURES]]) {dimension = 0 : i64}
+  // CHECK-DAG: %[[LHS:.+]] = "mhlo.dynamic_broadcast_in_dim"(%arg0, %[[SHAPE]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>}
+  // CHECK-DAG: %[[RHS:.+]] = "mhlo.dynamic_broadcast_in_dim"(%arg1, %[[SHAPE]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>}
+  // CHECK: %[[MUL:.+]] = mhlo.multiply %[[LHS]], %[[RHS]]
+  %0 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<4x?x1xf32>, tensor<4x1x309xf32>) -> tensor<4x?x309xf32>
+
+  // CHECK: return %[[MUL]]
+  return %0 : tensor<4x?x309xf32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dot_general_to_mul_cast
+func.func @dot_general_to_mul_cast(%arg0: tensor<4x17x1xf16>, %arg1: tensor<4x1x309xf16>) -> tensor<4x17x309xf32> {
+  // CHECK: %[[SHP:.+]] = mhlo.constant dense<[4, 17, 309]> : tensor<3xi32>
+  // CHECK: %[[BL:.+]] = "mhlo.dynamic_broadcast_in_dim"(%arg0, %[[SHP]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<4x17x1xf16>, tensor<3xi32>) -> tensor<4x17x309xf16>
+  // CHECK: %[[BR:.+]] = "mhlo.dynamic_broadcast_in_dim"(%arg1, %[[SHP]]) {broadcast_dimensions = dense<[0, 1, 2]> : tensor<3xi64>} : (tensor<4x1x309xf16>, tensor<3xi32>) -> tensor<4x17x309xf16>
+  // CHECK: %[[LHS:.+]] = mhlo.convert(%[[BL]]) : (tensor<4x17x309xf16>) -> tensor<4x17x309xf32>
+  // CHECK: %[[RHS:.+]] = mhlo.convert(%[[BR]]) : (tensor<4x17x309xf16>) -> tensor<4x17x309xf32>
+  // CHECK: %[[MUL:.+]] = mhlo.multiply %[[LHS]], %[[RHS]]
+  %0 = "mhlo.dot_general"(%arg0, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0], rhs_batching_dimensions = [0], lhs_contracting_dimensions = [2], rhs_contracting_dimensions = [1]>} : (tensor<4x17x1xf16>, tensor<4x1x309xf16>) -> tensor<4x17x309xf32>
+
+  // CHECK: return %[[MUL]]
+  return %0 : tensor<4x17x309xf32>
 }


### PR DESCRIPTION
Cases where all contraction dimensions are length-1 and the rest of the
dot general numbers are the canonicalize version. This can include
making an implicit cast surrounding the mul operation.