### PR TITLE
Pass env variable instructing CI to write Bazel cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
         # run in (to ensure correct cache hits).
         run: |
           ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_BAZEL_WRITE_REMOTE_CACHE=${IREE_BAZEL_WRITE_REMOTE_CACHE}" \
             gcr.io/iree-oss/frontends-swiftshader@sha256:41e516b8c1b432e3c02896c4bf4b7f06df6a67371aa167b88767b8d4d2018ea6 \
             ./build_tools/bazel/build_core.sh
 
@@ -330,6 +331,7 @@ jobs:
           IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ github.event_name != 'pull_request' && 1 || 0 }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_BAZEL_WRITE_REMOTE_CACHE=${IREE_BAZEL_WRITE_REMOTE_CACHE}" \
             --env "IREE_TF_BINARIES_OUTPUT_DIR=$(realpath "${IREE_TF_BINARIES_OUTPUT_DIR}")" \
             gcr.io/iree-oss/frontends-swiftshader@sha256:3090418a8d8a64c356d35eff285af32570a72f41127aa123209c1562f57abb01 \
             build_tools/cmake/build_tf_binaries.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: "Building with Bazel"
         env:
           # Psuedo-ternary hack. Don't swap the condition! See comment at top of file.
-          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ github.event_name != 'pull_request' && 1 || 0 }}
+          IREE_BAZEL_WRITE_REMOTE_CACHE: 1
         # This doesn't really need everything in the frontends image, but we
         # want the cache to be shared with the integrations build (no point
         # building LLVM twice) and the cache key is the docker container it's
@@ -328,7 +328,7 @@ jobs:
         env:
           IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
           # Psuedo-ternary hack. Don't swap the condition! See comment at top of file.
-          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ github.event_name != 'pull_request' && 1 || 0 }}
+          IREE_BAZEL_WRITE_REMOTE_CACHE: 1
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "IREE_BAZEL_WRITE_REMOTE_CACHE=${IREE_BAZEL_WRITE_REMOTE_CACHE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     env:
@@ -150,7 +150,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     steps:
@@ -178,7 +178,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     env:
@@ -208,7 +208,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - gpu
       - os-family=Linux
     env:
@@ -311,7 +311,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     outputs:
@@ -359,7 +359,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     env:
@@ -398,7 +398,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - gpu
       - os-family=Linux
     env:
@@ -445,7 +445,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     steps:
@@ -465,7 +465,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     steps:
@@ -485,7 +485,7 @@ jobs:
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     env:
@@ -525,7 +525,7 @@ jobs:
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     env:
@@ -556,7 +556,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     env:
@@ -590,7 +590,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=postsubmit
+      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
       - cpu
       - os-family=Linux
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: "Building with Bazel"
         env:
           # Psuedo-ternary hack. Don't swap the condition! See comment at top of file.
-          IREE_BAZEL_WRITE_REMOTE_CACHE: 1
+          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ github.event_name != 'pull_request' && 1 || 0 }}
         # This doesn't really need everything in the frontends image, but we
         # want the cache to be shared with the integrations build (no point
         # building LLVM twice) and the cache key is the docker container it's
@@ -328,7 +328,7 @@ jobs:
         env:
           IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
           # Psuedo-ternary hack. Don't swap the condition! See comment at top of file.
-          IREE_BAZEL_WRITE_REMOTE_CACHE: 1
+          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ github.event_name != 'pull_request' && 1 || 0 }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "IREE_BAZEL_WRITE_REMOTE_CACHE=${IREE_BAZEL_WRITE_REMOTE_CACHE}" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     env:
@@ -150,7 +150,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     steps:
@@ -178,7 +178,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     env:
@@ -208,7 +208,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - gpu
       - os-family=Linux
     env:
@@ -311,7 +311,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     outputs:
@@ -359,7 +359,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     env:
@@ -398,7 +398,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - gpu
       - os-family=Linux
     env:
@@ -445,7 +445,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     steps:
@@ -465,7 +465,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     steps:
@@ -485,7 +485,7 @@ jobs:
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     env:
@@ -525,7 +525,7 @@ jobs:
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     env:
@@ -556,7 +556,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     env:
@@ -590,7 +590,7 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=postsubmit
       - cpu
       - os-family=Linux
     env:


### PR DESCRIPTION
So it turns out that the postsubmit jobs were never actually writing to
the remote cache here. How were they still getting cache hits then?
Because until last week, the *Kokoro* postsubmit jobs were still
writing that cache. So given that they were running concurrently with
the GitHub jobs, we had a pattern that was totally consistent with
GitHub actions postsubmit jobs writing the cache: an initial build that
is slow followed by fast builds from a populated cache. The last Kokoro
build of the TF integration binaries was for
https://github.com/iree-org/iree/commit/e4dc88c3d1, so everything up to
that point was cached. When we next upgraded LLVM and invalidated a big
chunk of the cache, we no longer had anything writing it and builds
became very slow as they got no cache hits. Even more fun, I had ruled
out infrastructure issues because I could revert back to the old commit
and get a fast TF build, but of course that's just because the old
stuff was still cached!

This is basically impossible to test on presubmit because those runners
aren't allowed to write to the cache and I've put a lot of effort into
making it impossible to run presubmits to touch any postsubmit stuff.

(probably) fixes https://github.com/iree-org/iree/issues/10237