### PR TITLE
Add e2e matmul tests on vmvx+ukernels (float32-only for now)

### DIFF
--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -229,8 +229,12 @@ def iree_generated_trace_runner_test(
             **kwargs
         )
         tests.append(suite_entry_name)
+
+    # This suffix avoids clashes when two test suites generate tests differing
+    # only in the target backend.
+    test_suite_name_suffix = "_".join([backend for (backend, driver) in target_backends_and_drivers])
     native.test_suite(
-        name = name,
+        name = name + test_suite_name_suffix,
         tests = tests,
         tags = tags,
         **kwargs

--- a/build_tools/bazel/iree_trace_runner_test.bzl
+++ b/build_tools/bazel/iree_trace_runner_test.bzl
@@ -229,12 +229,8 @@ def iree_generated_trace_runner_test(
             **kwargs
         )
         tests.append(suite_entry_name)
-
-    # This suffix avoids clashes when two test suites generate tests differing
-    # only in the target backend.
-    test_suite_name_suffix = "_".join([backend for (backend, driver) in target_backends_and_drivers])
     native.test_suite(
-        name = name + test_suite_name_suffix,
+        name = name,
         tests = tests,
         tags = tags,
         **kwargs

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -119,7 +119,7 @@ py_binary(
     name = "e2e_matmul_%s_%s_small" % (strategy, lhs_rhs_type),
     compiler_flags = [
         "--iree-vmvx-enable-microkernels",
-    ] + ["--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"] if (strategy == "mmt4d") else [],
+    ] + (["--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"] if (strategy == "mmt4d") else []),
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=%s" % lhs_rhs_type,

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -114,9 +114,9 @@ py_binary(
     "small",
 ]]
 
-# Test VMVX
+# Test VMVX+ukernel
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_%s_%s_small" % (strategy, lhs_rhs_type),
+    name = "e2e_matmul_%s_%s_small_ukernel" % (strategy, lhs_rhs_type),
     compiler_flags = [
         "--iree-vmvx-enable-microkernels",
     ] + (["--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"] if (strategy == "mmt4d") else []),

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -28,7 +28,6 @@ py_binary(
     ],
     target_backends_and_drivers = [
         ("llvm-cpu", "local-task"),
-        ("vmvx", "local-task"),
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
@@ -113,6 +112,28 @@ py_binary(
     "f32",
 ] for size in [
     "small",
+]]
+
+# Test VMVX
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_%s_%s_small" % (strategy, lhs_rhs_type),
+    compiler_flags = [
+        "--iree-vmvx-enable-microkernels",
+    ] + ["--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"] if (strategy == "mmt4d") else [],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=%s" % lhs_rhs_type,
+        "--shapes=small",
+    ],
+    target_backends_and_drivers = [
+        ("vmvx", "local-task"),
+    ],
+    trace_runner = "//tools:iree-e2e-matmul-test",
+) for strategy in [
+    "direct",
+    "mmt4d",
+] for lhs_rhs_type in [
+    "f32",
 ]]
 
 [iree_generated_trace_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -185,7 +185,7 @@ iree_generated_trace_runner_test(
   DRIVERS
     "local-task"
   COMPILER_FLAGS
-
+    "--iree-vmvx-enable-microkernels"
 )
 
 iree_generated_trace_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -22,9 +22,7 @@ iree_generated_trace_runner_test(
     iree-e2e-matmul-test
   TARGET_BACKENDS
     "llvm-cpu"
-    "vmvx"
   DRIVERS
-    "local-task"
     "local-task"
 )
 
@@ -40,9 +38,7 @@ iree_generated_trace_runner_test(
     iree-e2e-matmul-test
   TARGET_BACKENDS
     "llvm-cpu"
-    "vmvx"
   DRIVERS
-    "local-task"
     "local-task"
 )
 
@@ -172,6 +168,43 @@ iree_generated_trace_runner_test(
     "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_direct_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "vmvx"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+
+)
+
+iree_generated_trace_runner_test(
+  NAME
+    e2e_matmul_mmt4d_f32_small
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=small"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "vmvx"
+  DRIVERS
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-vmvx-enable-microkernels"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
 )
 
 iree_generated_trace_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -172,7 +172,7 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f32_small
+    e2e_matmul_direct_f32_small_ukernel
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
@@ -190,7 +190,7 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_mmt4d_f32_small
+    e2e_matmul_mmt4d_f32_small_ukernel
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS


### PR DESCRIPTION
This is unblocked by #10192.

Other types than `float32` are blocked on vmvx ukernels support for those (#9903).  I'm interested in landing float32 support early because the path to supporting other data types goes through breaking changes in the existing vmvx ukernel interface for matmul (limiting the generality of the BLAS-inspired interface, particularly the `alpha` and `beta` parameters) so I want to have e2e tests in place at the start of that process.