### PR TITLE
Fix relative path used to search for linker tools.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
@@ -215,7 +215,7 @@ std::string LinkerTool::findToolFromExecutableDir(
   // Next search around in the CMake build tree.
   toolPath = findToolAtPath(
       normalizedToolNames,
-      mainExecutableDir + "/../../third_party/llvm-project/llvm/bin/");
+      mainExecutableDir + "/../third_party/llvm-project/llvm/bin/");
   if (!toolPath.empty()) {
     LLVM_DEBUG(llvm::dbgs()
                << "Found tool in build tree at path " << toolPath << "\n");


### PR DESCRIPTION
Leftover from the `iree/tools/` -> `tools/` move. I noticed this when trying to find `wasm-ld` from a regular build (i.e. without setting up the Emscripten SDK or putting a tool directly on my path).