### PR TITLE
Add more models for RISC-V e2e integration testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -635,7 +635,7 @@ jobs:
             --env "BUILD_RISCV_DIR=${BUILD_RISCV_DIR}" \
             --env "BUILD_PRESET=test" \
             --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            --env "IREE_IMPORT_TFLITE_BIN=${TF_BINARIES_DIR}/iree-import-tflite" \
+            --env "IREE_IMPORT_TFLITE_BIN=${DOCKER_CONTAINER_WORKDIR}/${TF_BINARIES_DIR}/iree-import-tflite" \
             --env "LLVM_BIN_DIR=${BUILD_DIR}/third_party/llvm-project/llvm/bin" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
             bash -euo pipefail -c \

--- a/build_tools/cmake/test_riscv64.sh
+++ b/build_tools/cmake/test_riscv64.sh
@@ -72,7 +72,7 @@ generate_llvm_cpu_vmfb tosa-rvv \
   -o "${BUILD_RISCV_DIR}/person_detect_rvv.vmfb"
 
 ${PYTHON_BIN} "${ROOT_DIR}/third_party/llvm-project/llvm/utils/lit/lit.py" \
-  -v --path "${LLVM_BIN_DIR}" "${ROOT_DIR}/tests/riscv64"
+  --path "${LLVM_BIN_DIR}" "${ROOT_DIR}/tests/riscv64"
 
 # Test e2e models. Excluding mobilebert for now.
 ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/models -R llvm-cpu_local-task_mobilenet -E bert

--- a/build_tools/testing/compare_run_module_output.py
+++ b/build_tools/testing/compare_run_module_output.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Compare iree-run-module dumped output
+
+This tool is used to check the consistency between two iree-run-module output
+dump. It can be used to check the cross compile consistency.
+"""
+
+import argparse
+import re
+import sys
+import numpy as np
+
+
+def parse_arguments():
+  parser = argparse.ArgumentParser(
+      description="Compare iree-run-module outputs")
+  parser.add_argument("--tol",
+                      required=True,
+                      type=str,
+                      help="consistency tolerance")
+  parser.add_argument('files', type=str, nargs='*', help='Files to be compared')
+  args = parser.parse_args()
+  return args
+
+
+def main(args):
+  data = None
+  if len(args.files) != 2:
+    sys.exit("Need to provide 2 input files")
+
+  for file in args.files:
+    with open(file, "r", encoding="utf-8") as f:
+      p = f.read()
+    # Read only numbers
+    line_list = re.findall(r"[\-*\d+\.*\d*]+", p)
+    # Remove unprinted numbers (elements > print_max_element_count)
+    line_list = list(filter(lambda a: a != "...", line_list))
+    a = np.array(line_list, dtype=float)
+    if data is None:
+      data = a
+    else:
+      data = np.vstack((data, a))
+
+  if not np.isclose(data[0,], data[1,], atol=float(args.tol)).all():
+    error = np.abs(data[0,] - data[1,])
+    max_error = np.max(error)
+    max_error_idx = np.argmax(error)
+    sys.exit(f"Max error: {max_error} at {max_error_idx} exceeds {args.tol}")
+
+
+if __name__ == "__main__":
+  main(parse_arguments())

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -170,7 +170,9 @@ iree_check_single_backend_test_suite(
   NAME
     tflite_llvm-cpu_local-task_x86_64
   SRCS
+    "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet_lite0_int8_2.tflite"
+    "https://storage.googleapis.com/iree-model-artifacts/deeplabv3.tflite"
   TARGET_BACKEND
     "llvm-cpu"
   COMPILER_FLAGS

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -143,3 +143,37 @@ iree_static_linker_test(
     "4xf32,4xf32"
   EMITC
 )
+
+# TFLite e2e test models. Need to have `iree-import-tflite`
+# installed or specified by `IREE_IMPORT_TFLITE_BIN` environment variable.
+if(NOT DEFINED ENV{IREE_IMPORT_TFLITE_BIN})
+  find_program(IREE_IMPORT_TFLITE_BIN "iree-import-tflite" HINTS ENV PATH)
+  if(NOT IREE_IMPORT_TFLITE_BIN)
+    return()
+  endif()
+endif()
+
+iree_check_single_backend_test_suite(
+  NAME
+    tflite_llvm-cpu_local-task
+  SRCS
+    "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
+    "https://storage.googleapis.com/iree-model-artifacts/efficientnet_lite0_int8_2.tflite"
+    "https://storage.googleapis.com/iree-model-artifacts/deeplabv3.tflite"
+  TARGET_BACKEND
+    "llvm-cpu"
+  COMPILER_FLAGS
+    "--iree-input-type=tosa"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
+    tflite_llvm-cpu_local-task_x86_64
+  SRCS
+    "https://storage.googleapis.com/iree-model-artifacts/efficientnet_lite0_int8_2.tflite"
+  TARGET_BACKEND
+    "llvm-cpu"
+  COMPILER_FLAGS
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-pc-linux-elf"
+)

--- a/tests/riscv64/deeplabv3_float_rvv_test.run
+++ b/tests/riscv64/deeplabv3_float_rvv_test.run
@@ -1,4 +1,13 @@
 // RUN: ${TEST_MODULE_CMD} \
 // RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_deeplabv3.tflite_module.vmfb" \
-// RUN:   --entry_function=main --function_input="1x257x257x3xf32=0"
-// iree-run-module can't printout the output selectively. Skip the numerical check.
+// RUN:   --entry_function=main --function_input="1x257x257x3xf32=0" --print_max_element_count=1008 | \
+// RUN:   grep "=\[" | tee %t
+//
+// RUN: ${HOST_TEST_MODULE_CMD} \
+// RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_x86_64_deeplabv3.tflite_module.vmfb" \
+// RUN:   --entry_function=main --function_input="1x257x257x3xf32=0" --print_max_element_count=1008 | \
+// RUN:   grep "=\[" | tee %t.x86_64
+//
+// Compare numerical results.
+// RUN: python ${IREE_ROOT_DIR}/build_tools/testing/compare_run_module_output.py \
+// RUN:   --tol=0.001 %t %t.x86_64

--- a/tests/riscv64/deeplabv3_float_rvv_test.run
+++ b/tests/riscv64/deeplabv3_float_rvv_test.run
@@ -1,0 +1,4 @@
+// RUN: ${TEST_MODULE_CMD} \
+// RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_deeplabv3.tflite_module.vmfb" \
+// RUN:   --entry_function=main --function_input="1x257x257x3xf32=0"
+// iree-run-module can't printout the output selectively. Skip the numerical check.

--- a/tests/riscv64/efficientnet_lite0_quant_rvv_test.run
+++ b/tests/riscv64/efficientnet_lite0_quant_rvv_test.run
@@ -1,0 +1,6 @@
+// RUN: ${TEST_MODULE_CMD} \
+// RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_efficientnet_lite0_int8_2.tflite_module.vmfb" \
+// RUN:   --entry_function=main --function_input="1x224x224x3xui8=0" > %t
+// RUN: ${HOST_TEST_MODULE_CMD} \
+// RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_x86_64_efficientnet_lite0_int8_2.tflite_module.vmfb" \
+// RUN:   --entry_function=main --function_input="1x224x224x3xui8=0" | diff %t -

--- a/tests/riscv64/efficientnet_lite0_quant_rvv_test.run
+++ b/tests/riscv64/efficientnet_lite0_quant_rvv_test.run
@@ -1,6 +1,13 @@
 // RUN: ${TEST_MODULE_CMD} \
 // RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_efficientnet_lite0_int8_2.tflite_module.vmfb" \
-// RUN:   --entry_function=main --function_input="1x224x224x3xui8=0" > %t
+// RUN:   --entry_function=main --function_input="1x224x224x3xui8=0" | \
+// RUN:   grep "=\[" | tee %t
+//
 // RUN: ${HOST_TEST_MODULE_CMD} \
 // RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_x86_64_efficientnet_lite0_int8_2.tflite_module.vmfb" \
-// RUN:   --entry_function=main --function_input="1x224x224x3xui8=0" | diff %t -
+// RUN:   --entry_function=main --function_input="1x224x224x3xui8=0" | \
+// RUN:   grep "=\[" | tee %t.x86_64
+//
+// Compare numerical results.
+// RUN: python ${IREE_ROOT_DIR}/build_tools/testing/compare_run_module_output.py \
+// RUN:   --tol=0 %t %t.x86_64

--- a/tests/riscv64/lit.cfg.py
+++ b/tests/riscv64/lit.cfg.py
@@ -30,6 +30,12 @@ test_module_cmd = test_cmd + [
 
 config.environment["TEST_MODULE_CMD"] = " ".join(test_module_cmd)
 
+HOST_BINARY_ROOT = os.path.abspath(os.environ["IREE_HOST_BINARY_ROOT"])
+
+config.environment["HOST_TEST_MODULE_CMD"] = " ".join([
+    os.path.join(HOST_BINARY_ROOT, "bin/iree-run-module"), "--device=local-task"
+])
+
 # Use the most preferred temp directory.
 config.test_exec_root = (os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or
                          os.environ.get("TEST_TMPDIR") or

--- a/tests/riscv64/lit.cfg.py
+++ b/tests/riscv64/lit.cfg.py
@@ -30,11 +30,14 @@ test_module_cmd = test_cmd + [
 
 config.environment["TEST_MODULE_CMD"] = " ".join(test_module_cmd)
 
-HOST_BINARY_ROOT = os.path.abspath(os.environ["IREE_HOST_BINARY_ROOT"])
+HOST_BINARY_ROOT = os.path.realpath(os.environ["IREE_HOST_BINARY_ROOT"])
 
 config.environment["HOST_TEST_MODULE_CMD"] = " ".join([
     os.path.join(HOST_BINARY_ROOT, "bin/iree-run-module"), "--device=local-task"
 ])
+
+config.environment["IREE_ROOT_DIR"] = os.path.dirname(
+    os.path.realpath(__file__)) + "/../.."
 
 # Use the most preferred temp directory.
 config.test_exec_root = (os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR") or

--- a/tests/riscv64/mobilenetv1_float_rvv_test.run
+++ b/tests/riscv64/mobilenetv1_float_rvv_test.run
@@ -1,0 +1,7 @@
+// RUN: ${TEST_MODULE_CMD} \
+// RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_mobilenet_v1_224_1.0_float.tflite_module.vmfb" \
+// RUN:   --entry_function=main --function_input="1x224x224x3xf32=0" | FileCheck %s
+// Only check the first 16 entries.
+// CHECK:1x1001xf32=[0.000268968 0.000481336 0.00131741 0.000940145 0.00096833 0.00297683 0.00218184
+// CHECK-SAME: 0.000806769 0.000280723 0.000171147 0.000345219 0.000892759 0.000576722 0.000428793
+// CHECK-SAME: 0.000316769 0.000701366

--- a/tests/riscv64/mobilenetv1_float_rvv_test.run
+++ b/tests/riscv64/mobilenetv1_float_rvv_test.run
@@ -1,7 +1,13 @@
 // RUN: ${TEST_MODULE_CMD} \
 // RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_mobilenet_v1_224_1.0_float.tflite_module.vmfb" \
-// RUN:   --entry_function=main --function_input="1x224x224x3xf32=0" | FileCheck %s
-// Only check the first 16 entries.
-// CHECK:1x1001xf32=[0.000268968 0.000481336 0.00131741 0.000940145 0.00096833 0.00297683 0.00218184
-// CHECK-SAME: 0.000806769 0.000280723 0.000171147 0.000345219 0.000892759 0.000576722 0.000428793
-// CHECK-SAME: 0.000316769 0.000701366
+// RUN:   --entry_function=main --function_input="1x224x224x3xf32=0" | \
+// RUN:   grep "=\[" | tee %t
+//
+// RUN: ${HOST_TEST_MODULE_CMD} \
+// RUN:   --module_file="${BUILD_RISCV_DIR}/tests/e2e/models/tflite_llvm-cpu_local-task_x86_64_mobilenet_v1_224_1.0_float.tflite_module.vmfb" \
+// RUN:   --entry_function=main --function_input="1x224x224x3xf32=0" | \
+// RUN:   grep "=\[" | tee %t.x86_64
+//
+// Compare numerical results.
+// RUN: python ${IREE_ROOT_DIR}/build_tools/testing/compare_run_module_output.py \
+// RUN:   --tol=0.0001 %t %t.x86_64


### PR DESCRIPTION
Add the following models
* MobileNetV1-float
* DeepLabV3-float
* EfficientNet-Lite0-quant

Update the smoke.sh utility function to parameterize the model configuration better.