### PR TITLE
Use mlir's map_nested_foreach_thread_to_gpu_threads

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
@@ -38,14 +38,13 @@ struct LLVMGPUDistributePass
     auto workgroupSize = llvm::to_vector(llvm::map_range(
         getEntryPoint(funcOp)->getWorkgroupSize().getValue(),
         [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
-    
+
     IRRewriter rewriter(funcOp->getContext());
     rewriter.setInsertionPoint(funcOp);
     auto walkResult = mlir::linalg::rewriteMapNestedForeachThreadToGpuThreads(
-      rewriter, funcOp, workgroupSize, false);
+        rewriter, funcOp, workgroupSize, false);
 
-    if (walkResult.wasInterrupted())
-      return signalPassFailure();
+    if (walkResult.wasInterrupted()) return signalPassFailure();
   }
 };
 }  // namespace

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
@@ -38,19 +38,14 @@ struct LLVMGPUDistributePass
     auto workgroupSize = llvm::to_vector(llvm::map_range(
         getEntryPoint(funcOp)->getWorkgroupSize().getValue(),
         [&](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
-    SmallVector<scf::ForeachThreadOp> foreachOps;
-    funcOp.walk([&](scf::ForeachThreadOp foreachOp) {
-      foreachOps.push_back(foreachOp);
-    });
-    for (scf::ForeachThreadOp op : foreachOps) {
-      IRRewriter rewriter(op->getContext());
-      rewriter.setInsertionPoint(op);
-      if (failed(
-              rewriteForeachThreadToGpu(op, workgroupSize, rewriter,
-                                        /*syncAfterDistributefalse=*/false))) {
-        return signalPassFailure();
-      }
-    }
+    
+    IRRewriter rewriter(funcOp->getContext());
+    rewriter.setInsertionPoint(funcOp);
+    auto walkResult = mlir::linalg::rewriteMapNestedForeachThreadToGpuThreads(
+      rewriter, funcOp, workgroupSize, false);
+
+    if (walkResult.wasInterrupted())
+      return signalPassFailure();
   }
 };
 }  // namespace

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
@@ -66,6 +66,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LinalgUtils",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:PDLDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_cc_library(
     MLIRFuncDialect
     MLIRGPUOps
     MLIRIR
+    MLIRLinalgTransforms
     MLIRLinalgUtils
     MLIRMemRefDialect
     MLIRPDLDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/IR/Region.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE;
@@ -32,165 +33,6 @@ iree_compiler::IREE::transform_dialect::LLVMGPUExtensions::LLVMGPUExtensions() {
 void mlir::iree_compiler::registerTransformDialectLLVMGPUExtension(
     DialectRegistry &registry) {
   registry.addExtensions<transform_dialect::LLVMGPUExtensions>();
-}
-
-// TODO: Maybe we need both a transform.iree.cpu.bufferize and a
-// transform.iree.gpu.bufferize rather than a single common bufferize op?
-
-/// Apply the permutation `perm` to `vals; i.e. vals[i] is stored into
-/// res[perm[i]] Return failure if perm is not a permutation.
-// TODO: upstream as extraClassDeclaration once stabilized.
-template <typename T>
-static FailureOr<SmallVector<T>> permute(const SmallVector<T> &vals,
-                                         ArrayRef<int64_t> perm) {
-  if (vals.size() != perm.size()) return failure();
-  SmallVector<T> result(vals.size());
-  SmallVector<bool> seen(vals.size());
-  for (auto [idx, val] : llvm::zip(perm, vals)) {
-    // Already seen, invalid thread_dim_mapping.
-    if (seen[idx]) return failure();
-    result[idx] = val;
-    seen[idx] = true;
-  }
-  // Some not seen, invalid thread_dim_mapping.
-  if (!llvm::all_of(seen, [](bool b) { return b; })) return failure();
-  return result;
-}
-
-/// Helper to get apply the `thread_dim_mapping` permutation of a
-/// `foreachThreadOp` to `values`.
-// TODO: upstream as extraClassDeclaration once stabilized.
-template <typename T>
-static FailureOr<SmallVector<T>> getValuesPermutedByThreadMapping(
-    scf::ForeachThreadOp foreachThreadOp, const SmallVector<T> &values) {
-  // Apply mapping permutation if specified.
-  auto mapping = foreachThreadOp.getThreadDimMapping();
-  if (mapping && !mapping.empty()) {
-    auto maybePermuted = permute(values, extractFromI64ArrayAttr(mapping));
-    if (failed(maybePermuted))
-      return foreachThreadOp->emitError("invalid permutation");
-    return *maybePermuted;
-  }
-  return values;
-}
-
-/// Helper to get the `num_threads` of a `foreachThreadOp` after applying the
-/// `thread_dim_mapping` permutation.
-// TODO: upstream as extraClassDeclaration once stabilized.
-static FailureOr<SmallVector<OpFoldResult>> getNumThreads(
-    OpBuilder &b, scf::ForeachThreadOp foreachThreadOp) {
-  SmallVector<OpFoldResult> threadCount = foreachThreadOp.getNumThreads();
-  threadCount.resize(3, b.getIndexAttr(1));
-  return getValuesPermutedByThreadMapping(foreachThreadOp, threadCount);
-}
-
-/// Helper to get the thread indices of a `foreachThreadOp` after applying the
-/// `thread_dim_mapping` permutation.
-// TODO: upstream as extraClassDeclaration once stabilized.
-static FailureOr<SmallVector<Value>> getThreadIndices(
-    OpBuilder &b, scf::ForeachThreadOp foreachThreadOp) {
-  SmallVector<Value> threadCount = foreachThreadOp.getThreadIndices();
-  threadCount.resize(3, Value());
-  return getValuesPermutedByThreadMapping(foreachThreadOp, threadCount);
-}
-
-//===---------------------------------------------------------------------===//
-// Patterns for ForeachThreadToGpu rewrite.
-//===---------------------------------------------------------------------===//
-
-FailureOr<SmallVector<OpFoldResult>>
-mlir::iree_compiler::rewriteForeachThreadToGpu(
-    scf::ForeachThreadOp foreachThreadOp,
-    const SmallVector<int64_t> &globalWorkgroupSizes, RewriterBase &rewriter,
-    bool syncAfterDistribute) {
-  if (foreachThreadOp.getNumResults() > 0)
-    return foreachThreadOp->emitError(
-        "only bufferized scf.foreach_thread lowers to gpu.thread");
-  if (foreachThreadOp.getNumThreads().size() > 3)
-    return foreachThreadOp->emitError(
-        "scf.foreach_thread with rank > 3 does not lower to gpu.thread");
-
-  auto maybeWorkgroupSizes = getNumThreads(rewriter, foreachThreadOp);
-  if (failed(maybeWorkgroupSizes) ||
-      llvm::any_of(*maybeWorkgroupSizes, [](OpFoldResult ofr) {
-        return !getConstantIntValue(ofr).has_value();
-      }))
-    return foreachThreadOp->emitError("unsupported dynamic workgroup size");
-
-  SmallVector<int64_t> workgroupSizes = llvm::to_vector(llvm::map_range(
-      *maybeWorkgroupSizes,
-      [](OpFoldResult ofr) { return getConstantIntValue(ofr).value(); }));
-
-  // Step 1. Create the gpu.thread ops
-  Location loc = foreachThreadOp.getLoc();
-  IndexType indexType = rewriter.getIndexType();
-
-  SmallVector<gpu::Dimension, 3> gpuDims{gpu::Dimension::x, gpu::Dimension::y,
-                                         gpu::Dimension::z};
-  SmallVector<Value, 3> threadOps;
-  for (int64_t idx : llvm::seq<int64_t>(0, workgroupSizes.size())) {
-    threadOps.push_back(
-        rewriter.create<gpu::ThreadIdOp>(loc, indexType, gpuDims[idx]));
-  }
-
-  // Step 2. Maybe create conditionals to predicate the region.
-  Value predicate;
-  for (auto [threadId, workgroupSize, globalWorkgroupSize] :
-       llvm::zip(threadOps, workgroupSizes, globalWorkgroupSizes)) {
-    if (workgroupSize > globalWorkgroupSize) {
-      return foreachThreadOp.emitOpError("workgroup size overflow: ")
-             << workgroupSize << " > " << globalWorkgroupSize;
-    }
-    if (workgroupSize == globalWorkgroupSize) continue;
-    Value tmpPredicate = rewriter.create<arith::CmpIOp>(
-        loc, arith::CmpIPredicate::ult, threadId,
-        rewriter.create<arith::ConstantIndexOp>(loc, workgroupSize));
-    predicate =
-        predicate ? rewriter.create<arith::AndIOp>(loc, predicate, tmpPredicate)
-                  : tmpPredicate;
-  }
-
-  // Step 3. Move the body of foreachThreadOp.
-  // Erase the terminator first, it will not be used.
-  rewriter.eraseOp(foreachThreadOp.getTerminator());
-  Block *targetBlock;
-  Block::iterator insertionPoint;
-  if (predicate) {
-    // Step 3.a. If predicated, move at the beginning.
-    auto ifOp =
-        rewriter.create<scf::IfOp>(loc, predicate, /*withElseRegion=*/false);
-    targetBlock = ifOp.thenBlock();
-    insertionPoint = ifOp.thenBlock()->begin();
-  } else {
-    // Step 3.a. Otherwise, move inline just before foreachThreadOp.
-    targetBlock = foreachThreadOp->getBlock();
-    insertionPoint = Block::iterator(foreachThreadOp);
-  }
-  Block &sourceBlock = foreachThreadOp.getRegion().front();
-  targetBlock->getOperations().splice(insertionPoint,
-                                      sourceBlock.getOperations());
-
-  // Step 4. RAUW thread indices to thread ops.
-  SmallVector<Value> threadIndices =
-      *getThreadIndices(rewriter, foreachThreadOp);
-  assert(threadOps.size() == 3 && "3 thread id ops are required");
-  assert(threadIndices.size() == 3 && "3 thread id dimensions are required");
-  for (auto it : llvm::zip(threadIndices, threadOps)) {
-    Value val = std::get<0>(it);
-    if (!val) continue;
-    for (Operation *user : llvm::make_early_inc_range(val.getUsers())) {
-      rewriter.updateRootInPlace(
-          user, [&]() { user->replaceUsesOfWith(val, std::get<1>(it)); });
-    }
-  }
-
-  // Step 5. syncthreads.
-  if (syncAfterDistribute) rewriter.create<gpu::BarrierOp>(loc);
-
-  // Step 6. Erase old op.
-  rewriter.eraseOp(foreachThreadOp);
-
-  return *maybeWorkgroupSizes;
 }
 
 //===---------------------------------------------------------------------===//
@@ -225,13 +67,8 @@ transform_dialect::ForeachThreadToGpuAndTranslationInfo::applyToOne(
   // TODO: no magic constant but IREE uses this extensively.
   workgroupSize.resize(/*size=*/3, /*value=*/1);
   SimplePatternRewriter rewriter(target);
-  auto walkResult = target->walk([&](scf::ForeachThreadOp foreachThreadOp) {
-    rewriter.setInsertionPoint(foreachThreadOp);
-    if (failed(rewriteForeachThreadToGpu(foreachThreadOp, workgroupSize,
-                                         rewriter)))
-      return WalkResult::interrupt();
-    return WalkResult::advance();
-  });
+  auto walkResult = mlir::linalg::rewriteMapNestedForeachThreadToGpuThreads(
+      rewriter, target, workgroupSize, true);
 
   if (walkResult.wasInterrupted())
     return DiagnosedSilenceableFailure(reportUnknownTransformError(target));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Arithmetic/IR/Arithmetic.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -18,7 +19,6 @@
 #include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/IR/Region.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
-#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 
 using namespace mlir;
 using namespace mlir::iree_compiler::IREE;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -43,7 +43,7 @@ void mlir::iree_compiler::registerTransformDialectLLVMGPUExtension(
 // reuse most of the code and not require a static number of threads.
 // TODO: synchronizations for imperfectly nested stuff.
 DiagnosedSilenceableFailure
-transform_dialect::ForeachThreadToGpuAndTranslationInfo::applyToOne(
+transform_dialect::MapNestedForeachThreadToGpuThreads::applyToOne(
     func::FuncOp target, SmallVectorImpl<Operation *> &results,
     transform::TransformState &state) {
   if (!isa<HAL::ExecutableOp, HAL::ExecutableVariantOp>(state.getTopLevel())) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -13,8 +13,8 @@ include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def ForeachThreadToGpuAndTranslationInfo : 
-  Op<Transform_Dialect, "iree.foreach_thread_to_gpu_and_translation_info",
+def MapNestedForeachThreadToGpuThreads : 
+  Op<Transform_Dialect, "iree.map_nested_foreach_thread_to_gpu_threads",
     [FunctionalStyleTransformOpTrait, 
      MemoryEffectsOpInterface,
      TransformEachOpTrait,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -11,5 +11,5 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // Get the function to which to apply to.
   %2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op_2
   %func = transform.get_closest_isolated_parent %2
-  transform.iree.foreach_thread_to_gpu_and_translation_info %func { workgroup_size = [10, 11]}
+  transform.iree.map_nested_foreach_thread_to_gpu_threads %func { workgroup_size = [10, 11]}
 }

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -43,7 +43,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
 
   %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
-  %func_6 = transform.iree.foreach_thread_to_gpu_and_translation_info %func_5
+  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
       { workgroup_size = [32, 2, 1] }
 
   // Vector distribution needs to happen on buffers.

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -66,7 +66,7 @@ transform.with_pdl_patterns {
 
     %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_2
     %func_3 = transform.iree.foreach_thread_to_workgroup %func_2
-    transform.iree.foreach_thread_to_gpu_and_translation_info %func_3
+    transform.iree.map_nested_foreach_thread_to_gpu_threads %func_3
       { workgroup_size = [32, 4, 1] }
 
     %end_func = transform.structured.match ops{["func.func"]} in %variant_op_2

--- a/tests/transform_dialect/cuda/softmax_fused_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_fused_codegen_spec.mlir
@@ -46,7 +46,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
   %func = transform.structured.match ops{["func.func"]} in %variant_op_2
   %func_2 = transform.iree.foreach_thread_to_workgroup %func
-  transform.iree.foreach_thread_to_gpu_and_translation_info %func_2
+  transform.iree.map_nested_foreach_thread_to_gpu_threads %func_2
     { workgroup_size = [32, 1, 1] }
   
   // Vector distribution needs to happen on buffers.


### PR DESCRIPTION
MLIR's transform dialect now has capability to map `scf.foreach_thread` to GPU threads. https://reviews.llvm.org/D133950

This PR makes iree specific transform dialect operation (iree.foreach_thread_to_gpu_and_translation_info) to use mlir's new feature.