### PR TITLE
Enable detensorize by default

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -82,7 +82,7 @@ static llvm::cl::opt<int> clLinalgOpsPaddingSize(
 static llvm::cl::opt<bool> clEnableLinalgDetensorize(
     "iree-flow-enable-linalg-detensorize",
     llvm::cl::desc("Enable detensorizing linalg ops to operate on primitives"),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 static llvm::cl::opt<std::string> clMmt4dTargetOptions(
     "iree-flow-mmt4d-target-options",


### PR DESCRIPTION
Wrote a simple cpu test that involves multiple iterations across
low compute workloads. Verified that we saw a 10% improvement in
performance due to detensoring the work. Validating on performance
benchmarks now.