### PR TITLE
Add target and result to transform.iree.bufferize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ iree/builtins/**/bin/*.ll
 # Archive files
 *.tar
 *.tar.*
+
+# Local cache files
+llvm-external-projects/iree-dialects/.cache

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -66,10 +66,11 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
 
 def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
     [FunctionalStyleTransformOpTrait, 
-     MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      DeclareOpInterfaceMethods<TransformOpInterface>]> {
   let description = [{
-    Call upstream comprehensive bufferize with extra IREE hooks.
+    Target the whole hal.executable_variant op and call upstream comprehensive
+    bufferize with extra IREE hooks.
 
     By default, CPU allocations are emitted. This behavior can be modified by 
     using the following attributes:
@@ -89,10 +90,11 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
     No handles are consumed or produced.
   }];
 
-  let arguments = (ins UnitAttr:$target_gpu);
-  let results = (outs);
+  let arguments = (ins PDL_Operation:$target,
+                       UnitAttr:$target_gpu);
+  let results = (outs PDL_Operation:$result);
 
-  let assemblyFormat = "attr-dict";
+  let assemblyFormat = "attr-dict $target";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
@@ -36,7 +36,7 @@ hal.executable private @pad_matmul_static_dispatch_0 {
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
   transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
-    transform.iree.bufferize
+  ^bb1(%variant_op: !pdl.operation):
+    transform.iree.bufferize %variant_op
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
@@ -1,33 +1,36 @@
 // RUN: iree-opt %s -iree-transform-dialect-interpreter -transform-dialect-drop-schedule | FileCheck %s
 
-func.func @pad_matmul_static_dispatch_0(%arg0: tensor<250x500xf32>, %arg1: tensor<500x1020xf32>) -> tensor<250x1020xf32> {
-  %c0 = arith.constant 0 : index
-  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:250x500xf32>
-  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:500x1020xf32>
-  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readwrite:250x1020xf32>
-  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [250, 500], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x500xf32> -> tensor<250x500xf32>
-  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [500, 1020], strides = [1, 1] : !flow.dispatch.tensor<readonly:500x1020xf32> -> tensor<500x1020xf32>
+hal.executable private @pad_matmul_static_dispatch_0  {
+  builtin.module {
+    func.func @pad_matmul_static_dispatch_0(%arg0: tensor<250x500xf32>, %arg1: tensor<500x1020xf32>) -> tensor<250x1020xf32> {
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:250x500xf32>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:500x1020xf32>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readwrite:250x1020xf32>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [250, 500], strides = [1, 1] : !flow.dispatch.tensor<readonly:250x500xf32> -> tensor<250x500xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [500, 1020], strides = [1, 1] : !flow.dispatch.tensor<readonly:500x1020xf32> -> tensor<500x1020xf32>
 
-  %50 = linalg.init_tensor [250, 1020] : tensor<250x1020xf32>
-  %cst = arith.constant 0.000000e+00 : f32
-  %5 = linalg.fill ins(%cst : f32) outs(%50 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+      %50 = linalg.init_tensor [250, 1020] : tensor<250x1020xf32>
+      %cst = arith.constant 0.000000e+00 : f32
+      %5 = linalg.fill ins(%cst : f32) outs(%50 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
 
-  //      CHECK: memref.alloc() {alignment = 128 : i64} : memref<250x1020xf32, 3>
-  // CHECK-NEXT: linalg.fill ins(%{{.*}} : f32) outs(%{{.*}} : memref<250x1020xf32, 3>)
-  // CHECK-NEXT: linalg.matmul{{.*}}ins(%{{.*}} : memref<250x500xf32>, memref<500x1020xf32>) outs(%{{.*}} : memref<250x1020xf32, 3>)
-  // CHECK-NEXT: bufferization.to_tensor %{{.*}} : memref<250x1020xf32, 3>
-  // CHECK-NEXT: memref.dealloc %{{.*}} : memref<250x1020xf32, 3>
+      //      CHECK: memref.alloc() {alignment = 128 : i64} : memref<250x1020xf32, 3>
+      // CHECK-NEXT: linalg.fill ins(%{{.*}} : f32) outs(%{{.*}} : memref<250x1020xf32, 3>)
+      // CHECK-NEXT: linalg.matmul{{.*}}ins(%{{.*}} : memref<250x500xf32>, memref<500x1020xf32>) outs(%{{.*}} : memref<250x1020xf32, 3>)
+      // CHECK-NEXT: bufferization.to_tensor %{{.*}} : memref<250x1020xf32, 3>
+      // CHECK-NEXT: memref.dealloc %{{.*}} : memref<250x1020xf32, 3>
 
-  %6 = linalg.matmul ins(%3, %4 : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%5 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
+      %6 = linalg.matmul ins(%3, %4 : tensor<250x500xf32>, tensor<500x1020xf32>) outs(%5 : tensor<250x1020xf32>) -> tensor<250x1020xf32>
 
-  // Returning a tensor force the allocation that we want to test here: and alloca with memory space "3" for GPU shared memory.
-  return %6: tensor<250x1020xf32>
-}
-
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
-    transform.iree.bufferize { target_gpu }
+      // Returning a tensor force the allocation that we want to test here: and alloca with memory space "3" for GPU shared memory.
+      return %6: tensor<250x1020xf32>
+    }
+  }
+  transform.with_pdl_patterns {
+  ^bb0(%arg0: !pdl.operation):
+    transform.structured.canonicalized_sequence %arg0 {
+    ^bb1(%variant_op: !pdl.operation):
+      transform.iree.bufferize { target_gpu } %variant_op
+    }
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
@@ -1,7 +1,7 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
   transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
-    transform.iree.bufferize
+  ^bb1(%variant_op: !pdl.operation):
+    transform.iree.bufferize %variant_op
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -1,17 +1,17 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
   transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["linalg.fill"]} in %arg1
+  ^bb1(%variant_op: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.fill"]} in %variant_op
     %foreach_thread, %tiled_fill = transform.structured.tile_to_foreach_thread_op %0 num_threads [5, 1] (mapped to dims [1, 0, 2])
 
-    %1 = transform.structured.match ops{["linalg.matmul"]} in %arg1
+    %1 = transform.structured.match ops{["linalg.matmul"]} in %variant_op
     %foreach_thread_2, %tiled_matmul = transform.structured.tile_to_foreach_thread_op %1 num_threads [7, 9]
 
-    transform.iree.bufferize
+    %variant_op_2 = transform.iree.bufferize %variant_op
 
     // Get the function to which to apply to.
-    %2 = transform.structured.match ops{["linalg.matmul"]} in %arg1
+    %2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op_2
     %func = transform.get_closest_isolated_parent %2
     transform.iree.foreach_thread_to_gpu_and_translation_info %func { workgroup_size = [10, 11]}
   }

--- a/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_codegen_spec.mlir
@@ -1,7 +1,7 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
   transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
-    transform.iree.bufferize
+  ^bb1(%variant_op: !pdl.operation):
+    transform.iree.bufferize %variant_op
   }
 }

--- a/tests/transform_dialect/cpu/matmul_codegen_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_spec.mlir
@@ -3,15 +3,15 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
   transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
+  ^bb1(%variant_op: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.matmul"]} in %variant_op
 
     %foreach_thread, %tiled_generic = 
       transform.structured.tile_to_foreach_thread_op %0 num_threads [2]
     
-    transform.iree.bufferize
+    transform.iree.bufferize %variant_op
     
-    %func = transform.structured.match ops{["func.func"]} in %arg1
+    %func = transform.structured.match ops{["func.func"]} in %variant_op
     transform.iree.foreach_thread_to_workgroup %func
   }
 }

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -3,16 +3,16 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
   transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
-    %fused_fill = transform.structured.match ops{["linalg.fill"]} in %arg1
+  ^bb1(%variant_op: !pdl.operation):
+    %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op
+    %fused_fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
     // Note: split by 32 to vector-distribute the tail combiner_op, but
     // split by 2 to vector-distribute the meaty %more_parallel_op
     %init_or_alloc_op, %fill_op, %more_parallel_op, %combiner_op = 
       transform.structured.split_reduction %0 
         { split_factor = 2, insert_split_dimension = 1, use_alloc }
     
-    %1 = transform.structured.match ops{["linalg.generic"]} in %arg1
+    %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op
     %foreach_thread_1, %tiled_fill = 
       transform.structured.tile_to_foreach_thread_op %fill_op num_threads [4, 2] (mapped to dims [2, 1, 0])
     %foreach_thread_2, %tiled_more_parallel_op = 
@@ -26,13 +26,14 @@ transform.with_pdl_patterns {
     %isolated_handle_2 = transform.structured.vectorize %isolated_handle_1
     %isolated_handle_3 = transform.iree.apply_patterns %isolated_handle_2 { rank_reducing }
 
-    transform.iree.bufferize { target_gpu }
+    %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+
     %isolated_handle_4 = 
       transform.iree.foreach_thread_to_gpu_and_translation_info %isolated_handle_3 
         { workgroup_size = [32, 2, 4] }
     
     // Vector distribution needs to happen on buffers.
-    %if_op = transform.structured.match ops{["scf.if"]} in %arg1
+    %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
     %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
     transform.iree.vector.warp_distribute %isolated_handle_4
     

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -4,14 +4,14 @@
 transform.with_pdl_patterns {
 ^bb0(%arg0: !pdl.operation):
   transform.structured.canonicalized_sequence %arg0 {
-  ^bb1(%arg1: !pdl.operation):
+  ^bb1(%variant_op: !pdl.operation):
     // First level of tiling + fusion parallelizes to blocks.
     // The mapping  to block ids can only happen after bufferization atm 
     %root = transform.structured.match interface{LinalgOp} 
-      attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %arg1
-    %fill = transform.structured.match ops{["linalg.fill"]} in %arg1
+      attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %variant_op
+    %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
     %red = transform.structured.match interface{LinalgOp} 
-      attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %arg1
+      attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %variant_op
     %not_root = merge_handles %fill, %red
     %foreach_thread, %tiled_generic = 
       transform.structured.tile_to_foreach_thread_op %root tile_sizes [1, 4]
@@ -22,11 +22,11 @@ transform.with_pdl_patterns {
     // threadIdx.x. After distribution, predication by if (threadIdx.x == 0) is
     // introduced and opportunities for distributing vector ops across warps
     // appear.
-    %fill_linalg = transform.structured.match ops{["linalg.fill"]} in %arg1
+    %fill_linalg = transform.structured.match ops{["linalg.fill"]} in %variant_op
     %reduction_linalg = transform.structured.match ops{["linalg.generic"]} 
-      attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %arg1
+      attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %variant_op
     %parallel_linalg = transform.structured.match ops{["linalg.generic"]} 
-      attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %arg1
+      attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %variant_op
     %foreach_thread_reduction, %tiled_reduction_generic = 
       transform.structured.tile_to_foreach_thread_op %reduction_linalg tile_sizes [1, 1]
         (mapped to dims [2, 1, 0])
@@ -53,7 +53,7 @@ transform.with_pdl_patterns {
     //
     // That is still not good enough because we need to predicate this in order
     // to enable the parallel reduction on warps.
-    %func = transform.structured.match ops{["func.func"]} in %arg1
+    %func = transform.structured.match ops{["func.func"]} in %variant_op
     %func_2 = transform.structured.vectorize %func
     
     // Bufferization is necessary for:
@@ -61,16 +61,17 @@ transform.with_pdl_patterns {
     //   2. lowering scf.foreach_thread to gpu (thread level parallelism)
     //   3. introducing predication (due to 1. + 2.) which enables rewriting to
     //      warp_execute_on_lane_0 and later vector distribution.
-    transform.iree.bufferize { target_gpu }
+    %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+
     %func_3 = transform.iree.foreach_thread_to_workgroup %func_2
     transform.iree.foreach_thread_to_gpu_and_translation_info %func_3
       { workgroup_size = [32, 4, 1] }
     
-    %end_func = transform.structured.match ops{["func.func"]} in %arg1
+    %end_func = transform.structured.match ops{["func.func"]} in %variant_op_2
     %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing }
 
     // Vector distribution needs to happen on buffers.
-    %if_op = transform.structured.match ops{["scf.if"]} in %arg1
+    %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
     %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
     transform.iree.vector.warp_distribute %end_func_2
   }


### PR DESCRIPTION
This is necessary as bufferize uses replaceOp and old ops get destroyed. Although all examples use bufferize as a barrier for transforms, certain transform dialect sanity checks do not like ops not being properly tracked.

Invalidating and recreating the handle is significantly easier than tracking with a Listener atm.