### PR TITLE
Add debug option to dump LLVMCPU/GPU pass pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -24,6 +24,8 @@
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/Passes.h"
 
+#define DEBUG_TYPE "iree-llvm-cpu-lowering-pass-pipeline"
+
 namespace mlir {
 namespace iree_compiler {
 
@@ -640,6 +642,12 @@ void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
   addLowerToLLVMPasses(nestedModulePM);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Using LLVMCPU pass pipeline:\n";
+    passManager.printAsTextualPipeline(llvm::dbgs());
+    llvm::dbgs() << "\n";
+  });
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -23,6 +23,8 @@
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"
 
+#define DEBUG_TYPE "iree-llvm-gpu-lowering-pass-pipeline"
+
 namespace mlir {
 namespace iree_compiler {
 
@@ -323,6 +325,12 @@ void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
   //   - The module contains the final llvm.module ready to be serialized.
   //===--------------------------------------------------------------------===//
   addLowerToLLVMGPUPasses(nestedModulePM, useROCM);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Using LLVMGPU pass pipeline:\n";
+    pm.printAsTextualPipeline(llvm::dbgs());
+    llvm::dbgs() << "\n";
+  });
 }
 
 }  // namespace iree_compiler


### PR DESCRIPTION
This is enabled using the
`--debug-only=iree-llvm-cpu-lowering-pass-pipeline` flag.
The SPIR-V codegen path has a similar option.