### PR TITLE
Tidy the VMVX ukernels matmul interface

### DIFF
--- a/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
@@ -876,20 +876,6 @@ struct LinalgMatmulConversion
       rhs = contract.rhs();
       out = op.outputs().front();
     }
-
-    Value getOneValue(PatternRewriter &rewriter) {
-      Location loc = op.getLoc();
-      Type elementType = out.getType().cast<MemRefType>().getElementType();
-      if (auto floatType = elementType.dyn_cast<FloatType>()) {
-        return rewriter.create<arith::ConstantOp>(
-            loc, FloatAttr::get(floatType, 1.0));
-      } else if (elementType.isa<IntegerType>()) {
-        return rewriter.create<arith::ConstantIntOp>(loc, 1, elementType);
-      }
-
-      assert(false && "unknown element type");
-      return nullptr;
-    }
   };
 
   LogicalResult matchAndRewrite(linalg::ContractionOpInterface op,

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
@@ -54,15 +54,14 @@ func.func @fill2d(%arg0 : memref<384x128xf32>, %arg1 : f32) {
 }
 
 // CHECK-LABEL: @matmul_row_major
-//   CHECK-DAG: %[[SCALE:.*]] = arith.constant 1.000000e+00 : f32
 //   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:2, %[[STRIDES0:.*]]:2 = vmvx.get_buffer_descriptor %arg0
 //   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:2, %[[STRIDES1:.*]]:2 = vmvx.get_buffer_descriptor %arg1
 //   CHECK-DAG: %[[BB2:.*]], %[[OFFSET2:.*]], %[[SIZES2:.*]]:2, %[[STRIDES2:.*]]:2 = vmvx.get_buffer_descriptor %arg2
 //       CHECK: vmvx.matmul lhs(%[[BB1]] offset %[[OFFSET1]] row_stride %[[STRIDES1]]#0 : !util.buffer)
 //  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
 //  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
-//  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#1, %[[SIZES2]]#0) scale(%[[SCALE]] : f32, %[[SCALE]] : f32)
-//  CHECK-SAME:   flags(0)
+//  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#1, %[[SIZES2]]#0)
+//  CHECK-SAME:   flags(1)
 func.func @matmul_row_major(%arg0 : memref<64x64xf32>, %arg1 : memref<64x384xf32>, %arg2 : memref<384x64xf32>) {
   linalg.matmul
       ins(%arg1, %arg2 : memref<64x384xf32>, memref<384x64xf32>)

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/matmul.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/matmul.mlir
@@ -10,21 +10,18 @@ func.func @matmul_f32f32f32(
     // OUT
     %arg6 : !util.buffer, %arg7 : index, %arg8 : index,
     // SIZE
-    %arg9 : index, %arg10 : index, %arg11 : index,
-    // SCALE
-    %arg12 : f32, %arg13 : f32) {
+    %arg9 : index, %arg10 : index, %arg11 : index) {
 
-  //  CHECK-DAG: %[[ZERO:.*]] = vm.const.i32.zero
+  //  CHECK-DAG: %[[FLAGS:.*]] = vm.const.i32 1
   //      CHECK: vm.call @vmvx.matmul.f32f32f32(
   // CHECK-SAME: %arg0, %arg1, %arg2,
   // CHECK-SAME: %arg3, %arg4, %arg5,
   // CHECK-SAME: %arg6, %arg7, %arg8,
-  // CHECK-SAME: %arg9, %arg10, %arg11, %arg12, %arg13, %[[ZERO]]) : (!vm.buffer, i64, i64, !vm.buffer, i64, i64, !vm.buffer, i64, i64, i64, i64, i64, f32, f32, i32) -> ()
+  // CHECK-SAME: %arg9, %arg10, %arg11, %[[FLAGS]]) : (!vm.buffer, i64, i64, !vm.buffer, i64, i64, !vm.buffer, i64, i64, i64, i64, i64, i32) -> ()
   vmvx.matmul lhs(%arg0 offset %arg1 row_stride %arg2 : !util.buffer)
               rhs(%arg3 offset %arg4 row_stride %arg5 : !util.buffer)
               out(%arg6 offset %arg7 row_stride %arg8 : !util.buffer)
               mnk(%arg9, %arg10, %arg11)
-              scale(%arg12 : f32, %arg13 : f32)
-              flags(0) : (f32, f32, f32)
+              flags(1) : (f32, f32, f32)
   func.return
 }

--- a/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
+++ b/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
@@ -198,10 +198,6 @@ def VMVX_MatmulOp : VMVX_Op<"matmul"> {
     VMVX_Index:$n,
     VMVX_Index:$k,
 
-    // Scale factors.
-    VMVX_ElementType:$alpha,
-    VMVX_ElementType:$beta,
-
     // Type and flag attributes.
     VMVX_ElementTypeAttr:$lhs_type,
     VMVX_ElementTypeAttr:$rhs_type,
@@ -214,7 +210,6 @@ def VMVX_MatmulOp : VMVX_Op<"matmul"> {
     `rhs` `` `(` $rhs_buffer `offset` $rhs_offset `row_stride` $rhs_row_stride `:` type($rhs_buffer)`)`
     `out` `` `(` $out_buffer `offset` $out_offset `row_stride` $out_row_stride `:` type($out_buffer) `)`
     `mnk` `` `(` $m `,` $n `,` $k `)`
-    `scale` `` `(` $alpha `:` type($alpha) `,` $beta `:` type($beta) `)`
     `flags` `` `(` $flags `)`
     `:` `(` $lhs_type `,` $rhs_type `,` $out_type `)`
     attr-dict

--- a/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
@@ -426,8 +426,6 @@ vm.import @matmul.f32f32f32(
   %m : i64,
   %n : i64,
   %k : i64,
-  %alpha : f32,
-  %beta : f32,
   %flags : i32
 )
 

--- a/runtime/src/iree/modules/vmvx/exports.inl
+++ b/runtime/src/iree/modules/vmvx/exports.inl
@@ -40,11 +40,11 @@ EXPORT_FN("exp.2d.f32", iree_ukernel_x32u_expf_2d, ukernel_x32u_2d, rIIIrIIIII, 
 EXPORT_FN("fill.2d.x32", iree_vmvx_fill2d_x32, fill2d_x32, irIIII, v)
 EXPORT_FN("floor.2d.f32", iree_ukernel_x32u_floorf_2d, ukernel_x32u_2d, rIIIrIIIII, v)
 EXPORT_FN("log.2d.f32", iree_ukernel_x32u_logf_2d, ukernel_x32u_2d, rIIIrIIIII, v)
-EXPORT_FN("matmul.f32f32f32", iree_vmvx_matmul_f32f32f32, matmul_f32, rIIrIIrIIIIIffi, v)
+EXPORT_FN("matmul.f32f32f32", iree_vmvx_matmul_f32f32f32, matmul_f32, rIIrIIrIIIIIi, v)
 // NOTE: must still be in alphabetical order with all other exports.
-#if defined(IREE_HAVE_MMT4D_BUILTINS)
+#if 0 // TODO: implement mmt4d ukernel
 EXPORT_FN("mmt4d.f32f32f32", iree_vmvx_mmt4d_f32f32f32, mmt4d_f32, rIIrIIrIIIIIffi, v)
-#endif  // IREE_HAVE_MMT4D_BUILTINS
+#endif
 EXPORT_FN("mul.2d.f32", iree_ukernel_x32b_mulf_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 EXPORT_FN("mul.2d.i32", iree_ukernel_x32b_muli_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 EXPORT_FN("neg.2d.f32", iree_ukernel_x32u_negf_2d, ukernel_x32u_2d, rIIIrIIIII, v)


### PR DESCRIPTION
This makes the VMVX ukernel interface for matmul somewhat sustainable and generalizable.

It's official now that the only supported case is when all operands are row-major (more general support might be wanted in the future, but would have to allow separate storage orders for each operand in order to be likely to be used).

The only flag now is one bit to tell whether to accumulate into an existing accumulator, or just zero it. At the moment we always accumulate but could soon generate calls without the accumulate flag when compiling code where the accumulator operand is known to be zero-filled. In terms of optimized runtime code, it is nearly zero overhead to support that boolean degree of generality in the ukernel.

The "reference" ukernel impl is changed to be a little more suggestive of how an optimized impl would look.

The alpha, beta parameters are gone. There were hard to generalize to integer data types, and they were mostly gratuitous generality anyway (they didn't do the same as the namesake BLAS GEMM parameters).
