### PR TITLE
Add experimental path to use transformer dialect only in the codegen

### DIFF
--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -5,7 +5,7 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
-    
+    %fused_fill = transform.structured.match ops{["linalg.fill"]} in %arg1
     // Note: split by 32 to vector-distribute the tail combiner_op, but
     // split by 2 to vector-distribute the meaty %more_parallel_op
     %init_or_alloc_op, %fill_op, %more_parallel_op, %combiner_op = 
@@ -19,6 +19,8 @@ transform.with_pdl_patterns {
        transform.structured.tile_to_foreach_thread_op %more_parallel_op num_threads [4, 2] (mapped to dims [2, 1, 0])
     %foreach_thread_3, %tiled_combiner_op = 
       transform.structured.tile_to_foreach_thread_op %combiner_op num_threads [4] (mapped to dims [2, 1, 0])
+    %foreach_thread_4, %tiled_fused_fill_op = 
+      transform.structured.tile_to_foreach_thread_op %fused_fill num_threads [4] (mapped to dims [2, 1, 0])      
 
     %isolated_handle_1 = transform.get_closest_isolated_parent %foreach_thread_2
     %isolated_handle_2 = transform.structured.vectorize %isolated_handle_1


### PR DESCRIPTION
Add a new option so that we can run transformer dialect after tile and
distribute on workgroup. This allows bypassing the problem of setting
the number of workgroups. For now we just pass a tile size through
command line.
This will then allow writing transform dialect pipelines decided by
KernelConfig. Later the transform dialect can evolve to do the tile and
distribute to workgroup.