### PR TITLE
Adding `--expected_output=` flag to iree-run-module.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -39,6 +39,7 @@ EXPLICIT_TARGET_MAPPING = {
     "@llvm-project//llvm:IPO": ["LLVMipo"],
     "@llvm-project//lld": ["${IREE_LLD_TARGET}"],
     "@llvm-project//llvm:FileCheck": ["FileCheck"],
+    "@llvm-project//llvm:not": ["not"],
     # MLIR
     "@llvm-project//mlir:AllPassesAndDialects": ["MLIRAllDialects"],
     "@llvm-project//mlir:DialectUtils": [""],

--- a/runtime/src/iree/base/string_builder.h
+++ b/runtime/src/iree/base/string_builder.h
@@ -106,6 +106,15 @@ IREE_API_EXPORT IREE_MUST_USE_RESULT char* iree_string_builder_take_storage(
 IREE_API_EXPORT iree_status_t iree_string_builder_reserve(
     iree_string_builder_t* builder, iree_host_size_t minimum_capacity);
 
+// Reserves storage for |count| characters (including NUL) and returns a mutable
+// pointer in |out_head| for the caller to write the characters.
+// The pointer is only valid so long as the string builder is initialized and
+// unmodified. No NUL terminator is added by this call.
+// |out_head| will be NULL if the string builder is operating in size
+// calculation mode.
+IREE_API_EXPORT iree_status_t iree_string_builder_append_inline(
+    iree_string_builder_t* builder, iree_host_size_t count, char** out_head);
+
 // Appends a string to the builder.
 IREE_API_EXPORT iree_status_t iree_string_builder_append_string(
     iree_string_builder_t* builder, iree_string_view_t value);

--- a/runtime/src/iree/hal/string_util.c
+++ b/runtime/src/iree/hal/string_util.c
@@ -106,6 +106,17 @@ iree_hal_format_shape(iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
                 : iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_append_shape_string(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_string_builder_t* string_builder) {
+  for (iree_host_size_t i = 0; i < shape_rank; ++i) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+        string_builder, (i < shape_rank - 1) ? "%" PRIdim "x" : "%" PRIdim,
+        shape[i]));
+  }
+  return iree_ok_status();
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_parse_element_type(
     iree_string_view_t value, iree_hal_element_type_t* out_element_type) {
   IREE_ASSERT_ARGUMENT(out_element_type);
@@ -196,6 +207,17 @@ IREE_API_EXPORT iree_status_t iree_hal_format_element_type(
                               : iree_ok_status();
 }
 
+IREE_API_EXPORT iree_status_t
+iree_hal_append_element_type_string(iree_hal_element_type_t element_type,
+                                    iree_string_builder_t* string_builder) {
+  char temp[8];
+  iree_host_size_t length = 0;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_format_element_type(element_type, sizeof(temp), temp, &length));
+  return iree_string_builder_append_string(string_builder,
+                                           iree_make_string_view(temp, length));
+}
+
 IREE_API_EXPORT iree_status_t iree_hal_parse_shape_and_element_type(
     iree_string_view_t value, iree_host_size_t shape_capacity,
     iree_host_size_t* out_shape_rank, iree_hal_dim_t* out_shape,
@@ -242,6 +264,19 @@ IREE_API_EXPORT iree_status_t iree_hal_parse_shape_and_element_type(
   IREE_RETURN_IF_ERROR(iree_hal_parse_element_type(type_str, out_element_type));
 
   return iree_ok_status();
+}
+
+IREE_API_EXPORT iree_status_t iree_hal_append_shape_and_element_type_string(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_hal_element_type_t element_type,
+    iree_string_builder_t* string_builder) {
+  if (shape_rank > 0) {
+    IREE_RETURN_IF_ERROR(
+        iree_hal_append_shape_string(shape_rank, shape, string_builder));
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_string(string_builder, IREE_SV("x")));
+  }
+  return iree_hal_append_element_type_string(element_type, string_builder);
 }
 
 // Parses a string of two character pairs representing hex numbers into bytes.

--- a/runtime/src/iree/hal/string_util.h
+++ b/runtime/src/iree/hal/string_util.h
@@ -32,6 +32,11 @@ iree_hal_format_shape(iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
                       iree_host_size_t buffer_capacity, char* buffer,
                       iree_host_size_t* out_buffer_length);
 
+// Appends shape dimensions to |string_builder| in a `4x5x6` format.
+IREE_API_EXPORT iree_status_t iree_hal_append_shape_string(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_string_builder_t* string_builder);
+
 // Parses a serialized iree_hal_element_type_t and sets |out_element_type| if
 // it is valid. The format is the same as produced by
 // iree_hal_format_element_type.
@@ -48,13 +53,24 @@ IREE_API_EXPORT iree_status_t iree_hal_format_element_type(
     iree_hal_element_type_t element_type, iree_host_size_t buffer_capacity,
     char* buffer, iree_host_size_t* out_buffer_length);
 
+// Appends an element type to |string_builder| such as `f16`.
+IREE_API_EXPORT iree_status_t
+iree_hal_append_element_type_string(iree_hal_element_type_t element_type,
+                                    iree_string_builder_t* string_builder);
+
 // Parses a shape and type from a `[shape]x[type]` string |value|.
 // Behaves the same as calling iree_hal_parse_shape and
-// iree_hal_parse_element_type. Ignores any training `=`.
+// iree_hal_parse_element_type. Ignores any trailing `=`.
 IREE_API_EXPORT iree_status_t iree_hal_parse_shape_and_element_type(
     iree_string_view_t value, iree_host_size_t shape_capacity,
     iree_host_size_t* out_shape_rank, iree_hal_dim_t* out_shape,
     iree_hal_element_type_t* out_element_type);
+
+// Appends shape dimensions and element type to |string_builder| as `4x5xf32`.
+IREE_API_EXPORT iree_status_t iree_hal_append_shape_and_element_type_string(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_hal_element_type_t element_type,
+    iree_string_builder_t* string_builder);
 
 // Parses a serialized element of |element_type| to its in-memory form.
 // |data_ptr| must be at least large enough to contain the bytes of the element.

--- a/runtime/src/iree/tooling/BUILD
+++ b/runtime/src/iree/tooling/BUILD
@@ -13,6 +13,67 @@ package(
 )
 
 cc_library(
+    name = "buffer_view_matchers",
+    srcs = ["buffer_view_matchers.c"],
+    hdrs = ["buffer_view_matchers.h"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/hal",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "buffer_view_matchers_test",
+    srcs = ["buffer_view_matchers_test.cc"],
+    deps = [
+        ":buffer_view_matchers",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal",
+        "//runtime/src/iree/base/internal:span",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "comparison",
+    srcs = ["comparison.cc"],
+    hdrs = ["comparison.h"],
+    deps = [
+        ":buffer_view_matchers",
+        ":vm_util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:cc",
+        "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal:flags",
+        "//runtime/src/iree/base/internal:span",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/modules/hal",
+        "//runtime/src/iree/vm",
+        "//runtime/src/iree/vm:cc",
+    ],
+)
+
+cc_test(
+    name = "comparison_test",
+    srcs = ["comparison_test.cc"],
+    deps = [
+        ":comparison",
+        ":vm_util",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/hal",
+        "//runtime/src/iree/modules/hal",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
+        "//runtime/src/iree/vm",
+        "//runtime/src/iree/vm:cc",
+    ],
+)
+
+cc_library(
     name = "context_util",
     srcs = ["context_util.c"],
     hdrs = ["context_util.h"],

--- a/runtime/src/iree/tooling/CMakeLists.txt
+++ b/runtime/src/iree/tooling/CMakeLists.txt
@@ -12,6 +12,75 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
+    buffer_view_matchers
+  HDRS
+    "buffer_view_matchers.h"
+  SRCS
+    "buffer_view_matchers.c"
+  DEPS
+    iree::base
+    iree::base::internal
+    iree::base::tracing
+    iree::hal
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    buffer_view_matchers_test
+  SRCS
+    "buffer_view_matchers_test.cc"
+  DEPS
+    ::buffer_view_matchers
+    iree::base
+    iree::base::internal
+    iree::base::internal::span
+    iree::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+)
+
+iree_cc_library(
+  NAME
+    comparison
+  HDRS
+    "comparison.h"
+  SRCS
+    "comparison.cc"
+  DEPS
+    ::buffer_view_matchers
+    ::vm_util
+    iree::base
+    iree::base::cc
+    iree::base::internal::flags
+    iree::base::internal::span
+    iree::base::tracing
+    iree::hal
+    iree::modules::hal
+    iree::vm
+    iree::vm::cc
+  PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    comparison_test
+  SRCS
+    "comparison_test.cc"
+  DEPS
+    ::comparison
+    ::vm_util
+    iree::base
+    iree::hal
+    iree::modules::hal
+    iree::testing::gtest
+    iree::testing::gtest_main
+    iree::vm
+    iree::vm::cc
+)
+
+iree_cc_library(
+  NAME
     context_util
   HDRS
     "context_util.h"

--- a/runtime/src/iree/tooling/buffer_view_matchers.c
+++ b/runtime/src/iree/tooling/buffer_view_matchers.c
@@ -1,0 +1,663 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/tooling/buffer_view_matchers.h"
+
+#include <math.h>
+
+#include "iree/base/internal/math.h"
+#include "iree/base/tracing.h"
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_equality_t
+//===----------------------------------------------------------------------===//
+
+static iree_hal_buffer_element_t iree_hal_buffer_element_at(
+    iree_hal_element_type_t element_type, iree_const_byte_span_t elements,
+    iree_host_size_t index) {
+  iree_host_size_t element_size =
+      iree_hal_element_dense_byte_count(element_type);
+  iree_const_byte_span_t element_data = iree_make_const_byte_span(
+      elements.data + index * element_size, element_size);
+  iree_hal_buffer_element_t element = {
+      .type = element_type,
+  };
+  memcpy(element.storage, element_data.data, element_size);
+  return element;
+}
+
+static iree_status_t iree_hal_append_element_string(
+    iree_hal_buffer_element_t value, iree_string_builder_t* builder) {
+  char temp[64];
+  iree_host_size_t temp_length = 0;
+  IREE_RETURN_IF_ERROR(iree_hal_format_element(
+      iree_make_const_byte_span(value.storage,
+                                iree_hal_element_dense_byte_count(value.type)),
+      value.type, sizeof(temp), temp, &temp_length));
+  return iree_string_builder_append_string(
+      builder, iree_make_string_view(temp, temp_length));
+}
+
+static iree_status_t iree_hal_append_element_mismatch_string(
+    iree_host_size_t index, iree_hal_buffer_element_t expected_element,
+    iree_hal_buffer_element_t actual_element, iree_string_builder_t* builder) {
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+      builder, "element at index %" PRIhsz " (", index));
+  IREE_RETURN_IF_ERROR(iree_hal_append_element_string(actual_element, builder));
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+      builder, IREE_SV(") does not match the expected (")));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_append_element_string(expected_element, builder));
+  IREE_RETURN_IF_ERROR(
+      iree_string_builder_append_string(builder, IREE_SV(")")));
+  return iree_ok_status();
+}
+
+static bool iree_hal_compare_strided_elements_exact(
+    iree_hal_element_type_t element_type, iree_host_size_t element_count,
+    iree_const_byte_span_t expected_elements, iree_host_size_t expected_stride,
+    iree_const_byte_span_t actual_elements, iree_host_size_t actual_stride,
+    iree_host_size_t* out_index) {
+  const iree_host_size_t element_size =
+      iree_hal_element_dense_byte_count(element_type);
+  const uint8_t* expected_ptr = expected_elements.data;
+  const uint8_t* actual_ptr = actual_elements.data;
+  for (iree_host_size_t i = 0; i < element_count; ++i) {
+    int cmp = memcmp(expected_ptr, actual_ptr, element_size);
+    if (cmp != 0) {
+      *out_index = i;
+      return false;
+    }
+    expected_ptr += expected_stride * element_size;
+    actual_ptr += actual_stride * element_size;
+  }
+  return true;
+}
+
+static bool iree_hal_compare_strided_elements_approximate_absolute_f16(
+    iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
+    const uint16_t* expected_ptr, iree_host_size_t expected_stride,
+    const uint16_t* actual_ptr, iree_host_size_t actual_stride,
+    iree_host_size_t* out_index) {
+  for (iree_host_size_t i = 0; i < element_count; ++i) {
+    if (fabsf(iree_math_f16_to_f32(*expected_ptr) -
+              iree_math_f16_to_f32(*actual_ptr)) > equality.f16_threshold) {
+      *out_index = i;
+      return false;
+    }
+    expected_ptr += expected_stride;
+    actual_ptr += actual_stride;
+  }
+  return true;
+}
+
+static bool iree_hal_compare_strided_elements_approximate_absolute_f32(
+    iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
+    const float* expected_ptr, iree_host_size_t expected_stride,
+    const float* actual_ptr, iree_host_size_t actual_stride,
+    iree_host_size_t* out_index) {
+  for (iree_host_size_t i = 0; i < element_count; ++i) {
+    if (fabsf(*expected_ptr - *actual_ptr) > equality.f32_threshold) {
+      *out_index = i;
+      return false;
+    }
+    expected_ptr += expected_stride;
+    actual_ptr += actual_stride;
+  }
+  return true;
+}
+
+static bool iree_hal_compare_strided_elements_approximate_absolute_f64(
+    iree_hal_buffer_equality_t equality, iree_host_size_t element_count,
+    const double* expected_ptr, iree_host_size_t expected_stride,
+    const double* actual_ptr, iree_host_size_t actual_stride,
+    iree_host_size_t* out_index) {
+  for (iree_host_size_t i = 0; i < element_count; ++i) {
+    if (fabs(*expected_ptr - *actual_ptr) > equality.f64_threshold) {
+      *out_index = i;
+      return false;
+    }
+    expected_ptr += expected_stride;
+    actual_ptr += actual_stride;
+  }
+  return true;
+}
+
+static bool iree_hal_compare_strided_elements_approximate_absolute(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t expected_elements,
+    iree_host_size_t expected_stride, iree_const_byte_span_t actual_elements,
+    iree_host_size_t actual_stride, iree_host_size_t* out_index) {
+  switch (element_type) {
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_16:
+      return iree_hal_compare_strided_elements_approximate_absolute_f16(
+          equality, element_count, (const uint16_t*)expected_elements.data,
+          expected_stride, (const uint16_t*)actual_elements.data, actual_stride,
+          out_index);
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_32:
+      return iree_hal_compare_strided_elements_approximate_absolute_f32(
+          equality, element_count, (const float*)expected_elements.data,
+          expected_stride, (const float*)actual_elements.data, actual_stride,
+          out_index);
+    case IREE_HAL_ELEMENT_TYPE_FLOAT_64:
+      return iree_hal_compare_strided_elements_approximate_absolute_f64(
+          equality, element_count, (const double*)expected_elements.data,
+          expected_stride, (const double*)actual_elements.data, actual_stride,
+          out_index);
+    default:
+      return iree_hal_compare_strided_elements_exact(
+          element_type, element_count, expected_elements, expected_stride,
+          actual_elements, actual_stride, out_index);
+  }
+}
+
+// Compares two buffers element by element.
+// The provided strides (in elements) are applied up to |element_count|.
+static bool iree_hal_compare_strided_elements(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t expected_elements,
+    iree_host_size_t expected_stride, iree_const_byte_span_t actual_elements,
+    iree_host_size_t actual_stride, iree_host_size_t* out_index) {
+  switch (equality.mode) {
+    case IREE_HAL_BUFFER_EQUALITY_EXACT:
+      return iree_hal_compare_strided_elements_exact(
+          element_type, element_count, expected_elements, expected_stride,
+          actual_elements, actual_stride, out_index);
+    case IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE:
+      return iree_hal_compare_strided_elements_approximate_absolute(
+          equality, element_type, element_count, expected_elements,
+          expected_stride, actual_elements, actual_stride, out_index);
+    default:
+      IREE_ASSERT(false && "unhandled equality mode");
+      return false;
+  }
+}
+
+bool iree_hal_compare_buffer_elements_broadcast(
+    iree_hal_buffer_equality_t equality,
+    iree_hal_buffer_element_t expected_element, iree_host_size_t element_count,
+    iree_const_byte_span_t actual_elements, iree_host_size_t* out_index) {
+  return iree_hal_compare_strided_elements(
+      equality, expected_element.type, element_count,
+      iree_make_const_byte_span(
+          expected_element.storage,
+          iree_hal_element_dense_byte_count(expected_element.type)),
+      /*expected_stride=*/0, actual_elements, /*actual_stride=*/1, out_index);
+}
+
+bool iree_hal_compare_buffer_elements_elementwise(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t expected_elements,
+    iree_const_byte_span_t actual_elements, iree_host_size_t* out_index) {
+  return iree_hal_compare_strided_elements(
+      equality, element_type, element_count, expected_elements,
+      /*expected_stride=*/1, actual_elements, /*actual_stride=*/1, out_index);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_metadata_matcher_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_buffer_view_metadata_matcher_initialize(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_hal_element_type_t element_type,
+    iree_hal_encoding_type_t encoding_type,
+    iree_hal_buffer_view_metadata_matcher_t* out_matcher) {
+  IREE_ASSERT_ARGUMENT(!shape_rank || shape);
+  memset(out_matcher, 0, sizeof(*out_matcher));
+  if (shape_rank > IREE_ARRAYSIZE(out_matcher->shape)) {
+    return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                            "maximum shape rank exceeded");
+  }
+  out_matcher->shape_rank = shape_rank;
+  memcpy(out_matcher->shape, shape, shape_rank * sizeof(*shape));
+  out_matcher->element_type = element_type;
+  out_matcher->encoding_type = encoding_type;
+  return iree_ok_status();
+}
+
+void iree_hal_buffer_view_metadata_matcher_deinitialize(
+    iree_hal_buffer_view_metadata_matcher_t* matcher) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  memset(matcher, 0, sizeof(*matcher));
+}
+
+iree_status_t iree_hal_buffer_view_metadata_matcher_describe(
+    iree_hal_buffer_view_metadata_matcher_t* matcher,
+    iree_string_builder_t* builder) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_RETURN_IF_ERROR(
+      iree_string_builder_append_string(builder, IREE_SV("matches ")));
+  IREE_RETURN_IF_ERROR(iree_hal_append_shape_and_element_type_string(
+      matcher->shape_rank, matcher->shape, matcher->element_type, builder));
+  return iree_ok_status();
+}
+
+static bool iree_hal_buffer_view_shape_matches(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_hal_buffer_view_t* matchee) {
+  if (shape_rank != iree_hal_buffer_view_shape_rank(matchee)) return false;
+  for (iree_host_size_t i = 0; i < shape_rank; ++i) {
+    if (shape[i] != iree_hal_buffer_view_shape_dim(matchee, i)) return false;
+  }
+  return true;
+}
+
+iree_status_t iree_hal_buffer_view_metadata_matcher_match(
+    iree_hal_buffer_view_metadata_matcher_t* matcher,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(matchee);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_ASSERT_ARGUMENT(out_matched);
+  *out_matched = false;
+
+  const bool shape_match = iree_hal_buffer_view_shape_matches(
+      matcher->shape_rank, matcher->shape, matchee);
+  const bool element_type_match =
+      matcher->element_type == IREE_HAL_ELEMENT_TYPE_NONE ||
+      matcher->element_type == iree_hal_buffer_view_element_type(matchee);
+  const bool encoding_type_match =
+      matcher->encoding_type == IREE_HAL_ENCODING_TYPE_OPAQUE ||
+      matcher->encoding_type == iree_hal_buffer_view_encoding_type(matchee);
+  if (shape_match && element_type_match && encoding_type_match) {
+    *out_matched = true;
+    return iree_ok_status();
+  }
+
+  IREE_RETURN_IF_ERROR(
+      iree_string_builder_append_string(builder, IREE_SV("metadata is ")));
+  IREE_RETURN_IF_ERROR(iree_hal_append_shape_and_element_type_string(
+      iree_hal_buffer_view_shape_rank(matchee),
+      iree_hal_buffer_view_shape_dims(matchee),
+      iree_hal_buffer_view_element_type(matchee), builder));
+
+  *out_matched = false;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_buffer_view_match_metadata(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_hal_element_type_t element_type,
+    iree_hal_encoding_type_t encoding_type, iree_hal_buffer_view_t* matchee,
+    iree_string_builder_t* builder, bool* out_matched) {
+  iree_hal_buffer_view_metadata_matcher_t matcher;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_metadata_matcher_initialize(
+      shape_rank, shape, element_type, encoding_type, &matcher));
+  iree_status_t status = iree_hal_buffer_view_metadata_matcher_match(
+      &matcher, matchee, builder, out_matched);
+  if (iree_status_is_ok(status) && !*out_matched) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV("; expected that the view ")));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_buffer_view_metadata_matcher_describe(&matcher, builder));
+  }
+  iree_hal_buffer_view_metadata_matcher_deinitialize(&matcher);
+  return status;
+}
+
+iree_status_t iree_hal_buffer_view_match_metadata_like(
+    iree_hal_buffer_view_t* expected, iree_hal_buffer_view_t* matchee,
+    iree_string_builder_t* builder, bool* out_matched) {
+  IREE_ASSERT_ARGUMENT(expected);
+  return iree_hal_buffer_view_match_metadata(
+      iree_hal_buffer_view_shape_rank(expected),
+      iree_hal_buffer_view_shape_dims(expected),
+      iree_hal_buffer_view_element_type(expected),
+      iree_hal_buffer_view_encoding_type(expected), matchee, builder,
+      out_matched);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_element_matcher_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_buffer_view_element_matcher_initialize(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_element_t value,
+    iree_hal_buffer_view_element_matcher_t* out_matcher) {
+  memset(out_matcher, 0, sizeof(*out_matcher));
+  out_matcher->equality = equality;
+  out_matcher->value = value;
+  return iree_ok_status();
+}
+
+void iree_hal_buffer_view_element_matcher_deinitialize(
+    iree_hal_buffer_view_element_matcher_t* matcher) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  memset(matcher, 0, sizeof(*matcher));
+}
+
+iree_status_t iree_hal_buffer_view_element_matcher_describe(
+    iree_hal_buffer_view_element_matcher_t* matcher,
+    iree_string_builder_t* builder) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+      builder, IREE_SV("has all elements match ")));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_append_element_type_string(matcher->value.type, builder));
+  IREE_RETURN_IF_ERROR(
+      iree_string_builder_append_string(builder, IREE_SV("=")));
+  IREE_RETURN_IF_ERROR(iree_hal_append_element_string(matcher->value, builder));
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_buffer_view_element_matcher_match(
+    iree_hal_buffer_view_element_matcher_t* matcher,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(matchee);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_ASSERT_ARGUMENT(out_matched);
+  *out_matched = false;
+
+  if (iree_hal_buffer_view_encoding_type(matchee) !=
+      IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "non-dense encodings not supported for matching");
+  } else if (iree_hal_buffer_view_element_type(matchee) !=
+             matcher->value.type) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV("whose element type (")));
+    IREE_RETURN_IF_ERROR(iree_hal_append_element_type_string(
+        iree_hal_buffer_view_element_type(matchee), builder));
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV(") does not match expected (")));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_append_element_type_string(matcher->value.type, builder));
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_string(builder, IREE_SV(")")));
+    *out_matched = false;
+    return iree_ok_status();
+  }
+
+  iree_hal_buffer_mapping_t actual_mapping;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_map_range(
+      iree_hal_buffer_view_buffer(matchee), IREE_HAL_MAPPING_MODE_SCOPED,
+      IREE_HAL_MEMORY_ACCESS_READ, 0, IREE_WHOLE_BUFFER, &actual_mapping));
+  iree_const_byte_span_t actual_contents = iree_make_const_byte_span(
+      actual_mapping.contents.data, actual_mapping.contents.data_length);
+
+  iree_host_size_t i = 0;
+  const bool all_match = iree_hal_compare_buffer_elements_broadcast(
+      matcher->equality, matcher->value,
+      iree_hal_buffer_view_element_count(matchee), actual_contents, &i);
+  iree_hal_buffer_element_t actual_element = iree_hal_buffer_element_at(
+      iree_hal_buffer_view_element_type(matchee), actual_contents, i);
+
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_unmap_range(&actual_mapping));
+
+  if (!all_match) {
+    IREE_RETURN_IF_ERROR(iree_hal_append_element_mismatch_string(
+        i, matcher->value, actual_element, builder));
+  }
+
+  *out_matched = all_match;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_buffer_view_match_elements(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_element_t value,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched) {
+  iree_hal_buffer_view_element_matcher_t matcher;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_element_matcher_initialize(
+      equality, value, &matcher));
+  iree_status_t status = iree_hal_buffer_view_element_matcher_match(
+      &matcher, matchee, builder, out_matched);
+  if (iree_status_is_ok(status) && !*out_matched) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV("; expected that the view ")));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_buffer_view_element_matcher_describe(&matcher, builder));
+  }
+  iree_hal_buffer_view_element_matcher_deinitialize(&matcher);
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_array_matcher_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_buffer_view_array_matcher_initialize(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t elements,
+    iree_hal_buffer_view_array_matcher_t* out_matcher) {
+  IREE_ASSERT_ARGUMENT(!element_count ||
+                       !iree_const_byte_span_is_empty(elements));
+  memset(out_matcher, 0, sizeof(*out_matcher));
+  out_matcher->equality = equality;
+  out_matcher->element_type = element_type;
+  out_matcher->element_count = element_count;
+  out_matcher->elements = elements;
+  return iree_ok_status();
+}
+
+void iree_hal_buffer_view_array_matcher_deinitialize(
+    iree_hal_buffer_view_array_matcher_t* matcher) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  memset(matcher, 0, sizeof(*matcher));
+}
+
+iree_status_t iree_hal_buffer_view_array_matcher_describe(
+    iree_hal_buffer_view_array_matcher_t* matcher,
+    iree_string_builder_t* builder) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+      builder,
+      "has all elements match those in %" PRIhsz " element <array> of ",
+      matcher->element_count));
+  IREE_RETURN_IF_ERROR(
+      iree_hal_append_element_type_string(matcher->element_type, builder));
+  // TODO(benvanik): format array contents (elided)? make caller do?
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_buffer_view_array_matcher_match(
+    iree_hal_buffer_view_array_matcher_t* matcher,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(matchee);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_ASSERT_ARGUMENT(out_matched);
+  *out_matched = false;
+
+  if (iree_hal_buffer_view_encoding_type(matchee) !=
+      IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "non-dense encodings not supported for matching");
+  } else if (iree_hal_buffer_view_element_type(matchee) !=
+             matcher->element_type) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV("whose element type (")));
+    IREE_RETURN_IF_ERROR(iree_hal_append_element_type_string(
+        iree_hal_buffer_view_element_type(matchee), builder));
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV(") does not match expected (")));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_append_element_type_string(matcher->element_type, builder));
+    IREE_RETURN_IF_ERROR(
+        iree_string_builder_append_string(builder, IREE_SV(")")));
+    *out_matched = false;
+    return iree_ok_status();
+  } else if (iree_hal_buffer_view_element_count(matchee) !=
+             matcher->element_count) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_format(
+        builder,
+        "whose element count (%" PRIhsz ") does not match expected (%" PRIhsz
+        ")",
+        iree_hal_buffer_view_element_count(matchee), matcher->element_count));
+    *out_matched = false;
+    return iree_ok_status();
+  }
+
+  iree_hal_buffer_mapping_t actual_mapping;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_map_range(
+      iree_hal_buffer_view_buffer(matchee), IREE_HAL_MAPPING_MODE_SCOPED,
+      IREE_HAL_MEMORY_ACCESS_READ, 0, IREE_WHOLE_BUFFER, &actual_mapping));
+  iree_const_byte_span_t actual_contents = iree_make_const_byte_span(
+      actual_mapping.contents.data, actual_mapping.contents.data_length);
+
+  iree_host_size_t i = 0;
+  const bool all_match = iree_hal_compare_buffer_elements_elementwise(
+      matcher->equality, iree_hal_buffer_view_element_type(matchee),
+      iree_hal_buffer_view_element_count(matchee), matcher->elements,
+      actual_contents, &i);
+  iree_hal_buffer_element_t actual_element = iree_hal_buffer_element_at(
+      iree_hal_buffer_view_element_type(matchee), actual_contents, i);
+  iree_hal_buffer_element_t expected_element = iree_hal_buffer_element_at(
+      iree_hal_buffer_view_element_type(matchee), matcher->elements, i);
+
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_unmap_range(&actual_mapping));
+
+  if (!all_match) {
+    IREE_RETURN_IF_ERROR(iree_hal_append_element_mismatch_string(
+        i, expected_element, actual_element, builder));
+  }
+
+  *out_matched = all_match;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_buffer_view_match_array(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t elements,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched) {
+  iree_hal_buffer_view_array_matcher_t matcher;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_array_matcher_initialize(
+      equality, element_type, element_count, elements, &matcher));
+  iree_status_t status = iree_hal_buffer_view_array_matcher_match(
+      &matcher, matchee, builder, out_matched);
+  if (iree_status_is_ok(status) && !*out_matched) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV("; expected that the view ")));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_buffer_view_array_matcher_describe(&matcher, builder));
+  }
+  iree_hal_buffer_view_array_matcher_deinitialize(&matcher);
+  return status;
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_matcher_t
+//===----------------------------------------------------------------------===//
+
+iree_status_t iree_hal_buffer_view_matcher_initialize(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_view_t* expected,
+    iree_hal_buffer_view_matcher_t* out_matcher) {
+  IREE_ASSERT_ARGUMENT(expected);
+  memset(out_matcher, 0, sizeof(*out_matcher));
+  out_matcher->equality = equality;
+  out_matcher->expected = expected;
+  iree_hal_buffer_view_retain(expected);
+  return iree_ok_status();
+}
+
+void iree_hal_buffer_view_matcher_deinitialize(
+    iree_hal_buffer_view_matcher_t* matcher) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  iree_hal_buffer_view_release(matcher->expected);
+  memset(matcher, 0, sizeof(*matcher));
+}
+
+iree_status_t iree_hal_buffer_view_matcher_describe(
+    iree_hal_buffer_view_matcher_t* matcher, iree_string_builder_t* builder) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+      builder, IREE_SV("is equal to contents of a view of ")));
+  IREE_RETURN_IF_ERROR(iree_hal_append_shape_and_element_type_string(
+      iree_hal_buffer_view_shape_rank(matcher->expected),
+      iree_hal_buffer_view_shape_dims(matcher->expected),
+      iree_hal_buffer_view_element_type(matcher->expected), builder));
+  // TODO(benvanik): format buffer view contents (elided)? make caller do?
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_buffer_view_matcher_match(
+    iree_hal_buffer_view_matcher_t* matcher, iree_hal_buffer_view_t* matchee,
+    iree_string_builder_t* builder, bool* out_matched) {
+  IREE_ASSERT_ARGUMENT(matcher);
+  IREE_ASSERT_ARGUMENT(matchee);
+  IREE_ASSERT_ARGUMENT(builder);
+  IREE_ASSERT_ARGUMENT(out_matched);
+  *out_matched = false;
+
+  if (iree_hal_buffer_view_encoding_type(matchee) !=
+      IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR) {
+    return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                            "non-dense encodings not supported for matching");
+  }
+
+  // Reuse metadata matching to ensure the buffer views are the same shape/type.
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_view_match_metadata_like(
+      matcher->expected, matchee, builder, out_matched));
+  if (!*out_matched) return iree_ok_status();
+
+  iree_hal_buffer_mapping_t actual_mapping;
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_map_range(
+      iree_hal_buffer_view_buffer(matchee), IREE_HAL_MAPPING_MODE_SCOPED,
+      IREE_HAL_MEMORY_ACCESS_READ, 0, IREE_WHOLE_BUFFER, &actual_mapping));
+  iree_hal_buffer_mapping_t expected_mapping;
+  iree_status_t status = iree_hal_buffer_map_range(
+      iree_hal_buffer_view_buffer(matcher->expected),
+      IREE_HAL_MAPPING_MODE_SCOPED, IREE_HAL_MEMORY_ACCESS_READ, 0,
+      IREE_WHOLE_BUFFER, &expected_mapping);
+  if (!iree_status_is_ok(status)) {
+    iree_hal_buffer_unmap_range(&actual_mapping);
+    return status;
+  }
+  iree_const_byte_span_t actual_contents = iree_make_const_byte_span(
+      actual_mapping.contents.data, actual_mapping.contents.data_length);
+  iree_const_byte_span_t expected_contents = iree_make_const_byte_span(
+      expected_mapping.contents.data, expected_mapping.contents.data_length);
+
+  iree_host_size_t i = 0;
+  const bool all_match = iree_hal_compare_buffer_elements_elementwise(
+      matcher->equality, iree_hal_buffer_view_element_type(matchee),
+      iree_hal_buffer_view_element_count(matchee), expected_contents,
+      actual_contents, &i);
+  iree_hal_buffer_element_t actual_element = iree_hal_buffer_element_at(
+      iree_hal_buffer_view_element_type(matchee), actual_contents, i);
+  iree_hal_buffer_element_t expected_element = iree_hal_buffer_element_at(
+      iree_hal_buffer_view_element_type(matchee), expected_contents, i);
+
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_unmap_range(&actual_mapping));
+  IREE_RETURN_IF_ERROR(iree_hal_buffer_unmap_range(&expected_mapping));
+
+  if (!all_match) {
+    IREE_RETURN_IF_ERROR(iree_hal_append_element_mismatch_string(
+        i, expected_element, actual_element, builder));
+  }
+
+  *out_matched = all_match;
+  return iree_ok_status();
+}
+
+iree_status_t iree_hal_buffer_view_match_equal(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_view_t* expected,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched) {
+  iree_hal_buffer_view_matcher_t matcher;
+  IREE_RETURN_IF_ERROR(
+      iree_hal_buffer_view_matcher_initialize(equality, expected, &matcher));
+  iree_status_t status = iree_hal_buffer_view_matcher_match(
+      &matcher, matchee, builder, out_matched);
+  if (iree_status_is_ok(status) && !*out_matched) {
+    IREE_RETURN_IF_ERROR(iree_string_builder_append_string(
+        builder, IREE_SV("; expected that the view ")));
+    IREE_RETURN_IF_ERROR(
+        iree_hal_buffer_view_matcher_describe(&matcher, builder));
+  }
+  iree_hal_buffer_view_matcher_deinitialize(&matcher);
+  return status;
+}

--- a/runtime/src/iree/tooling/buffer_view_matchers.h
+++ b/runtime/src/iree/tooling/buffer_view_matchers.h
@@ -1,0 +1,273 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+// Buffer view matchers
+//===----------------------------------------------------------------------===//
+//
+// Provides a set of gtest-like buffer views matchers that can either be
+// wrapped in C++ and exposed directly to gtest or used programmatically to
+// perform buffer view comparisons.
+//
+// Each matcher has a simple method that returns whether the match was
+// successful. Most code should prefer those.
+//
+// Support for rare element types and encodings are added as-needed and will
+// generally return match failure or a status error when unimplemented.
+//
+// TODO(benvanik): add C++ wrappers in iree/testing/.
+
+#ifndef IREE_TOOLING_BUFFER_VIEW_MATCHERS_H_
+#define IREE_TOOLING_BUFFER_VIEW_MATCHERS_H_
+
+#include "iree/base/api.h"
+#include "iree/base/internal/math.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_equality_t
+//===----------------------------------------------------------------------===//
+
+typedef enum {
+  // a == b
+  IREE_HAL_BUFFER_EQUALITY_EXACT = 0,
+  // abs(a - b) <= threshold
+  IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE,
+} iree_hal_buffer_equality_mode_t;
+
+// TODO(benvanik): initializers/configuration for equality comparisons.
+typedef struct {
+  iree_hal_buffer_equality_mode_t mode;
+  // TODO(benvanik): allow override in approximate modes (ULP, abs/rel diff).
+  // For now we just have some hardcoded types that are used in place of
+  // compile-time constants. Consider these provisional.
+  float f16_threshold;
+  float f32_threshold;
+  double f64_threshold;
+} iree_hal_buffer_equality_t;
+
+// Variant type storing known HAL buffer elements.
+typedef struct {
+  iree_hal_element_type_t type;
+  union {
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+    int64_t i64;
+    float f32;
+    double f64;
+    uint8_t storage[8];  // max size of all value types
+  };
+} iree_hal_buffer_element_t;
+
+static inline iree_hal_buffer_element_t iree_hal_make_buffer_element_i8(
+    int8_t value) {
+  iree_hal_buffer_element_t element;
+  element.type = IREE_HAL_ELEMENT_TYPE_INT_8;
+  element.i8 = value;
+  return element;
+}
+
+static inline iree_hal_buffer_element_t iree_hal_make_buffer_element_i16(
+    int16_t value) {
+  iree_hal_buffer_element_t element;
+  element.type = IREE_HAL_ELEMENT_TYPE_INT_16;
+  element.i16 = value;
+  return element;
+}
+
+static inline iree_hal_buffer_element_t iree_hal_make_buffer_element_i32(
+    int32_t value) {
+  iree_hal_buffer_element_t element;
+  element.type = IREE_HAL_ELEMENT_TYPE_INT_32;
+  element.i32 = value;
+  return element;
+}
+
+static inline iree_hal_buffer_element_t iree_hal_make_buffer_element_i64(
+    int64_t value) {
+  iree_hal_buffer_element_t element;
+  element.type = IREE_HAL_ELEMENT_TYPE_INT_64;
+  element.i64 = value;
+  return element;
+}
+
+static inline iree_hal_buffer_element_t iree_hal_make_buffer_element_f16(
+    float value) {
+  iree_hal_buffer_element_t element;
+  element.type = IREE_HAL_ELEMENT_TYPE_FLOAT_16;
+  element.i16 = iree_math_f32_to_f16(value);
+  return element;
+}
+
+static inline iree_hal_buffer_element_t iree_hal_make_buffer_element_f32(
+    float value) {
+  iree_hal_buffer_element_t element;
+  element.type = IREE_HAL_ELEMENT_TYPE_FLOAT_32;
+  element.f32 = value;
+  return element;
+}
+
+static inline iree_hal_buffer_element_t iree_hal_make_buffer_element_f64(
+    double value) {
+  iree_hal_buffer_element_t element;
+  element.type = IREE_HAL_ELEMENT_TYPE_FLOAT_64;
+  element.f64 = value;
+  return element;
+}
+
+// Returns true if all elements match the uniform value based on |equality|.
+// |out_index| will contain the first index that does not match.
+bool iree_hal_compare_buffer_elements_broadcast(
+    iree_hal_buffer_equality_t equality,
+    iree_hal_buffer_element_t expected_element, iree_host_size_t element_count,
+    iree_const_byte_span_t actual_elements, iree_host_size_t* out_index);
+
+// Returns true if all elements match based on |equality|.
+// |out_index| will contain the first index that does not match.
+bool iree_hal_compare_buffer_elements_elementwise(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t expected_elements,
+    iree_const_byte_span_t actual_elements, iree_host_size_t* out_index);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_metadata_matcher_t
+//===----------------------------------------------------------------------===//
+
+typedef struct {
+  iree_host_size_t shape_rank;
+  iree_hal_dim_t shape[128];
+  iree_hal_element_type_t element_type;
+  iree_hal_encoding_type_t encoding_type;
+} iree_hal_buffer_view_metadata_matcher_t;
+
+iree_status_t iree_hal_buffer_view_metadata_matcher_initialize(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_hal_element_type_t element_type,
+    iree_hal_encoding_type_t encoding_type,
+    iree_hal_buffer_view_metadata_matcher_t* out_matcher);
+void iree_hal_buffer_view_metadata_matcher_deinitialize(
+    iree_hal_buffer_view_metadata_matcher_t* matcher);
+iree_status_t iree_hal_buffer_view_metadata_matcher_describe(
+    iree_hal_buffer_view_metadata_matcher_t* matcher,
+    iree_string_builder_t* builder);
+iree_status_t iree_hal_buffer_view_metadata_matcher_match(
+    iree_hal_buffer_view_metadata_matcher_t* matcher,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched);
+
+// Matches |matchee| against the given metadata.
+// Use IREE_HAL_ELEMENT_TYPE_NONE to ignore |element_type| and
+// use IREE_HAL_ENCODING_TYPE_OPAQUE to ignore |encoding_type|.
+iree_status_t iree_hal_buffer_view_match_metadata(
+    iree_host_size_t shape_rank, const iree_hal_dim_t* shape,
+    iree_hal_element_type_t element_type,
+    iree_hal_encoding_type_t encoding_type, iree_hal_buffer_view_t* matchee,
+    iree_string_builder_t* builder, bool* out_matched);
+
+// Matches |matchee| against |expected| if all metadata (shape, encoding, etc)
+// is equivalent.
+iree_status_t iree_hal_buffer_view_match_metadata_like(
+    iree_hal_buffer_view_t* expected, iree_hal_buffer_view_t* matchee,
+    iree_string_builder_t* builder, bool* out_matched);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_element_matcher_t
+//===----------------------------------------------------------------------===//
+
+typedef struct {
+  iree_hal_buffer_equality_t equality;
+  iree_hal_buffer_element_t value;
+} iree_hal_buffer_view_element_matcher_t;
+
+iree_status_t iree_hal_buffer_view_element_matcher_initialize(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_element_t value,
+    iree_hal_buffer_view_element_matcher_t* out_matcher);
+void iree_hal_buffer_view_element_matcher_deinitialize(
+    iree_hal_buffer_view_element_matcher_t* matcher);
+iree_status_t iree_hal_buffer_view_element_matcher_describe(
+    iree_hal_buffer_view_element_matcher_t* matcher,
+    iree_string_builder_t* builder);
+iree_status_t iree_hal_buffer_view_element_matcher_match(
+    iree_hal_buffer_view_element_matcher_t* matcher,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched);
+
+// Matches all elements of |matchee| against |value|.
+iree_status_t iree_hal_buffer_view_match_elements(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_element_t value,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_array_matcher_t
+//===----------------------------------------------------------------------===//
+
+typedef struct {
+  iree_hal_buffer_equality_t equality;
+  iree_hal_element_type_t element_type;
+  iree_host_size_t element_count;
+  // TODO(benvanik): copy in? would make easier to take from std::vector.
+  iree_const_byte_span_t elements;  // unowned
+} iree_hal_buffer_view_array_matcher_t;
+
+iree_status_t iree_hal_buffer_view_array_matcher_initialize(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t elements,
+    iree_hal_buffer_view_array_matcher_t* out_matcher);
+void iree_hal_buffer_view_array_matcher_deinitialize(
+    iree_hal_buffer_view_array_matcher_t* matcher);
+iree_status_t iree_hal_buffer_view_array_matcher_describe(
+    iree_hal_buffer_view_array_matcher_t* matcher,
+    iree_string_builder_t* builder);
+iree_status_t iree_hal_buffer_view_array_matcher_match(
+    iree_hal_buffer_view_array_matcher_t* matcher,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched);
+
+// Matches |matchee| against all |element_count| elements in |elements|.
+// The element count of |matchee| must be equal to |element_count|.
+iree_status_t iree_hal_buffer_view_match_array(
+    iree_hal_buffer_equality_t equality, iree_hal_element_type_t element_type,
+    iree_host_size_t element_count, iree_const_byte_span_t elements,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched);
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_matcher_t
+//===----------------------------------------------------------------------===//
+
+typedef struct {
+  iree_hal_buffer_equality_t equality;
+  iree_hal_buffer_view_t* expected;
+} iree_hal_buffer_view_matcher_t;
+
+iree_status_t iree_hal_buffer_view_matcher_initialize(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_view_t* expected,
+    iree_hal_buffer_view_matcher_t* out_matcher);
+void iree_hal_buffer_view_matcher_deinitialize(
+    iree_hal_buffer_view_matcher_t* matcher);
+iree_status_t iree_hal_buffer_view_matcher_describe(
+    iree_hal_buffer_view_matcher_t* matcher, iree_string_builder_t* builder);
+iree_status_t iree_hal_buffer_view_matcher_match(
+    iree_hal_buffer_view_matcher_t* matcher, iree_hal_buffer_view_t* matchee,
+    iree_string_builder_t* builder, bool* out_matched);
+
+// Matches |matchee| against |expected| for both metadata and elements.
+iree_status_t iree_hal_buffer_view_match_equal(
+    iree_hal_buffer_equality_t equality, iree_hal_buffer_view_t* expected,
+    iree_hal_buffer_view_t* matchee, iree_string_builder_t* builder,
+    bool* out_matched);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_TOOLING_BUFFER_VIEW_MATCHERS_H_

--- a/runtime/src/iree/tooling/buffer_view_matchers_test.cc
+++ b/runtime/src/iree/tooling/buffer_view_matchers_test.cc
@@ -1,0 +1,698 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/tooling/buffer_view_matchers.h"
+
+#include "iree/base/api.h"
+#include "iree/base/internal/math.h"
+#include "iree/base/internal/span.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+namespace iree {
+namespace {
+
+using iree::testing::status::IsOk;
+using iree::testing::status::StatusIs;
+using ::testing::HasSubstr;
+
+// TODO(benvanik): move this handle type to a base cc helper.
+struct StringBuilder {
+  static StringBuilder MakeSystem() {
+    iree_string_builder_t builder;
+    iree_string_builder_initialize(iree_allocator_system(), &builder);
+    return StringBuilder(builder);
+  }
+  static StringBuilder MakeEmpty() {
+    iree_string_builder_t builder;
+    iree_string_builder_initialize(iree_allocator_null(), &builder);
+    return StringBuilder(builder);
+  }
+  explicit StringBuilder(iree_string_builder_t builder)
+      : builder(std::move(builder)) {}
+  ~StringBuilder() { iree_string_builder_deinitialize(&builder); }
+  operator iree_string_builder_t*() { return &builder; }
+  std::string ToString() const {
+    return std::string(builder.buffer, builder.size);
+  }
+  iree_string_builder_t builder;
+};
+
+// TODO(benvanik): move this handle type to a hal cc helper.
+
+// C API iree_*_retain/iree_*_release function pointer.
+template <typename T>
+using HandleRefFn = void(IREE_API_PTR*)(T*);
+
+// C++ RAII wrapper for an IREE C reference object.
+// Behaves the same as a thread-safe intrusive pointer.
+template <typename T, HandleRefFn<T> retain_fn, HandleRefFn<T> release_fn>
+class Handle {
+ public:
+  using handle_type = Handle<T, retain_fn, release_fn>;
+
+  static Handle Wrap(T* value) noexcept { return Handle(value, false); }
+
+  Handle() noexcept = default;
+  Handle(std::nullptr_t) noexcept {}
+  Handle(T* value) noexcept : value_(value) { retain_fn(value_); }
+
+  ~Handle() noexcept {
+    if (value_) release_fn(value_);
+  }
+
+  Handle(const Handle& rhs) noexcept : value_(rhs.value_) {
+    if (value_) retain_fn(value_);
+  }
+  Handle& operator=(const Handle& rhs) noexcept {
+    if (value_ != rhs.value_) {
+      if (value_) release_fn(value_);
+      value_ = rhs.get();
+      if (value_) retain_fn(value_);
+    }
+    return *this;
+  }
+
+  Handle(Handle&& rhs) noexcept : value_(rhs.release()) {}
+  Handle& operator=(Handle&& rhs) noexcept {
+    if (value_ != rhs.value_) {
+      if (value_) release_fn(value_);
+      value_ = rhs.release();
+    }
+    return *this;
+  }
+
+  // Gets the pointer referenced by this instance.
+  constexpr T* get() const noexcept { return value_; }
+  constexpr operator T*() const noexcept { return value_; }
+
+  // Resets the object to nullptr and decrements the reference count, possibly
+  // deleting it.
+  void reset() noexcept {
+    if (value_) {
+      release_fn(value_);
+      value_ = nullptr;
+    }
+  }
+
+  // Returns the current pointer held by this object without having its
+  // reference count decremented and resets the handle to empty. Returns
+  // nullptr if the handle holds no value. To re-wrap in a handle use either
+  // ctor(value) or assign().
+  T* release() noexcept {
+    auto* p = value_;
+    value_ = nullptr;
+    return p;
+  }
+
+  // Assigns a pointer.
+  // The pointer will be accepted by the handle and its reference count will
+  // not be incremented.
+  void assign(T* value) noexcept {
+    reset();
+    value_ = value;
+  }
+
+  // Returns a pointer to the inner pointer storage.
+  // This allows passing a pointer to the handle as an output argument to
+  // C-style creation functions.
+  constexpr T** operator&() noexcept { return &value_; }
+
+  // Support boolean expression evaluation ala unique_ptr/shared_ptr:
+  // https://en.cppreference.com/w/cpp/memory/shared_ptr/operator_bool
+  typedef T* Handle::*unspecified_bool_type;
+  constexpr operator unspecified_bool_type() const noexcept {
+    return value_ ? &Handle::value_ : nullptr;
+  }
+
+  // Supports unary expression evaluation.
+  constexpr bool operator!() const noexcept { return !value_; }
+
+  // Swap support.
+  void swap(Handle& rhs) noexcept { std::swap(value_, rhs.value_); }
+
+ protected:
+  Handle(T* value, bool) noexcept : value_(value) {}
+
+ private:
+  T* value_ = nullptr;
+};
+
+// C++ wrapper for iree_hal_buffer_view_t.
+struct BufferView final
+    : public Handle<iree_hal_buffer_view_t, iree_hal_buffer_view_retain,
+                    iree_hal_buffer_view_release> {
+  using handle_type::handle_type;
+};
+
+static const iree_hal_buffer_equality_t kExactEquality = ([]() {
+  iree_hal_buffer_equality_t equality;
+  equality.mode = IREE_HAL_BUFFER_EQUALITY_EXACT;
+  return equality;
+})();
+
+static const iree_hal_buffer_equality_t kApproximateEquality = ([]() {
+  iree_hal_buffer_equality_t equality;
+  equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE;
+  equality.f16_threshold = 0.001f;
+  equality.f32_threshold = 0.0001f;
+  equality.f64_threshold = 0.0001;
+  return equality;
+})();
+
+class BufferViewMatchersTest : public ::testing::Test {
+ protected:
+  iree_hal_allocator_t* device_allocator_ = nullptr;
+  virtual void SetUp() {
+    IREE_CHECK_OK(iree_hal_allocator_create_heap(
+        IREE_SV("heap"), iree_allocator_system(), iree_allocator_system(),
+        &device_allocator_));
+  }
+  virtual void TearDown() { iree_hal_allocator_release(device_allocator_); }
+
+  template <typename T>
+  StatusOr<BufferView> CreateBufferView(iree::span<const iree_hal_dim_t> shape,
+                                        iree_hal_element_type_t element_type,
+                                        const T* contents) {
+    iree_hal_dim_t num_elements = 1;
+    for (iree_hal_dim_t dim : shape) num_elements *= dim;
+    iree_hal_buffer_params_t params = {0};
+    params.type =
+        IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE,
+    params.usage =
+        IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
+    BufferView buffer_view;
+    IREE_RETURN_IF_ERROR(iree_hal_buffer_view_allocate_buffer(
+        device_allocator_, shape.size(), shape.data(), element_type,
+        IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR, params,
+        iree_make_const_byte_span(contents, num_elements * sizeof(T)),
+        &buffer_view));
+    return std::move(buffer_view);
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_equality_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastI8EQ) {
+  const int8_t lhs = 1;
+  const int8_t rhs[] = {1, 1, 1};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_i8(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastI8NE) {
+  const int8_t lhs = 1;
+  const int8_t rhs[] = {1, 2, 3};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_i8(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastI64EQ) {
+  const int64_t lhs = 1;
+  const int64_t rhs[] = {1, 1, 1};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_i64(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastI64NE) {
+  const int64_t lhs = 1;
+  const int64_t rhs[] = {1, 2, 3};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_i64(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF16EQ) {
+  const float lhs = 1.0f;
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(1.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_f16(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF16NE) {
+  const float lhs = 1.0f;
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(3.0f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_f16(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF32EQ) {
+  const float lhs = 1.0f;
+  const float rhs[] = {1.0f, 1.0f, 1.0f};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_f32(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF32NE) {
+  const float lhs = 1.0f;
+  const float rhs[] = {1.0f, 3.0f, 4.0f};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_f32(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF64EQ) {
+  const double lhs = 1.0;
+  const double rhs[] = {1.0, 1.0, 1.0};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_f64(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareBroadcastF64NE) {
+  const double lhs = 1.0;
+  const double rhs[] = {1.0, 3.0, 4.0};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_broadcast(
+      kApproximateEquality, iree_hal_make_buffer_element_f64(lhs),
+      IREE_ARRAYSIZE(rhs), iree_make_const_byte_span(rhs, sizeof(rhs)),
+      &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF16EQ) {
+  const uint16_t lhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(2.0f),
+      iree_math_f32_to_f16(3.0f),
+  };
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(2.0f),
+      iree_math_f32_to_f16(3.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16, IREE_ARRAYSIZE(lhs),
+      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF16NearEQ) {
+  const uint16_t lhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(1.99999f),
+      iree_math_f32_to_f16(0.00001f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(1.00001f),
+      iree_math_f32_to_f16(2.0f),
+      iree_math_f32_to_f16(0.0f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16, IREE_ARRAYSIZE(lhs),
+      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF16NE) {
+  const uint16_t lhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(2.0f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  const uint16_t rhs[] = {
+      iree_math_f32_to_f16(1.0f),
+      iree_math_f32_to_f16(3.0f),
+      iree_math_f32_to_f16(4.0f),
+  };
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_16, IREE_ARRAYSIZE(lhs),
+      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF32EQ) {
+  const float lhs[] = {1.0f, 2.0f, 3.0f};
+  const float rhs[] = {1.0f, 2.0f, 3.0f};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_ARRAYSIZE(lhs),
+      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF32NE) {
+  const float lhs[] = {1.0f, 2.0f, 4.0f};
+  const float rhs[] = {1.0f, 3.0f, 4.0f};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_32, IREE_ARRAYSIZE(lhs),
+      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+  EXPECT_EQ(index, 1);
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF64EQ) {
+  const double lhs[] = {1.0, 2.0, 3.0};
+  const double rhs[] = {1.0, 2.0, 3.0};
+  iree_host_size_t index = 0;
+  EXPECT_TRUE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_64, IREE_ARRAYSIZE(lhs),
+      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+}
+
+TEST_F(BufferViewMatchersTest, CompareElementwiseF64NE) {
+  const double lhs[] = {1.0, 2.0, 4.0};
+  const double rhs[] = {1.0, 3.0, 4.0};
+  iree_host_size_t index = 0;
+  EXPECT_FALSE(iree_hal_compare_buffer_elements_elementwise(
+      kApproximateEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_64, IREE_ARRAYSIZE(lhs),
+      iree_make_const_byte_span(lhs, sizeof(lhs)),
+      iree_make_const_byte_span(rhs, sizeof(rhs)), &index));
+  EXPECT_EQ(index, 1);
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_metadata_matcher_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(BufferViewMatchersTest, MetadataEmpty) {
+  const float contents[1] = {0};
+  iree_hal_dim_t shape[] = {0};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32, contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32, contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_metadata_like(lhs, rhs, sb, &match));
+  EXPECT_TRUE(match);
+}
+
+TEST_F(BufferViewMatchersTest, MetadataShapesDiffer) {
+  const float lhs_contents[] = {1.0f};
+  const float rhs_contents[] = {1.0f, 2.0f};
+  iree_hal_dim_t lhs_shape[] = {1};
+  iree_hal_dim_t rhs_shape[] = {1, 2};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs, CreateBufferView(lhs_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+                                 lhs_contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs, CreateBufferView(rhs_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+                                 rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_metadata_like(lhs, rhs, sb, &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("is 1x2xf32"));
+  EXPECT_THAT(sb.ToString(), HasSubstr("matches 1xf32"));
+}
+
+TEST_F(BufferViewMatchersTest, MetadataElementTypesDiffer) {
+  const float contents[] = {1.0f};
+  iree_hal_dim_t shape[] = {1};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32, contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_metadata_like(lhs, rhs, sb, &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("is 1xf32"));
+  EXPECT_THAT(sb.ToString(), HasSubstr("matches 1xi32"));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_element_matcher_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(BufferViewMatchersTest, ElementTypesDiffer) {
+  const float lhs_value = 1;
+  const int32_t rhs_contents[] = {1, 1, 1};
+  const iree_hal_dim_t shape[] = {1, 3};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(iree_hal_buffer_view_match_elements(
+      kExactEquality, iree_hal_make_buffer_element_f32(lhs_value), rhs, sb,
+      &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("type (i32)"));
+  EXPECT_THAT(sb.ToString(), HasSubstr("expected (f32)"));
+}
+
+TEST_F(BufferViewMatchersTest, MatchElementContentsI32) {
+  const int32_t lhs_value = 1;
+  const int32_t rhs_contents[] = {1, 1, 1};
+  const iree_hal_dim_t shape[] = {1, 3};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(iree_hal_buffer_view_match_elements(
+      kExactEquality, iree_hal_make_buffer_element_i32(lhs_value), rhs, sb,
+      &match));
+  EXPECT_TRUE(match);
+  EXPECT_TRUE(sb.ToString().empty());
+}
+
+TEST_F(BufferViewMatchersTest, MismatchElementContentsI32) {
+  const int32_t lhs_value = 1;
+  const int32_t rhs_contents[] = {1, 2, 3};
+  const iree_hal_dim_t shape[] = {1, 3};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(iree_hal_buffer_view_match_elements(
+      kExactEquality, iree_hal_make_buffer_element_i32(lhs_value), rhs, sb,
+      &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("element at index 1"));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_array_matcher_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(BufferViewMatchersTest, MatchArrayTypesDiffer) {
+  const float lhs_contents[] = {1, 1, 1};
+  const int32_t rhs_contents[] = {1, 1, 1};
+  const iree_hal_dim_t shape[] = {1, 3};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(iree_hal_buffer_view_match_array(
+      kExactEquality, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+      IREE_ARRAYSIZE(lhs_contents),
+      iree_make_const_byte_span(lhs_contents, sizeof(lhs_contents)), rhs, sb,
+      &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("type (i32)"));
+  EXPECT_THAT(sb.ToString(), HasSubstr("expected (f32)"));
+}
+
+TEST_F(BufferViewMatchersTest, MatchArrayCountsDiffer) {
+  const int32_t lhs_contents[] = {1, 1};
+  const int32_t rhs_contents[] = {1, 1, 1};
+  const iree_hal_dim_t shape[] = {1, 3};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(iree_hal_buffer_view_match_array(
+      kExactEquality, IREE_HAL_ELEMENT_TYPE_INT_32,
+      IREE_ARRAYSIZE(lhs_contents),
+      iree_make_const_byte_span(lhs_contents, sizeof(lhs_contents)), rhs, sb,
+      &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("count (3)"));
+  EXPECT_THAT(sb.ToString(), HasSubstr("expected (2)"));
+}
+
+TEST_F(BufferViewMatchersTest, MatchArrayContentsI32) {
+  const int32_t lhs_contents[] = {1, 1, 1};
+  const int32_t rhs_contents[] = {1, 1, 1};
+  const iree_hal_dim_t shape[] = {1, 3};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(iree_hal_buffer_view_match_array(
+      kExactEquality, IREE_HAL_ELEMENT_TYPE_INT_32,
+      IREE_ARRAYSIZE(lhs_contents),
+      iree_make_const_byte_span(lhs_contents, sizeof(lhs_contents)), rhs, sb,
+      &match));
+  EXPECT_TRUE(match);
+  EXPECT_TRUE(sb.ToString().empty());
+}
+
+TEST_F(BufferViewMatchersTest, MismatchArrayContentsI32) {
+  const int32_t lhs_contents[] = {1, 1, 1};
+  const int32_t rhs_contents[] = {1, 2, 3};
+  const iree_hal_dim_t shape[] = {1, 3};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(iree_hal_buffer_view_match_array(
+      kExactEquality, IREE_HAL_ELEMENT_TYPE_INT_32,
+      IREE_ARRAYSIZE(lhs_contents),
+      iree_make_const_byte_span(lhs_contents, sizeof(lhs_contents)), rhs, sb,
+      &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("element at index 1"));
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_buffer_view_matcher_t
+//===----------------------------------------------------------------------===//
+
+TEST_F(BufferViewMatchersTest, MatchEmpty) {
+  const float contents[1] = {0};
+  iree_hal_dim_t shape[] = {0};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32, contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32, contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_equal(kExactEquality, lhs, rhs, sb, &match));
+  EXPECT_TRUE(match);
+  EXPECT_TRUE(sb.ToString().empty());
+}
+
+TEST_F(BufferViewMatchersTest, MatchShapesDiffer) {
+  const float lhs_contents[] = {1.0f};
+  const float rhs_contents[] = {1.0f, 2.0f};
+  iree_hal_dim_t lhs_shape[] = {1};
+  iree_hal_dim_t rhs_shape[] = {1, 2};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs, CreateBufferView(lhs_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+                                 lhs_contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs, CreateBufferView(rhs_shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32,
+                                 rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_equal(kExactEquality, lhs, rhs, sb, &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("is 1x2xf32"));
+  EXPECT_THAT(sb.ToString(), HasSubstr("matches 1xf32"));
+}
+
+TEST_F(BufferViewMatchersTest, MatchElementTypesDiffer) {
+  const float contents[] = {1.0f};
+  iree_hal_dim_t shape[] = {1};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_INT_32, contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_32, contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_equal(kExactEquality, lhs, rhs, sb, &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("is 1xf32"));
+  EXPECT_THAT(sb.ToString(), HasSubstr("matches 1xi32"));
+}
+
+TEST_F(BufferViewMatchersTest, MatchContentsF16) {
+  const uint16_t lhs_contents[] = {iree_math_f32_to_f16(2.0f)};
+  const uint16_t rhs_contents[] = {iree_math_f32_to_f16(2.0f)};
+  iree_hal_dim_t shape[] = {1};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_16, lhs_contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_16, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_equal(kExactEquality, lhs, rhs, sb, &match));
+  EXPECT_TRUE(match);
+  EXPECT_TRUE(sb.ToString().empty());
+}
+
+TEST_F(BufferViewMatchersTest, MismatchContentsF16) {
+  const uint16_t lhs_contents[] = {iree_math_f32_to_f16(1.0f)};
+  const uint16_t rhs_contents[] = {iree_math_f32_to_f16(2.0f)};
+  const iree_hal_dim_t shape[] = {1};
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto lhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_16, lhs_contents));
+  IREE_ASSERT_OK_AND_ASSIGN(
+      auto rhs,
+      CreateBufferView(shape, IREE_HAL_ELEMENT_TYPE_FLOAT_16, rhs_contents));
+  auto sb = StringBuilder::MakeSystem();
+  bool match = false;
+  IREE_ASSERT_OK(
+      iree_hal_buffer_view_match_equal(kExactEquality, lhs, rhs, sb, &match));
+  EXPECT_FALSE(match);
+  EXPECT_THAT(sb.ToString(), HasSubstr("element at index 0"));
+}
+
+}  // namespace
+}  // namespace iree

--- a/runtime/src/iree/tooling/comparison.cc
+++ b/runtime/src/iree/tooling/comparison.cc
@@ -1,0 +1,296 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/tooling/comparison.h"
+
+#include <cstdint>
+#include <cstdio>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/flags.h"
+#include "iree/base/status_cc.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/api.h"
+#include "iree/modules/hal/module.h"
+#include "iree/tooling/buffer_view_matchers.h"
+#include "iree/tooling/vm_util.h"
+#include "iree/vm/ref_cc.h"
+
+using namespace iree;
+
+IREE_FLAG(float, expected_f16_threshold, 0.001f,
+          "Threshold under which two f16 values are considered equal.");
+IREE_FLAG(float, expected_f32_threshold, 0.0001f,
+          "Threshold under which two f32 values are considered equal.");
+IREE_FLAG(double, expected_f64_threshold, 0.0001,
+          "Threshold under which two f64 values are considered equal.");
+
+static iree_hal_buffer_equality_t iree_tooling_equality_from_flags(void) {
+  iree_hal_buffer_equality_t equality;
+  equality.mode = IREE_HAL_BUFFER_EQUALITY_APPROXIMATE_ABSOLUTE;
+  equality.f16_threshold = FLAG_expected_f16_threshold;
+  equality.f32_threshold = FLAG_expected_f32_threshold;
+  equality.f64_threshold = FLAG_expected_f64_threshold;
+  return equality;
+}
+
+// Prints a buffer view with contents without a trailing newline.
+static iree_status_t iree_tooling_append_buffer_view_string(
+    iree_hal_buffer_view_t* buffer_view, iree_host_size_t max_element_count,
+    iree_string_builder_t* builder) {
+  // NOTE: we could see how many bytes are available in the builder (capacity -
+  // size) and then pass those in to the initial format - if there's enough
+  // space it'll fill what it needs. We'd need to adjust the string builder
+  // afterward somehow.
+  iree_host_size_t required_length = 0;
+  iree_status_t status = iree_hal_buffer_view_format(
+      buffer_view, max_element_count, /*buffer_capacity=*/0, /*buffer=*/NULL,
+      &required_length);
+  if (!iree_status_is_out_of_range(status)) return status;
+  char* buffer = NULL;
+  IREE_RETURN_IF_ERROR(
+      iree_string_builder_append_inline(builder, required_length, &buffer));
+  if (!buffer) return iree_ok_status();
+  return iree_hal_buffer_view_format(buffer_view, max_element_count,
+                                     required_length + /*NUL=*/1, buffer,
+                                     &required_length);
+}
+
+static iree_status_t iree_vm_append_variant_type_string(
+    iree_vm_variant_t variant, iree_string_builder_t* builder) {
+  if (iree_vm_variant_is_empty(variant)) {
+    return iree_string_builder_append_string(builder, IREE_SV("empty"));
+  } else if (iree_vm_variant_is_value(variant)) {
+    const char* type = NULL;
+    switch (variant.type.value_type) {
+      case IREE_VM_VALUE_TYPE_I8:
+        type = "i8";
+        break;
+      case IREE_VM_VALUE_TYPE_I16:
+        type = "i16";
+        break;
+      case IREE_VM_VALUE_TYPE_I32:
+        type = "i32";
+        break;
+      case IREE_VM_VALUE_TYPE_I64:
+        type = "i64";
+        break;
+      case IREE_VM_VALUE_TYPE_F32:
+        type = "f32";
+        break;
+      case IREE_VM_VALUE_TYPE_F64:
+        type = "f64";
+        break;
+      default:
+        type = "?";
+        break;
+    }
+    return iree_string_builder_append_cstring(builder, type);
+  } else if (iree_vm_variant_is_ref(variant)) {
+    return iree_string_builder_append_string(
+        builder, iree_vm_ref_type_name(variant.type.ref_type));
+  } else {
+    return iree_string_builder_append_string(builder, IREE_SV("unknown"));
+  }
+}
+
+static bool iree_tooling_compare_values(int result_index,
+                                        iree_vm_variant_t expected_variant,
+                                        iree_vm_variant_t actual_variant,
+                                        iree_string_builder_t* builder) {
+  IREE_ASSERT_EQ(expected_variant.type.value_type,
+                 actual_variant.type.value_type);
+  switch (expected_variant.type.value_type) {
+    case IREE_VM_VALUE_TYPE_I8:
+      if (expected_variant.i8 != actual_variant.i8) {
+        IREE_CHECK_OK(iree_string_builder_append_format(
+            builder,
+            "[FAILED] result[%d]: i8 values differ\n  expected: %" PRIi8
+            "\n  actual: %" PRIi8 "\n",
+            result_index, expected_variant.i8, actual_variant.i8));
+        return false;
+      }
+      return true;
+    case IREE_VM_VALUE_TYPE_I16:
+      if (expected_variant.i16 != actual_variant.i16) {
+        IREE_CHECK_OK(iree_string_builder_append_format(
+            builder,
+            "[FAILED] result[%d]: i16 values differ\n  expected: %" PRIi16
+            "\n  actual: %" PRIi16 "\n",
+            result_index, expected_variant.i16, actual_variant.i16));
+        return false;
+      }
+      return true;
+    case IREE_VM_VALUE_TYPE_I32:
+      if (expected_variant.i32 != actual_variant.i32) {
+        IREE_CHECK_OK(iree_string_builder_append_format(
+            builder,
+            "[FAILED] result[%d]: i32 values differ\n  expected: %" PRIi32
+            "\n  actual: %" PRIi32 "\n",
+            result_index, expected_variant.i32, actual_variant.i32));
+        return false;
+      }
+      return true;
+    case IREE_VM_VALUE_TYPE_I64:
+      if (expected_variant.i64 != actual_variant.i64) {
+        IREE_CHECK_OK(iree_string_builder_append_format(
+            builder,
+            "[FAILED] result[%d]: i64 values differ\n  expected: %" PRIi64
+            "\n  actual: %" PRIi64 "\n",
+            result_index, expected_variant.i64, actual_variant.i64));
+        return false;
+      }
+      return true;
+    case IREE_VM_VALUE_TYPE_F32:
+      // TODO(benvanik): use tolerance flag.
+      if (expected_variant.f32 != actual_variant.f32) {
+        IREE_CHECK_OK(iree_string_builder_append_format(
+            builder,
+            "[FAILED] result[%d]: f32 values differ\n  expected: %G\n  actual: "
+            "%G\n",
+            result_index, expected_variant.f32, actual_variant.f32));
+        return false;
+      }
+      return true;
+    case IREE_VM_VALUE_TYPE_F64:
+      // TODO(benvanik): use tolerance flag.
+      if (expected_variant.f64 != actual_variant.f64) {
+        IREE_CHECK_OK(iree_string_builder_append_format(
+            builder,
+            "[FAILED] result[%d]: f64 values differ\n  expected: %G\n  actual: "
+            "%G\n",
+            result_index, expected_variant.f64, actual_variant.f64));
+        return false;
+      }
+      return true;
+    default:
+      IREE_CHECK_OK(iree_string_builder_append_format(
+          builder, "[FAILED] result[%d]: unknown value type, cannot match\n",
+          result_index));
+      return false;
+  }
+}
+
+static bool iree_tooling_compare_buffer_views(
+    int result_index, iree_hal_buffer_view_t* expected_view,
+    iree_hal_buffer_view_t* actual_view, iree_allocator_t host_allocator,
+    iree_host_size_t max_element_count, iree_string_builder_t* builder) {
+  iree_string_builder_t subbuilder;
+  iree_string_builder_initialize(host_allocator, &subbuilder);
+
+  iree_hal_buffer_equality_t equality = iree_tooling_equality_from_flags();
+  bool did_match = false;
+  IREE_CHECK_OK(iree_hal_buffer_view_match_equal(
+      equality, expected_view, actual_view, &subbuilder, &did_match));
+  if (did_match) {
+    iree_string_builder_deinitialize(&subbuilder);
+    return true;
+  }
+  IREE_CHECK_OK(iree_string_builder_append_format(
+      builder, "[FAILED] result[%d]: ", result_index));
+  IREE_CHECK_OK(iree_string_builder_append_string(
+      builder, iree_string_builder_view(&subbuilder)));
+  iree_string_builder_deinitialize(&subbuilder);
+
+  IREE_CHECK_OK(
+      iree_string_builder_append_string(builder, IREE_SV("\n  expected:\n")));
+  IREE_CHECK_OK(iree_tooling_append_buffer_view_string(
+      expected_view, max_element_count, builder));
+  IREE_CHECK_OK(
+      iree_string_builder_append_string(builder, IREE_SV("\n  actual:\n")));
+  IREE_CHECK_OK(iree_tooling_append_buffer_view_string(
+      actual_view, max_element_count, builder));
+  IREE_CHECK_OK(iree_string_builder_append_string(builder, IREE_SV("\n")));
+
+  return false;
+}
+
+static bool iree_tooling_compare_variants(int result_index,
+                                          iree_vm_variant_t expected_variant,
+                                          iree_vm_variant_t actual_variant,
+                                          iree_allocator_t host_allocator,
+                                          iree_host_size_t max_element_count,
+                                          iree_string_builder_t* builder) {
+  IREE_TRACE_SCOPE();
+
+  if (iree_vm_variant_is_empty(expected_variant)) {
+    return true;  // expected empty is sentinel for (ignored)
+  } else if (iree_vm_variant_is_empty(actual_variant) &&
+             iree_vm_variant_is_empty(expected_variant)) {
+    return true;  // both empty
+  } else if (iree_vm_variant_is_value(actual_variant) &&
+             iree_vm_variant_is_value(expected_variant)) {
+    if (expected_variant.type.value_type != actual_variant.type.value_type) {
+      return iree_tooling_compare_values(result_index, expected_variant,
+                                         actual_variant, builder);
+    }
+  } else if (iree_vm_variant_is_ref(actual_variant) &&
+             iree_vm_variant_is_ref(expected_variant)) {
+    if (iree_hal_buffer_view_isa(actual_variant.ref) &&
+        iree_hal_buffer_view_isa(expected_variant.ref)) {
+      return iree_tooling_compare_buffer_views(
+          result_index, iree_hal_buffer_view_deref(expected_variant.ref),
+          iree_hal_buffer_view_deref(actual_variant.ref), host_allocator,
+          max_element_count, builder);
+    }
+  }
+
+  IREE_CHECK_OK(iree_string_builder_append_format(
+      builder, "[FAILED] result[%d]: ", result_index));
+  IREE_CHECK_OK(iree_string_builder_append_string(
+      builder, IREE_SV("variant types mismatch; expected ")));
+  IREE_CHECK_OK(iree_vm_append_variant_type_string(expected_variant, builder));
+  IREE_CHECK_OK(
+      iree_string_builder_append_string(builder, IREE_SV(" but got ")));
+  IREE_CHECK_OK(iree_vm_append_variant_type_string(actual_variant, builder));
+  IREE_CHECK_OK(iree_string_builder_append_string(builder, IREE_SV("\n")));
+
+  return false;
+}
+
+static bool iree_tooling_compare_variants_to_stream(
+    int result_index, iree_vm_variant_t expected_variant,
+    iree_vm_variant_t actual_variant, iree_allocator_t host_allocator,
+    iree_host_size_t max_element_count, std::ostream* os) {
+  iree_string_builder_t builder;
+  iree_string_builder_initialize(host_allocator, &builder);
+  bool did_match = iree_tooling_compare_variants(result_index, expected_variant,
+                                                 actual_variant, host_allocator,
+                                                 max_element_count, &builder);
+  os->write(iree_string_builder_buffer(&builder),
+            iree_string_builder_size(&builder));
+  iree_string_builder_deinitialize(&builder);
+  return did_match;
+}
+
+bool iree_tooling_compare_variant_lists(iree_vm_list_t* expected_list,
+                                        iree_vm_list_t* actual_list,
+                                        iree_allocator_t host_allocator,
+                                        std::ostream* os) {
+  IREE_TRACE_SCOPE();
+
+  if (iree_vm_list_size(expected_list) != iree_vm_list_size(actual_list)) {
+    *os << "[FAILED] expected " << iree_vm_list_size(expected_list)
+        << " list elements but " << iree_vm_list_size(actual_list)
+        << " provided\n";
+    return false;
+  }
+
+  bool all_match = true;
+  for (iree_host_size_t i = 0; i < iree_vm_list_size(expected_list); ++i) {
+    iree_vm_variant_t expected_variant = iree_vm_variant_empty();
+    IREE_CHECK_OK(
+        iree_vm_list_get_variant(expected_list, i, &expected_variant));
+    iree_vm_variant_t actual_variant = iree_vm_variant_empty();
+    IREE_CHECK_OK(iree_vm_list_get_variant(actual_list, i, &actual_variant));
+    bool did_match = iree_tooling_compare_variants_to_stream(
+        (int)i, expected_variant, actual_variant, host_allocator,
+        /*max_element_count=*/1024, os);
+    if (!did_match) all_match = false;
+  }
+
+  return all_match;
+}

--- a/runtime/src/iree/tooling/comparison.h
+++ b/runtime/src/iree/tooling/comparison.h
@@ -1,0 +1,26 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_TOOLING_COMPARISON_H_
+#define IREE_TOOLING_COMPARISON_H_
+
+#include <ostream>
+
+#include "iree/base/api.h"
+#include "iree/vm/api.h"
+
+// Compares and prints expected results.
+// Returns true if all values match and false otherwise.
+// Errors when performing comparison will abort the process.
+// When all list elements match no output is written and otherwise
+// newline-separated strings detailing the differing elements is appended.
+// TODO(benvanik): change to FILE*.
+bool iree_tooling_compare_variant_lists(iree_vm_list_t* expected_list,
+                                        iree_vm_list_t* actual_list,
+                                        iree_allocator_t host_allocator,
+                                        std::ostream* os);
+
+#endif  // IREE_TOOLING_COMPARISON_H_

--- a/runtime/src/iree/tooling/comparison_test.cc
+++ b/runtime/src/iree/tooling/comparison_test.cc
@@ -1,0 +1,119 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/tooling/comparison.h"
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+#include "iree/modules/hal/module.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+#include "iree/tooling/vm_util.h"
+#include "iree/vm/api.h"
+#include "iree/vm/ref_cc.h"
+
+namespace iree {
+namespace {
+
+using ::testing::HasSubstr;
+
+class ComparisonTest : public ::testing::Test {
+ protected:
+  virtual void SetUp() {
+    IREE_ASSERT_OK(iree_vm_instance_create(host_allocator_, &instance_));
+    IREE_ASSERT_OK(iree_hal_module_register_all_types(instance_));
+    IREE_ASSERT_OK(iree_hal_allocator_create_heap(
+        IREE_SV("heap"), host_allocator_, host_allocator_, &device_allocator_));
+  }
+
+  virtual void TearDown() {
+    iree_hal_allocator_release(device_allocator_);
+    iree_vm_instance_release(instance_);
+  }
+
+  bool ParseAndCompareVariantLists(
+      iree::span<const std::string> expected_strings,
+      iree::span<const std::string> actual_strings, std::ostream* os) {
+    vm::ref<iree_vm_list_t> expected_list;
+    IREE_CHECK_OK(ParseToVariantList(device_allocator_, expected_strings,
+                                     host_allocator_, &expected_list));
+
+    vm::ref<iree_vm_list_t> actual_list;
+    IREE_CHECK_OK(ParseToVariantList(device_allocator_, actual_strings,
+                                     host_allocator_, &actual_list));
+
+    return iree_tooling_compare_variant_lists(
+        expected_list.get(), actual_list.get(), host_allocator_, os);
+  }
+
+  iree_vm_instance_t* instance_ = nullptr;
+  iree_allocator_t host_allocator_ = iree_allocator_system();
+  iree_hal_allocator_t* device_allocator_ = nullptr;
+};
+
+TEST_F(ComparisonTest, CompareEqualLists) {
+  std::string buf_string1 = "2x2xi32=[42 43][44 45]";
+  std::string buf_string2 = "2x3xf64=[1 2 3][4 5 6]";
+  auto buf_strings = std::vector<std::string>{buf_string1, buf_string2};
+  std::stringstream os;
+  EXPECT_TRUE(ParseAndCompareVariantLists(buf_strings, buf_strings, &os));
+  EXPECT_EQ(os.str(), "");
+}
+
+TEST_F(ComparisonTest, CompareListsWithIgnored) {
+  std::string buf_string1 = "2x2xi32=[42 43][44 45]";
+  std::string buf_string2 = "2x3xf64=[1 2 999][4 5 6]";
+  std::string buf_string2_ignored = "(ignored)";
+  auto actual_strings = std::vector<std::string>{buf_string1, buf_string2};
+  auto expected_strings =
+      std::vector<std::string>{buf_string1, buf_string2_ignored};
+  std::stringstream os;
+  EXPECT_TRUE(
+      ParseAndCompareVariantLists(expected_strings, actual_strings, &os));
+  EXPECT_EQ(os.str(), "");
+}
+
+TEST_F(ComparisonTest, CompareTruncatedLists) {
+  std::string buf_string1 = "2x2xi32=[42 43][44 45]";
+  std::string buf_string2 = "2x3xf64=[1 2 3][4 5 6]";
+  auto actual_strings = std::vector<std::string>{buf_string1, buf_string2};
+  auto expected_strings = std::vector<std::string>{buf_string1};
+  std::stringstream os;
+  EXPECT_FALSE(
+      ParseAndCompareVariantLists(expected_strings, actual_strings, &os));
+  EXPECT_THAT(os.str(), HasSubstr("expected 1 list elements but 2 provided"));
+}
+
+TEST_F(ComparisonTest, CompareDifferingLists) {
+  std::string buf_string1 = "2x2xi32=[42 43][44 45]";
+  std::string buf_string2 = "2x3xf64=[1 2 999][4 5 6]";
+  std::string buf_string2_good = "2x3xf64=[1 2 3][4 5 6]";
+  auto actual_strings = std::vector<std::string>{buf_string1, buf_string2};
+  auto expected_strings =
+      std::vector<std::string>{buf_string1, buf_string2_good};
+  std::stringstream os;
+  EXPECT_FALSE(
+      ParseAndCompareVariantLists(expected_strings, actual_strings, &os));
+  EXPECT_THAT(
+      os.str(),
+      HasSubstr("element at index 2 (999) does not match the expected (3)"));
+}
+
+TEST_F(ComparisonTest, CompareListsWithDifferingTypes) {
+  std::string buf_string1 = "2x2xi32=[42 43][44 45]";
+  std::string buf_string2 = "123";
+  std::string buf_string2_good = "2x3xf64=[1 2 3][4 5 6]";
+  auto actual_strings = std::vector<std::string>{buf_string1, buf_string2};
+  auto expected_strings =
+      std::vector<std::string>{buf_string1, buf_string2_good};
+  std::stringstream os;
+  EXPECT_FALSE(
+      ParseAndCompareVariantLists(expected_strings, actual_strings, &os));
+  EXPECT_THAT(os.str(), HasSubstr("variant types mismatch"));
+}
+
+}  // namespace
+}  // namespace iree

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -158,6 +158,8 @@ cc_binary(
         "//runtime/src/iree/base:tracing",
         "//runtime/src/iree/base/internal:flags",
         "//runtime/src/iree/hal",
+        "//runtime/src/iree/modules/hal:types",
+        "//runtime/src/iree/tooling:comparison",
         "//runtime/src/iree/tooling:context_util",
         "//runtime/src/iree/tooling:vm_util",
         "//runtime/src/iree/vm",

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -126,6 +126,8 @@ iree_cc_binary(
     iree::base::internal::flags
     iree::base::tracing
     iree::hal
+    iree::modules::hal::types
+    iree::tooling::comparison
     iree::tooling::context_util
     iree::tooling::vm_util
     iree::vm
@@ -266,16 +268,23 @@ if(IREE_BUILD_COMPILER)
     HOSTONLY
   )
 
-  # Ensure FileCheck gets built. Tests don't have dependencies in CMake because
-  # they aren't targets. So until we fix that, we just force this to get built.
+  # Ensure FileCheck and associated binaries get built. Tests don't have
+  # dependencies in CMake because they aren't targets. So until we fix that, we
+  # just force this to get built.
   # Limiting this to when IREE_BUILD_TESTS is set prevents the installation
   # below, which we use for cross-platform testing.
   set_target_properties(FileCheck PROPERTIES EXCLUDE_FROM_ALL OFF)
+  set_target_properties(not PROPERTIES EXCLUDE_FROM_ALL OFF)
 
-  # Bundle the FileCheck binary from LLVM into our tests/bin directory so
-  # installed FileCheck tests are hermetic.
+  # Bundle the FileCheck and associated binaries from LLVM into our tests/bin
+  # directory so installed FileCheck tests are hermetic.
   install(
     TARGETS FileCheck
+    DESTINATION "tests/bin"
+    COMPONENT Tests
+  )
+  install(
+    TARGETS not
     DESTINATION "tests/bin"
     COMPONENT Tests
   )

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "iree-benchmark-module.mlir",
             "iree-run-mlir.mlir",
             "iree-run-module.mlir",
+            "iree-run-module-expected.mlir",
             "multiple_args.mlir",
             "multiple_exported_functions.mlir",
             "null_values.mlir",
@@ -41,6 +42,7 @@ iree_lit_test_suite(
         "//tools:iree-run-module",
         "@llvm-project//lld",
         "@llvm-project//llvm:FileCheck",
+        "@llvm-project//llvm:not",
     ],
 )
 

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "executable_benchmarks.mlir"
     "iree-benchmark-module.mlir"
     "iree-run-mlir.mlir"
+    "iree-run-module-expected.mlir"
     "iree-run-module.mlir"
     "multiple_args.mlir"
     "multiple_exported_functions.mlir"
@@ -30,6 +31,7 @@ iree_lit_test_suite(
     iree-compile
     iree-run-mlir
     iree-run-module
+    not
   LABELS
     "hostonly"
 )

--- a/tools/test/iree-run-module-expected.mlir
+++ b/tools/test/iree-run-module-expected.mlir
@@ -1,0 +1,20 @@
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2 --expected_output=f32=-2 --expected_output=f32=2.0) | FileCheck %s --check-prefix=SUCCESS-MATCHES
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2 --expected_output=f32=-2 --expected_output="(ignored)") | FileCheck %s --check-prefix=SUCCESS-IGNORED
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2 --expected_output=f32=-2 --expected_output=f32=2.1 --expected_f32_threshold=0.1) | FileCheck %s --check-prefix=SUCCESS-THRESHOLD
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | not iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2 --expected_output=f32=123 --expected_output=f32=2.0) | FileCheck %s --check-prefix=FAILED-FIRST
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | not iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2 --expected_output=f32=-2 --expected_output=f32=4.5) | FileCheck %s --check-prefix=FAILED-SECOND
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | not iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2 --expected_output=f32=-2 --expected_output=4xf32=2.0) | FileCheck %s --check-prefix=FAILED-SHAPE
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | not iree-run-module --device=local-task --entry_function=abs --function_input=f32=-2 --expected_output=f32=-2 --expected_output=8) | FileCheck %s --check-prefix=FAILED-TYPE
+
+// SUCCESS-MATCHES: [SUCCESS]
+// SUCCESS-THRESHOLD: [SUCCESS]
+// SUCCESS-IGNORED: [SUCCESS]
+// FAILED-FIRST: [FAILED] result[0]: element at index 0 (-2) does not match the expected (123)
+// FAILED-SECOND: [FAILED] result[1]: element at index 0 (2) does not match the expected (4.5)
+// FAILED-SHAPE: [FAILED] result[1]: metadata is f32; expected that the view matches 4xf32
+// FAILED-TYPE: [FAILED] result[1]: variant types mismatch
+
+func.func @abs(%input: tensor<f32>) -> (tensor<f32>, tensor<f32>) {
+  %result = math.absf %input : tensor<f32>
+  return %input, %result : tensor<f32>, tensor<f32>
+}


### PR DESCRIPTION
This allows for super basic blackbox testing of compiled modules by way of iree-run-module that does not require any input changes like iree-check-module does. The flag accepts the same values as `--function_input` (including npy files) in addition to `(ignored)` for when a value is not of interest.

When the flag is provided the normal output printing is disabled and instead a comparison runs and prints detailed information about any diffs, for example:
```
[FAILED] result[0]: element at index 49 (0) does not match the expected (123); expected that the view is equal to contents of a view of 5x1x10xf32
  expected:
5x1x10xf32=[[0.743973 ... 0 0 123]]
  actual:
5x1x10xf32=[[0.743973 ... 0 0 0]]
```

The matching utilities are intended to be wrapped in gtest C++ matchers so that they can be used in iree-check-module and other tools but that is left for future work. This separation is required so that iree-run-module and other tools using the comparison utilities don't need to depend on gtest. It also means that users authoring their own test tools for bare metal/etc can easily use the comparison features.

There are three flags like `--expected_f32_threshold=` (+f16/f64) that allow for basic threshold overrides. Full customization of the equality comparisons that do smarter things (ULP, integer ranges, etc) are also left for future work and what's used here matches iree-check-module's current behavior.

Fixes #10376.