### PR TITLE
try to be compatible with more pyyaml versions

### DIFF
--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -537,7 +537,7 @@ def write_trace_file(traces, filename, module_path, requirements):
   for trace in traces:
     yaml_documents.append(trace)
 
-  dumped_yaml = yaml.dump_all(yaml_documents, sort_keys=False)
+  dumped_yaml = yaml.dump_all(yaml_documents)
 
   # TODO: This regex substitution is a hack as I couldn't figure how to have
   # PyYAML dump our custom contents_generator into the desired format, e.g.


### PR DESCRIPTION
Thomas's version of PyYAML does not know about `sort_keys`. Maybe we don't need it?