### PR TITLE
Only enable CUDA benchmarks when IREE_TARGET_BACKEND_CUDA is enabled

### DIFF
--- a/benchmarks/TF/CMakeLists.txt
+++ b/benchmarks/TF/CMakeLists.txt
@@ -34,4 +34,7 @@ set(MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE
 # Add benchmarks for all platforms.                                            #
 ################################################################################
 include(linux-x86_64.cmake)
-include(linux-cuda.cmake)
+
+if(IREE_TARGET_BACKEND_CUDA)
+  include(linux-cuda.cmake)
+endif()


### PR DESCRIPTION
Since we included the CUDA benchmarks into our benchmark suites, CUDA backend became a dependency to build the benchmark suites, while it is not enabled by default.

This change added a check to only include CUDA benchmarks if IREE_TARGET_BACKEND_CUDA is enabled. This makes the target `iree-benchmark-suites` can be built when the CUDA backend is disabled.

Fix #10455