### PR TITLE
Fix RISC-V 64 Linux test script

### DIFF
--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -89,6 +89,15 @@ function(iree_hal_cts_test_suite)
       list(APPEND _TRANSLATE_FLAGS "--iree-llvm-target-triple=${_TARGET_TRIPLE}")
     endif()
 
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv" AND
+      RISCV_CPU STREQUAL "rv64" AND
+      NOT  _TRANSLATE_FLAGS MATCHES "iree-llvm-target-triple")
+      # RV64 Linux crosscompile toolchain can support iree-compile with
+      # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
+      # llvm-target-triple is not specified.
+      list(APPEND  _TRANSLATE_FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
+    endif()
+
     # Skip if already created (multiple suites using the same compiler setting).
     iree_package_name(_PACKAGE_NAME)
     if(NOT TARGET ${_PACKAGE_NAME}_${_EXECUTABLES_TESTDATA_NAME}_c)

--- a/build_tools/cmake/run_riscv64_test.sh
+++ b/build_tools/cmake/run_riscv64_test.sh
@@ -15,9 +15,9 @@ set -e
 
 # A QEMU 64 Linux emulator must be available at the path specified by the
 # `QEMU_RV64_BIN` environment variable to run the artifacts under the emulator.
-if [[ -z "${QEMU_RV64_BIN}" ]]; then
-  "${QEMU_RV64_BIN}" "-cpu rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0 \
-  -L ${RISCV_RV64_LINUX_TOOLCHAIN_ROOT}/sysroot $*"
+if [[ ! -z "${QEMU_RV64_BIN}" ]]; then
+  "${QEMU_RV64_BIN}" "-cpu" "rv64,x-v=true,x-k=true,vlen=512,elen=64,vext_spec=v1.0" \
+  "-L" "${RISCV_RV64_LINUX_TOOLCHAIN_ROOT}/sysroot" $*
 fi
 
 # TODO(dcaballe): Add on-device run commands.

--- a/build_tools/cmake/test_riscv64.sh
+++ b/build_tools/cmake/test_riscv64.sh
@@ -79,8 +79,9 @@ ctest --test-dir ${BUILD_RISCV_DIR}/runtime/ --timeout 900 --output-on-failure \
   --no-tests=error --label-exclude \
   '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$|^requires-filesystem$|^requires-dtz$)'
 
-# Test e2e models. Excluding mobilebert and fp16 for now.
+# Test e2e models. Excluding mobilebert, fp16, and lowering_config regression
+# tests for now.
 ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e --timeout 900 --output-on-failure \
   --no-tests=error --label-exclude \
   '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$)' \
-  -E '(bert|fp16)'
+  -E '(bert|fp16|regression_llvm-cpu_lowering_config)'

--- a/build_tools/cmake/test_riscv64.sh
+++ b/build_tools/cmake/test_riscv64.sh
@@ -81,6 +81,7 @@ ctest --test-dir ${BUILD_RISCV_DIR}/runtime/ --timeout 900 --output-on-failure \
 
 # Test e2e models. Excluding mobilebert, fp16, and lowering_config regression
 # tests for now.
+# TODO(#10462): Investigate the lowering_config test issue.
 ctest --test-dir ${BUILD_RISCV_DIR}/tests/e2e --timeout 900 --output-on-failure \
   --no-tests=error --label-exclude \
   '(^nokokoro$|^driver=vulkan$|^driver=cuda$|^vulkan_uses_vk_khr_shader_float16_int8$)' \


### PR DESCRIPTION
The tests can actually be run via QEMU

* Fix iree_hal_cts_test_suite to support RISC-V cross compile
* Need to disable tests/e2e/regression/check_regression_llvm-cpu_lowering_config.mlir in the CI because it hangs indefinitely