### PR TITLE
Disable GPU builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,9 @@ jobs:
 
   test_gpu:
     needs: [should_run, build_all]
-    if: needs.should_run.outputs.should-run == 'true'
+    # TODO(gcmn): There is something wrong with the GPU MIG. The machines keep
+    # immediately shutting down.
+    if: false && needs.should_run.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -381,7 +383,9 @@ jobs:
 
   test_tf_integrations_gpu:
     needs: [should_run, build_tf_integrations, build_all]
-    if: needs.should_run.outputs.should-run == 'true'
+    # TODO(gcmn): There is something wrong with the GPU MIG. The machines keep
+    # immediately shutting down.
+    if: false && needs.should_run.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted


### PR DESCRIPTION
There is something wrong with the GPU MIG. The machines keep
immediately shutting down. I don't have time to investigate this
evening, so disabling these until I can debug. Luckily, we still have
the Kokoro postsubmits for GPU, so we're not in any worse shape than
we were before :-)