### PR TITLE
Remove vm includes in Python bindings that violate layering

### DIFF
--- a/runtime/bindings/python/py_module.cc
+++ b/runtime/bindings/python/py_module.cc
@@ -9,7 +9,6 @@
 #include <string_view>
 
 #include "./vm.h"
-#include "iree/vm/native_module.h"
 
 namespace iree::python {
 

--- a/runtime/bindings/python/vm.h
+++ b/runtime/bindings/python/vm.h
@@ -14,7 +14,6 @@
 #include "iree/base/api.h"
 #include "iree/vm/api.h"
 #include "iree/vm/bytecode_module.h"
-#include "iree/vm/ref.h"
 
 namespace iree {
 namespace python {


### PR DESCRIPTION
We don't build these with Bazel in OSS, so we don't have the layering
check to catch these issues, but this came up when importing into
Google's monorepo.