### PR TITLE
Exclude more tests from ASan test configuration.

### DIFF
--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -121,11 +121,17 @@ fi
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
 # These tests currently have asan failures
-# TODO(#5715): Fix these
 declare -a excluded_tests=(
-  "iree/samples/simple_embedding/simple_embedding_vulkan_test"
+  # TODO(#5716): Fix flaky ASan crash in these tests
+  "iree/tests/e2e/models/collatz.mlir.test"
+  "iree/tests/e2e/models/edge_detection.mlir.test"
   "iree/tests/e2e/models/fragment_000.mlir.test"
-  "iree/tests/e2e/models/fully_connected.mlir.test"
+  "iree/tests/e2e/models/fullyconnected.mlir.test"
+  "iree/tests/e2e/models/mnist_fake_weights.mlir.test"
+  "iree/tests/e2e/models/resnet50_fake_weights.mlir.test"
+  "iree/tests/e2e/models/unidirectional_lstm.mlir.test"
+  # TODO(#5715): Fix these
+  "iree/samples/simple_embedding/simple_embedding_vulkan_test"
   "iree/tools/test/iree-benchmark-module.mlir.test"
   "iree/tools/test/iree-run-module.mlir.test"
   "iree/tools/test/multiple_exported_functions.mlir.test"


### PR DESCRIPTION
See https://github.com/iree-org/iree/issues/5716. I just excluded all lit tests from here: https://github.com/iree-org/iree/blob/db6b68773e4daab4da2de1e835c16c4323b583ec/tests/e2e/models/CMakeLists.txt#L13-L24

As there are other tests in that file using runners other than `lit` that have _not_ crashed (that I'm aware of), I did not exclude the entire directory.

Most recent failure: https://github.com/iree-org/iree/runs/8146877750?check_suite_focus=true

```
1030/1030 Test   #46: iree/tests/e2e/models/resnet50_fake_weights.mlir.test ....................................................................***Failed   63.16 sec
-- Testing: 1 tests, 1 workers --
FAIL: IREE :: e2e/models/resnet50_fake_weights.mlir (1 of 1)
******************** TEST 'IREE :: e2e/models/resnet50_fake_weights.mlir' FAILED ********************
Script:
--
: 'RUN: at line 4';   iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=llvm-cpu /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/resnet50_fake_weights.mlir --function_input=1x224x224x3xf32 | FileCheck /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/resnet50_fake_weights.mlir
: 'RUN: at line 5';   [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/resnet50_fake_weights.mlir --function_input=1x224x224x3xf32 | FileCheck /home/runner/actions-runner/_work/iree/iree/tests/e2e/models/resnet50_fake_weights.mlir)
--
Exit Code: 1

Command Output (stderr):
--
Tracer caught signal 11: addr=0x0 pc=0x61dbf9 sp=0x7f63edb65d30
==53069==LeakSanitizer has encountered a fatal error.
==53069==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==53069==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)
```