### PR TITLE
Update import tooling to write to bytecode-ir format

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -78,6 +78,7 @@ cc_binary(
         "//iree_tf_compiler/MHLO",
         "//iree_tf_compiler/TF",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:BytecodeWriter",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Support",
@@ -96,6 +97,7 @@ cc_binary(
     deps = [
         "//iree_tf_compiler/TFL",
         "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:BytecodeWriter",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
@@ -116,6 +118,7 @@ cc_binary(
         "//iree_tf_compiler/MHLO",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithmeticDialect",
+        "@llvm-project//mlir:BytecodeWriter",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:MathDialect",

--- a/integrations/tensorflow/iree_tf_compiler/TFL/test/import/add.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/test/import/add.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-import-tflite %S/add.tflite | FileCheck %s
+// RUN: iree-import-tflite --output-format=mlir-ir %S/add.tflite | FileCheck %s
 
 //      CHECK: module {
 // CHECK-NEXT:   func.func @main(%arg0: tensor<1x8x8x3xf32> {iree.identifier = "input"}) -> (tensor<1x8x8x3xf32> {iree.identifier = "output"}) {

--- a/integrations/tensorflow/iree_tf_compiler/TFL/test/import/multi_add.mlir
+++ b/integrations/tensorflow/iree_tf_compiler/TFL/test/import/multi_add.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-import-tflite %S/multi_add.tflite | FileCheck %s
+// RUN: iree-import-tflite --output-format=mlir-ir %S/multi_add.tflite | FileCheck %s
 
 //      CHECK: module {
 // CHECK-NEXT:   func.func @main(%arg0: tensor<1x8x8x3xf32> {iree.identifier = "a"}, %arg1: tensor<1x8x8x3xf32> {iree.identifier = "b"}, %arg2: tensor<1x8x8x3xf32> {iree.identifier = "c"}, %arg3: tensor<1x8x8x3xf32> {iree.identifier = "d"}) -> (tensor<1x8x8x3xf32> {iree.identifier = "x"}, tensor<1x8x8x3xf32> {iree.identifier = "y"}) {

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
@@ -19,6 +19,7 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/IR/AsmState.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Dialect.h"
@@ -215,10 +216,11 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
+      mlir::writeCodeToFile(module, outputFile->os());
+      outputFile->keep();
       return success();
     }
-    llvm::errs() << "Unknown output format" << outputFormat << "\n";
+    llvm::errs() << "Unknown output format\n";
     return failure();
   };
 

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
@@ -216,7 +216,7 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeBytecodeToFile(module, outputFile->os());
+      mlir::writeBytecodeToFile(*module, outputFile->os());
       outputFile->keep();
       return success();
     }

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
@@ -216,7 +216,7 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeCodeToFile(module, outputFile->os());
+      mlir::writeBytecodeToFile(module, outputFile->os());
       outputFile->keep();
       return success();
     }

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.cpp
@@ -218,7 +218,7 @@ int main(int argc, char **argv) {
       mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
       return success();
     }
-    llvm::errs() << "Unkonwn output format" << outputFormat << "\n";
+    llvm::errs() << "Unknown output format" << outputFormat << "\n";
     return failure();
   };
 

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeBytecodeToFile(module, outputFile->os());
+      mlir::writeBytecodeToFile(*module, outputFile->os());
       outputFile->keep();
       return success();
     }

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -11,6 +11,7 @@
 #include "llvm/Support/MemoryBuffer.h"
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/ToolOutputFile.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/Quant/QuantOps.h"
 #include "mlir/Dialect/Tosa/IR/TosaOps.h"
 #include "mlir/IR/AsmState.h"
@@ -28,6 +29,12 @@
 using namespace llvm;
 using namespace mlir;
 
+enum class OutputFormat {
+  none,
+  mlir_ir,
+  mlir_bytecode,
+};
+
 int main(int argc, char **argv) {
   llvm::InitLLVM y(argc, argv);
 
@@ -36,6 +43,15 @@ int main(int argc, char **argv) {
   static cl::opt<std::string> outputFilename("o", cl::desc("Output filename"),
                                              cl::value_desc("filename"),
                                              cl::init("-"));
+
+  // The output format flag is the master control for what we do with the
+  // in-memory compiled form.
+  llvm::cl::opt<OutputFormat> outputFormat(
+      "output-format", llvm::cl::desc("Format of imported output"),
+      llvm::cl::values(clEnumValN(OutputFormat::mlir_bytecode, "mlir-bytecode",
+                                  "MLIR Bytecode (default)"),
+                       clEnumValN(OutputFormat::mlir_ir, "mlir-ir", "MLIR IR")),
+      llvm::cl::init(OutputFormat::mlir_bytecode));
 
   static cl::opt<std::string> saveTempTflInput(
       "save-temp-tfl-input",
@@ -119,11 +135,21 @@ int main(int argc, char **argv) {
       llvm::errs() << "Could not open output file: " << savePath << "\n";
       return failure();
     }
-    OpPrintingFlags printFlags;
-    module->print(outputFile->os(), printFlags);
-    outputFile->os() << "\n";
-    outputFile->keep();
-    return success();
+
+    if (outputFormat == OutputFormat::mlir_ir) {
+      OpPrintingFlags printFlags;
+      module->print(outputFile->os(), printFlags);
+      outputFile->os() << "\n";
+      outputFile->keep();
+      return success();
+    }
+
+    if (outputFormat == OutputFormat::mlir_bytecode) {
+      mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
+      return success();
+    }
+    llvm::errs() << "Unkonwn output format" << outputFormat << "\n";
+    return failure();
   };
 
   // Save temp input.

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -145,10 +145,11 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
+      mlir::writeCodeToFile(module, outputFile->os());
+      outputFile->keep();
       return success();
     }
-    llvm::errs() << "Unknown output format" << outputFormat << "\n";
+    llvm::errs() << "Unknown output format\n";
     return failure();
   };
 

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeCodeToFile(module, outputFile->os());
+      mlir::writeBytecodeToFile(module, outputFile->os());
       outputFile->keep();
       return success();
     }

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tflite-main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char **argv) {
       mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
       return success();
     }
-    llvm::errs() << "Unkonwn output format" << outputFormat << "\n";
+    llvm::errs() << "Unknown output format" << outputFormat << "\n";
     return failure();
   };
 

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -278,7 +278,7 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeCodeToFile(module, outputFile->os());
+      mlir::writeBytecodeToFile(module, outputFile->os());
       outputFile->keep();
       return success();
     }

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -16,6 +16,7 @@
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/ToolOutputFile.h"
 #include "mlir-hlo/Dialect/mhlo/IR/register.h"
+#include "mlir/Bytecode/BytecodeWriter.h"
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
@@ -277,10 +278,11 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
+      mlir::writeCodeToFile(module, outputFile->os());
+      outputFile->keep();
       return success();
     }
-    llvm::errs() << "Unknown output format" << outputFormat << "\n";
+    llvm::errs() << "Unknown output format\n";
     return failure();
   };
 

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -45,6 +45,12 @@ enum XlaFormat {
   mlir_text,
 };
 
+enum class OutputFormat {
+  none,
+  mlir_ir,
+  mlir_bytecode,
+};
+
 // Error collector that prints errors.
 class PrintErrorCollector : public tensorflow::protobuf::io::ErrorCollector {
  public:
@@ -118,6 +124,15 @@ int main(int argc, char **argv) {
           clEnumVal(text_proto, "Parse a text protocol buffer"),
           clEnumVal(hlo_text, "Parse an HLO module in its native text format"),
           clEnumVal(mlir_text, "Parse MLIR text containing MHLO ops")));
+
+  // The output format flag is the master control for what we do with the
+  // in-memory compiled form.
+  llvm::cl::opt<OutputFormat> outputFormat(
+      "output-format", llvm::cl::desc("Format of imported output"),
+      llvm::cl::values(clEnumValN(OutputFormat::mlir_bytecode, "mlir-bytecode",
+                                  "MLIR Bytecode (default)"),
+                       clEnumValN(OutputFormat::mlir_ir, "mlir-ir", "MLIR IR")),
+      llvm::cl::init(OutputFormat::mlir_bytecode));
 
   // Register any command line options.
   registerAsmPrinterCLOptions();
@@ -252,11 +267,21 @@ int main(int argc, char **argv) {
       llvm::errs() << "Could not open output file: " << savePath << "\n";
       return failure();
     }
-    OpPrintingFlags printFlags;
-    module->print(outputFile->os(), printFlags);
-    outputFile->os() << "\n";
-    outputFile->keep();
-    return success();
+
+    if (outputFormat == OutputFormat::mlir_ir) {
+      OpPrintingFlags printFlags;
+      module->print(outputFile->os(), printFlags);
+      outputFile->os() << "\n";
+      outputFile->keep();
+      return success();
+    }
+
+    if (outputFormat == OutputFormat::mlir_bytecode) {
+      mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
+      return success();
+    }
+    llvm::errs() << "Unkonwn output format" << outputFormat << "\n";
+    return failure();
   };
 
   // Save temp output.

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -278,7 +278,7 @@ int main(int argc, char **argv) {
     }
 
     if (outputFormat == OutputFormat::mlir_bytecode) {
-      mlir::writeBytecodeToFile(module, outputFile->os());
+      mlir::writeBytecodeToFile(*module, outputFile->os());
       outputFile->keep();
       return success();
     }

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-xla-main.cpp
@@ -280,7 +280,7 @@ int main(int argc, char **argv) {
       mlir::writeCodeToFile(module, outputFile->os()) outputFile->keep();
       return success();
     }
-    llvm::errs() << "Unkonwn output format" << outputFormat << "\n";
+    llvm::errs() << "Unknown output format" << outputFormat << "\n";
     return failure();
   };
 

--- a/integrations/tensorflow/test/python/iree_tfl_tests/test_util.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/test_util.py
@@ -63,9 +63,9 @@ class TFLiteModelTest(testing.absltest.TestCase):
       return
     self.workdir = _setup_artifacts_dir("download")
     print(f"TMPDIR = {self.workdir}")
-    self.tflite_file = '/'.join([self.workdir, 'model.bc'])
-    self.tflite_ir = '/'.join([self.workdir, 'tflite.bc'])
-    self.iree_ir = '/'.join([self.workdir, 'tosa.bc'])
+    self.tflite_file = '/'.join([self.workdir, 'model.mlirbc'])
+    self.tflite_ir = '/'.join([self.workdir, 'tflite.mlirbc'])
+    self.iree_ir = '/'.join([self.workdir, 'tosa.mlirbc'])
     if os.path.exists(self.model_path):
       self.tflite_file = self.model_path
     else:

--- a/integrations/tensorflow/test/python/iree_tfl_tests/test_util.py
+++ b/integrations/tensorflow/test/python/iree_tfl_tests/test_util.py
@@ -63,14 +63,14 @@ class TFLiteModelTest(testing.absltest.TestCase):
       return
     self.workdir = _setup_artifacts_dir("download")
     print(f"TMPDIR = {self.workdir}")
-    self.tflite_file = '/'.join([self.workdir, 'model.tflite'])
-    self.tflite_ir = '/'.join([self.workdir, 'tflite.mlir'])
-    self.iree_ir = '/'.join([self.workdir, 'tosa.mlir'])
+    self.tflite_file = '/'.join([self.workdir, 'model.bc'])
+    self.tflite_ir = '/'.join([self.workdir, 'tflite.bc'])
+    self.iree_ir = '/'.join([self.workdir, 'tosa.bc'])
     if os.path.exists(self.model_path):
       self.tflite_file = self.model_path
     else:
       urllib.request.urlretrieve(self.model_path, self.tflite_file)
-    self.binary = '/'.join([self.workdir, 'module.bytecode'])
+    self.binary = '/'.join([self.workdir, 'module.vmfb'])
 
   def generate_inputs(self, input_details):
     args = []


### PR DESCRIPTION
New bytecode IR format should significantly compress model sizes, especially on Op heavy modules. This adds an output-format flag with support for both the mlir-ir and mlir-bytecode formats.