### PR TITLE
Reactivate reduction test and improve strategy.

### DIFF
--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -26,7 +26,7 @@ endif()
 iree_lit_test_suite(
     name = "lit",
     srcs = [
-        # "reduction.mlir", // see #10398
+        "reduction.mlir",
         "softmax.mlir",
     ],
     cfg = "//tests:lit.cfg.py",

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "reduction.mlir"
     "softmax.mlir"
   TOOLS
     FileCheck

--- a/tests/transform_dialect/cuda/reduction.mlir
+++ b/tests/transform_dialect/cuda/reduction.mlir
@@ -1,21 +1,24 @@
-func.func @reduce() -> (tensor<8xf32>) {
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @reduce() -> (!out_tensor_t) {
   %cst = arith.constant -0.000000e+00 : f32
 
   // Note: arith.constant is good for our purposes here but it may be useful to use
   // util.unfoldable_constant.
-  %arg = arith.constant dense<1.0> : tensor<8x64xf32>
-  %0 = linalg.init_tensor [8] : tensor<8xf32>
-  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<8xf32>) ->   tensor<8xf32>
+  %arg = arith.constant dense<1.0> : !in_tensor_t
+  %0 = linalg.init_tensor [8] : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->   !out_tensor_t
   %2 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0)>],
     iterator_types = ["parallel", "reduction"]}
-    ins(%arg : tensor<8x64xf32>) outs(%1 : tensor<8xf32>) {
+    ins(%arg : !in_tensor_t) outs(%1 : !out_tensor_t) {
       ^bb0(%arg3: f32, %arg4: f32):
         %3 = arith.addf %arg3, %arg4 : f32
         linalg.yield %3 : f32
-      } -> tensor<8xf32>
-  return %2 : tensor<8xf32>
+      } -> !out_tensor_t
+  return %2 : !out_tensor_t
 }
 
 // RUN: iree-opt %s --iree-hal-target-backends=cuda \
@@ -26,17 +29,7 @@ func.func @reduce() -> (tensor<8xf32>) {
 // RUN:     --iree-hal-configuration-pipeline | \
 // RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' \
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
-// RUN: FileCheck %s --check-prefix=FLOW-AND-CG --check-prefix=CHECK
-
-// RUN: iree-opt %s --iree-hal-target-backends=cuda \
-// RUN:     --iree-abi-transformation-pipeline \
-// RUN:     --iree-flow-transformation-pipeline  \
-// RUN:     --iree-stream-transformation-pipeline \
-// RUN:     --iree-hal-configuration-pipeline | \
-// RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' \
-// RUN:     --iree-codegen-llvmgpu-workgroup-tile-sizes=4 \
-// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
-// RUN: FileCheck %s --check-prefix=CG-ONLY --check-prefix=CHECK
+// RUN: FileCheck %s --check-prefix=CHECK
 
 // RUN: iree-compile %s --iree-hal-target-backends=cuda \
 // RUN:     --iree-flow-dispatch-use-transform-dialect=%p/reduction_dispatch_spec.mlir \
@@ -44,74 +37,39 @@ func.func @reduce() -> (tensor<8xf32>) {
 // RUN: iree-run-module --entry_function=reduce --device=cuda |\
 // RUN: FileCheck %s --check-prefix=EXEC
 
-// RUN: iree-compile %s --iree-hal-target-backends=cuda \
-// RUN:     --iree-codegen-llvmgpu-workgroup-tile-sizes=4 \
-// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
-// RUN: iree-run-module --entry_function=reduce --device=cuda |\
-// RUN: FileCheck %s --check-prefix=EXEC
-
   //     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
   //     CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
-  //     CHECK-DAG: %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<1xf32>
-  //     CG-ONLY-DAG: %[[FMINUS0:.*]] = arith.constant dense<-0.000000e+00> : vector<1xf32>
+  //     CHECK-DAG: %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
+  //     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+  //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 128 : i64} : memref<1x2xf32, 3>
   //     CHECK-DAG: %[[TIDX:.]] = gpu.thread_id  x
   //     CHECK-DAG: %[[TIDY:.]] = gpu.thread_id  y
   //     CHECK-DAG: %[[TIDZ:.]] = gpu.thread_id  z
 
-  // When using IREE default flow path, fill op is being fused with the generic
-  // op, the rest of the IR generated is the same.
-  //       CG-ONLY: %[[CMP0:.*]] = arith.cmpi ult, %[[TIDX]], %[[C1]] : index
-  //       CG-ONLY: %[[CMP1:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
-  //       CG-ONLY: %[[CONXANDYARE0:.*]] = arith.andi %[[CMP0]], %[[CMP1]] : i1
-  //       CG-ONLY: scf.if %[[CONXANDYARE0]] {
-  //       CG-ONLY:   %[[SUBVIEW:.*]] = memref.subview %{{.*}}[%[[TIDZ]]] [1] [1] : memref<4xf32, {{.*}}> to memref<f32, {{.*}}>
-  //       CG-ONLY:   %[[EXPAND:.*]] = memref.expand_shape %[[SUBVIEW]] [] : memref<f32, {{.*}}> into memref<1xf32, {{.*}}>
-  //       CG-ONLY:   vector.transfer_write %[[FMINUS0]], %[[EXPAND]][%[[C0]]] {in_bounds = [true]} : vector<1xf32>, memref<1xf32, {{.*}}>
-  //       CG-ONLY: }
-  //       CG-ONLY: gpu.barrier
-  //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 128 : i64} : memref<4x2xf32, 3>
-  //         CHECK: %[[SHMEM_VIEW:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]
-  //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.expand_shape %[[SHMEM_VIEW]] [] : memref<f32, {{.*}}> into memref<1x1xf32, {{.*}}>
-  //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
-
-  // Distributed fill to shared memory, only threadIdx.x == 0 writes.
-  //         CHECK: scf.if %[[CONDXIS0]]
-  //         CHECK:   vector.transfer_write %[[F0]], %[[SHMEM_VIEW_EXPANDED]][%[[C0]], %[[C0]]]
-  //         CHECK: gpu.barrier
-
-  // Note some inefficiencies here: all threads read + addf but only threadIdx.x==0 commits.
-  // So only threadIdx.x == 0 could do that.
-  // Additionally, the value read is exactly the "Distributed fill to shared memory" from above
-  // and there is no interleaved read/write so we could fold this read into only
-  // %[[F0]] and only write back to shared memory.
-  //
-  // Note: This will probably happen once the fill is fused into the split op at the linalg level.
-  //         CHECK: %[[NEUTRAL_VEC:.*]] = vector.transfer_read %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}vector<1xf32>
+  //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
 
   // Distributed reduction: everyone loads then 5 xor + addf expected
-  //         CHECK: vector.transfer_read %{{.*}}[%[[C0]], %[[C0]], %[[TIDX]]]
-  // TODO: Some foldings are missing, no need to be in vector<1xf32>.
-  //         CHECK: %[[NEUTRAL:.*]] = vector.extract %[[NEUTRAL_VEC]][0] : vector<1xf32>
+  //         CHECK: vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
   // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
-  //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}, %[[NEUTRAL]]
+  //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}
 
-  // TODO: Some foldings are missing, no need to be in vector<1xf32>.
-  //         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<1xf32>
+  //         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+  //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
   //         CHECK: scf.if %[[CONDXIS0]]
-  //         CHECK:   vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][%[[C0]], %[[C0]]]
+  //         CHECK:   vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
   //         CHECK: gpu.barrier
 
   // Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
-  //   FLOW-AND-CG: %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
+  //         CHECK: %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
   //          TODO: cond eq 0 and cond ult 1 do not CSE atm.
-  //   FLOW-AND-CG: %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
+  //         CHECK: %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
   //         CHECK: scf.if %[[CONXANDYARE0]] {
-  // CHECK-COUNT-2:   vector.transfer_read
+  //         CHECK:   vector.transfer_read
   //         CHECK:   vector.reduction <add>
   //         CHECK:   vector.transfer_write
   //         CHECK: gpu.barrier
-  //         CHECK: memref.dealloc %[[SHMEM_ALLOC]] : memref<4x2xf32, 3>
+  //         CHECK: memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
 
 
 //      EXEC: result[0]: hal.buffer_view

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -2,37 +2,53 @@
 
 transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+
+  // Split the reduction by 2 to obtain a more meaty parallel op with
+  // parallelism across size(reduction) / 2 threads.
   %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op
-  %fused_fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
-  // Note: split by 32 to vector-distribute the tail combiner_op, but
-  // split by 2 to vector-distribute the meaty %more_parallel_op
-  %init_or_alloc_op, %fill_op, %more_parallel_op, %combiner_op =
+  %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
     transform.structured.split_reduction %0
-      { split_factor = 2, insert_split_dimension = 1, use_alloc }
+      { split_factor = 2, insert_split_dimension = 1 }
 
-  %1 = transform.structured.match ops{["linalg.generic"]} in %variant_op
-  %foreach_thread_1, %tiled_fill =
-    transform.structured.tile_to_foreach_thread_op %fill_op num_threads [4, 2] (mapped to dims [2, 1, 0])
-  %foreach_thread_2, %tiled_more_parallel_op =
-      transform.structured.tile_to_foreach_thread_op %more_parallel_op num_threads [4, 2] (mapped to dims [2, 1, 0])
-  %foreach_thread_3, %tiled_combiner_op =
-    transform.structured.tile_to_foreach_thread_op %combiner_op num_threads [4] (mapped to dims [2, 1, 0])
-  %foreach_thread_4, %tiled_fused_fill_op =
-    transform.structured.tile_to_foreach_thread_op %fused_fill num_threads [4] (mapped to dims [2, 1, 0])
+  // First level of tiling + fusion parallelizes to blocks.
+  // The mapping to block ids can only happen after bufferization atm.
+  %foreach_thread_grid, %grid_combiner_op =
+    transform.structured.tile_to_foreach_thread_op %combiner_op tile_sizes [1]
+  %not_combiner = transform.merge_handles %fill, %more_parallel_fill_op, %more_parallel_op
+  transform.structured.fuse_into_containing_op %not_combiner into %foreach_thread_grid
 
-  %isolated_handle_1 = transform.get_closest_isolated_parent %foreach_thread_2
-  %isolated_handle_2 = transform.structured.vectorize %isolated_handle_1
-  %isolated_handle_3 = transform.iree.apply_patterns %isolated_handle_2 { rank_reducing }
+  // Second level of tiling + fusion parallelizes to threads.
+  // The mapping to thread ids can only happen after bufferization atm.
+  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
+
+  %grid_more_parallel_op = transform.structured.match interface{LinalgOp}
+    attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %variant_op
+  %foreach_thread_block_more_parallel_op, %block_more_parallel_op =
+    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1, 0] (mapped to dims [2, 1, 0])
+  transform.structured.fuse_into_containing_op %fill_2d into %foreach_thread_block_more_parallel_op
+  
+  // Second level of tiling + fusion parallelizes to threads.
+  // The mapping to thread ids can only happen after bufferization atm.
+  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
+  %foreach_thread_block_combiner_op, %block_combiner_op =
+    transform.structured.tile_to_foreach_thread_op %grid_combiner_op tile_sizes [1, 0, 0] (mapped to dims [2, 1, 0])
+  transform.structured.fuse_into_containing_op %fill_1d into %foreach_thread_block_combiner_op
+
+  %func = transform.structured.match ops{["func.func"]} in %variant_op
+  %func_2 = transform.iree.apply_patterns %func { rank_reducing }
+  %func_3 = transform.structured.vectorize %func_2
 
   %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
 
-  %funcop = transform.structured.match ops{["func.func"]} in %variant_op_2
-  %isolated_handle_4 =
-    transform.iree.foreach_thread_to_gpu_and_translation_info %funcop
-      { workgroup_size = [32, 2, 4] }
+  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
+  %func_6 = transform.iree.foreach_thread_to_gpu_and_translation_info %func_5
+      { workgroup_size = [32, 2, 1] }
 
   // Vector distribution needs to happen on buffers.
+  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
-  transform.iree.vector.warp_distribute %isolated_handle_4
+  transform.iree.vector.warp_distribute %func_7
 }

--- a/tests/transform_dialect/cuda/reduction_dispatch_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_dispatch_spec.mlir
@@ -1,8 +1,15 @@
 // RUN: iree-opt %s
 
-transform.structured.canonicalized_sequence failures(propagate) {
-^bb1(%arg1: !pdl.operation):
-  %0 = transform.structured.match ops{["linalg.generic"]} in %arg1
-  %foreach_thread, %tiled_generic = transform.structured.tile_to_foreach_thread_op %0 num_threads [2]
-  transform.iree.foreach_thread_to_flow %foreach_thread
+// Dispatch reduction.
+transform.structured.canonicalized_sequence failures(propagate){
+^bb1(%variant_op: !pdl.operation):
+  %root = transform.structured.match interface{LinalgOp}
+    attributes{iterator_types = ["parallel", "reduction"]} in %variant_op
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+
+  // TODO: this could be replaced by a C++ only version.
+  // Atm the IR produced is not the same so all pieces do not connect.
+  %region_op = transform.iree.wrap_in_dispatch_region %root
+  %region_op_2 = transform.iree.move_preceding_op_into_dispatch_region %fill into %region_op
+  transform.iree.region_to_workgroups %region_op_2
 }


### PR DESCRIPTION
This revision reactivates the reduction unit test and provides the necessary fixes to both upstream and IREE to
get a good mapping.

The strategy introduced in this PR weak scales up to ~92% of memset BW at 39.84 MB as illustrated below.
The key there is to ensure `load4` instructions are emitted in addition to the `shfl` instructions.

```
==355359== Profiling result:
    Start  Duration            Grid Size      Block Size     Regs*    SSMem*    DSMem*      Size  Throughput  SrcMemType  DstMemType           Device   Context    Stream        Unified Memory  Virtual Address  Name
479.92ms  74.341us                    -               -         -         -         -  39.844MB  523.40GB/s      Device           -  NVIDIA GeForce          1        13                     -                -  [CUDA memset]
480.00ms  3.4560us                    -               -         -         -         -  39.844KB  10.995GB/s     Managed           -  NVIDIA GeForce          1        13                     -                -  [CUDA memset]
480.00ms  81.188us          (10200 1 1)        (32 8 1)        17        0B       36B         -           -           -           -  NVIDIA GeForce          1        13                     -                -  reduce_dispatch_0_generic_10200x1024 [25]
480.47ms         -                    -               -         -         -         -         -           -           -           -                -         -         -         PC 0xc7e307e5   0x7fc034000000  [Unified Memory CPU page faults]
480.55ms  1.4080us                    -               -         -         -         -         -           -           -           -  NVIDIA GeForce          -         -            4.000000KB   0x7fc034000000  [Unified Memory Memcpy DtoH]
480.55ms  7.1360us                    -               -         -         -         -         -           -           -           -  NVIDIA GeForce          -         -           36.000000KB   0x7fc034001000  [Unified Memory Memcpy DtoH]
```

This also prefetches the necessary upstream MLIR commits.
    
    bcf36ea60f4c9e334fba3abe5f6a1d69a58c054f
    38bbabe80af1a109c6227adf6e3b96aecbd2f0cd
    
Fixes #10398
