### PR TITLE
Install GitHub runner on startup in a tmpfs

### DIFF
--- a/build_tools/github_actions/runner/config/chown_workdir.sh
+++ b/build_tools/github_actions/runner/config/chown_workdir.sh
@@ -9,6 +9,7 @@
 set -euo pipefail
 
 # Docker has a tendency to make things owned by root unless you do a dance with
-# which user you run it as. This can make the workspace unusable.
-# TODO: switch to ephemeral runners and get rid of this.
-sudo chown -R runner:runner /home/runner
+# which user you run it as. This can make the workspace unusable. This isn't
+# really necessary with ephemeral runners, but it also doesn't hurt and we may
+# have some runners that aren't ephemeral
+sudo chown -R runner:runner /runner-root

--- a/build_tools/github_actions/runner/config/cleanup_workdir.sh
+++ b/build_tools/github_actions/runner/config/cleanup_workdir.sh
@@ -7,7 +7,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # Remove the working directory so we have a fresh version for subsequent
-# actions.
-# TODO: switch to ephemeral runners and get rid of this.
-sudo rm -rf /home/runner/actions-runner/_work/iree/iree/
-mkdir -p /home/runner/actions-runner/_work/iree/iree/
+# actions. This isn't really necessary with ephemeral runners, but it also
+# doesn't hurt and we will have some runners that aren't ephemeral.
+
+sudo rm -rf /runner-root/actions-runner/_work/iree/iree/
+mkdir -p /runner-root/actions-runner/_work/iree/iree/

--- a/build_tools/github_actions/runner/config/deregister.sh
+++ b/build_tools/github_actions/runner/config/deregister.sh
@@ -15,7 +15,6 @@ source "${SCRIPT_DIR}/functions.sh"
 
 TOKEN_PROXY_URL="$(get_attribute github-token-proxy-url)"
 RUNNER_SCOPE="$(get_attribute github-runner-scope)"
-GOOGLE_CLOUD_RUN_ID_TOKEN="$(get_metadata "instance/service-accounts/default/identity?audience=${TOKEN_PROXY_URL}")"
 DEREGISTER_TOKEN="$(get_token remove ${RUNNER_SCOPE})"
 
 if [ -z "${DEREGISTER_TOKEN}" ]; then
@@ -25,4 +24,4 @@ fi
 
 echo "removing github actions runner"
 
-~runner/actions-runner/config.sh remove --token "${DEREGISTER_TOKEN}"
+/runner-root/actions-runner/config.sh remove --token "${DEREGISTER_TOKEN}"

--- a/build_tools/github_actions/runner/config/github-actions-runner-deregister.service
+++ b/build_tools/github_actions/runner/config/github-actions-runner-deregister.service
@@ -7,7 +7,7 @@ Before=halt.target shutdown.target reboot.target
 User=runner
 Group=runner
 Type=oneshot
-ExecStart=/home/runner/config/deregister.sh
+ExecStart=/runner-root/config/deregister.sh
 RemainAfterExit=yes
 
 [Install]

--- a/build_tools/github_actions/runner/config/github-actions-runner-start.service
+++ b/build_tools/github_actions/runner/config/github-actions-runner-start.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 User=runner
 Group=runner
-ExecStart=/home/runner/config/start.sh
+ExecStart=/runner-root/config/start.sh
 Restart=no
 KillMode=process
 KillSignal=SIGTERM

--- a/build_tools/github_actions/runner/config/register.sh
+++ b/build_tools/github_actions/runner/config/register.sh
@@ -120,4 +120,4 @@ declare -a args=(
 # functionality.
 (set -x; : Running configuration with additional args: "${args[@]}")
 
-~runner/actions-runner/config.sh --token "${REGISTER_TOKEN}" "${args[@]}"
+/runner-root/actions-runner/config.sh --token "${REGISTER_TOKEN}" "${args[@]}"

--- a/build_tools/github_actions/runner/config/runner.env
+++ b/build_tools/github_actions/runner/config/runner.env
@@ -1,3 +1,3 @@
 LANG=C.UTF-8
-ACTIONS_RUNNER_HOOK_JOB_STARTED=/home/runner/config/pre_job.sh
-ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/home/runner/config/post_job.sh
+ACTIONS_RUNNER_HOOK_JOB_STARTED=/runner-root/config/pre_job.sh
+ACTIONS_RUNNER_HOOK_JOB_COMPLETED=/runner-root/config/post_job.sh

--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -6,29 +6,50 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Sets up GitHub actions runner services to start and teardown runner.
-# Registers the runner followed by enabling deregister service then 
-# starts the registered runner to accept self-hosted GitHub workflows.
+# Installs and sets up the GitHub actions runner, creating services to start and
+# tear down the runner.
 
-set -euo pipefail
+set -xeuo pipefail
 
-echo "Register the self-hoster runner."
-chmod +x ~runner/config/register.sh
-runuser --user runner ~runner/config/register.sh
+SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
+source "${SCRIPT_DIR}/functions.sh"
 
-echo "Setup the deregister service."
-cp ~runner/config/github-actions-runner-deregister.service /etc/systemd/system/
-chmod +x ~runner/config/deregister.sh
+echo "Creating tmpfs for runner"
+mkdir /runner-root
+mount -t tmpfs -o size=50g tmpfs /runner-root
+cp -r "${SCRIPT_DIR}" /runner-root/config
+chown -R runner:runner /runner-root/
 
-echo "Setup the start actions runner service."
-cp ~runner/config/github-actions-runner-start.service /etc/systemd/system/
-chmod +x ~runner/config/start.sh
+echo "Fetching the runner archive"
+RUNNER_VERSION="$(get_attribute github-runner-version)"
+RUNNER_ARCHIVE="actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz"
+RUNNER_ARCHIVE_DIGEST="$(get_attribute github-runner-archive-digest)"
 
-echo "Reload system service files to reflect changes."
+cd /runner-root
+mkdir actions-runner
+cd actions-runner
+curl --silent --fail --show-error --location \
+  "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_ARCHIVE}" \
+  -o "${RUNNER_ARCHIVE}"
+
+echo "${RUNNER_ARCHIVE_DIGEST} *${RUNNER_ARCHIVE}" | shasum -a 256 -c
+tar xzf "${RUNNER_ARCHIVE}"
+ln -s ../config/runner.env .env
+
+echo "Registering the runner."
+runuser --user runner /runner-root/config/register.sh
+
+echo "Setting up the deregister service."
+cp /runner-root/config/github-actions-runner-deregister.service /etc/systemd/system/
+
+echo "Setting up the runner service."
+cp /runner-root/config/github-actions-runner-start.service /etc/systemd/system/
+
+echo "Reloading system service files to reflect changes."
 systemctl daemon-reload
 
-echo "Enable deregister so it can hook onto system shutdown."
+echo "Enabling the deregister service."
 systemctl enable github-actions-runner-deregister
 
-echo "Start the runner so it can be assigned workflows."
+echo "Starting the runner service."
 systemctl start github-actions-runner-start

--- a/build_tools/github_actions/runner/config/start.sh
+++ b/build_tools/github_actions/runner/config/start.sh
@@ -16,4 +16,4 @@ set -euo pipefail
 
 echo "Starting runner"
 
-~runner/actions-runner/bin/Runner.Listener run --startuptype service
+/runner-root/actions-runner/bin/Runner.Listener run --startuptype service

--- a/build_tools/github_actions/runner/config/validate_trigger.postsubmit.sh
+++ b/build_tools/github_actions/runner/config/validate_trigger.postsubmit.sh
@@ -23,8 +23,9 @@ ALLOWED_EVENTS=(
 
 if ! is_contained "${GITHUB_EVENT_NAME}" "${ALLOWED_EVENTS[@]}"; then
   echo "Event type '${GITHUB_EVENT_NAME}' is not allowed on this runner. Aborting workflow."
-  # clean up any nefarious stuff we may have fetched in job setup
-  cd /home/runner/actions-runner/_work
-  rm -rf _actions/ _temp/
+  # clean up any nefarious stuff we may have fetched in job setup. This
+  # shouldn't be necessary with ephemeral runners, but shouldn't hurt either.
+  cd /runner-root/actions-runner/_work
+  rm -rfv _actions/ _temp/
   exit 1
 fi

--- a/build_tools/github_actions/runner/config/validate_trigger.releaser.sh
+++ b/build_tools/github_actions/runner/config/validate_trigger.releaser.sh
@@ -22,8 +22,9 @@ ALLOWED_EVENTS=(
 
 if ! is_contained "${GITHUB_EVENT_NAME}" "${ALLOWED_EVENTS[@]}"; then
   echo "Event type '${GITHUB_EVENT_NAME}' is not allowed on this runner. Aborting workflow."
-  # clean up any nefarious stuff we may have fetched in job setup
-  cd /home/runner/actions-runner/_work
-  rm -rf _actions/ _temp/
+  # clean up any nefarious stuff we may have fetched in job setup. This
+  # shouldn't be necessary with ephemeral runners, but shouldn't hurt either.
+  cd /runner-root/actions-runner/_work
+  rm -rfv _actions/ _temp/
   exit 1
 fi

--- a/build_tools/github_actions/runner/gcp/startup_script.sh
+++ b/build_tools/github_actions/runner/gcp/startup_script.sh
@@ -44,9 +44,4 @@ curl --silent --fail --show-error --location \
   --strip-components=4  --wildcards \
   */build_tools/github_actions/runner/config/
 
-chown -R runner:runner config/
-# The setup script currently expects the config to be in the runner home
-# directory, but we're making that configurable.
-# TODO: remove this when setup script is updated
-cp -r ./config /home/runner/
 ./config/setup.sh


### PR DESCRIPTION
The installation is just extracting an archive, so is not costly. This
makes the runner more decoupled from its boot disk. It allows us to
upgrade the runner version (which we'll need to do frequently) without
creating a whole new VM image (which is a pain and requires full VM
replacement to update). The tmpfs also gives us better IO performance,
which should speed a few things along (though we already give Docker a
tmpfs, so the difference won't be huge). It should allow us to switch
to a much simpler base image that just has a few dependencies
installed, rather than the current image, which I accidentally made 1TB
and is the product of much messing around.

Tested: https://github.com/iree-org/iree/pull/10298 targets the testing
runners which are using this config.

skip-ci

This is the last bit of https://github.com/iree-org/iree/pull/10133

Closes https://github.com/iree-org/iree/pull/10133