### PR TITLE
Plumbing and preparing HAL drivers for new queuing behavior.

### DIFF
--- a/experimental/rocm/executable_layout.c
+++ b/experimental/rocm/executable_layout.c
@@ -47,7 +47,7 @@ static void iree_hal_rocm_executable_layout_destroy(
 
 iree_status_t iree_hal_rocm_executable_layout_create(
     iree_hal_rocm_context_wrapper_t* context, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(context);

--- a/experimental/rocm/executable_layout.h
+++ b/experimental/rocm/executable_layout.h
@@ -20,7 +20,7 @@ extern "C" {
 // Creates the kernel arguments.
 iree_status_t iree_hal_rocm_executable_layout_create(
     iree_hal_rocm_context_wrapper_t* context, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t** out_executable_layout);
 

--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -262,7 +262,13 @@ static iree_status_t iree_hal_rocm_device_queue_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   // TODO: queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      iree_hal_device_allocator(base_device), params, allocation_size,
+      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_rocm_device_queue_dealloca(
@@ -271,7 +277,10 @@ static iree_status_t iree_hal_rocm_device_queue_dealloca(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer) {
   // TODO: queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_rocm_device_queue_execute(

--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -277,18 +277,6 @@ static iree_status_t iree_hal_rocm_device_wait_semaphores(
                           "semaphore not implemented");
 }
 
-static iree_status_t iree_hal_rocm_device_wait_idle(
-    iree_hal_device_t* base_device, iree_timeout_t timeout) {
-  iree_hal_rocm_device_t* device = iree_hal_rocm_device_cast(base_device);
-  // Wait until the stream is done.
-  // TODO(thomasraoux): HIP doesn't support a deadline for wait, figure out how
-  // to handle it better.
-  ROCM_RETURN_IF_ERROR(device->context_wrapper.syms,
-                       hipStreamSynchronize(device->stream),
-                       "hipStreamSynchronize");
-  return iree_ok_status();
-}
-
 static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .destroy = iree_hal_rocm_device_destroy,
     .id = iree_hal_rocm_device_id,
@@ -309,5 +297,4 @@ static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
     .queue_submit = iree_hal_rocm_device_queue_submit,
     .wait_semaphores = iree_hal_rocm_device_wait_semaphores,
-    .wait_idle = iree_hal_rocm_device_wait_idle,
 };

--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -254,6 +254,26 @@ iree_hal_rocm_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
+static iree_status_t iree_hal_rocm_device_queue_alloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_id_t pool_id, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  // TODO: queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
+static iree_status_t iree_hal_rocm_device_queue_dealloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* buffer) {
+  // TODO: queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
 static iree_status_t iree_hal_rocm_device_queue_execute(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -268,6 +288,12 @@ static iree_status_t iree_hal_rocm_device_queue_execute(
   // stream work with device->stream, we'll change
   ROCM_RETURN_IF_ERROR(device->context_wrapper.syms, hipStreamSynchronize(0),
                        "hipStreamSynchronize");
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_rocm_device_queue_flush(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity) {
+  // Currently unused; we flush as submissions are made.
   return iree_ok_status();
 }
 
@@ -296,6 +322,9 @@ static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .query_semaphore_compatibility =
         iree_hal_rocm_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
+    .queue_alloca = iree_hal_rocm_device_queue_alloca,
+    .queue_dealloca = iree_hal_rocm_device_queue_dealloca,
     .queue_execute = iree_hal_rocm_device_queue_execute,
+    .queue_flush = iree_hal_rocm_device_queue_flush,
     .wait_semaphores = iree_hal_rocm_device_wait_semaphores,
 };

--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -231,7 +231,7 @@ static iree_status_t iree_hal_rocm_device_create_executable_cache(
 static iree_status_t iree_hal_rocm_device_create_executable_layout(
     iree_hal_device_t* base_device, iree_host_size_t push_constants,
     iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_hal_executable_layout_t** out_executable_layout) {
   iree_hal_rocm_device_t* device = iree_hal_rocm_device_cast(base_device);
   return iree_hal_rocm_executable_layout_create(
@@ -254,11 +254,12 @@ iree_hal_rocm_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
-static iree_status_t iree_hal_rocm_device_queue_submit(
-    iree_hal_device_t* base_device,
-    iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches) {
+static iree_status_t iree_hal_rocm_device_queue_execute(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_host_size_t command_buffer_count,
+    iree_hal_command_buffer_t* const* command_buffers) {
   iree_hal_rocm_device_t* device = iree_hal_rocm_device_cast(base_device);
   // TODO(raikonenfnu): Once semaphore is implemented wait for semaphores
   // TODO(thomasraoux): implement semaphores - for now this conservatively
@@ -272,7 +273,7 @@ static iree_status_t iree_hal_rocm_device_queue_submit(
 
 static iree_status_t iree_hal_rocm_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
+    const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                           "semaphore not implemented");
 }
@@ -295,6 +296,6 @@ static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .query_semaphore_compatibility =
         iree_hal_rocm_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
-    .queue_submit = iree_hal_rocm_device_queue_submit,
+    .queue_execute = iree_hal_rocm_device_queue_execute,
     .wait_semaphores = iree_hal_rocm_device_wait_semaphores,
 };

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -38,6 +38,9 @@ typedef uint64_t iree_hal_queue_affinity_t;
 // Specifies that any queue may be selected.
 #define IREE_HAL_QUEUE_AFFINITY_ANY ((iree_hal_queue_affinity_t)(-1))
 
+// TBD: placeholder for reserving unique pools.
+typedef uint32_t iree_hal_allocator_pool_id_t;
+
 // Parameters defining how a buffer should be allocated.
 //
 // Designed to be zero-initialized: any field with a 0 value will be assigned

--- a/runtime/src/iree/hal/command_buffer.h
+++ b/runtime/src/iree/hal/command_buffer.h
@@ -260,7 +260,7 @@ typedef struct iree_hal_command_buffer_t iree_hal_command_buffer_t;
 // existing one from the |device| pool.
 //
 // |queue_affinity| specifies the device queues the command buffer may be
-// submitted to. The queue affinity provided to iree_hal_device_queue_submit
+// submitted to. The queue affinity provided to iree_hal_device_queue_execute
 // must match or be a subset of the |queue_affinity|.
 IREE_API_EXPORT iree_status_t iree_hal_command_buffer_create(
     iree_hal_device_t* device, iree_hal_command_buffer_mode_t mode,

--- a/runtime/src/iree/hal/cts/command_buffer_dispatch_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_dispatch_test.h
@@ -132,8 +132,7 @@ TEST_P(command_buffer_dispatch_test, DispatchAbs) {
 
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
-  IREE_ASSERT_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                            command_buffer));
+  IREE_ASSERT_OK(SubmitCommandBufferAndWait(command_buffer));
 
   float output_value = 0.0f;
   IREE_ASSERT_OK(iree_hal_device_transfer_d2h(

--- a/runtime/src/iree/hal/cts/command_buffer_test.h
+++ b/runtime/src/iree/hal/cts/command_buffer_test.h
@@ -65,8 +65,7 @@ class command_buffer_test : public CtsTestBase {
         command_buffer, device_buffer, target_offset, fill_length, pattern,
         pattern_length));
     IREE_CHECK_OK(iree_hal_command_buffer_end(command_buffer));
-    IREE_CHECK_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_ANY,
-                                             command_buffer));
+    IREE_CHECK_OK(SubmitCommandBufferAndWait(command_buffer));
 
     // Read data for returning.
     std::vector<uint8_t> actual_data(buffer_size);
@@ -120,8 +119,7 @@ TEST_P(command_buffer_test, SubmitEmpty) {
   IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
-  IREE_ASSERT_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                            command_buffer));
+  IREE_ASSERT_OK(SubmitCommandBufferAndWait(command_buffer));
 
   iree_hal_command_buffer_release(command_buffer);
 }
@@ -171,8 +169,7 @@ TEST_P(command_buffer_test, CopyWholeBuffer) {
       /*length=*/kDefaultAllocationSize));
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
-  IREE_ASSERT_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_TRANSFER,
-                                            command_buffer));
+  IREE_ASSERT_OK(SubmitCommandBufferAndWait(command_buffer));
 
   // Read the device buffer and compare.
   std::vector<uint8_t> actual_data(kDefaultAllocationSize);
@@ -245,8 +242,7 @@ TEST_P(command_buffer_test, CopySubBuffer) {
       /*pattern_length=*/sizeof(zero_val)));
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
-  IREE_ASSERT_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_TRANSFER,
-                                            command_buffer));
+  IREE_ASSERT_OK(SubmitCommandBufferAndWait(command_buffer));
 
   // Read the device buffer and compare.
   std::vector<uint8_t> actual_data(kDefaultAllocationSize);
@@ -454,8 +450,7 @@ TEST_P(command_buffer_test, UpdateBufferWholeBuffer) {
       command_buffer, source_buffer.data(), /*source_offset=*/0, device_buffer,
       /*target_offset=*/0, /*length=*/target_buffer_size));
   IREE_CHECK_OK(iree_hal_command_buffer_end(command_buffer));
-  IREE_CHECK_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_ANY,
-                                           command_buffer));
+  IREE_CHECK_OK(SubmitCommandBufferAndWait(command_buffer));
 
   // Check that the contents match what we expect.
   std::vector<uint8_t> actual_data(target_buffer_size);
@@ -491,8 +486,7 @@ TEST_P(command_buffer_test, UpdateBufferWithOffsets) {
       command_buffer, source_buffer.data(), /*source_offset=*/4, device_buffer,
       /*target_offset=*/4, /*length=*/8));
   IREE_CHECK_OK(iree_hal_command_buffer_end(command_buffer));
-  IREE_CHECK_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_ANY,
-                                           command_buffer));
+  IREE_CHECK_OK(SubmitCommandBufferAndWait(command_buffer));
 
   // Check that the contents match what we expect.
   std::vector<uint8_t> actual_data(target_buffer_size);
@@ -538,8 +532,7 @@ TEST_P(command_buffer_test, UpdateBufferSubspan) {
       command_buffer, source_buffer.data(), /*source_offset=*/4, buffer_subspan,
       /*target_offset=*/4, /*length=*/4));
   IREE_CHECK_OK(iree_hal_command_buffer_end(command_buffer));
-  IREE_CHECK_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_ANY,
-                                           command_buffer));
+  IREE_CHECK_OK(SubmitCommandBufferAndWait(command_buffer));
 
   // Check that the contents match what we expect.
   std::vector<uint8_t> actual_data(target_buffer_size);

--- a/runtime/src/iree/hal/cts/event_test.h
+++ b/runtime/src/iree/hal/cts/event_test.h
@@ -44,8 +44,7 @@ TEST_P(event_test, SignalAndReset) {
       command_buffer, event, IREE_HAL_EXECUTION_STAGE_COMMAND_RETIRE));
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
-  IREE_ASSERT_OK(SubmitCommandBufferAndWait(IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                            command_buffer));
+  IREE_ASSERT_OK(SubmitCommandBufferAndWait(command_buffer));
 
   iree_hal_event_release(event);
   iree_hal_command_buffer_release(command_buffer);
@@ -85,34 +84,15 @@ TEST_P(event_test, SubmitWithChainedCommandBuffers) {
       /*buffer_barriers=*/NULL));
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer_2));
 
-  // No wait semaphores, one signal which we immediately wait on after submit.
-  iree_hal_submission_batch_t submission_batch;
-  submission_batch.wait_semaphores.count = 0;
-  submission_batch.wait_semaphores.semaphores = NULL;
-  submission_batch.wait_semaphores.payload_values = NULL;
-  iree_hal_command_buffer_t* command_buffer_ptrs[] = {command_buffer_1,
-                                                      command_buffer_2};
-  submission_batch.command_buffer_count = IREE_ARRAYSIZE(command_buffer_ptrs);
-  submission_batch.command_buffers = command_buffer_ptrs;
-  iree_hal_semaphore_t* signal_semaphore;
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore));
-  iree_hal_semaphore_t* signal_semaphore_ptrs[] = {signal_semaphore};
-  submission_batch.signal_semaphores.count =
-      IREE_ARRAYSIZE(signal_semaphore_ptrs);
-  submission_batch.signal_semaphores.semaphores = signal_semaphore_ptrs;
-  uint64_t payload_values[] = {1ull};
-  submission_batch.signal_semaphores.payload_values = payload_values;
-
-  IREE_ASSERT_OK(
-      iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                   /*queue_affinity=*/0,
-                                   /*batch_count=*/1, &submission_batch));
-  IREE_ASSERT_OK(
-      iree_hal_semaphore_wait(signal_semaphore, 1ull, iree_infinite_timeout()));
+  iree_hal_command_buffer_t* command_buffer_ptrs[] = {
+      command_buffer_1,
+      command_buffer_2,
+  };
+  IREE_ASSERT_OK(SubmitCommandBuffersAndWait(
+      IREE_ARRAYSIZE(command_buffer_ptrs), command_buffer_ptrs));
 
   iree_hal_command_buffer_release(command_buffer_1);
   iree_hal_command_buffer_release(command_buffer_2);
-  iree_hal_semaphore_release(signal_semaphore);
   iree_hal_event_release(event);
 }
 

--- a/runtime/src/iree/hal/cts/semaphore_submission_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_submission_test.h
@@ -173,9 +173,8 @@ TEST_P(semaphore_submission_test, SubmitWithMultipleSemaphores) {
   IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore_1, 1ull));
   IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore_2, 1ull));
 
-  IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ALL, &signal_semaphores,
-      iree_infinite_timeout()));
+  IREE_ASSERT_OK(
+      iree_hal_semaphore_list_wait(signal_semaphores, iree_infinite_timeout()));
 
   iree_hal_command_buffer_release(command_buffer);
   iree_hal_semaphore_release(wait_semaphore_1);

--- a/runtime/src/iree/hal/cts/semaphore_submission_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_submission_test.h
@@ -23,25 +23,19 @@ class semaphore_submission_test : public CtsTestBase {};
 
 TEST_P(semaphore_submission_test, SubmitWithNoCommandBuffers) {
   // No waits, one signal which we immediately wait on after submit.
-  iree_hal_submission_batch_t submission_batch;
-  submission_batch.wait_semaphores.count = 0;
-  submission_batch.wait_semaphores.semaphores = NULL;
-  submission_batch.wait_semaphores.payload_values = NULL;
-  submission_batch.command_buffer_count = 0;
-  submission_batch.command_buffers = NULL;
   iree_hal_semaphore_t* signal_semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore));
-  iree_hal_semaphore_t* signal_semaphore_ptrs[] = {signal_semaphore};
-  submission_batch.signal_semaphores.count =
-      IREE_ARRAYSIZE(signal_semaphore_ptrs);
-  submission_batch.signal_semaphores.semaphores = signal_semaphore_ptrs;
-  uint64_t payload_values[] = {1ull};
-  submission_batch.signal_semaphores.payload_values = payload_values;
+  uint64_t signal_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t signal_semaphores = {
+      1,
+      &signal_semaphore,
+      signal_payload_values,
+  };
 
-  IREE_ASSERT_OK(
-      iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                   /*queue_affinity=*/0,
-                                   /*batch_count=*/1, &submission_batch));
+  IREE_ASSERT_OK(iree_hal_device_queue_execute(device_,
+                                               /*queue_affinity=*/0,
+                                               iree_hal_semaphore_list_empty(),
+                                               signal_semaphores, 0, NULL));
   IREE_ASSERT_OK(
       iree_hal_semaphore_wait(signal_semaphore, 1ull, iree_infinite_timeout()));
 
@@ -59,25 +53,19 @@ TEST_P(semaphore_submission_test, SubmitAndSignal) {
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
   // No waits, one signal which we immediately wait on after submit.
-  iree_hal_submission_batch_t submission_batch;
-  submission_batch.wait_semaphores.count = 0;
-  submission_batch.wait_semaphores.semaphores = NULL;
-  submission_batch.wait_semaphores.payload_values = NULL;
-  submission_batch.command_buffer_count = 1;
-  submission_batch.command_buffers = &command_buffer;
   iree_hal_semaphore_t* signal_semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore));
-  iree_hal_semaphore_t* signal_semaphore_ptrs[] = {signal_semaphore};
-  submission_batch.signal_semaphores.count =
-      IREE_ARRAYSIZE(signal_semaphore_ptrs);
-  submission_batch.signal_semaphores.semaphores = signal_semaphore_ptrs;
-  uint64_t payload_values[] = {1ull};
-  submission_batch.signal_semaphores.payload_values = payload_values;
+  uint64_t signal_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t signal_semaphores = {
+      1,
+      &signal_semaphore,
+      signal_payload_values,
+  };
 
-  IREE_ASSERT_OK(
-      iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                   /*queue_affinity=*/0,
-                                   /*batch_count=*/1, &submission_batch));
+  IREE_ASSERT_OK(iree_hal_device_queue_execute(
+      device_,
+      /*queue_affinity=*/0, iree_hal_semaphore_list_empty(), signal_semaphores,
+      1, &command_buffer));
   IREE_ASSERT_OK(
       iree_hal_semaphore_wait(signal_semaphore, 1ull, iree_infinite_timeout()));
 
@@ -96,29 +84,27 @@ TEST_P(semaphore_submission_test, SubmitWithWait) {
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
   // One wait and one signal semaphore.
-  iree_hal_submission_batch_t submission_batch;
   iree_hal_semaphore_t* wait_semaphore = NULL;
-  iree_hal_semaphore_t* signal_semaphore = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &wait_semaphore));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 100ull, &signal_semaphore));
-  iree_hal_semaphore_t* wait_semaphore_ptrs[] = {wait_semaphore};
-  iree_hal_semaphore_t* signal_semaphore_ptrs[] = {signal_semaphore};
   uint64_t wait_payload_values[] = {1ull};
+  iree_hal_semaphore_list_t wait_semaphores = {
+      1,
+      &wait_semaphore,
+      wait_payload_values,
+  };
+  iree_hal_semaphore_t* signal_semaphore = NULL;
+  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 100ull, &signal_semaphore));
   uint64_t signal_payload_values[] = {101ull};
-  submission_batch.wait_semaphores.count = IREE_ARRAYSIZE(wait_semaphore_ptrs);
-  submission_batch.wait_semaphores.semaphores = wait_semaphore_ptrs;
-  submission_batch.wait_semaphores.payload_values = wait_payload_values;
-  submission_batch.command_buffer_count = 1;
-  submission_batch.command_buffers = &command_buffer;
-  submission_batch.signal_semaphores.count =
-      IREE_ARRAYSIZE(signal_semaphore_ptrs);
-  submission_batch.signal_semaphores.semaphores = signal_semaphore_ptrs;
-  submission_batch.signal_semaphores.payload_values = signal_payload_values;
+  iree_hal_semaphore_list_t signal_semaphores = {
+      1,
+      &signal_semaphore,
+      signal_payload_values,
+  };
 
   IREE_ASSERT_OK(
-      iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                   /*queue_affinity=*/0,
-                                   /*batch_count=*/1, &submission_batch));
+      iree_hal_device_queue_execute(device_,
+                                    /*queue_affinity=*/0, wait_semaphores,
+                                    signal_semaphores, 1, &command_buffer));
 
   // Work shouldn't start until the wait semaphore reaches its payload value.
   uint64_t value;
@@ -145,35 +131,36 @@ TEST_P(semaphore_submission_test, SubmitWithMultipleSemaphores) {
   IREE_ASSERT_OK(iree_hal_command_buffer_begin(command_buffer));
   IREE_ASSERT_OK(iree_hal_command_buffer_end(command_buffer));
 
-  iree_hal_submission_batch_t submission_batch;
   iree_hal_semaphore_t* wait_semaphore_1 = NULL;
   iree_hal_semaphore_t* wait_semaphore_2 = NULL;
-  iree_hal_semaphore_t* signal_semaphore_1 = NULL;
-  iree_hal_semaphore_t* signal_semaphore_2 = NULL;
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &wait_semaphore_1));
   IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &wait_semaphore_2));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore_1));
-  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore_2));
   iree_hal_semaphore_t* wait_semaphore_ptrs[] = {wait_semaphore_1,
                                                  wait_semaphore_2};
+  uint64_t wait_payload_values[] = {1ull, 1ull};
+  iree_hal_semaphore_list_t wait_semaphores = {
+      IREE_ARRAYSIZE(wait_semaphore_ptrs),
+      wait_semaphore_ptrs,
+      wait_payload_values,
+  };
+
+  iree_hal_semaphore_t* signal_semaphore_1 = NULL;
+  iree_hal_semaphore_t* signal_semaphore_2 = NULL;
+  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore_1));
+  IREE_ASSERT_OK(iree_hal_semaphore_create(device_, 0ull, &signal_semaphore_2));
   iree_hal_semaphore_t* signal_semaphore_ptrs[] = {signal_semaphore_1,
                                                    signal_semaphore_2};
-  uint64_t wait_payload_values[] = {1ull, 1ull};
   uint64_t signal_payload_values[] = {1ull, 1ull};
-  submission_batch.wait_semaphores.count = IREE_ARRAYSIZE(wait_semaphore_ptrs);
-  submission_batch.wait_semaphores.semaphores = wait_semaphore_ptrs;
-  submission_batch.wait_semaphores.payload_values = wait_payload_values;
-  submission_batch.command_buffer_count = 1;
-  submission_batch.command_buffers = &command_buffer;
-  submission_batch.signal_semaphores.count =
-      IREE_ARRAYSIZE(signal_semaphore_ptrs);
-  submission_batch.signal_semaphores.semaphores = signal_semaphore_ptrs;
-  submission_batch.signal_semaphores.payload_values = signal_payload_values;
+  iree_hal_semaphore_list_t signal_semaphores = {
+      IREE_ARRAYSIZE(signal_semaphore_ptrs),
+      signal_semaphore_ptrs,
+      signal_payload_values,
+  };
 
   IREE_ASSERT_OK(
-      iree_hal_device_queue_submit(device_, IREE_HAL_COMMAND_CATEGORY_DISPATCH,
-                                   /*queue_affinity=*/0,
-                                   /*batch_count=*/1, &submission_batch));
+      iree_hal_device_queue_execute(device_,
+                                    /*queue_affinity=*/0, wait_semaphores,
+                                    signal_semaphores, 1, &command_buffer));
 
   // Work shouldn't start until all wait semaphores reach their payload values.
   uint64_t value;
@@ -186,13 +173,8 @@ TEST_P(semaphore_submission_test, SubmitWithMultipleSemaphores) {
   IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore_1, 1ull));
   IREE_ASSERT_OK(iree_hal_semaphore_signal(wait_semaphore_2, 1ull));
 
-  iree_hal_semaphore_list_t signal_semaphore_list;
-  signal_semaphore_list.count = IREE_ARRAYSIZE(signal_semaphore_ptrs);
-  signal_semaphore_list.semaphores = signal_semaphore_ptrs;
-  uint64_t payload_values[] = {1ull, 1ull};
-  signal_semaphore_list.payload_values = payload_values;
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ALL, &signal_semaphore_list,
+      device_, IREE_HAL_WAIT_MODE_ALL, &signal_semaphores,
       iree_infinite_timeout()));
 
   iree_hal_command_buffer_release(command_buffer);

--- a/runtime/src/iree/hal/cts/semaphore_test.h
+++ b/runtime/src/iree/hal/cts/semaphore_test.h
@@ -80,17 +80,17 @@ TEST_P(semaphore_test, Failure) {
 // Tests waiting on no semaphores.
 TEST_P(semaphore_test, EmptyWait) {
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ANY, NULL,
+      device_, IREE_HAL_WAIT_MODE_ANY, iree_hal_semaphore_list_empty(),
       iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ALL, NULL,
+      device_, IREE_HAL_WAIT_MODE_ALL, iree_hal_semaphore_list_empty(),
       iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ANY, NULL,
+      device_, IREE_HAL_WAIT_MODE_ANY, iree_hal_semaphore_list_empty(),
       iree_make_timeout_ns(IREE_DURATION_INFINITE)));
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ALL, NULL,
+      device_, IREE_HAL_WAIT_MODE_ALL, iree_hal_semaphore_list_empty(),
       iree_make_timeout_ns(IREE_DURATION_INFINITE)));
 }
 
@@ -149,7 +149,7 @@ TEST_P(semaphore_test, WaitAllButNotAllSignaled) {
   // Result status is undefined - some backends may return DeadlineExceededError
   // while others may return success.
   IREE_IGNORE_ERROR(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ALL, &semaphore_list,
+      device_, IREE_HAL_WAIT_MODE_ALL, semaphore_list,
       iree_make_deadline(IREE_TIME_INFINITE_PAST)));
 
   iree_hal_semaphore_release(semaphore_a);
@@ -174,7 +174,7 @@ TEST_P(semaphore_test, WaitAllAndAllSignaled) {
   // Result status is undefined - some backends may return DeadlineExceededError
   // while others may return success.
   IREE_IGNORE_ERROR(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ALL, &semaphore_list,
+      device_, IREE_HAL_WAIT_MODE_ALL, semaphore_list,
       iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
   iree_hal_semaphore_release(semaphore_a);
@@ -197,7 +197,7 @@ TEST_P(semaphore_test, DISABLED_WaitAny) {
   semaphore_list.payload_values = payload_values;
 
   IREE_ASSERT_OK(iree_hal_device_wait_semaphores(
-      device_, IREE_HAL_WAIT_MODE_ANY, &semaphore_list,
+      device_, IREE_HAL_WAIT_MODE_ANY, semaphore_list,
       iree_make_deadline(IREE_TIME_INFINITE_FUTURE)));
 
   iree_hal_semaphore_release(semaphore_a);

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -152,6 +152,51 @@ IREE_API_EXPORT iree_status_t iree_hal_device_transfer_d2d(
       flags, timeout);
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_device_queue_alloca(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_id_t pool_id, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(
+      !wait_semaphore_list.count ||
+      (wait_semaphore_list.semaphores && wait_semaphore_list.payload_values));
+  IREE_ASSERT_ARGUMENT(!signal_semaphore_list.count ||
+                       (signal_semaphore_list.semaphores &&
+                        signal_semaphore_list.payload_values));
+  IREE_ASSERT_ARGUMENT(out_buffer);
+  *out_buffer = NULL;
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(device, queue_alloca)(
+      device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+      pool_id, params, allocation_size, out_buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_device_queue_dealloca(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* buffer) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(
+      !wait_semaphore_list.count ||
+      (wait_semaphore_list.semaphores && wait_semaphore_list.payload_values));
+  IREE_ASSERT_ARGUMENT(!signal_semaphore_list.count ||
+                       (signal_semaphore_list.semaphores &&
+                        signal_semaphore_list.payload_values));
+  IREE_ASSERT_ARGUMENT(buffer);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status = _VTABLE_DISPATCH(device, queue_dealloca)(
+      device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+      buffer);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_device_queue_execute(
     iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -193,6 +238,16 @@ IREE_API_EXPORT iree_status_t iree_hal_device_queue_execute(
       device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
       command_buffer_count, command_buffers);
 
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_device_queue_flush(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_status_t status =
+      _VTABLE_DISPATCH(device, queue_flush)(device, queue_affinity);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -152,49 +152,56 @@ IREE_API_EXPORT iree_status_t iree_hal_device_transfer_d2d(
       flags, timeout);
 }
 
-// Validates that the submission is well-formed.
-static iree_status_t iree_hal_device_validate_submission(
-    iree_host_size_t batch_count, const iree_hal_submission_batch_t* batches) {
-  for (iree_host_size_t i = 0; i < batch_count; ++i) {
-    for (iree_host_size_t j = 0; j < batches[i].command_buffer_count; ++j) {
-      if (batches[i].wait_semaphores.count > 0 &&
-          iree_all_bits_set(
-              iree_hal_command_buffer_mode(batches[i].command_buffers[j]),
-              IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION)) {
-        // Inline command buffers are not allowed to wait (as they could have
-        // already been executed!). This is a requirement of the API so we
-        // validate it across all backends even if they don't support inline
-        // execution and ignore it.
-        return iree_make_status(
-            IREE_STATUS_INVALID_ARGUMENT,
-            "inline command buffer submitted with a wait; inline command "
-            "buffers must be ready to execute immediately");
-      }
+IREE_API_EXPORT iree_status_t iree_hal_device_queue_execute(
+    iree_hal_device_t* device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_host_size_t command_buffer_count,
+    iree_hal_command_buffer_t* const* command_buffers) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(
+      !wait_semaphore_list.count ||
+      (wait_semaphore_list.semaphores && wait_semaphore_list.payload_values));
+  IREE_ASSERT_ARGUMENT(!signal_semaphore_list.count ||
+                       (signal_semaphore_list.semaphores &&
+                        signal_semaphore_list.payload_values));
+  IREE_ASSERT_ARGUMENT(!command_buffer_count || command_buffers);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // TODO(benvanik): move into devices instead? then a synchronous/inline device
+  // could assert the waits are resolved instead of blanket failing on an
+  // already-resolved semaphore. This would make using stream-ordered
+  // allocations easier.
+  for (iree_host_size_t i = 0; i < command_buffer_count; ++i) {
+    if (wait_semaphore_list.count > 0 &&
+        iree_all_bits_set(
+            iree_hal_command_buffer_mode(command_buffers[i]),
+            IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION)) {
+      // Inline command buffers are not allowed to wait (as they could have
+      // already been executed!). This is a requirement of the API so we
+      // validate it across all backends even if they don't support inline
+      // execution and ignore it.
+      IREE_TRACE_ZONE_END(z0);
+      return iree_make_status(
+          IREE_STATUS_INVALID_ARGUMENT,
+          "inline command buffer submitted with a wait; inline command "
+          "buffers must be ready to execute immediately");
     }
   }
-  return iree_ok_status();
-}
 
-IREE_API_EXPORT iree_status_t iree_hal_device_queue_submit(
-    iree_hal_device_t* device, iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches) {
-  IREE_ASSERT_ARGUMENT(device);
-  IREE_ASSERT_ARGUMENT(!batch_count || batches);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_hal_device_validate_submission(batch_count, batches));
-  iree_status_t status = _VTABLE_DISPATCH(device, queue_submit)(
-      device, command_categories, queue_affinity, batch_count, batches);
+  iree_status_t status = _VTABLE_DISPATCH(device, queue_execute)(
+      device, queue_affinity, wait_semaphore_list, signal_semaphore_list,
+      command_buffer_count, command_buffers);
+
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_device_wait_semaphores(
     iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
+    const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
   IREE_ASSERT_ARGUMENT(device);
-  if (!semaphore_list || semaphore_list->count == 0) return iree_ok_status();
+  if (semaphore_list.count == 0) return iree_ok_status();
   IREE_TRACE_ZONE_BEGIN(z0);
   iree_status_t status = _VTABLE_DISPATCH(device, wait_semaphores)(
       device, wait_mode, semaphore_list, timeout);

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -201,12 +201,3 @@ IREE_API_EXPORT iree_status_t iree_hal_device_wait_semaphores(
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
-
-IREE_API_EXPORT iree_status_t
-iree_hal_device_wait_idle(iree_hal_device_t* device, iree_timeout_t timeout) {
-  IREE_ASSERT_ARGUMENT(device);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = _VTABLE_DISPATCH(device, wait_idle)(device, timeout);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}

--- a/runtime/src/iree/hal/device.h
+++ b/runtime/src/iree/hal/device.h
@@ -336,19 +336,6 @@ IREE_API_EXPORT iree_status_t iree_hal_device_wait_semaphores(
     iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout);
 
-// Blocks the caller until all outstanding requests on all queues have been
-// completed or the |timeout| elapses. This is equivalent to having waited
-// on all semaphores outstanding at the time of the call, meaning that if new
-// work is submitted by another thread it may not be waited on prior to this
-// call returning.
-//
-// Returns success if the device reaches an idle point during the call.
-//
-// Returns DEADLINE_EXCEEDED if the |timeout| elapses without the device having
-// become idle.
-IREE_API_EXPORT iree_status_t
-iree_hal_device_wait_idle(iree_hal_device_t* device, iree_timeout_t timeout);
-
 //===----------------------------------------------------------------------===//
 // iree_hal_device_t implementation details
 //===----------------------------------------------------------------------===//
@@ -423,9 +410,6 @@ typedef struct iree_hal_device_vtable_t {
   iree_status_t(IREE_API_PTR* wait_semaphores)(
       iree_hal_device_t* device, iree_hal_wait_mode_t wait_mode,
       const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout);
-
-  iree_status_t(IREE_API_PTR* wait_idle)(iree_hal_device_t* device,
-                                         iree_timeout_t timeout);
 } iree_hal_device_vtable_t;
 IREE_HAL_ASSERT_VTABLE_LAYOUT(iree_hal_device_vtable_t);
 

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -370,18 +370,6 @@ static iree_status_t iree_hal_cuda_device_wait_semaphores(
                           "semaphore not implemented");
 }
 
-static iree_status_t iree_hal_cuda_device_wait_idle(
-    iree_hal_device_t* base_device, iree_timeout_t timeout) {
-  iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
-  // Wait until the stream is done.
-  // TODO(thomasraoux): CUDA doesn't support a deadline for wait, figure out how
-  // to handle it better.
-  CUDA_RETURN_IF_ERROR(device->context_wrapper.syms,
-                       cuStreamSynchronize(device->stream),
-                       "cuStreamSynchronize");
-  return iree_ok_status();
-}
-
 static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .destroy = iree_hal_cuda_device_destroy,
     .id = iree_hal_cuda_device_id,
@@ -402,5 +390,4 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
     .queue_submit = iree_hal_cuda_device_queue_submit,
     .wait_semaphores = iree_hal_cuda_device_wait_semaphores,
-    .wait_idle = iree_hal_cuda_device_wait_idle,
 };

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -306,7 +306,7 @@ static iree_status_t iree_hal_cuda_device_create_executable_cache(
 static iree_status_t iree_hal_cuda_device_create_executable_layout(
     iree_hal_device_t* base_device, iree_host_size_t push_constants,
     iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_hal_executable_layout_t** out_executable_layout) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   return iree_hal_cuda_executable_layout_create(
@@ -329,30 +329,29 @@ iree_hal_cuda_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
-static iree_status_t iree_hal_cuda_device_queue_submit(
-    iree_hal_device_t* base_device,
-    iree_hal_command_category_t command_categories,
-    iree_hal_queue_affinity_t queue_affinity, iree_host_size_t batch_count,
-    const iree_hal_submission_batch_t* batches) {
+static iree_status_t iree_hal_cuda_device_queue_execute(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_host_size_t command_buffer_count,
+    iree_hal_command_buffer_t* const* command_buffers) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
-  for (int i = 0; i < batch_count; i++) {
-    for (int j = 0; j < batches[i].command_buffer_count; j++) {
-      iree_hal_command_buffer_t* command_buffer = batches[i].command_buffers[j];
-      if (iree_hal_cuda_stream_command_buffer_isa(command_buffer)) {
-        // Nothing to do for an inline command buffer; all the work has already
-        // been submitted. When we support semaphores we'll still need to signal
-        // their completion but do not have to worry about any waits: if there
-        // were waits we wouldn't have been able to execute inline!
-      } else if (iree_hal_cuda_graph_command_buffer_isa(command_buffer)) {
-        CUgraphExec exec = iree_hal_cuda_graph_command_buffer_exec(
-            batches[i].command_buffers[j]);
-        CUDA_RETURN_IF_ERROR(device->context_wrapper.syms,
-                             cuGraphLaunch(exec, device->stream),
-                             "cuGraphLaunch");
-      } else {
-        IREE_RETURN_IF_ERROR(iree_hal_deferred_command_buffer_apply(
-            batches[i].command_buffers[j], device->stream_command_buffer));
-      }
+  for (iree_host_size_t i = 0; i < command_buffer_count; i++) {
+    iree_hal_command_buffer_t* command_buffer = command_buffers[i];
+    if (iree_hal_cuda_stream_command_buffer_isa(command_buffer)) {
+      // Nothing to do for an inline command buffer; all the work has already
+      // been submitted. When we support semaphores we'll still need to signal
+      // their completion but do not have to worry about any waits: if there
+      // were waits we wouldn't have been able to execute inline!
+    } else if (iree_hal_cuda_graph_command_buffer_isa(command_buffer)) {
+      CUgraphExec exec =
+          iree_hal_cuda_graph_command_buffer_exec(command_buffers[i]);
+      CUDA_RETURN_IF_ERROR(device->context_wrapper.syms,
+                           cuGraphLaunch(exec, device->stream),
+                           "cuGraphLaunch");
+    } else {
+      IREE_RETURN_IF_ERROR(iree_hal_deferred_command_buffer_apply(
+          command_buffers[i], device->stream_command_buffer));
     }
   }
   // TODO(thomasraoux): implement semaphores - for now this conservatively
@@ -365,7 +364,7 @@ static iree_status_t iree_hal_cuda_device_queue_submit(
 
 static iree_status_t iree_hal_cuda_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout) {
+    const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
   return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
                           "semaphore not implemented");
 }
@@ -388,6 +387,6 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .query_semaphore_compatibility =
         iree_hal_cuda_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
-    .queue_submit = iree_hal_cuda_device_queue_submit,
+    .queue_execute = iree_hal_cuda_device_queue_execute,
     .wait_semaphores = iree_hal_cuda_device_wait_semaphores,
 };

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -337,7 +337,13 @@ static iree_status_t iree_hal_cuda_device_queue_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      iree_hal_device_allocator(base_device), params, allocation_size,
+      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_cuda_device_queue_dealloca(
@@ -346,7 +352,10 @@ static iree_status_t iree_hal_cuda_device_queue_dealloca(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_cuda_device_queue_execute(

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -329,6 +329,26 @@ iree_hal_cuda_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
+static iree_status_t iree_hal_cuda_device_queue_alloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_id_t pool_id, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
+static iree_status_t iree_hal_cuda_device_queue_dealloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
 static iree_status_t iree_hal_cuda_device_queue_execute(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -362,6 +382,12 @@ static iree_status_t iree_hal_cuda_device_queue_execute(
   return iree_ok_status();
 }
 
+static iree_status_t iree_hal_cuda_device_queue_flush(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity) {
+  // Currently unused; we flush as submissions are made.
+  return iree_ok_status();
+}
+
 static iree_status_t iree_hal_cuda_device_wait_semaphores(
     iree_hal_device_t* base_device, iree_hal_wait_mode_t wait_mode,
     const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
@@ -387,6 +413,9 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .query_semaphore_compatibility =
         iree_hal_cuda_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_submit_transfer_range_and_wait,
+    .queue_alloca = iree_hal_cuda_device_queue_alloca,
+    .queue_dealloca = iree_hal_cuda_device_queue_dealloca,
     .queue_execute = iree_hal_cuda_device_queue_execute,
+    .queue_flush = iree_hal_cuda_device_queue_flush,
     .wait_semaphores = iree_hal_cuda_device_wait_semaphores,
 };

--- a/runtime/src/iree/hal/drivers/cuda/executable_layout.c
+++ b/runtime/src/iree/hal/drivers/cuda/executable_layout.c
@@ -47,7 +47,7 @@ static void iree_hal_cuda_executable_layout_destroy(
 
 iree_status_t iree_hal_cuda_executable_layout_create(
     iree_hal_cuda_context_wrapper_t* context, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(context);

--- a/runtime/src/iree/hal/drivers/cuda/executable_layout.h
+++ b/runtime/src/iree/hal/drivers/cuda/executable_layout.h
@@ -20,7 +20,7 @@ extern "C" {
 // Creates the kernel arguments.
 iree_status_t iree_hal_cuda_executable_layout_create(
     iree_hal_cuda_context_wrapper_t* context, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_host_size_t push_constant_count,
     iree_hal_executable_layout_t** out_executable_layout);
 

--- a/runtime/src/iree/hal/drivers/local_sync/BUILD
+++ b/runtime/src/iree/hal/drivers/local_sync/BUILD
@@ -36,6 +36,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/local",
         "//runtime/src/iree/hal/utils:buffer_transfer",
+        "//runtime/src/iree/hal/utils:deferred_command_buffer",
         "//runtime/src/iree/hal/utils:semaphore_base",
     ],
 )

--- a/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_cc_library(
     iree::hal
     iree::hal::local
     iree::hal::utils::buffer_transfer
+    iree::hal::utils::deferred_command_buffer
     iree::hal::utils::semaphore_base
   PUBLIC
 )

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -254,7 +254,13 @@ static iree_status_t iree_hal_sync_device_queue_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      iree_hal_device_allocator(base_device), params, allocation_size,
+      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_sync_device_queue_dealloca(
@@ -263,7 +269,10 @@ static iree_status_t iree_hal_sync_device_queue_dealloca(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_sync_device_queue_execute(

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -285,14 +285,6 @@ static iree_status_t iree_hal_sync_device_wait_semaphores(
                                             semaphore_list, timeout);
 }
 
-static iree_status_t iree_hal_sync_device_wait_idle(
-    iree_hal_device_t* base_device, iree_timeout_t timeout) {
-  // No-op (in intended usages). If we allowed multiple threads to call into
-  // the same device then we may want to change this to an atomic flag as to
-  // whether any thread is actively performing work.
-  return iree_ok_status();
-}
-
 static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .destroy = iree_hal_sync_device_destroy,
     .id = iree_hal_sync_device_id,
@@ -313,5 +305,4 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .transfer_range = iree_hal_device_transfer_mappable_range,
     .queue_submit = iree_hal_sync_device_queue_submit,
     .wait_semaphores = iree_hal_sync_device_wait_semaphores,
-    .wait_idle = iree_hal_sync_device_wait_idle,
 };

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -246,6 +246,26 @@ iree_hal_sync_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
+static iree_status_t iree_hal_sync_device_queue_alloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_id_t pool_id, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
+static iree_status_t iree_hal_sync_device_queue_dealloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
 static iree_status_t iree_hal_sync_device_queue_execute(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -271,6 +291,12 @@ static iree_status_t iree_hal_sync_device_queue_execute(
   IREE_RETURN_IF_ERROR(iree_hal_sync_semaphore_multi_signal(
       &device->semaphore_state, signal_semaphore_list));
 
+  return iree_ok_status();
+}
+
+static iree_status_t iree_hal_sync_device_queue_flush(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity) {
+  // Currently unused; we flush as submissions are made.
   return iree_ok_status();
 }
 
@@ -300,6 +326,9 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .query_semaphore_compatibility =
         iree_hal_sync_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_transfer_mappable_range,
+    .queue_alloca = iree_hal_sync_device_queue_alloca,
+    .queue_dealloca = iree_hal_sync_device_queue_dealloca,
     .queue_execute = iree_hal_sync_device_queue_execute,
+    .queue_flush = iree_hal_sync_device_queue_flush,
     .wait_semaphores = iree_hal_sync_device_wait_semaphores,
 };

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.h
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.h
@@ -18,7 +18,10 @@ extern "C" {
 // Parameters configuring an iree_hal_sync_device_t.
 // Must be initialized with iree_hal_sync_device_params_initialize prior to use.
 typedef struct iree_hal_sync_device_params_t {
-  int reserved;
+  // Total size of each block in the device shared block pool.
+  // Larger sizes will lower overhead and ensure the heap isn't hit for
+  // transient allocations while also increasing memory consumption.
+  iree_host_size_t arena_block_size;
 } iree_hal_sync_device_params_t;
 
 // Initializes |out_params| to default values.

--- a/runtime/src/iree/hal/drivers/local_sync/sync_semaphore.h
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_semaphore.h
@@ -57,7 +57,7 @@ iree_status_t iree_hal_sync_semaphore_create(
 // batching up signals will reduce synchronization overhead.
 iree_status_t iree_hal_sync_semaphore_multi_signal(
     iree_hal_sync_semaphore_state_t* shared_state,
-    const iree_hal_semaphore_list_t* semaphore_list);
+    const iree_hal_semaphore_list_t semaphore_list);
 
 // Performs a multi-wait on one or more semaphores.
 // Returns IREE_STATUS_DEADLINE_EXCEEDED if the wait does not complete before
@@ -65,7 +65,7 @@ iree_status_t iree_hal_sync_semaphore_multi_signal(
 iree_status_t iree_hal_sync_semaphore_multi_wait(
     iree_hal_sync_semaphore_state_t* shared_state,
     iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout);
+    const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -319,6 +319,26 @@ iree_hal_task_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_ALL;
 }
 
+static iree_status_t iree_hal_task_device_queue_alloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_id_t pool_id, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
+static iree_status_t iree_hal_task_device_queue_dealloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
 static iree_status_t iree_hal_task_device_queue_execute(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -336,6 +356,12 @@ static iree_status_t iree_hal_task_device_queue_execute(
       .command_buffers = command_buffers,
   };
   return iree_hal_task_queue_submit(&device->queues[queue_index], 1, &batch);
+}
+
+static iree_status_t iree_hal_task_device_queue_flush(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity) {
+  // Currently unused; we flush as submissions are made.
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_task_device_wait_semaphores(
@@ -366,6 +392,9 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .query_semaphore_compatibility =
         iree_hal_task_device_query_semaphore_compatibility,
     .transfer_range = iree_hal_device_transfer_mappable_range,
+    .queue_alloca = iree_hal_task_device_queue_alloca,
+    .queue_dealloca = iree_hal_task_device_queue_dealloca,
     .queue_execute = iree_hal_task_device_queue_execute,
+    .queue_flush = iree_hal_task_device_queue_flush,
     .wait_semaphores = iree_hal_task_device_wait_semaphores,
 };

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -327,7 +327,13 @@ static iree_status_t iree_hal_task_device_queue_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      iree_hal_device_allocator(base_device), params, allocation_size,
+      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_task_device_queue_dealloca(
@@ -336,7 +342,10 @@ static iree_status_t iree_hal_task_device_queue_dealloca(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_task_device_queue_execute(

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -341,19 +341,6 @@ static iree_status_t iree_hal_task_device_wait_semaphores(
       &device->large_block_pool);
 }
 
-static iree_status_t iree_hal_task_device_wait_idle(
-    iree_hal_device_t* base_device, iree_timeout_t timeout) {
-  iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  iree_status_t status = iree_ok_status();
-  for (iree_host_size_t i = 0; i < device->queue_count; ++i) {
-    status = iree_hal_task_queue_wait_idle(&device->queues[i], timeout);
-    if (!iree_status_is_ok(status)) break;
-  }
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
-
 static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .destroy = iree_hal_task_device_destroy,
     .id = iree_hal_task_device_id,
@@ -374,5 +361,4 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .transfer_range = iree_hal_device_transfer_mappable_range,
     .queue_submit = iree_hal_task_device_queue_submit,
     .wait_semaphores = iree_hal_task_device_wait_semaphores,
-    .wait_idle = iree_hal_task_device_wait_idle,
 };

--- a/runtime/src/iree/hal/drivers/local_task/task_queue.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_queue.c
@@ -237,7 +237,7 @@ static void iree_hal_task_queue_issue_cmd_cleanup(
 static iree_status_t iree_hal_task_queue_issue_cmd_allocate(
     iree_task_scope_t* scope, iree_hal_task_queue_t* queue,
     iree_task_t* retire_task, iree_host_size_t command_buffer_count,
-    iree_hal_command_buffer_t** const command_buffers,
+    iree_hal_command_buffer_t* const* command_buffers,
     iree_arena_allocator_t* arena, iree_hal_task_queue_issue_cmd_t** out_cmd) {
   iree_hal_task_queue_issue_cmd_t* cmd = NULL;
   iree_host_size_t total_cmd_size =

--- a/runtime/src/iree/hal/drivers/local_task/task_semaphore.h
+++ b/runtime/src/iree/hal/drivers/local_task/task_semaphore.h
@@ -44,7 +44,7 @@ iree_status_t iree_hal_task_semaphore_enqueue_timepoint(
 // |deadline_ns| elapses.
 iree_status_t iree_hal_task_semaphore_multi_wait(
     iree_hal_wait_mode_t wait_mode,
-    const iree_hal_semaphore_list_t* semaphore_list, iree_timeout_t timeout,
+    const iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout,
     iree_event_pool_t* event_pool, iree_arena_block_pool_t* block_pool);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable_layout.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable_layout.cc
@@ -43,7 +43,7 @@ iree_hal_vulkan_native_executable_layout_cast(
 static iree_status_t iree_hal_vulkan_create_pipeline_layout(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     iree_host_size_t push_constant_count, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     VkPipelineLayout* out_handle) {
   VkDescriptorSetLayout* set_layout_handles =
       (VkDescriptorSetLayout*)iree_alloca(set_layout_count *
@@ -84,7 +84,7 @@ static void iree_hal_vulkan_destroy_pipeline_layout(
 iree_status_t iree_hal_vulkan_native_executable_layout_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     iree_host_size_t push_constant_count, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(logical_device);
   IREE_ASSERT_ARGUMENT(!set_layout_count || set_layouts);

--- a/runtime/src/iree/hal/drivers/vulkan/native_executable_layout.h
+++ b/runtime/src/iree/hal/drivers/vulkan/native_executable_layout.h
@@ -24,7 +24,7 @@ extern "C" {
 iree_status_t iree_hal_vulkan_native_executable_layout_create(
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     iree_host_size_t push_constant_count, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_hal_executable_layout_t** out_executable_layout);
 
 // Returns the native VkPipelineLayout handle for the executable layout.

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1084,7 +1084,13 @@ static iree_status_t iree_hal_vulkan_device_queue_alloca(
     iree_device_size_t allocation_size,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_allocator_allocate_buffer(
+      iree_hal_device_allocator(base_device), params, allocation_size,
+      iree_const_byte_span_empty(), out_buffer));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_vulkan_device_queue_dealloca(
@@ -1093,7 +1099,10 @@ static iree_status_t iree_hal_vulkan_device_queue_dealloca(
     const iree_hal_semaphore_list_t signal_semaphore_list,
     iree_hal_buffer_t* buffer) {
   // TODO(benvanik): queue-ordered allocations.
-  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_wait(wait_semaphore_list,
+                                                    iree_infinite_timeout()));
+  IREE_RETURN_IF_ERROR(iree_hal_semaphore_list_signal(signal_semaphore_list));
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_vulkan_device_queue_execute(

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1076,6 +1076,26 @@ iree_hal_vulkan_device_query_semaphore_compatibility(
   return IREE_HAL_SEMAPHORE_COMPATIBILITY_HOST_ONLY;
 }
 
+static iree_status_t iree_hal_vulkan_device_queue_alloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_allocator_pool_id_t pool_id, iree_hal_buffer_params_t params,
+    iree_device_size_t allocation_size,
+    iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
+static iree_status_t iree_hal_vulkan_device_queue_dealloca(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
+    const iree_hal_semaphore_list_t wait_semaphore_list,
+    const iree_hal_semaphore_list_t signal_semaphore_list,
+    iree_hal_buffer_t* buffer) {
+  // TODO(benvanik): queue-ordered allocations.
+  return iree_make_status(IREE_STATUS_UNIMPLEMENTED);
+}
+
 static iree_status_t iree_hal_vulkan_device_queue_execute(
     iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity,
     const iree_hal_semaphore_list_t wait_semaphore_list,
@@ -1093,6 +1113,12 @@ static iree_status_t iree_hal_vulkan_device_queue_execute(
       /*.signal_semaphores=*/signal_semaphore_list,
   };
   return queue->Submit(1, &batch);
+}
+
+static iree_status_t iree_hal_vulkan_device_queue_flush(
+    iree_hal_device_t* base_device, iree_hal_queue_affinity_t queue_affinity) {
+  // Currently unused; we flush as submissions are made.
+  return iree_ok_status();
 }
 
 static iree_status_t iree_hal_vulkan_device_wait_semaphores(
@@ -1128,7 +1154,10 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     /*.query_semaphore_compatibility=*/
     iree_hal_vulkan_device_query_semaphore_compatibility,
     /*.transfer_range=*/iree_hal_device_submit_transfer_range_and_wait,
+    /*.queue_alloca=*/iree_hal_vulkan_device_queue_alloca,
+    /*.queue_dealloca=*/iree_hal_vulkan_device_queue_dealloca,
     /*.queue_execute=*/iree_hal_vulkan_device_queue_execute,
+    /*.queue_flush=*/iree_hal_vulkan_device_queue_flush,
     /*.wait_semaphores=*/iree_hal_vulkan_device_wait_semaphores,
 };
 }  // namespace

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1099,15 +1099,6 @@ static iree_status_t iree_hal_vulkan_device_wait_semaphores(
       device->logical_device, semaphore_list, timeout, wait_flags);
 }
 
-static iree_status_t iree_hal_vulkan_device_wait_idle(
-    iree_hal_device_t* base_device, iree_timeout_t timeout) {
-  iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
-  for (iree_host_size_t i = 0; i < device->queue_count; ++i) {
-    IREE_RETURN_IF_ERROR(device->queues[i]->WaitIdle(timeout));
-  }
-  return iree_ok_status();
-}
-
 namespace {
 const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     /*.destroy=*/iree_hal_vulkan_device_destroy,
@@ -1131,6 +1122,5 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     /*.transfer_range=*/iree_hal_device_submit_transfer_range_and_wait,
     /*.queue_submit=*/iree_hal_vulkan_device_queue_submit,
     /*.wait_semaphores=*/iree_hal_vulkan_device_wait_semaphores,
-    /*.wait_idle=*/iree_hal_vulkan_device_wait_idle,
 };
 }  // namespace

--- a/runtime/src/iree/hal/executable_layout.c
+++ b/runtime/src/iree/hal/executable_layout.c
@@ -22,7 +22,7 @@ IREE_HAL_API_RETAIN_RELEASE(executable_layout);
 IREE_API_EXPORT iree_status_t iree_hal_executable_layout_create(
     iree_hal_device_t* device, iree_host_size_t push_constants,
     iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(device);
   IREE_ASSERT_ARGUMENT(!set_layout_count || set_layouts);

--- a/runtime/src/iree/hal/executable_layout.h
+++ b/runtime/src/iree/hal/executable_layout.h
@@ -48,7 +48,7 @@ typedef struct iree_hal_executable_layout_t iree_hal_executable_layout_t;
 IREE_API_EXPORT iree_status_t iree_hal_executable_layout_create(
     iree_hal_device_t* device, iree_host_size_t push_constants,
     iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_hal_executable_layout_t** out_executable_layout);
 
 // Retains the given |executable_layout| for the caller.

--- a/runtime/src/iree/hal/fence.c
+++ b/runtime/src/iree/hal/fence.c
@@ -10,6 +10,10 @@
 
 #include "iree/base/tracing.h"
 
+//===----------------------------------------------------------------------===//
+// iree_hal_fence_t
+//===----------------------------------------------------------------------===//
+
 IREE_API_EXPORT iree_status_t iree_hal_fence_create(
     iree_host_size_t capacity, iree_allocator_t host_allocator,
     iree_hal_fence_t** out_fence) {
@@ -195,16 +199,8 @@ IREE_API_EXPORT iree_status_t iree_hal_fence_query(iree_hal_fence_t* fence) {
 
 IREE_API_EXPORT iree_status_t iree_hal_fence_signal(iree_hal_fence_t* fence) {
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  iree_hal_semaphore_list_t semaphore_list =
-      iree_hal_fence_semaphore_list(fence);
-  iree_status_t status = iree_ok_status();
-  for (iree_host_size_t i = 0; i < semaphore_list.count; ++i) {
-    status = iree_hal_semaphore_signal(semaphore_list.semaphores[i],
-                                       semaphore_list.payload_values[i]);
-    if (!iree_status_is_ok(status)) break;
-  }
-
+  iree_status_t status =
+      iree_hal_semaphore_list_signal(iree_hal_fence_semaphore_list(fence));
   IREE_TRACE_ZONE_END(z0);
   return status;
 }
@@ -212,58 +208,17 @@ IREE_API_EXPORT iree_status_t iree_hal_fence_signal(iree_hal_fence_t* fence) {
 IREE_API_EXPORT void iree_hal_fence_fail(iree_hal_fence_t* fence,
                                          iree_status_t signal_status) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  IREE_TRACE_ZONE_APPEND_TEXT(
-      z0, iree_status_code_string(iree_status_code(signal_status)));
-
-  // This handles cases of empty lists by dropping signal_status if not
-  // consumed. Otherwise it clones the signal_status for each semaphore except
-  // the last, which in the common case of a single timepoint fence means no
-  // expensive clones.
-  iree_hal_semaphore_list_t semaphore_list =
-      iree_hal_fence_semaphore_list(fence);
-  for (iree_host_size_t i = 0; i < semaphore_list.count; ++i) {
-    const bool is_last = i == semaphore_list.count - 1;
-    iree_status_t semaphore_status;
-    if (is_last) {
-      // Can transfer ownership of the signal status.
-      semaphore_status = signal_status;
-      signal_status = iree_ok_status();
-    } else {
-      // Clone status for this particular signal.
-      semaphore_status = iree_status_clone(signal_status);
-    }
-    iree_hal_semaphore_fail(semaphore_list.semaphores[i], semaphore_status);
-  }
-  iree_status_ignore(signal_status);
-
+  iree_hal_semaphore_list_fail(iree_hal_fence_semaphore_list(fence),
+                               signal_status);
   IREE_TRACE_ZONE_END(z0);
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_fence_wait(iree_hal_fence_t* fence,
                                                   iree_timeout_t timeout) {
-  if (!fence) return iree_ok_status();
+  if (!fence || !fence->count) return iree_ok_status();
   IREE_TRACE_ZONE_BEGIN(z0);
-
-  // Ensure an absolute timeout so that as we loop through we don't drift from
-  // the user-intended relative timeout.
-  iree_convert_timeout_to_absolute(&timeout);
-
-  // Wait on all until done or we timeout.
-  // This is not the most efficient way to wait on semaphores as it performs
-  // no device-side batching. We should probably expose this as a device method
-  // instead or have a way to batch by semaphore implementation for heterogenous
-  // fences.
-  //
-  // TODO(benvanik): use iree_hal_device_wait_semaphores for each unique device.
-  iree_hal_semaphore_list_t semaphore_list =
-      iree_hal_fence_semaphore_list(fence);
-  iree_status_t status = iree_ok_status();
-  for (iree_host_size_t i = 0; i < semaphore_list.count; ++i) {
-    status = iree_hal_semaphore_wait(semaphore_list.semaphores[i],
-                                     semaphore_list.payload_values[i], timeout);
-    if (!iree_status_is_ok(status)) break;
-  }
-
+  iree_status_t status = iree_hal_semaphore_list_wait(
+      iree_hal_fence_semaphore_list(fence), timeout);
   IREE_TRACE_ZONE_END(z0);
   return status;
 }

--- a/runtime/src/iree/hal/fence.c
+++ b/runtime/src/iree/hal/fence.c
@@ -253,6 +253,8 @@ IREE_API_EXPORT iree_status_t iree_hal_fence_wait(iree_hal_fence_t* fence,
   // no device-side batching. We should probably expose this as a device method
   // instead or have a way to batch by semaphore implementation for heterogenous
   // fences.
+  //
+  // TODO(benvanik): use iree_hal_device_wait_semaphores for each unique device.
   iree_hal_semaphore_list_t semaphore_list =
       iree_hal_fence_semaphore_list(fence);
   iree_status_t status = iree_ok_status();

--- a/runtime/src/iree/hal/fence.h
+++ b/runtime/src/iree/hal/fence.h
@@ -20,22 +20,6 @@ extern "C" {
 // iree_hal_fence_t
 //===----------------------------------------------------------------------===//
 
-// A list of semaphores and their corresponding payloads.
-// When signaling each semaphore will be set to the new payload value provided.
-// When waiting each semaphore must reach or exceed the payload value.
-// This points at external storage and does not retain the semaphores itself.
-typedef struct iree_hal_semaphore_list_t {
-  iree_host_size_t count;
-  iree_hal_semaphore_t** semaphores;
-  uint64_t* payload_values;
-} iree_hal_semaphore_list_t;
-
-// Returns an empty semaphore list.
-static inline iree_hal_semaphore_list_t iree_hal_semaphore_list_empty(void) {
-  iree_hal_semaphore_list_t list = {0};
-  return list;
-}
-
 // A set of semaphores and their corresponding payloads.
 // When signaling each semaphore will be set to the new payload value provided.
 // When waiting each semaphore must reach or exceed the payload value.

--- a/runtime/src/iree/hal/fence.h
+++ b/runtime/src/iree/hal/fence.h
@@ -30,6 +30,12 @@ typedef struct iree_hal_semaphore_list_t {
   uint64_t* payload_values;
 } iree_hal_semaphore_list_t;
 
+// Returns an empty semaphore list.
+static inline iree_hal_semaphore_list_t iree_hal_semaphore_list_empty(void) {
+  iree_hal_semaphore_list_t list = {0};
+  return list;
+}
+
 // A set of semaphores and their corresponding payloads.
 // When signaling each semaphore will be set to the new payload value provided.
 // When waiting each semaphore must reach or exceed the payload value.

--- a/runtime/src/iree/hal/local/inline_command_buffer.h
+++ b/runtime/src/iree/hal/local/inline_command_buffer.h
@@ -14,6 +14,30 @@
 extern "C" {
 #endif  // __cplusplus
 
+// Returns the size, in bytes, of an inline command buffer.
+// This can be used for arena/stack allocations along with
+// iree_hal_inline_command_buffer_initialize/iree_hal_inline_command_buffer_deinitialize.
+iree_host_size_t iree_hal_inline_command_buffer_size(void);
+
+// Initializes an inline synchronous one-shot single-threaded command "buffer".
+// This is equivalent to iree_hal_inline_command_buffer_create but uses
+// caller-allocated |storage| (must be at least the capacity specified by
+// iree_hal_inline_command_buffer_size).
+//
+// NOTE: this must only be used when the command buffer handle cannot escape
+// the caller: attempting to use the resulting command buffer as a ref object
+// is invalid.
+iree_status_t iree_hal_inline_command_buffer_initialize(
+    iree_hal_device_t* device, iree_hal_command_buffer_mode_t mode,
+    iree_hal_command_category_t command_categories,
+    iree_hal_queue_affinity_t queue_affinity, iree_allocator_t host_allocator,
+    iree_byte_span_t storage, iree_hal_command_buffer_t** out_command_buffer);
+
+// Deinitializes an inline command buffer previously initialized with
+// iree_hal_inline_command_buffer_initialize.
+void iree_hal_inline_command_buffer_deinitialize(
+    iree_hal_command_buffer_t* command_buffer);
+
 // Creates an inline synchronous one-shot single-threaded command "buffer".
 // This is designed for ultra-low latency situations where we know the command
 // buffer is going to be submitted with no wait semaphores indicating that it

--- a/runtime/src/iree/hal/local/local_executable_layout.c
+++ b/runtime/src/iree/hal/local/local_executable_layout.c
@@ -22,7 +22,7 @@ iree_hal_local_executable_layout_t* iree_hal_local_executable_layout_cast(
 
 iree_status_t iree_hal_local_executable_layout_create(
     iree_host_size_t push_constants, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_allocator_t host_allocator,
     iree_hal_executable_layout_t** out_executable_layout) {
   IREE_ASSERT_ARGUMENT(!set_layout_count || set_layouts);

--- a/runtime/src/iree/hal/local/local_executable_layout.h
+++ b/runtime/src/iree/hal/local/local_executable_layout.h
@@ -36,7 +36,7 @@ typedef struct iree_hal_local_executable_layout_t {
 
 iree_status_t iree_hal_local_executable_layout_create(
     iree_host_size_t push_constants, iree_host_size_t set_layout_count,
-    iree_hal_descriptor_set_layout_t** set_layouts,
+    iree_hal_descriptor_set_layout_t* const* set_layouts,
     iree_allocator_t host_allocator,
     iree_hal_executable_layout_t** out_executable_layout);
 

--- a/runtime/src/iree/hal/semaphore.c
+++ b/runtime/src/iree/hal/semaphore.c
@@ -13,6 +13,10 @@
 #include "iree/hal/device.h"
 #include "iree/hal/resource.h"
 
+//===----------------------------------------------------------------------===//
+// iree_hal_semaphore_t
+//===----------------------------------------------------------------------===//
+
 #define _VTABLE_DISPATCH(semaphore, method_name) \
   IREE_HAL_VTABLE_DISPATCH(semaphore, iree_hal_semaphore, method_name)
 
@@ -129,4 +133,78 @@ iree_hal_semaphore_await(iree_hal_semaphore_t* semaphore, uint64_t value) {
       .data = value,
       .ctl = iree_hal_semaphore_wait_source_ctl,
   };
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_semaphore_list_t
+//===----------------------------------------------------------------------===//
+
+IREE_API_EXPORT iree_status_t
+iree_hal_semaphore_list_signal(iree_hal_semaphore_list_t semaphore_list) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < semaphore_list.count; ++i) {
+    status = iree_hal_semaphore_signal(semaphore_list.semaphores[i],
+                                       semaphore_list.payload_values[i]);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}
+
+IREE_API_EXPORT void iree_hal_semaphore_list_fail(
+    iree_hal_semaphore_list_t semaphore_list, iree_status_t signal_status) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_TEXT(
+      z0, iree_status_code_string(iree_status_code(signal_status)));
+
+  // This handles cases of empty lists by dropping signal_status if not
+  // consumed. Otherwise it clones the signal_status for each semaphore except
+  // the last, which in the common case of a single timepoint fence means no
+  // expensive clones.
+  for (iree_host_size_t i = 0; i < semaphore_list.count; ++i) {
+    const bool is_last = i == semaphore_list.count - 1;
+    iree_status_t semaphore_status;
+    if (is_last) {
+      // Can transfer ownership of the signal status.
+      semaphore_status = signal_status;
+      signal_status = iree_ok_status();
+    } else {
+      // Clone status for this particular signal.
+      semaphore_status = iree_status_clone(signal_status);
+    }
+    iree_hal_semaphore_fail(semaphore_list.semaphores[i], semaphore_status);
+  }
+  iree_status_ignore(signal_status);
+
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_semaphore_list_wait(
+    iree_hal_semaphore_list_t semaphore_list, iree_timeout_t timeout) {
+  if (!semaphore_list.count) return iree_ok_status();
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Ensure an absolute timeout so that as we loop through we don't drift from
+  // the user-intended relative timeout.
+  iree_convert_timeout_to_absolute(&timeout);
+
+  // Wait on all until done or we timeout.
+  // This is not the most efficient way to wait on semaphores as it performs
+  // no device-side batching. We should probably expose this as a device method
+  // instead or have a way to batch by semaphore implementation for heterogenous
+  // fences.
+  //
+  // TODO(benvanik): use iree_hal_device_wait_semaphores for each unique device.
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < semaphore_list.count; ++i) {
+    status = iree_hal_semaphore_wait(semaphore_list.semaphores[i],
+                                     semaphore_list.payload_values[i], timeout);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  IREE_TRACE_ZONE_END(z0);
+  return status;
 }

--- a/runtime/src/iree/hal/utils/deferred_command_buffer.c
+++ b/runtime/src/iree/hal/utils/deferred_command_buffer.c
@@ -205,6 +205,12 @@ static void iree_hal_deferred_command_buffer_destroy(
   IREE_TRACE_ZONE_END(z0);
 }
 
+bool iree_hal_deferred_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer) {
+  return iree_hal_command_buffer_dyn_cast(
+      command_buffer, &iree_hal_deferred_command_buffer_vtable);
+}
+
 static void* iree_hal_deferred_command_buffer_dyn_cast(
     iree_hal_command_buffer_t* command_buffer, const void* vtable) {
   if (vtable == &iree_hal_deferred_command_buffer_vtable) {

--- a/runtime/src/iree/hal/utils/deferred_command_buffer.h
+++ b/runtime/src/iree/hal/utils/deferred_command_buffer.h
@@ -48,6 +48,10 @@ IREE_API_EXPORT iree_status_t iree_hal_deferred_command_buffer_create(
     iree_arena_block_pool_t* block_pool, iree_allocator_t host_allocator,
     iree_hal_command_buffer_t** out_command_buffer);
 
+// Returns true if |command_buffer| is a deferred command buffer.
+bool iree_hal_deferred_command_buffer_isa(
+    iree_hal_command_buffer_t* command_buffer);
+
 // Replays a recorded |command_buffer| against a |target_command_buffer|.
 // If the command buffer was recorded in one-shot mode it will be reset upon
 // return.

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -934,14 +934,7 @@ IREE_VM_ABI_EXPORT(iree_hal_module_device_queue_flush,  //
   IREE_RETURN_IF_ERROR(iree_hal_device_check_deref(args->r0, &device));
   iree_hal_queue_affinity_t queue_affinity =
       (iree_hal_queue_affinity_t)args->i1;
-
-  // TODO(benvanik): queue flush API.
-  // This will be most useful for backends that perform internal batching and
-  // require the explicit flush. For now we don't have this exposed.
-  (void)device;
-  (void)queue_affinity;
-
-  return iree_ok_status();
+  return iree_hal_device_queue_flush(device, queue_affinity);
 }
 
 //===--------------------------------------------------------------------===//

--- a/runtime/src/iree/modules/hal/module.c
+++ b/runtime/src/iree/modules/hal/module.c
@@ -921,17 +921,10 @@ IREE_VM_ABI_EXPORT(iree_hal_module_device_queue_execute,  //
   iree_hal_command_buffer_t** command_buffers = NULL;
   IREE_VM_ABI_VLA_STACK_DEREF(args, a4_count, a4, iree_hal_command_buffer, 32,
                               &command_buffer_count, &command_buffers);
-
-  iree_hal_submission_batch_t batch = {
-      .wait_semaphores = iree_hal_fence_semaphore_list(wait_fence),
-      .signal_semaphores = iree_hal_fence_semaphore_list(signal_fence),
-      .command_buffer_count = command_buffer_count,
-      .command_buffers = command_buffers,
-  };
-  IREE_RETURN_IF_ERROR(iree_hal_device_queue_submit(
-      device, IREE_HAL_COMMAND_CATEGORY_ANY, queue_affinity, 1, &batch));
-
-  return iree_ok_status();
+  return iree_hal_device_queue_execute(
+      device, queue_affinity, iree_hal_fence_semaphore_list(wait_fence),
+      iree_hal_fence_semaphore_list(signal_fence), command_buffer_count,
+      command_buffers);
 }
 
 IREE_VM_ABI_EXPORT(iree_hal_module_device_queue_flush,  //

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -293,7 +293,8 @@ void iree_task_executor_schedule_ready_tasks(
     // If the scope has been marked as failing then we abort the task.
     // This needs to happen as a poll here because one or more of the tasks we
     // are joining may have failed.
-    if (IREE_UNLIKELY(iree_task_scope_has_failed(task->scope))) {
+    if (IREE_UNLIKELY(!task->scope ||
+                      iree_task_scope_has_failed(task->scope))) {
       iree_task_list_t discard_worklist;
       iree_task_list_initialize(&discard_worklist);
       iree_task_discard(task, &discard_worklist);


### PR DESCRIPTION
The compiler side had already been updated to use these new queue alloca/dealloca/execute/flush methods and this PR continues propagating that down to HAL drivers. Each driver can now implement the queuing behavior differently and future PRs will add some utilities for common execution models to reuse.

This allowed me to identify issues with the compiler lowerings for timepoints today that generate incorrect programs so unfortunately the backends supporting semaphores (CPU/vulkan) can't yet switch to running async. Future PRs will rework the compiler side and then remove the `legacy_sync` config attribute defined in their TargetBackends.