### PR TITLE
Generalize TransposeSharedMem Pipeline to Fusion with Other ElementWise

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -529,11 +529,26 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
   return success();
 }
 
+/// Returns true if the index map represents a transpose that benefits from
+/// shared mem. Currently supports 2D transposes.
+static bool isSharedMemTranspose(AffineMap indexMap) {
+  if (!indexMap.isEmpty() && indexMap.isPermutation() &&
+      indexMap.getNumInputs() == 2) {
+    // Ensure that the fasted moving dimension (the last one) is permuted,
+    // Otherwise shared memory promotion will not benefit the operation.
+    if (indexMap.getDimPosition(indexMap.getNumDims() - 1) !=
+        indexMap.getNumDims() - 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Returns true if the operation is a GenericOp implementing a 2D transpose.
 static bool isTransposeOp(linalg::LinalgOp linalgOp) {
   if (!isa<linalg::GenericOp>(linalgOp)) return false;
-  // Check that the op has 2 parallel loops.
-  if (linalgOp.getNumParallelLoops() != 2) {
+  // Check that the op has at least 2 parallel loops.
+  if (linalgOp.getNumParallelLoops() < 2) {
     return false;
   }
 
@@ -542,31 +557,19 @@ static bool isTransposeOp(linalg::LinalgOp linalgOp) {
     return false;
   }
 
-  // Check that the op has only one input and one output.
-  if ((linalgOp.getNumInputs() != 1) || (linalgOp.getNumOutputs() != 1)) {
-    return false;
-  }
-  // Check for 2D operations
-  auto inputShape =
-      linalgOp.inputs()[0].getType().cast<ShapedType>().getShape();
-  auto outputShape =
-      linalgOp.outputs()[0].getType().cast<ShapedType>().getShape();
-  if (inputShape.size() != 2 || outputShape.size() != 2) {
-    return false;
-  }
-
   // Only transpose static shapes
   if (linalgOp.hasDynamicShape()) {
     return false;
   }
 
-  // Check that the two indexing maps are a permutation of each other.
-  auto indexing_maps = linalgOp.getIndexingMapsArray();
-  return !indexing_maps[0].isEmpty() && !indexing_maps[1].isEmpty() &&
-         ((indexing_maps[0].isIdentity() && !indexing_maps[1].isIdentity() &&
-           indexing_maps[1].isPermutation()) ||
-          (!indexing_maps[0].isIdentity() && indexing_maps[0].isPermutation() &&
-           indexing_maps[1].isIdentity()));
+  // Check that at least one input operands is transposed.
+  bool hasPermutation = false;
+  for (auto indexMap : linalgOp.getIndexingMapsArray()) {
+    if (isSharedMemTranspose(indexMap)) {
+      hasPermutation = true;
+    }
+  }
+  return hasPermutation;
 }
 
 static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
@@ -576,12 +579,20 @@ static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
   TileSizesListType tileSizes;
   tileSizes.push_back({tileM, tileN});
 
-  // Check alignment with tile size
+  // Check alignment with tile size for each transpose.
   if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
-    auto inputShape =
-        genericOp.inputs()[0].getType().cast<ShapedType>().getShape();
-    if (inputShape[0] % tileM != 0 || inputShape[1] % tileN != 0) {
-      return failure();
+    for (auto operandIndexPair :
+         llvm::zip(genericOp.getOperands(), genericOp.getIndexingMapsArray())) {
+      if (isSharedMemTranspose(std::get<1>(operandIndexPair))) {
+        auto inputShape = std::get<0>(operandIndexPair)
+                              .getType()
+                              .cast<ShapedType>()
+                              .getShape();
+        if (inputShape[inputShape.size() - 1] % tileM != 0 ||
+            inputShape[inputShape.size() - 2] % tileN != 0) {
+          return failure();
+        }
+      }
     }
   } else {
     return failure();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -182,13 +182,73 @@ static LogicalResult copyToWorkgroupMemory(OpBuilder &b, Value src, Value dst) {
   return success();
 }
 
+/// Returns the indices of the transposed operands in a linalg generic.
+static SmallVector<int64_t> getTransposedOperands(linalg::GenericOp linalgOp) {
+  // Determine which operands to promote:
+  SmallVector<int64_t> transposedOperands;
+  for (auto indexValue : llvm::enumerate(linalgOp.getIndexingMapsArray())) {
+    int64_t opIndex = indexValue.index();
+    auto indexMap = indexValue.value();
+    if (!indexMap.isEmpty() && indexMap.isPermutation()) {
+      // Ensure that the fasted moving dimension (the last one) is permuted
+      // otherwise data isn't moved.
+      if (indexMap.getDimPosition(indexMap.getNumDims() - 1) !=
+          indexMap.getNumDims() - 1) {
+        // Add operand to promote to list and mark the linalg for this
+        // promotion.
+        transposedOperands.push_back(opIndex);
+      }
+    }
+  }
+  return transposedOperands;
+}
+
+using PromotionFilterFunction = std::function<LogicalResult(Operation *op)>;
+
+/// Returns true if op is appropriate transpose for promotion.
+static LogicalResult transposeFilter(
+    Operation *op, ArrayRef<int64_t> filterOperandsToPromote) {
+  auto linalgOp = dyn_cast<linalg::GenericOp>(op);
+  if (!linalgOp) return failure();
+
+  if (linalgOp.getNumParallelLoops() < 2) {
+    return failure();
+  }
+
+  // Ensure the operands to promote matches this filter.
+  SmallVector<int64_t> operandsToPromote = getTransposedOperands(linalgOp);
+  if (operandsToPromote.size() != filterOperandsToPromote.size()) {
+    return failure();
+  }
+  for (auto valPair : llvm::zip(operandsToPromote, filterOperandsToPromote)) {
+    if (std::get<0>(valPair) != std::get<1>(valPair)) {
+      return failure();
+    }
+  }
+  return success(
+      llvm::all_of_zip(operandsToPromote, filterOperandsToPromote,
+                       [](int64_t lhs, int64_t rhs) { return lhs == rhs; }));
+}
+
+/// Returns true if op is appropriate contract for promotion.
+static LogicalResult contractOpFilter(Operation *op) {
+  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+  if (!linalgOp) return failure();
+  // Limit promotion to matmul and batch matmul, there may be generic
+  // ops with more batch dimensions we didn't distribute and therefore
+  // cannot find a higher bound.
+  return success(linalg::isaContractionOpInterface(op) &&
+                 linalgOp.getNumParallelLoops() >= 2 &&
+                 linalgOp.getNumParallelLoops() <= 3);
+}
+
 template <typename T>
 using LinalgPromotionPattern =
     mlir::iree_compiler::IREE::LinalgExt::LinalgPromotionPattern<T>;
-static void populatePromotionPatterns(
-    MLIRContext *context, RewritePatternSet &patterns,
-    GPUPromoteSharedMemPattern promoteSharedMemPattern,
-    ArrayRef<int64_t> operandsToPromote) {
+static void populatePromotionPatterns(MLIRContext *context,
+                                      RewritePatternSet &patterns,
+                                      PromotionFilterFunction filterFunction,
+                                      ArrayRef<int64_t> operandsToPromote) {
   patterns.insert<LinalgPromotionPattern<linalg::MatmulOp>,
                   LinalgPromotionPattern<linalg::BatchMatmulOp>,
                   LinalgPromotionPattern<linalg::GenericOp>>(
@@ -203,20 +263,7 @@ static void populatePromotionPatterns(
           {StringAttr::get(context, getWorkgroupKTiledMarker())},
           StringAttr::get(context, getWorkgroupMemoryMarker()))
           .setMatchByDefault()
-          .addFilter([promoteSharedMemPattern](Operation *op) {
-            auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-            if (!linalgOp) return failure();
-            if (promoteSharedMemPattern ==
-                GPUPromoteSharedMemPattern::TransposeOpPattern) {
-              return success(linalgOp.getNumParallelLoops() == 2);
-            }
-            // Limit promotion to matmul and batch matmul, there may be generic
-            // ops with more batch dimensions we didn't distribute and therefore
-            // cannot find a higher bound.
-            return success(linalg::isaContractionOpInterface(op) &&
-                           linalgOp.getNumParallelLoops() >= 2 &&
-                           linalgOp.getNumParallelLoops() <= 3);
-          }));
+          .addFilter(filterFunction));
 }
 
 /// Transformation to propagate FillOp + CopyOp to temp allocation.
@@ -275,8 +322,8 @@ struct LLVMGPUTileAndDistributePass
     // allocation. This needs to be done before reduction tiling.
     if (llvmgpuUseMMASync) {
       RewritePatternSet promotionPatterns(&getContext());
-      populatePromotionPatterns(context, promotionPatterns,
-                                promoteSharedMemPattern, {2});
+      populatePromotionPatterns(context, promotionPatterns, contractOpFilter,
+                                {2});
       if (failed(applyPatternsAndFoldGreedily(funcOp,
                                               std::move(promotionPatterns)))) {
         return signalPassFailure();
@@ -309,12 +356,25 @@ struct LLVMGPUTileAndDistributePass
       switch (promoteSharedMemPattern) {
         case GPUPromoteSharedMemPattern::ContractionOpPattern:
           populatePromotionPatterns(context, promotionPatterns,
-                                    promoteSharedMemPattern, {0, 1});
+                                    contractOpFilter, {0, 1});
 
           break;
         case GPUPromoteSharedMemPattern::TransposeOpPattern:
-          populatePromotionPatterns(context, promotionPatterns,
-                                    promoteSharedMemPattern, {0});
+          funcOp.walk(
+              [&context, &promotionPatterns](linalg::GenericOp linalgOp) {
+                linalgOp.dump();
+                // For each linalg generic, determine out its operands to
+                // promote, then create a filter that will only apply to it's
+                // configuration.
+                SmallVector<int64_t> operandsToPromote =
+                    getTransposedOperands(linalgOp);
+                populatePromotionPatterns(
+                    context, promotionPatterns,
+                    [operandsToPromote](Operation *op) -> LogicalResult {
+                      return transposeFilter(op, operandsToPromote);
+                    },
+                    operandsToPromote);
+              });
 
           break;
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
@@ -48,4 +48,60 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 //       CHECK:  %[[D18:.+]] = vector.shape_cast %[[D17]] : vector<4x1xf32> to vector<1x4xf32>
 //       CHECK:  %[[D19:.+]] = vector.extract %[[D18]][0] : vector<1x4xf32>
 //       CHECK:  vector.transfer_write %[[D19]], %[[D16]][%{{.*}}, %{{.*}}] {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, #{{.*}}>
+
 // -----
+
+#device_target_cuda = #hal.device.target<"cuda", {executable_targets = [#hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>], legacy_sync}>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>
+module attributes {hal.device.targets = [#device_target_cuda]} {
+  hal.executable @transpose_single_operand_dispatch_0_generic_768x2048 {
+    hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
+      hal.executable.export public @transpose_single_operand_dispatch_0_generic_768x2048 ordinal(0) layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @transpose_single_operand_dispatch_0_generic_768x2048() {
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:2048x768xf32>
+          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:768x2048xf32>
+          %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:768x2048xf32>
+          %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 768], strides = [1, 1] : !flow.dispatch.tensor<readonly:2048x768xf32> -> tensor<2048x768xf32>
+          %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [768, 2048], strides = [1, 1] : !flow.dispatch.tensor<readonly:768x2048xf32> -> tensor<768x2048xf32>
+          %5 = linalg.init_tensor [768, 2048] : tensor<768x2048xf32>
+          %6 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%3, %4 : tensor<2048x768xf32>, tensor<768x2048xf32>) outs(%5 : tensor<768x2048xf32>) {
+          ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+            %7 = arith.addf %arg0, %arg1 : f32
+            linalg.yield %7 : f32
+          } -> tensor<768x2048xf32>
+          flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [768, 2048], strides = [1, 1] : tensor<768x2048xf32> -> !flow.dispatch.tensor<writeonly:768x2048xf32>
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL:  hal.executable public @transpose_single_operand_dispatch_0_generic_768x2048
+//       CHECK:  hal.executable.variant public @cuda
+//   CHECK-DAG:  %[[C0:.+]] = arith.constant 0
+//   CHECK-DAG:  %[[CST:.+]] = arith.constant 0
+//       CHECK:  %[[D3:.+]] = memref.alloc() : memref<32x33xf32, 3>
+//       CHECK:  %[[D4:.+]] = memref.subview %[[D3]][0, 0] [32, 32] [1, 1] : memref<32x33xf32, 3> to memref<32x32xf32, #{{.*}}, 3>
+//       CHECK:  %[[D5:.+]] = hal.interface.binding.subspan
+//       CHECK:  %[[D11:.+]] = memref.subview %[[D5:.+]][%{{.*}}, %{{.*}}] [32, 32] [1, 1] : memref<2048x768xf32> to memref<32x32xf32, #{{.*}}>
+//       CHECK:  gpu.barrier
+//       CHECK:  %[[D15:.+]] = vector.transfer_read %[[D11]][%{{.*}}, %{{.*}}], %[[CST]] {in_bounds = [true]} : memref<32x32xf32, #{{.*}}>, vector<4xf32>
+//       CHECK:  vector.transfer_write %[[D15]], %[[D4]][%{{.*}}, %{{.*}}] {in_bounds = [true]} : vector<4xf32>, memref<32x32xf32, #{{.*}}, 3>
+//       CHECK:  gpu.barrier
+//       CHECK:  %[[D17:.+]] = memref.subview %[[D4]][%{{.*}}, %{{.*}}] [4, 1] [1, 1] : memref<32x32xf32, #{{.*}}, 3> to memref<4x1xf32, #{{.*}}, 3>
+//       CHECK:  %[[D18:.+]] = memref.subview %{{.*}}[%{{.*}}, %{{.*}}] [1, 4] [1, 1] : memref<32x32xf32, #{{.*}}> to memref<1x4xf32, #{{.*}}>
+//       CHECK:  %[[D19:.+]] = memref.subview %{{.*}}[%{{.*}}, %{{.*}}] [1, 4] [1, 1] : memref<32x32xf32, #{{.*}}> to memref<1x4xf32, #{{.*}}>
+//       CHECK:  %[[D20:.+]] = vector.transfer_read %[[D17]][%{{.*}}, %{{.*}}], %[[CST]] {in_bounds = [true, true]} : memref<4x1xf32, #{{.*}}, 3>, vector<4x1xf32>
+//       CHECK:  %[[D21:.+]] = vector.shape_cast %[[D20]] : vector<4x1xf32> to vector<1x4xf32>
+//       CHECK:  %[[D22:.+]] = vector.transfer_read %[[D18]][%{{.*}}, %{{.*}}], %[[CST]] {in_bounds = [true]} : memref<1x4xf32, #{{.*}}>, vector<4xf32>
+//       CHECK:  %[[D23:.+]] = vector.extract %[[D21]][0] : vector<1x4xf32>
+//       CHECK:  %[[D24:.+]] = arith.addf %[[D23]], %[[D22]] : vector<4xf32>
+//       CHECK:  vector.transfer_write %[[D24]], %[[D19]][%{{.*}}, %{{.*}}] {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, #{{.*}}>


### PR DESCRIPTION
Updates transpose detection and shared mem promotion to support fusion with non transposed operands.

KernelConfig now identifies transposes based on individual operands that meet the criteria for shared mem usage then chooses the TransposeSharedMem pipeline. 

LLVMGPUTileAndDistribute only supports a hard coded list of "operandsToPromote" for promtion filter applied to the entire funcOp. This is problematic if we want to single out individual operands for each linalg generic within a funcOp. The solution is to walk the funcOp for linalg ops and create individual filters specific to promote each linalg op, then add them all to the pattern and apply. 