### PR TITLE
[LLVMGPU] Turn on C promotion by default for tensorcore gemm

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -136,20 +136,6 @@ static bool supportsTensorCore(func::FuncOp entryPoint, linalg::LinalgOp op) {
       if (outputMap.getResult(i) != b.getAffineDimExpr(i)) return false;
     }
   }
-  // Check that we support converting any fused operation. When using the
-  // tensorcore pipeline we need to be sure we can generate MMA ops otherwise
-  // the code will be highly inneficent.
-  bool fusedOpSupported = true;
-  entryPoint.walk([&fusedOpSupported](linalg::GenericOp linalgOp) {
-    for (Operation &fusedOp : linalgOp.getOps()) {
-      if (!isa<arith::AddFOp, arith::MulFOp, arith::MaxFOp, arith::MinFOp,
-               linalg::YieldOp, arith::DivFOp>(fusedOp)) {
-        fusedOpSupported = false;
-        break;
-      }
-    }
-  });
-  if (!fusedOpSupported) return false;
   return true;
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUMultiBuffering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUMultiBuffering.cpp
@@ -29,8 +29,10 @@ struct LLVMGPUMultiBufferingPass
     // Collect all the alloc operations.
     funcOp.walk([&](memref::AllocOp allocOp) {
       // Skip allocations not used in a loop.
-      auto loop = allocOp->getUsers().begin()->getParentOfType<scf::ForOp>();
-      if (!loop) return WalkResult::advance();
+      for (Operation* user : allocOp->getUsers()) {
+        auto loop = user->getParentOfType<scf::ForOp>();
+        if (!loop) return WalkResult::advance();
+      }
       allocs.push_back(allocOp);
       return WalkResult::advance();
     });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -36,9 +36,6 @@ using mlir::iree_compiler::IREE::LinalgExt::TilingPatterns;
 namespace mlir {
 namespace iree_compiler {
 
-/// Flag defined in Passes.cpp.
-extern llvm::cl::opt<bool> llvmgpuUseMMASync;
-
 /// Patterns for workgroup level tiling. Workgroup tiling is done at the flow
 /// level but we may have extra tiling for the reduction dimension. Therefore we
 /// tile again without distributing.
@@ -219,31 +216,86 @@ static void populatePromotionPatterns(MLIRContext *context,
           .addFilter(filterFunction));
 }
 
+static bool propagateIntoProducer(memref::CopyOp copyOp) {
+  // Look for a fill Op writing into the copyOp source.
+  Operation *prevOp = copyOp->getPrevNode();
+  while (prevOp) {
+    if (isSideEffectFree(prevOp)) {
+      prevOp = prevOp->getPrevNode();
+      continue;
+    }
+
+    auto fillOp = dyn_cast<linalg::FillOp>(prevOp);
+    if (!fillOp) break;
+    if (fillOp.output() != copyOp.getSource()) break;
+    // Move the fillOp and change the destination to the copy destination.
+    fillOp->moveBefore(copyOp);
+    fillOp.getOutputsMutable().assign(copyOp.getTarget());
+    return true;
+  }
+  return false;
+}
+
+// Split input/output operand from copy from shared memory into a separate
+// input.
+static void mergeCopySourceIntoGeneric(Value source, linalg::GenericOp op) {
+  SmallVector<Value> newOperands;
+  SmallVector<AffineMap> maps;
+  for (auto in : op.getInputOperands()) {
+    newOperands.push_back(in->get());
+    maps.push_back(op.getTiedIndexingMap(in));
+  }
+  newOperands.push_back(source);
+  maps.push_back(op.getTiedIndexingMap(*op.getOutputOperands().begin()));
+  maps.push_back(op.getTiedIndexingMap(*op.getOutputOperands().begin()));
+  Location loc = op.getLoc();
+  SmallVector<StringRef> iterTypes(op.getNumLoops(),
+                                   getParallelIteratorTypeName());
+  OpBuilder builder(op);
+  auto newOp = builder.create<linalg::GenericOp>(
+      loc, newOperands, (*op.getOutputOperands().begin())->get(), maps,
+      iterTypes);
+  newOp.getRegion().getBlocks().splice(newOp.getRegion().begin(),
+                                       op.getRegion().getBlocks());
+
+  Block &payload = newOp.getRegion().front();
+  payload.addArgument(payload.getArguments().back().getType(), loc);
+  setMarker(newOp, getCopyToWorkgroupMemoryMarker());
+}
+
+/// Propagate the shared memory copy into the consumer.
+static bool propagateIntoConsumer(memref::CopyOp copyOp,
+                                  SmallVector<Operation *> &toDelete) {
+  // Look for a generic Op reading the copyOp target.
+  Operation *nextOp = copyOp->getNextNode();
+  while (nextOp) {
+    if (isSideEffectFree(nextOp)) {
+      nextOp = nextOp->getNextNode();
+      continue;
+    }
+    auto consumer = dyn_cast<linalg::GenericOp>(nextOp);
+    if (!consumer || consumer.outputs().size() != 1 ||
+        consumer.getNumLoops() != consumer.getNumParallelLoops())
+      break;
+    if (*consumer.outputs().begin() != copyOp.getTarget()) break;
+    mergeCopySourceIntoGeneric(copyOp.getSource(), consumer);
+    toDelete.push_back(consumer);
+    return true;
+  }
+  return false;
+}
+
 /// Transformation to propagate FillOp + CopyOp to temp allocation.
 /// This is needed because we are doing promotion to shared memory on buffers.
 /// This is a fragile and temporary solution until we move to be able to do this
 /// kind of transformations on tensors.
-static void propagateFillIntoPromotionAlloc(func::FuncOp funcOp) {
+static void propagateSharedMemCopy(func::FuncOp funcOp) {
   SmallVector<Operation *> toDelete;
   funcOp.walk([&toDelete](memref::CopyOp copyOp) {
     if (hasMarker(copyOp, getCopyToWorkgroupMemoryMarker())) {
-      // Look for a fill Op writing into the copyOp source.
-      Operation *prevOp = copyOp->getPrevNode();
-      while (prevOp) {
-        if (isSideEffectFree(prevOp)) {
-          prevOp = prevOp->getPrevNode();
-          continue;
-        }
-
-        auto fillOp = dyn_cast<linalg::FillOp>(prevOp);
-        if (!fillOp) break;
-        if (fillOp.output() != copyOp.getSource()) break;
-        // Move the fillOp and change the destination to the copy destination.
-        fillOp->moveBefore(copyOp);
-        fillOp.getOutputsMutable().assign(copyOp.getTarget());
+      if (propagateIntoProducer(copyOp) ||
+          propagateIntoConsumer(copyOp, toDelete))
         toDelete.push_back(copyOp.getOperation());
-        break;
-      }
     }
   });
   for (Operation *op : toDelete) op->erase();
@@ -269,7 +321,7 @@ struct LLVMGPUTileAndDistributePass
 
     // Promote C matrix and propagate the potential  fill producer into the temp
     // allocation. This needs to be done before reduction tiling.
-    if (llvmgpuUseMMASync) {
+    {
       RewritePatternSet promotionPatterns(&getContext());
       populatePromotionPatterns(context, promotionPatterns, contractOpFilter,
                                 {2});
@@ -277,7 +329,7 @@ struct LLVMGPUTileAndDistributePass
                                               std::move(promotionPatterns)))) {
         return signalPassFailure();
       }
-      propagateFillIntoPromotionAlloc(funcOp);
+      propagateSharedMemCopy(funcOp);
     }
 
     // Tile again at the workgroup level since reduction dimension were
@@ -312,17 +364,17 @@ struct LLVMGPUTileAndDistributePass
       // Insert barriers before and after copies to workgroup memory and skip
       // insert barriers between back to back copy to workgroup memory.
       OpBuilder builder(&getContext());
-      funcOp.walk([&builder](memref::CopyOp copyOp) {
+      funcOp.walk([&builder](Operation *copyOp) {
         if (hasMarker(copyOp, getCopyToWorkgroupMemoryMarker())) {
           Operation *prevOp = copyOp->getPrevNode();
           if (!prevOp || !hasMarker(prevOp, getCopyToWorkgroupMemoryMarker())) {
             builder.setInsertionPoint(copyOp);
-            builder.create<gpu::BarrierOp>(copyOp.getLoc());
+            builder.create<gpu::BarrierOp>(copyOp->getLoc());
           }
           Operation *nextOp = copyOp->getNextNode();
           if (!nextOp || !hasMarker(nextOp, getCopyToWorkgroupMemoryMarker())) {
             builder.setInsertionPointAfter(copyOp);
-            builder.create<gpu::BarrierOp>(copyOp.getLoc());
+            builder.create<gpu::BarrierOp>(copyOp->getLoc());
           }
         }
       });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -257,6 +257,7 @@ struct LLVMGPUVectorToGPUPass
       return signalPassFailure();
     }
     RewritePatternSet patterns(funcOp.getContext());
+    mlir::vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
     populatePrepareVectorToMMAPatterns(patterns, llvmgpuUseMMASync);
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_to_thread.mlir
@@ -68,6 +68,7 @@ hal.executable private @dot_dispatch_0  {
 //     CHECK-DAG:  %[[C1024:.+]] = arith.constant 1024 : index
 //     CHECK-DAG:  %[[BUFFER0:.+]] = memref.alloc() : memref<4x256xf32, 3>
 //     CHECK-DAG:  %[[BUFFER1:.+]] = memref.alloc() : memref<2x4xf32, 3>
+//     CHECK-DAG:  %[[BUFFER2:.+]] = memref.alloc() : memref<2x256xf32, 3>
 //         CHECK:  scf.for %[[K:.+]] = %[[C0]] to %[[C1024]] step %[[C4]] {
 //         CHECK:    gpu.barrier
 //         CHECK:    memref.copy {{.*}}, {{.*}} {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<2x4xf32, strided<[1024, 1], offset: ?>> to memref<2x4xf32, 3>
@@ -78,10 +79,13 @@ hal.executable private @dot_dispatch_0  {
 //         CHECK:      scf.for %[[IND1:.+]] = %{{.*}} to %[[C256]] step %[[C256]] {
 //     CHECK-DAG:        %[[A:.+]] = memref.subview %[[BUFFER1]][%[[IND0]], 0] [2, 4] [1, 1] : memref<2x4xf32, 3> to memref<2x4xf32, strided<[4, 1], offset: ?>, 3>
 //     CHECK-DAG:        %[[B:.+]] = memref.subview %[[BUFFER0]][0, %[[IND1]]] [4, 4] [1, 1] : memref<4x256xf32, 3> to memref<4x4xf32, strided<[256, 1], offset: ?>, 3>
-//     CHECK-DAG:        %[[C:.+]] = memref.subview %{{.*}}[%[[IND0]], %[[IND1]]] [2, 4] [1, 1] : memref<2x256xf32, #{{.*}}> to memref<2x4xf32, strided<[1024, 1], offset: ?>>
-//         CHECK:        linalg.matmul {__internal_linalg_transform__ = "vectorize", {{.*}}} ins(%[[A]], %[[B]] : memref<2x4xf32, strided<[4, 1], offset: ?>, 3>, memref<4x4xf32, strided<[256, 1], offset: ?>, 3>) outs(%[[C]] : memref<2x4xf32, strided<[1024, 1], offset: ?>>)
+//     CHECK-DAG:        %[[C:.+]] = memref.subview %[[BUFFER2]][%[[IND0]], %[[IND1]]] [2, 4] [1, 1] : memref<2x256xf32, 3> to memref<2x4xf32, strided<[256, 1], offset: ?>, 3>
+//         CHECK:        linalg.matmul {__internal_linalg_transform__ = "vectorize", {{.*}}} ins(%[[A]], %[[B]] : memref<2x4xf32, strided<[4, 1], offset: ?>, 3>, memref<4x4xf32, strided<[256, 1], offset: ?>, 3>) outs(%[[C]] : memref<2x4xf32, strided<[256, 1], offset: ?>, 3>)
 //         CHECK:    }
 //         CHECK:  }
+//         CHECK:  gpu.barrier
+//         CHECK:  memref.copy {{.*}}, {{.*}} {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<2x256xf32, 3> to memref<2x256xf32,
+//         CHECK:  gpu.barrier
 
 // -----
 
@@ -148,14 +152,19 @@ builtin.module {
 //     CHECK-DAG:   %[[TX:.*]] = gpu.thread_id  x
 //     CHECK-DAG:   %[[TY:.*]] = gpu.thread_id  y
 //         CHECK:   scf.for %{{.*}} = %[[TY]] to %[[C8]] step %[[C8]] {
-//         CHECK:     %[[TX4:.*]] = affine.apply #[[$MAP]]()[%16]
+//     CHECK-DAG:     %[[TX:.*]] = gpu.thread_id  x
+//     CHECK-DAG:     %[[TY:.*]] = gpu.thread_id  y  
+//         CHECK:     %[[TX4:.*]] = affine.apply #[[$MAP]]()[%[[TX]]]
 //         CHECK:     scf.for %[[IND1:.+]] = %[[TX4]] to %[[C32]] step %[[C32]] {
 //     CHECK-DAG:       memref.subview
 //     CHECK-DAG:       memref.subview
 //     CHECK-DAG:       memref.subview
-//         CHECK:       linalg.batch_matmul {__internal_linalg_transform__ = "vectorize", {{.*}}} ins(%{{.*}}, %{{.*}} : memref<1x1x32xf32, strided<[256, 32, 1], offset: ?>, 3>, memref<1x32x4xf32, strided<[1024, 32, 1], offset: ?>, 3>) outs(%{{.*}} : memref<1x1x4xf32, strided<[2048, 64, 1], offset: ?>>)
+//         CHECK:       linalg.batch_matmul {__internal_linalg_transform__ = "vectorize", {{.*}}} ins(%{{.*}}, %{{.*}} : memref<1x1x32xf32, strided<[256, 32, 1], offset: ?>, 3>, memref<1x32x4xf32, strided<[1024, 32, 1], offset: ?>, 3>) outs(%{{.*}} : memref<1x1x4xf32, strided<[256, 32, 1], offset: ?>, 3>)
 //         CHECK:    }
 //         CHECK:  }
+//         CHECK:  gpu.barrier
+//         CHECK:  memref.copy {{.*}}, {{.*}} {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<1x8x32xf32, 3> to memref<1x8x32xf32
+//         CHECK:  gpu.barrier
 
 // -----
 
@@ -229,6 +238,7 @@ hal.executable private @dot_dispatch_0  {
 //     CHECK-DAG:  %[[C1024:.+]] = arith.constant 1024 : index
 //     CHECK-DAG:  %[[BUFFER0:.+]] = memref.alloc() : memref<4x32xf32, 3>
 //     CHECK-DAG:  %[[BUFFER1:.+]] = memref.alloc() : memref<2x4xf32, 3>
+//     CHECK-DAG:  %[[BUFFER2:.+]] = memref.alloc() : memref<2x32xf32, 3>
 //         CHECK:  scf.for %[[K:.+]] = %[[C0]] to %[[C1024]] step %[[C4]] {
 //         CHECK:    gpu.barrier
 //         CHECK:    memref.copy {{.*}}, {{.*}} {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<2x4xf32, strided<[1024, 1], offset: ?>> to memref<2x4xf32, 3>
@@ -239,10 +249,13 @@ hal.executable private @dot_dispatch_0  {
 //         CHECK:      scf.for %[[IND1:.+]] = %{{.*}} to %[[C32]] step %[[C64]] {
 //     CHECK-DAG:        %[[A:.+]] = memref.subview %[[BUFFER1]][%[[IND0]], 0] [1, 4] [1, 1] : memref<2x4xf32, 3> to memref<1x4xf32, strided<[4, 1], offset: ?>, 3>
 //     CHECK-DAG:        %[[B:.+]] = memref.subview %[[BUFFER0]][0, %[[IND1]]] [4, 1] [1, 1] : memref<4x32xf32, 3> to memref<4x1xf32, strided<[32, 1], offset: ?>, 3>
-//     CHECK-DAG:        %[[C:.+]] = memref.subview %{{.*}}[%[[IND0]], %[[IND1]]] [1, 1] [1, 1] : memref<2x32xf32, #{{.*}}> to memref<1x1xf32, strided<[1024, 1], offset: ?>>
-//         CHECK:        linalg.matmul {__internal_linalg_transform__ = "vectorize", {{.*}}} ins(%[[A]], %[[B]] : memref<1x4xf32, strided<[4, 1], offset: ?>, 3>, memref<4x1xf32, strided<[32, 1], offset: ?>, 3>) outs(%[[C]] : memref<1x1xf32, strided<[1024, 1], offset: ?>>)
+//     CHECK-DAG:        %[[C:.+]] = memref.subview %[[BUFFER2]][%[[IND0]], %[[IND1]]] [1, 1] [1, 1] : memref<2x32xf32, 3> to memref<1x1xf32, strided<[32, 1], offset: ?>, 3>
+//         CHECK:        linalg.matmul {__internal_linalg_transform__ = "vectorize", {{.*}}} ins(%[[A]], %[[B]] : memref<1x4xf32, strided<[4, 1], offset: ?>, 3>, memref<4x1xf32, strided<[32, 1], offset: ?>, 3>) outs(%[[C]] : memref<1x1xf32, strided<[32, 1], offset: ?>, 3>)
 //         CHECK:    }
 //         CHECK:  }
+//         CHECK:  gpu.barrier
+//         CHECK:  memref.copy {{.*}}, {{.*}} {__internal_linalg_transform__ = "copy_to_workgroup_memory"} : memref<2x32xf32, 3> to memref<2x32xf32
+//         CHECK:  gpu.barrier
 
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -476,8 +476,14 @@ hal.executable @mma_fused {
 //           CHECK:   nvvm.cp.async.commit.group
 //           CHECK:   llvm.br
 //       CHECK-NOT:   nvvm.wmma.mma
-//   CHECK-COUNT-8:   llvm.fadd
-//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f32>, f32, f32, f32, f32, f32, f32, f32, f32
+//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f32, 3>, f32, f32, f32, f32, f32, f32, f32, f32
+//           CHECK:   vvm.barrier0
+//           CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//           CHECK:   llvm.fadd {{.*}} : vector<4xf32>
+//           CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//           CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//           CHECK:   llvm.fadd {{.*}} : vector<4xf32>
+//           CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
 
 // mma.sync case:
 //    MMASYNC-LABEL: hal.executable public @mma_fused
@@ -504,12 +510,13 @@ hal.executable @mma_fused {
 //    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
 //    MMASYNC-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
 //    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
-
-// C matrix promotion prevent efficient fusion with matmul consumer, this needs
-// to be fixed to get good performance.
-// MMASYNC-COUNT-32:   llvm.load {{.*}} : !llvm.ptr<vector<8xf32>>
-// MMASYNC-COUNT-32:   llvm.fadd {{.*}} : vector<8xf32>
-// MMASYNC-COUNT-32:   llvm.store {{.*}} : !llvm.ptr<vector<8xf32>>
+//    MMASYNC-COUNT:   nvvm.barrier0
+//    MMASYNC-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    MMASYNC-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
+//    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//    MMASYNC-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    MMASYNC-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
+//    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
 
 
 
@@ -585,7 +592,12 @@ hal.executable @mma_fused_fp16 {
 //           CHECK:   nvvm.cp.async.commit.group
 //           CHECK:   llvm.br
 //       CHECK-NOT:   nvvm.wmma.mma
-//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f16>, vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>
+//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f16, 3>, vector<2xf16>, vector<2xf16>, vector<2xf16>, vector<2xf16>
+//           CHECK:   vvm.barrier0
+//           CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<8xf16>, 3>
+//           CHECK:   llvm.fadd {{.*}} : vector<8xf16>
+//           CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<8xf16>>
+//           CHECK:   vvm.barrier0
 
 // mma.sync case:
 //    MMASYNC-LABEL: hal.executable public @mma_fused_fp16
@@ -684,7 +696,12 @@ hal.executable @mma_fused_fp16 {
 //           CHECK:   nvvm.cp.async.commit.group
 //           CHECK:   llvm.br
 //       CHECK-NOT:   nvvm.wmma.mma
-//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f32>, f32, f32, f32, f32, f32, f32, f32, f32
+//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f32, 3>, f32, f32, f32, f32, f32, f32, f32, f32
+//           CHECK:   vvm.barrier0
+//           CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//           CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//           CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//           CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
 
 // -----
 
@@ -749,7 +766,12 @@ hal.executable @mma_fused_fp16 {
 //           CHECK:   nvvm.cp.async.commit.group
 //           CHECK:   llvm.br
 //       CHECK-NOT:   nvvm.wmma.mma
-//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f32>, f32, f32, f32, f32, f32, f32, f32, f32
+//   CHECK-COUNT-1:   nvvm.wmma.store {{.*}} : !llvm.ptr<f32, 3>, f32, f32, f32, f32, f32, f32, f32, f32
+//           CHECK:   vvm.barrier0
+//           CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//           CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//           CHECK:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//           CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
 
 // -----
 
@@ -1004,5 +1026,3 @@ hal.executable private @shared_mem_transpose  {
 //         CHECK:     llvm.load %{{.*}} {alignment = 4 : i64} : !llvm.ptr<vector<4xf32>>
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : !llvm.ptr<vector<4xf32>, 3>
 //         CHECK:     nvvm.barrier0
-
-// -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/vector_to_gpu.mlir
@@ -147,7 +147,7 @@ func.func @ksplitmatmul_4D_allone(%a: memref<128x16x32x256xf32>) -> vector<1x1x1
 //  CHECK-SAME:[2, 3, 4, 5] [1, 1, 1, 1] [1, 1, 1, 1]
 //  CHECK-SAME: memref<128x16x32x256xf32> to memref<1x1xf32, strided<[131072, 8192], offset: 287749>>
 //       CHECK: vector.transfer_read %[[M]][%[[ID]], %[[ID]]]
-//  CHECK-SAME: {in_bounds = [true, true]} :  memref<1x1xf32, strided<[131072, 8192], offset: 287749>>, vector<1x1xf32>
-//       CHECK: vector.broadcast %{{.*}} : vector<1x1xf32> to vector<1x1x1x1xf32>
+//  CHECK-SAME: {in_bounds = [true]} :  memref<1x1xf32, strided<[131072, 8192], offset: 287749>>, vector<1xf32>
+//       CHECK: vector.broadcast %{{.*}} : vector<1xf32> to vector<1x1x1x1xf32>
 //   CHECK-NOT: vector.transpose
 //       CHECK: return %{{.*}} : vector<1x1x1x1xf32>


### PR DESCRIPTION
Promoting C matrix allows better memory access patterns for the store to global memory. This allows simplify handling fusion with ops when tensorcore is used since we go through shared memory and don't have to rely on the register layout of tensorcores.