### PR TITLE
Implementation of GPU Shared Memory Transpose Pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -56,12 +56,12 @@ def DispatchLoweringPassPipelineEnum
                     CPU_DoubleTilingPadExpert, CPU_DoubleTilingPeelingExpert,
                     CPU_ConvTileAndDecomposeExpert, CPU_CPUAArchDoubleTilingExpert,
                     CPU_BufferOpsTileAndVectorize, CPU_TripleTilingExpert,
-                    Linalg_TransformInterpCodegen, LLVMGPU_SimpleDistribute,
-                    LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
+                    Linalg_TransformInterpCodegen, LLVMGPU_TransposeSharedMem,
+                    LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
                     LLVMGPU_MatmulTensorCore, LLVMGPU_WarpReduction,
                     SPIRV_Distribute, SPIRV_Vectorize,
                     SPIRV_VectorizeToCooperativeOps,
-                    SPIRV_VectorizeWithWorkgroupMemory, VMVX_Default,LLVMGPU_TransposeSharedMem, None
+                    SPIRV_VectorizeWithWorkgroupMemory, VMVX_Default, None
                   ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -34,17 +34,17 @@ def LLVMGPU_SimpleDistribute : I32EnumAttrCase<"LLVMGPUDistribute", 9>;
 def LLVMGPU_Vectorize : I32EnumAttrCase<"LLVMGPUVectorize", 10>;
 def LLVMGPU_MatmulSimt : I32EnumAttrCase<"LLVMGPUMatmulSimt", 11>;
 def LLVMGPU_MatmulTensorCore : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 12>;
-def LLVMGPU_WarpReduction : I32EnumAttrCase<"LLVMGPUWarpReduction", 13>;
+def LLVMGPU_TransposeSharedMem : I32EnumAttrCase<"LLVMGPUTransposeSharedMem", 13>;
+def LLVMGPU_WarpReduction : I32EnumAttrCase<"LLVMGPUWarpReduction", 14>;
 
-def SPIRV_Distribute : I32EnumAttrCase<"SPIRVDistribute", 14>;
-def SPIRV_Vectorize : I32EnumAttrCase<"SPIRVVectorize", 15>;
+def SPIRV_Distribute : I32EnumAttrCase<"SPIRVDistribute", 15>;
+def SPIRV_Vectorize : I32EnumAttrCase<"SPIRVVectorize", 16>;
 def SPIRV_VectorizeToCooperativeOps
-    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 16>;
+    : I32EnumAttrCase<"SPIRVVectorizeToCooperativeOps", 17>;
 def SPIRV_VectorizeWithWorkgroupMemory
-    : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 17>;
+    : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 18>;
 
-def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 18>;
-def LLVMGPU_TransposeSharedMem : I32EnumAttrCase<"LLVMGPUTransposeSharedMem", 19>;
+def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 19>;
 def None : I32EnumAttrCase<"None", 0xff>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
@@ -56,9 +56,9 @@ def DispatchLoweringPassPipelineEnum
                     CPU_DoubleTilingPadExpert, CPU_DoubleTilingPeelingExpert,
                     CPU_ConvTileAndDecomposeExpert, CPU_CPUAArchDoubleTilingExpert,
                     CPU_BufferOpsTileAndVectorize, CPU_TripleTilingExpert,
-                    Linalg_TransformInterpCodegen, LLVMGPU_TransposeSharedMem,
-                    LLVMGPU_SimpleDistribute, LLVMGPU_Vectorize, LLVMGPU_MatmulSimt,
-                    LLVMGPU_MatmulTensorCore, LLVMGPU_WarpReduction,
+                    Linalg_TransformInterpCodegen, LLVMGPU_SimpleDistribute,
+                    LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
+                    LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction,
                     SPIRV_Distribute, SPIRV_Vectorize,
                     SPIRV_VectorizeToCooperativeOps,
                     SPIRV_VectorizeWithWorkgroupMemory, VMVX_Default, None

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -44,7 +44,7 @@ def SPIRV_VectorizeWithWorkgroupMemory
     : I32EnumAttrCase<"SPIRVVectorizeWithWorkgroupMemory", 17>;
 
 def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 18>;
-
+def LLVMGPU_TransposeSharedMem : I32EnumAttrCase<"LLVMGPUTransposeSharedMem", 19>;
 def None : I32EnumAttrCase<"None", 0xff>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
@@ -61,7 +61,7 @@ def DispatchLoweringPassPipelineEnum
                     LLVMGPU_MatmulTensorCore, LLVMGPU_WarpReduction,
                     SPIRV_Distribute, SPIRV_Vectorize,
                     SPIRV_VectorizeToCooperativeOps,
-                    SPIRV_VectorizeWithWorkgroupMemory, VMVX_Default, None
+                    SPIRV_VectorizeWithWorkgroupMemory, VMVX_Default,LLVMGPU_TransposeSharedMem, None
                   ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -563,14 +563,16 @@ static bool isTransposeOp(linalg::LinalgOp linalgOp) {
 
 static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
                                         Operation *op) {
+  int32_t tileM = 32;
+  int32_t tileN = 32;
   TileSizesListType tileSizes;
-  tileSizes.push_back({32, 32});
+  tileSizes.push_back({tileM, tileN});
 
   // Check alignment with tile size
   if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
     auto inputShape =
         genericOp.inputs()[0].getType().cast<ShapedType>().getShape();
-    if (inputShape[0] % 32 != 0 || inputShape[1] % 32 != 0) {
+    if (inputShape[0] % tileM != 0 || inputShape[1] % tileN != 0) {
       return failure();
     }
   } else {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -547,11 +547,8 @@ static bool isTransposeOp(linalg::LinalgOp linalgOp) {
     return false;
   }
 
-  // Only transpose static sizes
-  if (inputShape[0] == ShapedType::kDynamicSize ||
-      inputShape[1] == ShapedType::kDynamicSize ||
-      outputShape[0] == ShapedType::kDynamicSize ||
-      outputShape[1] == ShapedType::kDynamicSize) {
+  // Only transpose static shapes
+  if (linalgOp.hasDynamicShape()) {
     return false;
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -521,6 +521,76 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
   return success();
 }
 
+/// Returns true if the operation is a GenericOp implementing a 2D transpose.
+static bool isTransposeOp(linalg::LinalgOp linalgOp) {
+  if (!isa<linalg::GenericOp>(linalgOp)) return false;
+  // Check that the op has 2 parallel loops.
+  if (linalgOp.getNumParallelLoops() != 2) {
+    return false;
+  }
+
+  // Check that all the iterators are parallel.
+  if (linalgOp.getNumParallelLoops() != linalgOp.getNumLoops()) {
+    return false;
+  }
+
+  // Check that the op has only one input and one output.
+  if ((linalgOp.getNumInputs() != 1) || (linalgOp.getNumOutputs() != 1)) {
+    return false;
+  }
+  // Check for 2D operations
+  auto inputShape =
+      linalgOp.inputs()[0].getType().cast<ShapedType>().getShape();
+  auto outputShape =
+      linalgOp.outputs()[0].getType().cast<ShapedType>().getShape();
+  if (inputShape.size() != 2 || outputShape.size() != 2) {
+    return false;
+  }
+
+  // Only transpose static sizes
+  if (inputShape[0] == ShapedType::kDynamicSize ||
+      inputShape[1] == ShapedType::kDynamicSize ||
+      outputShape[0] == ShapedType::kDynamicSize ||
+      outputShape[1] == ShapedType::kDynamicSize) {
+    return false;
+  }
+
+  // Check that the two indexing maps are a permutation of each other.
+  auto indexing_maps = linalgOp.getIndexingMapsArray();
+  return !indexing_maps[0].isEmpty() && !indexing_maps[1].isEmpty() &&
+         ((indexing_maps[0].isIdentity() && !indexing_maps[1].isIdentity() &&
+           indexing_maps[1].isPermutation()) ||
+          (!indexing_maps[0].isIdentity() && indexing_maps[0].isPermutation() &&
+           indexing_maps[1].isIdentity()));
+}
+
+static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
+                                        Operation *op) {
+  TileSizesListType tileSizes;
+  tileSizes.push_back({32, 32});
+
+  // Check alignment with tile size
+  if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
+    auto inputShape =
+        genericOp.inputs()[0].getType().cast<ShapedType>().getShape();
+    if (inputShape[0] % 32 != 0 || inputShape[1] % 32 != 0) {
+      return failure();
+    }
+  } else {
+    return failure();
+  }
+
+  // Workgroup size contains 8 warps. Configured with 8 threads on fastest
+  // moving dimension so each thread can execute a vectorized copy of 4
+  // contigious elements at a time from the 32 block.
+  std::array<int64_t, 3> workgroupSize = {8, 32, 1};
+
+  return setOpConfigAndEntryPointFnTranslation(
+      entryPoint, op, tileSizes,
+      IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUTransposeSharedMem,
+      workgroupSize);
+}
+
 static LogicalResult setRootConfig(func::FuncOp entryPointFn,
                                    Operation *computeOp) {
   if (IREE::Codegen::CompilationInfoAttr compilationInfo =
@@ -534,8 +604,13 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
         linalgOp.getNumParallelLoops() >= 2) {
       return setContractConfig(entryPointFn, linalgOp);
     }
-    if (succeeded(setWarpReductionConfig(entryPointFn, linalgOp)))
+    if (succeeded(setWarpReductionConfig(entryPointFn, linalgOp))) {
       return success();
+    }
+    if (isTransposeOp(linalgOp) &&
+        succeeded(setTransposeConfig(entryPointFn, linalgOp))) {
+      return success();
+    }
   }
   if (auto fftOp = dyn_cast<IREE::LinalgExt::FftOp>(computeOp)) {
     return setFftConfig(entryPointFn, fftOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -172,6 +172,10 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
             executableLoweringPipeline,
             translationInfo.value().getSoftwarePipelineDepth());
         break;
+      case IREE::Codegen::DispatchLoweringPassPipeline::
+          LLVMGPUTransposeSharedMem:
+        addGPUTransposePassPipeline(executableLoweringPipeline);
+        break;
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUWarpReduction:
         addGPUWarpReductionPassPipeline(executableLoweringPipeline);
         break;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUReduceBankConflicts.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUReduceBankConflicts.cpp
@@ -15,14 +15,14 @@ namespace iree_compiler {
 
 /// Padd out the inner dimension of the allocOp in order reduce the chances to
 /// have bank conflicts when reading 2D shapes within shared memory.
-static void padAlloc(memref::AllocOp allocOp) {
+static void padAlloc(memref::AllocOp allocOp, int64_t paddingSizeBits) {
   int64_t innerDim = allocOp.getType().getShape().back();
   if (ShapedType::isDynamic(innerDim)) return;
   Type elType = allocOp.getType().getElementType();
   unsigned bitwidth =
       mlir::DataLayout::closest(allocOp).getTypeSizeInBits(elType);
   // Pad with 128bits==16bytes so that accesses are still aligned on 16bytes.
-  int64_t paddingSize = 128 / bitwidth;
+  int64_t paddingSize = paddingSizeBits / bitwidth;
   SmallVector<int64_t> shape = llvm::to_vector(allocOp.getType().getShape());
   shape.back() = shape.back() + paddingSize;
   MemRefType allocType = MemRefType::get(
@@ -48,6 +48,13 @@ namespace {
 /// be removed once the better solution is implemented.
 struct LLVMGPUReduceBankConflictsPass
     : public LLVMGPUReduceBankConflictsBase<LLVMGPUReduceBankConflictsPass> {
+ private:
+  int64_t paddingSizeBits;
+
+ public:
+  LLVMGPUReduceBankConflictsPass(int64_t paddingSizeBits)
+      : paddingSizeBits(paddingSizeBits) {}
+
   void runOnOperation() override {
     auto funcOp = getOperation();
     SmallVector<memref::AllocOp> sharedMemAllocs;
@@ -58,14 +65,15 @@ struct LLVMGPUReduceBankConflictsPass
         sharedMemAllocs.push_back(allocOp);
       }
     });
-    for (memref::AllocOp alloc : sharedMemAllocs) padAlloc(alloc);
+    for (memref::AllocOp alloc : sharedMemAllocs)
+      padAlloc(alloc, paddingSizeBits);
   }
 };
 }  // namespace
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMGPUReduceSharedMemoryBankConflicts() {
-  return std::make_unique<LLVMGPUReduceBankConflictsPass>();
+createLLVMGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits) {
+  return std::make_unique<LLVMGPUReduceBankConflictsPass>(paddingSizeBits);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -185,9 +185,10 @@ static LogicalResult copyToWorkgroupMemory(OpBuilder &b, Value src, Value dst) {
 template <typename T>
 using LinalgPromotionPattern =
     mlir::iree_compiler::IREE::LinalgExt::LinalgPromotionPattern<T>;
-static void populatePromotionPatterns(MLIRContext *context,
-                                      RewritePatternSet &patterns,
-                                      ArrayRef<int64_t> operandsToPromote) {
+static void populatePromotionPatterns(
+    MLIRContext *context, RewritePatternSet &patterns,
+    GPUPromoteSharedMemPattern promoteSharedMemPattern,
+    ArrayRef<int64_t> operandsToPromote) {
   patterns.insert<LinalgPromotionPattern<linalg::MatmulOp>,
                   LinalgPromotionPattern<linalg::BatchMatmulOp>,
                   LinalgPromotionPattern<linalg::GenericOp>>(
@@ -202,9 +203,13 @@ static void populatePromotionPatterns(MLIRContext *context,
           {StringAttr::get(context, getWorkgroupKTiledMarker())},
           StringAttr::get(context, getWorkgroupMemoryMarker()))
           .setMatchByDefault()
-          .addFilter([](Operation *op) {
+          .addFilter([promoteSharedMemPattern](Operation *op) {
             auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
             if (!linalgOp) return failure();
+            if (promoteSharedMemPattern ==
+                GPUPromoteSharedMemPattern::TransposeOpPattern) {
+              return success(linalgOp.getNumParallelLoops() == 2);
+            }
             // Limit promotion to matmul and batch matmul, there may be generic
             // ops with more batch dimensions we didn't distribute and therefore
             // cannot find a higher bound.
@@ -250,10 +255,14 @@ struct LLVMGPUTileAndDistributePass
  private:
   // Distribute the workloads to warp if true otherwise distribute to threads.
   bool distributeToWarp = false;
+  GPUPromoteSharedMemPattern promoteSharedMemPattern =
+      GPUPromoteSharedMemPattern::ContractionOpPattern;
 
  public:
-  LLVMGPUTileAndDistributePass(bool distributeToWarp)
-      : distributeToWarp(distributeToWarp) {}
+  LLVMGPUTileAndDistributePass(
+      bool distributeToWarp, GPUPromoteSharedMemPattern promoteSharedMemPattern)
+      : distributeToWarp(distributeToWarp),
+        promoteSharedMemPattern(promoteSharedMemPattern) {}
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<AffineDialect, gpu::GPUDialect>();
   }
@@ -266,7 +275,8 @@ struct LLVMGPUTileAndDistributePass
     // allocation. This needs to be done before reduction tiling.
     if (llvmgpuUseMMASync) {
       RewritePatternSet promotionPatterns(&getContext());
-      populatePromotionPatterns(context, promotionPatterns, {2});
+      populatePromotionPatterns(context, promotionPatterns,
+                                promoteSharedMemPattern, {2});
       if (failed(applyPatternsAndFoldGreedily(funcOp,
                                               std::move(promotionPatterns)))) {
         return signalPassFailure();
@@ -274,7 +284,7 @@ struct LLVMGPUTileAndDistributePass
       propagateFillIntoPromotionAlloc(funcOp);
     }
 
-    // Tile again at the workgroup level since redution dimension were
+    // Tile again at the workgroup level since reduction dimension were
     // ignored. Dimensions already tiled will be ignore since we tile to the
     // same size.
     if (failed(tileReduction(funcOp))) {
@@ -295,7 +305,19 @@ struct LLVMGPUTileAndDistributePass
     // Only promote to workgroup size if there are multiple warps.
     if (flatWorkgroupSize > kWarpSize) {
       RewritePatternSet promotionPatterns(&getContext());
-      populatePromotionPatterns(context, promotionPatterns, {0, 1});
+
+      switch (promoteSharedMemPattern) {
+        case GPUPromoteSharedMemPattern::ContractionOpPattern:
+          populatePromotionPatterns(context, promotionPatterns,
+                                    promoteSharedMemPattern, {0, 1});
+
+          break;
+        case GPUPromoteSharedMemPattern::TransposeOpPattern:
+          populatePromotionPatterns(context, promotionPatterns,
+                                    promoteSharedMemPattern, {0});
+
+          break;
+      }
       if (failed(applyPatternsAndFoldGreedily(funcOp,
                                               std::move(promotionPatterns)))) {
         return signalPassFailure();
@@ -373,8 +395,9 @@ struct LLVMGPUTileAndDistributePass
 }  // namespace
 
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileAndDistribute(
-    bool distributeToWarp) {
-  return std::make_unique<LLVMGPUTileAndDistributePass>(distributeToWarp);
+    bool distributeToWarp, GPUPromoteSharedMemPattern promoteSharedMemPattern) {
+  return std::make_unique<LLVMGPUTileAndDistributePass>(
+      distributeToWarp, promoteSharedMemPattern);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -223,6 +223,36 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
       createGPUPipeliningPass(pipelineDepth));
 }
 
+void addGPUTransposePassPipeline(OpPassManager &pm) {
+  llvm::dbgs() << "LLVMGPU::addGPUTransposePassPipeline()\n";
+  tileAndBufferize(pm);
+
+  auto &nestedModulePM = pm.nest<ModuleOp>();
+  // Distribute linalg onto threads within the workgroup.
+  nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUTileAndDistribute(
+      false, GPUPromoteSharedMemPattern::TransposeOpPattern));
+  nestedModulePM.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createGPUDistributeSharedMemoryCopy());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
+  // May or may not need to reduce shared mememory conflicts
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUReduceSharedMemoryBankConflicts());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
+  // Linalg -> vector
+  nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUVectorizationPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createOptimizeVectorTransferPass());
+}
+
 void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -224,7 +224,6 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
 }
 
 void addGPUTransposePassPipeline(OpPassManager &pm) {
-  llvm::dbgs() << "LLVMGPU::addGPUTransposePassPipeline()\n";
   tileAndBufferize(pm);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
@@ -239,7 +238,7 @@ void addGPUTransposePassPipeline(OpPassManager &pm) {
 
   // May or may not need to reduce shared mememory conflicts
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createLLVMGPUReduceSharedMemoryBankConflicts());
+      createLLVMGPUReduceSharedMemoryBankConflicts(/*paddingSizeBits=*/32));
   nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
   nestedModulePM.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -1016,3 +1016,52 @@ hal.executable private @shared_mem_alloc {
 //         CHECK:     nvvm.barrier0
 //         CHECK:     llvm.load %{{.*}} : !llvm.ptr<f32, 3>
 //         CHECK:     nvvm.barrier0
+
+// -----
+
+
+#config = #iree_codegen.lowering_config<tile_sizes = [[32,32]]>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+#map0 = affine_map<(d0, d1) -> (d1, d0)>
+#map1 = affine_map<(d0, d1) -> (d0, d1)>
+hal.executable private @shared_mem_transpose  {
+  hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
+    hal.executable.export @shared_mem_transpose layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+        %x, %y, %z = flow.dispatch.default_workgroup_count %arg1, %arg2
+        hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+        func.func @shared_mem_transpose() {
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:2048x768xf32>
+          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:768x2048xf32>
+          %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:2048x768xf32> -> tensor<2048x768xf32>
+          %3 = linalg.init_tensor [768, 2048] : tensor<768x2048xf32>
+          %4 = linalg.generic {indexing_maps = [#map0, #map1], iterator_types = ["parallel", "parallel"]} ins(%2 : tensor<2048x768xf32>) outs(%3 : tensor<768x2048xf32>) {
+          ^bb0(%arg0: f32, %arg1: f32):
+            linalg.yield %arg0 : f32
+          } -> tensor<768x2048xf32>
+          flow.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [768, 2048], strides = [1, 1] : tensor<768x2048xf32> -> !flow.dispatch.tensor<writeonly:768x2048xf32>
+          return
+        }
+    }
+  }
+}
+
+// Check that bufferization is emitting correct code for the temp shared
+// memory alloc.
+//   CHECK-LABEL: hal.executable private @shared_mem_transpose
+//         CHECK:   hal.executable.variant public @cuda
+//         CHECK:     nvvm.barrier0
+//         CHECK:     llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<vector<4xf32>>
+//         CHECK:     llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : !llvm.ptr<vector<4xf32>, 3>
+//         CHECK:     nvvm.barrier0
+
+// -----

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -312,6 +312,14 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
                                         unsigned pipelineDepth);
 
+enum class GPUPromoteSharedMemPattern {
+  ContractionOpPattern = 0,
+  TransposeOpPattern = 1,
+};
+
+/// Lowering transpose using shared memory.
+void addGPUTransposePassPipeline(OpPassManager &pm);
+
 /// Lowering reductions to warp reductions.
 void addGPUWarpReductionPassPipeline(OpPassManager &pm);
 
@@ -336,7 +344,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertToROCDLPass();
 
 /// Perform tiling and distribution to threads.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileAndDistribute(
-    bool distributeToWarp = false);
+    bool distributeToWarp = false,
+    GPUPromoteSharedMemPattern promoteSharedMemPattern =
+        GPUPromoteSharedMemPattern::ContractionOpPattern);
 
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileTensor(
     bool distributeToWarp = false);

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -375,9 +375,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUMultiBuffering(
     unsigned numBuffers = 5);
 
 /// Apply transformation to reduce the number of bank conflicts when accessing
-/// shared memory.
+/// shared memory by padding fastest moving dimension with the specified size.
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMGPUReduceSharedMemoryBankConflicts();
+createLLVMGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits = 128);
 
 /// Converts vector ops to gpu dialect.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU();


### PR DESCRIPTION
Currently only `32x32` aligned 2D transposes are supported. Based on https://developer.nvidia.com/blog/efficient-matrix-transpose-cuda-cc/, uses a fixed tile size of `32x32` and workgroup size of `{8x32}` to preform vectorized copy for transpose. The tile is padded to `32x33` to reduce bank conflicts. Note that bank conflicts aren fully eliminated due to use of vector load/store 4.

Todo:
* Move beyond single hard coded workgroup and tile size?
* Handle non aligned transpose
* Handle dynamic sized transpose

Related to #10005