### PR TITLE
Revert "Only enable CUDA benchmarks when IREE_TARGET_BACKEND_CUDA is enabled"

### DIFF
--- a/benchmarks/TF/CMakeLists.txt
+++ b/benchmarks/TF/CMakeLists.txt
@@ -34,7 +34,4 @@ set(MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE
 # Add benchmarks for all platforms.                                            #
 ################################################################################
 include(linux-x86_64.cmake)
-
-if(IREE_TARGET_BACKEND_CUDA)
-  include(linux-cuda.cmake)
-endif()
+include(linux-cuda.cmake)


### PR DESCRIPTION
Reverts iree-org/iree#10457 that breaks the benchmark pipeline.