### PR TITLE
Remove anonymous namespace causing TypeID failures

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/TF/LowerGlobalTensors.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/TF/LowerGlobalTensors.cpp
@@ -80,7 +80,6 @@ struct ResourceLatticeValue {
   mutable DenseSet<tf_saved_model::GlobalTensorOp> ops;
 };
 
-namespace {
 class ResourceAnalysis : public ::mlir::dataflow::SparseDataFlowAnalysis<
                              dataflow::Lattice<ResourceLatticeValue>> {
  public:
@@ -240,8 +239,6 @@ void LowerGlobalTensors::runOnOperation() {
     globalTensor.erase();
   }
 }
-
-}  // namespace
 
 std::unique_ptr<OperationPass<ModuleOp>> createLowerGlobalTensorsPass() {
   return std::make_unique<LowerGlobalTensors>();


### PR DESCRIPTION
Without this builds without `NDEBUG` fail with an error about defining
explicit type IDs. I think the correct fix is really to have these
passes defined with ODS instead of using the static pass registration
that has been discouraged for years, but TF doesn't do that and we
don't try to clean up TF's messes here.

This wasn't caught in OSS because TF in OSS is unbuildable without
`NDEBUG`. Internally we can still manage to do that though, so I got
failures when integrating into our internal source control.

The error is:

> LLVM ERROR: TypeID::get<mlir::iree_integrations::TF::(anonymous namespace)::LowerGlobalTensors>(): Using TypeID on a class with an anonymous namespace requires an explicit TypeID definition. The implicit fallback uses string name, which does not guarantee uniqueness in anonymous contexts. Define an explicit TypeID instantiation for this type using `MLIR_DECLARE_EXPLICIT_TYPE_ID`/`MLIR_DEFINE_EXPLICIT_TYPE_ID` or `MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID`.
