### PR TITLE
Reworking CPU data queries and access for vmvx/builtins/compiler-produced code.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Modules/HAL/Inline/Transforms/InlineExecutables.cpp
@@ -154,15 +154,13 @@ class InlineExecutablesPass
   //   (local_memory, [constants], [bindings],
   //    workgroup_x, workgroup_y, workgroup_z,
   //    workgroup_size_x, workgroup_size_y, workgroup_size_z,
-  //    workgroup_count_x, workgroup_count_y, workgroup_count_z,
-  //    processor_id)
+  //    workgroup_count_x, workgroup_count_y, workgroup_count_z)
   //
   // Body after rewrite:
   //   (local_memory, constants..., bindings...,
   //    workgroup_x, workgroup_y, workgroup_z,
   //    workgroup_size_x, workgroup_size_y, workgroup_size_z,
-  //    workgroup_count_x, workgroup_count_y, workgroup_count_z,
-  //    processor_id)
+  //    workgroup_count_x, workgroup_count_y, workgroup_count_z)
   //
   // To make this process easier and lighten the load on the downstream passes
   // we muck with the ABI to pass a flattened list of constants and bindings.
@@ -220,15 +218,6 @@ class InlineExecutablesPass
     // Take care of the workgroup id/size/count tuples.
     auto entryBuilder = OpBuilder::atBlockBegin(entryBlock);
     for (unsigned i = 0; i < 3 * /*xyz=*/3; ++i) {
-      newArgTypes.push_back(indexType);
-      auto oldArg = entryBlock->getArgument(argOffset++);
-      auto newArg = entryBlock->addArgument(indexType, oldArg.getLoc());
-      oldArg.replaceAllUsesWith(entryBuilder.create<arith::IndexCastOp>(
-          oldArg.getLoc(), i32Type, newArg));
-    }
-
-    // Add processor ID (which may be zero for now).
-    {
       newArgTypes.push_back(indexType);
       auto oldArg = entryBlock->getArgument(argOffset++);
       auto newArg = entryBlock->addArgument(indexType, oldArg.getLoc());
@@ -329,8 +318,7 @@ class InlineExecutablesPass
   //   (local_memory, [constants], [bindings],
   //    workgroup_x, workgroup_y, workgroup_z,
   //    workgroup_size_x, workgroup_size_y, workgroup_size_z,
-  //    workgroup_count_x, workgroup_count_y, workgroup_count_z,
-  //    processor_id)
+  //    workgroup_count_x, workgroup_count_y, workgroup_count_z)
   void buildDispatchFunc(IREE::HAL::ExecutableExportOp exportOp,
                          IREE::HAL::PipelineLayoutAttr layoutAttr,
                          size_t totalBindingCount, func::FuncOp bodyFuncOp,
@@ -390,7 +378,6 @@ class InlineExecutablesPass
     workgroupArgs.push_back(workgroupCount[0]);  // workgroup_count_x
     workgroupArgs.push_back(workgroupCount[1]);  // workgroup_count_y
     workgroupArgs.push_back(workgroupCount[2]);  // workgroup_count_z
-    workgroupArgs.push_back(indexSet.get(0));    // processor_id
 
     // Z -> Y -> Z loop nest.
     builder.create<scf::ForOp>(

--- a/compiler/src/iree/compiler/Dialect/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
+++ b/compiler/src/iree/compiler/Dialect/Modules/HAL/Inline/Transforms/test/inline_executables.mlir
@@ -35,8 +35,7 @@ hal.executable private @ex {
           %bindings: !util.list<!util.buffer>,
           %workgroup_x: i32, %workgroup_y: i32, %workgroup_z: i32,
           %workgroup_size_x: i32, %workgroup_size_y: i32, %workgroup_size_z: i32,
-          %workgroup_count_x: i32, %workgroup_count_y: i32, %workgroup_count_z: i32,
-          %processor_id: i32) {
+          %workgroup_count_x: i32, %workgroup_count_y: i32, %workgroup_count_z: i32) {
         // Unpack push constants:
         %constants_size = util.buffer.size %constants : !util.buffer
         %constant1_offset = arith.constant 4 : index
@@ -58,8 +57,6 @@ hal.executable private @ex {
         %global_constant = util.global.load @global_constant : !util.buffer
         util.do_not_optimize(%global_constant) : !util.buffer
 
-        // Use processor ID.
-        util.do_not_optimize(%processor_id) : i32
 
         %c4 = arith.constant 4 : index
         %workgroup_x_idx = arith.index_cast %workgroup_x : i32 to index
@@ -93,8 +90,7 @@ func.func private @dispatch_0()
 // CHECK-SAME:  %[[BINDING0:.+]]: !util.buffer, %[[BINDING1:.+]]: !util.buffer, %[[BINDING2:.+]]: !util.buffer,
 // CHECK-SAME:  %[[X:[a-z0-9]+]]: index, %[[Y:[a-z0-9]+]]: index, %[[Z:[a-z0-9]+]]: index,
 // CHECK-SAME:  %[[SIZE_XYZ:[a-z0-9]+]]: index, %[[SIZE_XYZ:[a-z0-9]+]]: index, %[[SIZE_XYZ:[a-z0-9]+]]: index,
-// CHECK-SAME:  %[[COUNT_X:[a-z0-9]+]]: index, %[[COUNT_Y:[a-z0-9]+]]: index, %[[COUNT_Z:[a-z0-9]+]]: index,
-// CHECK-SAME:  %[[PROCESSOR_ID:[a-z0-9]+]]: index)
+// CHECK-SAME:  %[[COUNT_X:[a-z0-9]+]]: index, %[[COUNT_Y:[a-z0-9]+]]: index, %[[COUNT_Z:[a-z0-9]+]]: index)
 
 // Type conversion; most of these will fold away.
 // CHECK: %[[X_I32:.+]] = arith.index_cast %[[X]]
@@ -154,8 +150,7 @@ func.func private @dispatch_0()
 // CHECK-SAME:         %[[BINDING0_SPAN]], %[[BINDING1_SPAN]], %[[BINDING2_SPAN]],
 // CHECK-SAME:         %[[X]], %[[Y]], %[[Z]],
 // CHECK-SAME:         %[[SIZE_XYZ]], %[[SIZE_XYZ]], %[[SIZE_XYZ]],
-// CHECK-SAME:         %[[COUNT_X]], %[[COUNT_Y]], %[[COUNT_Z]],
-// CHECK-SAME:         %c0)
+// CHECK-SAME:         %[[COUNT_X]], %[[COUNT_Y]], %[[COUNT_Z]])
 // CHECK:   return
 
 // CHECK-LABEL: @dispatch0

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/ConvertHALToVMVX.cpp
@@ -64,8 +64,7 @@ enum EntryArgOrdinals {
 ///       %workgroup_size_z: i32,
 ///       %workgroup_count_x: i32,
 ///       %workgroup_count_y: i32,
-///       %workgroup_count_z: i32,
-///       %processor_id: i32
+///       %workgroup_count_z: i32
 ///   )
 LogicalResult updateHALToVMVXEntryFuncOp(func::FuncOp funcOp,
                                          TypeConverter &typeConverter) {
@@ -91,7 +90,6 @@ LogicalResult updateHALToVMVXEntryFuncOp(func::FuncOp funcOp,
                                        /*workgroup_count_x=*/i32Type,
                                        /*workgroup_count_y=*/i32Type,
                                        /*workgroup_count_z=*/i32Type,
-                                       /*processor_id=*/i32Type,
                                    },
                                    {});
 

--- a/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/test/interface_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Conversion/HALToVMVX/test/interface_ops.mlir
@@ -18,8 +18,7 @@ memref.global "private" constant @__constant_5xi32 : memref<5xi32> = dense<[1, 2
 //  CHECK-SAME:   %[[WORKGROUP_SIZE_Z:[a-z0-9]+]]: i32,
 //  CHECK-SAME:   %[[WORKGROUP_COUNT_X:[a-z0-9]+]]: i32,
 //  CHECK-SAME:   %[[WORKGROUP_COUNT_Y:[a-z0-9]+]]: i32,
-//  CHECK-SAME:   %[[WORKGROUP_COUNT_Z:[a-z0-9]+]]: i32,
-//  CHECK-SAME:   %[[PROCESSOR_ID:.+]]: i32) {
+//  CHECK-SAME:   %[[WORKGROUP_COUNT_Z:[a-z0-9]+]]: i32) {
 func.func @entry() {
   %cst = arith.constant 0.000000e+00 : f32
   %c5 = arith.constant 5 : index

--- a/runtime/src/iree/base/internal/BUILD
+++ b/runtime/src/iree/base/internal/BUILD
@@ -109,6 +109,8 @@ iree_runtime_cc_library(
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",
+        "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/schemas:cpu_data",
     ],
 )
 

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -102,6 +102,8 @@ iree_cc_library(
   DEPS
     iree::base
     iree::base::core_headers
+    iree::base::tracing
+    iree::schemas::cpu_data
   PUBLIC
 )
 

--- a/runtime/src/iree/base/internal/cpu.h
+++ b/runtime/src/iree/base/internal/cpu.h
@@ -10,13 +10,56 @@
 #include <stddef.h>
 
 #include "iree/base/api.h"
+#include "iree/schemas/cpu_data.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
 
 //===----------------------------------------------------------------------===//
-// iree_cpu_*
+// Processor data query
+//===----------------------------------------------------------------------===//
+
+// Initializes cached CPU data using |temp_allocator| for any temporary
+// allocations required during initialization.
+void iree_cpu_initialize(iree_allocator_t temp_allocator);
+
+// Initializes cached CPU data with the given fields.
+// Extraneous fields will be ignored and unspecified fields will be set to zero.
+void iree_cpu_initialize_with_data(iree_host_size_t field_count,
+                                   const uint64_t* fields);
+
+// Returns all fields up to IREE_CPU_DATA_FIELD_COUNT.
+// Data will be zeroed until initialized with iree_cpu_initialize.
+// See iree/schemas/cpu_data.h for interpretation.
+const uint64_t* iree_cpu_data_fields(void);
+
+// Returns the CPU data field or zero if the field is not available.
+// Data will be zeroed until initialized with iree_cpu_initialize.
+// See iree/schemas/cpu_data.h for interpretation.
+//
+// Common usage:
+// if (iree_all_bits_set(iree_cpu_data_field(0),
+//                       IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD)) {
+//   // Bit is set and known true.
+// } else {
+//   // Bit is unset but _may_ be true (CPU data not available, etc).
+// }
+uint64_t iree_cpu_data_field(iree_host_size_t field);
+
+// Queries the CPU data from the system and stores it into |out_fields|.
+// Up to |field_count| fields will be written and if greater than the number
+// available the remaining fields will be set to zero.
+// See iree/schemas/cpu_data.h for interpretation.
+void iree_cpu_read_data(iree_host_size_t field_count, uint64_t* out_fields);
+
+// Looks up a canonical value in the CPU data fields.
+// Keys are defined in iree/schemas/cpu_data.h.
+iree_status_t iree_cpu_lookup_data_by_key(iree_string_view_t key,
+                                          int64_t* IREE_RESTRICT out_value);
+
+//===----------------------------------------------------------------------===//
+// Processor identification
 //===----------------------------------------------------------------------===//
 
 typedef uint32_t iree_cpu_processor_id_t;

--- a/runtime/src/iree/builtins/ukernel/BUILD
+++ b/runtime/src/iree/builtins/ukernel/BUILD
@@ -35,5 +35,6 @@ iree_runtime_cc_library(
     ],
     deps = [
         "//runtime/src/iree/base:core_headers",
+        "//runtime/src/iree/schemas:cpu_data",
     ],
 )

--- a/runtime/src/iree/builtins/ukernel/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "mmt4d_generic.c"
   DEPS
     iree::base::core_headers
+    iree::schemas::cpu_data
   DEFINES
     "IREE_HAVE_UKERNEL_BUILTINS=1"
   PUBLIC

--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -38,6 +38,7 @@
 // These two headers are clean and do not include any other headers:
 #include "iree/base/attributes.h"
 #include "iree/base/target_platform.h"
+#include "iree/schemas/cpu_data.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/src/iree/hal/drivers/local_sync/BUILD
+++ b/runtime/src/iree/hal/drivers/local_sync/BUILD
@@ -32,6 +32,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base:tracing",
         "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/base/internal:cpu",
         "//runtime/src/iree/base/internal:synchronization",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/local",

--- a/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_sync/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_cc_library(
     iree::base::core_headers
     iree::base::internal
     iree::base::internal::arena
+    iree::base::internal::cpu
     iree::base::internal::synchronization
     iree::base::tracing
     iree::hal

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "iree/base/internal/arena.h"
+#include "iree/base/internal/cpu.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/local_sync/sync_event.h"
 #include "iree/hal/drivers/local_sync/sync_semaphore.h"
@@ -178,11 +179,8 @@ static iree_status_t iree_hal_sync_device_query_i64(
       *out_value = 1;
       return iree_ok_status();
     }
-  } else if (iree_string_view_equal(category, IREE_SV("hal.processor"))) {
-    // TODO(benvanik): memoize processor information.
-    iree_hal_processor_v0_t processor;
-    iree_hal_processor_query(device->host_allocator, &processor);
-    return iree_hal_processor_lookup_by_key(&processor, key, out_value);
+  } else if (iree_string_view_equal(category, IREE_SV("hal.cpu"))) {
+    return iree_cpu_lookup_data_by_key(key, out_value);
   }
 
   return iree_make_status(

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -231,7 +231,7 @@ static iree_status_t iree_hal_sync_device_create_executable_cache(
     iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
   return iree_hal_local_executable_cache_create(
-      identifier, device->loader_count, device->loaders,
+      identifier, /*worker_capacity=*/1, device->loader_count, device->loaders,
       iree_hal_device_host_allocator(base_device), out_executable_cache);
 }
 

--- a/runtime/src/iree/hal/drivers/local_task/BUILD
+++ b/runtime/src/iree/hal/drivers/local_task/BUILD
@@ -41,6 +41,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base:tracing",
         "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/internal:arena",
+        "//runtime/src/iree/base/internal:cpu",
         "//runtime/src/iree/base/internal:event_pool",
         "//runtime/src/iree/base/internal:synchronization",
         "//runtime/src/iree/base/internal:wait_handle",

--- a/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_cc_library(
     iree::base::core_headers
     iree::base::internal
     iree::base::internal::arena
+    iree::base::internal::cpu
     iree::base::internal::event_pool
     iree::base::internal::synchronization
     iree::base::internal::wait_handle

--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -848,7 +848,8 @@ static iree_status_t iree_hal_cmd_dispatch_tile(
           .local_memory_size = (size_t)tile_context->local_memory.data_length,
       };
   iree_status_t status = iree_hal_local_executable_issue_call(
-      cmd->executable, cmd->ordinal, &dispatch_state, &workgroup_state);
+      cmd->executable, cmd->ordinal, &dispatch_state, &workgroup_state,
+      tile_context->worker_id);
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -272,7 +272,8 @@ static iree_status_t iree_hal_task_device_create_executable_cache(
     iree_loop_t loop, iree_hal_executable_cache_t** out_executable_cache) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
   return iree_hal_local_executable_cache_create(
-      identifier, device->loader_count, device->loaders,
+      identifier, iree_task_executor_worker_count(device->executor),
+      device->loader_count, device->loaders,
       iree_hal_device_host_allocator(base_device), out_executable_cache);
 }
 

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -11,6 +11,7 @@
 #include <string.h>
 
 #include "iree/base/internal/arena.h"
+#include "iree/base/internal/cpu.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/local_task/task_command_buffer.h"
 #include "iree/hal/drivers/local_task/task_event.h"
@@ -209,11 +210,8 @@ static iree_status_t iree_hal_task_device_query_i64(
       *out_value = (int64_t)iree_task_executor_worker_count(device->executor);
       return iree_ok_status();
     }
-  } else if (iree_string_view_equal(category, IREE_SV("hal.processor"))) {
-    // TODO(benvanik): memoize processor information.
-    iree_hal_processor_v0_t processor;
-    iree_hal_processor_query(device->host_allocator, &processor);
-    return iree_hal_processor_lookup_by_key(&processor, key, out_value);
+  } else if (iree_string_view_equal(category, IREE_SV("hal.cpu"))) {
+    return iree_cpu_lookup_data_by_key(key, out_value);
   }
 
   return iree_make_status(

--- a/runtime/src/iree/hal/local/BUILD
+++ b/runtime/src/iree/hal/local/BUILD
@@ -63,6 +63,7 @@ iree_runtime_cc_test(
         ":executable_library",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",
+        "//runtime/src/iree/base/internal:cpu",
     ],
 )
 
@@ -107,6 +108,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/base:core_headers",
         "//runtime/src/iree/base:tracing",
         "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/internal:cpu",
         "//runtime/src/iree/base/internal:fpu_state",
         "//runtime/src/iree/hal",
     ],

--- a/runtime/src/iree/hal/local/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/CMakeLists.txt
@@ -67,6 +67,7 @@ iree_cc_test(
     ::executable_library
     iree::base
     iree::base::core_headers
+    iree::base::internal::cpu
 )
 
 iree_cc_library(
@@ -107,6 +108,7 @@ iree_cc_library(
     iree::base
     iree::base::core_headers
     iree::base::internal
+    iree::base::internal::cpu
     iree::base::internal::fpu_state
     iree::base::tracing
     iree::hal

--- a/runtime/src/iree/hal/local/elf/BUILD
+++ b/runtime/src/iree/hal/local/elf/BUILD
@@ -51,6 +51,7 @@ cc_binary(
         ":elf_module",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",
+        "//runtime/src/iree/base/internal:cpu",
         "//runtime/src/iree/hal/local:executable_environment",
         "//runtime/src/iree/hal/local:executable_library",
         "//runtime/src/iree/hal/local/elf/testdata:elementwise_mul",

--- a/runtime/src/iree/hal/local/elf/CMakeLists.txt
+++ b/runtime/src/iree/hal/local/elf/CMakeLists.txt
@@ -41,6 +41,7 @@ iree_cc_binary(
     ::elf_module
     iree::base
     iree::base::core_headers
+    iree::base::internal::cpu
     iree::hal::local::elf::testdata::elementwise_mul
     iree::hal::local::executable_environment
     iree::hal::local::executable_library

--- a/runtime/src/iree/hal/local/elf/elf_module_test_main.c
+++ b/runtime/src/iree/hal/local/elf/elf_module_test_main.c
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/base/api.h"
+#include "iree/base/internal/cpu.h"
 #include "iree/base/target_platform.h"
 #include "iree/hal/local/elf/elf_module.h"
 #include "iree/hal/local/executable_environment.h"

--- a/runtime/src/iree/hal/local/executable_environment.c
+++ b/runtime/src/iree/hal/local/executable_environment.c
@@ -6,33 +6,8 @@
 
 #include "iree/hal/local/executable_environment.h"
 
+#include "iree/base/internal/cpu.h"
 #include "iree/base/tracing.h"
-
-//===----------------------------------------------------------------------===//
-// iree_hal_processor_*_t
-//===----------------------------------------------------------------------===//
-
-void iree_hal_processor_query(iree_allocator_t temp_allocator,
-                              iree_hal_processor_v0_t* out_processor) {
-  IREE_ASSERT_ARGUMENT(out_processor);
-  IREE_TRACE_ZONE_BEGIN(z0);
-  memset(out_processor, 0, sizeof(*out_processor));
-
-  // TODO(benvanik): define processor features we want to query for each arch.
-  // This needs to be baked into the executable library API and made consistent
-  // with the compiler side producing the executables that access it.
-
-  IREE_TRACE_ZONE_END(z0);
-}
-
-iree_status_t iree_hal_processor_lookup_by_key(
-    const iree_hal_processor_v0_t* processor, iree_string_view_t key,
-    int64_t* IREE_RESTRICT out_value) {
-  // TODO(benvanik): arch-specific switches here to poke into processor info.
-  return iree_make_status(IREE_STATUS_NOT_FOUND,
-                          "processor information key '%.*s' not found",
-                          (int)key.size, key.data);
-}
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_environment_*_t
@@ -44,6 +19,15 @@ void iree_hal_executable_environment_initialize(
   IREE_ASSERT_ARGUMENT(out_environment);
   IREE_TRACE_ZONE_BEGIN(z0);
   memset(out_environment, 0, sizeof(*out_environment));
-  iree_hal_processor_query(temp_allocator, &out_environment->processor);
+
+  // Force CPU initialization.
+  // TODO(benvanik): move this someplace better? Technically not thread-safe
+  // but should be enough for usage within the HAL.
+  iree_cpu_initialize(temp_allocator);
+
+  // Will fill all of the required fields and zero any extras.
+  iree_cpu_read_data(IREE_HAL_PROCESSOR_DATA_CAPACITY_V0,
+                     &out_environment->processor.data[0]);
+
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/src/iree/hal/local/executable_environment.h
+++ b/runtime/src/iree/hal/local/executable_environment.h
@@ -10,29 +10,12 @@
 #include <stdint.h>
 
 #include "iree/base/api.h"
-#include "iree/base/internal/cpu.h"
 #include "iree/hal/api.h"
 #include "iree/hal/local/executable_library.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
-
-//===----------------------------------------------------------------------===//
-// iree_hal_processor_*_t
-//===----------------------------------------------------------------------===//
-
-// Queries the current processor information and writes it to |out_processor|.
-// |temp_allocator| may be used for temporary allocations required while
-// querying. If the processor cannot be queried then |out_processor| will be
-// zeroed.
-void iree_hal_processor_query(iree_allocator_t temp_allocator,
-                              iree_hal_processor_v0_t* out_processor);
-
-// Looks up a field of the processor information by canonicalized string key.
-iree_status_t iree_hal_processor_lookup_by_key(
-    const iree_hal_processor_v0_t* processor, iree_string_view_t key,
-    int64_t* IREE_RESTRICT out_value);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_environment_*_t

--- a/runtime/src/iree/hal/local/executable_library.h
+++ b/runtime/src/iree/hal/local/executable_library.h
@@ -220,13 +220,15 @@ typedef struct iree_hal_executable_import_table_v0_t {
 // allows us to simplify this interface as we can't for example load the same
 // executable library for both aarch64 on riscv32 and don't need to normalize
 // any of the fields across them both.
+//
+// See iree/schemas/cpu_data.h for details.
 typedef struct iree_hal_processor_v0_t {
   // Opaque architecture-specific encoding in 64-bit words.
   // This may represent a fixed-length data structure, a series of hardware
   // registers, or key-value pairs.
   //
   // The contents are opaque here as to support out-of-tree architectures. The
-  // runtime code deriving the identifier/flags and providing it here is losely
+  // runtime code deriving the identifier/flags and providing it here is loosely
   // coupled with the compiler code emitting checks based on the identifier and
   // only those two places ever need to change.
   uint64_t data[IREE_HAL_PROCESSOR_DATA_CAPACITY_V0];

--- a/runtime/src/iree/hal/local/executable_library_benchmark.c
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.c
@@ -171,8 +171,9 @@ static iree_status_t iree_hal_executable_library_run(
   // Perform the load, which will fail if the executable cannot be loaded or
   // there was an issue with the layouts.
   iree_hal_executable_t* executable = NULL;
-  IREE_RETURN_IF_ERROR(iree_hal_executable_loader_try_load(
-      executable_loader, &executable_params, &executable));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_executable_loader_try_load(executable_loader, &executable_params,
+                                          /*worker_capacity=*/1, &executable));
   iree_hal_local_executable_t* local_executable =
       iree_hal_local_executable_cast(executable);
 

--- a/runtime/src/iree/hal/local/executable_library_test.c
+++ b/runtime/src/iree/hal/local/executable_library_test.c
@@ -10,6 +10,7 @@
 #include <string.h>
 
 #include "iree/base/api.h"
+#include "iree/base/internal/cpu.h"
 #include "iree/hal/local/executable_environment.h"
 #include "iree/hal/local/executable_library_demo.h"
 

--- a/runtime/src/iree/hal/local/executable_loader.c
+++ b/runtime/src/iree/hal/local/executable_loader.c
@@ -87,7 +87,7 @@ bool iree_hal_query_any_executable_loader_support(
 iree_status_t iree_hal_executable_loader_try_load(
     iree_hal_executable_loader_t* executable_loader,
     const iree_hal_executable_params_t* executable_params,
-    iree_hal_executable_t** out_executable) {
+    iree_host_size_t worker_capacity, iree_hal_executable_t** out_executable) {
   IREE_ASSERT_ARGUMENT(executable_loader);
   IREE_ASSERT_ARGUMENT(executable_params);
   IREE_ASSERT_ARGUMENT(!executable_params->pipeline_layout_count ||
@@ -95,6 +95,6 @@ iree_status_t iree_hal_executable_loader_try_load(
   IREE_ASSERT_ARGUMENT(!executable_params->executable_data.data_length ||
                        executable_params->executable_data.data);
   IREE_ASSERT_ARGUMENT(out_executable);
-  return executable_loader->vtable->try_load(executable_loader,
-                                             executable_params, out_executable);
+  return executable_loader->vtable->try_load(
+      executable_loader, executable_params, worker_capacity, out_executable);
 }

--- a/runtime/src/iree/hal/local/executable_loader.h
+++ b/runtime/src/iree/hal/local/executable_loader.h
@@ -122,7 +122,7 @@ bool iree_hal_query_any_executable_loader_support(
 iree_status_t iree_hal_executable_loader_try_load(
     iree_hal_executable_loader_t* executable_loader,
     const iree_hal_executable_params_t* executable_params,
-    iree_hal_executable_t** out_executable);
+    iree_host_size_t worker_capacity, iree_hal_executable_t** out_executable);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_loader_t implementation details
@@ -139,7 +139,7 @@ typedef struct iree_hal_executable_loader_vtable_t {
   iree_status_t(IREE_API_PTR* try_load)(
       iree_hal_executable_loader_t* executable_loader,
       const iree_hal_executable_params_t* executable_params,
-      iree_hal_executable_t** out_executable);
+      iree_host_size_t worker_capacity, iree_hal_executable_t** out_executable);
 } iree_hal_executable_loader_vtable_t;
 
 #ifdef __cplusplus

--- a/runtime/src/iree/hal/local/inline_command_buffer.c
+++ b/runtime/src/iree/hal/local/inline_command_buffer.c
@@ -11,10 +11,10 @@
 #include <string.h>
 
 #include "iree/base/api.h"
+#include "iree/base/internal/cpu.h"
 #include "iree/base/internal/fpu_state.h"
 #include "iree/base/internal/math.h"
 #include "iree/base/tracing.h"
-#include "iree/hal/local/executable_environment.h"
 #include "iree/hal/local/executable_library.h"
 #include "iree/hal/local/local_executable.h"
 #include "iree/hal/local/local_pipeline_layout.h"

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -246,7 +246,8 @@ static void iree_hal_elf_executable_destroy(
 static iree_status_t iree_hal_elf_executable_issue_call(
     iree_hal_local_executable_t* base_executable, iree_host_size_t ordinal,
     const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
-    const iree_hal_executable_workgroup_state_v0_t* workgroup_state) {
+    const iree_hal_executable_workgroup_state_v0_t* workgroup_state,
+    uint32_t worker_id) {
   iree_hal_elf_executable_t* executable =
       (iree_hal_elf_executable_t*)base_executable;
   const iree_hal_executable_library_v0_t* library = executable->library.v0;
@@ -369,7 +370,7 @@ static bool iree_hal_embedded_elf_loader_query_support(
 static iree_status_t iree_hal_embedded_elf_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
     const iree_hal_executable_params_t* executable_params,
-    iree_hal_executable_t** out_executable) {
+    iree_host_size_t worker_capacity, iree_hal_executable_t** out_executable) {
   iree_hal_embedded_elf_loader_t* executable_loader =
       (iree_hal_embedded_elf_loader_t*)base_executable_loader;
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/hal/local/loaders/static_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/static_library_loader.c
@@ -117,7 +117,8 @@ static void iree_hal_static_executable_destroy(
 static iree_status_t iree_hal_static_executable_issue_call(
     iree_hal_local_executable_t* base_executable, iree_host_size_t ordinal,
     const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
-    const iree_hal_executable_workgroup_state_v0_t* workgroup_state) {
+    const iree_hal_executable_workgroup_state_v0_t* workgroup_state,
+    uint32_t worker_id) {
   iree_hal_static_executable_t* executable =
       (iree_hal_static_executable_t*)base_executable;
   const iree_hal_executable_library_v0_t* library = executable->library.v0;
@@ -286,7 +287,7 @@ static bool iree_hal_static_library_loader_query_support(
 static iree_status_t iree_hal_static_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
     const iree_hal_executable_params_t* executable_params,
-    iree_hal_executable_t** out_executable) {
+    iree_host_size_t worker_capacity, iree_hal_executable_t** out_executable) {
   iree_hal_static_library_loader_t* executable_loader =
       (iree_hal_static_library_loader_t*)base_executable_loader;
 

--- a/runtime/src/iree/hal/local/loaders/system_library_loader.c
+++ b/runtime/src/iree/hal/local/loaders/system_library_loader.c
@@ -366,7 +366,8 @@ static void iree_hal_system_executable_destroy(
 static iree_status_t iree_hal_system_executable_issue_call(
     iree_hal_local_executable_t* base_executable, iree_host_size_t ordinal,
     const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
-    const iree_hal_executable_workgroup_state_v0_t* workgroup_state) {
+    const iree_hal_executable_workgroup_state_v0_t* workgroup_state,
+    uint32_t worker_id) {
   iree_hal_system_executable_t* executable =
       (iree_hal_system_executable_t*)base_executable;
   const iree_hal_executable_library_v0_t* library = executable->library.v0;
@@ -499,7 +500,7 @@ static bool iree_hal_system_library_loader_query_support(
 static iree_status_t iree_hal_system_library_loader_try_load(
     iree_hal_executable_loader_t* base_executable_loader,
     const iree_hal_executable_params_t* executable_params,
-    iree_hal_executable_t** out_executable) {
+    iree_host_size_t worker_capacity, iree_hal_executable_t** out_executable) {
   iree_hal_system_library_loader_t* executable_loader =
       (iree_hal_system_library_loader_t*)base_executable_loader;
   IREE_TRACE_ZONE_BEGIN(z0);

--- a/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
+++ b/runtime/src/iree/hal/local/loaders/vmvx_module_loader.c
@@ -22,7 +22,7 @@
 // iree_hal_vmvx_executable_t
 //===----------------------------------------------------------------------===//
 
-#define IREE_VMVX_ENTRY_SIGNATURE "0rrriiiiiiiiii_v"
+#define IREE_VMVX_ENTRY_SIGNATURE "0rrriiiiiiiii_v"
 
 typedef struct iree_hal_vmvx_executable_t {
   iree_hal_local_executable_t base;
@@ -359,8 +359,7 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
   //       %workgroup_size_z: i32,
   //       %workgroup_count_x: i32,
   //       %workgroup_count_y: i32,
-  //       %workgroup_count_z: i32,
-  //       %processor_id: i32
+  //       %workgroup_count_z: i32
   //    )
   //
   // NOTE: this level of the VM ABI is supported - but may change in the future.
@@ -378,7 +377,6 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
     uint32_t workgroup_count_x;
     uint32_t workgroup_count_y;
     uint32_t workgroup_count_z;
-    uint32_t processor_id;
   } call_args = {
       .local_memory =
           {
@@ -407,7 +405,6 @@ static iree_status_t iree_hal_vmvx_executable_issue_call(
       .workgroup_count_x = dispatch_state->workgroup_count_x,
       .workgroup_count_y = dispatch_state->workgroup_count_y,
       .workgroup_count_z = dispatch_state->workgroup_count_z,
-      .processor_id = workgroup_state->processor_id,
   };
 
   // On-stack stack. We really do abuse the stack too much here.

--- a/runtime/src/iree/hal/local/local_executable.c
+++ b/runtime/src/iree/hal/local/local_executable.c
@@ -50,13 +50,15 @@ iree_hal_local_executable_t* iree_hal_local_executable_cast(
 iree_status_t iree_hal_local_executable_issue_call(
     iree_hal_local_executable_t* executable, iree_host_size_t ordinal,
     const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
-    const iree_hal_executable_workgroup_state_v0_t* workgroup_state) {
+    const iree_hal_executable_workgroup_state_v0_t* workgroup_state,
+    uint32_t worker_id) {
   IREE_ASSERT_ARGUMENT(executable);
   IREE_ASSERT_ARGUMENT(dispatch_state);
   IREE_ASSERT_ARGUMENT(workgroup_state);
   return ((const iree_hal_local_executable_vtable_t*)
               executable->resource.vtable)
-      ->issue_call(executable, ordinal, dispatch_state, workgroup_state);
+      ->issue_call(executable, ordinal, dispatch_state, workgroup_state,
+                   worker_id);
 }
 
 iree_status_t iree_hal_local_executable_issue_dispatch_inline(
@@ -95,7 +97,8 @@ iree_status_t iree_hal_local_executable_issue_dispatch_inline(
       for (uint32_t x = 0; x < workgroup_count_x; ++x) {
         workgroup_state.workgroup_id_x = x;
         status = iree_hal_local_executable_issue_call(
-            executable, ordinal, dispatch_state, &workgroup_state);
+            executable, ordinal, dispatch_state, &workgroup_state,
+            /*worker_id=*/0);
         if (!iree_status_is_ok(status)) break;
       }
     }

--- a/runtime/src/iree/hal/local/local_executable.h
+++ b/runtime/src/iree/hal/local/local_executable.h
@@ -45,7 +45,8 @@ typedef struct iree_hal_local_executable_vtable_t {
   iree_status_t(IREE_API_PTR* issue_call)(
       iree_hal_local_executable_t* executable, iree_host_size_t ordinal,
       const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
-      const iree_hal_executable_workgroup_state_v0_t* workgroup_state);
+      const iree_hal_executable_workgroup_state_v0_t* workgroup_state,
+      uint32_t worker_id);
 } iree_hal_local_executable_vtable_t;
 
 // Initializes the local executable base type.
@@ -69,7 +70,8 @@ iree_hal_local_executable_t* iree_hal_local_executable_cast(
 iree_status_t iree_hal_local_executable_issue_call(
     iree_hal_local_executable_t* executable, iree_host_size_t ordinal,
     const iree_hal_executable_dispatch_state_v0_t* dispatch_state,
-    const iree_hal_executable_workgroup_state_v0_t* workgroup_state);
+    const iree_hal_executable_workgroup_state_v0_t* workgroup_state,
+    uint32_t worker_id);
 
 iree_status_t iree_hal_local_executable_issue_dispatch_inline(
     iree_hal_local_executable_t* executable, iree_host_size_t ordinal,

--- a/runtime/src/iree/hal/local/local_executable_cache.h
+++ b/runtime/src/iree/hal/local/local_executable_cache.h
@@ -24,8 +24,9 @@ extern "C" {
 // situations we're likely to want that isolation _and_ sharing.
 
 iree_status_t iree_hal_local_executable_cache_create(
-    iree_string_view_t identifier, iree_host_size_t loader_count,
-    iree_hal_executable_loader_t** loaders, iree_allocator_t host_allocator,
+    iree_string_view_t identifier, iree_host_size_t worker_capacity,
+    iree_host_size_t loader_count, iree_hal_executable_loader_t** loaders,
+    iree_allocator_t host_allocator,
     iree_hal_executable_cache_t** out_executable_cache);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/modules/hal/inline/BUILD
+++ b/runtime/src/iree/modules/hal/inline/BUILD
@@ -26,8 +26,8 @@ iree_runtime_cc_library(
     deps = [
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal:cpu",
         "//runtime/src/iree/hal",
-        "//runtime/src/iree/hal/local:executable_environment",
         "//runtime/src/iree/modules/hal:types",
         "//runtime/src/iree/modules/hal/utils:buffer_diagnostics",
         "//runtime/src/iree/vm",

--- a/runtime/src/iree/modules/hal/inline/CMakeLists.txt
+++ b/runtime/src/iree/modules/hal/inline/CMakeLists.txt
@@ -21,9 +21,9 @@ iree_cc_library(
     "module.c"
   DEPS
     iree::base
+    iree::base::internal::cpu
     iree::base::tracing
     iree::hal
-    iree::hal::local::executable_environment
     iree::modules::hal::types
     iree::modules::hal::utils::buffer_diagnostics
     iree::vm

--- a/runtime/src/iree/modules/hal/inline/module.c
+++ b/runtime/src/iree/modules/hal/inline/module.c
@@ -7,9 +7,9 @@
 #include "iree/modules/hal/inline/module.h"
 
 #include "iree/base/api.h"
+#include "iree/base/internal/cpu.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/api.h"
-#include "iree/hal/local/executable_environment.h"
 #include "iree/modules/hal/utils/buffer_diagnostics.h"
 #include "iree/vm/api.h"
 
@@ -503,12 +503,8 @@ IREE_VM_ABI_EXPORT(iree_hal_inline_module_device_query_i64,  //
 
   iree_status_t query_status = iree_status_from_code(IREE_STATUS_NOT_FOUND);
   int64_t value = 0;
-  if (iree_string_view_equal(category_str, IREE_SV("hal.processor"))) {
-    // TODO(benvanik): memoize processor information.
-    iree_hal_processor_v0_t processor;
-    iree_hal_processor_query(state->host_allocator, &processor);
-    query_status =
-        iree_hal_processor_lookup_by_key(&processor, key_str, &value);
+  if (iree_string_view_equal(category_str, IREE_SV("hal.cpu"))) {
+    query_status = iree_cpu_lookup_data_by_key(key_str, &value);
   }
 
   rets->i0 = iree_status_consume_code(query_status) == IREE_STATUS_OK ? 1 : 0;

--- a/runtime/src/iree/modules/hal/loader/module.c
+++ b/runtime/src/iree/modules/hal/loader/module.c
@@ -156,7 +156,7 @@ static iree_status_t iree_hal_loader_module_try_load(
     // supported then the try will fail with IREE_STATUS_CANCELLED and we should
     // continue trying other loaders.
     iree_status_t status = iree_hal_executable_loader_try_load(
-        loader, executable_params, out_executable);
+        loader, executable_params, /*worker_capacity=*/1, out_executable);
     if (iree_status_is_ok(status)) {
       // Executable was successfully loaded.
       return status;

--- a/runtime/src/iree/modules/vmvx/module.c
+++ b/runtime/src/iree/modules/vmvx/module.c
@@ -44,6 +44,11 @@ typedef struct iree_vmvx_module_t {
 typedef struct iree_vmvx_module_state_t {
   iree_allocator_t host_allocator;
 
+  // Logical processor identifier used to index into processor info fields.
+  // Depending on the implementation this may be an ordinal, a bitfield, or an
+  // opaque unique identifier.
+  uint32_t processor_id;
+
   // If we have any external libraries we want to interact with that are
   // stateful we could store their state here. Note that VMVX invocations may
   // happen from any thread and concurrently and if the state is not thread-safe
@@ -887,4 +892,10 @@ IREE_API_EXPORT iree_status_t iree_vmvx_module_create(
 
   *out_module = base_module;
   return iree_ok_status();
+}
+
+IREE_API_EXPORT void iree_vmvx_module_state_update_workgroup_state(
+    iree_vm_module_state_t* module_state, uint32_t processor_id) {
+  iree_vmvx_module_state_t* state = (iree_vmvx_module_state_t*)module_state;
+  state->processor_id = processor_id;
 }

--- a/runtime/src/iree/modules/vmvx/module.h
+++ b/runtime/src/iree/modules/vmvx/module.h
@@ -21,6 +21,10 @@ IREE_API_EXPORT iree_status_t iree_vmvx_module_create(
     iree_vm_instance_t* instance, iree_allocator_t host_allocator,
     iree_vm_module_t** out_module);
 
+// Updates the context-local state of the module.
+IREE_API_EXPORT void iree_vmvx_module_state_update_workgroup_state(
+    iree_vm_module_state_t* module_state, uint32_t processor_id);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/schemas/BUILD
+++ b/runtime/src/iree/schemas/BUILD
@@ -4,7 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_build_test")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_build_test", "iree_runtime_cc_library")
 load("//build_tools/bazel:iree_flatcc.bzl", "iree_flatbuffer_c_library")
 
 package(
@@ -63,5 +63,12 @@ iree_build_test(
         ":metal_executable_def_c_fbs",
         ":spirv_executable_def_c_fbs",
         ":wgsl_executable_def_c_fbs",
+    ],
+)
+
+iree_runtime_cc_library(
+    name = "cpu_data",
+    hdrs = [
+        "cpu_data.h",
     ],
 )

--- a/runtime/src/iree/schemas/CMakeLists.txt
+++ b/runtime/src/iree/schemas/CMakeLists.txt
@@ -88,4 +88,14 @@ flatbuffer_c_library(
   PUBLIC
 )
 
+iree_cc_library(
+  NAME
+    cpu_data
+  HDRS
+    "cpu_data.h"
+  DEPS
+
+  PUBLIC
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/schemas/cpu_data.h
+++ b/runtime/src/iree/schemas/cpu_data.h
@@ -1,0 +1,78 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_SCHEMAS_CPU_DATA_H_
+#define IREE_SCHEMAS_CPU_DATA_H_
+
+//===----------------------------------------------------------------------===//
+// CPU processor data field values
+//===----------------------------------------------------------------------===//
+// IREE treats architecture-specific processor information as an opaque set of
+// 64-bit values, each of which encodes fields of interest to the generated
+// code from the compiler and the runtime. This file is included from both the
+// compiler, runtime, and compiler-generated binaries and must have zero
+// includes and unconditionally define all values to enable the compiler to
+// target non-host architectures.
+//
+// The format of the data is architecture-specific as by construction no value
+// will ever be used in a compiled binary from another architecture. This
+// allows us to simplify this interface as we can't for example load the same
+// executable library for both aarch64 on riscv32 and don't need to normalize
+// any of the fields across them both.
+//
+// As the values of the fields are encoded in generated binaries their meaning
+// here cannot change once deployed: only new meaning for unused bits can be
+// specified, and zeros must always be assumed to be unknown/undefined/false.
+// Since IREE executables can run on many architectures and operating systems we
+// also cannot directly expose the architecture-specific registers as not all
+// environments and access-levels can query them.
+//
+// This is similar in functionality to getauxval(AT_HWCAP*) in linux but
+// platform-independent and with additional fields and values that may not yet
+// be available in cpufeature.h. AT_HWCAP stores only bit flags but we can
+// store any bit-packed scalar value as well such as cache sizes.
+//
+// Wherever possible compile-time checks should be used instead to allow for
+// smaller and more optimizable code. For example if compiling for armv8.6+ the
+// I8MM feature will always be available and does not need to be tested.
+//
+// NOTE: when adding values with more than 1 bit define both a shift amount
+// and mask used for selecting the bits from the field. An example of where this
+// could be used is a field that contains one bit per physical processor
+// indicating whether it is big/LITTLE that can be indexed by the processor ID.
+
+// Number of 64-bit data values captured.
+// The current value gives us hundreds of bits to work with and can be extended
+// in the future.
+#define IREE_CPU_DATA_FIELD_COUNT 8
+
+// Bitmasks and values for processor data field 0.
+enum iree_cpu_data_field_0_e {
+
+  //===--------------------------------------------------------------------===//
+  // IREE_ARCH_ARM_64 / aarch64
+  //===--------------------------------------------------------------------===//
+
+  // Indicates support for Dot Product instructions.
+  //
+  // UDOT and SDOT instructions implemented.
+  //
+  // Source: ID_AA64ISAR0_EL1.DP [47:44] == 0b0001 / HWCAP_ASIMDDP
+  // Canonical key: "dotprod"
+  IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD = 1ull << 0,
+
+  // Indicates support for Advanced SIMD and Floating-point Int8 matrix
+  // multiplication instructions.
+  //
+  // SMMLA, SUDOT, UMMLA, USMMLA, and USDOT instructions are implemented.
+  //
+  // Source: ID_AA64ISAR1_EL1.I8MM [55:52] == 0b0001 / HWCAP2_I8MM
+  // Canonical key: "i8mm"
+  IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM = 1ull << 1,
+
+};
+
+#endif  // IREE_SCHEMAS_CPU_DATA_H_

--- a/runtime/src/iree/task/affinity_set.h
+++ b/runtime/src/iree/task/affinity_set.h
@@ -44,6 +44,8 @@ static inline iree_task_affinity_set_t iree_task_affinity_for_any_worker(void) {
   return UINT64_MAX;
 }
 
+#define iree_task_affinity_set_count_leading_zeros \
+  iree_math_count_leading_zeros_u64
 #define iree_task_affinity_set_count_trailing_zeros \
   iree_math_count_trailing_zeros_u64
 #define iree_task_affinity_set_count_ones iree_math_count_ones_u64

--- a/runtime/src/iree/task/task.c
+++ b/runtime/src/iree/task/task.c
@@ -709,7 +709,7 @@ iree_task_dispatch_shard_t* iree_task_dispatch_shard_allocate(
 
 void iree_task_dispatch_shard_execute(
     iree_task_dispatch_shard_t* task, iree_cpu_processor_id_t processor_id,
-    iree_byte_span_t worker_local_memory,
+    uint32_t worker_id, iree_byte_span_t worker_local_memory,
     iree_task_submission_t* pending_submission) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
@@ -745,6 +745,7 @@ void iree_task_dispatch_shard_execute(
          sizeof(tile_context.workgroup_count));
   uint32_t workgroup_count_x = tile_context.workgroup_count[0];
   uint32_t workgroup_count_y = tile_context.workgroup_count[1];
+  tile_context.worker_id = worker_id;
   tile_context.local_memory = local_memory;
 
   // We perform all our shard statistics work locally here and only push back to

--- a/runtime/src/iree/task/task.h
+++ b/runtime/src/iree/task/task.h
@@ -536,6 +536,9 @@ typedef iree_alignas(iree_max_align_t) struct {
   // May be slightly out of date or 0 if the processor could not be queried.
   iree_cpu_processor_id_t processor_id;
 
+  // Worker that is processing the tile, [0, worker_capacity).
+  uint32_t worker_id;
+
   // Tile-local memory that is pinned to each worker ensuring no cache
   // thrashing. Aligned to at least the natural pointer size of the machine.
   // Contents are (today) undefined upon entry.

--- a/runtime/src/iree/task/task_impl.h
+++ b/runtime/src/iree/task/task_impl.h
@@ -122,7 +122,7 @@ iree_task_dispatch_shard_t* iree_task_dispatch_shard_allocate(
 // all shards have completed.
 void iree_task_dispatch_shard_execute(
     iree_task_dispatch_shard_t* task, iree_cpu_processor_id_t processor_id,
-    iree_byte_span_t worker_local_memory,
+    uint32_t worker_id, iree_byte_span_t worker_local_memory,
     iree_task_submission_t* pending_submission);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/task/worker.c
+++ b/runtime/src/iree/task/worker.c
@@ -182,6 +182,7 @@ static void iree_task_worker_execute(
     case IREE_TASK_TYPE_DISPATCH_SHARD: {
       iree_task_dispatch_shard_execute(
           (iree_task_dispatch_shard_t*)task, worker->processor_id,
+          iree_task_affinity_set_count_trailing_zeros(worker->worker_bit),
           worker->local_memory, pending_submission);
       break;
     }

--- a/runtime/src/iree/vm/stack.c
+++ b/runtime/src/iree/vm/stack.c
@@ -230,13 +230,24 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_initialize(
   return iree_ok_status();
 }
 
-IREE_API_EXPORT void iree_vm_stack_deinitialize(iree_vm_stack_t* stack) {
+IREE_API_EXPORT void iree_vm_stack_reset(iree_vm_stack_t* stack) {
   IREE_TRACE_ZONE_BEGIN(z0);
 
+  // Pop each frame of the stack in reverse.
   while (stack->top) {
     iree_status_ignore(iree_vm_stack_function_leave(stack));
   }
 
+  IREE_TRACE_ZONE_END(z0);
+}
+
+IREE_API_EXPORT void iree_vm_stack_deinitialize(iree_vm_stack_t* stack) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // Release stack frame resources.
+  iree_vm_stack_reset(stack);
+
+  // Drop allocated frame storage.
   if (stack->owns_frame_storage) {
     iree_allocator_free(stack->allocator, stack->frame_storage);
   }

--- a/runtime/src/iree/vm/stack.h
+++ b/runtime/src/iree/vm/stack.h
@@ -215,6 +215,9 @@ IREE_API_EXPORT iree_status_t iree_vm_stack_initialize(
     iree_vm_state_resolver_t state_resolver, iree_allocator_t allocator,
     iree_vm_stack_t** out_stack);
 
+// Resets the stack to its initial state by popping all stack frames.
+IREE_API_EXPORT void iree_vm_stack_reset(iree_vm_stack_t* stack);
+
 // Deinitializes a statically-allocated |stack| previously initialized with
 // iree_vm_stack_initialize.
 IREE_API_EXPORT void iree_vm_stack_deinitialize(iree_vm_stack_t* stack);


### PR DESCRIPTION
This partially reverts #10249 and instead passes the processor ID through to a worker-specific VMVX module state. The VM side shouldn't really need the processor ID while the VMVX side does and this way we don't need to perform complex pass-throughs.

In addition CPU data (features, values, etc) is now centralized and specified in a header that can be shared across all potential consumers. The storage of the CPU data cannot cross the builtins barrier but can be queried directly from the VMVX module and then passed into the builtins library as an argument. Now any VMVX function defined in the vmvx module.c can now use `iree_cpu_data_fields()` to get the bits and the `IREE_CPU_DATA_FIELD_*` macros to test the bits, or pass the fields into the ukernel builtins and let that test the bits.

Since we aren't stable yet we're free to change the fields for now - what's here can be considered a template.