### PR TITLE
Fix the typos of riscv names in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,7 +558,7 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_RISCV_DIR: "build-riscv-rv32-baremetal"
+      BUILD_RISCV_DIR: "build-riscv32-baremetal"
       RISCV_CONFIG: "rv32-baremetal"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
@@ -592,7 +592,7 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_RISCV_DIR: "build-riscv-r64"
+      BUILD_RISCV_DIR: "build-riscv64"
       RISCV_CONFIG: "rv64"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}


### PR DESCRIPTION
RISC-V 32/64 can be called either riscv32/riscv64 or rv32/rv64. Fixed several names in the CI workflow.