### PR TITLE
Rollup of latency improvements to the task system.

### DIFF
--- a/experimental/web/sample_static/device_multithreaded.c
+++ b/experimental/web/sample_static/device_multithreaded.c
@@ -27,9 +27,9 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
       &library_loader);
 
   // Create a task executor.
-  iree_task_executor_t* executor = NULL;
-  iree_task_scheduling_mode_t scheduling_mode = 0;
-  iree_host_size_t worker_local_memory = 0;
+  iree_task_executor_options_t options;
+  iree_task_executor_options_initialize(&options);
+  options.worker_local_memory_size = 0;
   iree_task_topology_t topology;
   iree_task_topology_initialize(&topology);
   iree_task_topology_initialize_from_group_count(
@@ -39,9 +39,9 @@ iree_status_t create_device_with_static_loader(iree_allocator_t host_allocator,
   // INITIAL_MEMORY, or setting Emscripten's ALLOW_MEMORY_GROWTH.
   // iree_task_topology_initialize_from_group_count(
   //     /*group_count=*/emscripten_num_logical_cores(), &topology);
+  iree_task_executor_t* executor = NULL;
   if (iree_status_is_ok(status)) {
-    status = iree_task_executor_create(scheduling_mode, &topology,
-                                       worker_local_memory, host_allocator,
+    status = iree_task_executor_create(options, &topology, host_allocator,
                                        &executor);
   }
   iree_task_topology_deinitialize(&topology);

--- a/runtime/src/iree/base/internal/synchronization.c
+++ b/runtime/src/iree/base/internal/synchronization.c
@@ -612,6 +612,7 @@ iree_wait_token_t iree_notification_prepare_wait(
 
 bool iree_notification_commit_wait(iree_notification_t* notification,
                                    iree_wait_token_t wait_token,
+                                   iree_duration_t spin_ns,
                                    iree_time_t deadline_ns) {
   return true;
 }
@@ -667,6 +668,7 @@ iree_wait_token_t iree_notification_prepare_wait(
 
 bool iree_notification_commit_wait(iree_notification_t* notification,
                                    iree_wait_token_t wait_token,
+                                   iree_duration_t spin_ns,
                                    iree_time_t deadline_ns) {
   struct timespec abs_ts = {
       .tv_sec = (time_t)(deadline_ns / 1000000000ull),
@@ -769,21 +771,59 @@ iree_wait_token_t iree_notification_prepare_wait(
   return (iree_wait_token_t)(previous_value >> IREE_NOTIFICATION_EPOCH_SHIFT);
 }
 
+typedef enum iree_notification_result_e {
+  IREE_NOTIFICATION_RESULT_UNRESOLVED = 0,
+  IREE_NOTIFICATION_RESULT_RESOLVED,
+  IREE_NOTIFICATION_RESULT_REJECTED,
+} iree_notification_result_t;
+
+static iree_notification_result_t iree_notification_test_wait_condition(
+    iree_notification_t* notification, iree_wait_token_t wait_token) {
+  return (iree_atomic_load_int64(&notification->value,
+                                 iree_memory_order_acquire) >>
+          IREE_NOTIFICATION_EPOCH_SHIFT) != wait_token
+             ? IREE_NOTIFICATION_RESULT_RESOLVED
+             : IREE_NOTIFICATION_RESULT_UNRESOLVED;
+}
+
 bool iree_notification_commit_wait(iree_notification_t* notification,
                                    iree_wait_token_t wait_token,
+                                   iree_duration_t spin_ns,
                                    iree_time_t deadline_ns) {
-  bool result = true;
+  // Quick check to see if the wait has already succeeded (the epoch advances
+  // from when it was captured in iree_notification_prepare_wait).
+  iree_notification_result_t result =
+      iree_notification_test_wait_condition(notification, wait_token);
 
-  // Spin until notified and the epoch increments from what we captured during
-  // iree_notification_prepare_wait.
-  while ((iree_atomic_load_int64(&notification->value,
-                                 iree_memory_order_acquire) >>
-          IREE_NOTIFICATION_EPOCH_SHIFT) == wait_token) {
-    iree_status_code_t status_code = iree_futex_wait(
-        iree_notification_epoch_address(notification), wait_token, deadline_ns);
-    if (status_code != IREE_STATUS_OK) {
-      result = false;
-      break;
+  // If not already reached and spinning is enabled then we'll try that first.
+  if (result == IREE_NOTIFICATION_RESULT_UNRESOLVED &&
+      spin_ns != IREE_DURATION_ZERO) {
+    // If spinning we need to compute the absolute deadline that we'll spin
+    // until (as we may be descheduled while spinning and time may drift).
+    const iree_time_t spin_deadline_ns = iree_time_now() + spin_ns;
+    IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_notification_commit_wait_spin");
+    do {
+      // Try to be nice to the processor when using SMT.
+      iree_processor_yield();
+      result = iree_notification_test_wait_condition(notification, wait_token);
+    } while (result == IREE_NOTIFICATION_RESULT_UNRESOLVED &&
+             iree_time_now() < spin_deadline_ns);
+    IREE_TRACE_ZONE_END(z0);
+  }
+
+  // If spinning failed let the kernel do what it does ... okish at.
+  // We loop until notified and the epoch increments from what we captured
+  // during iree_notification_prepare_wait.
+  if (deadline_ns != IREE_TIME_INFINITE_PAST) {
+    while (result == IREE_NOTIFICATION_RESULT_UNRESOLVED) {
+      iree_status_code_t status_code =
+          iree_futex_wait(iree_notification_epoch_address(notification),
+                          wait_token, deadline_ns);
+      if (status_code != IREE_STATUS_OK) {
+        result = IREE_NOTIFICATION_RESULT_REJECTED;
+        break;
+      }
+      result = iree_notification_test_wait_condition(notification, wait_token);
     }
   }
 
@@ -795,7 +835,7 @@ bool iree_notification_commit_wait(iree_notification_t* notification,
       iree_memory_order_acq_rel);
   SYNC_ASSERT((previous_value & IREE_NOTIFICATION_WAITER_MASK) != 0);
 
-  return result;
+  return result == IREE_NOTIFICATION_RESULT_RESOLVED;
 }
 
 void iree_notification_cancel_wait(iree_notification_t* notification) {
@@ -833,6 +873,7 @@ bool iree_notification_await(iree_notification_t* notification,
       return true;
     } else {
       if (!iree_notification_commit_wait(notification, wait_token,
+                                         /*spin_ns=*/IREE_DURATION_ZERO,
                                          deadline_ns)) {
         // Wait hit the deadline before we hit the condition.
         return false;

--- a/runtime/src/iree/base/internal/synchronization.h
+++ b/runtime/src/iree/base/internal/synchronization.h
@@ -401,6 +401,9 @@ iree_wait_token_t iree_notification_prepare_wait(
 // is reached. Returns false if the deadline is reached before a notification is
 // posted.
 //
+// If |spin_ns| is not IREE_DURATION_ZERO the wait _may_ spin for at least the
+// specified duration before entering the system wait API.
+//
 // Acts as (at least) a memory_order_acquire operation on the notification
 // object. This is meant to be paired with iree_notification_post, which is a
 // memory_order_release operation. This means the following guarantee:
@@ -411,6 +414,7 @@ iree_wait_token_t iree_notification_prepare_wait(
 // memory read or write on thread T1.
 bool iree_notification_commit_wait(iree_notification_t* notification,
                                    iree_wait_token_t wait_token,
+                                   iree_duration_t spin_ns,
                                    iree_time_t deadline_ns);
 
 // Cancels a pending wait operation without blocking.

--- a/runtime/src/iree/task/api.c
+++ b/runtime/src/iree/task/api.c
@@ -17,13 +17,6 @@
 // Executor configuration
 //===----------------------------------------------------------------------===//
 
-IREE_FLAG(
-    bool, task_scheduling_defer_worker_startup, false,
-    "Creates all workers suspended and waits until work is first scheduled to\n"
-    "them to resume. This trades off initial blocking startup time waking the\n"
-    "threads for potential latency additions later on as threads take longer\n"
-    "to wake on their first use.");
-
 // TODO(benvanik): enable this when we use it - though hopefully we don't!
 IREE_FLAG(
     int32_t, task_worker_local_memory, 0,  // 64 * 1024,
@@ -74,9 +67,6 @@ iree_status_t iree_task_executor_create_from_flags(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   iree_task_scheduling_mode_t scheduling_mode = 0;
-  if (FLAG_task_scheduling_defer_worker_startup) {
-    scheduling_mode |= IREE_TASK_SCHEDULING_MODE_DEFER_WORKER_STARTUP;
-  }
 
   iree_host_size_t worker_local_memory =
       (iree_host_size_t)FLAG_task_worker_local_memory;

--- a/runtime/src/iree/task/api.h
+++ b/runtime/src/iree/task/api.h
@@ -16,6 +16,20 @@ extern "C" {
 #endif  // __cplusplus
 
 //===----------------------------------------------------------------------===//
+// Flag parsing
+//===----------------------------------------------------------------------===//
+
+// Initializes |out_options| from the command line flags.
+// Used in place of iree_task_executor_options_initialize.
+iree_status_t iree_task_executor_options_initialize_from_flags(
+    iree_task_executor_options_t* out_options);
+
+// Initializes |out_topology| from the command line flags.
+// Used in place of iree_task_topology_initialize.
+iree_status_t iree_task_topology_initialize_from_flags(
+    iree_task_topology_t* out_topology);
+
+//===----------------------------------------------------------------------===//
 // Task system factory functions
 //===----------------------------------------------------------------------===//
 

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -129,15 +129,10 @@ iree_status_t iree_task_executor_create(
 
     iree_task_affinity_set_t worker_idle_mask = 0;
     iree_task_affinity_set_t worker_live_mask = 0;
-    iree_task_affinity_set_t worker_suspend_mask = 0;
     for (iree_host_size_t i = 0; i < worker_count; ++i) {
       iree_task_affinity_set_t worker_bit = iree_task_affinity_for_worker(i);
       worker_idle_mask |= worker_bit;
       worker_live_mask |= worker_bit;
-      if (executor->scheduling_mode &
-          IREE_TASK_SCHEDULING_MODE_DEFER_WORKER_STARTUP) {
-        worker_suspend_mask |= worker_bit;
-      }
 
       iree_task_worker_t* worker = &executor->workers[i];
       status = iree_task_worker_initialize(
@@ -148,9 +143,6 @@ iree_status_t iree_task_executor_create(
       if (!iree_status_is_ok(status)) break;
     }
     // The masks are accessed with 'relaxed' order because they are just hints.
-    iree_atomic_task_affinity_set_store(&executor->worker_suspend_mask,
-                                        worker_suspend_mask,
-                                        iree_memory_order_relaxed);
     iree_atomic_task_affinity_set_store(&executor->worker_idle_mask,
                                         worker_idle_mask,
                                         iree_memory_order_relaxed);

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -24,11 +24,15 @@
 
 static void iree_task_executor_destroy(iree_task_executor_t* executor);
 
-iree_status_t iree_task_executor_create(
-    iree_task_scheduling_mode_t scheduling_mode,
-    const iree_task_topology_t* topology,
-    iree_host_size_t worker_local_memory_size, iree_allocator_t allocator,
-    iree_task_executor_t** out_executor) {
+void iree_task_executor_options_initialize(
+    iree_task_executor_options_t* out_options) {
+  memset(out_options, 0, sizeof(*out_options));
+}
+
+iree_status_t iree_task_executor_create(iree_task_executor_options_t options,
+                                        const iree_task_topology_t* topology,
+                                        iree_allocator_t allocator,
+                                        iree_task_executor_t** out_executor) {
   iree_host_size_t worker_count = iree_task_topology_group_count(topology);
   if (worker_count > IREE_TASK_EXECUTOR_MAX_WORKER_COUNT) {
     return iree_make_status(
@@ -52,17 +56,19 @@ iree_status_t iree_task_executor_create(
   // The executor is followed in memory by worker[] + worker_local_memory[].
   // The whole point is that we don't want destructive sharing between workers
   // so ensure we are aligned to at least the destructive interference size.
-  worker_local_memory_size = iree_host_align(
-      worker_local_memory_size, iree_hardware_destructive_interference_size);
-  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)worker_local_memory_size);
+  options.worker_local_memory_size =
+      iree_host_align(options.worker_local_memory_size,
+                      iree_hardware_destructive_interference_size);
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, (int64_t)options.worker_local_memory_size);
   iree_host_size_t executor_base_size =
       iree_host_align(sizeof(iree_task_executor_t),
                       iree_hardware_destructive_interference_size);
   iree_host_size_t worker_list_size =
       iree_host_align(worker_count * sizeof(iree_task_worker_t),
                       iree_hardware_destructive_interference_size);
-  iree_host_size_t executor_size = executor_base_size + worker_list_size +
-                                   worker_count * worker_local_memory_size;
+  iree_host_size_t executor_size =
+      executor_base_size + worker_list_size +
+      worker_count * options.worker_local_memory_size;
 
   iree_task_executor_t* executor = NULL;
   IREE_RETURN_AND_END_ZONE_IF_ERROR(
@@ -70,7 +76,8 @@ iree_status_t iree_task_executor_create(
   memset(executor, 0, executor_size);
   iree_atomic_ref_count_init(&executor->ref_count);
   executor->allocator = allocator;
-  executor->scheduling_mode = scheduling_mode;
+  executor->scheduling_mode = options.scheduling_mode;
+  executor->worker_spin_ns = options.worker_spin_ns;
   iree_atomic_task_slist_initialize(&executor->incoming_ready_slist);
   iree_slim_mutex_initialize(&executor->coordinator_mutex);
 
@@ -137,9 +144,10 @@ iree_status_t iree_task_executor_create(
       iree_task_worker_t* worker = &executor->workers[i];
       status = iree_task_worker_initialize(
           executor, i, iree_task_topology_get_group(topology, i),
-          iree_make_byte_span(worker_local_memory, worker_local_memory_size),
+          iree_make_byte_span(worker_local_memory,
+                              options.worker_local_memory_size),
           &seed_prng, worker);
-      worker_local_memory += worker_local_memory_size;
+      worker_local_memory += options.worker_local_memory_size;
       if (!iree_status_is_ok(status)) break;
     }
     // The masks are accessed with 'relaxed' order because they are just hints.

--- a/runtime/src/iree/task/executor.h
+++ b/runtime/src/iree/task/executor.h
@@ -265,23 +265,6 @@ enum iree_task_scheduling_mode_bits_t {
   // reach peak utilization or artificially limiting which tasks we allow
   // through to keep certain CPU cores asleep unless absolutely required.
   IREE_TASK_SCHEDULING_MODE_RESERVED = 0u,
-
-  // Creates all workers suspended and waits until work is first scheduled to
-  // them to resume. This trades off initial blocking startup time waking the
-  // threads for potential latency additions later on as threads take longer to
-  // wake on their first use.
-  //
-  // Prefer this setting in systems where startup time is the priority and work
-  // may not be scheduled for awhile or scheduled unevenly to start; otherwise
-  // the executor creation will take longer and a thundering herd will occur
-  // forcing context switches even if no work is needed.
-  //
-  // Avoid in systems where the latency from initial submission to worker
-  // execution is critical as this will ensure all worker threads are waiting
-  // for their respective wake notifications. The kernel then will be able to
-  // much faster schedule all worker quantums and in many cases all workers will
-  // begin processing simultaneously immediately after the submission is made.
-  IREE_TASK_SCHEDULING_MODE_DEFER_WORKER_STARTUP = 1u << 0,
 };
 typedef uint32_t iree_task_scheduling_mode_t;
 

--- a/runtime/src/iree/task/executor_demo.cc
+++ b/runtime/src/iree/task/executor_demo.cc
@@ -51,13 +51,12 @@ extern "C" int main(int argc, char* argv) {
   iree_task_topology_initialize_from_group_count(/*group_count=*/6, &topology);
 #endif
 
+  iree_task_executor_options_t options;
+  iree_task_executor_options_initialize(&options);
+  options.worker_local_memory_size = 0;  // 64 * 1024;
   iree_task_executor_t* executor = NULL;
-  iree_task_scheduling_mode_t scheduling_mode =
-      IREE_TASK_SCHEDULING_MODE_RESERVED;
-  iree_host_size_t worker_local_memory_size = 0;  // 64 * 1024;
-  IREE_CHECK_OK(iree_task_executor_create(scheduling_mode, &topology,
-                                          worker_local_memory_size, allocator,
-                                          &executor));
+  IREE_CHECK_OK(
+      iree_task_executor_create(options, &topology, allocator, &executor));
   iree_task_topology_deinitialize(&topology);
 
   //

--- a/runtime/src/iree/task/executor_impl.h
+++ b/runtime/src/iree/task/executor_impl.h
@@ -99,13 +99,6 @@ struct iree_task_executor_t {
   // live state without having to perform N expensive atomic ops.
   iree_atomic_task_affinity_set_t worker_live_mask;
 
-  // A bitset indicating which workers may be suspended and need to be resumed
-  // via iree_thread_resume prior to them being able to execute work.
-  //
-  // This mask is just a hint, accessed with memory_order_relaxed. See the
-  // comment on worker_live_mask.
-  iree_atomic_task_affinity_set_t worker_suspend_mask;
-
   // A bitset indicating which workers are currently idle. Used to bias incoming
   // tasks to workers that aren't doing much else. This is a balance of latency
   // to wake the idle workers vs. latency to wait for existing work to complete

--- a/runtime/src/iree/task/executor_impl.h
+++ b/runtime/src/iree/task/executor_impl.h
@@ -34,6 +34,10 @@ struct iree_task_executor_t {
   // TODO(benvanik): make mutable; currently always the same reserved value.
   iree_task_scheduling_mode_t scheduling_mode;
 
+  // Time each worker should spin before parking itself to wait for more work.
+  // IREE_DURATION_ZERO is used to disable spinning.
+  iree_duration_t worker_spin_ns;
+
   // State used by the work-stealing operations performed by donated threads.
   // This is **NOT SYNCHRONIZED** and relies on the fact that we actually don't
   // much care about the precise selection of workers enough to mind any tears

--- a/runtime/src/iree/task/executor_test.cc
+++ b/runtime/src/iree/task/executor_test.cc
@@ -22,13 +22,12 @@ TEST(ExecutorTest, Lifetime) {
   iree_task_topology_initialize_from_group_count(/*group_count=*/4, &topology);
 
   for (int i = 0; i < 100; ++i) {
+    iree_task_executor_options_t options;
+    iree_task_executor_options_initialize(&options);
+    options.worker_local_memory_size = 64 * 1024;
     iree_task_executor_t* executor = NULL;
-    iree_task_scheduling_mode_t scheduling_mode =
-        IREE_TASK_SCHEDULING_MODE_RESERVED;
-    iree_host_size_t worker_local_memory_size = 64 * 1024;
     IREE_ASSERT_OK(iree_task_executor_create(
-        scheduling_mode, &topology, worker_local_memory_size,
-        iree_allocator_system(), &executor));
+        options, &topology, iree_allocator_system(), &executor));
     // -- idle --
     iree_task_executor_release(executor);
   }
@@ -43,13 +42,12 @@ TEST(ExecutorTest, LifetimeStress) {
   iree_task_topology_initialize_from_group_count(/*group_count=*/4, &topology);
 
   for (int i = 0; i < 100; ++i) {
+    iree_task_executor_options_t options;
+    iree_task_executor_options_initialize(&options);
+    options.worker_local_memory_size = 64 * 1024;
     iree_task_executor_t* executor = NULL;
-    iree_task_scheduling_mode_t scheduling_mode =
-        IREE_TASK_SCHEDULING_MODE_RESERVED;
-    iree_host_size_t worker_local_memory_size = 64 * 1024;
     IREE_ASSERT_OK(iree_task_executor_create(
-        scheduling_mode, &topology, worker_local_memory_size,
-        iree_allocator_system(), &executor));
+        options, &topology, iree_allocator_system(), &executor));
     iree_task_scope_t scope;
     iree_task_scope_initialize(iree_make_cstring_view("scope"), &scope);
 
@@ -90,14 +88,13 @@ TEST(ExecutorTest, LifetimeStress) {
 // Tests heavily serialized submission to an executor.
 // This puts pressure on the overheads involved in spilling up threads.
 TEST(ExecutorTest, SubmissionStress) {
+  iree_task_executor_options_t options;
+  iree_task_executor_options_initialize(&options);
+  options.worker_local_memory_size = 64 * 1024;
   iree_task_topology_t topology;
   iree_task_topology_initialize_from_group_count(/*group_count=*/4, &topology);
   iree_task_executor_t* executor = NULL;
-  iree_task_scheduling_mode_t scheduling_mode =
-      IREE_TASK_SCHEDULING_MODE_RESERVED;
-  iree_host_size_t worker_local_memory_size = 64 * 1024;
-  IREE_ASSERT_OK(iree_task_executor_create(scheduling_mode, &topology,
-                                           worker_local_memory_size,
+  IREE_ASSERT_OK(iree_task_executor_create(options, &topology,
                                            iree_allocator_system(), &executor));
   iree_task_scope_t scope;
   iree_task_scope_initialize(iree_make_cstring_view("scope"), &scope);

--- a/runtime/src/iree/task/testing/task_test.h
+++ b/runtime/src/iree/task/testing/task_test.h
@@ -22,12 +22,13 @@
 class TaskTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
+    iree_task_executor_options_t options;
+    options.worker_local_memory_size = 64 * 1024;
+    iree_task_executor_options_initialize(&options);
     iree_task_topology_t topology;
     iree_task_topology_initialize_from_group_count(8, &topology);
-    IREE_ASSERT_OK(
-        iree_task_executor_create(IREE_TASK_SCHEDULING_MODE_RESERVED, &topology,
-                                  /*worker_local_memory_size=*/(64 * 1024),
-                                  iree_allocator_system(), &executor_));
+    IREE_ASSERT_OK(iree_task_executor_create(
+        options, &topology, iree_allocator_system(), &executor_));
     iree_task_topology_deinitialize(&topology);
 
     iree_task_scope_initialize(iree_make_cstring_view("scope"), &scope_);

--- a/runtime/src/iree/task/tuning.h
+++ b/runtime/src/iree/task/tuning.h
@@ -57,6 +57,7 @@ extern "C" {
 // steal tasks from other workers. By default all other workers will be
 // attempted while setting this to 2, for example, will try for only half of
 // the available workers.
+// Setting this to 0 will disable thefts.
 #define IREE_TASK_EXECUTOR_MAX_THEFT_ATTEMPTS_DIVISOR (1)
 
 // Maximum number of tasks that will be stolen in one go from another worker.

--- a/runtime/src/iree/task/worker.h
+++ b/runtime/src/iree/task/worker.h
@@ -37,17 +37,15 @@ extern "C" {
 // that for example all states after resuming are > SUSPENDED and all states
 // before exiting are < EXITING.
 typedef enum iree_task_worker_state_e {
-  // Worker has been created in a suspended state and must be resumed to wake.
-  IREE_TASK_WORKER_STATE_SUSPENDED = 0,
   // Worker is idle or actively processing tasks (either its own or others).
-  IREE_TASK_WORKER_STATE_RUNNING = 1,
+  IREE_TASK_WORKER_STATE_RUNNING = 0,
   // Worker should exit (or is exiting) and will soon enter the zombie state.
   // Coordinators can request workers to exit by setting their state to this and
   // then waking.
-  IREE_TASK_WORKER_STATE_EXITING = 2,
+  IREE_TASK_WORKER_STATE_EXITING = 1,
   // Worker has exited and entered a 🧟 state (waiting for join).
   // The thread handle is still valid and must be destroyed.
-  IREE_TASK_WORKER_STATE_ZOMBIE = 3,
+  IREE_TASK_WORKER_STATE_ZOMBIE = 2,
 } iree_task_worker_state_t;
 
 // A worker within the executor pool.

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -199,6 +199,7 @@ static void BenchmarkGenericFunction(const std::string& benchmark_name,
         inputs, outputs.get(), iree_allocator_system()));
     IREE_CHECK_OK(iree_vm_list_resize(outputs.get(), 0));
   }
+  state.SetItemsProcessed(state.iterations());
 }
 
 void RegisterGenericBenchmark(const std::string& function_name,
@@ -251,6 +252,7 @@ static void BenchmarkDispatchFunction(const std::string& benchmark_name,
         inputs.get(), outputs.get(), iree_allocator_system()));
     IREE_CHECK_OK(iree_vm_list_resize(outputs.get(), 0));
   }
+  state.SetItemsProcessed(state.iterations());
 }
 
 void RegisterDispatchBenchmark(const std::string& function_name,

--- a/tools/iree-benchmark-module-main.cc
+++ b/tools/iree-benchmark-module-main.cc
@@ -292,7 +292,7 @@ class IREEBenchmark {
     iree_vm_instance_release(instance_);
 
     // Tear down device last in order to get accurate statistics.
-    if (FLAG_print_statistics) {
+    if (device_allocator_ && FLAG_print_statistics) {
       IREE_IGNORE_ERROR(
           iree_hal_allocator_statistics_fprint(stderr, device_allocator_));
     }

--- a/tools/iree-run-module-main.cc
+++ b/tools/iree-run-module-main.cc
@@ -139,7 +139,7 @@ iree_status_t Run() {
   iree_vm_module_release(main_module);
   iree_vm_context_release(context);
 
-  if (FLAG_print_statistics) {
+  if (device_allocator && FLAG_print_statistics) {
     IREE_IGNORE_ERROR(
         iree_hal_allocator_statistics_fprint(stderr, device_allocator));
   }


### PR DESCRIPTION
The major addition is the `--task_worker_spin_us=` flag (and `iree_task_executor_options_t` struct for the API) that allows users to opt in to having the workers spin before waiting. There's no good default for that value (depends on both workloads and machine) so by default it's set to 0 ("don't spin").

The utility of spinning appears almost exclusively in single-tenant latency-sensitive workloads that don't have much/any built-in concurrency (mostly old models like resnet). Even in those cases the tradeoff is usually saving hundreds of microseconds wall time for hundreds of milliseconds of burned CPU time and it's unclear how badly the spinning pessimizes the memory subsystem (as each spinning thread is hammering shared memory). Future improvements to iree-benchmark-module will allow for pipelined invocations using a shared device that demonstrates how pipelining mostly negates the benefits of spinning as with sufficient pipeline depth the utilization is 100% doing meaningful work.