### PR TITLE
Allow blank issues to be created

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: 📄 Blank Issue
     url: https://github.com/iree-org/iree/issues/new


### PR DESCRIPTION
Currently clicking the "Blank Issue" button loops you back to the issue choose page because blank issues are disabled.

When disabled, the following redirect is in place:
https://github.com/iree-org/iree/issues/new  --> https://github.com/iree-org/iree/issues/new/choose

Background: I based the StableHLO issues config off this file, and noticed that the blank issues are not working on that repo because they are disabled. Flipping this boolean did the trick in openxla/stablehlo.