### PR TITLE
Add CI job to build benchmark tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,6 +585,68 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
+    needs: [should_run, build_all]
+    if: needs.should_run.outputs.should-run == 'true'
+    runs-on:
+      # Pseudo-ternary hack and order matters. See comment at top of file.
+      - self-hosted
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - cpu
+      - os-family=Linux
+    outputs:
+      tools-dir: ${{ steps.build.outputs.tools-dir }}
+      tools-archive: ${{ steps.archive.outputs.tools-archive }}
+      tools-gcs-artifact: ${{ steps.upload.outputs.tools-gcs-artifact }}
+    env:
+      BUILD_RISCV_DIR: "build-riscv64"
+      RISCV_CONFIG: "rv64"
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          submodules: true
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Cross-compiling and testing riscv64"
+        id: build
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "RISCV_CONFIG=${RISCV_CONFIG}" \
+            --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
+            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+            --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \
+            --env "LLVM_BIN_DIR=${BUILD_DIR}/third_party/llvm-project/llvm/bin" \
+            gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
+            bash -euo pipefail -c \
+              "./build_tools/cmake/build_riscv.sh"
+          echo "::set-output name=tools-dir::${BUILD_RISCV_DIR}/tools"
+      - name: "Creating riscv64 cross-compiled tools archive"
+        id: archive
+        env:
+          TOOLS_ARCHIVE: riscv64-tools.tar
+        run: |
+          tar -cf ${TOOLS_ARCHIVE} \
+            ${BUILD_RISCV_DIR}/tools/iree-benchmark-module \
+            ${BUILD_RISCV_DIR}/tools/iree-benchmark-trace \
+            ${BUILD_RISCV_DIR}/tools/iree-check-module \
+            ${BUILD_RISCV_DIR}/tools/iree-run-module \
+            ${BUILD_RISCV_DIR}/tools/iree-run-trace
+          echo "::set-output name=tools-archive::${TOOLS_ARCHIVE}"
+      - name: "Uploading riscv64 cross-compiled tools archive"
+        id: upload
+        env:
+          TOOLS_ARCHIVE: ${{ steps.archive.outputs.tools-archive }}
+          TOOLS_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.tools-archive }}
+        run: |
+          gcloud alpha storage cp "${TOOLS_ARCHIVE}" "${TOOLS_GCS_ARTIFACT}"
+          echo "::set-output name=tools-gcs-artifact::${TOOLS_GCS_ARTIFACT}"
+
+  test-riscv64:
     needs: [should_run, build_all, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -652,7 +652,7 @@ jobs:
             docker_image: "gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35"
             enable_tracing: true
     outputs:
-      benchmark-tools-gcs-artifacts: ${{ steps.upload.outputs }}
+      benchmark-tools-gcs-artifacts: ${{ toJSON(steps.upload.outputs) }}
     env:
       PLATFORM: ${{ matrix.target.platform }}
       ARCHITECTURE: ${{ matrix.target.architecture }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -626,7 +626,7 @@ jobs:
             bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
           echo "::set-output name=build-dir::${BUILD_RISCV_DIR}"
           echo "::set-output name=tools-dir::${BUILD_RISCV_DIR}/tools"
-      - name: "Creating riscv64 cross-compiled archives"
+      - name: "Creating riscv64 cross-compiled build dir and tool archives"
         id: archive
         env:
           BUILD_RISCV_DIR_ARCHIVE: ${{ env.BUILD_RISCV_DIR }}.tar.zst
@@ -643,7 +643,7 @@ jobs:
             ${BUILD_RISCV_DIR}/tools/iree-run-trace
           echo "::set-output name=build-dir-archive::${BUILD_RISCV_DIR_ARCHIVE}"
           echo "::set-output name=tools-archive::${TOOLS_ARCHIVE}"
-      - name: "Uploading riscv64 cross-compiled archives"
+      - name: "Uploading riscv64 cross-compiled build dir and tool archives"
         id: upload
         env:
           BUILD_RISCV_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,7 @@ jobs:
           TRACED_BENCHMARK_TOOLS_DIR: ${{ steps.build-with-tracing.outputs.traced-benchmark-tools-dir }}
           BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.config }}-benchmarks-tools.tar
         run: |
-          tar -cf ${TOOLS_ARCHIVE} \
+          tar -cf ${BENCHMARK_TOOLS_ARCHIVE} \
             ${BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module \
             ${TRACED_BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module
           echo "::set-output name=benchmark-tools-archive::${BENCHMARK_TOOLS_ARCHIVE}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -619,8 +619,8 @@ jobs:
       - name: "Cross-compiling and testing riscv64"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "BUILD_ARCH=${BUILD_ARCH}" \
-            --env "BUILD_TARGET_DIR=${BUILD_TARGET_DIR}" \
+            --env "${PLATFORM^^}_ARCH=${BUILD_ARCH}" \
+            --env "BUILD_${ARCH^^}_DIR=${BUILD_TARGET_DIR}" \
             --env "BUILD_RISCV_DIR=${BUILD_TARGET_DIR}" \
             --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
@@ -668,8 +668,8 @@ jobs:
         id: build
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "BUILD_ARCH=${ARCHITECTURE}" \
-            --env "BUILD_TARGET_DIR=${BUILD_TOOLS_DIR}/normal" \
+            --env "${PLATFORM^^}_ARCH=${ARCHITECTURE}" \
+            --env "BUILD_${PLATFORM^^}_DIR=${BUILD_TOOLS_DIR}/normal" \
             --env "BUILD_PRESET=benchmark" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             "${DOCKER_IMAGE}" \
@@ -678,7 +678,7 @@ jobs:
         id: build-with-tracing
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "BUILD_ARCH=${ARCHITECTURE}" \
+            --env "${PLATFORM^^}_ARCH=${ARCHITECTURE}" \
             --env "BUILD_${PLATFORM^^}_DIR=${BUILD_TOOLS_DIR}/traced" \
             --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,9 +642,6 @@ jobs:
       matrix:
         target:
           - platform: riscv
-            architecture: rv32-baremetal
-            docker_image: gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35
-          - platform: riscv
             architecture: rv64
             docker_image: gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,14 +643,8 @@ jobs:
       matrix:
         target:
           - platform: "riscv"
-            architecture: "rv32-baremetal"
-            docker_image: "gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35"
-            # Tracy runtime can't be built on baremetal yet.
-            enable_tracing: false
-          - platform: "riscv"
             architecture: "rv64"
             docker_image: "gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35"
-            enable_tracing: true
     outputs:
       benchmark-tools-gcs-artifacts: ${{ toJSON(steps.upload.outputs) }}
     env:
@@ -682,7 +676,6 @@ jobs:
             bash -euo pipefail -c "./build_tools/cmake/build_${PLATFORM}.sh"
       - name: "Compiling the benchmark tools with tracing"
         id: build-with-tracing
-        if: ${{ matrix.target.enable_tracing }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "BUILD_ARCH=${ARCHITECTURE}" \
@@ -697,7 +690,7 @@ jobs:
           BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.architecture }}-benchmarks-tools.tar
         run: |
           tar -cf ${BENCHMARK_TOOLS_ARCHIVE} \
-            ${BUILD_TOOLS_DIR}/normal/tools/iree-benchmark-module
+            ${BUILD_TOOLS_DIR}/*/tools/iree-benchmark-module
           echo "::set-output name=benchmark-tools-archive::${BENCHMARK_TOOLS_ARCHIVE}"
       - name: "Uploading the benchmark tools archive"
         id: upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,7 @@ jobs:
           BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.architecture }}-benchmarks-tools.tar
         run: |
           tar -cf ${BENCHMARK_TOOLS_ARCHIVE} \
-            ${BUILD_TOOLS_DIR}/*/tools/iree-benchmark-module \
+            ${BUILD_TOOLS_DIR}/*/tools/iree-benchmark-module
           echo "::set-output name=benchmark-tools-archive::${BENCHMARK_TOOLS_ARCHIVE}"
       - name: "Uploading the benchmark tools archive"
         id: upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -642,18 +642,22 @@ jobs:
     strategy:
       matrix:
         target:
-          - platform: riscv
-            architecture: rv64
-            docker_image: gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35
+          - platform: "riscv"
+            architecture: "rv32-baremetal"
+            docker_image: "gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35"
+            # Tracy runtime can't be built on baremetal yet.
+            enable_tracing: false
+          - platform: "riscv"
+            architecture: "rv64"
+            docker_image: "gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35"
+            enable_tracing: true
     outputs:
-      riscv-rv32-baremetal-benchmark-tools-gcs-artifact: ${{ steps.upload.outputs.riscv-rv32-baremetal-benchmark-tools-gcs-artifact }}
-      riscv-rv64-benchmark-tools-gcs-artifact: ${{ steps.upload.outputs.riscv-rv64-benchmark-tools-gcs-artifact }}
+      benchmark-tools-gcs-artifacts: ${{ steps.upload.outputs }}
     env:
       PLATFORM: ${{ matrix.target.platform }}
       ARCHITECTURE: ${{ matrix.target.architecture }}
       DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-      BUILD_TOOLS_DIR: "benchmark-tools-dir"
-      BUILD_TRACED_TOOLS_DIR: "traced-benchmark-tools-dir"
+      BUILD_TOOLS_DIR: ${{ matrix.target.platform }}-${{ matrix.target.architecture }}-benchmark-tools-dir
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
@@ -671,33 +675,29 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "BUILD_ARCH=${ARCHITECTURE}" \
-            --env "BUILD_TARGET_DIR=${BUILD_TOOLS_DIR}" \
+            --env "BUILD_TARGET_DIR=${BUILD_TOOLS_DIR}/normal" \
             --env "BUILD_PRESET=benchmark" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             "${DOCKER_IMAGE}" \
             bash -euo pipefail -c "./build_tools/cmake/build_${PLATFORM}.sh"
-          echo "::set-output name=benchmark-tools-dir::${BUILD_TOOLS_DIR}"
       - name: "Compiling the benchmark tools with tracing"
         id: build-with-tracing
+        if: ${{ matrix.target.enable_tracing }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "BUILD_ARCH=${ARCHITECTURE}" \
-            --env "BUILD_TARGET_DIR=${BUILD_TRACED_TOOLS_DIR}" \
+            --env "BUILD_TARGET_DIR=${BUILD_TOOLS_DIR}/traced" \
             --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             "${DOCKER_IMAGE}" \
             bash -euo pipefail -c "./build_tools/cmake/build_${PLATFORM}.sh"
-          echo "::set-output name=traced-benchmark-tools-dir::${BUILD_TRACED_TOOLS_DIR}"
       - name: "Creating the benchmark tools archive"
         id: archive
         env:
-          BENCHMARK_TOOLS_DIR: ${{ steps.build.outputs.benchmark-tools-dir }}
-          TRACED_BENCHMARK_TOOLS_DIR: ${{ steps.build-with-tracing.outputs.traced-benchmark-tools-dir }}
           BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.architecture }}-benchmarks-tools.tar
         run: |
           tar -cf ${BENCHMARK_TOOLS_ARCHIVE} \
-            ${BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module \
-            ${TRACED_BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module
+            ${BUILD_TOOLS_DIR}/*/tools/iree-benchmark-module \
           echo "::set-output name=benchmark-tools-archive::${BENCHMARK_TOOLS_ARCHIVE}"
       - name: "Uploading the benchmark tools archive"
         id: upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -697,7 +697,7 @@ jobs:
           BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.architecture }}-benchmarks-tools.tar
         run: |
           tar -cf ${BENCHMARK_TOOLS_ARCHIVE} \
-            ${BUILD_TOOLS_DIR}/*/tools/iree-benchmark-module
+            ${BUILD_TOOLS_DIR}/normal/tools/iree-benchmark-module
           echo "::set-output name=benchmark-tools-archive::${BENCHMARK_TOOLS_ARCHIVE}"
       - name: "Uploading the benchmark tools archive"
         id: upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,9 +577,9 @@ jobs:
       - name: "Cross-compiling and testing riscv32"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "BUILD_ARCH=${BUILD_ARCH}" \
-            --env "BUILD_TARGET_DIR=${BUILD_TARGET_DIR}" \
+            --env "RISCV_ARCH=${BUILD_ARCH}" \
             --env "BUILD_RISCV_DIR=${BUILD_TARGET_DIR}" \
+            --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
             bash -euo pipefail -c \
@@ -619,8 +619,7 @@ jobs:
       - name: "Cross-compiling and testing riscv64"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "${PLATFORM^^}_ARCH=${BUILD_ARCH}" \
-            --env "BUILD_${ARCH^^}_DIR=${BUILD_TARGET_DIR}" \
+            --env "RISCV_ARCH=${BUILD_ARCH}" \
             --env "BUILD_RISCV_DIR=${BUILD_TARGET_DIR}" \
             --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
@@ -662,8 +661,8 @@ jobs:
           submodules: true
       - name: "Downloading build dir archive"
         run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting host binaries"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
       - name: "Compiling the benchmark tools"
         id: build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -693,7 +693,7 @@ jobs:
         run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
       - name: "Extracting TF binaries archive"
         run: tar -xf "${TF_BINARIES_ARCHIVE}"
-      - name: "Cross-compiling and testing riscv64"
+      - name: "Testing riscv64"
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "RISCV_CONFIG=${RISCV_CONFIG}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,6 +621,7 @@ jobs:
           ./build_tools/github_actions/docker_run.sh \
             --env "BUILD_ARCH=${BUILD_ARCH}" \
             --env "BUILD_TARGET_DIR=${BUILD_TARGET_DIR}" \
+            --env "BUILD_RISCV_DIR=${BUILD_TARGET_DIR}" \
             --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,8 +560,8 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_RISCV_DIR: "build-riscv32-baremetal"
-      RISCV_CONFIG: "rv32-baremetal"
+      BUILD_TARGET_DIR: "build-riscv32-baremetal"
+      BUILD_ARCH: "rv32-baremetal"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
@@ -577,14 +577,15 @@ jobs:
       - name: "Cross-compiling and testing riscv32"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "RISCV_CONFIG=${RISCV_CONFIG}" \
-            --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
+            --env "BUILD_ARCH=${BUILD_ARCH}" \
+            --env "BUILD_TARGET_DIR=${BUILD_TARGET_DIR}" \
+            --env "BUILD_RISCV_DIR=${BUILD_TARGET_DIR}" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
             bash -euo pipefail -c \
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
-  build_and_test_riscv64:
+  riscv64:
     needs: [should_run, build_all, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
@@ -594,8 +595,8 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_RISCV_DIR: "build-riscv64"
-      RISCV_CONFIG: "rv64"
+      BUILD_TARGET_DIR: "build-riscv64"
+      BUILD_ARCH: "rv64"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
@@ -618,8 +619,8 @@ jobs:
       - name: "Cross-compiling and testing riscv64"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "RISCV_CONFIG=${RISCV_CONFIG}" \
-            --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
+            --env "BUILD_ARCH=${BUILD_ARCH}" \
+            --env "BUILD_TARGET_DIR=${BUILD_TARGET_DIR}" \
             --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \
@@ -640,14 +641,19 @@ jobs:
     strategy:
       matrix:
         target:
-          - {platform: riscv, config: rv32-baremetal}
-          - {platform: riscv, config: rv64}
+          - platform: riscv
+            architecture: rv32-baremetal
+            docker_image: gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35
+          - platform: riscv
+            architecture: rv64
+            docker_image: gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35
     outputs:
       riscv-rv32-baremetal-benchmark-tools-gcs-artifact: ${{ steps.upload.outputs.riscv-rv32-baremetal-benchmark-tools-gcs-artifact }}
       riscv-rv64-benchmark-tools-gcs-artifact: ${{ steps.upload.outputs.riscv-rv64-benchmark-tools-gcs-artifact }}
     env:
-      TARGET_PLATFORM: ${{ matrix.target.platform }}
-      TARGET_CONFIG: ${{ matrix.target.config }}
+      PLATFORM: ${{ matrix.target.platform }}
+      ARCHITECTURE: ${{ matrix.target.architecture }}
+      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
       BUILD_TOOLS_DIR: "benchmark-tools-dir"
       BUILD_TRACED_TOOLS_DIR: "traced-benchmark-tools-dir"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
@@ -666,30 +672,30 @@ jobs:
         id: build
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "RISCV_CONFIG=${TARGET_CONFIG}" \
-            --env "BUILD_RISCV_DIR=${BUILD_TOOLS_DIR}" \
+            --env "BUILD_ARCH=${ARCHITECTURE}" \
+            --env "BUILD_TARGET_DIR=${BUILD_TOOLS_DIR}" \
             --env "BUILD_PRESET=benchmark" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
-            bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
+            "${DOCKER_IMAGE}" \
+            bash -euo pipefail -c "./build_tools/cmake/build_${PLATFORM}.sh"
           echo "::set-output name=benchmark-tools-dir::${BUILD_TOOLS_DIR}"
       - name: "Compiling the benchmark tools with tracing"
         id: build-with-tracing
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            --env "RISCV_CONFIG=${TARGET_CONFIG}" \
-            --env "BUILD_RISCV_DIR=${BUILD_TRACED_TOOLS_DIR}" \
+            --env "BUILD_ARCH=${ARCHITECTURE}" \
+            --env "BUILD_TARGET_DIR=${BUILD_TRACED_TOOLS_DIR}" \
             --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
-            bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
+            "${DOCKER_IMAGE}" \
+            bash -euo pipefail -c "./build_tools/cmake/build_${PLATFORM}.sh"
           echo "::set-output name=traced-benchmark-tools-dir::${BUILD_TRACED_TOOLS_DIR}"
       - name: "Creating the benchmark tools archive"
         id: archive
         env:
           BENCHMARK_TOOLS_DIR: ${{ steps.build.outputs.benchmark-tools-dir }}
           TRACED_BENCHMARK_TOOLS_DIR: ${{ steps.build-with-tracing.outputs.traced-benchmark-tools-dir }}
-          BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.config }}-benchmarks-tools.tar
+          BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.architecture }}-benchmarks-tools.tar
         run: |
           tar -cf ${BENCHMARK_TOOLS_ARCHIVE} \
             ${BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module \
@@ -702,7 +708,7 @@ jobs:
           BENCHMARK_TOOLS_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.benchmark-tools-archive }}
         run: |
           gcloud alpha storage cp "${BENCHMARK_TOOLS_ARCHIVE}" "${BENCHMARK_TOOLS_GCS_ARTIFACT}"
-          echo "::set-output name=${TARGET_PLATFORM}-${TARGET_CONFIG}-benchmark-tools-gcs-artifact::${BENCHMARK_TOOLS_GCS_ARTIFACT}"
+          echo "::set-output name=${PLATFORM}-${ARCHITECTURE}-benchmark-tools-gcs-artifact::${BENCHMARK_TOOLS_GCS_ARTIFACT}"
 
   ##############################################################################
 
@@ -736,7 +742,7 @@ jobs:
       # Crosscompilation
       - android_arm64
       - riscv32
-      - build_and_test_riscv64
+      - riscv64
 
       # Benchmark tools
       - build_benchmark_tools

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -662,29 +662,29 @@ jobs:
         run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Cross-compiling the benchmark tools"
+      - name: "Compiling the benchmark tools"
         id: build
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "RISCV_CONFIG=${TARGET_CONFIG}" \
             --env "BUILD_RISCV_DIR=${BUILD_TOOLS_DIR}" \
-            --env "BUILD_PRESET=benchmarks" \
+            --env "BUILD_PRESET=benchmark" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
             bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
           echo "::set-output name=benchmark-tools-dir::${BUILD_TOOLS_DIR}"
-      - name: "Cross-compiling the benchmark tools with tracing"
+      - name: "Compiling the benchmark tools with tracing"
         id: build-with-tracing
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "RISCV_CONFIG=${TARGET_CONFIG}" \
             --env "BUILD_RISCV_DIR=${BUILD_TRACED_TOOLS_DIR}" \
-            --env "BUILD_PRESET=benchmarks-with-tracing" \
+            --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
             bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
           echo "::set-output name=traced-benchmark-tools-dir::${BUILD_TRACED_TOOLS_DIR}"
-      - name: "Creating the cross-compiled benchmark tools archive"
+      - name: "Creating the benchmark tools archive"
         id: archive
         env:
           BENCHMARK_TOOLS_DIR: ${{ steps.build.outputs.benchmark-tools-dir }}
@@ -695,7 +695,7 @@ jobs:
             ${BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module \
             ${TRACED_BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module
           echo "::set-output name=benchmark-tools-archive::${BENCHMARK_TOOLS_ARCHIVE}"
-      - name: "Uploading the cross-compiled benchmark tools archive"
+      - name: "Uploading the benchmark tools archive"
         id: upload
         env:
           BENCHMARK_TOOLS_ARCHIVE: ${{ steps.archive.outputs.benchmark-tools-archive }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -679,7 +679,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "BUILD_ARCH=${ARCHITECTURE}" \
-            --env "BUILD_TARGET_DIR=${BUILD_TOOLS_DIR}/traced" \
+            --env "BUILD_${PLATFORM^^}_DIR=${BUILD_TOOLS_DIR}/traced" \
             --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             "${DOCKER_IMAGE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,8 +584,8 @@ jobs:
             bash -euo pipefail -c \
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
-  build_riscv64:
-    needs: [should_run, build_all]
+  build_and_test_riscv64:
+    needs: [should_run, build_all, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -593,86 +593,12 @@ jobs:
       - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
-    outputs:
-      build-dir: ${{ steps.build.outputs.build-dir }}
-      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
-      tools-dir: ${{ steps.build.outputs.tools-dir }}
-      tools-archive: ${{ steps.archive.outputs.tools-archive }}
-      tools-gcs-artifact: ${{ steps.upload.outputs.tools-gcs-artifact }}
     env:
       BUILD_RISCV_DIR: "build-riscv64"
       RISCV_CONFIG: "rv64"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
-        with:
-          submodules: true
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Cross-compiling riscv64"
-        id: build
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "RISCV_CONFIG=${RISCV_CONFIG}" \
-            --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
-            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
-            bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
-          echo "::set-output name=build-dir::${BUILD_RISCV_DIR}"
-          echo "::set-output name=tools-dir::${BUILD_RISCV_DIR}/tools"
-      - name: "Creating riscv64 cross-compiled build dir and tool archives"
-        id: archive
-        env:
-          BUILD_RISCV_DIR_ARCHIVE: ${{ env.BUILD_RISCV_DIR }}.tar.zst
-          TOOLS_ARCHIVE: riscv64-tools.tar
-        run: |
-          tar --exclude '*.a' --exclude '*.o' \
-            -I 'zstd -T0' \
-            -cf ${BUILD_RISCV_DIR_ARCHIVE} ${BUILD_RISCV_DIR}
-          tar -cf ${TOOLS_ARCHIVE} \
-            ${BUILD_RISCV_DIR}/tools/iree-benchmark-module \
-            ${BUILD_RISCV_DIR}/tools/iree-benchmark-trace \
-            ${BUILD_RISCV_DIR}/tools/iree-check-module \
-            ${BUILD_RISCV_DIR}/tools/iree-run-module \
-            ${BUILD_RISCV_DIR}/tools/iree-run-trace
-          echo "::set-output name=build-dir-archive::${BUILD_RISCV_DIR_ARCHIVE}"
-          echo "::set-output name=tools-archive::${TOOLS_ARCHIVE}"
-      - name: "Uploading riscv64 cross-compiled build dir and tool archives"
-        id: upload
-        env:
-          BUILD_RISCV_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
-          BUILD_RISCV_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
-          TOOLS_ARCHIVE: ${{ steps.archive.outputs.tools-archive }}
-          TOOLS_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.tools-archive }}
-        run: |
-          gcloud alpha storage cp "${BUILD_RISCV_DIR_ARCHIVE}" "${BUILD_RISCV_DIR_GCS_ARTIFACT}"
-          gcloud alpha storage cp "${TOOLS_ARCHIVE}" "${TOOLS_GCS_ARTIFACT}"
-          echo "::set-output name=build-dir-gcs-artifact::${BUILD_RISCV_DIR_GCS_ARTIFACT}"
-          echo "::set-output name=tools-gcs-artifact::${TOOLS_GCS_ARTIFACT}"
-
-  test_riscv64:
-    needs: [should_run, build_all, build_riscv64, build_tf_integrations]
-    if: needs.should_run.outputs.should-run == 'true'
-    runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
-      - cpu
-      - os-family=Linux
-    env:
-      RISCV_CONFIG: "rv64"
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      BUILD_RISCV_DIR: ${{ needs.build_riscv64.outputs.build-dir }}
-      BUILD_RISCV_DIR_ARCHIVE: ${{ needs.build_riscv64.outputs.build-dir-archive }}
-      BUILD_RISCV_DIR_GCS_ARTIFACT: ${{ needs.build_riscv64.outputs.build-dir-gcs-artifact }}
       TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
       TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
       TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
@@ -685,24 +611,98 @@ jobs:
         run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Downloading build riscv dir archive"
-        run: gcloud alpha storage cp "${BUILD_RISCV_DIR_GCS_ARTIFACT}" "${BUILD_RISCV_DIR_ARCHIVE}"
-      - name: "Extracting build riscv dir archive"
-        run: tar -xf "${BUILD_RISCV_DIR_ARCHIVE}"
       - name: "Downloading TF binaries archive"
         run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
       - name: "Extracting TF binaries archive"
         run: tar -xf "${TF_BINARIES_ARCHIVE}"
-      - name: "Testing riscv64"
+      - name: "Cross-compiling and testing riscv64"
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "RISCV_CONFIG=${RISCV_CONFIG}" \
             --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
+            --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \
             --env "LLVM_BIN_DIR=${BUILD_DIR}/third_party/llvm-project/llvm/bin" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
-            bash -euo pipefail -c "./tests/riscv64/smoke.sh"
+            bash -euo pipefail -c \
+              "./build_tools/cmake/build_riscv.sh && ./tests/riscv64/smoke.sh"
+
+  build_benchmark_tools:
+    needs: [should_run, build_all]
+    if: needs.should_run.outputs.should-run == 'true'
+    runs-on:
+      # Pseudo-ternary hack and order matters. See comment at top of file.
+      - self-hosted
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - cpu
+      - os-family=Linux
+    strategy:
+      matrix:
+        target:
+          - {platform: riscv, config: rv32-baremetal}
+          - {platform: riscv, config: rv64}
+    outputs:
+      riscv-rv32-baremetal-benchmark-tools-gcs-artifact: ${{ steps.upload.outputs.riscv-rv32-baremetal-benchmark-tools-gcs-artifact }}
+      riscv-rv64-benchmark-tools-gcs-artifact: ${{ steps.upload.outputs.riscv-rv64-benchmark-tools-gcs-artifact }}
+    env:
+      TARGET_PLATFORM: ${{ matrix.target.platform }}
+      TARGET_CONFIG: ${{ matrix.target.config }}
+      BUILD_TOOLS_DIR: "benchmark-tools-dir"
+      BUILD_TRACED_TOOLS_DIR: "traced-benchmark-tools-dir"
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          submodules: true
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Cross-compiling the benchmark tools"
+        id: build
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "RISCV_CONFIG=${TARGET_CONFIG}" \
+            --env "BUILD_RISCV_DIR=${BUILD_TOOLS_DIR}" \
+            --env "BUILD_PRESET=benchmarks" \
+            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+            gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
+            bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
+          echo "::set-output name=benchmark-tools-dir::${BUILD_TOOLS_DIR}"
+      - name: "Cross-compiling the benchmark tools with tracing"
+        id: build-with-tracing
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "RISCV_CONFIG=${TARGET_CONFIG}" \
+            --env "BUILD_RISCV_DIR=${BUILD_TRACED_TOOLS_DIR}" \
+            --env "BUILD_PRESET=benchmarks-with-tracing" \
+            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+            gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
+            bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
+          echo "::set-output name=traced-benchmark-tools-dir::${BUILD_TRACED_TOOLS_DIR}"
+      - name: "Creating the cross-compiled benchmark tools archive"
+        id: archive
+        env:
+          BENCHMARK_TOOLS_DIR: ${{ steps.build.outputs.benchmark-tools-dir }}
+          TRACED_BENCHMARK_TOOLS_DIR: ${{ steps.build-with-tracing.outputs.traced-benchmark-tools-dir }}
+          BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.config }}-benchmarks-tools.tar
+        run: |
+          tar -cf ${TOOLS_ARCHIVE} \
+            ${BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module \
+            ${TRACED_BENCHMARK_TOOLS_DIR}/tools/iree-benchmark-module
+          echo "::set-output name=benchmark-tools-archive::${BENCHMARK_TOOLS_ARCHIVE}"
+      - name: "Uploading the cross-compiled benchmark tools archive"
+        id: upload
+        env:
+          BENCHMARK_TOOLS_ARCHIVE: ${{ steps.archive.outputs.benchmark-tools-archive }}
+          BENCHMARK_TOOLS_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.benchmark-tools-archive }}
+        run: |
+          gcloud alpha storage cp "${BENCHMARK_TOOLS_ARCHIVE}" "${BENCHMARK_TOOLS_GCS_ARTIFACT}"
+          echo "::set-output name=${TARGET_PLATFORM}-${TARGET_CONFIG}-benchmark-tools-gcs-artifact::${BENCHMARK_TOOLS_GCS_ARTIFACT}"
 
   ##############################################################################
 
@@ -736,8 +736,10 @@ jobs:
       # Crosscompilation
       - android_arm64
       - riscv32
-      - build_riscv64
-      - test_riscv64
+      - build_and_test_riscv64
+
+      # Benchmark tools
+      - build_benchmark_tools
     steps:
       - name: Getting combined job status
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,7 @@ jobs:
             bash -euo pipefail -c \
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
-  riscv64:
+  build_riscv64:
     needs: [should_run, build_all]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
@@ -594,6 +594,9 @@ jobs:
       - cpu
       - os-family=Linux
     outputs:
+      build-dir: ${{ steps.build.outputs.build-dir }}
+      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
+      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
       tools-dir: ${{ steps.build.outputs.tools-dir }}
       tools-archive: ${{ steps.archive.outputs.tools-archive }}
       tools-gcs-artifact: ${{ steps.upload.outputs.tools-gcs-artifact }}
@@ -612,42 +615,49 @@ jobs:
         run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Cross-compiling and testing riscv64"
+      - name: "Cross-compiling riscv64"
         id: build
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "RISCV_CONFIG=${RISCV_CONFIG}" \
             --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \
-            --env "LLVM_BIN_DIR=${BUILD_DIR}/third_party/llvm-project/llvm/bin" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
-            bash -euo pipefail -c \
-              "./build_tools/cmake/build_riscv.sh"
+            bash -euo pipefail -c "./build_tools/cmake/build_riscv.sh"
+          echo "::set-output name=build-dir::${BUILD_RISCV_DIR}"
           echo "::set-output name=tools-dir::${BUILD_RISCV_DIR}/tools"
-      - name: "Creating riscv64 cross-compiled tools archive"
+      - name: "Creating riscv64 cross-compiled archives"
         id: archive
         env:
+          BUILD_RISCV_DIR_ARCHIVE: ${{ env.BUILD_RISCV_DIR }}.tar.zst
           TOOLS_ARCHIVE: riscv64-tools.tar
         run: |
+          tar --exclude '*.a' --exclude '*.o' \
+            -I 'zstd -T0' \
+            -cf ${BUILD_RISCV_DIR_ARCHIVE} ${BUILD_RISCV_DIR}
           tar -cf ${TOOLS_ARCHIVE} \
             ${BUILD_RISCV_DIR}/tools/iree-benchmark-module \
             ${BUILD_RISCV_DIR}/tools/iree-benchmark-trace \
             ${BUILD_RISCV_DIR}/tools/iree-check-module \
             ${BUILD_RISCV_DIR}/tools/iree-run-module \
             ${BUILD_RISCV_DIR}/tools/iree-run-trace
+          echo "::set-output name=build-dir-archive::${BUILD_RISCV_DIR_ARCHIVE}"
           echo "::set-output name=tools-archive::${TOOLS_ARCHIVE}"
-      - name: "Uploading riscv64 cross-compiled tools archive"
+      - name: "Uploading riscv64 cross-compiled archives"
         id: upload
         env:
+          BUILD_RISCV_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
+          BUILD_RISCV_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
           TOOLS_ARCHIVE: ${{ steps.archive.outputs.tools-archive }}
           TOOLS_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.tools-archive }}
         run: |
+          gcloud alpha storage cp "${BUILD_RISCV_DIR_ARCHIVE}" "${BUILD_RISCV_DIR_GCS_ARTIFACT}"
           gcloud alpha storage cp "${TOOLS_ARCHIVE}" "${TOOLS_GCS_ARTIFACT}"
+          echo "::set-output name=build-dir-gcs-artifact::${BUILD_RISCV_DIR_GCS_ARTIFACT}"
           echo "::set-output name=tools-gcs-artifact::${TOOLS_GCS_ARTIFACT}"
 
   test-riscv64:
-    needs: [should_run, build_all, build_tf_integrations]
+    needs: [should_run, build_all, build_riscv64, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
@@ -656,11 +666,13 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_RISCV_DIR: "build-riscv64"
       RISCV_CONFIG: "rv64"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      BUILD_RISCV_DIR: ${{ needs.build_riscv64.outputs.build-dir }}
+      BUILD_RISCV_DIR_ARCHIVE: ${{ needs.build_riscv64.outputs.build-dir-archive }}
+      BUILD_RISCV_DIR_GCS_ARTIFACT: ${{ needs.build_riscv64.outputs.build-dir-gcs-artifact }}
       TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
       TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
       TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
@@ -673,6 +685,10 @@ jobs:
         run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
         run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Downloading build riscv dir archive"
+        run: gcloud alpha storage cp "${BUILD_RISCV_DIR_GCS_ARTIFACT}" "${BUILD_RISCV_DIR_ARCHIVE}"
+      - name: "Extracting build riscv dir archive"
+        run: tar -xf "${BUILD_RISCV_DIR_ARCHIVE}"
       - name: "Downloading TF binaries archive"
         run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
       - name: "Extracting TF binaries archive"
@@ -686,8 +702,7 @@ jobs:
             --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \
             --env "LLVM_BIN_DIR=${BUILD_DIR}/third_party/llvm-project/llvm/bin" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
-            bash -euo pipefail -c \
-              "./build_tools/cmake/build_riscv.sh && ./tests/riscv64/smoke.sh"
+            bash -euo pipefail -c "./tests/riscv64/smoke.sh"
 
   ##############################################################################
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,7 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_TARGET_DIR: "build-riscv32-baremetal"
+      BUILD_RISCV_DIR: "build-riscv32-baremetal"
       BUILD_ARCH: "rv32-baremetal"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
@@ -578,7 +578,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "RISCV_ARCH=${BUILD_ARCH}" \
-            --env "BUILD_RISCV_DIR=${BUILD_TARGET_DIR}" \
+            --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
             --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
@@ -595,7 +595,7 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      BUILD_TARGET_DIR: "build-riscv64"
+      BUILD_RISCV_DIR: "build-riscv64"
       BUILD_ARCH: "rv64"
       BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
@@ -620,7 +620,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "RISCV_ARCH=${BUILD_ARCH}" \
-            --env "BUILD_RISCV_DIR=${BUILD_TARGET_DIR}" \
+            --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
             --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,7 +668,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "${PLATFORM^^}_ARCH=${ARCHITECTURE}" \
-            --env "BUILD_${PLATFORM^^}_DIR=${BUILD_TOOLS_DIR}/normal" \
+            --env "BUILD_${PLATFORM^^}_DIR=${BUILD_TOOLS_DIR}/build" \
             --env "BUILD_PRESET=benchmark" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             "${DOCKER_IMAGE}" \
@@ -678,7 +678,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "${PLATFORM^^}_ARCH=${ARCHITECTURE}" \
-            --env "BUILD_${PLATFORM^^}_DIR=${BUILD_TOOLS_DIR}/traced" \
+            --env "BUILD_${PLATFORM^^}_DIR=${BUILD_TOOLS_DIR}/build-traced" \
             --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
             "${DOCKER_IMAGE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -656,7 +656,7 @@ jobs:
           echo "::set-output name=build-dir-gcs-artifact::${BUILD_RISCV_DIR_GCS_ARTIFACT}"
           echo "::set-output name=tools-gcs-artifact::${TOOLS_GCS_ARTIFACT}"
 
-  test-riscv64:
+  test_riscv64:
     needs: [should_run, build_all, build_riscv64, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
@@ -736,7 +736,8 @@ jobs:
       # Crosscompilation
       - android_arm64
       - riscv32
-      - riscv64
+      - build_riscv64
+      - test_riscv64
     steps:
       - name: Getting combined job status
         run: |

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -22,41 +22,41 @@ ROOT_DIR="${ROOT_DIR:-$(git rev-parse --show-toplevel)}"
 cd "${ROOT_DIR}"
 
 CMAKE_BIN="${CMAKE_BIN:-$(which cmake)}"
-BUILD_ARCH="${BUILD_ARCH:-rv64}"
+RISCV_ARCH="${RISCV_ARCH:-rv64}"
 RISCV_COMPILER_FLAGS="${RISCV_COMPILER_FLAGS:--O3}"
 IREE_HOST_BINARY_ROOT="$(realpath ${IREE_HOST_BINARY_ROOT})"
-BUILD_TARGET_DIR="${BUILD_TARGET_DIR:-$ROOT_DIR/build-riscv}"
+BUILD_RISCV_DIR="${BUILD_RISCV_DIR:-$ROOT_DIR/build-riscv}"
 BUILD_PRESET="${BUILD_PRESET:-test}"
 
 # --------------------------------------------------------------------------- #
 # Build for the target (riscv).
-if [[ -d "${BUILD_TARGET_DIR}" ]]; then
+if [[ -d "${BUILD_RISCV_DIR}" ]]; then
   echo "build-riscv directory already exists. Will use cached results there."
 else
   echo "build-riscv directory does not already exist. Creating a new one."
-  mkdir -p "${BUILD_TARGET_DIR}"
+  mkdir -p "${BUILD_RISCV_DIR}"
 fi
 
-echo "Build riscv target with the config of ${BUILD_ARCH}"
+echo "Build riscv target with the config of ${RISCV_ARCH}"
 TOOLCHAIN_FILE="$(realpath ${ROOT_DIR}/build_tools/cmake/riscv.toolchain.cmake)"
 declare -a args
 args=(
   "-G" "Ninja"
-  "-B" "${BUILD_TARGET_DIR}"
+  "-B" "${BUILD_RISCV_DIR}"
   -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN_FILE}"
   -DIREE_HOST_BINARY_ROOT="${IREE_HOST_BINARY_ROOT}"
-  -DRISCV_CPU="${BUILD_ARCH}"
+  -DRISCV_CPU="${RISCV_ARCH}"
   -DRISCV_COMPILER_FLAGS="${RISCV_COMPILER_FLAGS}"
   -DIREE_BUILD_COMPILER=OFF
   # CPU info doesn't work on RISCV
   -DIREE_ENABLE_CPUINFO=OFF
 )
 
-if [[ "${BUILD_ARCH}" == "rv64" ]]; then
+if [[ "${RISCV_ARCH}" == "rv64" ]]; then
   args+=(
     -DRISCV_TOOLCHAIN_ROOT="${RISCV_RV64_LINUX_TOOLCHAIN_ROOT}"
   )
-elif [[ "${BUILD_ARCH}" == "rv32-baremetal" ]]; then
+elif [[ "${RISCV_ARCH}" == "rv32-baremetal" ]]; then
   args+=(
     # TODO(#6353): Off until tools/ are refactored to support threadless config.
     -DIREE_BUILD_TESTS=OFF
@@ -97,4 +97,4 @@ esac
 
 args_str=$(IFS=' ' ; echo "${args[*]}")
 "${CMAKE_BIN}" ${args_str} "${ROOT_DIR}"
-"${CMAKE_BIN}" --build "${BUILD_TARGET_DIR}" -- -k 0
+"${CMAKE_BIN}" --build "${BUILD_RISCV_DIR}" -- -k 0

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -72,7 +72,6 @@ case "${BUILD_PRESET}" in
     args+=(
       -DIREE_ENABLE_ASSERTIONS=ON
       -DIREE_BUILD_SAMPLES=ON
-      -DIREE_BUILD_TESTS=ON
     )
     ;;
   benchmark)

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -13,7 +13,7 @@
 # Host binaries (e.g. compiler tools) will be built and installed in build-host/
 # RISCV binaries (e.g. tests) will be built in build-riscv/.
 #
-# BUILD_PRESET can be: test, benchmark, benchmark_with_tracing to build with
+# BUILD_PRESET can be: test, benchmark, benchmark-with-tracing to build with
 # different flags.
 
 set -xeuo pipefail
@@ -81,7 +81,7 @@ case "${BUILD_PRESET}" in
       -DIREE_BUILD_TESTS=OFF
     )
     ;;
-  benchmark_with_tracing)
+  benchmark-with-tracing)
     args+=(
       -DIREE_ENABLE_ASSERTIONS=OFF
       -DIREE_BUILD_SAMPLES=OFF

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -22,41 +22,41 @@ ROOT_DIR="${ROOT_DIR:-$(git rev-parse --show-toplevel)}"
 cd "${ROOT_DIR}"
 
 CMAKE_BIN="${CMAKE_BIN:-$(which cmake)}"
-RISCV_CONFIG="${RISCV_CONFIG:-rv64}"
+BUILD_ARCH="${BUILD_ARCH:-rv64}"
 RISCV_COMPILER_FLAGS="${RISCV_COMPILER_FLAGS:--O3}"
 IREE_HOST_BINARY_ROOT="$(realpath ${IREE_HOST_BINARY_ROOT})"
-BUILD_RISCV_DIR="${BUILD_RISCV_DIR:-$ROOT_DIR/build-riscv}"
+BUILD_TARGET_DIR="${BUILD_TARGET_DIR:-$ROOT_DIR/build-riscv}"
 BUILD_PRESET="${BUILD_PRESET:-test}"
 
 # --------------------------------------------------------------------------- #
 # Build for the target (riscv).
-if [[ -d "${BUILD_RISCV_DIR}" ]]; then
+if [[ -d "${BUILD_TARGET_DIR}" ]]; then
   echo "build-riscv directory already exists. Will use cached results there."
 else
   echo "build-riscv directory does not already exist. Creating a new one."
-  mkdir -p "${BUILD_RISCV_DIR}"
+  mkdir -p "${BUILD_TARGET_DIR}"
 fi
 
-echo "Build riscv target with the config of ${RISCV_CONFIG}"
+echo "Build riscv target with the config of ${BUILD_ARCH}"
 TOOLCHAIN_FILE="$(realpath ${ROOT_DIR}/build_tools/cmake/riscv.toolchain.cmake)"
 declare -a args
 args=(
   "-G" "Ninja"
-  "-B" "${BUILD_RISCV_DIR}"
+  "-B" "${BUILD_TARGET_DIR}"
   -DCMAKE_TOOLCHAIN_FILE="${TOOLCHAIN_FILE}"
   -DIREE_HOST_BINARY_ROOT="${IREE_HOST_BINARY_ROOT}"
-  -DRISCV_CPU="${RISCV_CONFIG}"
+  -DRISCV_CPU="${BUILD_ARCH}"
   -DRISCV_COMPILER_FLAGS="${RISCV_COMPILER_FLAGS}"
   -DIREE_BUILD_COMPILER=OFF
   # CPU info doesn't work on RISCV
   -DIREE_ENABLE_CPUINFO=OFF
 )
 
-if [[ "${RISCV_CONFIG}" == "rv64" ]]; then
+if [[ "${BUILD_ARCH}" == "rv64" ]]; then
   args+=(
     -DRISCV_TOOLCHAIN_ROOT="${RISCV_RV64_LINUX_TOOLCHAIN_ROOT}"
   )
-elif [[ "${RISCV_CONFIG}" == "rv32-baremetal" ]]; then
+elif [[ "${BUILD_ARCH}" == "rv32-baremetal" ]]; then
   args+=(
     # TODO(#6353): Off until tools/ are refactored to support threadless config.
     -DIREE_BUILD_TESTS=OFF
@@ -97,4 +97,4 @@ esac
 
 args_str=$(IFS=' ' ; echo "${args[*]}")
 "${CMAKE_BIN}" ${args_str} "${ROOT_DIR}"
-"${CMAKE_BIN}" --build "${BUILD_RISCV_DIR}" -- -k 0
+"${CMAKE_BIN}" --build "${BUILD_TARGET_DIR}" -- -k 0


### PR DESCRIPTION
Add a CI job to build benchmark tools and upload them to GCS.

This job uses the matrix to generate build parameters for different target platforms. The RISC-V build script is also standardized so the matrix can use generic parameters to config the build.