### PR TITLE
[RISCV] Limit max unroll factor to 8 by default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -215,41 +215,34 @@ static SmallVector<int64_t> getMinTilingSizesForEachDim(
     auto operandType =
         inputOutputOpOperands[map.index()]->get().getType().cast<ShapedType>();
     int64_t tileSize = getVectorSize(entryPointFn, operandType);
-    // Vectorization of reductions is driven by input tensors and considering
-    // the output's fastest varying dim leads to large unroll factors. We limit
-    // the tile size for this case to 'maxUnrollFactor'.
-    if (linalgOpInfo.isReduction() &&
-        op.isOutputTensor(inputOutputOpOperands[map.index()])) {
-      tileSize = std::min<int64_t>(
-          tileSize, targetMLTransInfo.defaultMaxReductionUnrollFactor);
-    }
-
-    if (isMajorIdentityMap(map.value())) {
-      tileSize = std::min<int64_t>(
-          tileSize, targetMLTransInfo.defaultMaxReductionUnrollFactor);
-    }
 
     minTileSizes[fastestVaryingDim] =
         std::max<int64_t>(minTileSizes[fastestVaryingDim], tileSize);
   }
 
-  // Limit unrolling on transpose operations. For know, we assume the rightmost
-  // non-one tiled dimension is for vectorization and any other non-one
-  // dimension is for unrolling.
-  // TODO(dcaballe): Consider input and output transposes.
-  if (linalgOpInfo.isTranspose()) {
+  // Limit unroll factor. For know, we assume the rightmost non-one tiled
+  // dimension is for vectorization and any other non-one dimension is for
+  // unrolling.
+  auto limitUnrollFactor = [&](int64_t maxUnrollFactor) {
     int vecDim;
     for (vecDim = minTileSizes.size() - 1; vecDim >= 0; --vecDim) {
       if (minTileSizes[vecDim] > 1) {
         break;
       }
     }
-
     for (int unrollDim = vecDim - 1; unrollDim >= 0; --unrollDim) {
       minTileSizes[unrollDim] =
-          std::min<int64_t>(minTileSizes[unrollDim],
-                            targetMLTransInfo.defaultMaxTransposeUnrollFactor);
+          std::min<int64_t>(minTileSizes[unrollDim], maxUnrollFactor);
     }
+  };
+
+  if (linalgOpInfo.isTranspose()) {
+    // Limit unrolling on transpose operations.
+    // TODO(dcaballe): Consider input and output transposes.
+    limitUnrollFactor(targetMLTransInfo.defaultMaxTransposeUnrollFactor);
+  } else {
+    // Limit unrolling to the default target maximum.
+    limitUnrollFactor(targetMLTransInfo.defaultMaxUnrollFactor);
   }
 
   return minTileSizes;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -203,7 +203,7 @@ static SmallVector<int64_t> getMinTilingSizesForEachDim(
         std::max<int64_t>(minTileSizes[fastestVaryingDim], tileSize);
   }
 
-  // Limit unroll factor. For know, we assume the rightmost non-one tiled
+  // Limit unroll factor. For now, we assume the rightmost non-one tiled
   // dimension is for vectorization and any other non-one dimension is for
   // unrolling.
   auto limitUnrollFactor = [&](int64_t maxUnrollFactor) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -172,23 +172,6 @@ static int64_t getVectorSize(func::FuncOp entryPointFn, ShapedType shapedType) {
   return getVectorSize(entryPointFn, byteWidth);
 }
 
-static bool isMajorIdentityMap(AffineMap map) {
-  if (map.getNumInputs() <= map.getNumResults())
-    return false;
-
-  for (auto &en : llvm::enumerate(map.getResults())) {
-    AffineExpr expr = en.value();
-    if (!expr.isa<AffineDimExpr>())
-      return false;
-
-    AffineDimExpr dimExpr = expr.cast<AffineDimExpr>();
-    if (dimExpr.getPosition() != en.index())
-      return false;
-  }
-
-  return true;
-}
-
 /// Returns minimum tiling sizes for each dimension. One dimension is possible
 /// to access at different element types. It determines the tiling sizes by
 /// looking into all the operands.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.cpp
@@ -15,7 +15,7 @@ namespace {
 
 struct RISCVTargetMLTransformInfo : TargetMLTransformInfo {
   RISCVTargetMLTransformInfo() {
-    defaultMaxReductionUnrollFactor = 8;
+    defaultMaxUnrollFactor = 8;
     defaultMaxTransposeUnrollFactor = 1;
   }
 };

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h
@@ -17,7 +17,7 @@ namespace iree_compiler {
 /// Holds target specific information to specialize ML transformations.
 // TODO(dcaballe): Move to a Concept-Model implementation when it's worth it.
 struct TargetMLTransformInfo {
-  unsigned defaultMaxReductionUnrollFactor = 8;
+  unsigned defaultMaxUnrollFactor = 8;
   unsigned defaultMaxTransposeUnrollFactor =
       std::numeric_limits<unsigned>::max();
 


### PR DESCRIPTION
We have been trying to selectively limit unrolling on RISC-V for those
cases that lead to register spilling. Unfortunately, it's becoming a
never-ending problem so this PR is limiting unrolling to 8 by default on
RISC-V while keeping unrolling of transpose operations disabled. That
seems to get rid of register spilling altogether. This sets a good
starting point for further unrolling tuning.