### PR TITLE
Disable nounroll workaround for CUDA 11.3

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -37,11 +37,13 @@ static llvm::cl::opt<bool> dumpPtx(
     "iree-hal-cuda-dump-ptx", llvm::cl::init(false),
     llvm::cl::desc("Dump ptx to the debug stream."));
 
+// TODO: remove this workaround altogether once we decide not to support
+// CUDA 11.3
 static llvm::cl::opt<bool> clDisableLoopNounrollWa(
     "iree-hal-cuda-disable-loop-nounroll-wa",
     llvm::cl::desc("Disable the workaround for bug in ptxas for CUDA version "
                    "before 11.4."),
-    llvm::cl::init(false));
+    llvm::cl::init(true));
 
 static llvm::cl::opt<std::string> clTargetChip(
     "iree-hal-cuda-llvm-target-arch", llvm::cl::desc("LLVM target chip."),


### PR DESCRIPTION
Now that we upgraded our CI we don't need to have this workaround by default. We can later remove the code altogether once we are sure we don't need to support older CUDA versions.