### PR TITLE
Add dry-run and expanded filtering options to update script

### DIFF
--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -87,7 +87,6 @@ class MigFetcher():
       )
       region_migs = self._migs_client.list(list_mig_request)
       migs.extend([mig for mig in region_migs])
-    sys.exit(0)
     return migs
 
 

--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -20,9 +20,6 @@ DIRECT_UPDATE_COMMAND_NAME = "direct-update"
 
 CANARY_SIZE = compute.FixedOrPercent(fixed=1)
 
-GROUPS = ["presubmit", "postsubmit"]
-TYPES = ["cpu", "gpu"]
-
 
 def resource_basename(resource):
   return os.path.basename(urllib.parse.urlparse(resource).path)

--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -153,6 +153,11 @@ def main(args):
               f" automatic canary. Current versions:"
               f" {summarize_versions(mig.versions)}")
 
+      if base_template == template_url:
+        error(f"Instance group '{mig.name}' already has the requested canary"
+              f" version '{template_name}' as its base version. Current"
+              " versions:"
+              f" {summarize_versions(mig.versions)}")
       new_versions = [
           compute.InstanceGroupManagerVersion(name=args.base_version_name,
                                               instance_template=base_template),
@@ -171,12 +176,22 @@ def main(args):
       ]
     elif args.command == PROMOTE_CANARY_COMMAND_NAME:
       new_base_template = current_templates.get(args.canary_version_name)
+      if new_base_template is None:
+        error(f"Instance group '{mig.name}' does not have a current version"
+              f" named '{args.canary_version_name}', which is required for an"
+              f" automatic canary promotion. Current versions:"
+              f" {summarize_versions(mig.versions)}")
       new_versions = [
           compute.InstanceGroupManagerVersion(
               name=args.base_version_name, instance_template=new_base_template)
       ]
     elif args.command == ROLLBACK_CANARY_COMMAND_NAME:
       base_template = current_templates.get(args.base_version_name)
+      if base_template is None:
+        error(f"Instance group '{mig.name}' does not have a current version"
+              f" named '{args.base_version_name}', which is required for an"
+              f" automatic canary rollback. Current versions:"
+              f" {summarize_versions(mig.versions)}")
       new_versions = [
           compute.InstanceGroupManagerVersion(name=args.base_version_name,
                                               instance_template=base_template)

--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -72,14 +72,14 @@ class MigFetcher():
     regions = [r.name for r in self._regions_client.list(request)]
 
     if type == "all":
-      type = f"({'|'.join(TYPES)})"
+      type = r"\w+"
 
     if group == "all":
-      group = f"({'|'.join(GROUPS)})"
+      group = r"\w+"
 
     for region in regions:
       filter_parts = [p for p in [prefix, modifier, group, type, region] if p]
-      filter = f"name eq {'-'.join(filter_parts)}"
+      filter = f"name eq '{'-'.join(filter_parts)}'"
       list_mig_request = compute.ListRegionInstanceGroupManagersRequest(
           project=self._project,
           region=region,
@@ -229,7 +229,6 @@ def parse_args():
   subparser_base.add_argument(
       "--group",
       "--groups",
-      choices=GROUPS + ["all"],
       required=True,
       help=("The runner group of the MIGs to update, an RE2 regex for matching"
             " the group (e.g. 'cpu|gpu'), or 'all' to search for MIGs for all"
@@ -239,7 +238,6 @@ def parse_args():
       "--type",
       "--types",
       required=True,
-      choices=TYPES + ["all"],
       help=("The runner type of the MIGs to update, an RE2 regex for matching"
             " the type (e.g. 'presubmit|postsubmit'), or 'all' to search for"
             " MIGs for all types."),

--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -192,13 +192,17 @@ def main(args):
     print(f"Updating {mig.name} to new versions:"
           f" {summarize_versions(new_versions)}")
 
+    request = compute.PatchRegionInstanceGroupManagerRequest(
+        project=args.project,
+        region=region,
+        instance_group_manager=mig.name,
+        instance_group_manager_resource=compute.InstanceGroupManager(
+            versions=new_versions, update_policy=update_policy))
+
     if not args.dry_run:
-      migs_client.patch(
-          project=args.project,
-          region=region,
-          instance_group_manager=mig.name,
-          instance_group_manager_resource=compute.InstanceGroupManager(
-              versions=new_versions, update_policy=update_policy))
+      migs_client.patch(request)
+    else:
+      print(f"Dry run, so not sending this patch request:\n```\n{request}```")
     print(f"Successfully updated {mig.name}")
 
 


### PR DESCRIPTION
Dry-run is always a nice feature.

The existing filtering scheme using '.*' for group and type was
matching other components of the MIG name and picking up testing MIGs
even when environment was set to "prod".

Having a filter for region allows limiting to regions where we actually
have instance groups, which speeds things up quite a bit. We *could*
just list them in the script, which would avoid the call to list
regions entirely. I avoided this because I didn't want to bake too many
assumptions into the script, but IDK if that was the right call.

skip-ci