### PR TITLE
[WIP] Replace GetBufferDescriptor with memref::extract_strided_metadata

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
+++ b/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXOps.td
@@ -49,6 +49,21 @@ def VMVX_GetBufferDescriptorOp : VMVX_PureOp<"get_buffer_descriptor", [
   }];
 }
 
+def VMX_GetBufferPointerOp : VMVX_PureOp<"get_buffer_point"> {
+  let summary = "Wrap a memref into a !util.buffer";
+  let description = [{
+    The main purpose of this op is to convert a memref type into a
+    !util.buffer.
+  }];
+
+  let arguments = (ins AnyMemRef:$source);
+  let results = (outs Util_BufferType:$base_buffer);
+
+  let assemblyFormat = [{
+    $source `:` type($source) `->` type(results) attr-dict
+  }];
+}
+
 def VMVX_GetRawInterfaceBindingBufferOp : VMVX_PureOp<
     "get_raw_interface_binding_buffer"> {
   let summary = "Gets the raw buffer associated with a binding";


### PR DESCRIPTION
TL;DR Just a sneak peak of what's coming, don't spend time reviewing (at least for now)

The following patch is a draft of the direction we are going with memref::extract_strided_metadata in "MLIR core".  Essentially, this operator has the same semantic as GetBufferDescriptor except that the return `base_buffer` is in the memref space, not the iree one. To close this gap, we introduce a `get_buffer_pointer` operation that is just a wrapper around the returned `base_buffer` memref.

The current patch is not funtional for a lot of cases because the core MLIR logic is still missing the simplification patterns for alloc op (and some other simplifications that were not performed with GetBufferDescriptor.)
(It does work in a handful of cases though!)

The idea here is just to demonstrate what it will look like in the future. (I put comments where the code should be moved (though my suggestion may not be the correct ones!) and what should be removed.)