### PR TITLE
Update default tiling sizes for ARM convolution configurations.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAArch64VectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAArch64VectorLowering.cpp
@@ -45,15 +45,12 @@ void LLVMCPUAArch64VectorLoweringPass::runOnOperation() {
   auto funcOp = getOperation();
 
   Optional<int64_t> numLoops;
-  auto walkRes = funcOp.walk([&](vector::ContractionOp op) -> WalkResult {
-    int64_t opNumLoops = op.getIndexingMapsArray()[0].getNumDims();
-    if (numLoops && *numLoops != opNumLoops) return WalkResult::interrupt();
-    numLoops = opNumLoops;
-    return WalkResult::advance();
+  funcOp.walk([&](vector::ContractionOp op) {
+    if (numLoops) return signalPassFailure();
+    numLoops = op.getIndexingMapsArray()[0].getNumDims();
   });
   // No vector.contract op to optimize.
   if (!numLoops) return;
-  if (walkRes.wasInterrupted()) return signalPassFailure();
 
   {
     // Fold consumer add ops into the contraction op itself.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAArch64VectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAArch64VectorLowering.cpp
@@ -45,12 +45,15 @@ void LLVMCPUAArch64VectorLoweringPass::runOnOperation() {
   auto funcOp = getOperation();
 
   Optional<int64_t> numLoops;
-  funcOp.walk([&](vector::ContractionOp op) {
-    if (numLoops) return signalPassFailure();
-    numLoops = op.getIndexingMapsArray()[0].getNumDims();
+  auto walkRes = funcOp.walk([&](vector::ContractionOp op) -> WalkResult {
+    int64_t opNumLoops = op.getIndexingMapsArray()[0].getNumDims();
+    if (numLoops && *numLoops != opNumLoops) return WalkResult::interrupt();
+    numLoops = opNumLoops;
+    return WalkResult::advance();
   });
   // No vector.contract op to optimize.
   if (!numLoops) return;
+  if (walkRes.wasInterrupted()) return signalPassFailure();
 
   {
     // Fold consumer add ops into the contraction op itself.


### PR DESCRIPTION
This is the first round of tuning for ARM normal convolution codegen. The parameters are derived from experiments for 3x3 kernel cases.

Benchmark file:

```mlir
util.global private @"__iree_flow_lhs" {noinline} = dense<1.0> : tensor<1x51x41x512xf32>
util.global private @"__iree_flow_rhs" {noinline} = dense<1.0> : tensor<3x3x512x512xf32>
func.func @conv_3x3filter() ->tensor<1x25x20x512xf32> {
  %lhs_ptr = util.global.address @"__iree_flow_lhs" : !util.ptr<tensor<1x51x41x512xf32>>
  %rhs_ptr = util.global.address @"__iree_flow_rhs" : !util.ptr<tensor<3x3x512x512xf32>>
  %lhs = util.global.load.indirect %lhs_ptr : !util.ptr<tensor<1x51x41x512xf32>> -> tensor<1x51x41x512xf32>
  %rhs = util.global.load.indirect %rhs_ptr : !util.ptr<tensor<3x3x512x512xf32>> -> tensor<3x3x512x512xf32>

  %cst = arith.constant 0.000000e+00 : f32
  %2 = linalg.init_tensor [1, 25, 20, 512] : tensor<1x25x20x512xf32>
  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<1x25x20x512xf32>) -> tensor<1x25x20x512xf32>
  %4 = linalg.conv_2d_nhwc_hwcf
    { dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>}
    ins(%lhs, %rhs : tensor<1x51x41x512xf32>, tensor<3x3x512x512xf32>)
    outs(%3 : tensor<1x25x20x512xf32>) -> tensor<1x25x20x512xf32>
  return %4 : tensor<1x25x20x512xf32>
}
```

Before:

```
# 1-threaded, taskset 80
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_conv_3x3filter/process_time/real_time       1164 ms         1126 ms            1

# 4-threaded, taskset f0
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_conv_3x3filter/process_time/real_time        643 ms         1764 ms            1
```

After:

```
# 1-threaded, taskset 80
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_conv_3x3filter/process_time/real_time        160 ms          155 ms            4

# 4-threaded, taskset f0
-----------------------------------------------------------------------------------
Benchmark                                         Time             CPU   Iterations
-----------------------------------------------------------------------------------
BM_conv_3x3filter/process_time/real_time       65.6 ms          160 ms            9
```