### PR TITLE
[SPIRV] Add support for lowering specified in IR

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -194,6 +194,7 @@ iree_compiler_cc_library(
     ],
     hdrs = [
         "LinalgOpInfo.h",
+        "UserConfig.h",
     ],
     deps = [
         ":CommonPasses",

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -187,6 +187,7 @@ iree_compiler_cc_library(
         "TestPartitionableLoopsInterface.cpp",
         "TileAndDistributeToWorkgroupsPass.cpp",
         "TileDispatchUsingInterface.cpp",
+        "UserConfig.cpp",
         "VectorReductionToGPU.cpp",
         "VectorizeConv.cpp",
         "WorkGroupSwizzle.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -147,6 +147,7 @@ iree_cc_library(
     Common
   HDRS
     "LinalgOpInfo.h"
+    "UserConfig.h"
   SRCS
     "DecomposeLinalgGeneric.cpp"
     "FoldAffineMinInDistributedLoops.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -160,6 +160,7 @@ iree_cc_library(
     "TestPartitionableLoopsInterface.cpp"
     "TileAndDistributeToWorkgroupsPass.cpp"
     "TileDispatchUsingInterface.cpp"
+    "UserConfig.cpp"
     "VectorReductionToGPU.cpp"
     "VectorizeConv.cpp"
     "WorkGroupSwizzle.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 
@@ -18,6 +19,10 @@ void populateTileAndDistributeToWorkgroupsPatterns(
 /// Populate patterns that fold tensor.expand/collapse_shape into the source
 /// hal.interface.binding.subspan.
 void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns);
+
+/// Sets compilation configuration annotated in the incoming IR.
+LogicalResult setUserConfig(func::FuncOp entryPointFn, Operation *computeOp,
+                            IREE::Codegen::CompilationInfoAttr compilationInfo);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Common/Transforms.h
@@ -4,7 +4,6 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 
@@ -19,10 +18,6 @@ void populateTileAndDistributeToWorkgroupsPatterns(
 /// Populate patterns that fold tensor.expand/collapse_shape into the source
 /// hal.interface.binding.subspan.
 void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns);
-
-/// Sets compilation configuration annotated in the incoming IR.
-LogicalResult setUserConfig(func::FuncOp entryPointFn, Operation *computeOp,
-                            IREE::Codegen::CompilationInfoAttr compilationInfo);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/UserConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/UserConfig.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Common/UserConfig.h"
 
 namespace mlir {
 namespace iree_compiler {

--- a/compiler/src/iree/compiler/Codegen/Common/UserConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/UserConfig.cpp
@@ -1,0 +1,32 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/Transforms.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Propagate the configuration annotated in the incoming IR.
+LogicalResult setUserConfig(
+    func::FuncOp entryPointFn, Operation *computeOp,
+    IREE::Codegen::CompilationInfoAttr compilationInfo) {
+  if (auto translationInfo = getTranslationInfo(entryPointFn)) {
+    return computeOp->emitOpError(
+        "multiple ops within dispatch trying to set the translation "
+        "info");
+  }
+
+  SmallVector<int64_t> workgroupSize = compilationInfo.getWorkgroupSizeVals();
+  setTranslationInfo(entryPointFn, compilationInfo.getTranslationInfo(),
+                     workgroupSize);
+
+  setLoweringConfig(computeOp, compilationInfo.getLoweringConfig());
+  eraseCompilationInfo(computeOp);
+  return success();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/UserConfig.h
+++ b/compiler/src/iree/compiler/Codegen/Common/UserConfig.h
@@ -1,0 +1,17 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Sets compilation configuration annotated in the incoming IR.
+LogicalResult setUserConfig(func::FuncOp entryPointFn, Operation *computeOp,
+                            IREE::Codegen::CompilationInfoAttr compilationInfo);
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1520,7 +1520,8 @@ static LogicalResult setTranslationInfoAndRootConfig(
   for (auto computeOp : computeOps) {
     if (IREE::Codegen::CompilationInfoAttr compilationInfo =
             getCompilationInfo(computeOp)) {
-      (void)setUserConfig(entryPointFn, computeOp, compilationInfo);
+      if (failed(setUserConfig(entryPointFn, computeOp, compilationInfo)))
+        return failure();
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -10,6 +10,7 @@
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Codegen/Common/LinalgOpInfo.h"
+#include "iree/compiler/Codegen/Common/UserConfig.h"
 #include "iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -1519,19 +1520,7 @@ static LogicalResult setTranslationInfoAndRootConfig(
   for (auto computeOp : computeOps) {
     if (IREE::Codegen::CompilationInfoAttr compilationInfo =
             getCompilationInfo(computeOp)) {
-      // If the function already has a translation, error out.
-      if (auto translationInfo = getTranslationInfo(entryPointFn)) {
-        return computeOp->emitOpError(
-            "multiple ops within dispatch trying to set the translation "
-            "info");
-      }
-
-      SmallVector<int64_t> workgroupSize =
-          compilationInfo.getWorkgroupSizeVals();
-      setTranslationInfo(entryPointFn, compilationInfo.getTranslationInfo(),
-                         workgroupSize);
-      setLoweringConfig(computeOp, compilationInfo.getLoweringConfig());
-      eraseCompilationInfo(computeOp);
+      (void)setUserConfig(entryPointFn, computeOp, compilationInfo);
     }
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "llvm/Support/CommandLine.h"
@@ -437,25 +438,6 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
   tileSizes.emplace_back(std::move(workgroupTileSizes));  // Workgroup level
   return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,
                                                passPipeline, workgroupSize);
-}
-
-/// Propagate the configuration annotated in the incoming IR.
-static LogicalResult setUserConfig(
-    func::FuncOp entryPointFn, Operation *computeOp,
-    IREE::Codegen::CompilationInfoAttr compilationInfo) {
-  if (auto translationInfo = getTranslationInfo(entryPointFn)) {
-    return computeOp->emitOpError(
-        "multiple ops within dispatch trying to set the translation "
-        "info");
-  }
-
-  SmallVector<int64_t> workgroupSize = compilationInfo.getWorkgroupSizeVals();
-  setTranslationInfo(entryPointFn, compilationInfo.getTranslationInfo(),
-                     workgroupSize);
-
-  setLoweringConfig(computeOp, compilationInfo.getLoweringConfig());
-  eraseCompilationInfo(computeOp);
-  return success();
 }
 
 /// Return the size of the given dimension in the linalg op.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -9,7 +9,7 @@
 #include <numeric>
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
-#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Common/UserConfig.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "llvm/Support/CommandLine.h"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -10,7 +10,7 @@
 #include <numeric>
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
-#include "iree/compiler/Codegen/Common/Transforms.h"
+#include "iree/compiler/Codegen/Common/UserConfig.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -689,8 +689,8 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
                                       Operation *rootOp) {
   if (IREE::Codegen::CompilationInfoAttr compilationInfo =
           getCompilationInfo(rootOp)) {
-    // If the op already has a lowering config coming from the IR use this and
-    // bypass the heuristic.
+    // If the op already has a lowering configuration specified from the
+    // original source by the user, then use it directly.
     return setUserConfig(entryPointFn, rootOp, compilationInfo);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -10,6 +10,7 @@
 #include <numeric>
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
@@ -684,7 +685,15 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
 /// Sets the CodeGen configuration as attributes to the given `rootOp` if it's a
 /// known Linalg matmul/convolution op with good configurations.
 static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
+                                      func::FuncOp entryPointFn,
                                       Operation *rootOp) {
+  if (IREE::Codegen::CompilationInfoAttr compilationInfo =
+          getCompilationInfo(rootOp)) {
+    // If the op already has a lowering config coming from the IR use this and
+    // bypass the heuristic.
+    return setUserConfig(entryPointFn, rootOp, compilationInfo);
+  }
+
   LogicalResult result = success();
   // First try to find a proper CodeGen configuration to tile and vectorize for
   // the current target architecture.
@@ -798,7 +807,8 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     // Try to find a configuration according to a matmul/convolution op and use
     // it as the root op.
     for (Operation *computeOp : computeOps) {
-      if (failed(setSPIRVOpConfig(targetEnv, computeOp))) return failure();
+      if (failed(setSPIRVOpConfig(targetEnv, funcOp, computeOp)))
+        return failure();
 
       // Check if the op configuration was set.
       if (!getLoweringConfig(computeOp)) continue;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -29,6 +29,7 @@ iree_lit_test_suite(
             "config_mali_reduction.mlir",
             "config_nvidia_matmul.mlir",
             "config_nvidia_matmul_cooperative_ops.mlir",
+            "config_user.mlir",
             "convert_to_spirv.mlir",
             "create_fast_slow_path.mlir",
             "distribute_to_invocations.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "config_mali_reduction.mlir"
     "config_nvidia_matmul.mlir"
     "config_nvidia_matmul_cooperative_ops.mlir"
+    "config_user.mlir"
     "convert_to_spirv.mlir"
     "create_fast_slow_path.mlir"
     "distribute_to_invocations.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
@@ -1,0 +1,55 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='hal.executable(hal.executable.variant(iree-spirv-lower-executable-target-pass{test-lowering-configuration=true}))' %s | FileCheck %s
+
+#compilation = #iree_codegen.compilation_info<
+    lowering_config  = <tile_sizes = [[8, 8], [1, 1]]>,
+    translation_info = <SPIRVVectorize workload_per_wg = [64, 8]>,
+    workgroup_size = [16, 8, 1]>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable public @user_config {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+      spv.target_env = #spv.target_env<#spv.vce<v1.4, [Shader], []>, Unknown:IntegratedGPU, #spv.resource_limits<
+          max_compute_shared_memory_size = 16384,
+          max_compute_workgroup_invocations = 128,
+          max_compute_workgroup_size = [128, 128, 64],
+          subgroup_size = 32>>
+    }> {
+    hal.executable.export public @matmul_128x1024x256 layout(#pipeline_layout)
+    builtin.module {
+      func.func @matmul_128x1024x256() {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c128 = arith.constant 128 : index
+        %c1024 = arith.constant 1024 : index
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:128x256xf32>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:256x1024xf32>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:128x1024xf32>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:128x256xf32> -> tensor<128x256xf32>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:256x1024xf32> -> tensor<256x1024xf32>
+        %15 = linalg.init_tensor [128, 1024] : tensor<128x1024xf32>
+        %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+        %17 = linalg.matmul {__internal_linalg_transform__ = "workgroup", compilation_info = #compilation}
+            ins(%3, %4 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%16 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+        flow.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : tensor<128x1024xf32> -> !flow.dispatch.tensor<writeonly:128x1024xf32>
+        return
+      }
+    }
+  }
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 8], [1, 1]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize workload_per_wg = [64, 8]>
+//      CHECK: hal.executable.export public @matmul_128x1024x256
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+// CHECK-SAME:     workgroup_size = [16 : index, 8 : index, 1 : index]
+//      CHECK: linalg.fill
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
+//      CHECK: linalg.matmul
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_user.mlir
@@ -1,8 +1,8 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='hal.executable(hal.executable.variant(iree-spirv-lower-executable-target-pass{test-lowering-configuration=true}))' %s | FileCheck %s
 
 #compilation = #iree_codegen.compilation_info<
-    lowering_config  = <tile_sizes = [[8, 8], [1, 1]]>,
-    translation_info = <SPIRVVectorize workload_per_wg = [64, 8]>,
+    lowering_config  = <tile_sizes = [[128, 256], [16, 16]]>,
+    translation_info = <SPIRVVectorize>,
     workgroup_size = [16, 8, 1]>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -44,8 +44,8 @@ hal.executable public @user_config {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[8, 8], [1, 1]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize workload_per_wg = [64, 8]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 256], [16, 16]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVVectorize>
 //      CHECK: hal.executable.export public @matmul_128x1024x256
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 // CHECK-SAME:     workgroup_size = [16 : index, 8 : index, 1 : index]

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -258,7 +258,7 @@ py_binary(
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for vulkan_target_and_pipeline in [
-    ("valhall-unknown-android31", "SPIRVVectorizeAndroid"),
+    ("valhall-unknown-android31", "SPIRVVectorizeMali"),
     ("ampere-unknown-linux", "SPIRVVectorizeNVIDIA"),
 ]]
 

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -240,15 +240,15 @@ py_binary(
 ]]
 
 [iree_generated_trace_runner_test(
-    name = "e2e_matmul_direct_f32_gpu_large_%s" % vulkan_target,
+    name = "e2e_matmul_direct_f32_gpu_large_%s" % vulkan_target_and_pipeline[0],
     compiler_flags = [
-        "--iree-vulkan-target-triple=%s" % vulkan_target,
+        "--iree-vulkan-target-triple=%s" % vulkan_target_and_pipeline[0],
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
         "--lhs_rhs_type=f32",
         "--shapes=gpu_large",
-        "--compilation_info=SPIRVVectorize",
+        "--compilation_info=%s" % vulkan_target_and_pipeline[1],
     ],
     tags = [
         "requires-gpu-nvidia",
@@ -257,9 +257,9 @@ py_binary(
         ("vulkan-spirv", "vulkan"),
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
-) for vulkan_target in [
-    "valhall-unknown-android31",
-    "ampere-unknown-linux",
+) for vulkan_target_and_pipeline in [
+    ("valhall-unknown-android31", "SPIRVVectorizeAndroid"),
+    ("ampere-unknown-linux", "SPIRVVectorizeNVIDIA"),
 ]]
 
 # Check tests

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -332,7 +332,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=gpu_large"
-    "--compilation_info=SPIRVVectorizeAndroid"
+    "--compilation_info=SPIRVVectorizeMali"
   TRACE_RUNNER
     iree-e2e-matmul-test
   TARGET_BACKENDS

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -332,7 +332,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=gpu_large"
-    "--compilation_info=SPIRVVectorize"
+    "--compilation_info=SPIRVVectorizeAndroid"
   TRACE_RUNNER
     iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -353,7 +353,7 @@ iree_generated_trace_runner_test(
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=gpu_large"
-    "--compilation_info=SPIRVVectorize"
+    "--compilation_info=SPIRVVectorizeNVIDIA"
   TRACE_RUNNER
     iree-e2e-matmul-test
   TARGET_BACKENDS

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -43,7 +43,7 @@ class CompilationInfoId(enum.Enum):
   NONE = ""
   LLVMGPUMatmulSimt = "LLVMGPUMatmulSimt"
   LLVMGPUMatmulTensorCore = "LLVMGPUMatmulTensorCore"
-  SPIRVVectorizeAndroid = "SPIRVVectorizeAndroid"
+  SPIRVVectorizeMali = "SPIRVVectorizeMali"
   SPIRVVectorizeNVIDIA = "SPIRVVectorizeNVIDIA"
 
 
@@ -75,7 +75,7 @@ class TestShape:
 @dataclasses.dataclass
 class CompilationInfo:
   # Lowering Config
-  tile_sizes: typing.Union[typing.List[int], typing.List[typing.List[int]]]
+  tile_sizes: typing.List[typing.List[int]]
   # Translation Info
   dispatch_lowering_pass_pipeline: str
   workload_per_wg: typing.List[int]
@@ -157,8 +157,36 @@ def get_dynamicities(shapes_id: ShapesId):
 
 @dataclasses.dataclass
 class TileWorkgroupSizePair:
-  tile_size: typing.Union[typing.List[int], typing.List[typing.List[int]]]
+  tile_size: typing.List[typing.List[int]]
   workgroup_size: typing.List[int]
+
+
+# Constructs a TileWorkgroupSizePair for SPIRV Targets enforcing the constraints between
+# the workgroup_size and tile size
+def get_spirv_tile_workgroup_size_pair(workgroup_size,
+                                       t_tile_k,
+                                       t_tile_m=4,
+                                       t_tile_n=4):
+  x, y, z = workgroup_size
+  wg_tile_m = y * t_tile_m
+  wg_tile_n = x * t_tile_n
+  return TileWorkgroupSizePair(
+      [[wg_tile_m, wg_tile_n], [t_tile_m, t_tile_n], [0, 0, t_tile_k]],
+      workgroup_size)
+
+
+# Returns all the TileWorkgroupSizePairs for a given SPIRV Target
+def get_all_spirv_tile_workgroup_size_pairs(t_tile_k):
+  tile_workgroup_size_pairs = [
+      get_spirv_tile_workgroup_size_pair([32, 8, 1], t_tile_k),
+      get_spirv_tile_workgroup_size_pair([16, 8, 1], t_tile_k),
+      get_spirv_tile_workgroup_size_pair([64, 2, 1], t_tile_k),
+      get_spirv_tile_workgroup_size_pair([8, 8, 1], t_tile_k),
+      get_spirv_tile_workgroup_size_pair([32, 1, 1], t_tile_k),
+      get_spirv_tile_workgroup_size_pair([16, 2, 1], t_tile_k),
+      get_spirv_tile_workgroup_size_pair([32, 1, 1], t_tile_k),
+  ]
+  return tile_workgroup_size_pairs
 
 
 # Returns the list of CompilationInfo's to use for the CompilationInfoId.
@@ -169,37 +197,21 @@ def get_test_compilation_infos(
     return [None]
   if compilation_info_id == CompilationInfoId.LLVMGPUMatmulSimt:
     tile_workgroup_size_pairs = [
-        TileWorkgroupSizePair([32, 128, 32], [32, 8, 1]),
-        TileWorkgroupSizePair([128, 64, 8], [16, 8, 1]),
-        TileWorkgroupSizePair([16, 256, 32], [64, 2, 1]),
-        TileWorkgroupSizePair([8, 32, 32], [8, 8, 1]),
-        TileWorkgroupSizePair([8, 128, 4], [32, 1, 1]),
-        TileWorkgroupSizePair([16, 64, 4], [16, 2, 1]),
-        TileWorkgroupSizePair([1, 128, 8], [32, 1, 1]),
+        TileWorkgroupSizePair([[32, 128, 32]], [32, 8, 1]),
+        TileWorkgroupSizePair([[128, 64, 8]], [16, 8, 1]),
+        TileWorkgroupSizePair([[16, 256, 32]], [64, 2, 1]),
+        TileWorkgroupSizePair([[8, 32, 32]], [8, 8, 1]),
+        TileWorkgroupSizePair([[8, 128, 4]], [32, 1, 1]),
+        TileWorkgroupSizePair([[16, 64, 4]], [16, 2, 1]),
+        TileWorkgroupSizePair([[1, 128, 8]], [32, 1, 1]),
     ]
   elif compilation_info_id == CompilationInfoId.SPIRVVectorizeNVIDIA:
-    tile_workgroup_size_pairs = [
-        TileWorkgroupSizePair([[32, 128], [4, 4], [0, 0, 32]], [32, 8, 1]),
-        TileWorkgroupSizePair([[32, 128], [4, 4], [0, 0, 32]], [16, 8, 1]),
-        TileWorkgroupSizePair([[32, 128], [4, 4], [0, 0, 32]], [64, 2, 1]),
-        TileWorkgroupSizePair([[32, 128], [4, 4], [0, 0, 32]], [8, 8, 1]),
-        TileWorkgroupSizePair([[32, 128], [4, 4], [0, 0, 32]], [32, 1, 1]),
-        TileWorkgroupSizePair([[32, 128], [4, 4], [0, 0, 32]], [16, 2, 1]),
-        TileWorkgroupSizePair([[32, 128], [4, 4], [0, 0, 32]], [32, 1, 1]),
-    ]
-  elif compilation_info_id == CompilationInfoId.SPIRVVectorizeAndroid:
-    tile_workgroup_size_pairs = [
-        TileWorkgroupSizePair([[8, 32], [4, 4], [0, 0, 4]], [32, 8, 1]),
-        TileWorkgroupSizePair([[8, 32], [4, 4], [0, 0, 4]], [16, 8, 1]),
-        TileWorkgroupSizePair([[8, 32], [4, 4], [0, 0, 4]], [64, 2, 1]),
-        TileWorkgroupSizePair([[8, 32], [4, 4], [0, 0, 4]], [8, 8, 1]),
-        TileWorkgroupSizePair([[8, 32], [4, 4], [0, 0, 4]], [32, 1, 1]),
-        TileWorkgroupSizePair([[8, 32], [4, 4], [0, 0, 4]], [16, 2, 1]),
-        TileWorkgroupSizePair([[8, 32], [4, 4], [0, 0, 4]], [32, 1, 1]),
-    ]
+    tile_workgroup_size_pairs = get_all_spirv_tile_workgroup_size_pairs(32)
+  elif compilation_info_id == CompilationInfoId.SPIRVVectorizeMali:
+    tile_workgroup_size_pairs = get_all_spirv_tile_workgroup_size_pairs(4)
   elif compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCore:
     tile_workgroup_size_pairs = [
-        TileWorkgroupSizePair([32, 32, 16], [64, 2, 1]),
+        TileWorkgroupSizePair([[32, 32, 16]], [64, 2, 1]),
     ]
 
   compilation_infos = []
@@ -316,11 +328,6 @@ def generate_shapes(shape: TestShape, dynamicity: Dynamicity):
   return shapes
 
 
-# Helper to see if tile sizes are specified as list of lists
-def is_list_of_lists(tile_sizes):
-  return all(isinstance(size, list) for size in tile_sizes)
-
-
 # Helper for generate_function.
 # Generates a name for a test function in the generated MLIR code.
 def generate_function_name(
@@ -339,9 +346,7 @@ def generate_function_name(
 
   info = ""
   if compilation_info:
-    tile_sizes = compilation_info.tile_sizes
-    if is_list_of_lists(compilation_info.tile_sizes):
-      tile_sizes = list(itertools.chain(*compilation_info.tile_sizes))
+    tile_sizes = list(itertools.chain(*compilation_info.tile_sizes))
     tile_workgroup_key = "_".join([
         str(a) for a in tile_sizes
     ]) + "_" + "_".join([str(a) for a in compilation_info.workgroup_size])
@@ -383,15 +388,12 @@ def generate_function(
   func_definition = ""
   compilation_info_attr = ""
   if compilation_info:
-    tile_sizes_str = f"{compilation_info.tile_sizes}"
-    if not is_list_of_lists(compilation_info.tile_sizes):
-      tile_sizes_str = f"[{compilation_info.tile_sizes}]"
     dispatch_lowering_pass_pipeline = compilation_info.dispatch_lowering_pass_pipeline
     if "SPIRV" in compilation_info.dispatch_lowering_pass_pipeline:
       dispatch_lowering_pass_pipeline = "SPIRVVectorize"
     compilation_info_string = (
         f"#compilation{generate_function.compilation_index} = #iree_codegen.compilation_info<\n"
-        f"  lowering_config = <tile_sizes = {tile_sizes_str}>,\n"
+        f"  lowering_config = <tile_sizes = {compilation_info.tile_sizes}>,\n"
         f"  translation_info = <{dispatch_lowering_pass_pipeline}\n"
         f"  pipeline_depth = {compilation_info.software_pipeline_depth}>,\n"
         f"  workgroup_size = {compilation_info.workgroup_size_str()}>\n")


### PR DESCRIPTION
This patch adds support to have config coming from higher level IR (to enable search).

It reuses the functionality from the LLVMGPU pipeline.