### PR TITLE
Add a check before inverse an affine_map.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.cpp
@@ -77,8 +77,11 @@ static bool isTransposeLinalgOp(linalg::LinalgOp linalgOp) {
       linalgOp.getTiedIndexingMap(linalgOp.getOutputOperand(0)));
   SmallVector<AffineMap> inputInversedMaps;
   for (OpOperand *linalgOperand : linalgOp.getInputOperands()) {
-    inputInversedMaps.push_back(inverseAndBroadcastProjectedPermutation(
-        linalgOp.getTiedIndexingMap(linalgOperand)));
+    auto map = linalgOp.getTiedIndexingMap(linalgOperand);
+    if (!map.isProjectedPermutation(/*allowZeroInResults=*/true)) {
+      return false;
+    }
+    inputInversedMaps.push_back(inverseAndBroadcastProjectedPermutation(map));
   }
 
   bool isInputTransposed = llvm::any_of(


### PR DESCRIPTION
We should check if the map is a projected permutation before inversing it.