### PR TITLE
foreach_thread_to_flow: Support dynamic tile sizes

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
@@ -1,8 +1,9 @@
-// RUN: iree-opt --pass-pipeline="func.func(iree-flow-dispatch-with-transform-dialect{transform-file-name=%p/transform_dialect_dispatch_spec.mlir})" %s | \
+// RUN: iree-opt --pass-pipeline="func.func(iree-flow-dispatch-with-transform-dialect{transform-file-name=%p/transform_dialect_dispatch_spec.mlir})" --allow-unregistered-dialect %s | \
 // RUN: FileCheck %s
 
 func.func @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
                              %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = "test.dummy"() : () -> (index)
   %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
     outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
   return %1 : tensor<?x?xf32>
@@ -12,6 +13,7 @@ func.func @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
 
 func.func @tile_matmul_with_constant(
     %arg1 : tensor<5x10xf32>, %arg2 : tensor<10x10xf32>) -> tensor<10x10xf32> {
+  %0 = "test.dummy"() : () -> (index)
   // The constant is cloned and fused into the dispatch region.
   %a = arith.constant dense<1.0> : tensor<10x5xf32>
   %1 = linalg.matmul ins(%a, %arg1 : tensor<10x5xf32>, tensor<5x10xf32>)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
@@ -3,7 +3,10 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
-    %foreach_op, %tiled_op = transform.structured.tile_to_foreach_thread_op %0 num_threads [42, 67]
+    %sz = transform.structured.match ops{["test.dummy"]} in %arg1
+
+    // One tile size (via num_threads) is static, the other one is dynamic.
+    %foreach_op, %tiled_op = transform.structured.tile_to_foreach_thread_op %0 num_threads [42, %sz]
     %dispatch_op = transform.iree.foreach_thread_to_flow %foreach_op
   }
 }


### PR DESCRIPTION
This change adds support for dynamic workloads when using the
foreach_thread_to_flow transform op.