### PR TITLE
Refactor iree_bytecode_module and iree_c_module static lib support

### DIFF
--- a/build_tools/bazel/iree_bytecode_module.bzl
+++ b/build_tools/bazel/iree_bytecode_module.bzl
@@ -45,15 +45,15 @@ def iree_bytecode_module(
         module_name = "%s.vmfb" % (name)
 
     out_files = [module_name]
-    module_flags = ["--output-format=vm-bytecode"]
+    flags.append("--output-format=vm-bytecode")
     if static_lib_path:
         static_header_path = static_lib_path.replace(".o", ".h")
         out_files.extend([static_lib_path, static_header_path])
-        module_flags.extend([
+        flags += [
             "--iree-llvm-link-embedded=false",
             "--iree-llvm-link-static",
             "--iree-llvm-static-library-output-path=$(location %s)" % (static_lib_path),
-        ])
+        ]
 
     native.genrule(
         name = name,
@@ -62,7 +62,7 @@ def iree_bytecode_module(
         cmd = " && ".join([
             " ".join([
                 "$(location %s)" % (compile_tool),
-                " ".join(module_flags + flags),
+                " ".join(flags),
                 "--iree-llvm-embedded-linker-path=$(location %s)" % (linker_tool),
                 "--iree-llvm-wasm-linker-path=$(location %s)" % (linker_tool),
                 # Note: --iree-llvm-system-linker-path is left unspecified.

--- a/build_tools/bazel/iree_bytecode_module.bzl
+++ b/build_tools/bazel/iree_bytecode_module.bzl
@@ -18,6 +18,7 @@ def iree_bytecode_module(
         compile_tool = "//tools:iree-compile",
         linker_tool = "@llvm-project//lld:lld",
         c_identifier = "",
+        static_lib_path = "",
         deps = [],
         **kwargs):
     """Builds an IREE bytecode module.
@@ -34,6 +35,8 @@ def iree_bytecode_module(
         linker_tool: the linker to use.
             Defaults to the lld from the llvm-project directory.
         c_identifier: Optional. Enables embedding the module as C data.
+        static_lib_path: When set, the module is compiled into a LLVM static
+            library with the specified library path.
         deps: Optional. Dependencies to add to the generated library.
         **kwargs: any additional attributes to pass to the underlying rules.
     """
@@ -41,16 +44,25 @@ def iree_bytecode_module(
     if not module_name:
         module_name = "%s.vmfb" % (name)
 
+    out_files = [module_name]
+    module_flags = ["--output-format=vm-bytecode"]
+    if static_lib_path:
+        static_header_path = static_lib_path.replace(".o", ".h")
+        out_files.extend([static_lib_path, static_header_path])
+        module_flags.extend([
+            "--iree-llvm-link-embedded=false",
+            "--iree-llvm-link-static",
+            "--iree-llvm-static-library-output-path=$(location %s)" % (static_lib_path),
+        ])
+
     native.genrule(
         name = name,
         srcs = [src],
-        outs = [
-            module_name,
-        ],
+        outs = out_files,
         cmd = " && ".join([
             " ".join([
                 "$(location %s)" % (compile_tool),
-                " ".join(["--output-format=vm-bytecode"] + flags),
+                " ".join(module_flags + flags),
                 "--iree-llvm-embedded-linker-path=$(location %s)" % (linker_tool),
                 "--iree-llvm-wasm-linker-path=$(location %s)" % (linker_tool),
                 # Note: --iree-llvm-system-linker-path is left unspecified.

--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -20,6 +20,8 @@ def iree_c_module(
             "//runtime/src/iree/vm:shims_emitc",
         ],
         compile_tool = "//tools:iree-compile",
+        no_runtime = None,
+        static_lib_path = "",
         **kwargs):
     """Builds an IREE C module.
 
@@ -32,17 +34,32 @@ def iree_c_module(
         deps: Optional. Dependencies to add to the generated library.
         compile_tool: the compiler to use to generate the module.
             Defaults to iree-compile.
+        static_lib_path: When set, the module is compiled into a LLVM static
+            library with the specified library path.
+        no_runtime: When set, this target will be built without the
+            runtime library support.
         **kwargs: any additional attributes to pass to the underlying rules.
     """
+
+    out_files = [h_file_output]
+    module_flags = ["--output-format=vm-c"]
+    if static_lib_path:
+        static_header_path = static_lib_path.replace(".o", ".h")
+        out_files.extend([static_lib_path, static_header_path])
+        module_flags.extend([
+            "--iree-llvm-link-embedded=false",
+            "--iree-llvm-link-static",
+            "--iree-llvm-static-library-output-path=$(location %s)" % (static_lib_path),
+        ])
 
     native.genrule(
         name = name + "_gen",
         srcs = [src],
-        outs = [h_file_output],
+        outs = out_files,
         cmd = " && ".join([
             " ".join([
                 "$(location %s)" % (compile_tool),
-                " ".join(["--output-format=vm-c"] + flags),
+                " ".join(module_flags + flags),
                 "-o $(location %s)" % (h_file_output),
                 "$(location %s)" % (src),
             ]),
@@ -52,13 +69,24 @@ def iree_c_module(
         output_to_bindir = 1,
         **kwargs
     )
-    iree_runtime_cc_library(
-        name = name,
-        hdrs = [h_file_output],
-        srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
-        copts = [
-            "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
-        ],
-        deps = deps,
-        **kwargs
-    )
+
+    if no_runtime:
+        iree_runtime_cc_library(
+            name = name,
+            hdrs = [h_file_output],
+            copts = [
+                "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
+            ],
+            **kwargs
+        )
+    else:
+        iree_runtime_cc_library(
+            name = name,
+            hdrs = [h_file_output],
+            srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
+            copts = [
+                "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
+            ],
+            deps = deps,
+            **kwargs
+        )

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -444,6 +444,7 @@ class BuildFileFunctions(object):
                            flags=None,
                            compile_tool=None,
                            c_identifier=None,
+                           static_lib_path=None,
                            deps=None,
                            testonly=None):
     name_block = _convert_string_arg_block("NAME", name, quote=False)
@@ -451,6 +452,8 @@ class BuildFileFunctions(object):
     module_name_block = _convert_string_arg_block("MODULE_FILE_NAME",
                                                   module_name)
     c_identifier_block = _convert_string_arg_block("C_IDENTIFIER", c_identifier)
+    static_lib_block = _convert_string_arg_block("STATIC_LIB_PATH",
+                                                 static_lib_path)
     compile_tool_block = _convert_target_block("COMPILE_TOOL", compile_tool)
     flags_block = _convert_string_list_block("FLAGS", flags)
     deps_block = _convert_target_list_block("DEPS", deps)
@@ -462,6 +465,7 @@ class BuildFileFunctions(object):
                             f"{module_name_block}"
                             f"{c_identifier_block}"
                             f"{compile_tool_block}"
+                            f"{static_lib_block}"
                             f"{flags_block}"
                             f"{deps_block}"
                             f"{testonly_block}"

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -102,18 +102,15 @@ function(iree_bytecode_module)
     get_filename_component(_FRIENDLY_NAME "${_RULE_SRC}" NAME)
   endif()
 
+  set(_OUTPUT_FILES "${_MODULE_FILE_NAME}")
   # Check LLVM static library setting. If the static libary output path is set,
   # retrieve the object path and the corresponding header file path.
   if(_RULE_STATIC_LIB_PATH)
-    list(APPEND _ARGS "--iree-hal-target-backends=llvm-cpu")
     list(APPEND _ARGS "--iree-llvm-link-embedded=false")
     list(APPEND _ARGS "--iree-llvm-link-static")
     list(APPEND _ARGS "--iree-llvm-static-library-output-path=${_RULE_STATIC_LIB_PATH}")
-    string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_RULE_STATIC_LIB_PATH}")
-  endif()
 
-  set(_OUTPUT_FILES "${_MODULE_FILE_NAME}")
-  if(_RULE_STATIC_LIB_PATH)
+    string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_RULE_STATIC_LIB_PATH}")
     list(APPEND _OUTPUT_FILES "${_RULE_STATIC_LIB_PATH}" "${_STATIC_HDR_PATH}")
   endif()
 

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -22,6 +22,8 @@ include(CMakeParseArguments)
 #     "iree-compile".
 # C_IDENTIFIER: Identifier to use for generate c embed code.
 #     If omitted then no C embed code will be generated.
+# STATIC_LIB_PATH: When added, the module is compiled into a LLVM static
+#     library with the specified library path.
 # FRIENDLY_NAME: Optional. Name to use to display build progress info.
 # PUBLIC: Add this so that this library will be exported under ${PACKAGE}::
 #     Also in IDE, target will appear in ${PACKAGE} folder while non PUBLIC
@@ -39,13 +41,17 @@ function(iree_bytecode_module)
   cmake_parse_arguments(
     _RULE
     "PUBLIC;TESTONLY"
-    "NAME;SRC;MODULE_FILE_NAME;COMPILE_TOOL;C_IDENTIFIER;FRIENDLY_NAME"
+    "NAME;SRC;MODULE_FILE_NAME;COMPILE_TOOL;C_IDENTIFIER;FRIENDLY_NAME;STATIC_LIB_PATH"
     "FLAGS;DEPENDS;DEPS"
     ${ARGN}
   )
 
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
+  endif()
+
+  if(_RULE_STATIC_LIB_PATH AND NOT IREE_TARGET_BACKEND_LLVM_CPU)
+    message(SEND_ERROR "Static library only supports llvm-cpu backend")
   endif()
 
   # Set default for COMPILE_TOOL.
@@ -98,21 +104,17 @@ function(iree_bytecode_module)
 
   # Check LLVM static library setting. If the static libary output path is set,
   # retrieve the object path and the corresponding header file path.
-  foreach(_FLAG ${_RULE_FLAGS})
-    string(REGEX MATCH
-      "-iree-llvm-static-library-output-path=(.+)" _MATCH_STRING "${_FLAG}"
-    )
-    if(_MATCH_STRING)
-      set(_STATIC_LIB TRUE)
-      # Get the static object path from the regex match result.
-      set(_STATIC_OBJ_PATH ${CMAKE_MATCH_1})
-      string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_STATIC_OBJ_PATH}")
-    endif()
-  endforeach(_FLAG)
+  if(_RULE_STATIC_LIB_PATH)
+    list(APPEND _ARGS "--iree-hal-target-backends=llvm-cpu")
+    list(APPEND _ARGS "--iree-llvm-link-embedded=false")
+    list(APPEND _ARGS "--iree-llvm-link-static")
+    list(APPEND _ARGS "--iree-llvm-static-library-output-path=${_RULE_STATIC_LIB_PATH}")
+    string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_RULE_STATIC_LIB_PATH}")
+  endif()
 
   set(_OUTPUT_FILES "${_MODULE_FILE_NAME}")
-  if(_STATIC_LIB)
-    list(APPEND _OUTPUT_FILES "${_STATIC_OBJ_PATH}" "${_STATIC_HDR_PATH}")
+  if(_RULE_STATIC_LIB_PATH)
+    list(APPEND _OUTPUT_FILES "${_RULE_STATIC_LIB_PATH}" "${_STATIC_HDR_PATH}")
   endif()
 
   # Depending on the binary instead of the target here given we might not have

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -68,20 +68,18 @@ function(iree_c_module)
   list(APPEND _ARGS "-o")
   list(APPEND _ARGS "${_RULE_H_FILE_OUTPUT}")
 
+  set(_OUTPUT_FILES "${_RULE_H_FILE_OUTPUT}")
   # Check LLVM static library setting. If the static libary output path is set,
   # retrieve the object path and the corresponding header file path.
   if(_RULE_STATIC_LIB_PATH)
-    list(APPEND _ARGS "--iree-hal-target-backends=llvm-cpu")
     list(APPEND _ARGS "--iree-llvm-link-embedded=false")
     list(APPEND _ARGS "--iree-llvm-link-static")
     list(APPEND _ARGS "--iree-llvm-static-library-output-path=${_RULE_STATIC_LIB_PATH}")
-    string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_RULE_STATIC_LIB_PATH}")
-  endif()
 
-  set(_OUTPUT_FILES "${_RULE_H_FILE_OUTPUT}")
-  if(_RULE_STATIC_LIB_PATH)
+    string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_RULE_STATIC_LIB_PATH}")
     list(APPEND _OUTPUT_FILES "${_RULE_STATIC_LIB_PATH}" "${_STATIC_HDR_PATH}")
   endif()
+
   add_custom_command(
     OUTPUT ${_OUTPUT_FILES}
     COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -16,6 +16,8 @@ include(CMakeParseArguments)
 #     "iree-compile".
 # FLAGS: Additional flags to pass to the compile tool (list of strings).
 #     `--output-format=vm-c` is included automatically.
+# STATIC_LIB_PATH: When added, the module is compiled into a LLVM static
+#     library with the specified library path.
 # TESTONLY: When added, this target will only be built if user passes
 #     -DIREE_BUILD_TESTS=ON to CMake.
 # NO_RUNTIME: When added, this target will be built without the runtime library
@@ -29,13 +31,17 @@ function(iree_c_module)
   cmake_parse_arguments(
     _RULE
     "TESTONLY;NO_RUNTIME"
-    "NAME;SRC;H_FILE_OUTPUT;COMPILE_TOOL"
+    "NAME;SRC;H_FILE_OUTPUT;COMPILE_TOOL;STATIC_LIB_PATH"
     "FLAGS"
     ${ARGN}
   )
 
   if(_RULE_TESTONLY AND NOT IREE_BUILD_TESTS)
     return()
+  endif()
+
+  if(_RULE_STATIC_LIB_PATH AND NOT IREE_TARGET_BACKEND_LLVM_CPU)
+    message(SEND_ERROR "Static library only supports llvm-cpu backend")
   endif()
 
   # Replace dependencies passed by ::name with iree::package::name
@@ -64,21 +70,17 @@ function(iree_c_module)
 
   # Check LLVM static library setting. If the static libary output path is set,
   # retrieve the object path and the corresponding header file path.
-  foreach(_FLAG ${_RULE_FLAGS})
-    string(REGEX MATCH
-      "-iree-llvm-static-library-output-path=(.+)" _MATCH_STRING "${_FLAG}"
-    )
-    if(_MATCH_STRING)
-      set(_STATIC_LIB TRUE)
-      # Get the static object path from the regex match result.
-      set(_STATIC_OBJ_PATH ${CMAKE_MATCH_1})
-      string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_STATIC_OBJ_PATH}")
-    endif()
-  endforeach(_FLAG)
+  if(_RULE_STATIC_LIB_PATH)
+    list(APPEND _ARGS "--iree-hal-target-backends=llvm-cpu")
+    list(APPEND _ARGS "--iree-llvm-link-embedded=false")
+    list(APPEND _ARGS "--iree-llvm-link-static")
+    list(APPEND _ARGS "--iree-llvm-static-library-output-path=${_RULE_STATIC_LIB_PATH}")
+    string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_RULE_STATIC_LIB_PATH}")
+  endif()
 
   set(_OUTPUT_FILES "${_RULE_H_FILE_OUTPUT}")
-  if(_STATIC_LIB)
-    list(APPEND _OUTPUT_FILES "${_STATIC_OBJ_PATH}" "${_STATIC_HDR_PATH}")
+  if(_RULE_STATIC_LIB_PATH)
+    list(APPEND _OUTPUT_FILES "${_RULE_STATIC_LIB_PATH}" "${_STATIC_HDR_PATH}")
   endif()
   add_custom_command(
     OUTPUT ${_OUTPUT_FILES}

--- a/build_tools/cmake/iree_static_linker_test.cmake
+++ b/build_tools/cmake/iree_static_linker_test.cmake
@@ -80,6 +80,7 @@ function(iree_static_linker_test)
 
   # Set common iree-compile flags
   set(_COMPILER_ARGS ${_RULE_COMPILER_FLAGS})
+  list(APPEND _COMPILER_ARGS "--iree-hal-target-backends=llvm-cpu")
   if(_RULE_TARGET_CPU_FEATURES)
     list(APPEND _COMPILER_ARGS "--iree-llvm-target-cpu-features=${_RULE_TARGET_CPU_FEATURES}")
   endif()

--- a/build_tools/cmake/iree_static_linker_test.cmake
+++ b/build_tools/cmake/iree_static_linker_test.cmake
@@ -80,10 +80,6 @@ function(iree_static_linker_test)
 
   # Set common iree-compile flags
   set(_COMPILER_ARGS ${_RULE_COMPILER_FLAGS})
-  list(APPEND _COMPILER_ARGS "--iree-hal-target-backends=llvm-cpu")
-  list(APPEND _COMPILER_ARGS "--iree-llvm-link-embedded=false")
-  list(APPEND _COMPILER_ARGS "--iree-llvm-link-static")
-  list(APPEND _COMPILER_ARGS "--iree-llvm-static-library-output-path=${_O_FILE_NAME}")
   if(_RULE_TARGET_CPU_FEATURES)
     list(APPEND _COMPILER_ARGS "--iree-llvm-target-cpu-features=${_RULE_TARGET_CPU_FEATURES}")
   endif()
@@ -99,6 +95,8 @@ function(iree_static_linker_test)
         ${_COMPILER_ARGS}
       H_FILE_OUTPUT
         "${_C_FILE_NAME}"
+      STATIC_LIB_PATH
+        "${_O_FILE_NAME}"
       NO_RUNTIME
 
     )
@@ -113,6 +111,8 @@ function(iree_static_linker_test)
         "${_RULE_SRC}"
       FLAGS
         ${_COMPILER_ARGS}
+      STATIC_LIB_PATH
+        "${_O_FILE_NAME}"
       C_IDENTIFIER
         "${_NAME}"
       PUBLIC


### PR DESCRIPTION
Add STATIC_LIB_PATH option instead of parsing the compiler flags