### PR TITLE
Specify runner environment that jobs should target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,7 @@ jobs:
     needs: should_run
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -158,8 +157,7 @@ jobs:
     needs: should_run
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -187,8 +185,7 @@ jobs:
     needs: [should_run, build_all]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -218,8 +215,7 @@ jobs:
     needs: [should_run, build_all]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - gpu
@@ -322,8 +318,7 @@ jobs:
     needs: should_run
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -371,8 +366,7 @@ jobs:
     needs: [should_run, build_all, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -411,8 +405,7 @@ jobs:
     needs: [should_run, build_all, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - gpu
@@ -459,8 +452,7 @@ jobs:
     needs: should_run
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -480,8 +472,7 @@ jobs:
     needs: should_run
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -574,8 +565,7 @@ jobs:
     needs: [should_run, build_all]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -610,8 +600,7 @@ jobs:
     needs: [should_run, build_all, build_tf_integrations]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu
@@ -655,8 +644,7 @@ jobs:
     needs: [should_run, build_all]
     if: needs.should_run.outputs.should-run == 'true'
     runs-on:
-      # Pseudo-ternary hack and order matters. See comment at top of file.
-      - self-hosted
+      - self-hosted  # must come first
       - runner-group=${{ needs.should_run.outputs.runner-group }}
       - environment=${{ needs.should_run.outputs.environment }}
       - cpu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,23 +8,28 @@ name: CI
 
 # A few notes:
 #
+# Variables:
 # GitHub actions don't have variables or even support normal yaml anchors (they
 # are specially disabled because...reasons?):
 # See https://github.com/github-community/community/discussions/4501
 # https://github.community/t/support-for-yaml-anchors/16128/92
 # https://github.com/actions/runner/issues/1182
-#
-# Neither does it have any variables that are available everywhere. The
-# top-level `env` field is available in many places, but not all
+# Neither does it have any contexts that are available everywhere. The
+# top-level `env` field is available in many places, but not all. We already
+# have a "should-run" job that every other job depends on, so we leverage that
+# for variables that every other job can use, since that *is* available in all
+# sub-fields of the job.
 # See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
 # and https://github.com/community/community/discussions/27370
 #
 # So there are some odd patterns that are repeated in many places. To avoid
 # repeating the comments, they are mentioned here:
 #
+# Runner label ordering:
 # - self-hosted always has to be listed first in a runs-on block:
 # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow
 #
+# Pseudo-ternary hack:
 # - We have to do a weird hack to get a pseudo-ternary operator. See
 # https://github.com/actions/runner/issues/409, hence patterns like:
 # `github.event_name == 'pull_request' && 'presubmit' || 'postsubmit'`
@@ -61,6 +66,10 @@ jobs:
       PR_DESCRIPTION: ${{ github.event.pull_request.body }}
     outputs:
       should-run: ${{ steps.should-run.outputs.should-run }}
+      # Variables for dependent jobs. See comment at top.
+      environment: prod
+      # pseudo-ternary hack. See comment at top
+      runner-group: ${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -97,7 +106,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -150,7 +160,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     steps:
@@ -178,7 +189,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -208,7 +220,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - gpu
       - os-family=Linux
     env:
@@ -311,7 +324,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     outputs:
@@ -359,7 +373,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -398,7 +413,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - gpu
       - os-family=Linux
     env:
@@ -445,7 +461,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     steps:
@@ -465,7 +482,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     steps:
@@ -485,7 +503,8 @@ jobs:
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -525,7 +544,8 @@ jobs:
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -556,7 +576,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -591,7 +612,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -635,7 +657,8 @@ jobs:
     runs-on:
       # Pseudo-ternary hack and order matters. See comment at top of file.
       - self-hosted
-      - runner-group=${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      - runner-group=${{ needs.should_run.outputs.runner-group }}
+      - environment=${{ needs.should_run.outputs.environment }}
       - cpu
       - os-family=Linux
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ env:
 
 # Jobs are organized into groups and topologically sorted by dependencies
 jobs:
-  should_run:
+  setup:
     runs-on: ubuntu-20.04
     env:
       # The commit being checked out is the merge commit for the PR. Its first
@@ -100,12 +100,12 @@ jobs:
   # Jobs that build all of IREE "normally"
   ##############################################################################
   build_all:
-    needs: should_run
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -153,12 +153,12 @@ jobs:
           echo "::set-output name=build-dir-gcs-artifact::${BUILD_DIR_GCS_ARTIFACT}"
 
   build_test_all_bazel:
-    needs: should_run
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     steps:
@@ -168,7 +168,7 @@ jobs:
           submodules: true
       - name: "Building with Bazel"
         env:
-          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ needs.should_run.outputs.write-caches }}
+          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ needs.setup.outputs.write-caches }}
         # This doesn't really need everything in the frontends image, but we
         # want the cache to be shared with the integrations build (no point
         # building LLVM twice) and the cache key is the docker container it's
@@ -180,12 +180,12 @@ jobs:
             ./build_tools/bazel/build_core.sh
 
   test_all:
-    needs: [should_run, build_all]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -210,12 +210,12 @@ jobs:
             "${BUILD_DIR}"
 
   test_gpu:
-    needs: [should_run, build_all]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - gpu
       - os-family=Linux
     env:
@@ -253,8 +253,8 @@ jobs:
   # Jobs that build some subset of IREE
   ##############################################################################
   build_runtime:
-    needs: should_run
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
@@ -285,8 +285,8 @@ jobs:
           path: "${{ env.BUILD_DIR }}.tar"
 
   test_runtime:
-    needs: [should_run, build_runtime]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_runtime]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on: ubuntu-20.04
     env:
       BUILD_DIR: ${{ needs.build_runtime.outputs.build-dir }}
@@ -313,12 +313,12 @@ jobs:
   # Jobs that build the IREE-Tensorflow integrations
   ##############################################################################
   build_tf_integrations:
-    needs: should_run
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     outputs:
@@ -334,7 +334,7 @@ jobs:
         id: build
         env:
           IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
-          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ needs.should_run.outputs.write-caches }}
+          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ needs.setup.outputs.write-caches }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "IREE_BAZEL_WRITE_REMOTE_CACHE=${IREE_BAZEL_WRITE_REMOTE_CACHE}" \
@@ -360,12 +360,12 @@ jobs:
           echo "::set-output name=binaries-gcs-artifact::${BINARIES_GCS_ARTIFACT}"
 
   test_tf_integrations:
-    needs: [should_run, build_all, build_tf_integrations]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -399,12 +399,12 @@ jobs:
             "${BUILD_DIR}"
 
   test_tf_integrations_gpu:
-    needs: [should_run, build_all, build_tf_integrations]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - gpu
       - os-family=Linux
     env:
@@ -446,12 +446,12 @@ jobs:
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
   asan:
-    needs: should_run
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     steps:
@@ -466,12 +466,12 @@ jobs:
             ./build_tools/cmake/build_and_test_asan.sh
 
   tsan:
-    needs: should_run
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     steps:
@@ -486,13 +486,13 @@ jobs:
             ./build_tools/cmake/build_and_test_tsan.sh
 
   build_benchmarks:
-    needs: [should_run, build_all, build_tf_integrations]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -527,13 +527,13 @@ jobs:
   # Jobs that cross-compile IREE for other platforms
   ##############################################################################
   android_arm64:
-    needs: [should_run, build_all]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -559,12 +559,12 @@ jobs:
             build_tools/cmake/build_android.sh
 
   riscv32:
-    needs: [should_run, build_all]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -594,12 +594,12 @@ jobs:
             "./build_tools/cmake/build_riscv.sh && tests/riscv32/smoke.sh"
 
   riscv64:
-    needs: [should_run, build_all, build_tf_integrations]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     env:
@@ -638,12 +638,12 @@ jobs:
               "./build_tools/cmake/build_riscv.sh && ./tests/riscv64/smoke.sh"
 
   build_benchmark_tools:
-    needs: [should_run, build_all]
-    if: needs.should_run.outputs.should-run == 'true'
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
-      - runner-group=${{ needs.should_run.outputs.runner-group }}
-      - environment=${{ needs.should_run.outputs.environment }}
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.environment }}
       - cpu
       - os-family=Linux
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,6 @@ name: CI
 # See https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
 # and https://github.com/community/community/discussions/27370
 #
-# So there are some odd patterns that are repeated in many places. To avoid
-# repeating the comments, they are mentioned here:
-#
 # Runner label ordering:
 # - self-hosted always has to be listed first in a runs-on block:
 # https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
+  # This is mostly here so we can compute it once and use it in outputs below.
+  # See note above regarding lack of proper variables. Also see note about
+  # pseudo-ternary hack.
+  _CI_STAGE: ${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
 
 # Jobs are organized into groups and topologically sorted by dependencies
 jobs:
@@ -64,10 +67,11 @@ jobs:
     outputs:
       should-run: ${{ steps.should-run.outputs.should-run }}
       # Variables for dependent jobs. See comment at top.
-      environment: prod
-      # pseudo-ternary hack. See comment at top
-      runner-group: ${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
-      # Note that we can't flip the condition here because 0 is falsey
+      runner-env: prod
+      gcs-dir: gs://iree-github-actions-${{ env._CI_STAGE }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
+      runner-group: ${{ env._CI_STAGE }}
+      # Note that we can't flip the condition here because 0 is falsey. See
+      # comment at top.
       write-caches: ${{ github.event_name != 'pull_request' && 1 || 0 }}
     steps:
       - name: "Checking out repository"
@@ -105,7 +109,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:
@@ -147,7 +151,7 @@ jobs:
         id: upload
         env:
           BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
-          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
+          BUILD_DIR_GCS_ARTIFACT: ${{ needs.setup.outputs.gcs-dir }}/${{ steps.archive.outputs.build-dir-archive }}
         run: |
           gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
           echo "::set-output name=build-dir-gcs-artifact::${BUILD_DIR_GCS_ARTIFACT}"
@@ -158,7 +162,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     steps:
@@ -185,7 +189,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:
@@ -215,7 +219,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - gpu
       - os-family=Linux
     env:
@@ -318,7 +322,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     outputs:
@@ -354,7 +358,7 @@ jobs:
         id: upload
         env:
           BINARIES_ARCHIVE: ${{ steps.archive.outputs.binaries-archive }}
-          BINARIES_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.binaries-archive }}
+          BINARIES_GCS_ARTIFACT: ${{ needs.setup.outputs.gcs-dir }}/${{ steps.archive.outputs.binaries-archive }}
         run: |
           gcloud alpha storage cp "${BINARIES_ARCHIVE}" "${BINARIES_GCS_ARTIFACT}"
           echo "::set-output name=binaries-gcs-artifact::${BINARIES_GCS_ARTIFACT}"
@@ -365,7 +369,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:
@@ -404,7 +408,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - gpu
       - os-family=Linux
     env:
@@ -451,7 +455,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     steps:
@@ -471,7 +475,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     steps:
@@ -492,7 +496,7 @@ jobs:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:
@@ -533,7 +537,7 @@ jobs:
       # Hacks, and order matters. See the comment at the top of the file.
       - self-hosted
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:
@@ -564,7 +568,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:
@@ -599,7 +603,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     env:
@@ -643,7 +647,7 @@ jobs:
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.environment }}
+      - environment=${{ needs.setup.outputs.runner-env }}
       - cpu
       - os-family=Linux
     strategy:
@@ -703,7 +707,7 @@ jobs:
         id: upload
         env:
           BENCHMARK_TOOLS_ARCHIVE: ${{ steps.archive.outputs.benchmark-tools-archive }}
-          BENCHMARK_TOOLS_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.benchmark-tools-archive }}
+          BENCHMARK_TOOLS_GCS_ARTIFACT: ${{ needs.setup.outputs.gcs-dir }}/${{ steps.archive.outputs.benchmark-tools-archive }}
         run: |
           gcloud alpha storage cp "${BENCHMARK_TOOLS_ARCHIVE}" "${BENCHMARK_TOOLS_GCS_ARTIFACT}"
           echo "::set-output name=${PLATFORM}-${ARCHITECTURE}-benchmark-tools-gcs-artifact::${BENCHMARK_TOOLS_GCS_ARTIFACT}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
       environment: prod
       # pseudo-ternary hack. See comment at top
       runner-group: ${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}
+      # Note that we can't flip the condition here because 0 is falsey
+      write-caches: ${{ github.event_name != 'pull_request' && 1 || 0 }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -169,8 +171,7 @@ jobs:
           submodules: true
       - name: "Building with Bazel"
         env:
-          # Psuedo-ternary hack. Don't swap the condition! See comment at top of file.
-          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ github.event_name != 'pull_request' && 1 || 0 }}
+          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ needs.should_run.outputs.write-caches }}
         # This doesn't really need everything in the frontends image, but we
         # want the cache to be shared with the integrations build (no point
         # building LLVM twice) and the cache key is the docker container it's
@@ -336,8 +337,7 @@ jobs:
         id: build
         env:
           IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
-          # Psuedo-ternary hack. Don't swap the condition! See comment at top of file.
-          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ github.event_name != 'pull_request' && 1 || 0 }}
+          IREE_BAZEL_WRITE_REMOTE_CACHE: ${{ needs.should_run.outputs.write-caches }}
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --env "IREE_BAZEL_WRITE_REMOTE_CACHE=${IREE_BAZEL_WRITE_REMOTE_CACHE}" \


### PR DESCRIPTION
Tested: configuration with environment specified is in canary and
presubmits for this PR will run on those runners. I'll roll it out to
100% before submitting this.