### PR TITLE
Fix iree_c_module function to generate the useful library

### DIFF
--- a/build_tools/bazel/iree_c_module.bzl
+++ b/build_tools/bazel/iree_c_module.bzl
@@ -69,16 +69,15 @@ def iree_c_module(
         output_to_bindir = 1,
         **kwargs
     )
-    src_files = [h_file_output]
+
     deps_list = None
     if not no_runtime:
-        src_files.append("//runtime/src/iree/vm:module_impl_emitc.c")
         deps_list = deps
 
     iree_runtime_cc_library(
         name = name,
         hdrs = [h_file_output],
-        srcs = src_files,
+        srcs = ["//runtime/src/iree/vm:module_impl_emitc.c", h_file_output],
         copts = [
             "-DEMITC_IMPLEMENTATION='\"$(location %s)\"'" % h_file_output,
         ],

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -87,23 +87,17 @@ function(iree_c_module)
     DEPENDS ${_COMPILE_TOOL_EXECUTABLE} ${_SRC_PATH}
   )
 
-  if(NOT _RULE_NO_RUNTIME)
-    set(_LIB_RUNTIME_SRC
-      "${IREE_SOURCE_DIR}/runtime/src/iree/vm/module_impl_emitc.c")
-    # Include paths and options for the runtime sources.
-    set(_LIB_RUNTIME_DEP iree::runtime::src::defs)
-  endif()
-
   iree_cc_library(
     NAME ${_RULE_NAME}
     HDRS "${_RULE_H_FILE_OUTPUT}"
-    SRCS "${_LIB_RUNTIME_SRC}"
+    SRCS "${IREE_SOURCE_DIR}/runtime/src/iree/vm/module_impl_emitc.c"
     INCLUDES "${CMAKE_CURRENT_BINARY_DIR}"
     COPTS
       "-DEMITC_IMPLEMENTATION=\"${_RULE_H_FILE_OUTPUT}\""
       "${_TESTONLY_ARG}"
     DEPS
-      ${_LIB_RUNTIME_DEP}
+      # Include paths and options for the runtime sources.
+      iree::runtime::src::defs
   )
 
   if(_RULE_NO_RUNTIME)


### PR DESCRIPTION
`iree_cc_library` has to include non-header source code to create the
static library. Add the stub source file and depenency back to ensure
the library is built.