### PR TITLE
Add RISC-V cross compile/run support for iree_check_test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,7 +627,7 @@ jobs:
             --env "LLVM_BIN_DIR=${BUILD_DIR}/third_party/llvm-project/llvm/bin" \
             gcr.io/iree-oss/riscv@sha256:720bc0215d8462ea14352edc22710a6ce4c0c1daff581d179dd173885f1d8a35 \
             bash -euo pipefail -c \
-              "./build_tools/cmake/build_riscv.sh && ./tests/riscv64/smoke.sh"
+              "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv64.sh"
 
   build_benchmark_tools:
     needs: [should_run, build_all]

--- a/build_tools/cmake/build_host_and_riscv.sh
+++ b/build_tools/cmake/build_host_and_riscv.sh
@@ -72,6 +72,7 @@ args=(
   -DIREE_ENABLE_ASSERTIONS=ON
   -DIREE_BUILD_COMPILER=OFF
   -DIREE_BUILD_SAMPLES=ON
+  -DIREE_ENABLE_CPUINFO=OFF
 )
 
 if [[ "${RISCV_CONFIG?}" == "rv64" ]]; then
@@ -92,3 +93,7 @@ fi
 args_str=$(IFS=' ' ; echo "${args[*]}")
 "${CMAKE_BIN?}" ${args_str} "${ROOT_DIR?}"
 "${CMAKE_BIN?}" --build "${BUILD_RISCV_DIR?}" -- -k 0
+
+if [[ "${RISCV_CONFIG?}" == "rv64" ]]; then
+  "${CMAKE_BIN?}" --build "${BUILD_RISCV_DIR?}" --target iree-test-deps -- -k 0
+fi

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -95,12 +95,11 @@ case "${BUILD_PRESET}" in
     ;;
 esac
 
-args_str=$(IFS=' ' ; echo "${args[*]}")
-"${CMAKE_BIN}" ${args_str} "${ROOT_DIR}"
+"${CMAKE_BIN}" "${args[@]}" "${ROOT_DIR}"
 "${CMAKE_BIN}" --build "${BUILD_RISCV_DIR}" -- -k 0
 
 if [[ "${RISCV_ARCH}" == "rv64" ]]; then
   echo "Building test deps for RISC-V"
-  echo "------------------"
+  echo "-----------------------------"
   "${CMAKE_BIN}" --build "${BUILD_RISCV_DIR}" --target iree-test-deps -- -k 0
 fi

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -98,3 +98,9 @@ esac
 args_str=$(IFS=' ' ; echo "${args[*]}")
 "${CMAKE_BIN}" ${args_str} "${ROOT_DIR}"
 "${CMAKE_BIN}" --build "${BUILD_RISCV_DIR}" -- -k 0
+
+if [[ "${RISCV_ARCH}" == "rv64" ]]; then
+  echo "Building test deps for RISC-V"
+  echo "------------------"
+  "${CMAKE_BIN}" --build "${BUILD_RISCV_DIR}" --target iree-test-deps -- -k 0
+fi

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -37,6 +37,23 @@ function(iree_bytecode_module_for_iree_check_test_and_friends)
     list(APPEND _RULE_FLAGS "--iree-llvm-target-triple=${_TARGET_TRIPLE}")
   endif()
 
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND
+     RISCV_CPU STREQUAL "rv64" AND
+     _RULE_TARGET_BACKEND STREQUAL "llvm-cpu" AND
+     NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
+    # RV64 Linux crosscompile toolchain can support iree_check_test with
+    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
+    # llvm-target-triple is not specified.
+    list(APPEND _RULE_FLAGS "--iree-llvm-target-triple=riscv64")
+    list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu=generic-rv64")
+    list(APPEND _RULE_FLAGS "--iree-llvm-target-abi=lp64d")
+    if(NOT _RULE_TARGET_CPU_FEATURES)
+      list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c,+v")
+      list(APPEND _RULE_FLAGS "--riscv-v-fixed-length-vector-lmul-max=8")
+      list(APPEND _RULE_FLAGS "--riscv-v-vector-bits-min=512")
+    endif()
+  endif()
+
   if(_RULE_TARGET_CPU_FEATURES)
     if(NOT _RULE_TARGET_BACKEND STREQUAL "llvm-cpu")
       message(SEND_ERROR "TARGET_CPU_FEATURES should be empty when \

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -115,8 +115,8 @@ function(iree_native_test)
     set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND RISCV_CPU STREQUAL "rv64")
     # The test target needs to run within the QEMU emulator for RV64 Linux
-    # crosscompile build. A QEMU 64 Linux emulator is assumed to be available
-    # and its path is set at QEMU_RV64_BIN enviroment varilable
+    # crosscompile build. A QEMU 64 Linux emulator must be available at the
+    # path specified by the  `QEMU_RV64_BIN` environment variable.
     if(DEFINED ENV{QEMU_RV64_BIN})
       add_test(
         NAME

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -113,6 +113,25 @@ function(iree_native_test)
         "TEST_TMPDIR=${_ANDROID_ABS_DIR}/test_tmpdir"
     )
     set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND RISCV_CPU STREQUAL "rv64")
+    # The test target needs to run within the QEMU emulator for RV64 Linux
+    # crosscompile build. A QEMU 64 Linux emulator is assumed to be available
+    # and its path is set at QEMU_RV64_BIN enviroment varilable
+    if(DEFINED ENV{QEMU_RV64_BIN})
+      add_test(
+        NAME
+          ${_TEST_NAME}
+        COMMAND
+          "$ENV{QEMU_RV64_BIN}"
+          -cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0
+          -L "${RISCV_TOOLCHAIN_ROOT}/sysroot"
+          "$<TARGET_FILE:${_SRC_TARGET}>"
+          ${_RULE_ARGS}
+      )
+      iree_configure_test(${_TEST_NAME})
+    else()
+      message(SEND_ERROR "QEMU not found.")
+    endif()
   else()
     add_test(
       NAME

--- a/build_tools/cmake/test_riscv64.sh
+++ b/build_tools/cmake/test_riscv64.sh
@@ -6,7 +6,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Test the cross-compiled RISCV targets using Kokoro.
+# Test the cross-compiled RISCV 64-bit Linux targets.
 
 set -xeuo pipefail
 

--- a/tests/riscv64/smoke.sh
+++ b/tests/riscv64/smoke.sh
@@ -73,3 +73,10 @@ generate_llvm_cpu_vmfb tosa-rvv \
 
 ${PYTHON_BIN} "${ROOT_DIR}/third_party/llvm-project/llvm/utils/lit/lit.py" \
   -v --path "${LLVM_BIN_DIR}" "${ROOT_DIR}/tests/riscv64"
+
+# Test e2e models. Excluding mobilebert for now.
+ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/models -R llvm-cpu_local-task_mobilenet -E bert
+# Test all tosa ops
+ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/tosa_ops -R check_llvm-cpu_local-task
+# Test all xla ops except fp16, which is not supported properly
+ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/xla_ops -R check_llvm-cpu_local-task -E fp16


### PR DESCRIPTION
* Add the cross compile support to compile RISC-V compatible vmfb modules for iree_check_test
* Attach RISC-V QEMU Linux emulator to iree_native_test
* Extend riscv64 smoke test to cover tests/e2e/{tosa_ops, xla_ops, models} tests