### PR TITLE
Remove ArithmeticExpandOpsPass from SPIRV and VMVX lowerings.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -154,7 +154,6 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
   // In SPIR-V we don't use memref descriptor so it's not possible to handle
   // subview ops.
   pm.addPass(memref::createFoldSubViewOpsPass());
-  pm.addNestedPass<func::FuncOp>(arith::createArithmeticExpandOpsPass());
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -58,8 +58,6 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createConvertVectorToSCFPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      arith::createArithmeticExpandOpsPass());
   nestedModulePM.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
 
   // Handle tensor-type constants.


### PR DESCRIPTION
Based on discussion at https://github.com/iree-org/iree/issues/10142#issuecomment-1223107567 . This "fixes" one case of `spv.IsNan` ops getting introduced while lowering of `arith.minf`, but it does not generally address NaNs coming from other sources (user-space or internal to the compiler).

## Rationale

The `ArithmeticExpandOpsPass` pass (declaration [here](https://github.com/llvm/llvm-project/blob/af29db64b2c7091070dd623c81872559657e7b3d/mlir/include/mlir/Dialect/Arithmetic/Transforms/Passes.td#L31-L34) and [here](https://github.com/llvm/llvm-project/blob/af29db64b2c7091070dd623c81872559657e7b3d/mlir/include/mlir/Dialect/Arithmetic/Transforms/Passes.h#L23-L24)) is overly specific to a particular lowering to LLVM. The `minf` and `maxf` lowerings in particular generate IR like
```mlir
  %8 = arith.cmpf ult, %7, %5 : vector<1x5xf32>
  %9 = arith.select %8, %7, %5 : vector<1x5xi1>, vector<1x5xf32>
  %10 = arith.cmpf uno, %5, %5 : vector<1x5xf32>
  %11 = arith.select %10, %5, %9 : vector<1x5xi1>, vector<1x5xf32>
```
rather than tunnel down to intrinsics like [`llvm.minnum`](https://llvm.org/docs/LangRef.html#llvm-minnum-intrinsic). Digging through the history a bit, I see where the min/max ops were added in https://reviews.llvm.org/D110540, which carries forward some rational for using `select` to implement min/max.

For our uses, quoting @benvanik ,
> Yeah, that cmp/select/cmp/select dance is really bad as IIRC LLVM/other backends can't/don't practically ever simplify that again while retaining the same semantics. The behavior that nearly everything uses is "return the non-nan value if either value is nan" (GLSL min, OpenCL fminf, C/C++ fminf, CUDA fminf, numpy.fmin, AVX minps, etc), aka "between a NaN and a numeric value, the numeric value is chosen". We need to make sure that if that's the intent of the model (which I hope it is, as it's the only thing that makes sense) we can propagate that all the way to backends. There's some ISAs that do weird things but it'd be better to pay the cost there rather than everywhere like we do today.

So this PR removes the `ArithmeticExpandOpsPass` from our SPIRV and VMVX lowerings, allowing us to lower min/max/ceil/floor directly from `arith` to the backend dialects (e.g. `spv.GL.FMin`). The LLVM-based backends would need direct lowerings implemented for us to drop the pass there too (e.g. I see errors like `error: failed to legalize operation 'arith.maxf' that was explicitly marked illegal` if I remove it from the LLVMGPU pipeline used for CUDA).