### PR TITLE
Add softmax transform dialect spec and e2e test

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -99,7 +99,7 @@ def ForeachThreadToGpuAndTranslationInfo :
   }];
 }
 
-def VectorWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.warp_execute_on_lane_0",
+def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_execute_on_lane_0",
     [FunctionalStyleTransformOpTrait, 
      MemoryEffectsOpInterface,
      TransformEachOpTrait, 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_distribution_spec.mlir
@@ -3,7 +3,7 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %if_op = transform.structured.match ops{["scf.if"]} in %arg1
-    %warp = transform.iree.vector.warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
     %isolated = transform.get_closest_isolated_parent %warp
     transform.iree.vector.warp_distribute %isolated
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_vector_warp_execute_on_lane_0_spec.mlir
@@ -3,6 +3,6 @@ transform.with_pdl_patterns {
   transform.structured.canonicalized_sequence %arg0 {
   ^bb1(%arg1: !pdl.operation):
     %if_op = transform.structured.match ops{["scf.if"]} in %arg1
-    transform.iree.vector.warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -707,6 +707,12 @@ transform_dialect::ClonePrecedingOpIntoDispatchRegionOp::apply(
   ArrayRef<Operation *> dispatchRegion =
       state.getPayloadOps(getDispatchRegion());
 
+  if (targetOps.empty() && dispatchRegion.empty()) {
+    transformResults.set(getResult().cast<OpResult>(),
+                         SmallVector<mlir::Operation *>{});
+    return DiagnosedSilenceableFailure::success();
+  }
+
   if (dispatchRegion.size() != 1)
     return DiagnosedSilenceableFailure(this->emitOpError(
         "requires exactly one target/dispatch region handle"));

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -25,13 +25,18 @@ endif()
 
 iree_lit_test_suite(
     name = "lit",
-    srcs = ["reduction.mlir"],
+    srcs = [
+        "reduction.mlir",
+        "softmax.mlir",
+    ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.
     data = [
         "reduction_codegen_spec.mlir",
         "reduction_dispatch_spec.mlir",
+        "softmax_codegen_spec.mlir",
+        "softmax_dispatch_spec.mlir",
     ],
     tags = [
         # CUDA cuInit fails with sanitizer on.

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "reduction.mlir"
+    "softmax.mlir"
   TOOLS
     FileCheck
     iree-compile
@@ -27,6 +28,8 @@ iree_lit_test_suite(
   DATA
     reduction_codegen_spec.mlir
     reduction_dispatch_spec.mlir
+    softmax_codegen_spec.mlir
+    softmax_dispatch_spec.mlir
   LABELS
     "noasan"
     "nomsan"

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -33,7 +33,7 @@ transform.with_pdl_patterns {
     
     // Vector distribution needs to happen on buffers.
     %if_op = transform.structured.match ops{["scf.if"]} in %arg1
-    %warp = transform.iree.vector.warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
     transform.iree.vector.warp_distribute %isolated_handle_4
     
     // transform.print { name = "after codegen"}

--- a/tests/transform_dialect/cuda/softmax.mlir
+++ b/tests/transform_dialect/cuda/softmax.mlir
@@ -1,0 +1,47 @@
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/softmax_dispatch_spec.mlir \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/softmax_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=max_sub_exp --device=cuda | \
+// RUN: FileCheck %s
+
+// TODO: make this test drop transform dialect usage at the flow level and use:
+//   --iree-flow-transformation-pipeline --iree-flow-convert-region-to-workgroups
+
+!tmp_tensor_t = tensor<12x128xf32>
+!out_tensor_t = tensor<12x128x128xf32>
+
+// Execution only checks that @max_sub_exp runs.
+// CHECK: EXEC @max_sub_exp
+func.func @max_sub_exp() {
+  %cst = arith.constant -3.40282347E+38 : f32
+  %cst_0 = arith.constant dense<1.000000e+00> : !out_tensor_t
+  %cst_1 = arith.constant dense<5.000000e+00> : !out_tensor_t
+  %0 = util.do_not_optimize(%cst_1) : !out_tensor_t
+
+  %1 = linalg.init_tensor [12, 128] : !tmp_tensor_t
+  %2 = linalg.fill ins(%cst : f32) outs(%1 : !tmp_tensor_t) -> !tmp_tensor_t
+  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
+                                        affine_map<(d0, d1, d2) -> (d0, d1)>], 
+                       iterator_types = ["parallel", "parallel", "reduction"]} 
+  ins(%0 : !out_tensor_t) outs(%2 : !tmp_tensor_t) {
+  ^bb0(%arg0: f32, %arg1: f32):
+    %8 = arith.maxf %arg0, %arg1 : f32
+    linalg.yield %8 : f32
+  } -> !tmp_tensor_t
+
+  // This has been fused manually to avoid the fusion on tensors pass and reduce noise atm.
+  %4 = linalg.init_tensor [12, 128, 128] : !out_tensor_t
+  %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                                        affine_map<(d0, d1, d2) -> (d0, d1)>,
+                                        affine_map<(d0, d1, d2) -> (d0, d1, d2)>], 
+                       iterator_types = ["parallel", "parallel", "parallel"]}
+  ins(%0, %3 : !out_tensor_t, !tmp_tensor_t) outs(%4 : !out_tensor_t) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %6 = arith.subf %arg0, %arg1 : f32
+    %7 = math.exp %6 : f32
+    linalg.yield %7 : f32
+  } -> !out_tensor_t
+
+  check.expect_almost_eq(%5, %cst_0) : !out_tensor_t
+  return
+}

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -1,0 +1,79 @@
+// RUN: iree-opt %s 
+
+// Codegen
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.structured.canonicalized_sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    // First level of tiling + fusion parallelizes to blocks.
+    // The mapping  to block ids can only happen after bufferization atm 
+    %root = transform.structured.match interface{LinalgOp} 
+      attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %arg1
+    %fill = transform.structured.match ops{["linalg.fill"]} in %arg1
+    %red = transform.structured.match interface{LinalgOp} 
+      attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %arg1
+    %not_root = merge_handles %fill, %red
+    %foreach_thread, %tiled_generic = 
+      transform.structured.tile_to_foreach_thread_op %root tile_sizes [1, 4]
+    transform.structured.fuse_into_containing_op %not_root into %foreach_thread
+    
+    // Second level of tiling + fusion parallelizes to threads.
+    // Leaving the reduction untiled on threadIdx.x makes it sequential on 
+    // threadIdx.x. After distribution, predication by if (threadIdx.x == 0) is
+    // introduced and opportunities for distributing vector ops across warps
+    // appear.
+    %fill_linalg = transform.structured.match ops{["linalg.fill"]} in %arg1
+    %reduction_linalg = transform.structured.match ops{["linalg.generic"]} 
+      attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %arg1
+    %parallel_linalg = transform.structured.match ops{["linalg.generic"]} 
+      attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %arg1
+    %foreach_thread_reduction, %tiled_reduction_generic = 
+      transform.structured.tile_to_foreach_thread_op %reduction_linalg tile_sizes [1, 1]
+        (mapped to dims [2, 1, 0])
+    // TODO: this fusion currently does not happen properly, this is related to the clone 
+    // behavior when fusing into scf.foreach_thread.
+    // Once fixed we'll be able to fuse.
+    // Fusion will save us one roundtrip to memory.
+    // transform.structured.fuse_into_containing_op %fill_linalg into %foreach_thread_reduction
+    transform.structured.tile_to_foreach_thread_op %parallel_linalg num_threads [1, 4, 32]
+        (mapped to dims [2, 1, 0])
+
+
+    // Inability to tile reductions to scf.foreach_thread has 2 implications:
+    //   1. since no scf.foreach_thread is present, no gpu.barrier is added.
+    //      This should be fixed independently: ops that are not nested in an scf.foreach_thread
+    //      should have a gpu.barrier. Later needs to be complemented by a barrier
+    //      removal pass.
+    //   2. Similarly, needs to be predicated under an if threadIx == 0 to avoid
+    //      multiple threads updating the buffer inplace once bufferized.
+    //
+    // Instead, we can vectorize and go to vector SSA values that sidestep these
+    // issues.
+    // Everyone will race to the write while still computing the same value.
+    //
+    // That is still not good enough because we need to predicate this in order
+    // to enable the parallel reduction on warps.
+    %func = transform.structured.match ops{["func.func"]} in %arg1
+    %func_2 = transform.structured.vectorize %func
+    
+    // Bufferization is necessary for:
+    //   1. lowering scf.foreach_thread to workgroup (block level parallelism)
+    //   2. lowering scf.foreach_thread to gpu (thread level parallelism)
+    //   3. introducing predication (due to 1. + 2.) which enables rewriting to
+    //      warp_execute_on_lane_0 and later vector distribution.
+    transform.iree.bufferize { target_gpu }
+    %func_3 = transform.iree.foreach_thread_to_workgroup %func_2
+    transform.iree.foreach_thread_to_gpu_and_translation_info %func_3
+      { workgroup_size = [32, 4, 1] }
+    
+    %end_func = transform.structured.match ops{["func.func"]} in %arg1
+    %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing }
+
+    // Vector distribution needs to happen on buffers.
+    %if_op = transform.structured.match ops{["scf.if"]} in %arg1
+    %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+    transform.iree.vector.warp_distribute %end_func_2
+  }
+}
+
+

--- a/tests/transform_dialect/cuda/softmax_dispatch_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_dispatch_spec.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt %s 
+
+// Dispatch softmax.
+transform.with_pdl_patterns {
+^bb0(%arg0: !pdl.operation):
+  transform.structured.canonicalized_sequence %arg0 {
+  ^bb1(%arg1: !pdl.operation):
+    %root = transform.structured.match interface{LinalgOp} 
+      attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %arg1
+    %fill = transform.structured.match ops{["linalg.fill"]} in %arg1
+    %red = transform.structured.match interface{LinalgOp} 
+      attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %arg1
+
+    // TODO: this could be replaced by a C++ only version.
+    // Atm the IR produced is not the same so all pieces do not connect.
+    %region_op = transform.iree.wrap_in_dispatch_region %root
+    %region_op_2 = transform.iree.clone_preceding_op_into_dispatch_region %red into %region_op
+    %region_op_3 = transform.iree.clone_preceding_op_into_dispatch_region %fill into %region_op_2
+    transform.iree.region_to_workgroups %region_op_3
+  }
+}


### PR DESCRIPTION
Add softmax transform dialect spec and run it e2e.
    
This revision adds a transform dialect spec that allows more advanced intermixing
of tiling to threads using `scf.foreach_thread` and later mapping an `scf.if(threadIdx.x)`
region to warps.
    
This ordering requires a legalization phase that ensures no value that
transitively depends on `threadIdx.x` is used in the region.
Atm this legalization is brittle, a more powerful analysis related to a scoped SCCP is
left for future work.
    
This e2e exploration also exhibited a bug in `clone_preceding_op_into_dispatch_region`
which did not properly propagate empty handles.
    
The whole example runs end to end, nvprof shows:
```
EXEC @max_sub_exp
==4061710== Profiling application: iree-run-module --entry_function=max_sub_exp --device=cuda
==4061710== Profiling result:
Start  Duration            Grid Size      Block Size     Regs*    SSMem*    DSMem*      Size  Throughput  SrcMemType  DstMemType           Device   Context    Stream  Name
457.08ms  3.4880us                    -               -         -         -         -  768.00KB  209.98GB/s      Device           -  NVIDIA GeForce          1        13  [CUDA memset]
478.24ms  2.5600us                    -               -         -         -         -  6.0000KB  2.2352GB/s      Device           -  NVIDIA GeForce          1        13  [CUDA memset]
478.26ms  3.6480us                    -               -         -         -         -  768.00KB  200.77GB/s     Managed           -  NVIDIA GeForce          1        13  [CUDA memset]
478.28ms  3.9680us            (12 32 1)        (32 4 1)        29        0B       16B         -           -           -           -  NVIDIA GeForce          1        13  _max_sub_exp_dispatch_0_generic_12x128x128 [28]
478.29ms  3.1040us                    -               -         -         -         -  768.00KB  235.96GB/s     Managed           -  NVIDIA GeForce          1        13  [CUDA memset]
```

Note: this was additionally tested on a larger scale `1200*128*128` example and the computed bandwidth is `> 524GB/s`, very close to the `528GB/s` measured performance of `memset`:

```
EXEC @max_sub_exp
==9177== Profiling application: iree-run-module --entry_function=max_sub_exp --device=cuda
==9177== Profiling result:
   Start  Duration            Grid Size      Block Size     Regs*    SSMem*    DSMem*      Size  Throughput  SrcMemType  DstMemType           Device   Context    Stream  Name
453.99ms  138.76us                    -               -         -         -         -  75.000MB  527.83GB/s      Device           -  NVIDIA GeForce          1        13  [CUDA memset]
477.24ms  3.6170us                    -               -         -         -         -  600.00KB  158.20GB/s      Device           -  NVIDIA GeForce          1        13  [CUDA memset]
477.25ms  138.47us                    -               -         -         -         -  75.000MB  528.93GB/s     Managed           -  NVIDIA GeForce          1        13  [CUDA memset]
477.39ms  300.82us          (1200 32 1)        (32 4 1)        29        0B       16B         -           -           -           -  NVIDIA GeForce          1        13  _max_sub_exp_dispatch_0_generic_1200x128x128 [28]
477.69ms  140.81us                    -               -         -         -         -  75.000MB  520.16GB/s     Managed           -  NVIDIA GeForce          1        13  [CUDA memset]
```