### PR TITLE
Fix executable names for web samples.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -196,7 +196,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
 
     // Create our new "linked" hal.executable.
     std::string linkedExecutableName =
-        llvm::formatv("{0}_linked_{1}", moduleName, name());
+        llvm::formatv("{0}_linked_{1}", moduleName, "llvm_cpu");
     auto linkedExecutableOp = builder.create<IREE::HAL::ExecutableOp>(
         moduleOp.getLoc(), linkedExecutableName);
     linkedExecutableOp.setVisibility(

--- a/experimental/web/sample_static/device_multithreaded.c
+++ b/experimental/web/sample_static/device_multithreaded.c
@@ -18,7 +18,7 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
 
   // Register the statically linked executable library.
   const iree_hal_executable_library_query_fn_t libraries[] = {
-      mnist_linked_llvm_library_query,
+      mnist_linked_llvm_cpu_library_query,
   };
   iree_hal_executable_loader_t* library_loader = NULL;
   iree_status_t status = iree_hal_static_library_loader_create(

--- a/experimental/web/sample_static/device_sync.c
+++ b/experimental/web/sample_static/device_sync.c
@@ -15,7 +15,7 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
 
   // Register the statically linked executable library.
   const iree_hal_executable_library_query_fn_t libraries[] = {
-      mnist_linked_llvm_library_query,
+      mnist_linked_llvm_cpu_library_query,
   };
   iree_hal_executable_loader_t* library_loader = NULL;
   iree_status_t status = iree_hal_static_library_loader_create(


### PR DESCRIPTION
Fixes https://buildkite.com/iree/iree-samples/builds/442

* Use `_` instead of `-` in names, as they will appear in C++ identifiers (a more general name sanitization might be better than this bandaid)
* Update static library name from 'llvm' to 'llvm_cpu'

```
[2022-08-13T00:19:29Z] In file included from /usr/src/github/iree/experimental/web/sample_static/device_sync.c:9:
[2022-08-13T00:19:29Z] /usr/src/github/iree/build-emscripten/experimental/web/sample_static/mnist_static.h:11:67: error: extra tokens at end of #ifndef directive [-Werror,-Wextra-tokens]
[2022-08-13T00:19:29Z] #ifndef IREE_GENERATED_STATIC_EXECUTABLE_LIBRARY_MNIST_LINKED_LLVM-CPU_
[2022-08-13T00:19:29Z]                                                                   ^
[2022-08-13T00:19:29Z]                                                                   //
[2022-08-13T00:19:29Z] /usr/src/github/iree/build-emscripten/experimental/web/sample_static/mnist_static.h:12:67: error: ISO C99 requires whitespace after the macro name [-Werror,-Wc99-extensions]
[2022-08-13T00:19:29Z] #define IREE_GENERATED_STATIC_EXECUTABLE_LIBRARY_MNIST_LINKED_LLVM-CPU_
[2022-08-13T00:19:29Z]                                                                   ^
[2022-08-13T00:19:29Z] /usr/src/github/iree/build-emscripten/experimental/web/sample_static/mnist_static.h:21:18: error: expected ';' after top level declarator
[2022-08-13T00:19:29Z] mnist_linked_llvm-cpu_library_query(
[2022-08-13T00:19:29Z]                  ^
[2022-08-13T00:19:29Z]                  ;
[2022-08-13T00:19:29Z] /usr/src/github/iree/experimental/web/sample_static/device_sync.c:18:7: error: use of undeclared identifier 'mnist_linked_llvm_library_query'
[2022-08-13T00:19:29Z]       mnist_linked_llvm_library_query,
[2022-08-13T00:19:29Z]       ^                                                           //
```