### PR TITLE
Add a registerHALConfigurationPassPipeline

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.cpp
@@ -241,6 +241,16 @@ void buildHALTransformPassPipeline(OpPassManager &passManager,
   buildHALTransformPassPipeline(passManager, targetOptions, transformOptions);
 }
 
+void registerHALConfigurationPassPipeline() {
+  PassPipelineRegistration<>("iree-hal-configuration-pipeline",
+                             "Runs the IREE HAL dialect configuration pipeline",
+                             [](OpPassManager &passManager) {
+                               buildHALConfigurationPassPipeline(
+                                   passManager,
+                                   TargetOptions::FromFlags::get());
+                             });
+}
+
 void registerHALTransformPassPipeline() {
   PassPipelineRegistration<TransformOptions>(
       "iree-hal-transformation-pipeline",

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -45,6 +45,7 @@ void buildHALConfigurationPassPipeline(OpPassManager &passManager,
                                        const TargetOptions &targetOptions);
 
 void registerHALTransformPassPipeline();
+void registerHALConfigurationPassPipeline();
 
 //===----------------------------------------------------------------------===//
 // Conversion
@@ -164,6 +165,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createBenchmarkBatchDispatchesPass(
 
 inline void registerHALPasses() {
   registerHALTransformPassPipeline();
+  registerHALConfigurationPassPipeline();
   auto targetOptions = TargetOptions::FromFlags::get();
   createAssignTargetDevicesPass({});
   createBenchmarkBatchDispatchesPass(/*repeatCount=*/1);


### PR DESCRIPTION
This is useful to isolate the control for running HAL configuration from the triggering of codegen.