### PR TITLE
TSan testing: rerun certain cheap tests many times

### DIFF
--- a/build_tools/cmake/build_and_test_tsan.sh
+++ b/build_tools/cmake/build_and_test_tsan.sh
@@ -74,4 +74,11 @@ export IREE_CUDA_DISABLE=1
 # Honor the "notsan" label on tests.
 export IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE=notsan
 
+# Run all tests, once
+"${SCRIPT_DIR}/ctest_all.sh" "${BUILD_DIR}"
+
+# Re-run many times certain tests that are cheap and prone to nondeterministic
+# failure (typically, IREE runtime tests exercising multi-threading features).
+export IREE_CTEST_TESTS_REGEX="(^iree/base/|^iree/task/)"
+export IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT=32
 "${SCRIPT_DIR}/ctest_all.sh" "${BUILD_DIR}"

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -25,6 +25,10 @@ export IREE_CUDA_DISABLE=${IREE_CUDA_DISABLE:-1}
 # The VK_KHR_shader_float16_int8 extension is optional prior to Vulkan 1.2.
 # We test on SwiftShader as a baseline, which does not support this extension.
 export IREE_VULKAN_F16_DISABLE=${IREE_VULKAN_F16_DISABLE:-1}
+# Respect the user setting, default to no --repeat-until-fail.
+export IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT=${IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT:-}
+# Respect the user setting, default to no --tests-regex.
+export IREE_CTEST_TESTS_REGEX=${IREE_CTEST_TESTS_REGEX:-}
 
 # Tests to exclude by label. In addition to any custom labels (which are carried
 # over from Bazel tags), every test should be labeled with its directory.
@@ -61,13 +65,32 @@ fi
 IFS=',' read -ra extra_label_exclude_args <<< "${IREE_EXTRA_COMMA_SEPARATED_CTEST_LABELS_TO_EXCLUDE:-}"
 label_exclude_args+=(${extra_label_exclude_args[@]})
 
-# Join on "|"
-label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]}"))"
+important_ctest_args=()
 
-echo "******************** Running main project ctests ************************"
+if [[ -n "${IREE_CTEST_TESTS_REGEX}" ]]; then
+  important_ctest_args+=("--tests-regex ${IREE_CTEST_TESTS_REGEX}")
+fi
+
+if [[ -n "${IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT}" ]]; then
+  important_ctest_args+=("--repeat-until-fail ${IREE_CTEST_REPEAT_UNTIL_FAIL_COUNT}")
+fi
+
+if (( ${#label_exclude_args[@]} )); then
+  # Join on "|"
+  label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]}"))"
+  important_ctest_args+=("--label-exclude ${label_exclude_regex}")
+fi
+
+echo "************************************************************************"
+echo "Running CTest with these important args:"
+for important_arg in "${important_ctest_args[@]}"; do
+  echo "  ${important_arg}"
+done
+echo "************************************************************************"
+
 ctest \
   --test-dir "${BUILD_DIR}" \
   --timeout 900 \
   --output-on-failure \
   --no-tests=error \
-  --label-exclude "${label_exclude_regex}"
+  ${important_ctest_args[@]}


### PR DESCRIPTION
In the past I used GNU Parallel for this, but this just uses `ctest --repeat-until-fail`. The downside is that `ctest` won't use more threads than there are tests to run (it wants all tests to complete repetition N before letting any start repetition N+1). This is mitigated by running more tests than strictly needed --- this is running all `iree/base/` and `iree/task/` tests. This still completes very quickly -- each repetition adds only 1 second of real latency on my cloudtop. And by running more tests we also create more entropy which also helps hit more bugs (some TSan failures never reproduce when rerunning 1 test in a loop and only reproduce when running multiple tests concurrently). Moreover, by rounding up the set of tests to whole directories `iree/base/` and `iree/task/` we are making it less likely that a future renaming or move will inadvertently make this fail to match the tests that we intend to run (or if we end up matching no tests at all, ctest will error out thanks to `--no-tests=error`).