### PR TITLE
Remove legacy and abbreviated llvm-cpu target name registrations.

### DIFF
--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/__init__.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/__init__.py
@@ -29,7 +29,7 @@ Example
   # There are many keyword options available.
   # See iree.compiler.CompilerOptions
   binary = iree.compiler.tools.compile_str(
-      SIMPLE_MUL_ASM, input_type="tosa", target_backends=["cpu"])
+      SIMPLE_MUL_ASM, input_type="tosa", target_backends=["llvm-cpu"])
 '''
 
 from .core import *

--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_trivial_loops.mlir
@@ -197,9 +197,9 @@ hal.executable private @both_workgroup_and_workitem  {
 
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[4], [4], [0]]>
-#device_target_cpu = #hal.device.target<"cpu", {executable_targets = [#hal.executable.target<"llvm", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>]}>
+#device_target_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>]}>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert workload_per_wg = [4]>
 #map0 = affine_map<()[s0] -> (s0 ceildiv 4)>
 #map1 = affine_map<()[s0] -> (s0 * 4)>

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -9,7 +9,7 @@
     #hal.descriptor_set.binding<3, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm", "embedded-elf-arm_64", {
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-unknown-unknown-eabi-elf"
@@ -106,7 +106,7 @@ hal.executable private @matmul_tensors {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"
@@ -180,7 +180,7 @@ hal.executable private @add {
     #hal.descriptor_set.binding<3, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
@@ -255,7 +255,7 @@ hal.executable private @add4D {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm", "embedded-elf-arm_64", {
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-unknown-unknown-eabi-elf"}>
@@ -325,7 +325,7 @@ hal.executable private @batch_matmul_tensors {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
 #translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
 hal.executable private @preset_config_matmul_tensors {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
@@ -392,7 +392,7 @@ hal.executable private @preset_config_matmul_tensors {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
 #translation = #iree_codegen.translation_info<CPUBufferOpsTileAndVectorize>
 hal.executable public @copy_op {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
@@ -486,7 +486,7 @@ hal.executable public @copy_op {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_1d_fft_stage2 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
@@ -544,7 +544,7 @@ hal.executable private @static_1d_fft_stage2 {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
 #translation = #iree_codegen.translation_info<CPUDefault>
 hal.executable private @static_3d_fft_stage3 {
   hal.executable.variant public @system_elf_x86_64, target = #executable_target_system_elf_x86_64_ {
@@ -601,7 +601,7 @@ hal.executable private @static_3d_fft_stage3 {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64">
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64">
 #map0 = affine_map<(d0, d1) -> (d0, d1)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>
 #map2 = affine_map<(d0, d1, d2) -> (d2, d1)>
@@ -683,7 +683,7 @@ hal.executable private @outs_fusion {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64", {
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
@@ -764,7 +764,7 @@ hal.executable private @conv {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64", {
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
@@ -838,7 +838,7 @@ hal.executable private @conv_static {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm", "system-elf-x86_64", {
+#executable_target_system_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "system-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 64 : index,
   target_triple = "x86_64-pc-linux-gnu"}>
@@ -903,7 +903,7 @@ hal.executable private @generic_static {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm", "system-elf-arm_64", {
+#executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {
   data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-none-linux-android30"}>
@@ -964,7 +964,7 @@ hal.executable private @matmul_static {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm", "system-elf-arm_64", {
+#executable_target_system_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "system-elf-arm_64", {
   data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-none-linux-android30"}>
@@ -1027,7 +1027,7 @@ hal.executable private @restrict_num_workgroups {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-unknown-eabi-elf"}>
@@ -1102,7 +1102,7 @@ hal.executable private @reduction {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-unknown-eabi-elf"}>
@@ -1173,7 +1173,7 @@ hal.executable private @gemm_unit_N {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-unknown-eabi-elf"}>
@@ -1235,7 +1235,7 @@ hal.executable private @gemm_unit_M_unit_N {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
@@ -1310,7 +1310,7 @@ hal.executable private @generic_unit_dims {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
@@ -1370,7 +1370,7 @@ hal.executable private @reduce_to_scalar {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
@@ -1427,7 +1427,7 @@ hal.executable private @scalar {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm", "embedded-elf-arm_64", {
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "aarch64-unknown-unknown-eabi-elf"
@@ -1496,7 +1496,7 @@ hal.executable private @rank_reduced_slice {
     #hal.descriptor_set.binding<3, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
   target_triple = "x86_64-unknown-linux-gnu"}>
@@ -1558,7 +1558,7 @@ hal.executable private @matmul_interchange {
 // -----
 
 hal.executable private @no_compute {
-  hal.executable.variant public @embedded_elf_x86_64, target = <"llvm", "embedded-elf-x86_64", {}> {
+  hal.executable.variant public @embedded_elf_x86_64, target = <"llvm-cpu", "embedded-elf-x86_64", {}> {
     hal.executable.export public @no_compute ordinal(0) layout(#hal.executable.layout<push_constants = 5, sets = [<0, bindings = [<0, storage_buffer>, <1, storage_buffer>]>]>) attributes {translation_info = #iree_codegen.translation_info<CPUDefault>} {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
       %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_dotprod_vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_dotprod_vector_lowering.mlir
@@ -12,7 +12,7 @@
 ]>
 
 hal.executable private @foo {
-hal.executable.variant @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {cpu_features = "+dotprod", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android29"}> {
+hal.executable.variant @system_elf_arm_64, target = <"llvm-cpu", "system-elf-arm_64", {cpu_features = "+dotprod", data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-none-linux-android29"}> {
 hal.executable.export @foo layout(#executable_layout)
 builtin.module attributes {llvm.data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", llvm.target_triple = "aarch64-none-linux-android29"} {
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/apply_scale_lowering.mlir
@@ -6,7 +6,7 @@
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm", "embedded-elf-riscv_64", {
+#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {
   cpu_features = "+m,+a,+f,+d,+c",
   data_layout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128",
   native_vector_size = 256 : index,
@@ -54,7 +54,7 @@ hal.executable private @apply_scale_no_vector_feature {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm", "embedded-elf-riscv_64", {
+#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {
   cpu_features = "+m,+a,+f,+d,+c,+v",
   data_layout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128",
   native_vector_size = 256 : index,
@@ -100,7 +100,7 @@ hal.executable private @apply_scale_v {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm", "embedded-elf-riscv_64", {
+#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {
   cpu_features = "+m,+a,+f,+d,+c,+zve64x",
   data_layout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128",
   native_vector_size = 256 : index,
@@ -146,7 +146,7 @@ hal.executable private @apply_scale_zve64x {
     #hal.descriptor_set.binding<1, storage_buffer>
   ]>
 ]>
-#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm", "embedded-elf-riscv_64", {
+#executable_target_embedded_elf_riscv_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-riscv_64", {
   cpu_features = "+m,+a,+f,+d,+c,+zve32x",
   data_layout = "e-m:e-p:64:64-i64:64-i128:128-n64-S128",
   native_vector_size = 256 : index,
@@ -185,4 +185,3 @@ hal.executable private @apply_scale_zve32x {
 //       CHECK:   %[[MUL:.*]] = llvm.mul %{{.*}}, %{{.*}} : vector<2xi64>
 //  CHECK-NEXT:   %[[SHR:.*]] = llvm.lshr %{{.*}}, %{{.*}} : vector<2xi64>
 //  CHECK-NEXT:   llvm.trunc %[[SHR]] : vector<2xi64> to vector<2xi32>
-

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/illegal_configuration.mlir
@@ -10,7 +10,7 @@
   ]>
 ]>
 hal.executable private @matmul_tensors {
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {}> {
     hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
@@ -39,7 +39,7 @@ hal.executable private @matmul_tensors {
   ]>
 ]>
 hal.executable private @matmul_tensors {
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {}> {
     hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
@@ -68,7 +68,7 @@ hal.executable private @matmul_tensors {
   ]>
 ]>
 hal.executable private @matmul_tensors {
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {}> {
     hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
@@ -97,7 +97,7 @@ hal.executable private @matmul_tensors {
   ]>
 ]>
 hal.executable private @matmul_tensors {
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {}> {
     hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
@@ -126,7 +126,7 @@ hal.executable private @matmul_tensors {
   ]>
 ]>
 hal.executable private @matmul_tensors {
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {}> {
     hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {
@@ -157,7 +157,7 @@ hal.executable private @matmul_tensors {
   ]>
 ]>
 hal.executable private @matmul_tensors {
-  hal.executable.variant @llvm, target = #hal.executable.target<"llvm", "embedded-elf-x86_64", {}> {
+  hal.executable.variant @llvm, target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {}> {
     hal.executable.export @illegal layout(#executable_layout) attributes {translation_info = #translation}
     builtin.module {
       func.func @illegal() {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -9,7 +9,7 @@
   ]>
 ]>
 hal.executable private @matmul_tensors  {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-arm_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-arm_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "aarch64-unknown-unknown-eabi-elf"
@@ -61,7 +61,7 @@ hal.executable private @matmul_tensors  {
   ]>
 ]>
 hal.executable private @batch_matmul_tensors {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-arm_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-arm_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "aarch64-unknown-unknown-eabi-elf"
@@ -112,7 +112,7 @@ hal.executable private @batch_matmul_tensors {
   ]>
 ]>
 hal.executable private @matmul_static {
-  hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {
+  hal.executable.variant public @system_elf_arm_64, target = <"llvm-cpu", "system-elf-arm_64", {
     data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"
@@ -160,7 +160,7 @@ hal.executable private @matmul_static {
   ]>
 ]>
 hal.executable private @restrict_num_workgroups {
-  hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {
+  hal.executable.variant public @system_elf_arm_64, target = <"llvm-cpu", "system-elf-arm_64", {
     data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"
@@ -209,7 +209,7 @@ hal.executable private @restrict_num_workgroups {
   ]>
 ]>
 hal.executable private @matmul_aarch_i8_i8_i32_static  {
-  hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {
+  hal.executable.variant public @system_elf_arm_64, target = <"llvm-cpu", "system-elf-arm_64", {
     data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"
@@ -251,7 +251,7 @@ hal.executable private @matmul_aarch_i8_i8_i32_static  {
   ]>
 ]>
 hal.executable private @matmul_aarch_i8_i8_i32_dynamic  {
-  hal.executable.variant public @system_elf_arm_64, target = <"llvm", "system-elf-arm_64", {
+  hal.executable.variant public @system_elf_arm_64, target = <"llvm-cpu", "system-elf-arm_64", {
     data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "aarch64-none-linux-android30"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
@@ -9,7 +9,7 @@
 ]>
 hal.executable private @matmul_riscv  {
   hal.executable.variant public @embedded_elf_x86_64, target = #hal.executable.target<
-    "llvm",
+    "llvm-cpu",
     "embedded-elf-riscv_32", {
       cpu_features = "+m,+f",
       data_layout = "e-m:e-p:32:32-i64:64-n32-S128",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -8,7 +8,7 @@
   ]>
 ]>
 hal.executable private @matvec_static  {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -49,7 +49,7 @@ hal.executable private @matvec_static  {
   ]>
 ]>
 hal.executable private @matvec_dynamic  {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -98,7 +98,7 @@ hal.executable private @matvec_dynamic  {
   ]>
 ]>
 hal.executable private @dot_static  {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -139,7 +139,7 @@ hal.executable private @dot_static  {
   ]>
 ]>
 hal.executable private @dot_dynamic  {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -184,7 +184,7 @@ hal.executable private @dot_dynamic  {
   ]>
 ]>
 hal.executable private @add {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -236,7 +236,7 @@ hal.executable private @add {
   ]>
 ]>
 hal.executable private @add4D  {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -292,7 +292,7 @@ hal.executable private @add4D  {
   ]>
 ]>
 hal.executable private @add_static {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -337,7 +337,7 @@ hal.executable private @add_static {
   ]>
 ]>
 hal.executable private @preset_config_matmul_tensors  {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @preset_config layout(#executable_layout)
     builtin.module {
       func.func @preset_config() {
@@ -382,7 +382,7 @@ hal.executable private @preset_config_matmul_tensors  {
   ]>
 ]>
 hal.executable @copy_op_dynamic {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @copy_op_dynamic layout(#executable_layout)
     builtin.module {
       func.func @copy_op_dynamic() {
@@ -424,7 +424,7 @@ hal.executable @copy_op_dynamic {
   ]>
 ]>
 hal.executable private @static_1d_fft_stage2  {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @static_1d_fft_stage2 layout(#executable_layout)
     builtin.module {
       func.func @static_1d_fft_stage2() {
@@ -462,7 +462,7 @@ hal.executable private @static_1d_fft_stage2  {
   ]>
 ]>
 hal.executable private @static_3d_fft_stage3  {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @static_3d_fft_stage3 layout(#executable_layout)
     builtin.module {
       func.func @static_3d_fft_stage3() {
@@ -500,7 +500,7 @@ hal.executable private @static_3d_fft_stage3  {
   ]>
 ]>
 hal.executable private @outs_fusion {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @outs_fusion_fn layout(#executable_layout)
     builtin.module {
       func.func @outs_fusion_fn() {
@@ -564,7 +564,7 @@ hal.executable private @outs_fusion {
   ]>
 ]>
 hal.executable private @conv_dynamic {
-  hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {
+  hal.executable.variant public @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -621,7 +621,7 @@ hal.executable private @conv_dynamic {
   ]>
 ]>
 hal.executable private @conv_static {
-  hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {
+  hal.executable.variant public @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -663,7 +663,7 @@ hal.executable private @conv_static {
   ]>
 ]>
 hal.executable private @depthwise_conv_static {
-  hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {
+  hal.executable.variant public @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 64 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -709,7 +709,7 @@ hal.executable private @depthwise_conv_static {
   ]>
 ]>
 hal.executable private @generic_static {
-  hal.executable.variant public @system_elf_x86_64, target = <"llvm", "system-elf-x86_64", {
+  hal.executable.variant public @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 64 : index,
     target_triple = "x86_64-pc-linux-gnu"
@@ -756,7 +756,7 @@ hal.executable private @generic_static {
 ]>
 hal.executable private @matmul_static  {
   hal.executable.variant public @embedded_elf_x86_64, target = #hal.executable.target<
-    "llvm",
+    "llvm-cpu",
     "embedded-elf-x86_64", {
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 16 : index,
@@ -802,7 +802,7 @@ hal.executable private @matmul_static  {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm", "embedded-elf-x86_64", {
+  "llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-unknown-eabi-elf"
@@ -861,7 +861,7 @@ hal.executable private @reduction {
 ]>
 hal.executable private @matmul_i8_i8_i32_static  {
   hal.executable.variant public @embedded_elf_x86_64, target = #hal.executable.target<
-    "llvm",
+    "llvm-cpu",
     "embedded-elf-x86_64", {
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 4 : index,
@@ -904,7 +904,7 @@ hal.executable private @matmul_i8_i8_i32_static  {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm", "embedded-elf-x86_64", {
+  "llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-unknown-eabi-elf"
@@ -957,7 +957,7 @@ hal.executable private @gemm_unit_N {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm", "embedded-elf-x86_64", {
+  "llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-unknown-eabi-elf"
@@ -1004,7 +1004,7 @@ hal.executable private @gemm_unit_M_unit_N {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm", "embedded-elf-x86_64", {
+  "llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-unknown-eabi-elf"
@@ -1050,7 +1050,7 @@ hal.executable private @matmul_odd {
   ]>
 ]>
 hal.executable private @generic_unit_dims_dynamic {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -1105,7 +1105,7 @@ hal.executable private @generic_unit_dims_dynamic {
   ]>
 ]>
 hal.executable private @reduce_to_scalar_static {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -1148,7 +1148,7 @@ hal.executable private @reduce_to_scalar_static {
   ]>
 ]>
 hal.executable private @reduce_to_scalar_dynamic {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -1193,7 +1193,7 @@ hal.executable private @reduce_to_scalar_dynamic {
   ]>
 ]>
 hal.executable private @scalar {
-  hal.executable.variant @llvm, target = <"llvm", "embedded-elf-x86_64", {
+  hal.executable.variant @llvm, target = <"llvm-cpu", "embedded-elf-x86_64", {
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
     native_vector_size = 16 : index,
     target_triple = "x86_64-unknown-linux-gnu"
@@ -1234,7 +1234,7 @@ hal.executable private @scalar {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     cpu_features = "+avx2",
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/peel_and_vectorize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/peel_and_vectorize.mlir
@@ -14,7 +14,7 @@
   ]>
 ]>
 hal.executable private @preset_config_matmul  {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @no_peel_static_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
       %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
@@ -70,7 +70,7 @@ hal.executable private @preset_config_matmul  {
   ]>
 ]>
 hal.executable private @preset_config_matmul  {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @peel_static_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
       %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
@@ -138,7 +138,7 @@ hal.executable private @preset_config_matmul  {
   ]>
 ]>
 hal.executable private @preset_config_matmul  {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @peel_dynamic_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
       %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
@@ -205,4 +205,3 @@ hal.executable private @preset_config_matmul  {
 // CHECK:                   linalg.matmul
 
 // CHECK-NOT: scf.for
-

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -10,7 +10,7 @@
 #map3 = affine_map<(d0) -> (d0)>
 #map4 = affine_map<(d0, d1) -> (d0)>
 #map5 = affine_map<(d0, d1) -> (d0, d1)>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   cpu_features = "",
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
@@ -80,7 +80,7 @@ hal.executable private @check_no_cse {
   ]>
 ]>
 hal.executable private @preset_config_matmul  {
-  hal.executable.variant @system_elf_x86_64, target = <"llvm", "system-elf-x86_64"> {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
     hal.executable.export @preset_config_matmul layout(#executable_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
       %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2, %arg3
@@ -119,7 +119,7 @@ hal.executable private @preset_config_matmul  {
 
 // -----
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   cpu_features = "",
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
@@ -172,7 +172,7 @@ hal.executable private @batch_matmul_dynamic {
 
 // -----
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
   cpu_features = "",
   data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
   native_vector_size = 16 : index,
@@ -217,7 +217,7 @@ hal.executable private @check_buffer_ops_vectorization {
 
 hal.executable private @vectorize_fill_conv2d_generic {
   hal.executable.variant public @embedded_elf_x86_64, target = #hal.executable.target<
-    "llvm", "embedded-elf-x86_64", {
+    "llvm-cpu", "embedded-elf-x86_64", {
       cpu_features = "",
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 16 : index,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/test_config_mmt4d.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target{test-lowering-configuration=true}))' %s | FileCheck %s
 
-#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm", "embedded-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-unknown-unknown-eabi-elf"}>
+#executable_target_embedded_elf_arm_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {data_layout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128", native_vector_size = 16 : index, target_triple = "aarch64-unknown-unknown-eabi-elf"}>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
@@ -1,8 +1,8 @@
 // RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule | FileCheck %s
 
-#device_target_cpu = #hal.device.target<"cpu", {executable_targets = [#hal.executable.target<"llvm", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>]}>
+#device_target_cpu = #hal.device.target<"llvm-cpu", {executable_targets = [#hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>]}>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {cpu_features = "", data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128", native_vector_size = 16 : index, target_triple = "x86_64-unknown-unknown-eabi-elf"}>
 
 hal.executable private @pad_matmul_static_dispatch_0 {
   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transpose_avx2_lowering.mlir
@@ -7,7 +7,7 @@
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     cpu_features = "+avx2",
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
@@ -65,7 +65,7 @@ hal.executable private @transpose_10_8x8_pattern {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     cpu_features = "+avx2",
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
@@ -123,7 +123,7 @@ hal.executable private @transpose_021_8x8_pattern {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     cpu_features = "+avx2",
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
@@ -181,7 +181,7 @@ hal.executable private @transpose_201_8x8_pattern {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     cpu_features = "+avx2",
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
@@ -239,7 +239,7 @@ hal.executable private @transpose_210_8x8_pattern {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     cpu_features = "+avx2",
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
@@ -297,7 +297,7 @@ hal.executable private @transpose_120_8x8_pattern {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     cpu_features = "+avx2",
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
@@ -347,7 +347,7 @@ hal.executable private @transpose_102 {
   ]>
 ]>
 #executable_target_embedded_elf_x86_64_ = #hal.executable.target<
-  "llvm",
+  "llvm-cpu",
   "embedded-elf-x86_64", {
     // No '+avx2' cpu feature.
     data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/triple_tiling_expert_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/triple_tiling_expert_pipeline.mlir
@@ -9,7 +9,7 @@
 ]>
 hal.executable private @matmul_128_384_1536  {
   hal.executable.variant @system_elf_x86_64, target = <
-    "llvm",
+    "llvm-cpu",
     "embedded-elf-x86_64", {
       data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
       native_vector_size = 4 : index,

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -102,8 +102,8 @@ func.func @cmdExecute(%arg0: !stream.resource<transient>, %arg1: index, %arg2: !
 
 // -----
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64">
-#device_target_cpu = #hal.device.target<"cpu", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
+#device_target_cpu = #hal.device.target<"llvm-cpu", {
   executable_targets = [#executable_target_embedded_elf_x86_64_]
 }>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -541,10 +541,10 @@ def HAL_DeviceTargetAttr :
 
     Example:
     ```mlir
-    #hal.device.target<"cpu", {
+    #hal.device.target<"llvm-cpu", {
       executable_targets = [
-        #hal.executable.target<"llvm", "embedded-elf-arm_32">,
-        #hal.executable.target<"llvm", "embedded-elf-arm_64">,
+        #hal.executable.target<"llvm-cpu", "embedded-elf-arm_32">,
+        #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64">,
       ]
     }>
     ```
@@ -601,7 +601,7 @@ def HAL_ExecutableTargetAttr :
     Example:
     ```mlir
       // Produce a system-native ELF for x86-64 systems using the LLVM backend:
-      #hal.executable.target<"llvm", "system-elf-x86_64", {
+      #hal.executable.target<"llvm-cpu", "system-elf-x86_64", {
         triple = "x86_64-unknown-linux-elf",
         cpu = "host",
         cpu_features = "host",

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -144,9 +144,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     initConfiguration();
   }
 
-  std::string name() const override { return "llvm"; }
-
-  std::string deviceID() const override { return "cpu"; }
+  std::string name() const override { return "llvm-cpu"; }
 
   void getDependentDialects(DialectRegistry &registry) const override {
     mlir::registerLLVMDialectTranslation(registry);
@@ -742,7 +740,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
               StringAttr::get(context, options_.targetCPUFeatures));
 
     return IREE::HAL::ExecutableTargetAttr::get(
-        context, StringAttr::get(context, "llvm"),
+        context, StringAttr::get(context, "llvm-cpu"),
         StringAttr::get(context, format), DictionaryAttr::get(context, config));
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -843,21 +843,9 @@ void registerLLVMCPUTargetBackends(
     return std::make_shared<LLVMCPUTargetBackend>(queryOptions());
   };
 
-  // Preferred name.
+  // #hal.device.target<"llvm-cpu", ...
   // #hal.executable.target<"llvm-cpu", ...
-  static TargetBackendRegistration registration0("llvm-cpu", backendFactory);
-
-  // Abbreviated names.
-  // #hal.device.target<"cpu", ...
-  static TargetBackendRegistration registration1("cpu", backendFactory);
-  // #hal.executable.target<"llvm", ...
-  static TargetBackendRegistration registration2("llvm", backendFactory);
-
-  // Legacy names.
-  // TODO(benvanik): remove legacy dylib name.
-  static TargetBackendRegistration registration3("dylib", backendFactory);
-  static TargetBackendRegistration registration4("dylib-llvm-aot",
-                                                 backendFactory);
+  static TargetBackendRegistration registration("llvm-cpu", backendFactory);
 }
 
 }  // namespace HAL

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
@@ -5,7 +5,7 @@ module attributes {
   hal.device.targets = [
     #hal.device.target<"dylib", {
       executable_targets = [
-        #hal.executable.target<"llvm", "embedded-elf-x86_64">
+        #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
       ]
     }>
   ]

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_embedded.mlir
@@ -3,7 +3,7 @@
 
 module attributes {
   hal.device.targets = [
-    #hal.device.target<"dylib", {
+    #hal.device.target<"llvm-cpu", {
       executable_targets = [
         #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
       ]

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
@@ -7,7 +7,7 @@ module attributes {
   hal.device.targets = [
     #hal.device.target<"dylib", {
       executable_targets = [
-        #hal.executable.target<"llvm", "embedded-elf-x86_64">
+        #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
       ]
     }>
   ]

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir
@@ -5,7 +5,7 @@
 
 module attributes {
   hal.device.targets = [
-    #hal.device.target<"dylib", {
+    #hal.device.target<"llvm-cpu", {
       executable_targets = [
         #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
       ]

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/convert_to_hal.mlir
@@ -2,8 +2,8 @@
 
 // Tests an end-to-end simple single-dispatch `dispatch(arg0, arg1) -> result`.
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64">
-#device_target_cpu = #hal.device.target<"cpu", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
+#device_target_cpu = #hal.device.target<"llvm-cpu", {
   executable_targets = [#executable_target_embedded_elf_x86_64_]
 }>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -3,8 +3,8 @@
 // Tests dumping executable benchmarks to stdout - it's more common to use files
 // but this is much easier to test with lit.
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64">
-#device_target_cpu = #hal.device.target<"cpu", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
+#device_target_cpu = #hal.device.target<"llvm-cpu", {
   executable_targets = [#executable_target_embedded_elf_x86_64_]
 }>
 #executable_layout_0 = #hal.executable.layout<push_constants = 2, sets = [

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_sources.mlir
@@ -3,8 +3,8 @@
 // Tests dumping executable sources to stdout - it's more common to use files
 // but this is much easier to test with lit.
 
-#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm", "embedded-elf-x86_64">
-#device_target_cpu = #hal.device.target<"cpu", {
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
+#device_target_cpu = #hal.device.target<"llvm-cpu", {
   executable_targets = [#executable_target_embedded_elf_x86_64_]
 }>
 #executable_layout = #hal.executable.layout<push_constants = 0, sets = [
@@ -20,7 +20,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
   // CHECK: hal.executable private @ex0
   hal.executable private @ex0 {
     // We expect local outputs with attributes inlined:
-    // CHECK-NEXT: hal.executable.variant {{.+}}, target = <"llvm"
+    // CHECK-NEXT: hal.executable.variant {{.+}}, target = <"llvm-cpu"
     hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
       hal.executable.export public @dispatch0 ordinal(0) layout(#executable_layout) attributes {
         translation_info = #iree_codegen.translation_info<CPUDefault workload_per_wg = [4]>

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -3,10 +3,10 @@
 // Tests an executable with a workgroup count region specified.
 
 module attributes {hal.device.targets = [
-  #hal.device.target<"cpu", {
+  #hal.device.target<"llvm-cpu", {
     executable_targets = [
-      #hal.executable.target<"llvm", "embedded-elf-arm_64">,
-      #hal.executable.target<"llvm", "embedded-elf-x86_64">
+      #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64">,
+      #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
     ]
   }>
 ]} {
@@ -57,10 +57,10 @@ func.func @main(%arg0: !stream.resource<external>, %arg1: index) -> !stream.reso
 // themselves.
 
 module attributes {hal.device.targets = [
-  #hal.device.target<"cpu", {
+  #hal.device.target<"llvm-cpu", {
     executable_targets = [
-      #hal.executable.target<"llvm", "embedded-elf-arm_64">,
-      #hal.executable.target<"llvm", "embedded-elf-x86_64">
+      #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64">,
+      #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64">
     ]
   }>
 ]} {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -116,7 +116,7 @@ func.func @otherDescriptorSetLayoutLookup(%device : !hal.device) -> !hal.descrip
   ]>
 ]>
 
-module attributes {hal.device.targets = [#hal.device.target<"cpu">]} {
+module attributes {hal.device.targets = [#hal.device.target<"llvm-cpu">]} {
 
 // TODO(scotttodd): Test without depending on a specific HAL target? Or move to HAL/Target/*/test/?
 //   - If there is no matching hal.executable.variant then the executable will not be cached

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/verify_target_environment.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/verify_target_environment.mlir
@@ -42,7 +42,7 @@ module @module attributes {hal.device.targets = [#device_target_vmvx]} {
 
 // Modules without anything that needs an environment are OK.
 
-#executable_target = #hal.executable.target<"llvm", "embedded-elf-arm_64", {}>
+#executable_target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {}>
 
 // CHECK: module @module
 module @module {


### PR DESCRIPTION
Removed: `cpu`, `llvm`, `dylib`, `dylib-llvm-aot`
Use `llvm-cpu` instead

See https://github.com/iree-org/iree/issues/9930 and https://groups.google.com/g/iree-discuss/c/N-BBCURS7g4/