### PR TITLE
Copy the upstream mhlo.scatter -> Linalg pattern to IREE.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -221,7 +221,7 @@ struct ScatterUpdateConversion : public OpConversionPattern<mhlo::ScatterOp> {
 
   LogicalResult matchAndRewrite(
       mhlo::ScatterOp op, OpAdaptor adaptor,
-      ConversionPatternRewriter& rewriter) const final {
+      ConversionPatternRewriter &rewriter) const final {
     // Variadic Scatter support not yet implemented
     if (op.operands().size() != 1 || op.updates().size() != 1) return failure();
 
@@ -294,7 +294,7 @@ struct ScatterUpdateConversion : public OpConversionPattern<mhlo::ScatterOp> {
                    adaptor.updates()[0]},
         /*outputs=*/adaptor.operands()[0], indexingMaps,
         mhlo::getNParallelLoopsAttrs(nloops),
-        [](OpBuilder& b, Location loc, ValueRange args) {},
+        [](OpBuilder &b, Location loc, ValueRange args) {},
         mhlo::pruneAttributeList(op));
 
     // Transform the scatter update computation region
@@ -305,7 +305,7 @@ struct ScatterUpdateConversion : public OpConversionPattern<mhlo::ScatterOp> {
     //   result = idx == cmpIdx ? update : old_value
     //   linalg.yield result
     bool updateIsTrivial = (op.getRegion().front().getOperations().size() == 1);
-    Block* block = &linalgOp->getRegion(0).front();
+    Block *block = &linalgOp->getRegion(0).front();
     auto args = block->getArguments();
 
     BlockAndValueMapping mapping;
@@ -334,7 +334,7 @@ struct ScatterUpdateConversion : public OpConversionPattern<mhlo::ScatterOp> {
     rewriter.mergeBlocks(&linalgOp->getRegion(0).back(), block, llvm::None);
 
     // Generate: result = idx == cmpIdx ? update : old_value.
-    Operation* terminator = block->getTerminator();
+    Operation *terminator = block->getTerminator();
     rewriter.setInsertionPoint(terminator);
     Value cmpIdx =
         rewriter.create<linalg::IndexOp>(loc, scatterDimsToOperandDims[0]);

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -348,6 +348,7 @@ struct ScatterUpdateConversion : public OpConversionPattern<mhlo::ScatterOp> {
     result = rewriter.create<arith::SelectOp>(loc, args[2].getType(), pred,
                                               args[2], result);
 
+    op.emitWarning("op is lowered to an inefficient way, which is unexpected");
     rewriter.replaceOpWithNewOp<linalg::YieldOp>(terminator, result);
     rewriter.replaceOp(op, linalgOp.getResults());
     return success();
@@ -535,9 +536,9 @@ void populateMHLOToLinalgOnTensorsConversionPatterns(
   mhlo::populateHloToLinalgConversionPattern(context, typeConverter, &patterns);
   // TODO(#5809): Drop ConcatenateOp lowering in favor of the upstream version
   //              then remove the PatternBenefit here
-  patterns.insert<ConcatenateOpConversion, FftOpConversion,
-                  ScatterUpdateConversion>(typeConverter, context,
-                                           PatternBenefit(1000));
+  patterns.insert<ScatterUpdateConversion>(typeConverter, context);
+  patterns.insert<ConcatenateOpConversion, FftOpConversion>(
+      typeConverter, context, PatternBenefit(1000));
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>> createMHLOToLinalgOnTensorsPass() {

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -21,6 +21,7 @@
 #include "iree/compiler/InputConversion/MHLO/Rewriters.h"
 #include "mlir-hlo/Dialect/mhlo/IR/chlo_ops.h"
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
+#include "mlir-hlo/Dialect/mhlo/transforms/legalize_to_linalg_utils.h"
 #include "mlir-hlo/Dialect/mhlo/transforms/rewriters.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Complex/IR/Complex.h"
@@ -213,6 +214,146 @@ struct FftOpConversion : public OpConversionPattern<mhlo::FftOp> {
   }
 };
 
+// TODO(#9361): Retire the pattern. The implementation is partial, and it has
+// bad performance. It's added for not regressing scatter support.
+struct ScatterUpdateConversion : public OpConversionPattern<mhlo::ScatterOp> {
+  using OpConversionPattern<mhlo::ScatterOp>::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      mhlo::ScatterOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter& rewriter) const final {
+    // Variadic Scatter support not yet implemented
+    if (op.operands().size() != 1 || op.updates().size() != 1) return failure();
+
+    // Check if it is a tensor_scatter_nd_update-like op.
+    if (op.getRegion().front().getNumArguments() != 2) return failure();
+
+    auto operandTy =
+        adaptor.operands()[0].getType().dyn_cast<RankedTensorType>();
+    auto indicesTy =
+        adaptor.scatter_indices().getType().dyn_cast<RankedTensorType>();
+    if (!operandTy || !indicesTy) return failure();
+
+    // Linalg operations put all the computation to the innermost loop. Since we
+    // also iterate over scatter_indices() with some loops, we can only check
+    // one scatter index in one iteration. If there are multiple indices (ie,
+    // the index depth is greater than 1), we don't have a way to keep the
+    // comparison state. E.g., if the index_depth is 2, like indices = [[0, 1]],
+    // we should use the update value only if (i == 0 and j == 1). However, we
+    // can not get both indices in one iteration unless we pack them together.
+    auto indexVectorDim = op.scatter_dimension_numbers().getIndexVectorDim();
+    if (indicesTy.getDimSize(indexVectorDim) != 1)
+      return rewriter.notifyMatchFailure(op, "require index depth to be 1");
+    if (indexVectorDim != indicesTy.getRank() - 1) {
+      return rewriter.notifyMatchFailure(
+          op, "require index_vector_dim to be the last dim");
+    }
+
+    // One of indices dims is index depth vector.
+    int64_t nloops = operandTy.getRank() + indicesTy.getRank() - 1;
+    SmallVector<AffineMap, 3> indexingMaps;
+    {
+      SmallVector<AffineExpr> exprs;
+      for (int64_t i = 0, e = operandTy.getRank(); i < e; ++i)
+        exprs.push_back(rewriter.getAffineDimExpr(i));
+      indexingMaps.push_back(AffineMap::get(nloops, /*symbolCount=*/0, exprs,
+                                            rewriter.getContext()));
+    }
+    {
+      SmallVector<AffineExpr> exprs;
+      for (int64_t i = operandTy.getRank(); i < nloops; ++i)
+        exprs.push_back(rewriter.getAffineDimExpr(i));
+      // The index depth is 1.
+      exprs.push_back(rewriter.getAffineConstantExpr(0));
+      indexingMaps.push_back(AffineMap::get(nloops, /*symbolCount=*/0, exprs,
+                                            rewriter.getContext()));
+
+      exprs.pop_back();
+      auto updateWindowDims =
+          op.scatter_dimension_numbers().getUpdateWindowDims();
+      for (auto d : updateWindowDims)
+        exprs.push_back(rewriter.getAffineDimExpr(d));
+      indexingMaps.push_back(AffineMap::get(nloops, /*symbolCount=*/0, exprs,
+                                            rewriter.getContext()));
+    }
+    indexingMaps.push_back(indexingMaps.front());
+
+    auto resultTy =
+        this->typeConverter->convertType(op.getResults()[0].getType())
+            .cast<ShapedType>();
+    auto scatterDimsToOperandDims =
+        op.scatter_dimension_numbers().getScatterDimsToOperandDims();
+    assert(scatterDimsToOperandDims.size() == 1);
+    // Do not need init_tensor because we'd like to initialize the output as
+    // operand.
+    auto loc = op.getLoc();
+    auto linalgOp = rewriter.create<linalg::GenericOp>(
+        loc, /*resultTensors=*/ArrayRef<Type>{resultTy},
+        /*inputs=*/
+        ValueRange{adaptor.operands()[0], adaptor.scatter_indices(),
+                   adaptor.updates()[0]},
+        /*outputs=*/adaptor.operands()[0], indexingMaps,
+        mhlo::getNParallelLoopsAttrs(nloops),
+        [](OpBuilder& b, Location loc, ValueRange args) {},
+        mhlo::pruneAttributeList(op));
+
+    // Transform the scatter update computation region
+    //   update = a bunch of computation
+    //   return update
+    // to linalg.generic region:
+    //   update = a bunch of computation
+    //   result = idx == cmpIdx ? update : old_value
+    //   linalg.yield result
+    bool updateIsTrivial = (op.getRegion().front().getOperations().size() == 1);
+    Block* block = &linalgOp->getRegion(0).front();
+    auto args = block->getArguments();
+
+    BlockAndValueMapping mapping;
+    // The scatter update computation block arguments are tensors of scalars
+    // while the linalg.generic block arguments are scalars.
+    if (updateIsTrivial) {
+      // If there is no actual update computation, directly use the
+      // linalg.generic block arguments.
+      for (auto pair : llvm::zip_first(op.getRegion().front().getArguments(),
+                                       args.drop_front(2)))
+        mapping.map(std::get<0>(pair), std::get<1>(pair));
+    } else {
+      // Otherwise, convert the linalg.generic block scalar arguments to
+      // tensors, to avoid producing illegal mhlo instructions.
+      rewriter.setInsertionPointToStart(block);
+      for (auto pair : llvm::zip_first(op.getRegion().front().getArguments(),
+                                       args.drop_front(2)))
+        mapping.map(std::get<0>(pair),
+                    rewriter.create<tensor::FromElementsOp>(
+                        loc, std::get<0>(pair).getType(), std::get<1>(pair)));
+    }
+
+    // Transform the computation block over to the linalg.generic op.
+    rewriter.cloneRegionBefore(op.getRegion(), linalgOp->getRegion(0),
+                               linalgOp->getRegion(0).end(), mapping);
+    rewriter.mergeBlocks(&linalgOp->getRegion(0).back(), block, llvm::None);
+
+    // Generate: result = idx == cmpIdx ? update : old_value.
+    Operation* terminator = block->getTerminator();
+    rewriter.setInsertionPoint(terminator);
+    Value cmpIdx =
+        rewriter.create<linalg::IndexOp>(loc, scatterDimsToOperandDims[0]);
+    Value idx = rewriter.create<arith::IndexCastOp>(
+        loc, rewriter.getIndexType(), args[1]);
+    Value pred = rewriter.create<arith::CmpIOp>(
+        loc, rewriter.getI1Type(), arith::CmpIPredicate::eq, cmpIdx, idx);
+    Value result = terminator->getOperand(0);
+    if (!updateIsTrivial)
+      result = rewriter.create<tensor::ExtractOp>(loc, result, ValueRange({}));
+    result = rewriter.create<arith::SelectOp>(loc, args[2].getType(), pred,
+                                              args[2], result);
+
+    rewriter.replaceOpWithNewOp<linalg::YieldOp>(terminator, result);
+    rewriter.replaceOp(op, linalgOp.getResults());
+    return success();
+  }
+};
+
 // We need to convert func ops in order to convert types.
 class BuiltinFuncOpPattern : public OpConversionPattern<func::FuncOp> {
   using OpConversionPattern<func::FuncOp>::OpConversionPattern;
@@ -394,8 +535,9 @@ void populateMHLOToLinalgOnTensorsConversionPatterns(
   mhlo::populateHloToLinalgConversionPattern(context, typeConverter, &patterns);
   // TODO(#5809): Drop ConcatenateOp lowering in favor of the upstream version
   //              then remove the PatternBenefit here
-  patterns.insert<ConcatenateOpConversion, FftOpConversion>(
-      typeConverter, context, PatternBenefit(1000));
+  patterns.insert<ConcatenateOpConversion, FftOpConversion,
+                  ScatterUpdateConversion>(typeConverter, context,
+                                           PatternBenefit(1000));
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>> createMHLOToLinalgOnTensorsPass() {

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_linalg.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_linalg.mlir
@@ -14,3 +14,124 @@ func.func @concatenate(%arg0: tensor<2x2xi32>, %arg1: tensor<2x4xi32>) -> tensor
 // CHECK:         %[[T1:.+]] = tensor.insert_slice %[[CST]] into %[[T0]][0, 2] [2, 3] [1, 1]
 // CHECK:         %[[T2:.+]] = tensor.insert_slice %[[ARG1]] into %[[T1]][0, 5] [2, 4] [1, 1]
 // CHECK:         return %[[T2]]
+
+// -----
+
+func.func @scatter_update_scalar(%arg0: tensor<3xi32>, %arg1: tensor<1x1xi32>,
+                            %arg2: tensor<1xi32>) -> tensor<3xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ({
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #mhlo.scatter<
+      update_window_dims = [],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = false
+  } : (tensor<3xi32>, tensor<1x1xi32>, tensor<1xi32>) -> tensor<3xi32>
+  func.return %0 : tensor<3xi32>
+}
+// CHECK:   #[[MAP0:.*]] = affine_map<(d0, d1) -> (d1, 0)>
+// CHECK:   #[[MAP1:.*]] = affine_map<(d0, d1) -> (d1)>
+// CHECK:   #[[MAP2:.*]] = affine_map<(d0, d1) -> (d0)>
+// CHECK:       func @scatter_update_scalar
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-SAME:      indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:      iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:      ins(%[[ARG1]], %[[ARG2]] : tensor<1x1xi32>, tensor<1xi32>)
+// CHECK-SAME:     outs(%[[ARG0]] : tensor<3xi32>) {
+// CHECK:         ^bb0(%[[IDX_I32:.*]]: i32, %[[UPDATE:.*]]: i32, %[[OUT:.*]]: i32):
+// CHECK:           %[[CMP_IDX:.*]] = linalg.index 0 : index
+// CHECK:           %[[IDX:.*]] = arith.index_cast %[[IDX_I32]] : i32 to index
+// CHECK:           %[[PRED:.*]] = arith.cmpi eq, %[[CMP_IDX]], %[[IDX]] : index
+// CHECK:           %[[SELECT:.*]] = arith.select %[[PRED]], %[[UPDATE]], %[[OUT]] : i32
+// CHECK:           linalg.yield %[[SELECT]] : i32
+// CHECK:         } -> tensor<3xi32>
+// CHECK:         return %[[RES]] : tensor<3xi32>
+
+// -----
+
+func.func @scatter_update_slice(%arg0: tensor<6x3xi32>, %arg1: tensor<2x1xi32>,
+                           %arg2: tensor<2x3xi32>) -> tensor<6x3xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ({
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #mhlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = false
+  } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x3xi32>) -> tensor<6x3xi32>
+  func.return %0 : tensor<6x3xi32>
+}
+// CHECK-DAG:   #[[MAP0:.*]] = affine_map<(d0, d1, d2) -> (d2, 0)>
+// CHECK-DAG:   #[[MAP1:.*]] = affine_map<(d0, d1, d2) -> (d2, d1)>
+// CHECK-DAG:   #[[MAP2:.*]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK:       func @scatter_update_slice
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-SAME:      indexing_maps = [#[[MAP0]], #[[MAP1]], #[[MAP2]]]
+// CHECK-SAME:      iterator_types = ["parallel", "parallel", "parallel"]
+// CHECK-SAME:      ins(%[[ARG1]], %[[ARG2]] : tensor<2x1xi32>, tensor<2x3xi32>)
+// CHECK-SAME:     outs(%[[ARG0]] : tensor<6x3xi32>) {
+// CHECK:         ^bb0(%[[IDX_I32:.*]]: i32, %[[UPDATE:.*]]: i32, %[[OUT:.*]]: i32):
+// CHECK:           %[[CMP_IDX:.*]] = linalg.index 0 : index
+// CHECK:           %[[IDX:.*]] = arith.index_cast %[[IDX_I32]] : i32 to index
+// CHECK:           %[[PRED:.*]] = arith.cmpi eq, %[[CMP_IDX]], %[[IDX]] : index
+// CHECK:           %[[SELECT:.*]] = arith.select %[[PRED]], %[[UPDATE]], %[[OUT]] : i32
+// CHECK:           linalg.yield %[[SELECT]] : i32
+// CHECK:         } -> tensor<6x3xi32>
+// CHECK:         return %[[RES]] : tensor<6x3xi32>
+
+// -----
+
+func.func @scatter_update_nontrivial_computation(%arg0: tensor<3xi32>,
+  %arg1: tensor<6x1xi32>, %arg2: tensor<6xi32>) -> tensor<3xi32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ({
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):
+    %1 = mhlo.add %arg3, %arg4 : tensor<i32>
+    "mhlo.return"(%1) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #mhlo.scatter<
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1
+    >,
+    unique_indices = false
+  } : (tensor<3xi32>, tensor<6x1xi32>, tensor<6xi32>) -> tensor<3xi32>
+  return %0 : tensor<3xi32>
+}
+
+// CHECK-DAG:   #[[MAP0:.*]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-DAG:   #[[MAP1:.*]] = affine_map<(d0, d1) -> (d1, 0)>
+// CHECK-DAG:   #[[MAP2:.*]] = affine_map<(d0, d1) -> (d1)>
+// CHECK:       func @scatter_update_nontrivial_computation
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9_]*]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9_]*]]
+// CHECK:         %[[RES:.*]] = linalg.generic
+// CHECK-SAME:      indexing_maps = [#[[MAP1]], #[[MAP2]], #[[MAP0]]]
+// CHECK-SAME:      iterator_types = ["parallel", "parallel"]
+// CHECK-SAME:      ins(%[[ARG1]], %[[ARG2]] : tensor<6x1xi32>, tensor<6xi32>)
+// CHECK-SAME:     outs(%[[ARG0]] : tensor<3xi32>) {
+// CHECK:         ^bb0(%[[IDX_I32:.*]]: i32, %{{.*}}: i32, %{{.*}}: i32):
+// CHECK:           %[[CMP_IDX:.*]] = linalg.index 0 : index
+// CHECK:           %[[IDX:.*]] = arith.index_cast %[[IDX_I32]] : i32 to index
+// CHECK:           %[[PRED:.*]] = arith.cmpi eq, %[[CMP_IDX]], %[[IDX]] : index
+// CHECK:           %[[SELECT:.*]] =  arith.select %[[PRED]], %{{.*}}, %{{.*}}: i32
+// CHECK:           linalg.yield %[[SELECT]] : i32
+// CHECK:         } -> tensor<3xi32>
+// CHECK:         return %[[RES]] : tensor<3xi32>


### PR DESCRIPTION
The upstream pattern is going to be retired. It's not a proper way to
lower a mhlo.scatter op. Ideally, we should move them to LinalgExt path.
This is a workaround to not regress mhlo.scatter support in IREE.