### PR TITLE
Use string in PR description instead of label to skip CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       # The commit being checked out is the merge commit for the PR. Its first
       # parent will be the tip of main.
       BASE_REF: HEAD^
-      LABELS: join(${{ github.event.pull_request.labels.*.name }})
+      PR_DESCRIPTION: ${{ github.event.pull_request.body }}
     outputs:
       should-run: ${{ steps.should-run.outputs.should-run }}
     steps:

--- a/build_tools/github_actions/should_ci_run.py
+++ b/build_tools/github_actions/should_ci_run.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 
-SKIPC_CI_TAG = "skip-ci"
+SKIP_CI_TAG = "skip-ci"
 
 # Note that these are fnmatch patterns, which are not the same as gitignore
 # patterns because they don't treat '/' specially. The standard library doesn't
@@ -72,8 +72,8 @@ def should_run_ci():
     return True
 
   for line in description.splitlines():
-    if line.strip().lower() == SKIPC_CI_TAG:
-      print(f"Not running CI because PR description has '{SKIPC_CI_TAG}' line.")
+    if line.strip().lower() == SKIP_CI_TAG:
+      print(f"Not running CI because PR description has '{SKIP_CI_TAG}' line.")
       return False
 
   try:

--- a/build_tools/github_actions/should_ci_run.py
+++ b/build_tools/github_actions/should_ci_run.py
@@ -16,7 +16,7 @@ import os
 import subprocess
 import sys
 
-SKIP_CI_LABEL = "skip-ci"
+SKIPC_CI_TAG = "skip-ci"
 
 # Note that these are fnmatch patterns, which are not the same as gitignore
 # patterns because they don't treat '/' specially. The standard library doesn't
@@ -64,16 +64,17 @@ def modifies_included_path(base_ref):
 def should_run_ci():
   event_name = os.environ["GITHUB_EVENT_NAME"]
   base_ref = os.environ["BASE_REF"]
-  labels = os.environ["LABELS"].split(",")
+  description = os.environ["PR_DESCRIPTION"]
 
   if event_name != "pull_request":
     print("Running CI independent of diff because run was not triggered by a"
           "pull request event.")
     return True
 
-  if SKIP_CI_LABEL in labels:
-    print(f"Not running CI because PR has label '{SKIP_CI_LABEL}'.")
-    return False
+  for line in description.splitlines():
+    if line.strip().lower() == SKIPC_CI_TAG:
+      print(f"Not running CI because PR description has '{SKIPC_CI_TAG}' line.")
+      return False
 
   try:
     modifies = modifies_included_path(base_ref)


### PR DESCRIPTION
As discussed in https://github.com/iree-org/iree/issues/10042, we
discovered that using a label doesn't work for the very important
case of when the PR is just created, so we're shifting to use the PR
body instead.

Tested: Created this PR with "skip-ci" as the entire body, which
resulted in correctly skipping the CI. Also added some additional lines
before and after, and CI was still correctly skipped. Finally, this PR
body as written contains the string, but not on its own line and CI is
not skipped.

Just skip-ci: https://github.com/iree-org/iree/runs/7866417853

With other content in the PR body:
![also_other_content](https://user-images.githubusercontent.com/5732088/184980308-ab8f1e90-453e-493c-9224-a10acdc5cc2b.png)
https://github.com/iree-org/iree/runs/7866417853


