### PR TITLE
Add RISC-V 64-bit Linux unit tests

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -70,6 +70,20 @@ function(iree_bytecode_module)
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
 
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND
+    RISCV_CPU STREQUAL "rv64" AND
+    NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
+    # RV64 Linux crosscompile toolchain can support iree-compile with
+    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
+    # llvm-target-triple is not specified.
+    list(APPEND _RULE_FLAGS "--iree-llvm-target-triple=riscv64")
+    list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu=generic-rv64")
+    list(APPEND _RULE_FLAGS "--iree-llvm-target-abi=lp64d")
+    list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c,+v")
+    list(APPEND _RULE_FLAGS "--riscv-v-fixed-length-vector-lmul-max=8")
+    list(APPEND _RULE_FLAGS "--riscv-v-vector-bits-min=512")
+  endif()
+
   set(_ARGS "--output-format=vm-bytecode")
   list(APPEND _ARGS "${_RULE_FLAGS}")
 

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -76,12 +76,7 @@ function(iree_bytecode_module)
     # RV64 Linux crosscompile toolchain can support iree-compile with
     # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
     # llvm-target-triple is not specified.
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-triple=riscv64")
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu=generic-rv64")
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-abi=lp64d")
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c,+v")
-    list(APPEND _RULE_FLAGS "--riscv-v-fixed-length-vector-lmul-max=8")
-    list(APPEND _RULE_FLAGS "--riscv-v-vector-bits-min=512")
+    list(APPEND _RULE_FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
   endif()
 
   set(_ARGS "--output-format=vm-bytecode")

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -70,15 +70,6 @@ function(iree_bytecode_module)
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
 
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND
-    RISCV_CPU STREQUAL "rv64" AND
-    NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
-    # RV64 Linux crosscompile toolchain can support iree-compile with
-    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
-    # llvm-target-triple is not specified.
-    list(APPEND _RULE_FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
-  endif()
-
   set(_ARGS "--output-format=vm-bytecode")
   list(APPEND _ARGS "${_RULE_FLAGS}")
 
@@ -106,12 +97,6 @@ function(iree_bytecode_module)
     list(APPEND _ARGS "--iree-llvm-sanitize=thread")
   endif()
 
-  if(_RULE_FRIENDLY_NAME)
-    set(_FRIENDLY_NAME "${_RULE_FRIENDLY_NAME}")
-  else()
-    get_filename_component(_FRIENDLY_NAME "${_RULE_SRC}" NAME)
-  endif()
-
   set(_OUTPUT_FILES "${_MODULE_FILE_NAME}")
   # Check LLVM static library setting. If the static libary output path is set,
   # retrieve the object path and the corresponding header file path.
@@ -122,6 +107,21 @@ function(iree_bytecode_module)
 
     string(REPLACE ".o" ".h" _STATIC_HDR_PATH "${_RULE_STATIC_LIB_PATH}")
     list(APPEND _OUTPUT_FILES "${_RULE_STATIC_LIB_PATH}" "${_STATIC_HDR_PATH}")
+  endif()
+
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND
+    RISCV_CPU STREQUAL "rv64" AND
+    NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
+    # RV64 Linux crosscompile toolchain can support iree-compile with
+    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
+    # llvm-target-triple is not specified.
+    list(APPEND _RULE_FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
+  endif()
+
+  if(_RULE_FRIENDLY_NAME)
+    set(_FRIENDLY_NAME "${_RULE_FRIENDLY_NAME}")
+  else()
+    get_filename_component(_FRIENDLY_NAME "${_RULE_SRC}" NAME)
   endif()
 
   # Depending on the binary instead of the target here given we might not have

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -162,23 +162,16 @@ function(iree_cc_test)
     set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND RISCV_CPU STREQUAL "rv64")
     # The test target needs to run within the QEMU emulator for RV64 Linux
-    # crosscompile build. A QEMU 64 Linux emulator must be available at the
-    # path specified by the `QEMU_RV64_BIN` environment variable.
-    if(DEFINED ENV{QEMU_RV64_BIN})
-      add_test(
-        NAME
-          ${_NAME_PATH}
-        COMMAND
-          "$ENV{QEMU_RV64_BIN}"
-          -cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0
-          -L "${RISCV_TOOLCHAIN_ROOT}/sysroot"
-          "$<TARGET_FILE:${_NAME}>"
-          ${_RULE_ARGS}
-      )
-      iree_configure_test(${_NAME_PATH})
-    else()
-      return()
-    endif()
+    # crosscompile build or on-device.
+    add_test(
+      NAME
+        ${_NAME_PATH}
+      COMMAND
+       "${IREE_ROOT_DIR}/build_tools/cmake/run_riscv64_test.sh"
+        "$<TARGET_FILE:${_NAME}>"
+        ${_RULE_ARGS}
+    )
+    iree_configure_test(${_NAME_PATH})
   else(ANDROID)
     add_test(
       NAME

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -160,6 +160,25 @@ function(iree_cc_test)
         TEST_TMPDIR=${_ANDROID_ABS_DIR}/test_tmpdir
     )
     set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND RISCV_CPU STREQUAL "rv64")
+    # The test target needs to run within the QEMU emulator for RV64 Linux
+    # crosscompile build. A QEMU 64 Linux emulator must be available at the
+    # path specified by the `QEMU_RV64_BIN` environment variable.
+    if(DEFINED ENV{QEMU_RV64_BIN})
+      add_test(
+        NAME
+          ${_NAME_PATH}
+        COMMAND
+          "$ENV{QEMU_RV64_BIN}"
+          -cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0
+          -L "${RISCV_TOOLCHAIN_ROOT}/sysroot"
+          "$<TARGET_FILE:${_NAME}>"
+          ${_RULE_ARGS}
+      )
+      iree_configure_test(${_NAME_PATH})
+    else()
+      return()
+    endif()
   else(ANDROID)
     add_test(
       NAME

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -44,14 +44,7 @@ function(iree_bytecode_module_for_iree_check_test_and_friends)
     # RV64 Linux crosscompile toolchain can support iree_check_test with
     # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
     # llvm-target-triple is not specified.
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-triple=riscv64")
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu=generic-rv64")
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-abi=lp64d")
-    if(NOT _RULE_TARGET_CPU_FEATURES)
-      list(APPEND _RULE_FLAGS "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c,+v")
-      list(APPEND _RULE_FLAGS "--riscv-v-fixed-length-vector-lmul-max=8")
-      list(APPEND _RULE_FLAGS "--riscv-v-vector-bits-min=512")
-    endif()
+    list(APPEND _RULE_FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
   endif()
 
   if(_RULE_TARGET_CPU_FEATURES)

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -116,7 +116,7 @@ function(iree_native_test)
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND RISCV_CPU STREQUAL "rv64")
     # The test target needs to run within the QEMU emulator for RV64 Linux
     # crosscompile build. A QEMU 64 Linux emulator must be available at the
-    # path specified by the  `QEMU_RV64_BIN` environment variable.
+    # path specified by the `QEMU_RV64_BIN` environment variable.
     if(DEFINED ENV{QEMU_RV64_BIN})
       add_test(
         NAME
@@ -130,7 +130,7 @@ function(iree_native_test)
       )
       iree_configure_test(${_TEST_NAME})
     else()
-      message(SEND_ERROR "QEMU not found.")
+      return()
     endif()
   else()
     add_test(

--- a/build_tools/cmake/iree_native_test.cmake
+++ b/build_tools/cmake/iree_native_test.cmake
@@ -115,23 +115,16 @@ function(iree_native_test)
     set_property(TEST ${_TEST_NAME} PROPERTY ENVIRONMENT ${_ENVIRONMENT_VARS})
   elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND RISCV_CPU STREQUAL "rv64")
     # The test target needs to run within the QEMU emulator for RV64 Linux
-    # crosscompile build. A QEMU 64 Linux emulator must be available at the
-    # path specified by the `QEMU_RV64_BIN` environment variable.
-    if(DEFINED ENV{QEMU_RV64_BIN})
-      add_test(
-        NAME
-          ${_TEST_NAME}
-        COMMAND
-          "$ENV{QEMU_RV64_BIN}"
-          -cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0
-          -L "${RISCV_TOOLCHAIN_ROOT}/sysroot"
-          "$<TARGET_FILE:${_SRC_TARGET}>"
-          ${_RULE_ARGS}
-      )
-      iree_configure_test(${_TEST_NAME})
-    else()
-      return()
-    endif()
+    # crosscompile build or on-device.
+    add_test(
+      NAME
+        ${_TEST_NAME}
+      COMMAND
+        "${IREE_ROOT_DIR}/build_tools/cmake/run_riscv64_test.sh"
+        "$<TARGET_FILE:${_SRC_TARGET}>"
+        ${_RULE_ARGS}
+    )
+    iree_configure_test(${_TEST_NAME})
   else()
     add_test(
       NAME

--- a/build_tools/cmake/riscv.toolchain.cmake
+++ b/build_tools/cmake/riscv.toolchain.cmake
@@ -50,6 +50,14 @@ if(RISCV_CPU STREQUAL "rv64")
   set(CMAKE_SYSTEM_LIBRARY_PATH "${RISCV_TOOLCHAIN_ROOT}/sysroot/usr/lib")
   set(RISCV_COMPILER_FLAGS "${RISCV_COMPILER_FLAGS} -march=rv64gc -mabi=lp64d")
   set(RISCV_LINKER_FLAGS "${RISCV_LINKER_FLAGS} -lstdc++ -lpthread -lm -ldl")
+  set(RISCV64_TEST_DEFAULT_LLVM_FLAGS
+    "--iree-llvm-target-triple=riscv64"
+    "--iree-llvm-target-cpu=generic-rv64"
+    "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c,+v"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--riscv-v-vector-bits-min=512"
+    CACHE INTERNAL "Default llvm codegen flags for testing purposes")
 elseif(RISCV_CPU STREQUAL "rv32-baremetal")
   set(CMAKE_SYSTEM_NAME Generic)
   set(CMAKE_CROSSCOMPILING ON CACHE BOOL "")

--- a/build_tools/cmake/run_riscv64_test.sh
+++ b/build_tools/cmake/run_riscv64_test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Copyright 2020 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Wrapper script to run the artifact on RISC-V 64-bit Linux device.
+# This script checks if QEMU emulator is set, and use either the emulator or
+# the actual device to run the cross-compiled RISC-V 64-bit linux artifacts.
+
+set -x
+set -e
+
+# A QEMU 64 Linux emulator must be available at the path specified by the
+# `QEMU_RV64_BIN` environment variable to run the artifacts under the emulator.
+if [[ -z "${QEMU_RV64_BIN}" ]]; then
+  "${QEMU_RV64_BIN}" "-cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0 \
+  -L ${RISCV_RV64_LINUX_TOOLCHAIN_ROOT}/sysroot $*"
+fi
+
+# TODO(dcaballe): Add on-device run commands.

--- a/build_tools/cmake/run_riscv64_test.sh
+++ b/build_tools/cmake/run_riscv64_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright 2020 The IREE Authors
+# Copyright 2022 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.

--- a/build_tools/cmake/test_riscv64.sh
+++ b/build_tools/cmake/test_riscv64.sh
@@ -74,13 +74,13 @@ generate_llvm_cpu_vmfb tosa-rvv \
 ${PYTHON_BIN} "${ROOT_DIR}/third_party/llvm-project/llvm/utils/lit/lit.py" \
   -v --path "${LLVM_BIN_DIR}" "${ROOT_DIR}/tests/riscv64"
 
-# Test e2e models. Excluding mobilebert for now.
-ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/models -R llvm-cpu_local-task_mobilenet -E bert
-# Test all tosa ops
-ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/tosa_ops -R check_llvm-cpu_local-task
-# Test all xla ops except fp16, which is not supported properly
-ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/xla_ops -R check_llvm-cpu_local-task -E fp16
 # Test runtime unit tests
 ctest --test-dir ${BUILD_RISCV_DIR}/runtime/ --timeout 900 --output-on-failure \
   --no-tests=error --label-exclude \
   '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$|^requires-filesystem$|^requires-dtz$)'
+
+# Test e2e models. Excluding mobilebert and fp16 for now.
+ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e --timeout 900 --output-on-failure \
+  --no-tests=error --label-exclude \
+  '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$)' \
+  -E '(bert|fp16)'

--- a/build_tools/cmake/test_riscv64.sh
+++ b/build_tools/cmake/test_riscv64.sh
@@ -83,4 +83,4 @@ ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/xla_ops -R check_llvm-cpu_local-ta
 # Test runtime unit tests
 ctest --test-dir ${BUILD_RISCV_DIR}/runtime/ --timeout 900 --output-on-failure \
   --no-tests=error --label-exclude \
-  '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$|^no-qemu$|^no-riscv$)'
+  '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$|^requires-filesystem$|^requires-dtz$)'

--- a/build_tools/cmake/test_riscv64.sh
+++ b/build_tools/cmake/test_riscv64.sh
@@ -80,3 +80,7 @@ ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/models -R llvm-cpu_local-task_mobi
 ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/tosa_ops -R check_llvm-cpu_local-task
 # Test all xla ops except fp16, which is not supported properly
 ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e/xla_ops -R check_llvm-cpu_local-task -E fp16
+# Test runtime unit tests
+ctest --test-dir ${BUILD_RISCV_DIR}/runtime/ --timeout 900 --output-on-failure \
+  --no-tests=error --label-exclude \
+  '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$|^no-qemu$|^no-riscv$)'

--- a/runtime/src/iree/base/internal/BUILD
+++ b/runtime/src/iree/base/internal/BUILD
@@ -146,7 +146,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_test(
     name = "file_io_test",
     srcs = ["file_io_test.cc"],
-    tags = ["no-qemu"],
+    tags = ["requires-filesystem"],
     deps = [
         ":file_io",
         "//runtime/src/iree/base:cc",
@@ -213,7 +213,7 @@ cc_binary_benchmark(
 iree_runtime_cc_test(
     name = "fpu_state_test",
     srcs = ["fpu_state_test.cc"],
-    tags = ["no-riscv"],
+    tags = ["requires-dtz"],
     deps = [
         ":fpu_state",
         "//runtime/src/iree/testing:gtest",

--- a/runtime/src/iree/base/internal/BUILD
+++ b/runtime/src/iree/base/internal/BUILD
@@ -146,6 +146,7 @@ iree_runtime_cc_library(
 iree_runtime_cc_test(
     name = "file_io_test",
     srcs = ["file_io_test.cc"],
+    tags = ["no-qemu"],
     deps = [
         ":file_io",
         "//runtime/src/iree/base:cc",
@@ -212,6 +213,7 @@ cc_binary_benchmark(
 iree_runtime_cc_test(
     name = "fpu_state_test",
     srcs = ["fpu_state_test.cc"],
+    tags = ["no-riscv"],
     deps = [
         ":fpu_state",
         "//runtime/src/iree/testing:gtest",

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -150,6 +150,8 @@ iree_cc_test(
     iree::base::core_headers
     iree::testing::gtest
     iree::testing::gtest_main
+  LABELS
+    "no-qemu"
 )
 
 iree_cc_library(
@@ -225,6 +227,8 @@ iree_cc_test(
     ::fpu_state
     iree::testing::gtest
     iree::testing::gtest_main
+  LABELS
+    "no-riscv"
 )
 
 iree_cc_library(

--- a/runtime/src/iree/base/internal/CMakeLists.txt
+++ b/runtime/src/iree/base/internal/CMakeLists.txt
@@ -151,7 +151,7 @@ iree_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
   LABELS
-    "no-qemu"
+    "requires-filesystem"
 )
 
 iree_cc_library(
@@ -228,7 +228,7 @@ iree_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
   LABELS
-    "no-riscv"
+    "requires-dtz"
 )
 
 iree_cc_library(

--- a/runtime/src/iree/base/testing/CMakeLists.txt
+++ b/runtime/src/iree/base/testing/CMakeLists.txt
@@ -43,5 +43,5 @@ iree_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
   LABELS
-    "no-qemu"
+    "requires-filesystem"
 )

--- a/runtime/src/iree/base/testing/CMakeLists.txt
+++ b/runtime/src/iree/base/testing/CMakeLists.txt
@@ -42,4 +42,6 @@ iree_cc_test(
     iree::base::internal::file_io
     iree::testing::gtest
     iree::testing::gtest_main
+  LABELS
+    "no-qemu"
 )

--- a/runtime/src/iree/tooling/BUILD
+++ b/runtime/src/iree/tooling/BUILD
@@ -61,7 +61,7 @@ cc_library(
 iree_runtime_cc_test(
     name = "numpy_io_test",
     srcs = ["numpy_io_test.cc"],
-    tags = ["no-qemu"],
+    tags = ["requires-filesystem"],
     deps = [
         ":device_util",
         ":numpy_io",

--- a/runtime/src/iree/tooling/BUILD
+++ b/runtime/src/iree/tooling/BUILD
@@ -61,6 +61,7 @@ cc_library(
 iree_runtime_cc_test(
     name = "numpy_io_test",
     srcs = ["numpy_io_test.cc"],
+    tags = ["no-qemu"],
     deps = [
         ":device_util",
         ":numpy_io",

--- a/runtime/src/iree/tooling/CMakeLists.txt
+++ b/runtime/src/iree/tooling/CMakeLists.txt
@@ -77,6 +77,8 @@ iree_cc_test(
     iree::testing::gtest
     iree::testing::gtest_main
     iree::tooling::testdata::npy
+  LABELS
+    "no-qemu"
 )
 
 iree_cc_library(

--- a/runtime/src/iree/tooling/CMakeLists.txt
+++ b/runtime/src/iree/tooling/CMakeLists.txt
@@ -78,7 +78,7 @@ iree_cc_test(
     iree::testing::gtest_main
     iree::tooling::testdata::npy
   LABELS
-    "no-qemu"
+    "requires-filesystem"
 )
 
 iree_cc_library(


### PR DESCRIPTION
* Add RISCV cross compile flags in `iree_bytecode_module.cmake`
* Attach QEMU emulator to `iree_cc_test.cmake`

Qemu userspace emulator doesn't support fileIO. Disable tests that read/write files.

RISC-V doesn't have a specific FPU subnormal behavior listed (follows IEEE754-2008). Disable the fpu_state_test for RISCV.