### PR TITLE
Remove RV32 Mobile Bert Compilation Benchmark

### DIFF
--- a/benchmarks/TFLite/linux-riscv.cmake
+++ b/benchmarks/TFLite/linux-riscv.cmake
@@ -73,7 +73,6 @@ iree_benchmark_suite(
     "linux-riscv"
 
   MODULES
-    "${MOBILEBERT_INT8_MODULE}"
     "${PERSON_DETECT_INT8_MODULE}"
     "${EFFICIENTNET_INT8_MODULE}"
 


### PR DESCRIPTION
Building the benchmarks is currently the critical path in CI latency,
taking almost 25 minutes for just that job, after it waits 25 minutes
for the TF integrations binaries (was that alway so slow??).

[![ci_run_graph](https://user-images.githubusercontent.com/5732088/187279027-21137775-5a3b-4ddf-ae4d-42e39051e7b2.png)](https://github.com/iree-org/iree/actions/runs/2950708667)


Of that time, 20 minutes is spent compiling this one vmfb, which we
only do so we can get statistics on how long it takes to compile. I
sampled the ten slowest build actions from a local build of the
benchmarks:

```
1179.39 benchmark_suites/TFLite/vmfb/mobilebert-baseline-tf2-quant.tflite.mlir-22179362840f853977acc734ee75e6ce.vmfb
216.321 benchmark_suites/TFLite/vmfb/mobilebert-baseline-tf2-quant.tflite.mlir-53b16b00b2d02162b1706d73ab6270b4.vmfb
159.585 benchmark_suites/TFLite/vmfb/mobilebert-baseline-tf2-quant.tflite.mlir-3bcb3f959e9f123bbaa01aa4d237bab8.vmfb
146.027 benchmark_suites/TFLite/vmfb/mobilebert-baseline-tf2-quant.tflite.mlir-73879267ae95d3551e73c7f078f4410d.vmfb
109.922 benchmark_suites/TFLite/vmfb/mobilebert-baseline-tf2-quant.tflite.mlir-cf781c710ad5c59b5e7f205b17b3c37b.vmfb
104.864 benchmark_suites/TFLite/vmfb/mobilebertsquad.tflite.mlir-fddd07b06a1abf9f5d4ea97225066f01.vmfb
88.665 benchmark_suites/TFLite/vmfb/mobilebertsquad.tflite.mlir-4fe50b8684bdd4684941c8a5698d3a48.vmfb
88.316 benchmark_suites/TFLite/vmfb/mobilebertsquad.tflite.mlir-833fba075c9cf413b8acbea9be0acade.vmfb
87.238 benchmark_suites/TFLite/vmfb/mobilebert-baseline-tf2-float.tflite.mlir-8a916ab990bd1cb5521dce6dd6a5ac6a.vmfb
86.905 benchmark_suites/TFLite/vmfb/mobilebert-baseline-tf2-float.tflite.mlir-e304860762a8369f86b813d45b3c699a.vmfb
```

This one is the clear winner. I don't think it's worth running this
compilation only to discover what we already know (it is very slow to
run this compilation).

Tested:
- `build_benchmarks` for this PR ran in 7 minutes instead of 25.
- Ran riscv benchmark pipeline.