### PR TITLE
Add region_to_workgroups transform

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -8,6 +8,7 @@
 
 #include "iree-dialects/Dialect/LinalgTransform/SimplePatternRewriter.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.h"
 #include "iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -441,6 +442,18 @@ transform_dialect::ForeachThreadToFlowDispatchWorkgroupsOp::applyToOne(
   SimplePatternRewriter rewriter(target->getContext());
   FailureOr<Flow::DispatchWorkgroupsOp> result =
       rewriteForeachThreadToFlowDispatchWorkgroups(target, rewriter);
+  if (failed(result))
+    return DiagnosedSilenceableFailure(reportUnknownTransformError(target));
+  results.push_back(*result);
+  return DiagnosedSilenceableFailure(success());
+}
+
+DiagnosedSilenceableFailure transform_dialect::RegionToWorkgroupsOp::applyToOne(
+    Flow::DispatchRegionOp target, SmallVectorImpl<Operation *> &results,
+    transform::TransformState &state) {
+  IRRewriter rewriter(target->getContext());
+  FailureOr<Flow::DispatchWorkgroupsOp> result =
+      rewriteFlowDispatchRegionToFlowDispatchWorkgroups(target, rewriter);
   if (failed(result))
     return DiagnosedSilenceableFailure(reportUnknownTransformError(target));
   results.push_back(*result);

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h
@@ -21,6 +21,7 @@ namespace iree_compiler {
 namespace IREE {
 namespace Flow {
 class DispatchWorkgroupsOp;
+class DispatchRegionOp;
 }  // namespace Flow
 }  // namespace IREE
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -50,6 +50,32 @@ def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreac
   }];
 }
 
+def RegionToWorkgroupsOp : Op<Transform_Dialect, "iree.region_to_workgroups",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformOpInterface,
+     TransformEachOpTrait]> {
+  let description = [{
+    Convert a flow.dispatch.region op into a flow.dispatch.workgroups op.
+
+    Region ops can capture any values that are in scope in their body, whereas
+    workgroup ops are isolated from above and all values must be explicitly
+    captured via operands.
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::iree_compiler::IREE::Flow::DispatchRegionOp target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 def WrapInDispatchRegionOp : Op<
     Transform_Dialect, "iree.wrap_in_dispatch_region",
     [FunctionalStyleTransformOpTrait, MemoryEffectsOpInterface,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -64,6 +64,7 @@ iree_compiler_cc_library(
         "VerifyInputLegality.cpp",
     ],
     hdrs = [
+        "ConvertRegionToWorkgroups.h",
         "DispatchLinalgOnTensors.h",
         "FusionUtils.h",
         "Passes.h",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
   NAME
     Transforms
   HDRS
+    "ConvertRegionToWorkgroups.h"
     "DispatchLinalgOnTensors.h"
     "FusionUtils.h"
     "Passes.h"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.cpp
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.h"
+
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
@@ -69,11 +71,13 @@ static Optional<Value> findFirstTiedValueOutsideOfRegionOp(
   return value;
 }
 
+}  // namespace
+
 /// Rewrite the DispatchRegionOp into a DispatchWorkgroupsOp. The
 /// DispatchRegionOp is not isolated from above and may capture any SSA value
 /// that is in scope. The generated DispatchWorkgroupsOp captures all SSA values
 /// explicitly and makes them available inside the region via block arguments.
-static FailureOr<Flow::DispatchWorkgroupsOp>
+FailureOr<Flow::DispatchWorkgroupsOp>
 rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
     Flow::DispatchRegionOp regionOp, RewriterBase &rewriter) {
   // Only ops with a single block are supported.
@@ -200,6 +204,7 @@ rewriteFlowDispatchRegionToFlowDispatchWorkgroups(
   return workgroupsOp;
 }
 
+namespace {
 struct ConvertRegionToWorkgroupsPass
     : public ConvertRegionToWorkgroupsBase<ConvertRegionToWorkgroupsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -220,7 +225,6 @@ struct ConvertRegionToWorkgroupsPass
     }
   }
 };
-
 }  // namespace
 
 std::unique_ptr<Pass> createConvertRegionToWorkgroupsPass() {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertRegionToWorkgroups.h
@@ -1,0 +1,34 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_CONVERTREGIONTOWORKGROUPS_H_
+#define IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_CONVERTREGIONTOWORKGROUPS_H_
+
+#include "mlir/Support/LogicalResult.h"
+
+namespace mlir {
+class RewriterBase;
+
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+class DispatchRegionOp;
+class DispatchWorkgroupsOp;
+
+/// Rewrite the DispatchRegionOp into a DispatchWorkgroupsOp. The
+/// DispatchRegionOp is not isolated from above and may capture any SSA value
+/// that is in scope. The generated DispatchWorkgroupsOp captures all SSA values
+/// explicitly and makes them available inside the region via block arguments.
+FailureOr<DispatchWorkgroupsOp>
+rewriteFlowDispatchRegionToFlowDispatchWorkgroups(DispatchRegionOp regionOp,
+                                                  RewriterBase &rewriter);
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_FLOW_TRANSFORMS_CONVERTREGIONTOWORKGROUPS_H_


### PR DESCRIPTION
This op is useful in combination with
`iree-flow-dispatch-use-transform-dialect` in order to experiment with
dispatch region formation with the transform dialect, while also running
the remaining Flow transformation pipeline.