### PR TITLE
Add lld dep to transform test

### DIFF
--- a/tests/transform_dialect/cpu/BUILD
+++ b/tests/transform_dialect/cpu/BUILD
@@ -35,6 +35,7 @@ iree_lit_test_suite(
         "//tools:iree-compile",
         "//tools:iree-opt",
         "//tools:iree-run-module",
+        "@llvm-project//lld",
         "@llvm-project//llvm:FileCheck",
     ],
 )

--- a/tests/transform_dialect/cpu/CMakeLists.txt
+++ b/tests/transform_dialect/cpu/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "matmul.mlir"
   TOOLS
+    ${IREE_LLD_TARGET}
     FileCheck
     iree-benchmark-module
     iree-compile


### PR DESCRIPTION
Else running into

```
required embedded linker tool (typically `lld`) not found
```