### PR TITLE
Add a fused softmax strategy on GPU

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -347,6 +347,7 @@ static linalg::LinalgOp findSingleLinalgOpDefiningAll(ValueRange range) {
           DBGS() << "different source linalg ops for replacing one op: \n"
                  << sourceOp << "\n"
                  << currentSourceOp << "\n");
+      return nullptr;
     }
     LLVM_DEBUG(DBGS() << "replacing linalg op with unknown non-linalg op:\n"
                       << *value.getDefiningOp() << "\n");
@@ -366,6 +367,7 @@ static scf::ForOp findSingleForOpDefiningAll(ValueRange range) {
       }
       LLVM_DEBUG(
           DBGS() << "different source scf.for ops when replacing one op\n");
+      return nullptr;
     }
 
     LLVM_DEBUG(
@@ -374,6 +376,26 @@ static scf::ForOp findSingleForOpDefiningAll(ValueRange range) {
     return nullptr;
   }
   return forOp;
+}
+
+/// Find the op that defines all values in the range.
+static Operation *findSingleOpDefiningAll(ValueRange range) {
+  Operation *op = nullptr;
+  for (Value value : range) {
+    if (auto currentSourceOp = value.getDefiningOp()) {
+      if (!op || op == currentSourceOp) {
+        op = currentSourceOp;
+        continue;
+      }
+      LLVM_DEBUG(DBGS() << "different source op when replacing one op\n");
+      return nullptr;
+    }
+
+    LLVM_DEBUG(
+        DBGS() << "could not find a source op when replacing another op\n");
+    return nullptr;
+  }
+  return op;
 }
 
 // Find a single op that defines all values in the range, optionally
@@ -387,7 +409,9 @@ static Operation *findSingleDefiningOp(Operation *replacedOp,
       .Case<scf::ForOp>([&](scf::ForOp) -> Operation * {
         return findSingleForOpDefiningAll(range);
       })
-      .Default([](Operation *) -> Operation * { return nullptr; });
+      .Default([&](Operation *) -> Operation * {
+        return findSingleOpDefiningAll(range);
+      });
 }
 
 void mlir::TrackingListener::notifyOperationReplaced(Operation *op,

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -37,6 +37,7 @@ iree_lit_test_suite(
         "reduction_dispatch_spec.mlir",
         "softmax_codegen_spec.mlir",
         "softmax_dispatch_spec.mlir",
+        "softmax_fused_codegen_spec.mlir",
     ],
     tags = [
         # CUDA cuInit fails with sanitizer on.

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     reduction_dispatch_spec.mlir
     softmax_codegen_spec.mlir
     softmax_dispatch_spec.mlir
+    softmax_fused_codegen_spec.mlir
   LABELS
     "noasan"
     "nomsan"

--- a/tests/transform_dialect/cuda/softmax.mlir
+++ b/tests/transform_dialect/cuda/softmax.mlir
@@ -1,24 +1,55 @@
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/softmax_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/softmax_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK-SHUFFLE
+
 // RUN: iree-compile %s --iree-hal-target-backends=cuda \
 // RUN:     --iree-flow-dispatch-use-transform-dialect=%p/softmax_dispatch_spec.mlir \
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/softmax_codegen_spec.mlir | \
 // RUN: iree-run-module --entry_function=max_sub_exp --device=cuda | \
 // RUN: FileCheck %s
 
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/softmax_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/softmax_fused_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK-SHUFFLE
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/softmax_dispatch_spec.mlir \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/softmax_fused_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=max_sub_exp --device=cuda | \
+// RUN: FileCheck %s
+
 // TODO: make this test drop transform dialect usage at the flow level and use:
 //   --iree-flow-transformation-pipeline --iree-flow-convert-region-to-workgroups
 
-!tmp_tensor_t = tensor<12x128xf32>
-!out_tensor_t = tensor<12x128x128xf32>
+!tmp_tensor_t = tensor<16x128xf32>
+!out_tensor_t = tensor<16x128x128xf32>
+
+// Compilation checks that shuffles are produced.
+// CHECK-SHUFFLE: gpu.shuffle  xor
 
 // Execution only checks that @max_sub_exp runs.
 // CHECK: EXEC @max_sub_exp
+
 func.func @max_sub_exp() {
   %cst = arith.constant -3.40282347E+38 : f32
   %cst_0 = arith.constant dense<1.000000e+00> : !out_tensor_t
   %cst_1 = arith.constant dense<5.000000e+00> : !out_tensor_t
   %0 = util.do_not_optimize(%cst_1) : !out_tensor_t
 
-  %1 = linalg.init_tensor [12, 128] : !tmp_tensor_t
+  %1 = linalg.init_tensor [16, 128] : !tmp_tensor_t
   %2 = linalg.fill ins(%cst : f32) outs(%1 : !tmp_tensor_t) -> !tmp_tensor_t
   %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
                                         affine_map<(d0, d1, d2) -> (d0, d1)>], 
@@ -30,7 +61,7 @@ func.func @max_sub_exp() {
   } -> !tmp_tensor_t
 
   // This has been fused manually to avoid the fusion on tensors pass and reduce noise atm.
-  %4 = linalg.init_tensor [12, 128, 128] : !out_tensor_t
+  %4 = linalg.init_tensor [16, 128, 128] : !out_tensor_t
   %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
                                         affine_map<(d0, d1, d2) -> (d0, d1)>,
                                         affine_map<(d0, d1, d2) -> (d0, d1, d2)>], 

--- a/tests/transform_dialect/cuda/softmax_fused_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_fused_codegen_spec.mlir
@@ -1,0 +1,57 @@
+// RUN: iree-opt %s 
+ 
+// Codegen
+transform.structured.canonicalized_sequence failures(propagate) {
+// transform.sequence %arg0 failures(propagate) {
+^bb1(%variant_op: !pdl.operation):
+  // First level of tiling + fusion parallelizes to blocks.
+  // The mapping  to block ids can only happen after bufferization atm 
+  %root = transform.structured.match interface{LinalgOp} 
+    attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %variant_op
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+  %red = transform.structured.match interface{LinalgOp} 
+    attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %variant_op
+  %not_root = merge_handles %fill, %red
+  %foreach_thread, %tiled_generic = 
+    transform.structured.tile_to_foreach_thread_op %root tile_sizes [1, 1]
+      (mapped to dims [0, 1, 2])
+  transform.structured.fuse_into_containing_op %not_root into %foreach_thread
+  
+  // Second level of tiling + fusion parallelizes to threads.
+  // Leaving the reduction untiled on threadIdx.x makes it sequential on 
+  // threadIdx.x. After distribution, predication by if (threadIdx.x == 0) is
+  // introduced and opportunities for distributing vector ops across warps
+  // appear.
+  %fill_linalg = transform.structured.match ops{["linalg.fill"]} in %variant_op
+  %reduction_linalg = transform.structured.match ops{["linalg.generic"]} 
+    attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %variant_op
+  %not_root_2 = merge_handles %fill_linalg, %reduction_linalg
+  %parallel_linalg = transform.structured.match ops{["linalg.generic"]} 
+    attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %variant_op
+  %foreach_thread_2, %parallel_linalg_2 = 
+    transform.structured.tile_to_foreach_thread_op %parallel_linalg tile_sizes [1, 1, 0]
+      (mapped to dims [2, 1, 0])
+  transform.structured.fuse_into_containing_op %not_root_2 into %foreach_thread_2
+  
+  // Rank-reduce and vectorize.
+  %funcx = transform.structured.match ops{["func.func"]} in %variant_op
+  %funcx_2 = transform.iree.apply_patterns %funcx { rank_reducing }
+  transform.structured.vectorize %funcx_2
+  
+  // Bufferization is necessary for:
+  //   1. lowering scf.foreach_thread to workgroup (block level parallelism)
+  //   2. lowering scf.foreach_thread to gpu (thread level parallelism)
+  //   3. introducing predication (due to 1. + 2.) which enables rewriting to
+  //      warp_execute_on_lane_0 and later vector distribution.
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+  %func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_2 = transform.iree.foreach_thread_to_workgroup %func
+  transform.iree.foreach_thread_to_gpu_and_translation_info %func_2
+    { workgroup_size = [32, 1, 1] }
+  
+  // Vector distribution needs to happen on buffers.
+  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  transform.iree.vector.warp_distribute %end_func
+}


### PR DESCRIPTION
This revision adds a second type of strategy that runs at peak on GPU. The strategy consistes in fusing both at the block and thread level.

This uncovered few issues that the PR also fixes:
  - improve tracking support by implementng a `findSingleOpDefiningAll` for the general non-Linalg, non-scf::For case.
  - add support to distribute a 0-D load during vector distribution, for which a specific pattern is added. This requires a gpu.synchronize and cannot go upstream atm.
  - apply vector distribution patterns iteratively and only when convergence is obtained lower to scf.if.
  - various issues around vector distribution have been fixed upstream and integrated.

Additionally, this prefetches the following LLVM commits:

  0b77a6734c294d60c37617c4010c803e92191b65                           
  8d483e752513d5270b1438c8a4be068bb0c6f945
  d1336e664bd0aeef2004e11f4ba4edf203b75190