### PR TITLE
Fix tests hardcoded to x86/linux

### DIFF
--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -26,7 +26,8 @@ class BenchmarkConfigTest(unittest.TestCase):
     self.traced_tool_dir = os.path.join(self.build_dir_name, "traced_tool")
     os.mkdir(self.traced_tool_dir)
     self.trace_capture_tool = tempfile.NamedTemporaryFile()
-    self.trace_capture_tool_name = os.path.realpath(self.trace_capture_tool.name)
+    self.trace_capture_tool_name = os.path.realpath(
+        self.trace_capture_tool.name)
     os.chmod(self.trace_capture_tool.name, stat.S_IEXEC)
 
   def tearDown(self):
@@ -53,7 +54,8 @@ class BenchmarkConfigTest(unittest.TestCase):
         capture_tarball=os.path.realpath("capture.tar"),
         capture_tmp_dir=os.path.join(per_commit_tmp_dir, "captures"))
     print(config)
-    print(BenchmarkConfig(root_benchmark_dir=os.path.join(self.build_dir_name,
+    print(
+        BenchmarkConfig(root_benchmark_dir=os.path.join(self.build_dir_name,
                                                         "benchmark_suites"),
                         benchmark_results_dir=os.path.join(
                             per_commit_tmp_dir, "benchmark-results"),

--- a/tests/transform_dialect/cpu/matmul.mlir
+++ b/tests/transform_dialect/cpu/matmul.mlir
@@ -48,7 +48,7 @@ func.func @matmul_static(
 // RUN: FileCheck %s --check-prefixes=CODEGEN
 
 // CODEGEN: hal.executable private @matmul_static_dispatch_0 {
-// CODEGEN:   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64_ {
+// CODEGEN:   hal.executable.variant public @embedded_elf_{{.*}}, target = #executable_target_embedded_elf_{{.*}} {
 //
 // The signature of the hal.executable.export region is subject to conventions
 // at the flow level. These conventions are materialized in IR e.g. into


### PR DESCRIPTION
Some tests assumed execution on an x64/linux device. Updated these tests to pass on an M1 Macbook.