### PR TITLE
Don't explicitly set MLIR_PDLL_TABLEGEN_EXE

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -428,7 +428,6 @@ endif()
 # Third party: llvm-project
 #-------------------------------------------------------------------------------
 if(IREE_BUILD_COMPILER)
-  set(MLIR_PDLL_TABLEGEN_EXE mlir-pdll)
   # iree-tblgen is not defined using the add_tablegen mechanism as other TableGen
   # tools in LLVM.
   iree_get_executable_path(IREE_TABLEGEN_EXE iree-tblgen)


### PR DESCRIPTION
With llvm/llvm-project@91b6f76, the variable `MLIR_PDLL_TABLEGEN_EXE` is
set as a cache variable in MLIR upstream.