### PR TITLE
Re-enable GPU tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,9 +198,7 @@ jobs:
 
   test_gpu:
     needs: [should_run, build_all]
-    # TODO(gcmn): There is something wrong with the GPU MIG. The machines keep
-    # immediately shutting down.
-    if: false && needs.should_run.outputs.should-run == 'true'
+    if: needs.should_run.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
@@ -397,9 +395,7 @@ jobs:
 
   test_tf_integrations_gpu:
     needs: [should_run, build_tf_integrations, build_all]
-    # TODO(gcmn): There is something wrong with the GPU MIG. The machines keep
-    # immediately shutting down.
-    if: false && needs.should_run.outputs.should-run == 'true'
+    if: needs.should_run.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted


### PR DESCRIPTION
The GPU runners had an outdated version of the GitHub runner, which was
causing runner startup to fail and the instances too bootloop. I've
updated the image, so they are working now and we can re-enable.

Fixes https://github.com/iree-org/iree/issues/9856