### PR TITLE
Replace MiniLM benchmark with seqlen=128 version.

### DIFF
--- a/benchmarks/TF/CMakeLists.txt
+++ b/benchmarks/TF/CMakeLists.txt
@@ -16,11 +16,11 @@
 #                                                                              #
 ################################################################################
 
-set(MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE
+set(MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE
   NAME
-    "MiniLML12H384UncasedSeqlen128"
+    "MiniLML12H384Uncased"
   TAGS
-    "int32"
+    "int32,seqlen128"
   SOURCE
     # Converted from https://huggingface.co/microsoft/MiniLM-L12-H384-uncased/commit/44acabbec0ef496f6dbc93adadea57f376b7c0ec
     "https://storage.googleapis.com/iree-model-artifacts/minilm-l12-h384-uncased-seqlen128-tf-model.tar.gz"

--- a/benchmarks/TF/CMakeLists.txt
+++ b/benchmarks/TF/CMakeLists.txt
@@ -16,18 +16,18 @@
 #                                                                              #
 ################################################################################
 
-set(MINILM_L12_H384_UNCASED_INT32_MODULE
+set(MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE
   NAME
-    "MiniLML12H384Uncased"
+    "MiniLML12H384UncasedSeqlen128"
   TAGS
     "int32"
   SOURCE
     # Converted from https://huggingface.co/microsoft/MiniLM-L12-H384-uncased/commit/44acabbec0ef496f6dbc93adadea57f376b7c0ec
-    "https://storage.googleapis.com/iree-model-artifacts/minilm-l12-h384-uncased-tf-model.tar.gz"
+    "https://storage.googleapis.com/iree-model-artifacts/minilm-l12-h384-uncased-seqlen128-tf-model.tar.gz"
   ENTRY_FUNCTION
     "predict"
   FUNCTION_INPUTS
-    "1x512xi32,1x512xi32,1x512xi32"
+    "1x128xi32,1x128xi32,1x128xi32"
 )
 
 ################################################################################

--- a/benchmarks/TF/linux-cuda.cmake
+++ b/benchmarks/TF/linux-cuda.cmake
@@ -27,7 +27,7 @@ iree_benchmark_suite(
     "linux-cuda"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE}"
 
   BENCHMARK_MODES
     "full-inference,default-flags"

--- a/benchmarks/TF/linux-cuda.cmake
+++ b/benchmarks/TF/linux-cuda.cmake
@@ -27,7 +27,7 @@ iree_benchmark_suite(
     "linux-cuda"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
 
   BENCHMARK_MODES
     "full-inference,default-flags"

--- a/benchmarks/TF/linux-x86_64.cmake
+++ b/benchmarks/TF/linux-x86_64.cmake
@@ -28,7 +28,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
 
   BENCHMARK_MODES
     "full-inference,default-flags"
@@ -52,7 +52,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
 
   BENCHMARK_MODES
     "1-thread,full-inference,default-flags"
@@ -78,7 +78,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
 
   BENCHMARK_MODES
     "4-thread,full-inference,default-flags"
@@ -104,7 +104,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
 
   BENCHMARK_MODES
     "8-thread,full-inference,default-flags"

--- a/benchmarks/TF/linux-x86_64.cmake
+++ b/benchmarks/TF/linux-x86_64.cmake
@@ -28,7 +28,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE}"
 
   BENCHMARK_MODES
     "full-inference,default-flags"
@@ -52,7 +52,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE}"
 
   BENCHMARK_MODES
     "1-thread,full-inference,default-flags"
@@ -78,7 +78,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE}"
 
   BENCHMARK_MODES
     "4-thread,full-inference,default-flags"
@@ -104,7 +104,7 @@ iree_benchmark_suite(
     "linux-x86_64"
 
   MODULES
-    "${MINILM_L12_H384_UNCASED_SEQLEN128_INT32_MODULE}"
+    "${MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE}"
 
   BENCHMARK_MODES
     "8-thread,full-inference,default-flags"


### PR DESCRIPTION
As the offline discussion, we care more about the MiniLM performance with seqlen=128 instead of the current seqlen=512.

This change will create a new series of MiniLM with seqlen=128, and the old one will be inactive and hidden.