### PR TITLE
Add iree_bytecode_module and iree_c_module static lib support

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -96,16 +96,16 @@ function(iree_bytecode_module)
     get_filename_component(_FRIENDLY_NAME "${_RULE_SRC}" NAME)
   endif()
 
-  # Check LLVM static library setting.
+  # Check LLVM static library setting. If the static libary output path is set,
+  # retrieve the object path and the corresponding header file path.
   foreach(_FLAG ${_RULE_FLAGS})
-    string(FIND
-      "${_FLAG}" "--iree-llvm-static-library-output-path=" _STATIC_OBJ_IDX
+    string(REGEX MATCH
+      "-iree-llvm-static-library-output-path=(.+)" _MATCH_STRING "${_FLAG}"
     )
-    if(_STATIC_OBJ_IDX GREATER_EQUAL 0)
+    if(_MATCH_STRING)
       set(_STATIC_LIB TRUE)
-      string(REPLACE
-        "--iree-llvm-static-library-output-path=" "" _STATIC_OBJ_PATH "${_FLAG}"
-      )
+      # Get the static object path from the regex match result.
+      set(_STATIC_OBJ_PATH ${CMAKE_MATCH_1})
       string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_STATIC_OBJ_PATH}")
     endif()
   endforeach(_FLAG)

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -62,16 +62,16 @@ function(iree_c_module)
   list(APPEND _ARGS "-o")
   list(APPEND _ARGS "${_RULE_H_FILE_OUTPUT}")
 
-  # Check LLVM static library setting.
+  # Check LLVM static library setting. If the static libary output path is set,
+  # retrieve the object path and the corresponding header file path.
   foreach(_FLAG ${_RULE_FLAGS})
-    string(FIND
-      "${_FLAG}" "--iree-llvm-static-library-output-path=" _STATIC_OBJ_IDX
+    string(REGEX MATCH
+      "-iree-llvm-static-library-output-path=(.+)" _MATCH_STRING "${_FLAG}"
     )
-    if(_STATIC_OBJ_IDX GREATER_EQUAL 0)
+    if(_MATCH_STRING)
       set(_STATIC_LIB TRUE)
-      string(REPLACE
-        "--iree-llvm-static-library-output-path=" "" _STATIC_OBJ_PATH "${_FLAG}"
-      )
+      # Get the static object path from the regex match result.
+      set(_STATIC_OBJ_PATH ${CMAKE_MATCH_1})
       string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_STATIC_OBJ_PATH}")
     endif()
   endforeach(_FLAG)

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -18,6 +18,8 @@ include(CMakeParseArguments)
 #     `--output-format=vm-c` is included automatically.
 # TESTONLY: When added, this target will only be built if user passes
 #     -DIREE_BUILD_TESTS=ON to CMake.
+# NO_RUNTIME: When added, this target will be built without the runtime library
+#     support.
 #
 # Note:
 # By default, iree_c_module will create a library named ${NAME},
@@ -26,7 +28,7 @@ include(CMakeParseArguments)
 function(iree_c_module)
   cmake_parse_arguments(
     _RULE
-    "TESTONLY"
+    "TESTONLY;NO_RUNTIME"
     "NAME;SRC;H_FILE_OUTPUT;COMPILE_TOOL"
     "FLAGS"
     ${ARGN}
@@ -52,32 +54,61 @@ function(iree_c_module)
   endif()
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
+  get_filename_component(_SRC_PATH "${_RULE_SRC}" REALPATH)
 
   set(_ARGS "--output-format=vm-c")
   list(APPEND _ARGS "${_RULE_FLAGS}")
-  list(APPEND _ARGS "${CMAKE_CURRENT_SOURCE_DIR}/${_RULE_SRC}")
+  list(APPEND _ARGS "${_SRC_PATH}")
   list(APPEND _ARGS "-o")
   list(APPEND _ARGS "${_RULE_H_FILE_OUTPUT}")
 
+  # Check LLVM static library setting.
+  foreach(_FLAG ${_RULE_FLAGS})
+    string(FIND
+      "${_FLAG}" "--iree-llvm-static-library-output-path=" _STATIC_OBJ_IDX
+    )
+    if(_STATIC_OBJ_IDX GREATER_EQUAL 0)
+      set(_STATIC_LIB TRUE)
+      string(REPLACE
+        "--iree-llvm-static-library-output-path=" "" _STATIC_OBJ_PATH "${_FLAG}"
+      )
+      string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_STATIC_OBJ_PATH}")
+    endif()
+  endforeach(_FLAG)
+
+  set(_OUTPUT_FILES "${_RULE_H_FILE_OUTPUT}")
+  if(_STATIC_LIB)
+    list(APPEND _OUTPUT_FILES "${_STATIC_OBJ_PATH}" "${_STATIC_HDR_PATH}")
+  endif()
   add_custom_command(
-    OUTPUT "${_RULE_H_FILE_OUTPUT}"
+    OUTPUT ${_OUTPUT_FILES}
     COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}
     # Changes to either the compiler tool or the input source should rebuild.
-    DEPENDS ${_COMPILE_TOOL_EXECUTABLE} ${_RULE_SRC}
+    DEPENDS ${_COMPILE_TOOL_EXECUTABLE} ${_SRC_PATH}
   )
+
+  if(NOT _RULE_NO_RUNTIME)
+    set(_LIB_RUNTIME_SRC
+      "${IREE_SOURCE_DIR}/runtime/src/iree/vm/module_impl_emitc.c")
+    # Include paths and options for the runtime sources.
+    set(_LIB_RUNTIME_DEP iree::runtime::src::defs)
+  endif()
 
   iree_cc_library(
     NAME ${_RULE_NAME}
     HDRS "${_RULE_H_FILE_OUTPUT}"
-    SRCS "${IREE_SOURCE_DIR}/runtime/src/iree/vm/module_impl_emitc.c"
+    SRCS "${_LIB_RUNTIME_SRC}"
     INCLUDES "${CMAKE_CURRENT_BINARY_DIR}"
     COPTS
       "-DEMITC_IMPLEMENTATION=\"${_RULE_H_FILE_OUTPUT}\""
       "${_TESTONLY_ARG}"
     DEPS
-      # Include paths and options for the runtime sources.
-      iree::runtime::src::defs
+      ${_LIB_RUNTIME_DEP}
   )
+
+  if(_RULE_NO_RUNTIME)
+    return()
+  endif()
 
   set(_GEN_TARGET "${_NAME}_gen")
   add_custom_target(

--- a/build_tools/cmake/iree_static_linker_test.cmake
+++ b/build_tools/cmake/iree_static_linker_test.cmake
@@ -69,7 +69,7 @@ function(iree_static_linker_test)
   endif()
 
   iree_get_executable_path(_COMPILER_TOOL "iree-compile")
-  get_filename_component(_SRC_PATH "${_RULE_SRC}" REALPATH)
+
   iree_package_name(_PACKAGE_NAME)
   iree_package_ns(_PACKAGE_NS)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")
@@ -87,66 +87,34 @@ function(iree_static_linker_test)
   if(_RULE_TARGET_CPU_FEATURES)
     list(APPEND _COMPILER_ARGS "--iree-llvm-target-cpu-features=${_RULE_TARGET_CPU_FEATURES}")
   endif()
-  list(APPEND _COMPILER_ARGS "${_SRC_PATH}")
 
   if(_RULE_EMITC)
     set(_C_FILE_NAME "${_RULE_NAME}_emitc.h")
-    list(APPEND _COMPILER_ARGS "--output-format=vm-c")
-    list(APPEND _COMPILER_ARGS "-o")
-    list(APPEND _COMPILER_ARGS "${_C_FILE_NAME}")
+    iree_c_module(
+      NAME
+        ${_RULE_NAME}_emitc
+      SRC
+        "${_RULE_SRC}"
+      FLAGS
+        ${_COMPILER_ARGS}
+      H_FILE_OUTPUT
+        "${_C_FILE_NAME}"
+      NO_RUNTIME
 
-    # Custom command for iree-compile to generate static library and C module.
-    add_custom_command(
-      OUTPUT
-        ${_H_FILE_NAME}
-        ${_O_FILE_NAME}
-        ${_C_FILE_NAME}
-      COMMAND ${_COMPILER_TOOL} ${_COMPILER_ARGS}
-      DEPENDS ${_COMPILER_TOOL} ${_RULE_SRC}
-    )
-
-    set(_EMITC_LIB_NAME "${_NAME}_emitc")
-    add_library(${_EMITC_LIB_NAME}
-      STATIC
-      ${_C_FILE_NAME}
-    )
-    target_compile_definitions(${_EMITC_LIB_NAME} PUBLIC EMITC_IMPLEMENTATION)
-    SET_TARGET_PROPERTIES(
-      ${_EMITC_LIB_NAME}
-      PROPERTIES
-        LINKER_LANGUAGE C
     )
   else()  # bytecode module path
-    set(_VMFB_FILE_NAME ${_RULE_NAME}.vmfb)
-    list(APPEND _COMPILER_ARGS "-o")
-    list(APPEND _COMPILER_ARGS "${_VMFB_FILE_NAME}")
-
-    # Custom command for iree-compile to generate static library and VM module.
-    add_custom_command(
-      OUTPUT
-        ${_H_FILE_NAME}
-        ${_O_FILE_NAME}
-        ${_VMFB_FILE_NAME}
-      COMMAND ${_COMPILER_TOOL} ${_COMPILER_ARGS}
-      DEPENDS ${_COMPILER_TOOL} ${_RULE_SRC}
-    )
-
     # Generate the embed data with the bytecode module.
-    set(_MODULE_C_NAME "${_RULE_NAME}_module_c")
-    set(_EMBED_H_FILE_NAME ${_MODULE_C_NAME}.h)
-    set(_EMBED_C_FILE_NAME ${_MODULE_C_NAME}.c)
-    iree_c_embed_data(
+    set(_MODULE_NAME "${_RULE_NAME}_module")
+    set(_EMBED_H_FILE_NAME ${_MODULE_NAME}_c.h)
+    iree_bytecode_module(
       NAME
-        "${_MODULE_C_NAME}"
-      IDENTIFIER
+        ${_MODULE_NAME}
+      SRC
+        "${_RULE_SRC}"
+      FLAGS
+        ${_COMPILER_ARGS}
+      C_IDENTIFIER
         "${_NAME}"
-      GENERATED_SRCS
-        "${_VMFB_FILE_NAME}"
-      C_FILE_OUTPUT
-        "${_EMBED_C_FILE_NAME}"
-      H_FILE_OUTPUT
-        "${_EMBED_H_FILE_NAME}"
-      FLATTEN
       PUBLIC
     )
   endif(_RULE_EMITC)
@@ -277,7 +245,11 @@ function(iree_static_linker_test)
     target_link_libraries(${_NAME}_run
         PRIVATE
           iree_vm_shims_emitc
-          ${_EMITC_LIB_NAME}
+          ${_NAME}_emitc
+    )
+    target_compile_definitions(${_NAME}_run
+      PRIVATE
+      EMITC_IMPLEMENTATION=\"${_C_FILE_NAME}\"
     )
   else()
     target_link_libraries(${_NAME}_run PRIVATE ${_NAME}_module_c)


### PR DESCRIPTION
To make the secondary function like iree_static_linker_test cleaner.