### PR TITLE
Add elementwise fusion on multiuse ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -116,7 +116,7 @@ struct FuseElementwiseOpsWithMultipleUses
       return rewriter.notifyMatchFailure(consumerOp, "failed to get producer");
     }
     OpOperand *fusedOperand = fusedOperandIt;
-    assert(linalg::areElementwiseOpsFusable(fusedOperand.getValue()) &&
+    assert(linalg::areElementwiseOpsFusable(fusedOperand) &&
            "expected producer and consumer to be fusable");
     Operation *producerOp = fusedOperand->get().getDefiningOp();
     FailureOr<Operation *> fusedOperation =

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -118,7 +118,7 @@ struct FuseElementwiseOpsWithMultipleUses
     OpOperand *fusedOperand = fusedOperandIt;
     assert(linalg::areElementwiseOpsFusable(fusedOperand.getValue()) &&
            "expected producer and consumer to be fusable");
-    Operation *producerOp = fusedOperand->getDefiningOp();
+    Operation *producerOp = fusedOperand->get().getDefiningOp();
     FailureOr<Operation *> fusedOperation =
         linalg::fuseElementwiseOps(rewriter, fusedOperand);
     if (failed(fusedOperation)) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -195,6 +195,12 @@ class FusionOfTensorOpsPass
   FusionOfTensorOpsPass(const FusionOfTensorOpsPass &pass)
       : fuseMultiUse(pass.fuseMultiUse) {}
 
+  LogicalResult initializeOptions(StringRef options) override {
+    if (failed(Pass::initializeOptions(options))) return failure();
+    fuseMultiUse = fuseMultiUseOption;
+    return success();
+  }
+
   void runOnOperation() override {
     Operation *funcOp = getOperation();
     MLIRContext *context = funcOp->getContext();
@@ -331,7 +337,6 @@ class FusionOfTensorOpsPass
   }
 
  private:
-  // Fuse ops with multiuse.
   bool fuseMultiUse;
 };
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -185,25 +185,17 @@ static FailureOr<unsigned> fuseMultiUseProducers(Operation *funcOp,
 
 /// Pass to fuse linalg on tensor operations as well as fusion of hal.interface*
 /// operations with linalg.tensor_reshape operation.
-class FusionOfTensorOpsPass
+struct FusionOfTensorOpsPass
     : public FusionOfTensorOpsBase<FusionOfTensorOpsPass> {
- public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<AffineDialect, linalg::LinalgDialect, math::MathDialect>();
   }
-  FusionOfTensorOpsPass(bool fuseMultiUse, unsigned multiUseFusionIteration)
-      : fuseMultiUse(fuseMultiUse),
-        multiUseFusionIteration(multiUseFusionIteration) {}
+  FusionOfTensorOpsPass(bool fuseMultiUse, unsigned multiUseFusionIteration) {
+    this->fuseMultiUse = fuseMultiUse;
+    this->multiUseFusionIteration = multiUseFusionIteration;
+  }
   FusionOfTensorOpsPass(const FusionOfTensorOpsPass &pass)
-      : fuseMultiUse(pass.fuseMultiUse),
-        multiUseFusionIteration(pass.multiUseFusionIteration) {}
-
-  LogicalResult initializeOptions(StringRef options) override {
-    if (failed(Pass::initializeOptions(options))) return failure();
-    // Initialize fusion options from the pass options.
-    fuseMultiUse = fuseMultiUseOption;
-    multiUseFusionIteration = multiUseFusionIterationOption;
-    return success();
+      : FusionOfTensorOpsPass(pass.fuseMultiUse, pass.multiUseFusionIteration) {
   }
 
   void runOnOperation() override {
@@ -340,10 +332,6 @@ class FusionOfTensorOpsPass
       }
     }
   }
-
- private:
-  bool fuseMultiUse;
-  unsigned multiUseFusionIteration;
 };
 
 }  // namespace

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -84,10 +84,11 @@ static llvm::cl::opt<bool> clEnableLinalgDetensorize(
     llvm::cl::desc("Enable detensorizing linalg ops to operate on primitives"),
     llvm::cl::init(true));
 
-static llvm::cl::opt<bool> clEnableFusionOnMultiUseAndReduction(
-    "iree-flow-enable-fusion-on-multi-use-and-reduction",
-    llvm::cl::desc("Enable the fusion heuristic to fuse multiuse ops and ops "
-                   "with reduction loops"),
+static llvm::cl::opt<bool> clEnableAggressiveFusion(
+    "iree-flow-enable-aggressive-fusion",
+    llvm::cl::desc(
+        "Enable the aggressive fusion heuristic to fuse multiuse ops and ops "
+        "with reduction loops"),
     llvm::cl::init(false));
 
 static llvm::cl::opt<std::string> clMmt4dTargetOptions(
@@ -247,7 +248,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
 
   // Elementwise fusion.
   passManager.addNestedPass<func::FuncOp>(
-      createFusionOfTensorOpsPass(clEnableFusionOnMultiUseAndReduction));
+      createFusionOfTensorOpsPass(clEnableAggressiveFusion));
 
   FunctionLikeNest(passManager)
       .addPredicatedPass(clEnableLinalgDetensorize,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -246,7 +246,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(mlir::createCSEPass);
 
   // Elementwise fusion.
-  passManager.addNestedPass<func::FuncOp>(createFusionOfTensorOpsPass());
+  passManager.addNestedPass<func::FuncOp>(
+      createFusionOfTensorOpsPass(clEnableFusionOnMultiUseAndReduction));
 
   FunctionLikeNest(passManager)
       .addPredicatedPass(clEnableLinalgDetensorize,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -244,15 +244,11 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(createInterchangeGenericOpsPass)
       .addPass(memref::createResolveShapedTypeResultDimsPass)
       .addPass(mlir::createCanonicalizerPass)
-      .addPass(mlir::createCSEPass);
-
-  // Elementwise fusion.
-  passManager.addNestedPass<func::FuncOp>(
-      createFusionOfTensorOpsPass(clEnableAggressiveFusion));
-  passManager.addNestedPass<IREE::Util::InitializerOp>(
-      createFusionOfTensorOpsPass(clEnableAggressiveFusion));
-
-  FunctionLikeNest(passManager)
+      .addPass(mlir::createCSEPass)
+      // Elementwise fusion.
+      .addPass([]() {
+        return createFusionOfTensorOpsPass(clEnableAggressiveFusion);
+      })
       .addPredicatedPass(clEnableLinalgDetensorize,
                          mlir::createLinalgDetensorizePass)
       .addPass(mlir::createCanonicalizerPass)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -249,6 +249,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   // Elementwise fusion.
   passManager.addNestedPass<func::FuncOp>(
       createFusionOfTensorOpsPass(clEnableAggressiveFusion));
+  passManager.addNestedPass<IREE::Util::InitializerOp>(
+      createFusionOfTensorOpsPass(clEnableAggressiveFusion));
 
   FunctionLikeNest(passManager)
       .addPredicatedPass(clEnableLinalgDetensorize,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -97,7 +97,8 @@ std::unique_ptr<Pass> createConvertLinalgMatmulToMmt4DPass(StringRef options);
 std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
 
 // Creates a pass to fuse Linalg operations on tensors.
-std::unique_ptr<Pass> createFusionOfTensorOpsPass();
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createFusionOfTensorOpsPass();
 
 // Infers and inserts util.numeric.optional_narrow ops at points that may be
 // beneficial.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -98,7 +98,7 @@ std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
 
 // Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createFusionOfTensorOpsPass();
+createFusionOfTensorOpsPass(bool fuseMultiUse = false);
 
 // Infers and inserts util.numeric.optional_narrow ops at points that may be
 // beneficial.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -98,7 +98,8 @@ std::unique_ptr<Pass> createDetachElementwiseFromNamedOpsPass();
 
 // Creates a pass to fuse Linalg operations on tensors.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createFusionOfTensorOpsPass(bool fuseMultiUse = false);
+createFusionOfTensorOpsPass(bool fuseMultiUse = false,
+                            unsigned multiUseFusionIteration = 2);
 
 // Infers and inserts util.numeric.optional_narrow ops at points that may be
 // beneficial.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -101,6 +101,10 @@ def FusionOfTensorOps :
     InterfacePass<"iree-flow-fusion-of-tensor-ops", "mlir::FunctionOpInterface"> {
   let summary = "Fuse operations on tensors";
   let constructor = "mlir::iree_compiler::IREE::Flow::createFusionOfTensorOpsPass()";
+  let options = [
+    Option<"fuseMultiUseOption", "fuse-multi-use", "bool",
+           /*default=*/"false", "Fuse ops with multiuse">
+  ];
 }
 
 def InferNumericNarrowing :

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -102,9 +102,9 @@ def FusionOfTensorOps :
   let summary = "Fuse operations on tensors";
   let constructor = "mlir::iree_compiler::IREE::Flow::createFusionOfTensorOpsPass()";
   let options = [
-    Option<"fuseMultiUseOption", "fuse-multi-use", "bool",
+    Option<"fuseMultiUse", "fuse-multi-use", "bool",
            /*default=*/"false", "Fuse ops with multiuse">,
-    Option<"multiUseFusionIterationOption", "multi-use-fusion-iteration", "unsigned",
+    Option<"multiUseFusionIteration", "multi-use-fusion-iteration", "unsigned",
            /*default=*/"2", "Number of iterations to fuse multiuse ops">
   ];
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -103,7 +103,9 @@ def FusionOfTensorOps :
   let constructor = "mlir::iree_compiler::IREE::Flow::createFusionOfTensorOpsPass()";
   let options = [
     Option<"fuseMultiUseOption", "fuse-multi-use", "bool",
-           /*default=*/"false", "Fuse ops with multiuse">
+           /*default=*/"false", "Fuse ops with multiuse">,
+    Option<"multiUseFusionIterationOption", "multi-use-fusion-iteration", "unsigned",
+           /*default=*/"2", "Number of iterations to fuse multiuse ops">
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -98,7 +98,7 @@ def ExportBenchmarkFuncs :
 }
 
 def FusionOfTensorOps :
-    Pass<"iree-flow-fusion-of-tensor-ops", ""> {
+    InterfacePass<"iree-flow-fusion-of-tensor-ops", "mlir::FunctionOpInterface"> {
   let summary = "Fuse operations on tensors";
   let constructor = "mlir::iree_compiler::IREE::Flow::createFusionOfTensorOpsPass()";
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -30,6 +30,7 @@ iree_lit_test_suite(
             "dispatch_linalg_transform_dialect.mlir",
             "expand_tensor_shapes.mlir",
             "export_benchmark_funcs.mlir",
+            "fusion_of_tensor_ops.mlir",
             "infer_numeric_narrowing.mlir",
             "initialize_empty_tensor.mlir",
             "inject_dispatch_tracing.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_lit_test_suite(
     "dispatch_linalg_transform_dialect.mlir"
     "expand_tensor_shapes.mlir"
     "export_benchmark_funcs.mlir"
+    "fusion_of_tensor_ops.mlir"
     "infer_numeric_narrowing.mlir"
     "initialize_empty_tensor.mlir"
     "inject_dispatch_tracing.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fusion_of_tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fusion_of_tensor_ops.mlir
@@ -1,0 +1,123 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="func.func(iree-flow-fusion-of-tensor-ops{fuse-multi-use=true})" %s | FileCheck %s
+
+func.func @softmax(%arg0 : tensor<12x128x128xf32>) -> tensor<12x128x128xf32> {
+  %cst = arith.constant 1.000000e+00 : f32
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %1 = linalg.init_tensor [12, 128] : tensor<12x128xf32>
+  %2 = linalg.fill ins(%cst_1 : f32) outs(%1 : tensor<12x128xf32>) -> tensor<12x128xf32>
+  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%arg0 : tensor<12x128x128xf32>) outs(%2 : tensor<12x128xf32>) {
+  ^bb0(%b0: f32, %b1: f32):
+    %11 = arith.maxf %b0, %b1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128xf32>
+  %4 = linalg.init_tensor [12, 128, 128] : tensor<12x128x128xf32>
+  %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%arg0, %3 : tensor<12x128x128xf32>, tensor<12x128xf32>) outs(%4 : tensor<12x128x128xf32>) {
+  ^bb0(%b0: f32, %b1: f32, %arg2: f32):
+    %11 = arith.subf %b0, %b1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128x128xf32>
+  %6 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5 : tensor<12x128x128xf32>) outs(%4 : tensor<12x128x128xf32>) {
+  ^bb0(%b0: f32, %b1: f32):
+    %11 = math.exp %b0 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128x128xf32>
+  %7 = linalg.fill ins(%cst_0 : f32) outs(%1 : tensor<12x128xf32>) -> tensor<12x128xf32>
+  %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%6 : tensor<12x128x128xf32>) outs(%7 : tensor<12x128xf32>) {
+  ^bb0(%b0: f32, %b1: f32):
+    %11 = arith.addf %b0, %b1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128xf32>
+  %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%8 : tensor<12x128xf32>) outs(%1 : tensor<12x128xf32>) {
+  ^bb0(%b0: f32, %b1: f32):
+    %11 = arith.divf %cst, %b0 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128xf32>
+  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%6, %9 : tensor<12x128x128xf32>, tensor<12x128xf32>) outs(%4 : tensor<12x128x128xf32>) {
+  ^bb0(%b0: f32, %b1: f32, %arg2: f32):
+    %11 = arith.mulf %b0, %b1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128x128xf32>
+  return %10 : tensor<12x128x128xf32>
+}
+// CHECK-LABEL: func.func @softmax
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<12x128x128xf32>
+//       CHECK:   %[[INIT0:.+]] = linalg.init_tensor [12, 128]
+//       CHECK:   %[[FILL0:.+]] = linalg.fill
+//  CHECK-SAME:       outs(%[[INIT0]] :
+//       CHECK:   %[[GENERIC0:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0]] :
+//  CHECK-SAME:       outs(%[[FILL0]] :
+//       CHECK:   %[[INIT1:.+]] = linalg.init_tensor [12, 128, 128]
+//       CHECK:   %[[FILL1:.+]] = linalg.fill
+//  CHECK-SAME:       outs(%[[INIT0]] :
+//       CHECK:   %[[GENERIC1:.+]]:2 = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0]], %[[GENERIC0]] :
+//  CHECK-SAME:       outs(%[[INIT1]], %[[FILL1]] :
+//       CHECK:   %[[GENERIC2:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[GENERIC1]]#0, %[[GENERIC1]]#1 :
+//  CHECK-SAME:       outs(%[[INIT1]] :
+//       CHECK:   return %[[GENERIC2]]
+
+// -----
+
+func.func @batchnorm_training(%10 : tensor<12xf32>, %11 : tensor<12x12x12x12x12xf32>, %12 : tensor<12xf32>) -> (tensor<12xf32>, tensor<12xf32>, tensor<12xf32>)
+{
+  %cst = arith.constant 1.42 : f32
+  %cst_1 = arith.constant 1.45 : f32
+  %cst_0 = arith.constant 1.3 : f32
+  %cst_2 = arith.constant 0.0 : f32
+  %13 = linalg.init_tensor [12] : tensor<12xf32>
+  %14 = linalg.fill ins(%cst_2 : f32) outs(%13 : tensor<12xf32>) -> tensor<12xf32>
+  %15 = linalg.generic {
+      indexing_maps = [affine_map<(d0, d1, d2, d3, d4) -> (d1, d2, d3, d4, d0)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d0)>,
+                       affine_map<(d0, d1, d2, d3, d4) -> (d0)>],
+      iterator_types = ["parallel", "reduction", "reduction", "reduction", "reduction"]}
+      ins(%11, %12 : tensor<12x12x12x12x12xf32>, tensor<12xf32>) outs(%14 : tensor<12xf32>) {
+    ^bb0(%arg1: f32, %arg2: f32, %arg3: f32):
+      %19 = arith.subf %arg1, %arg2 : f32
+      %20 = arith.mulf %19, %19 : f32
+      %21 = arith.addf %arg3, %20 : f32
+      linalg.yield %21 : f32
+    } -> tensor<12xf32>
+  %16 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+      ins(%15: tensor<12xf32>) outs(%13 : tensor<12xf32>) {
+    ^bb0(%arg1: f32, %arg2 : f32):
+      %19 = arith.divf %arg1, %cst_1 : f32
+      %20 = arith.addf %19, %cst_0 : f32
+      linalg.yield %20 : f32
+    } -> tensor<12xf32>
+  %17 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%16 : tensor<12xf32>) outs(%13 : tensor<12xf32>) {
+    ^bb0(%arg1: f32, %arg2 : f32):
+      %19 = math.sqrt %arg1 : f32
+      linalg.yield %19 : f32
+    } -> tensor<12xf32>
+  %18 = linalg.generic {
+      indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]}
+      {__internal_linalg_transform__ = "tensor_fuse_err"}
+      ins(%10, %17 : tensor<12xf32>, tensor<12xf32>) outs(%13 : tensor<12xf32>)  {
+    ^bb0(%arg1: f32, %arg2: f32, %arg3 : f32):
+      %19 = arith.subf %arg1, %arg2 : f32
+      %20 = arith.mulf %19, %cst : f32
+      %21 = arith.subf %arg1, %20 : f32
+      linalg.yield %21 : f32
+    } -> tensor<12xf32>
+  return %16, %17, %18 : tensor<12xf32>, tensor<12xf32>, tensor<12xf32>
+}
+// CHECK-LABEL: func @batchnorm_training(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<12xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<12x12x12x12x12xf32>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<12xf32>
+//       CHECK:   %[[INIT:.+]] = linalg.init_tensor [12] : tensor<12xf32>
+//       CHECK:   %[[FILL:.+]] = linalg.fill
+//  CHECK-SAME:       outs(%[[INIT]] :
+//       CHECK:   %[[GENERIC0:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG1]], %[[ARG2]] :
+//  CHECK-SAME:       outs(%[[FILL]] :
+//       CHECK:   %[[GENERIC1:.+]]:3 = linalg.generic
+//  CHECK-SAME:       ins(%[[ARG0]], %[[GENERIC0]] :
+//  CHECK-SAME:       outs(%[[INIT]], %[[INIT]], %[[INIT]] :
+//       CHECK:   return %[[GENERIC1]]#0, %[[GENERIC1]]#1, %[[GENERIC1]]#2


### PR DESCRIPTION
Add the option to enable elementwise fusion on multiuse ops.

The code is guarded by `iree-flow-enable-aggressive-fusion` and disabled by default. We need some fixes in the backends to make this work.