### PR TITLE
VMVX mmt4d ukernel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
@@ -79,7 +79,7 @@ void leftPadToRank(Location loc, SmallVectorImpl<Value> &indices,
 // asking for the strides of all but the outermost dimension to equal the
 // product of the static sizes inner dimensions past them --- so in particular,
 // this is requiring all but the outer two dimensions to have a static size.
-bool areInnerDimsContiguousRowMajor(MemRefType type) {
+bool verifyMemRefInnerDimsContiguousRowMajor(MemRefType type) {
   int rank = type.getRank();
   if (rank <= 1) {
     return true;
@@ -131,7 +131,7 @@ struct StridedBufferDescriptor {
   // Returns true if all inner dimensions (that is, all but the outer-most dim)
   // are statically known to be contiguous row-major.
   bool areInnerDimsContiguousRowMajor() const {
-    return ::mlir::iree_compiler::areInnerDimsContiguousRowMajor(memRefType);
+    return verifyMemRefInnerDimsContiguousRowMajor(memRefType);
   }
 
   /// Casts the memref to a memref<?x...> that is safe for linear access
@@ -168,7 +168,7 @@ class StridedBufferAnalysis {
   // Returns true if all inner dimensions (that is, all but the outer-most dim)
   // are statically known to be contiguous row-major.
   bool areInnerDimsContiguousRowMajor() {
-    return ::mlir::iree_compiler::areInnerDimsContiguousRowMajor(getType());
+    return verifyMemRefInnerDimsContiguousRowMajor(getType());
   }
 
   StridedBufferDescriptor &getDesc(OpBuilder &builder) {

--- a/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/VMVX/LowerLinalgMicrokernels.cpp
@@ -72,7 +72,19 @@ void leftPadToRank(Location loc, SmallVectorImpl<Value> &indices,
   }
 }
 
-bool isMemRefUnitInnerStride(MemRefType type) {
+// Returns true if all inner dimensions (that is, all but the outer-most dim)
+// are statically known to be contiguous row-major. This is vacuously true for
+// rank<=1 (as there are no inner dims). For rank 2, this is equivalent to
+// asking for the inner dimension to have unit stride. For rank>=3, this is
+// asking for the strides of all but the outermost dimension to equal the
+// product of the static sizes inner dimensions past them --- so in particular,
+// this is requiring all but the outer two dimensions to have a static size.
+bool areInnerDimsContiguousRowMajor(MemRefType type) {
+  int rank = type.getRank();
+  if (rank <= 1) {
+    return true;
+  }
+
   SmallVector<int64_t> strides;
   int64_t offset;
   if (type.getLayout().isIdentity()) {
@@ -82,7 +94,24 @@ bool isMemRefUnitInnerStride(MemRefType type) {
   if (failed(mlir::getStridesAndOffset(type, strides, offset))) {
     return false;
   }
-  return strides.back() == 1;
+
+  ArrayRef<int64_t> sizes = type.getShape();
+  assert(rank >= 2);  // Ensured by above early return.
+  if (strides[rank - 1] != 1) {
+    return false;
+  }
+  int64_t product_of_inner_sizes = 1;
+  for (int i = rank - 1; i >= 2; --i) {
+    if (sizes[i] == ShapedType::kDynamicSize) {
+      return false;
+    }
+    product_of_inner_sizes *= sizes[i];
+    if (strides[i - 1] != product_of_inner_sizes) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 struct StridedBufferDescriptor {
@@ -99,9 +128,11 @@ struct StridedBufferDescriptor {
   Type getElementType() { return memRefType.getElementType(); }
   TypeAttr getElementTypeAttr() { return TypeAttr::get(getElementType()); }
 
-  /// Returns whether the innermost stride is statically 1. Many kernels
-  /// require this, so we provide the convenience here.
-  bool isUnitInnerStride() { return isMemRefUnitInnerStride(memRefType); }
+  // Returns true if all inner dimensions (that is, all but the outer-most dim)
+  // are statically known to be contiguous row-major.
+  bool areInnerDimsContiguousRowMajor() const {
+    return ::mlir::iree_compiler::areInnerDimsContiguousRowMajor(memRefType);
+  }
 
   /// Casts the memref to a memref<?x...> that is safe for linear access
   /// with element-based addressing.
@@ -134,9 +165,11 @@ class StridedBufferAnalysis {
   // Gets the rank of the buffer being analyzed.
   unsigned getRank() { return getType().getRank(); }
 
-  /// Returns whether the innermost stride is statically 1. Many kernels
-  /// require this, so we provide the convenience here.
-  bool isUnitInnerStride() { return isMemRefUnitInnerStride(getType()); }
+  // Returns true if all inner dimensions (that is, all but the outer-most dim)
+  // are statically known to be contiguous row-major.
+  bool areInnerDimsContiguousRowMajor() {
+    return ::mlir::iree_compiler::areInnerDimsContiguousRowMajor(getType());
+  }
 
   StridedBufferDescriptor &getDesc(OpBuilder &builder) {
     assert(isValid() && "invalid StridedBufferAnalysis");
@@ -829,7 +862,7 @@ struct LinalgFillConversion : public OpRewritePattern<linalg::FillOp> {
     }
 
     // Switch based on specialization.
-    if (info.getRank() == 2 && info.outAnal.isUnitInnerStride()) {
+    if (info.getRank() == 2 && info.outAnal.areInnerDimsContiguousRowMajor()) {
       return handle2DTile(info, rewriter);
     }
 
@@ -850,8 +883,37 @@ struct LinalgFillConversion : public OpRewritePattern<linalg::FillOp> {
   }
 };
 
-/// Convert a linalg.matmul.
-struct LinalgMatmulConversion
+bool isMmt4d(ArrayAttr indexingMaps) {
+  if (indexingMaps.size() != 3) return false;
+
+  auto map0 = indexingMaps[0].cast<AffineMapAttr>().getValue();
+  auto map1 = indexingMaps[1].cast<AffineMapAttr>().getValue();
+  auto map2 = indexingMaps[2].cast<AffineMapAttr>().getValue();
+
+  if (map0.getNumResults() != 4 || map1.getNumResults() != 4 ||
+      map2.getNumResults() != 4 || map0.getNumInputs() != 6 ||
+      map1.getNumInputs() != 6 || map2.getNumInputs() != 6) {
+    return false;
+  }
+
+  // Extract dimensions for MxK * KxN -> MxN
+  AffineExpr m = map2.getResult(0);
+  AffineExpr n = map2.getResult(1);
+  AffineExpr k = map0.getResult(1);
+  AffineExpr m0 = map2.getResult(2);
+  AffineExpr n0 = map2.getResult(3);
+  AffineExpr k0 = map0.getResult(3);
+
+  auto *context = indexingMaps.getContext();
+  auto mapA = AffineMapAttr::get(AffineMap::get(6, 0, {m, k, m0, k0}, context));
+  auto mapB = AffineMapAttr::get(AffineMap::get(6, 0, {n, k, n0, k0}, context));
+  auto mapC = AffineMapAttr::get(AffineMap::get(6, 0, {m, n, m0, n0}, context));
+  auto maps = ArrayAttr::get(context, {mapA, mapB, mapC});
+  return indexingMaps == maps;
+}
+
+/// Convert supported linalg contraction ops like matmul and mmt4d.
+struct LinalgContractionConversion
     : public OpInterfaceRewritePattern<linalg::ContractionOpInterface> {
   using OpInterfaceRewritePattern::OpInterfaceRewritePattern;
   struct OpInfo {
@@ -909,19 +971,23 @@ struct LinalgMatmulConversion
     }
 
     // Check for unit inner strides.
-    if (!info.lhsAnal.isUnitInnerStride()) {
+    if (!info.lhsAnal.areInnerDimsContiguousRowMajor()) {
       return rewriter.notifyMatchFailure(op, "lhs has non-unit inner stride");
     }
-    if (!info.rhsAnal.isUnitInnerStride()) {
+    if (!info.rhsAnal.areInnerDimsContiguousRowMajor()) {
       return rewriter.notifyMatchFailure(op, "rhs has non-unit inner stride");
     }
-    if (!info.outAnal.isUnitInnerStride()) {
+    if (!info.outAnal.areInnerDimsContiguousRowMajor()) {
       return rewriter.notifyMatchFailure(op, "out has non-unit inner stride");
     }
 
     // Switch on contraction type.
     if (info.contract.isRowMajorMatmul()) {
       if (succeeded(handleConformingMatmul2D(info, rewriter))) {
+        return success();
+      }
+    } else if (isMmt4d(info.op.getIndexingMaps())) {
+      if (succeeded(handleConformingMmt4d(info, rewriter))) {
         return success();
       }
     }
@@ -936,11 +1002,9 @@ struct LinalgMatmulConversion
     auto &lhsDesc = info.lhsAnal.getDesc(rewriter);
     auto &rhsDesc = info.rhsAnal.getDesc(rewriter);
     auto &outDesc = info.outAnal.getDesc(rewriter);
+
     int flags = IREE_VMVX_MATMUL_FLAG_ACCUMULATE;
-    // Determine m, n, k based on dims.
-    if (!info.contract.isRowMajorMatmul()) {
-      return failure();
-    }
+
     Value m = lhsDesc.sizes[0];
     Value k = rhsDesc.sizes[0];
     Value n = rhsDesc.sizes[1];
@@ -964,6 +1028,42 @@ struct LinalgMatmulConversion
         outDesc.getElementTypeAttr(), rewriter.getI32IntegerAttr(flags));
     return success();
   }
+
+  LogicalResult handleConformingMmt4d(OpInfo &info,
+                                      PatternRewriter &rewriter) const {
+    auto loc = info.op.getLoc();
+    auto &lhsDesc = info.lhsAnal.getDesc(rewriter);
+    auto &rhsDesc = info.rhsAnal.getDesc(rewriter);
+    auto &outDesc = info.outAnal.getDesc(rewriter);
+    int flags = IREE_VMVX_MATMUL_FLAG_ACCUMULATE;
+    Value m = lhsDesc.sizes[0];
+    Value n = rhsDesc.sizes[0];
+    Value k = rhsDesc.sizes[1];
+    Value m0 = lhsDesc.sizes[2];
+    Value n0 = rhsDesc.sizes[2];
+    Value k0 = rhsDesc.sizes[3];
+
+    auto lhsBuffer = lhsDesc.castToLinear(loc, rewriter);
+    auto rhsBuffer = rhsDesc.castToLinear(loc, rewriter);
+    auto outBuffer = outDesc.castToLinear(loc, rewriter);
+
+    rewriter.replaceOpWithNewOp<IREE::VMVX::Mmt4dOp>(
+        info.op,
+        // LHS
+        lhsBuffer, lhsDesc.offset, lhsDesc.strides[0],
+        // RHS
+        rhsBuffer, rhsDesc.offset, rhsDesc.strides[0],
+        // Out
+        outBuffer, outDesc.offset, outDesc.strides[0],
+        // m,n,k
+        m, n, k,
+        // m0,n0,k0
+        m0, n0, k0,
+        // flags
+        lhsDesc.getElementTypeAttr(), rhsDesc.getElementTypeAttr(),
+        outDesc.getElementTypeAttr(), rewriter.getI32IntegerAttr(flags));
+    return success();
+  }
 };
 
 }  // namespace
@@ -978,7 +1078,7 @@ class VMVXLowerLinalgMicrokernelsPass
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
     patterns.insert<LinalgBinaryGenericConversion, LinalgFillConversion,
-                    LinalgMatmulConversion, LinalgTrivialGenericConversion,
+                    LinalgContractionConversion, LinalgTrivialGenericConversion,
                     LinalgUnaryGenericConversion>(&getContext());
 
     if (failed(applyPatternsAndFoldGreedily(getOperation(),

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
@@ -85,6 +85,138 @@ func.func @matmul_i8i8i32_row_major(%arg0 : memref<64x64xi32>, %arg1 : memref<64
   func.return
 }
 
+// CHECK-LABEL: @mmt4d_f32f32f32
+//   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:4, %[[STRIDES0:.*]]:4 = vmvx.get_buffer_descriptor %arg0
+//   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:4, %[[STRIDES1:.*]]:4 = vmvx.get_buffer_descriptor %arg1
+//   CHECK-DAG: %[[BB2:.*]], %[[OFFSET2:.*]], %[[SIZES2:.*]]:4, %[[STRIDES2:.*]]:4 = vmvx.get_buffer_descriptor %arg2
+//       CHECK: vmvx.mmt4d lhs(%[[BB1]] offset %[[OFFSET1]] row_stride %[[STRIDES1]]#0 : !util.buffer)
+//  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
+//  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
+//  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#0, %[[SIZES2]]#1)
+//  CHECK-SAME:   m0n0k0(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
+//  CHECK-SAME:   flags(1)
+func.func @mmt4d_f32f32f32(%arg0 : memref<5x4x7x3xf32>, %arg1 : memref<5x6x7x8xf32>, %arg2 : memref<4x6x3x8xf32>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xf32>, memref<4x6x3x8xf32>)
+      outs(%arg0 : memref<5x4x7x3xf32>)
+  func.return
+}
+
+// CHECK-LABEL: @mmt4d_i8i8i32
+//   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:4, %[[STRIDES0:.*]]:4 = vmvx.get_buffer_descriptor %arg0
+//   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:4, %[[STRIDES1:.*]]:4 = vmvx.get_buffer_descriptor %arg1
+//   CHECK-DAG: %[[BB2:.*]], %[[OFFSET2:.*]], %[[SIZES2:.*]]:4, %[[STRIDES2:.*]]:4 = vmvx.get_buffer_descriptor %arg2
+//       CHECK: vmvx.mmt4d lhs(%[[BB1]] offset %[[OFFSET1]] row_stride %[[STRIDES1]]#0 : !util.buffer)
+//  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
+//  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
+//  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#0, %[[SIZES2]]#1)
+//  CHECK-SAME:   m0n0k0(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
+//  CHECK-SAME:   flags(1)
+func.func @mmt4d_i8i8i32(%arg0 : memref<5x4x7x3xi32>, %arg1 : memref<5x6x7x8xi8>, %arg2 : memref<4x6x3x8xi8>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32>)
+  func.return
+}
+
+
+// Now we test some variations of @mmt4d_i8i8i32 where the only thing that
+// varies is the affine_map on some memref, in order to test the logic deciding
+// whether a linalg.mmt4d meets the buffer layout requirements to be rewritten
+// as a vmvx.mmt4d. The requirement is that all 3 operand buffers (lhs, rhs,
+// acc) must be contiguous row-major except perhaps in the outer-most dimension.
+#map_5x4x7x3_contiguous_rowmajor_with_offset = affine_map<(d0, d1, d2, d3)[offset] -> (84 * d0 + 21 * d1 + 3 * d2 + d3 + offset)>
+#map_5x4x7x3_noncontiguous_dim0 = affine_map<(d0, d1, d2, d3) -> (85 * d0 + 21 * d1 + 3 * d2 + d3)>
+#map_5x4x7x3_noncontiguous_dim1 = affine_map<(d0, d1, d2, d3) -> (88 * d0 + 22 * d1 + 3 * d2 + d3)>
+#map_5x4x7x3_noncontiguous_dim2 = affine_map<(d0, d1, d2, d3) -> (112 * d0 + 28 * d1 + 4 * d2 + d3)>
+#map_5x6x7x8_noncontiguous_dim1 = affine_map<(d0, d1, d2, d3) -> (360 * d0 + 60 * d1 + 8 * d2 + d3)>
+#map_4x6x3x8_noncontiguous_dim1 = affine_map<(d0, d1, d2, d3) -> (150 * d0 + 25 * d1 + 8 * d2 + d3)>
+
+// Test mmt4d with accumulator with an affine_map with an offset symbol.
+// The offset shouldn't matter, so this should become a vmvx.mmt4d.
+// CHECK-LABEL: @mmt4d_buffer_layout_edge_case_0
+//   CHECK: vmvx.mmt4d
+func.func @mmt4d_buffer_layout_edge_case_0(
+    %arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_contiguous_rowmajor_with_offset>,
+    %arg1 : memref<5x6x7x8xi8>,
+    %arg2 : memref<4x6x3x8xi8>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_contiguous_rowmajor_with_offset>)
+  func.return
+}
+
+// Test mmt4d with accumulator with an affine_map with a non-contiguous
+// outermost dimension. The outermost dimension shouldn't matter, so this
+// should become a vmvx.mmt4d.
+// CHECK-LABEL: @mmt4d_buffer_layout_edge_case_1
+//   CHECK: vmvx.mmt4d
+func.func @mmt4d_buffer_layout_edge_case_1(
+    %arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_noncontiguous_dim0>,
+    %arg1 : memref<5x6x7x8xi8>,
+    %arg2 : memref<4x6x3x8xi8>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_noncontiguous_dim0>)
+  func.return
+}
+
+// Test mmt4d with accumulator with an affine_map with a non-contiguous
+// dimension 1. This should prevent it from becoming a vmvx.mmt4d.
+// CHECK-LABEL: @mmt4d_buffer_layout_edge_case_2
+//   CHECK: linalg.mmt4d
+func.func @mmt4d_buffer_layout_edge_case_2(
+    %arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_noncontiguous_dim1>,
+    %arg1 : memref<5x6x7x8xi8>,
+    %arg2 : memref<4x6x3x8xi8>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_noncontiguous_dim1>)
+  func.return
+}
+
+// Test mmt4d with accumulator with an affine_map with a non-contiguous
+// dimension 2. This should prevent it from becoming a vmvx.mmt4d.
+// CHECK-LABEL: @mmt4d_buffer_layout_edge_case_3
+//   CHECK: linalg.mmt4d
+func.func @mmt4d_buffer_layout_edge_case_3(
+    %arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_noncontiguous_dim2>,
+    %arg1 : memref<5x6x7x8xi8>,
+    %arg2 : memref<4x6x3x8xi8>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32, #map_5x4x7x3_noncontiguous_dim2>)
+  func.return
+}
+
+// Test mmt4d with LHS with an affine_map with a non-contiguous
+// dimension 1. This should prevent it from becoming a vmvx.mmt4d.
+// CHECK-LABEL: @mmt4d_buffer_layout_edge_case_4
+//   CHECK: linalg.mmt4d
+func.func @mmt4d_buffer_layout_edge_case_4(
+    %arg0 : memref<5x4x7x3xi32>,
+    %arg1 : memref<5x6x7x8xi8, #map_5x6x7x8_noncontiguous_dim1>,
+    %arg2 : memref<4x6x3x8xi8>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8, #map_5x6x7x8_noncontiguous_dim1>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32>)
+  func.return
+}
+
+// Test mmt4d with RHS with an affine_map with a non-contiguous
+// dimension 1. This should prevent it from becoming a vmvx.mmt4d.
+// CHECK-LABEL: @mmt4d_buffer_layout_edge_case_5
+//   CHECK: linalg.mmt4d
+func.func @mmt4d_buffer_layout_edge_case_5(
+    %arg0 : memref<5x4x7x3xi32>,
+    %arg1 : memref<5x6x7x8xi8>,
+    %arg2 : memref<4x6x3x8xi8, #map_4x6x3x8_noncontiguous_dim1>) {
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8, #map_4x6x3x8_noncontiguous_dim1>)
+      outs(%arg0 : memref<5x4x7x3xi32>)
+  func.return
+}
+
 // CHECK-LABEL: @addf2d_rank_broadcast
 //   CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
 //   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:2, %[[STRIDES0:.*]]:2 = vmvx.get_buffer_descriptor %arg0

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
@@ -93,7 +93,7 @@ func.func @matmul_i8i8i32_row_major(%arg0 : memref<64x64xi32>, %arg1 : memref<64
 //  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
 //  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
 //  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#0, %[[SIZES2]]#1)
-//  CHECK-SAME:   m0n0k0(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
+//  CHECK-SAME:   tile_mnk(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
 //  CHECK-SAME:   flags(1)
 func.func @mmt4d_f32f32f32(%arg0 : memref<5x4x7x3xf32>, %arg1 : memref<5x6x7x8xf32>, %arg2 : memref<4x6x3x8xf32>) {
   linalg.mmt4d
@@ -110,7 +110,7 @@ func.func @mmt4d_f32f32f32(%arg0 : memref<5x4x7x3xf32>, %arg1 : memref<5x6x7x8xf
 //  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
 //  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
 //  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#0, %[[SIZES2]]#1)
-//  CHECK-SAME:   m0n0k0(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
+//  CHECK-SAME:   tile_mnk(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
 //  CHECK-SAME:   flags(1)
 func.func @mmt4d_i8i8i32(%arg0 : memref<5x4x7x3xi32>, %arg1 : memref<5x6x7x8xi8>, %arg2 : memref<4x6x3x8xi8>) {
   linalg.mmt4d

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/ConvertVMVXToVM.cpp
@@ -174,6 +174,20 @@ class MatmulOpConversion : public VMVXImportOpConversion<IREE::VMVX::MatmulOp> {
   }
 };
 
+// Converts the vmvx.mmt4d op to an appropriate typed import.
+class Mmt4dOpConversion : public VMVXImportOpConversion<IREE::VMVX::Mmt4dOp> {
+ public:
+  using VMVXImportOpConversion::VMVXImportOpConversion;
+
+  std::string getImportFqName(IREE::VMVX::Mmt4dOp op) const override {
+    std::string name("vmvx.mmt4d.");
+    name.append(getTypedTypeStr(op.getLhsType()));
+    name.append(getTypedTypeStr(op.getRhsType()));
+    name.append(getTypedTypeStr(op.getOutType()));
+    return name;
+  }
+};
+
 class UnaryOpConversion : public VMVXImportOpConversion<IREE::VMVX::UnaryOp> {
  public:
   using VMVXImportOpConversion::VMVXImportOpConversion;
@@ -198,8 +212,8 @@ void populateVMVXToVMPatterns(MLIRContext *context,
                               SymbolTable &importSymbols,
                               RewritePatternSet &patterns) {
   patterns.insert<BinaryOpConversion, CopyOpConversion, Fill2DOpConversion,
-                  MatmulOpConversion, UnaryOpConversion>(context, importSymbols,
-                                                         typeConverter);
+                  MatmulOpConversion, Mmt4dOpConversion, UnaryOpConversion>(
+      context, importSymbols, typeConverter);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
             "copy.mlir",
             "fill.mlir",
             "matmul.mlir",
+            "mmt4d.mlir",
             "unary.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "copy.mlir"
     "fill.mlir"
     "matmul.mlir"
+    "mmt4d.mlir"
     "unary.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/mmt4d.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/mmt4d.mlir
@@ -11,7 +11,7 @@ func.func @mmt4d_f32f32f32(
     %arg6 : !util.buffer, %arg7 : index, %arg8 : index,
     // MNK
     %arg9 : index, %arg10 : index, %arg11 : index,
-    // M0N0K0
+    // TILE_MNK
     %arg12 : index, %arg13 : index, %arg14 : index
     ) {
 
@@ -26,7 +26,7 @@ func.func @mmt4d_f32f32f32(
              rhs(%arg3 offset %arg4 row_stride %arg5 : !util.buffer)
              out(%arg6 offset %arg7 row_stride %arg8 : !util.buffer)
              mnk(%arg9, %arg10, %arg11)
-             m0n0k0(%arg12, %arg13, %arg14)
+             tile_mnk(%arg12, %arg13, %arg14)
              flags(1) : (f32, f32, f32)
   func.return
 }
@@ -41,7 +41,7 @@ func.func @mmt4d_i8i8i32(
     %arg6 : !util.buffer, %arg7 : index, %arg8 : index,
     // MNK
     %arg9 : index, %arg10 : index, %arg11 : index,
-    // M0N0K0
+    // TILE_MNK
     %arg12 : index, %arg13 : index, %arg14 : index
     ) {
 
@@ -56,7 +56,7 @@ func.func @mmt4d_i8i8i32(
              rhs(%arg3 offset %arg4 row_stride %arg5 : !util.buffer)
              out(%arg6 offset %arg7 row_stride %arg8 : !util.buffer)
              mnk(%arg9, %arg10, %arg11)
-             m0n0k0(%arg12, %arg13, %arg14)
+             tile_mnk(%arg12, %arg13, %arg14)
              flags(1) : (i8, i8, i32)
   func.return
 }

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/mmt4d.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/VMVXToVM/test/mmt4d.mlir
@@ -1,0 +1,62 @@
+// RUN: iree-opt --iree-vm-target-index-bits=64 --split-input-file \
+// RUN:   --iree-vm-conversion --canonicalize %s | FileCheck %s
+
+// CHECK-LABEL: @mmt4d_f32f32f32
+func.func @mmt4d_f32f32f32(
+    // LHS
+    %arg0 : !util.buffer, %arg1 : index, %arg2 : index,
+    // RHS
+    %arg3 : !util.buffer, %arg4 : index, %arg5 : index,
+    // OUT
+    %arg6 : !util.buffer, %arg7 : index, %arg8 : index,
+    // MNK
+    %arg9 : index, %arg10 : index, %arg11 : index,
+    // M0N0K0
+    %arg12 : index, %arg13 : index, %arg14 : index
+    ) {
+
+  //  CHECK-DAG: %[[FLAGS:.*]] = vm.const.i32 1
+  //      CHECK: vm.call @vmvx.mmt4d.f32f32f32(
+  // CHECK-SAME: %arg0, %arg1, %arg2,
+  // CHECK-SAME: %arg3, %arg4, %arg5,
+  // CHECK-SAME: %arg6, %arg7, %arg8,
+  // CHECK-SAME: %arg9, %arg10, %arg11,
+  // CHECK-SAME: %[[FLAGS]]) : (!vm.buffer, i64, i64, !vm.buffer, i64, i64, !vm.buffer, i64, i64, i64, i64, i64, i32, i32, i32, i32) -> ()
+  vmvx.mmt4d lhs(%arg0 offset %arg1 row_stride %arg2 : !util.buffer)
+             rhs(%arg3 offset %arg4 row_stride %arg5 : !util.buffer)
+             out(%arg6 offset %arg7 row_stride %arg8 : !util.buffer)
+             mnk(%arg9, %arg10, %arg11)
+             m0n0k0(%arg12, %arg13, %arg14)
+             flags(1) : (f32, f32, f32)
+  func.return
+}
+
+// CHECK-LABEL: @mmt4d_i8i8i32
+func.func @mmt4d_i8i8i32(
+    // LHS
+    %arg0 : !util.buffer, %arg1 : index, %arg2 : index,
+    // RHS
+    %arg3 : !util.buffer, %arg4 : index, %arg5 : index,
+    // OUT
+    %arg6 : !util.buffer, %arg7 : index, %arg8 : index,
+    // MNK
+    %arg9 : index, %arg10 : index, %arg11 : index,
+    // M0N0K0
+    %arg12 : index, %arg13 : index, %arg14 : index
+    ) {
+
+  //  CHECK-DAG: %[[FLAGS:.*]] = vm.const.i32 1
+  //      CHECK: vm.call @vmvx.mmt4d.i8i8i32(
+  // CHECK-SAME: %arg0, %arg1, %arg2,
+  // CHECK-SAME: %arg3, %arg4, %arg5,
+  // CHECK-SAME: %arg6, %arg7, %arg8,
+  // CHECK-SAME: %arg9, %arg10, %arg11,
+  // CHECK-SAME: %[[FLAGS]]) : (!vm.buffer, i64, i64, !vm.buffer, i64, i64, !vm.buffer, i64, i64, i64, i64, i64, i32, i32, i32, i32) -> ()
+  vmvx.mmt4d lhs(%arg0 offset %arg1 row_stride %arg2 : !util.buffer)
+             rhs(%arg3 offset %arg4 row_stride %arg5 : !util.buffer)
+             out(%arg6 offset %arg7 row_stride %arg8 : !util.buffer)
+             mnk(%arg9, %arg10, %arg11)
+             m0n0k0(%arg12, %arg13, %arg14)
+             flags(1) : (i8, i8, i32)
+  func.return
+}

--- a/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
+++ b/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
@@ -216,6 +216,54 @@ def VMVX_MatmulOp : VMVX_Op<"matmul"> {
   }];
 }
 
+def VMVX_Mmt4dOp : VMVX_Op<"mmt4d"> {
+  let summary = "mmt4d";
+  let description = [{
+    Tiled matmul mirroring linalg.mmt4d
+  }];
+  let arguments = (ins
+    // Lhs buffer.
+    VMVX_Buffer:$lhs_buffer,
+    VMVX_Index:$lhs_offset,
+    VMVX_Index:$lhs_row_stride,
+    // Rhs buffer.
+    VMVX_Buffer:$rhs_buffer,
+    VMVX_Index:$rhs_offset,
+    VMVX_Index:$rhs_row_stride,
+    // Out buffer.
+    VMVX_Buffer:$out_buffer,
+    VMVX_Index:$out_offset,
+    VMVX_Index:$out_row_stride,
+
+    // Dimensions.
+    VMVX_Index:$m,
+    VMVX_Index:$n,
+    VMVX_Index:$k,
+
+    // Tile dimensions.
+    VMVX_Index:$m0,
+    VMVX_Index:$n0,
+    VMVX_Index:$k0,
+
+    // Type and flag attributes.
+    VMVX_ElementTypeAttr:$lhs_type,
+    VMVX_ElementTypeAttr:$rhs_type,
+    VMVX_ElementTypeAttr:$out_type,
+    I32Attr:$flags
+  );
+
+  let assemblyFormat = [{
+    `lhs` `` `(` $lhs_buffer `offset` $lhs_offset `row_stride` $lhs_row_stride `:` type($lhs_buffer) `)`
+    `rhs` `` `(` $rhs_buffer `offset` $rhs_offset `row_stride` $rhs_row_stride `:` type($rhs_buffer)`)`
+    `out` `` `(` $out_buffer `offset` $out_offset `row_stride` $out_row_stride `:` type($out_buffer) `)`
+    `mnk` `` `(` $m `,` $n `,` $k `)`
+    `m0n0k0` `` `(` $m0 `,` $n0 `,` $k0 `)`
+    `flags` `` `(` $flags `)`
+    `:` `(` $lhs_type `,` $rhs_type `,` $out_type `)`
+    attr-dict
+  }];
+}
+
 def VMVX_UnaryOp : VMVX_Op<"unary", [SameVariadicOperandSize]> {
   let summary = "Performs a strided elementwise unary operation";
   let description = [{

--- a/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
+++ b/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
@@ -241,9 +241,9 @@ def VMVX_Mmt4dOp : VMVX_Op<"mmt4d"> {
     VMVX_Index:$k,
 
     // Tile dimensions.
-    VMVX_Index:$m0,
-    VMVX_Index:$n0,
-    VMVX_Index:$k0,
+    VMVX_Index:$tile_m,
+    VMVX_Index:$tile_n,
+    VMVX_Index:$tile_k,
 
     // Type and flag attributes.
     VMVX_ElementTypeAttr:$lhs_type,
@@ -257,7 +257,7 @@ def VMVX_Mmt4dOp : VMVX_Op<"mmt4d"> {
     `rhs` `` `(` $rhs_buffer `offset` $rhs_offset `row_stride` $rhs_row_stride `:` type($rhs_buffer)`)`
     `out` `` `(` $out_buffer `offset` $out_offset `row_stride` $out_row_stride `:` type($out_buffer) `)`
     `mnk` `` `(` $m `,` $n `,` $k `)`
-    `m0n0k0` `` `(` $m0 `,` $n0 `,` $k0 `)`
+    `tile_mnk` `` `(` $tile_m `,` $tile_n `,` $tile_k `)`
     `flags` `` `(` $flags `)`
     `:` `(` $lhs_type `,` $rhs_type `,` $out_type `)`
     attr-dict

--- a/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/vmvx.imports.mlir
@@ -449,4 +449,46 @@ vm.import @matmul.i8i8i32(
   %flags : i32
 )
 
+//==============================================================================
+// mmt4d ops
+//==============================================================================
+
+vm.import @mmt4d.f32f32f32(
+  %lhs_buffer : !vm.buffer,
+  %lhs_offset : i64,
+  %lhs_row_stride : i64,
+  %rhs_buffer : !vm.buffer,
+  %rhs_offset : i64,
+  %rhs_row_stride : i64,
+  %out_buffer : !vm.buffer,
+  %out_offset : i64,
+  %out_row_stride : i64,
+  %m : i64,
+  %n : i64,
+  %k : i64,
+  %m0 : i32,
+  %n0 : i32,
+  %k0 : i32,
+  %flags : i32
+)
+
+vm.import @mmt4d.i8i8i32(
+  %lhs_buffer : !vm.buffer,
+  %lhs_offset : i64,
+  %lhs_row_stride : i64,
+  %rhs_buffer : !vm.buffer,
+  %rhs_offset : i64,
+  %rhs_row_stride : i64,
+  %out_buffer : !vm.buffer,
+  %out_offset : i64,
+  %out_row_stride : i64,
+  %m : i64,
+  %n : i64,
+  %k : i64,
+  %m0 : i32,
+  %n0 : i32,
+  %k0 : i32,
+  %flags : i32
+)
+
 }  // module

--- a/runtime/src/iree/modules/vmvx/exports.inl
+++ b/runtime/src/iree/modules/vmvx/exports.inl
@@ -42,10 +42,8 @@ EXPORT_FN("floor.2d.f32", iree_ukernel_x32u_floorf_2d, ukernel_x32u_2d, rIIIrIII
 EXPORT_FN("log.2d.f32", iree_ukernel_x32u_logf_2d, ukernel_x32u_2d, rIIIrIIIII, v)
 EXPORT_FN("matmul.f32f32f32", iree_vmvx_matmul_f32f32f32, matmul, rIIrIIrIIIIIi, v)
 EXPORT_FN("matmul.i8i8i32", iree_vmvx_matmul_i8i8i32, matmul, rIIrIIrIIIIIi, v)
-// NOTE: must still be in alphabetical order with all other exports.
-#if 0 // TODO: implement mmt4d ukernel
-EXPORT_FN("mmt4d.f32f32f32", iree_vmvx_mmt4d_f32f32f32, mmt4d_f32, rIIrIIrIIIIIffi, v)
-#endif
+EXPORT_FN("mmt4d.f32f32f32", iree_vmvx_mmt4d_f32f32f32, mmt4d, rIIrIIrIIIIIiiii, v)
+EXPORT_FN("mmt4d.i8i8i32", iree_vmvx_mmt4d_i8i8i32, mmt4d, rIIrIIrIIIIIiiii, v)
 EXPORT_FN("mul.2d.f32", iree_ukernel_x32b_mulf_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 EXPORT_FN("mul.2d.i32", iree_ukernel_x32b_muli_2d, ukernel_x32b_2d, rIIIrIIIrIIIII, v)
 EXPORT_FN("neg.2d.f32", iree_ukernel_x32u_negf_2d, ukernel_x32u_2d, rIIIrIIIII, v)


### PR DESCRIPTION
This brings an initial (unoptimized, reference code only) mmt4d ukernel - both `f32f32f32` and `i8i8i32`.

It is covered by the e2e matmul tests: if you purposefully introduce a numerical bug in the ukernel function, `iree_vmvx_mmt4d_f32f32f32` then this test fails: `iree/tests/e2e/matmul/e2e_matmul_mmt4d_f32_small_ukernel_vmvx_local-task` . Ditto for `i8i8i32`.

That the whole reference code is for now in `module.c`, as opposed to being nicely isolated in `iree/builtings/ukernel`, is temporary. I have a few questions to ask about the placeholders in this directory, but it will be so much more concrete to discuss after we are done reviewing this PR so I hope that's OK to split as a separate code move for another PR.

A couple of nontrivial decisions in this PR:

* In `LowerLinalgMicrokernels.cpp` there was a `isUnitInnerStride` helper function. It was only applied to 2D memrefs. The underlying question is how much layout generality do we want ukernels to support, and the existing code embodied a decision on this for 2D arrays, but mmt4d deals with 4D arrays so the question was how to generalize this from 2D to 4D arrays. I chose to generalize `isUnitInnerStride` into `areInnerDimsContiguousRowMajor`. See the comment where it is defined. The lit test, `lower_linalg_microkernels.mlir`, has testcases to cover several edge cases here.

* Similar to what we decided last week for matmul in #10211, there was the question of how to deal with the accumulators that is nonzero in the general case but that we know will often be zero in practice so that we will want to retain the ability to take advantage of that. This is handled here exactly like it was for matmul in #10211. I even reused the flag symbolic constant rather than create a separate one. Yay for weak typing.

