### PR TITLE
Handle multi-result operations and dispatches.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -198,6 +198,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
+        "//compiler/src/iree/compiler/Utils",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -206,6 +206,7 @@ iree_cc_library(
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::Util::IR
+    iree::compiler::Utils
   PUBLIC
 )
 


### PR DESCRIPTION
The TileAndDistributeToWorkgroups could only handle cases where fused
producer has a single use. For multiple uses, each use would introduce
new instance of the tiled producer with tile + fuse. To address this
add a `TileAndFuse` pattern that fuses the producer right after
tiling. This allows updating multiple uses of the producer and also
update the `flow.dispatch.tensor.store` operations to use tiled
versions of this operation. This also allows handling dispatches where
multiple results are returned.

Issue #10228 