### PR TITLE
[LLVMGPU] Move bufferization after vectorization for matmulSIMT

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
@@ -95,9 +95,11 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns) {
 /// Compute a vector size so that the numer of elements is equal to the flat
 /// workgroup size.
 static Optional<SmallVector<int64_t, 4>> getGPUNativeVectorSize(
-    Operation *op, int64_t flatWorkgroupSize) {
+    Operation *op, int64_t flatWorkgroupSize,
+    const llvm::SmallDenseSet<VectorTransferOpInterface> &opsToIgnore) {
   auto vt = dyn_cast<VectorTransferOpInterface>(op);
   if (!vt) return llvm::None;
+  if (opsToIgnore.count(vt)) return llvm::None;
   if (!vt.permutation_map().isMinorIdentity()) return llvm::None;
   ArrayRef<int64_t> shape = vt.getVectorType().getShape();
   int targetVectorSize =
@@ -121,10 +123,11 @@ static Optional<SmallVector<int64_t, 4>> getGPUNativeVectorSize(
   return unroll;
 }
 
-static void populateVectorUnrollPatterns(RewritePatternSet &patterns,
-                                         int64_t flatWorkgroupSize) {
-  auto getShape = [flatWorkgroupSize](Operation *op) {
-    return getGPUNativeVectorSize(op, flatWorkgroupSize);
+static void populateVectorUnrollPatterns(
+    RewritePatternSet &patterns, int64_t flatWorkgroupSize,
+    const llvm::SmallDenseSet<VectorTransferOpInterface> &opsToIgnore) {
+  auto getShape = [flatWorkgroupSize, &opsToIgnore](Operation *op) {
+    return getGPUNativeVectorSize(op, flatWorkgroupSize, opsToIgnore);
   };
   vector::populateVectorUnrollPatterns(
       patterns, vector::UnrollVectorOptions().setNativeShapeFn(getShape));
@@ -152,9 +155,13 @@ static Value createFlatId(func::FuncOp funcOp,
 }
 
 /// Distribute a transfer read operations on the given thread ids.
-static void distributeTransferRead(func::FuncOp funcOp, Value flatThreadId,
-                                   int64_t flatWorkgroupSize) {
+static void distributeTransferRead(
+    func::FuncOp funcOp, Value flatThreadId, int64_t flatWorkgroupSize,
+    const llvm::SmallDenseSet<VectorTransferOpInterface> &opsToIgnore) {
   funcOp.walk([&](vector::TransferReadOp readOp) {
+    if (opsToIgnore.count(
+            cast<VectorTransferOpInterface>(readOp.getOperation())))
+      return WalkResult::advance();
     OpBuilder b(readOp);
     Value id = flatThreadId;
     SmallVector<int64_t, 2> multiplier;
@@ -195,6 +202,40 @@ static void distributeTransferRead(func::FuncOp funcOp, Value flatThreadId,
       readOp.getResult().replaceAllUsesExcept(ops->insert.getResult(),
                                               extractOp);
     }
+    return WalkResult::advance();
+  });
+}
+
+/// Hoist allocations to the top of the loop if they have no dependencies.
+static void hoistAlloc(func::FuncOp funcOp) {
+  SmallVector<memref::AllocOp> allocs;
+  funcOp.walk([&](memref::AllocOp alloc) {
+    if (alloc.getOperands().empty()) allocs.push_back(alloc);
+  });
+  for (memref::AllocOp alloc : allocs) {
+    alloc->moveBefore(&(*funcOp.getBlocks().begin()),
+                      funcOp.getBlocks().begin()->begin());
+  }
+}
+
+/// We insert barriers conservatively, remove barriers that are obviously not
+/// needed.
+static void removeRedundantBarriers(func::FuncOp funcOp) {
+  funcOp.walk([](linalg::GenericOp copyOp) {
+    if (hasMarker(copyOp, getCopyToWorkgroupMemoryMarker())) {
+      Operation *prevOp = copyOp->getPrevNode();
+      SmallVector<Operation *> redundantBarriers;
+      while (prevOp) {
+        if (isa<gpu::BarrierOp>(prevOp))
+          redundantBarriers.push_back(prevOp);
+        else
+          break;
+        prevOp = prevOp->getPrevNode();
+      }
+      if (prevOp && hasMarker(prevOp, getCopyToWorkgroupMemoryMarker())) {
+        for (Operation *op : redundantBarriers) op->erase();
+      }
+    }
   });
 }
 
@@ -219,6 +260,11 @@ class GPUDistributeSharedMemoryCopyPass
         copiesToWorkgroupMem.push_back(copyOp);
     });
     if (copiesToWorkgroupMem.empty()) return;
+
+    // Step 0. First clean up the IR.
+    hoistAlloc(funcOp);
+    removeRedundantBarriers(funcOp);
+
     int64_t flatWorkgroupSize =
         workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
     bool isAligned = llvm::all_of(
@@ -232,6 +278,11 @@ class GPUDistributeSharedMemoryCopyPass
                                                        targetVectorSize);
         });
     if (isAligned) {
+      // Ignore all the exisiting vector transfer ops.
+      llvm::SmallDenseSet<VectorTransferOpInterface> opsToIgnore;
+      funcOp.walk([&](VectorTransferOpInterface transferOp) {
+        opsToIgnore.insert(transferOp);
+      });
       // Step 1. Vectorize the shared memory copy.
       RewritePatternSet vectorizationPatterns(context);
       populateVectorizationPatterns(vectorizationPatterns);
@@ -245,14 +296,15 @@ class GPUDistributeSharedMemoryCopyPass
       // transfer op generated can. then be distributed to a single op of target
       // size.
       RewritePatternSet vectorUnrollPatterns(context);
-      populateVectorUnrollPatterns(vectorUnrollPatterns, flatWorkgroupSize);
+      populateVectorUnrollPatterns(vectorUnrollPatterns, flatWorkgroupSize,
+                                   opsToIgnore);
       if (failed(applyPatternsAndFoldGreedily(
               funcOp, std::move(vectorUnrollPatterns)))) {
         return signalPassFailure();
       }
       // Step 3. Distribute the transfer ops onto the flat ids.
       Value flatId = createFlatId(funcOp, workgroupSize);
-      distributeTransferRead(funcOp, flatId, flatWorkgroupSize);
+      distributeTransferRead(funcOp, flatId, flatWorkgroupSize, opsToIgnore);
       // Propagate vector distribution to the chain of ops.
       RewritePatternSet distributePatterns(context);
       vector::populatePropagateVectorDistributionPatterns(distributePatterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -23,6 +23,7 @@ iree_compiler_cc_library(
         "LLVMGPULowerExecutableTarget.cpp",
         "LLVMGPUMultiBuffering.cpp",
         "LLVMGPUReduceBankConflicts.cpp",
+        "LLVMGPUTensorAlloc.cpp",
         "LLVMGPUTensorCoreVectorization.cpp",
         "LLVMGPUTileAndDistribute.cpp",
         "LLVMGPUTileTensor.cpp",
@@ -36,6 +37,7 @@ iree_compiler_cc_library(
     hdrs = [
         "ConvertToLLVM.h",
         "KernelConfig.h",
+        "TilingUtils.h",
     ],
     deps = [
         "//compiler/src/iree/compiler/Codegen:PassHeaders",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -61,6 +61,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithmeticDialect",
         "@llvm-project//mlir:ArithmeticToLLVM",
         "@llvm-project//mlir:ArithmeticTransforms",
+        "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:ControlFlowToLLVM",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:FuncToLLVM",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -49,6 +49,7 @@ iree_cc_library(
     MLIRArithmeticDialect
     MLIRArithmeticToLLVM
     MLIRArithmeticTransforms
+    MLIRBufferizationDialect
     MLIRControlFlowToLLVM
     MLIRFuncDialect
     MLIRFuncToLLVM

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "ConvertToLLVM.h"
     "KernelConfig.h"
+    "TilingUtils.h"
   SRCS
     "ConvertToLLVM.cpp"
     "ConvertToNVVM.cpp"
@@ -25,6 +26,7 @@ iree_cc_library(
     "LLVMGPULowerExecutableTarget.cpp"
     "LLVMGPUMultiBuffering.cpp"
     "LLVMGPUReduceBankConflicts.cpp"
+    "LLVMGPUTensorAlloc.cpp"
     "LLVMGPUTensorCoreVectorization.cpp"
     "LLVMGPUTileAndDistribute.cpp"
     "LLVMGPUTileTensor.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
@@ -25,22 +25,6 @@
 namespace mlir {
 namespace iree_compiler {
 
-/// Clean up barriers if we have no shared memory allocations we expect to not
-/// need any barriers and remove them.
-static void cleanUpBarriers(func::FuncOp funcOp) {
-  bool hasAlloc = false;
-  SmallVector<Operation*> barriers;
-  funcOp.walk([&](Operation* op) {
-    if (isa<memref::AllocOp>(op))
-      hasAlloc = true;
-    else if (isa<gpu::BarrierOp>(op))
-      barriers.push_back(op);
-  });
-  if (!hasAlloc) {
-    for (Operation* op : barriers) op->erase();
-  }
-}
-
 namespace {
 struct LLVMGPUDistributePass
     : public LLVMGPUDistributeBase<LLVMGPUDistributePass> {
@@ -61,15 +45,12 @@ struct LLVMGPUDistributePass
     for (scf::ForeachThreadOp op : foreachOps) {
       IRRewriter rewriter(op->getContext());
       rewriter.setInsertionPoint(op);
-      if (failed(rewriteForeachThreadToGpu(op, workgroupSize, rewriter))) {
+      if (failed(
+              rewriteForeachThreadToGpu(op, workgroupSize, rewriter,
+                                        /*syncAfterDistributefalse=*/false))) {
         return signalPassFailure();
       }
     }
-
-    // Workaround, since we conservatively insert barrier ops, remove them if
-    // they are obviously not needed.
-    // TODO(thomasraoux): Improve barrier placement.
-    cleanUpBarriers(funcOp);
   }
 };
 }  // namespace

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
@@ -1,0 +1,72 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/TilingUtils.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Transforms/Passes.h"
+
+#define DEBUG_TYPE "iree-llvmgpu-alloc"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Filter to decide which ops need allocations.
+static bool filter(Operation *op) {
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  if (!linalgOp) return false;
+  // Can't promote dynamic shapes.
+  if (linalgOp.hasDynamicShape()) return false;
+  return linalg::isaContractionOpInterface(op) &&
+         linalgOp.getNumParallelLoops() >= 2 &&
+         linalgOp.getNumParallelLoops() <= 3;
+}
+
+namespace {
+struct LLVMGPUTensorAllocPass
+    : public LLVMGPUTensorAllocBase<LLVMGPUTensorAllocPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<bufferization::BufferizationDialect>();
+  }
+  void runOnOperation() override {
+    auto funcOp = getOperation();
+
+    // Tile the reduction first to reduce the alloc size.
+    if (failed(tileReduction(funcOp))) {
+      return signalPassFailure();
+    }
+
+    SmallVector<Operation *> opsToPromote;
+    funcOp.walk([&](Operation *op) {
+      if (filter(op)) opsToPromote.push_back(op);
+    });
+    for (Operation *op : opsToPromote) {
+      OpBuilder builder(op);
+      auto linalgOp = cast<linalg::LinalgOp>(op);
+      bufferization::BufferizationOptions options;
+      // Promote all the input operands.
+      for (auto operand : linalgOp.getInputOperands()) {
+        FailureOr<Value> ret = bufferization::allocateTensorForShapedValue(
+            builder, op->getLoc(), operand->get(), false, options, true);
+        if (failed(ret)) {
+          return signalPassFailure();
+        }
+        Value v = ret.getValue();
+        operand->get().replaceAllUsesExcept(v, v.getDefiningOp());
+      }
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorAlloc() {
+  return std::make_unique<LLVMGPUTensorAllocPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorization.cpp
@@ -30,7 +30,8 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns) {
   MLIRContext *ctx = patterns.getContext();
   linalg::LinalgVectorizationOptions opt;
   linalg::LinalgTransformationFilter f(
-      StringAttr::get(ctx, getVectorizeMarker()));
+      {StringAttr::get(ctx, getWorkgroupKTiledMarker()),
+       StringAttr::get(ctx, getVectorizeMarker())});
   f.setMatchByDefault();
   linalg::VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(
       patterns, opt, f);
@@ -39,53 +40,10 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns) {
       ctx, f.addOpFilter<linalg::ContractionOpInterface>(), opt);
 }
 
-static Optional<SmallVector<int64_t, 4>> getGPUNativeVectorSize(
-    Operation *op, int64_t nativeVector) {
-  if ((OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1)) {
-    if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>()) {
-      // Map elementwise ops to vec4.
-      SmallVector<int64_t, 4> nativeSize(vecType.getRank(), 1);
-      nativeSize.back() = nativeVector;
-      return nativeSize;
-    }
-  } else if (auto vt = dyn_cast<VectorTransferOpInterface>(op)) {
-    auto rank = vt.getVectorType().getRank();
-    SmallVector<int64_t, 4> nativeSize(rank, 1);
-    // Load 4 elements on the most inner dimension.
-    for (auto dim : llvm::enumerate(vt.permutation_map().getResults())) {
-      if (auto dimExpr = dim.value().dyn_cast<AffineDimExpr>()) {
-        if (dimExpr.getPosition() == vt.permutation_map().getNumDims() - 1) {
-          nativeSize[dim.index()] = nativeVector;
-        }
-      }
-    }
-    return nativeSize;
-  } else if (auto contract = dyn_cast<vector::ContractionOp>(op)) {
-    unsigned lastParalleldim = 0;
-    for (auto it : llvm::enumerate(contract.getIteratorTypes())) {
-      if (isParallelIterator(it.value())) lastParalleldim = it.index();
-    }
-    SmallVector<int64_t, 4> nativeSize(contract.getIteratorTypes().size(), 1);
-    nativeSize[lastParalleldim] = nativeVector;
-    return nativeSize;
-  }
-  return llvm::None;
-}
-
-static void populateVectorUnrollPatterns(RewritePatternSet &patterns,
-                                         int64_t nativeVector) {
-  vector::populateVectorUnrollPatterns(
-      patterns, vector::UnrollVectorOptions().setNativeShapeFn(
-                    [nativeVector](Operation *op) {
-                      return getGPUNativeVectorSize(op, nativeVector);
-                    }));
-}
-
 namespace {
 struct LLVMGPUVectorizationPass
     : public LLVMGPUVectorizationBase<LLVMGPUVectorizationPass> {
-  LLVMGPUVectorizationPass(int64_t nativeVector, bool generateContract) {
-    this->nativeVector = nativeVector;
+  LLVMGPUVectorizationPass(bool generateContract) {
     this->generateContract = generateContract;
   }
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -94,87 +52,24 @@ struct LLVMGPUVectorizationPass
   void runOnOperation() override {
     auto funcOp = getOperation();
     MLIRContext *context = &getContext();
-
-    {
-      // Step 1. Vectorize
-      RewritePatternSet vectorizationPatterns(context);
-      populateVectorizationPatterns(vectorizationPatterns);
-      if (generateContract) {
-        vector::populateVectorTransferPermutationMapLoweringPatterns(
-            vectorizationPatterns);
-        vector::populateVectorReductionToContractPatterns(
-            vectorizationPatterns);
-      }
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(vectorizationPatterns)))) {
-        return signalPassFailure();
-      }
-
-      // Fold consumer add ops into the contraction op itself.
-      RewritePatternSet canonicalizationPatterns(context);
-      vector::ContractionOp::getCanonicalizationPatterns(
-          canonicalizationPatterns, context);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(canonicalizationPatterns)))) {
-        return signalPassFailure();
-      }
-
-      if (nativeVector > 0) {
-        RewritePatternSet vectorUnrollPatterns(context);
-        populateVectorUnrollPatterns(vectorUnrollPatterns, nativeVector);
-        if (failed(applyPatternsAndFoldGreedily(
-                funcOp, std::move(vectorUnrollPatterns)))) {
-          return signalPassFailure();
-        }
-      }
-      DEBUG_WITH_TYPE(DEBUG_TYPE, {
-        llvm::dbgs() << "\n--- After Step 1: Vectorization ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
+    RewritePatternSet vectorizationPatterns(context);
+    populateVectorizationPatterns(vectorizationPatterns);
+    if (generateContract) {
+      vector::populateVectorTransferPermutationMapLoweringPatterns(
+          vectorizationPatterns);
+      vector::populateVectorReductionToContractPatterns(vectorizationPatterns);
     }
-    {
-      // Step 2. Lower transfer op to canonical form.
-      RewritePatternSet lowerTransferOpPatterns(funcOp.getContext());
-      vector::populateVectorToVectorCanonicalizationPatterns(
-          lowerTransferOpPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(lowerTransferOpPatterns)))) {
-        return signalPassFailure();
-      }
-      DEBUG_WITH_TYPE(DEBUG_TYPE, {
-        llvm::dbgs()
-            << "\n--- After Step 2: Lower transfer op to canonical form. ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
-    }
-
-    {
-      // Step 3. Canonicalize.
-      RewritePatternSet canonicalizationPatterns(funcOp.getContext());
-      vector::ExtractStridedSliceOp::getCanonicalizationPatterns(
-          canonicalizationPatterns, canonicalizationPatterns.getContext());
-      vector::populateVectorToVectorCanonicalizationPatterns(
-          canonicalizationPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(canonicalizationPatterns)))) {
-        return signalPassFailure();
-      }
-      DEBUG_WITH_TYPE(DEBUG_TYPE, {
-        llvm::dbgs() << "\n--- After Step 3: Canonicalize. ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
+    if (failed(applyPatternsAndFoldGreedily(
+            funcOp, std::move(vectorizationPatterns)))) {
+      return signalPassFailure();
     }
   }
 };
 }  // namespace
 
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorizationPass(
-    int64_t nativeVector, bool generateContract) {
-  return std::make_unique<LLVMGPUVectorizationPass>(nativeVector,
-                                                    generateContract);
+    bool generateContract) {
+  return std::make_unique<LLVMGPUVectorizationPass>(generateContract);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TilingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TilingUtils.h
@@ -1,0 +1,24 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_LLVMGPU_TILINGHELPER_H_
+#define IREE_COMPILER_CODEGEN_LLVMGPU_TILINGHELPER_H_
+
+#include "mlir/IR/BuiltinOps.h"
+
+namespace mlir {
+namespace func {
+class FuncOp;
+}
+namespace iree_compiler {
+
+/// Apply tiling to reduction dimensions based on op attributes.
+LogicalResult tileReduction(func::FuncOp funcOp);
+
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_LLVMGPU_TILINGHELPER_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h
@@ -47,7 +47,8 @@ class LLVMGPUExtensions
 /// Transformation to convert scf.foreach_thread to gpu distribution.
 FailureOr<SmallVector<OpFoldResult>> rewriteForeachThreadToGpu(
     scf::ForeachThreadOp foreachThreadOp,
-    const SmallVector<int64_t> &globalWorkgroupSizes, RewriterBase &rewriter);
+    const SmallVector<int64_t> &globalWorkgroupSizes, RewriterBase &rewriter,
+    bool syncAfterDistribute = true);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "illegal_configuration.mlir",
             "linalg_transform.mlir",
             "legalize.mlir",
+            "tensor_alloc.mlir",
             "tensorcore_vectorization.mlir",
             "tile_on_tensor.mlir",
             "transform_dialect_vector_distribution.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "nvvm_pipeline_test.mlir"
     "reduce_bank_conflicts.mlir"
     "rocdl_pipeline_test.mlir"
+    "tensor_alloc.mlir"
     "tensorcore_vectorization.mlir"
     "tile_on_tensor.mlir"
     "transform_dialect_bufferize.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/tensor_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/tensor_alloc.mlir
@@ -1,0 +1,29 @@
+// RUN: iree-opt %s -iree-llvmgpu-alloc | FileCheck %s
+
+func.func @matmul_2048x512x1024() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:2048x1024xf32>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:1024x512xf32>
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:2048x512xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %3 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_y]
+  %4 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
+  %5 = flow.dispatch.tensor.load %2, offsets = [%3, %4], sizes = [32, 128], strides = [1, 1] : !flow.dispatch.tensor<writeonly:2048x512xf32> -> tensor<32x128xf32>
+  %6 = flow.dispatch.tensor.load %0, offsets = [%3, 0], sizes = [32, 1024], strides = [1, 1] : !flow.dispatch.tensor<readonly:2048x1024xf32> -> tensor<32x1024xf32>
+  %7 = flow.dispatch.tensor.load %1, offsets = [0, %4], sizes = [1024, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:1024x512xf32> -> tensor<1024x128xf32>
+  %8 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[32, 128, 32]]>} ins(%cst : f32) outs(%5 : tensor<32x128xf32>) -> tensor<32x128xf32>
+  %9 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[32, 128, 32]]>} ins(%6, %7 : tensor<32x1024xf32>, tensor<1024x128xf32>) outs(%8 : tensor<32x128xf32>) -> tensor<32x128xf32>
+  flow.dispatch.tensor.store %9, %2, offsets = [%3, %4], sizes = [32, 128], strides = [1, 1] : tensor<32x128xf32> -> !flow.dispatch.tensor<writeonly:2048x512xf32>
+  return
+}
+
+//    CHECK-LABEL: func.func @matmul_2048x512x1024
+//         CHECK:    scf.for {{.*}} -> (tensor<32x128xf32>) {
+//         CHECK:      %[[A:.*]] = tensor.extract_slice %{{.*}}[0, %{{.*}}] [32, 32] [1, 1] : tensor<32x1024xf32> to tensor<32x32xf32>
+//         CHECK:      %[[B:.*]] = tensor.extract_slice %{{.*}}[%{{.*}}, 0] [32, 128] [1, 1] : tensor<1024x128xf32> to tensor<32x128xf32>
+//         CHECK:      %[[PA:.*]] = bufferization.alloc_tensor() copy(%[[A]]) {bufferization.escape = [false]} : tensor<32x32xf32>
+//         CHECK:      %[[PB:.*]] = bufferization.alloc_tensor() copy(%[[B]]) {bufferization.escape = [false]} : tensor<32x128xf32>
+//         CHECK:      %[[M:.*]] = linalg.matmul {{.*}} ins(%[[PA]], %[[PB]] : tensor<32x32xf32>, tensor<32x128xf32>) outs(%{{.*}} : tensor<32x128xf32>) -> tensor<32x128xf32>
+//         CHECK:      scf.yield %[[M]] : tensor<32x128xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vectorization.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vectorization.mlir
@@ -15,7 +15,7 @@ func.func @add_dispatch_0(%arg0: memref<1x8x4xf32>, %arg1: memref<1x4x8xf32>, %a
   return
 }
 // CHECK-LABEL: func.func @add_dispatch_0
-// CHECK-COUNT-8: vector.transfer_read {{.*}} : memref<1x8x4xf32>, vector<1x1x4xf32>
-// CHECK-COUNT-8: vector.transfer_read {{.*}} : memref<1x4x8xf32>, vector<1x1x4xf32>
-// CHECK-COUNT-8: addf %{{.*}}, %{{.*}} : vector<1x1x4xf32>
-// CHECK-COUNT-8: vector.transfer_write {{.*}} : vector<1x1x4xf32>, memref<1x4x8xf32>
+// CHECK: vector.transfer_read {{.*}} : memref<1x8x4xf32>, vector<1x8x4xf32>
+// CHECK: vector.transfer_read {{.*}} : memref<1x4x8xf32>, vector<1x4x8xf32>
+// CHECK: addf %{{.*}}, %{{.*}} : vector<1x4x8xf32>
+// CHECK: vector.transfer_write {{.*}} : vector<1x4x8xf32>, memref<1x4x8xf32>

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -343,13 +343,15 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTileTensor(
 
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUDistribute();
 
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorAlloc();
+
 /// Create pass calling the dynamic pipeline for LLVMGPU.
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createLLVMGPULowerExecutableTargetPass();
 
 /// Convert Linalg ops to Vector.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorizationPass(
-    int64_t nativeVector = 4, bool generateContract = true);
+    bool generateContract = true);
 
 /// Convert Linalg ops to Vector and prepare converstion to GPU MMA ops.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -316,14 +316,17 @@ def LLVMGPUDistribute :
   let constructor = "mlir::iree_compiler::createLLVMGPUDistribute()";
 }
 
+def LLVMGPUTensorAlloc :
+    Pass<"iree-llvmgpu-alloc", "func::FuncOp"> {
+  let summary = "Pass to create allocation for some values.";
+  let constructor = "mlir::iree_compiler::createLLVMGPUTensorAlloc()";
+}
+
 def LLVMGPUVectorization :
     Pass<"iree-llvmgpu-vectorization", "func::FuncOp"> {
   let summary = "Pass to convert linalg into Vector.";
   let constructor = "mlir::iree_compiler::createLLVMGPUVectorizationPass()";
   let options = [
-    Option<"nativeVector", "native-vector", "int64_t",
-            /*default=*/"4",
-           "Pick the native size being targeted.">,
     Option<"generateContract", "generate-contract", "bool",
             /*default=*/"true",
            "Try to convert reduction to vector.contract.">,


### PR DESCRIPTION
Transition mamul SIMT pipeline to do vectorization before bufferization.
This relies on alloc_tensor op to model shared memory promotion and
foreach_thread for the tiling at the tensor level.

Also simplify significantly the vectorization pass by removing patterns not needed anymore.

This will allow us to do more optimizations at the tensor going forward.
