### PR TITLE
Add Pack operation to LinalgExt dialect

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -502,20 +502,26 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
       return getOutputType().cast<ShapedType>().getShape();
     }
 
+    // Return the input shape.
+    ArrayRef<int64_t> getInputShape() {
+      return getInputType().cast<ShapedType>().getShape();
+    }
+
     // Return the rank of the input operand.
     int64_t getInputRank() {
       return getInput().getType().cast<ShapedType>().getRank();
     }
 
-    // Return the tile sizes ad OpFoldResults.
+    // Return the tile sizes.
     SmallVector<OpFoldResult> getMixedTiles();
+    SmallVector<int64_t> getStaticTiles();
 
     // Infer the output type.
     ShapedType inferResultType();
 
     // Return a mapping from positions `dims_pos` to their tile factors.
     DenseMap<int64_t, OpFoldResult> getDimAndTileMapping();
-
+    DenseMap<int64_t, int64_t> getDimAndStaticTileMapping();
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -449,6 +449,7 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
                        Variadic<AnyShaped>:$outputs,
+                       OptionalAttr<DefaultValuedAttr<I64ArrayAttr, "{}">>:$iterator_interchange,
                        Variadic<Index>:$inner_tiles,
                        I64ArrayAttr:$static_inner_tiles);
 
@@ -459,6 +460,7 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
     `inner_tiles`
     custom<DynamicIndexList>($inner_tiles, $static_inner_tiles,
                              "ShapedType::kDynamicStrideOrOffset")
+    (`interchange` `=` $iterator_interchange^)?
     `into` $outputs `:` `(` type($inputs) type($outputs) `)`
      (`->` type($results)^)?
   }];

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -444,12 +444,12 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 ]>{
   let summary = "pack operation"; 
   let description = [{
-    The pack operation takes as input an array of dimensions to tile. Each
-    element in the array indexes a specific dimension that will be tiled
-    accordingly to the tile factor provided. A tile factor can either be a constant
-    or an index type. We handle only full tiles now; it is UB  if the tile does not
-    perfectly divide the dimension. We will relax this constraint in the future
-    when we add pad semantics to the operation.
+    The pack operation takes a shaped type as input, tiles, and transposes it
+    based on `dims_pos` and `inner_tiles`. The former carries the indices of the
+    dimension to tile, while the latter the tiling factor. A tile factor can
+    either be a constant or an index type. We handle only full tiles now; it is UB
+    if the tile does not perfectly divide the dimension. We will relax this
+    constraint in the future when we add pad semantics to the operation.
   }];
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -443,6 +443,14 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]>{
   let summary = "pack operation"; 
+  let description = [{
+    The pack operation takes as input an array of dimensions to tile. Each
+    element in the array indexes a specific dimension that will be tiled
+    accordingly to the tile factor provided. A tile factor can either be a constant
+    or an index type. We handle only full tiles now; it is UB  if the tile does not
+    perfectly divide the dimension. We will relax this constraint in the future
+    when we add pad semantics to the operation.
+  }];
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
     Variadic<AnyShaped>:$outputs,

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -444,12 +444,32 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 ]>{
   let summary = "pack operation"; 
   let description = [{
-    The pack operation takes a shaped type as input, tiles, and transposes it
-    based on `dims_pos` and `inner_tiles`. The former carries the indices of the
-    dimension to tile, while the latter the tiling factor. A tile factor can
-    either be a constant or an index type. We handle only full tiles now; it is UB
-    if the tile does not perfectly divide the dimension. We will relax this
-    constraint in the future when we add pad semantics to the operation.
+    The pack operation converts an `input` into a tiled and packed layout. The
+    dimensions to be tiled are obtained from `dims_pos` and the size of the tile is
+    obtained from `inner_tiles`. The dimensions listed in `dims_pos` do not need to
+    be contiguous in which case the tile will get transposed.  We handle only full
+    tiles now; it is UB if the tile does not perfectly divide the dimension. We
+    will relax this constraint in the future when we add pad semantics to the
+    operation.
+
+    Example KC_to_KCck:
+    
+    ```mlir
+    iree_linalg_ext.pack %arg0 dims_pos = [1, 0] 
+      inner_tiles = [32, 8] into %arg1 : (memref<128x256xf32> memref<16x8x32x8xf32>)
+    ```
+    
+    Example NC_to_NCnc:
+    
+    ```mlir
+    iree_linalg_ext.pack %arg0 dims_pos = [0, 1] 
+      inner_tiles = [8, 32] into %arg1 : (memref<128x256xf32> memref<16x8x8x32xf32>)
+    ``` 
+    
+    In both cases, dimension at position 0 in the input memref (128) is tiled
+    with a factor of 8, while dimension at position 1 (256) is tiled with a factor
+    of 32. In the KC_to_KCck example, the point loops are interchanged. 
+
   }];
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
@@ -484,32 +504,32 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 
     // Return the output rank.
     int64_t getOutputRank() {
-      return  getOutput().getType().cast<ShapedType>().getRank();
+      return  getOutputType().getRank();
     }
 
     // Return the output type.
     ShapedType getOutputType() {
-      return getOutput().getType().cast<ShapedType>();
+      return getOutput().getType();
     }
 
     // Return the input type.
     ShapedType getInputType() {
-      return getInput().getType().cast<ShapedType>();
+      return getInput().getType();
     }
 
     // Return the output shape.
     ArrayRef<int64_t> getOutputShape() {
-      return getOutputType().cast<ShapedType>().getShape();
+      return getOutputType().getShape();
     }
 
     // Return the input shape.
     ArrayRef<int64_t> getInputShape() {
-      return getInputType().cast<ShapedType>().getShape();
+      return getInputType().getShape();
     }
 
     // Return the rank of the input operand.
     int64_t getInputRank() {
-      return getInput().getType().cast<ShapedType>().getRank();
+      return getInputType().getRank();
     }
 
     // Return the tile sizes.
@@ -521,7 +541,6 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 
     // Return a mapping from positions `dims_pos` to their tile factors.
     DenseMap<int64_t, OpFoldResult> getDimAndTileMapping();
-    DenseMap<int64_t, int64_t> getDimAndStaticTileMapping();
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -513,6 +513,9 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
     // Infer the output type.
     ShapedType inferResultType();
 
+    // Return a mapping from positions `dims_pos` to their tile factors.
+    DenseMap<int64_t, OpFoldResult> getDimAndTileMapping();
+
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -457,7 +457,7 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
     `dims_pos` `=` $dims_pos
     `inner_tiles` `=`
     custom<DynamicIndexList>($inner_tiles, $static_inner_tiles,
-                             "ShapedType::kDynamicStrideOrOffset")
+                             "ShapedType::kDynamicSize")
     `into` $outputs `:` `(` type($inputs) type($outputs) `)`
      (`->` type($results)^)?
   }];

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -455,11 +455,11 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
     attr-dict
-    `ins` `(` $inputs `:` type($inputs) `)`
-    `outs` `(` $outputs `:` type($outputs) `)` 
+    $inputs 
     `inner_tiles`
     custom<DynamicIndexList>($inner_tiles, $static_inner_tiles,
                              "ShapedType::kDynamicStrideOrOffset")
+    `into` $outputs `:` `(` type($inputs) type($outputs) `)`
      (`->` type($results)^)?
   }];
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -29,8 +29,7 @@ class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
         [AttrSizedOperandSegments,
          DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
          LinalgExtInterface,
-         SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
-         ReifyRankedShapedTypeOpInterface
+         SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">
   ])> {
   let hasVerifier = 1;
   let hasCustomAssemblyFormat = 1;
@@ -38,12 +37,6 @@ class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
     SmallVector<Value> getDestinationOperands(OpBuilder &b) {
       SmallVector<Value> dest(getOutputs().begin(), getOutputs().end());
       return dest;
-    }
-
-    LogicalResult reifyResultShapes(OpBuilder &b,
-        mlir::ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
-      return llvm::cast<LinalgExtOp>(getOperation()).reifyResultShapes(b,
-          reifiedReturnShapes);
     }
   }];
 }
@@ -53,7 +46,8 @@ class IREELinalgExt_Op<string mnemonic, list<Trait> traits = []> :
 //===----------------------------------------------------------------------===//
 
 def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
-    [DeclareOpInterfaceMethods<TilingInterface,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+     DeclareOpInterfaceMethods<TilingInterface,
         ["generateScalarImplementation",
          "getIterationDomain",
          "getLoopIteratorTypes",
@@ -151,7 +145,8 @@ def IREELinalgExt_ScatterOp : IREELinalgExt_Op<"scatter",
 }
 
 def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
-    [DeclareOpInterfaceMethods<TilingInterface,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+     DeclareOpInterfaceMethods<TilingInterface,
         ["generateScalarImplementation",
          "getIterationDomain",
          "getLoopIteratorTypes",
@@ -195,6 +190,7 @@ def IREELinalgExt_SortOp : IREELinalgExt_Op<"sort",
 }
 
 def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
+  DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
       ["generateScalarImplementation",
        "getIterationDomain",
@@ -258,7 +254,8 @@ def IREELinalgExt_FftOp : IREELinalgExt_Op<"fft", [
 }
 
 def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
-    [DeclareOpInterfaceMethods<TilingInterface,
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+     DeclareOpInterfaceMethods<TilingInterface,
       ["generateScalarImplementation",
        "getIterationDomain",
        "getLoopIteratorTypes",
@@ -312,6 +309,7 @@ def IREELinalgExt_ScanOp : IREELinalgExt_Op<"scan",
 }
 
 def IREELinalgExt_ReverseOp : IREELinalgExt_Op<"reverse", [
+  DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
   DeclareOpInterfaceMethods<
       TilingInterface,
       ["generateScalarImplementation",
@@ -365,14 +363,14 @@ def IREELinalgExt_ReverseOp : IREELinalgExt_Op<"reverse", [
 }
 
 def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
+  DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
   DeclareOpInterfaceMethods<LinalgExtInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
     ["generateScalarImplementation",
      "getIterationDomain",
      "getLoopIteratorTypes",
      "getResultTilePosition",
-     "getTiledImplementation"]>,
-  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
+     "getTiledImplementation"]>
 ]>{
   let summary = "Top-K operator";
   let description = [{
@@ -435,8 +433,8 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
   }];
 }
 
-// TODO: destination passing style.
-def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
+def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
+  DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
   DeclareOpInterfaceMethods<LinalgExtInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
     ["getIterationDomain",
@@ -503,12 +501,6 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
 
     // Return the tile sizes ad OpFoldResults.
     SmallVector<OpFoldResult> getMixedTiles();
-
-    // Return the shape of the output.
-    SmallVector<OpFoldResult> buildOutputShape(OpBuilder &builder);
-
-    // Build the output position at pos `dimIdx`.
-    OpFoldResult buildOutputDim(OpBuilder &builder, size_t dimIdx);
 
     // Infer the output type.
     ShapedType inferResultType();

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -435,7 +435,6 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
   }];
 }
 
-// TODO: is pack the right name? After all we are re-arranging the tensor.
 // TODO: destination passing style.
 def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
   DeclareOpInterfaceMethods<LinalgExtInterface>,
@@ -448,16 +447,18 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
   let summary = "pack operation"; 
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
-                       Variadic<AnyShaped>:$outputs,
-                       OptionalAttr<DefaultValuedAttr<I64ArrayAttr, "{}">>:$iterator_interchange,
-                       Variadic<Index>:$inner_tiles,
-                       I64ArrayAttr:$static_inner_tiles);
+    Variadic<AnyShaped>:$outputs,
+    OptionalAttr<DefaultValuedAttr<I64ArrayAttr, "{}">>:$iterator_interchange,
+    DefaultValuedAttr<I64ArrayAttr, "{}">:$dims_pos,
+    Variadic<Index>:$inner_tiles,
+    I64ArrayAttr:$static_inner_tiles);
 
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
     attr-dict
     $inputs 
-    `inner_tiles`
+    `dims_pos` `=` $dims_pos
+    `inner_tiles` `=`
     custom<DynamicIndexList>($inner_tiles, $static_inner_tiles,
                              "ShapedType::kDynamicStrideOrOffset")
     (`interchange` `=` $iterator_interchange^)?

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -436,51 +436,57 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
 }
 
 // TODO: is pack the right name? After all we are re-arranging the tensor.
+// TODO: destination passing style.
 def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
   DeclareOpInterfaceMethods<LinalgExtInterface>,
   DeclareOpInterfaceMethods<TilingInterface,
     ["getIterationDomain",
      "getLoopIteratorTypes",
      "generateScalarImplementation"]>,
-  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, 
-  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]>{
-  let summary = "pack operation";
-  let description = [{
-    Expand the input tensor based on the access pattern provided by the affine
-    map.
-  }];
-  
+  let summary = "pack operation"; 
+
   let arguments = (ins Variadic<AnyShaped>:$inputs,
                        Variadic<AnyShaped>:$outputs,
-                       AffineMapAttr:$packMap);
+                       Variadic<Index>:$inner_tiles,
+                       I64ArrayAttr:$static_inner_tiles);
 
   let results = (outs Variadic<AnyRankedTensor>:$results);
   let assemblyFormat = [{
     attr-dict
     `ins` `(` $inputs `:` type($inputs) `)`
-    `outs` `(` $outputs `:` type($outputs) `)` $packMap
+    `outs` `(` $outputs `:` type($outputs) `)` 
+    `inner_tiles`
+    custom<DynamicIndexList>($inner_tiles, $static_inner_tiles,
+                             "ShapedType::kDynamicStrideOrOffset")
      (`->` type($results)^)?
   }];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
-    
+
     Value getOutput() {
       return getOutputOperand(0)->get();
     }
-    
+
     Value getInput() {
       return getInputOperand(0)->get();
     }
-    
+
     int64_t getOutputRank() {
       return  getOutput().getType().cast<ShapedType>().getRank();
     }
-  
+
+    ShapedType getOutputType() {
+      return getOutput().getType();
+    }
+
     int64_t getInputRank() {
       return getInput().getType().cast<ShapedType>().getRank();
     }
- 
+
+    SmallVector<OpFoldResult> getMixedInnerTiles();
+
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -468,12 +468,12 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
 
-    // Return the output operand `destination`.
+    // Return the output operand.
     Value getOutput() {
       return getOutputOperand(0)->get();
     }
 
-    // Return the input operand `source`.
+    // Return the input operand.
     Value getInput() {
       return getInputOperand(0)->get();
     }
@@ -485,7 +485,12 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
 
     // Return the output type.
     ShapedType getOutputType() {
-      return getOutput().getType();
+      return getOutput().getType().cast<ShapedType>();
+    }
+
+    // Return the input type.
+    ShapedType getInputType() {
+      return getInput().getType().cast<ShapedType>();
     }
 
     // Return the output shape.
@@ -499,13 +504,16 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
     }
 
     // Return the tile sizes ad OpFoldResults.
-    SmallVector<OpFoldResult> getMixedInnerTiles();
+    SmallVector<OpFoldResult> getMixedTiles();
 
-    // Infer and return the shape of the output.
+    // Return the shape of the output.
     SmallVector<OpFoldResult> buildOutputShape(OpBuilder &builder);
 
     // Build the output position at pos `dimIdx`.
     OpFoldResult buildOutputDim(OpBuilder &builder, size_t dimIdx);
+
+    // Infer the output type.
+    ShapedType inferResultType();
 
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -465,27 +465,44 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
 
+    // Return the output operand `destination`.
     Value getOutput() {
       return getOutputOperand(0)->get();
     }
 
+    // Return the input operand `source`.
     Value getInput() {
       return getInputOperand(0)->get();
     }
 
+    // Return the output rank.
     int64_t getOutputRank() {
       return  getOutput().getType().cast<ShapedType>().getRank();
     }
 
+    // Return the output type.
     ShapedType getOutputType() {
       return getOutput().getType();
     }
 
+    // Return the output shape.
+    ArrayRef<int64_t> getOutputShape() {
+      return getOutputType().cast<ShapedType>().getShape();
+    }
+
+    // Return the rank of the input operand.
     int64_t getInputRank() {
       return getInput().getType().cast<ShapedType>().getRank();
     }
 
+    // Return the tile sizes ad OpFoldResults.
     SmallVector<OpFoldResult> getMixedInnerTiles();
+
+    // Infer and return the shape of the output.
+    SmallVector<OpFoldResult> buildOutputShape(OpBuilder &builder);
+
+    // Build the output position at pos `dimIdx`.
+    OpFoldResult buildOutputDim(OpBuilder &builder, size_t dimIdx);
 
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -448,7 +448,6 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
     Variadic<AnyShaped>:$outputs,
-    OptionalAttr<DefaultValuedAttr<I64ArrayAttr, "{}">>:$iterator_interchange,
     DefaultValuedAttr<I64ArrayAttr, "{}">:$dims_pos,
     Variadic<Index>:$inner_tiles,
     I64ArrayAttr:$static_inner_tiles);
@@ -461,7 +460,6 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
     `inner_tiles` `=`
     custom<DynamicIndexList>($inner_tiles, $static_inner_tiles,
                              "ShapedType::kDynamicStrideOrOffset")
-    (`interchange` `=` $iterator_interchange^)?
     `into` $outputs `:` `(` type($inputs) type($outputs) `)`
      (`->` type($results)^)?
   }];

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -435,6 +435,55 @@ def IREELinalgExt_TopkOp : IREELinalgExt_Op<"topk",[
   }];
 }
 
+// TODO: is pack the right name? After all we are re-arranging the tensor.
+def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack",[
+  DeclareOpInterfaceMethods<LinalgExtInterface>,
+  DeclareOpInterfaceMethods<TilingInterface,
+    ["getIterationDomain",
+     "getLoopIteratorTypes",
+     "generateScalarImplementation"]>,
+  DeclareOpInterfaceMethods<MemoryEffectsOpInterface>, 
+  SingleBlockImplicitTerminator<"::mlir::iree_compiler::IREE::LinalgExt::YieldOp">,
+]>{
+  let summary = "pack operation";
+  let description = [{
+    Expand the input tensor based on the access pattern provided by the affine
+    map.
+  }];
+  
+  let arguments = (ins Variadic<AnyShaped>:$inputs,
+                       Variadic<AnyShaped>:$outputs,
+                       AffineMapAttr:$packMap);
+
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let assemblyFormat = [{
+    attr-dict
+    `ins` `(` $inputs `:` type($inputs) `)`
+    `outs` `(` $outputs `:` type($outputs) `)` $packMap
+     (`->` type($results)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    
+    Value getOutput() {
+      return getOutputOperand(0)->get();
+    }
+    
+    Value getInput() {
+      return getInputOperand(0)->get();
+    }
+    
+    int64_t getOutputRank() {
+      return  getOutput().getType().cast<ShapedType>().getRank();
+    }
+  
+    int64_t getInputRank() {
+      return getInput().getType().cast<ShapedType>().getRank();
+    }
+ 
+  }];
+}
+
 //===----------------------------------------------------------------------===//
 // Pure ops
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1652,13 +1652,7 @@ SmallVector<Range> PackOp::getIterationDomain(OpBuilder &builder) {
     loopBounds[dim].stride = one;
     loopBounds[dim].size = upperBounds[dim];
   }
-  auto interchangeVector = getIteratorInterchange();
-  if (!interchangeVector || (*interchangeVector).empty())
-    return loopBounds;
-  assert((*interchangeVector).size() == getMixedTiles().size() &&
-         "interchange vector must equal blocking factors");
-  return interchange<Range>(
-      loopBounds, extractFromI64ArrayAttr(*interchangeVector), getInputRank());
+  return loopBounds;
 }
 
 // Implements `getIterationDomain` from the tiling interface.

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1532,18 +1532,19 @@ ShapedType PackOp::inferResultType() {
     if (tileAndPosMapping.count(i)) {
       Optional<int64_t> tileSize =
           getConstantIntValue(tileAndPosMapping.lookup(i));
-      if (inputType.isDynamicDim(i) || !tileSize)
+      if (inputType.isDynamicDim(i) || !tileSize) {
         inferredShape.push_back(ShapedType::kDynamicSize);
-      else {
+      } else {
         int64_t sizeTiledDim = ceilDiv(inputType.getDimSize(i), *tileSize);
         inferredShape.push_back(sizeTiledDim);
       }
-    } else
+    } else {
       inferredShape.push_back(inputType.getShape()[i]);
+    }
   }
 
   // point loop.
-  SmallVector staticTiles = getStaticTiles();
+  auto staticTiles = getStaticTiles();
   inferredShape.append(staticTiles.begin(), staticTiles.end());
 
   return TypeSwitch<Type, ShapedType>(inputType)
@@ -1782,8 +1783,9 @@ LogicalResult PackOp::generateScalarImplementation(OpBuilder &builder,
               dimAndTileMapping[dim]});
       sourceIndices.push_back(sourceIndex);
       ++pointLoopsOffset;
-    } else
+    } else {
       sourceIndices.push_back(interchangedIvs[dim]);
+    }
   }
   Value scalar = builder.create<memref::LoadOp>(
       loc, getInput(), getAsValues(builder, loc, sourceIndices));

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1607,7 +1607,6 @@ SmallVector<StringRef> PackOp::getLoopIteratorTypes() {
 // https://mlir.llvm.org/doxygen/TensorInferTypeOpInterfaceImpl_8cpp_source.html
 /// Helper function to convert a vector of `OpFoldResult`s into a vector of
 /// `Value`s.
-// TODO: https://reviews.llvm.org/D134451
 static SmallVector<Value> getAsValues(OpBuilder &b, Location loc,
                                       ArrayRef<OpFoldResult> valueOrAttrVec) {
   return llvm::to_vector<4>(
@@ -1628,6 +1627,7 @@ OpFoldResult PackOp::buildOutputDim(OpBuilder &builder, size_t dimIdx) {
   return nullptr;
 }
 
+// TODO: ReifyRankedShapedTypeOpInterface
 // Infer and return the shape of the output as OpFoldResult.
 SmallVector<OpFoldResult> PackOp::buildOutputShape(OpBuilder &builder) {
   ArrayRef<int64_t> outputShape = getOutputShape();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1518,13 +1518,9 @@ static SmallVector<T> interchange(ArrayRef<T> elements,
   return rearrangedElements;
 }
 
-// Infer result/output type given the input and the tile sizes. Take
-// into account the optional interchange.
+// Infer result/output type given the input and the tile sizes.
 ShapedType PackOp::inferResultType() {
-
-  // bind the dimension to tile with the tile factor.
   DenseMap<int64_t, int64_t> tileAndPosMapping = getDimAndStaticTileMapping();
-
   SmallVector<int64_t> inferredShape;
   inferredShape.reserve(getOutputRank());
   ShapedType inputType = getInputType();
@@ -1717,7 +1713,7 @@ DenseMap<int64_t, OpFoldResult> PackOp::getDimAndTileMapping() {
   SmallVector<OpFoldResult> tiles = getMixedTiles();
   assert(tiles.size() == dimsToBlock.size() &&
          "tiles must match indices of dimension to block");
-  // bind the dimension to tile with the tile factor.
+  // bind the dimension with the tile factor.
   for (auto i : llvm::seq<int64_t>(0, dimsToBlock.size()))
     dimAndTileMapping[dimsToBlock[i]] = tiles[i];
   return dimAndTileMapping;
@@ -1735,7 +1731,7 @@ DenseMap<int64_t, int64_t> PackOp::getDimAndStaticTileMapping() {
 
   assert(staticTiles.size() == indicesOfBlockedDims.size() &&
          "tiles must match indices of dimension to block");
-  // bind the dimension to tile with the tile factor.
+  // bind the dimension with the tile factor.
   DenseMap<int64_t, int64_t> tileAndPosMapping;
   for (auto i : llvm::seq<int64_t>(0, indicesOfBlockedDims.size()))
     tileAndPosMapping[indicesOfBlockedDims[i]] = staticTiles[i];

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1799,7 +1799,6 @@ PackOp::reifyResultShapes(OpBuilder &builder,
 
   // Build the output dimension at pos `dimIdx`.
   auto buildOutputDim = [&](OpBuilder &builder, size_t dimIdx) -> OpFoldResult {
-    unsigned inputRank = getInputRank();
     ArrayRef<int64_t> outputShape = getOutputShape();
     if (!ShapedType::isDynamic(outputShape[dimIdx]))
       return builder.getI64IntegerAttr(outputShape[dimIdx]);

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertToLoops.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertToLoops.cpp
@@ -82,13 +82,11 @@ struct TilingInterfaceLowerToLoopsPattern : public RewritePattern {
     if (isa<linalg::LinalgOp>(op)) {
       return rewriter.notifyMatchFailure(op, "ignoring LinalgOps");
     }
-    // Tensor semantics?
-    // if (llvm::any_of(tilableOp->getResults(),
-    //                 [&](Value v) { return v.getType().isa<ShapedType>(); }))
-    //                 {
-    //  return rewriter.notifyMatchFailure(
-    //      tilableOp, "lower to loops needs to have tensor semantics");
-    //}
+    if (llvm::any_of(tilableOp->getResults(),
+                     [&](Value v) { return v.getType().isa<ShapedType>(); })) {
+      return rewriter.notifyMatchFailure(
+          tilableOp, "lower to loops needs to have tensor semantics");
+    }
     if (failed(lowerToLoops(rewriter, tilableOp))) {
       return failure();
     }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertToLoops.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertToLoops.cpp
@@ -90,7 +90,6 @@ struct TilingInterfaceLowerToLoopsPattern : public RewritePattern {
     //      tilableOp, "lower to loops needs to have tensor semantics");
     //}
     if (failed(lowerToLoops(rewriter, tilableOp))) {
-      llvm::errs() << "failed to lower to loops\n";
       return failure();
     }
     rewriter.eraseOp(op);

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertToLoops.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertToLoops.cpp
@@ -82,12 +82,15 @@ struct TilingInterfaceLowerToLoopsPattern : public RewritePattern {
     if (isa<linalg::LinalgOp>(op)) {
       return rewriter.notifyMatchFailure(op, "ignoring LinalgOps");
     }
-    if (llvm::any_of(tilableOp->getResults(),
-                     [&](Value v) { return v.getType().isa<ShapedType>(); })) {
-      return rewriter.notifyMatchFailure(
-          tilableOp, "lower to loops needs to have tensor semantics");
-    }
+    // Tensor semantics?
+    // if (llvm::any_of(tilableOp->getResults(),
+    //                 [&](Value v) { return v.getType().isa<ShapedType>(); }))
+    //                 {
+    //  return rewriter.notifyMatchFailure(
+    //      tilableOp, "lower to loops needs to have tensor semantics");
+    //}
     if (failed(lowerToLoops(rewriter, tilableOp))) {
+      llvm::errs() << "failed to lower to loops\n";
       return failure();
     }
     rewriter.eraseOp(op);

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -789,16 +789,16 @@ func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) 
 
 // -----
 
-func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) {
-  iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [32, 32] interchange = [1, 0] into %arg1 : (memref<128x256xf32> memref<8x4x32x32xf32>)
+func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) {
+  iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [32, 32] interchange = [1, 0] into %arg1 : (memref<128x256xf32> memref<4x8x32x32xf32>)
   return
 }
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
 // CHECK-LABEL: func.func @KC_to_KCck(
 // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[ubK:.*]] = arith.constant 8 : index
+// CHECK-DAG: %[[ubK:.*]] = arith.constant 4 : index
 // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[ubC:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[ubC:.*]] = arith.constant 8 : index
 // CHECK-DAG: %[[block:.*]] = arith.constant 32 : index
 // CHECK: scf.for %[[K:.*]] = %[[lb]] to %[[ubK]] step %[[step]] {
 // CHECK:   scf.for %[[C:.*]] = %[[lb]] to %[[ubC]] step %[[step]] {
@@ -807,7 +807,7 @@ func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) 
 // CHECK-DAG:         %[[applyMapC:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
 // CHECK-DAG:         %[[applyMapK:.*]] = affine.apply #[[MAP]](%[[K]], %[[k]])
 // CHECK:         %[[scalar]] = memref.load %arg0[%[[applyMapK]], %[[applyMapC]]] : memref<128x256xf32>
-// CHECK:         memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]], %[[k]]] : memref<8x4x32x32xf32>          
+// CHECK:         memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]], %[[k]]] : memref<4x8x32x32xf32>          
 // CHECK:       }
 // CHECK:     }
 // CHECK:   }
@@ -816,8 +816,8 @@ func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) 
 // -----
 
 // This should be a simple expand shape.
-func.func @KC_to_KCc(%arg0: memref<128x256xf32>, %arg1: memref<128x4x32xf32>) {
-  iree_linalg_ext.pack %arg0 dims_pos = [1] inner_tiles = [32] into %arg1 : (memref<128x256xf32> memref<128x4x32xf32>)
+func.func @KC_to_KCc(%arg0: memref<128x256xf32>, %arg1: memref<128x8x32xf32>) {
+  iree_linalg_ext.pack %arg0 dims_pos = [1] inner_tiles = [32] into %arg1 : (memref<128x256xf32> memref<128x8x32xf32>)
   return
 }
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
@@ -825,14 +825,14 @@ func.func @KC_to_KCc(%arg0: memref<128x256xf32>, %arg1: memref<128x4x32xf32>) {
 // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
 // CHECK-DAG: %[[ubK:.*]] = arith.constant 128 : index
-// CHECK-DAG: %[[ubC:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[ubC:.*]] = arith.constant 8 : index
 // CHECK-DAG: %[[block:.*]] = arith.constant 32 : index
 // CHECK: scf.for %[[K:.*]] = %[[lb]] to %[[ubK]] step %[[step]] {
 // CHECK:   scf.for %[[C:.*]] = %[[lb]] to %[[ubC]] step %[[step]] {
 // CHECK:     scf.for %[[c:.*]] = %[[lb]] to %[[block]] step %[[step]] {
 // CHECK:       %[[applyMapC:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
 // CHECK:       %[[scalar:.*]] = memref.load %arg0[%[[K]], %[[applyMapC]]] : memref<128x256xf32>
-// CHECK:       memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]]] : memref<128x4x32xf32>
+// CHECK:       memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]]] : memref<128x8x32xf32>
 // CHECK:     }
 // CHECK:   }
 // CHECK: }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -763,12 +763,12 @@ func.func @topk_memref_optional(%input_values: memref<2x10xf32>, %out_values: me
 
 // -----
 
-func.func @NC_to_NCNC(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) -> memref<4x8x32x32xf32> {  
-  iree_linalg_ext.pack ins(%arg0: memref<128x256xf32>) outs(%arg1: memref<4x8x32x32xf32>) inner_tiles [32, 32]
+func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) -> memref<4x8x32x32xf32> {  
+  iree_linalg_ext.pack %arg0 inner_tiles [32, 32] into %arg1 : (memref<128x256xf32> memref<4x8x32x32xf32>)
   return %arg1 : memref<4x8x32x32xf32>
 }
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
-// CHECK-LABEL: func.func @NC_to_NCNC(
+// CHECK-LABEL: func.func @NC_to_NCnc(
 // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
 // CHECK-DAG: %[[ubN:.*]] = arith.constant 4 : index
 // CHECK-DAG: %[[step:.*]] = arith.constant 1 : index

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -763,9 +763,9 @@ func.func @topk_memref_optional(%input_values: memref<2x10xf32>, %out_values: me
 
 // -----
 
-func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) -> memref<4x8x32x32xf32> {  
+func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) {  
   iree_linalg_ext.pack %arg0 inner_tiles [32, 32] into %arg1 : (memref<128x256xf32> memref<4x8x32x32xf32>)
-  return %arg1 : memref<4x8x32x32xf32>
+  return
 }
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
 // CHECK-LABEL: func.func @NC_to_NCnc(
@@ -789,11 +789,10 @@ func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) 
 
 // -----
 
-func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) -> memref<8x4x32x32xf32> {
+func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) {
   iree_linalg_ext.pack %arg0 inner_tiles [32, 32] interchange = [0, 1, 3, 2] into %arg1 : (memref<128x256xf32> memref<8x4x32x32xf32>)
-  return %arg1 : memref<8x4x32x32xf32>
+  return
 }
-
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
 // CHECK-LABEL: func.func @KC_to_KCck(
 // CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -790,7 +790,7 @@ func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) 
 // -----
 
 func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) {
-  iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [32, 32] interchange = [1, 0] into %arg1 : (memref<128x256xf32> memref<4x8x32x32xf32>)
+  iree_linalg_ext.pack %arg0 dims_pos = [1, 0] inner_tiles = [32, 32] into %arg1 : (memref<128x256xf32> memref<4x8x32x32xf32>)
   return
 }
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
@@ -864,7 +864,7 @@ func.func @KC_to_KCk(%arg0: memref<128x256xf32>, %arg1: memref<4x256x32xf32>) {
 // -----
 
 func.func @KCRS_to_KCRSck(%arg0: memref<128x64x1x1xf32>, %arg1: memref<4x8x1x1x8x32xf32>) {
-  iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [32, 8] interchange = [1, 0] into %arg1 : (memref<128x64x1x1xf32> memref<4x8x1x1x8x32xf32>)
+  iree_linalg_ext.pack %arg0 dims_pos = [1, 0] inner_tiles = [8, 32] into %arg1 : (memref<128x64x1x1xf32> memref<4x8x1x1x8x32xf32>)
   return 
 }
 
@@ -896,7 +896,7 @@ func.func @KCRS_to_KCRSck(%arg0: memref<128x64x1x1xf32>, %arg1: memref<4x8x1x1x8
 // -----
 
 func.func @KCRS_to_KCRSsr(%arg0: memref<1x1x128x64xf32>, %arg1: memref<1x1x4x8x8x32xf32>) {
-  iree_linalg_ext.pack %arg0 dims_pos = [2, 3] inner_tiles = [32, 8] interchange = [1, 0] into %arg1 : (memref<1x1x128x64xf32> memref<1x1x4x8x8x32xf32>)
+  iree_linalg_ext.pack %arg0 dims_pos = [3, 2] inner_tiles = [8, 32] into %arg1 : (memref<1x1x128x64xf32> memref<1x1x4x8x8x32xf32>)
   return
 }
 
@@ -924,3 +924,13 @@ func.func @KCRS_to_KCRSsr(%arg0: memref<1x1x128x64xf32>, %arg1: memref<1x1x4x8x8
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
+
+// -----
+
+// Test to check that we properly handle shuffled `dims_pos` and `tiles.
+// In this example, the dimension at position `0` (aka `128`) is tiled with a factor of `32`.
+// While the dimension at position `2` (aka `2`) is tiled with a factor of `2`.
+func.func @shuffled_dim_pos_and_tiles(%arg0: memref<128x256x2x1000xf32>, %arg1: memref<4x256x1x1000x2x32xf32>) {
+  iree_linalg_ext.pack %arg0 dims_pos = [2, 0] inner_tiles = [2, 32] into %arg1 : (memref<128x256x2x1000xf32> memref<4x256x1x1000x2x32xf32>)
+  return
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -1002,3 +1002,45 @@ func.func @KCRS_to_KCRSsr(%arg0: memref<?x?x?x?xf32>, %arg1: memref<?x?x?x?x8x32
 // CHECK:     }
 // CHECK:   }
 // CHECK: }
+
+// -----
+
+func.func @KCRS_to_KCRSsr(%arg0: memref<?x?x?x?xf32>, %arg1: memref<?x?x?x?x8x?xf32>, %block : index) {
+  iree_linalg_ext.pack %arg0 dims_pos = [3, 2] inner_tiles = [8, %block] into %arg1 : (memref<?x?x?x?xf32> memref<?x?x?x?x8x?xf32>)
+  return
+}
+
+// CHECK-DAG: #[[MAP0:.*]] = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
+// CHECK-DAG: #[[MAP1:.*]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+// CHECK-DAG: #[[MAP2:.*]] = affine_map<(d0, d1)[s0] -> (d0 * s0 + d1)>
+// CHECK-DAG: #[[MAP3:.*]] = affine_map<(d0, d1) -> (d0 * 8 + d1)>
+// CHECK-LABEL: func.func @KCRS_to_KCRSsr(
+// CHECK-DAG: %[[zero:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[one:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[eight:.*]] = arith.constant 8 : index
+// CHECK-DAG: %[[two:.*]] = arith.constant 2 : index
+// CHECK-DAG: %[[three:.*]] = arith.constant 3 : index
+// CHECK-DAG: %[[five:.*]] = arith.constant 5 : index
+// CHECK-DAG: %[[dimZero:.*]] = memref.dim %arg1, %[[zero]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG: %[[dimOne:.*]] = memref.dim %arg1, %[[one]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG: %[[dimTwo:.*]] = memref.dim %arg1, %[[two]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG: %[[dimThree:.*]] = memref.dim %arg1, %[[three]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG: %[[dimFive:.*]] = memref.dim %arg1, %[[five]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG: %[[mapOnDimTwo:.*]] = affine.apply #[[MAP0]]()[%[[dimTwo]], %arg2]
+// CHECK-DAG: %[[mapOnDimThree:.*]] = affine.apply #[[MAP1]]()[%[[dimThree]]]
+// CHECK: scf.for %[[K:.*]] = %[[zero]] to %[[dimZero]] step %[[one]] {
+// CHECK:   scf.for %[[C:.*]] = %[[zero]] to %[[dimOne]] step %[[one]] {
+// CHECK:     scf.for %[[R:.*]] = %[[zero]] to %[[mapOnDimTwo]] step %[[one]] {
+// CHECK:       scf.for %[[S:.*]] = %[[zero]] to %[[mapOnDimThree]] step %[[one]] {
+// CHECK:         scf.for %[[s:.*]] = %[[zero]] to %[[eight]] step %[[step]] {
+// CHECK:           scf.for %[[r:.*]] = %[[zero]] to %[[dimFive]] step %[[step]] {
+// CHECK-DAG:         %[[affineMapR:.*]] = affine.apply #[[MAP2]](%[[R]], %[[r]])
+// CHECK-DAG:         %[[affineMapS:.*]] = affine.apply #[[MAP3]](%[[S]], %[[s]])
+// CHECK:             %[[scalar:.*]] = memref.load %arg0[%[[K]], %[[C]], %[[affineMapR]], %[[affineMapS]]] : memref<?x?x?x?xf32>
+// CHECK:             memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[R]], %[[S]], %[[s]], %[[r]]] : memref<?x?x?x?x8x?xf32>
+// CHECK:           }
+// CHECK:         }
+// CHECK:       }
+// CHECK:     }
+// CHECK:   }
+// CHECK: }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -790,7 +790,7 @@ func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) 
 // -----
 
 func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) {
-  iree_linalg_ext.pack %arg0 inner_tiles [32, 32] interchange = [0, 1, 3, 2] into %arg1 : (memref<128x256xf32> memref<8x4x32x32xf32>)
+  iree_linalg_ext.pack %arg0 inner_tiles [32, 32] interchange = [1, 0] into %arg1 : (memref<128x256xf32> memref<8x4x32x32xf32>)
   return
 }
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -763,12 +763,9 @@ func.func @topk_memref_optional(%input_values: memref<2x10xf32>, %out_values: me
 
 // -----
 
-#mapPack = affine_map<(d0, d1, d2, d3) -> (d0 * 32 + d2, d1 * 32 + d3)>
-
-func.func @NC_to_NCNC(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) {  
-  iree_linalg_ext.pack ins(%arg0: memref<128x256xf32>) 
-                      outs(%arg1: memref<4x8x32x32xf32>) #mapPack
-  return
+func.func @NC_to_NCNC(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) -> memref<4x8x32x32xf32> {  
+  iree_linalg_ext.pack ins(%arg0: memref<128x256xf32>) outs(%arg1: memref<4x8x32x32xf32>) inner_tiles [32, 32]
+  return %arg1 : memref<4x8x32x32xf32>
 }
 // CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
 // CHECK-LABEL: func.func @NC_to_NCNC(
@@ -792,29 +789,27 @@ func.func @NC_to_NCNC(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) 
 
 // -----
 
-#mapPack = affine_map<(d0, d1, d2, d3) -> (d1 * 32 + d2, d0 * 32 + d3)>
+// TODO: not too convinced. Memref op should not have results IMO.
+//func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) -> memref<8x4x32x32xf32> {
+//  %0 = iree_linalg_ext.pack %arg0 inner_tiles [32, 32] : memref<128x256xf32> to memref<8x4x32x32xf32>
+//  return %0 : memref<8x4x32x32xf32>
+//}
 
-func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) {
-  iree_linalg_ext.pack ins(%arg0: memref<128x256xf32>)
-                      outs(%arg1: memref<8x4x32x32xf32>) #mapPack
-  return
-}
-
-// CHECK-LABEL: func.func @KC_to_KCck(
-// CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
-// CHECK-DAG: %[[ubK:.*]] = arith.constant 8 : index
-// CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
-// CHECK-DAG: %[[ubC:.*]] = arith.constant 4 : index
-// CHECK-DAG: %[[block:.*]] = arith.constant 32 : index
-// CHECK: scf.for %[[K:.*]] = %[[lb]] to %[[ubK]] step %[[step]] {
-// CHECK:   scf.for %[[C:.*]] = %[[lb]] to %[[ubC]] step %[[step]] {
-// CHECK:     scf.for %[[c:.*]] = %[[lb]] to %[[block]] step %[[step]] {
-// CHECK:       scf.for %[[k:.*]] = %[[lb]] to %[[block]] step %[[step]] {
-// CHECK:         %[[applyMapI:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
-// CHECK:         %[[applyMapJ:.*]] = affine.apply #[[MAP]](%[[K]], %[[k]])
-// CHECK:         %[[scalar]] = memref.load %arg0[%[[applyMapI]], %[[applyMapJ]]] : memref<128x256xf32>
-// CHECK:         memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]], %[[k]]] : memref<8x4x32x32xf32>          
-// CHECK:       }
-// CHECK:     }
-// CHECK:   }
-// CHECK: }
+// TODO-LABEL: func.func @KC_to_KCck(
+// TODO-DAG: %[[lb:.*]] = arith.constant 0 : index
+// TODO-DAG: %[[ubK:.*]] = arith.constant 8 : index
+// TODO-DAG: %[[step:.*]] = arith.constant 1 : index
+// TODO-DAG: %[[ubC:.*]] = arith.constant 4 : index
+// TODO-DAG: %[[block:.*]] = arith.constant 32 : index
+// TODO: scf.for %[[K:.*]] = %[[lb]] to %[[ubK]] step %[[step]] {
+// TODO:   scf.for %[[C:.*]] = %[[lb]] to %[[ubC]] step %[[step]] {
+// TODO:     scf.for %[[c:.*]] = %[[lb]] to %[[block]] step %[[step]] {
+// TODO:       scf.for %[[k:.*]] = %[[lb]] to %[[block]] step %[[step]] {
+// TODO:         %[[applyMapI:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
+// TODO:         %[[applyMapJ:.*]] = affine.apply #[[MAP]](%[[K]], %[[k]])
+// TODO:         %[[scalar]] = memref.load %arg0[%[[applyMapI]], %[[applyMapJ]]] : memref<128x256xf32>
+// TODO:         memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]], %[[k]]] : memref<8x4x32x32xf32>          
+// TODO:       }
+// TODO:     }
+// TODO:   }
+// TODO: }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -778,8 +778,8 @@ func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) 
 // CHECK:   scf.for %[[C:.*]] = %[[lb]] to %[[ubC]] step %[[step]] {
 // CHECK:     scf.for %[[n:.*]] = %[[lb]] to %[[block]] step %[[step]] {
 // CHECK:       scf.for %[[c:.*]] = %[[lb]] to %[[block]] step %[[step]] {
-// CHECK:         %[[applyMapI:.*]] = affine.apply #[[MAP]](%[[N]], %[[n]])
-// CHECK:         %[[applyMapJ:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
+// CHECK-DAG:         %[[applyMapI:.*]] = affine.apply #[[MAP]](%[[N]], %[[n]])
+// CHECK-DAG:         %[[applyMapJ:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
 // CHECK:         %[[scalar:.*]] = memref.load %arg0[%[[applyMapI]], %[[applyMapJ]]] : memref<128x256xf32>
 // CHECK:         memref.store %[[scalar]], %arg1[%[[N]], %[[C]], %[[n]], %[[c]]] : memref<4x8x32x32xf32>
 // CHECK:       }
@@ -789,27 +789,27 @@ func.func @NC_to_NCnc(%arg0: memref<128x256xf32>, %arg1: memref<4x8x32x32xf32>) 
 
 // -----
 
-// TODO: not too convinced. Memref op should not have results IMO.
-//func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) -> memref<8x4x32x32xf32> {
-//  %0 = iree_linalg_ext.pack %arg0 inner_tiles [32, 32] : memref<128x256xf32> to memref<8x4x32x32xf32>
-//  return %0 : memref<8x4x32x32xf32>
-//}
+func.func @KC_to_KCck(%arg0: memref<128x256xf32>, %arg1: memref<8x4x32x32xf32>) -> memref<8x4x32x32xf32> {
+  iree_linalg_ext.pack %arg0 inner_tiles [32, 32] interchange = [0, 1, 3, 2] into %arg1 : (memref<128x256xf32> memref<8x4x32x32xf32>)
+  return %arg1 : memref<8x4x32x32xf32>
+}
 
-// TODO-LABEL: func.func @KC_to_KCck(
-// TODO-DAG: %[[lb:.*]] = arith.constant 0 : index
-// TODO-DAG: %[[ubK:.*]] = arith.constant 8 : index
-// TODO-DAG: %[[step:.*]] = arith.constant 1 : index
-// TODO-DAG: %[[ubC:.*]] = arith.constant 4 : index
-// TODO-DAG: %[[block:.*]] = arith.constant 32 : index
-// TODO: scf.for %[[K:.*]] = %[[lb]] to %[[ubK]] step %[[step]] {
-// TODO:   scf.for %[[C:.*]] = %[[lb]] to %[[ubC]] step %[[step]] {
-// TODO:     scf.for %[[c:.*]] = %[[lb]] to %[[block]] step %[[step]] {
-// TODO:       scf.for %[[k:.*]] = %[[lb]] to %[[block]] step %[[step]] {
-// TODO:         %[[applyMapI:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
-// TODO:         %[[applyMapJ:.*]] = affine.apply #[[MAP]](%[[K]], %[[k]])
-// TODO:         %[[scalar]] = memref.load %arg0[%[[applyMapI]], %[[applyMapJ]]] : memref<128x256xf32>
-// TODO:         memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]], %[[k]]] : memref<8x4x32x32xf32>          
-// TODO:       }
-// TODO:     }
-// TODO:   }
-// TODO: }
+// CHECK: #[[MAP:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
+// CHECK-LABEL: func.func @KC_to_KCck(
+// CHECK-DAG: %[[lb:.*]] = arith.constant 0 : index
+// CHECK-DAG: %[[ubK:.*]] = arith.constant 8 : index
+// CHECK-DAG: %[[step:.*]] = arith.constant 1 : index
+// CHECK-DAG: %[[ubC:.*]] = arith.constant 4 : index
+// CHECK-DAG: %[[block:.*]] = arith.constant 32 : index
+// CHECK: scf.for %[[K:.*]] = %[[lb]] to %[[ubK]] step %[[step]] {
+// CHECK:   scf.for %[[C:.*]] = %[[lb]] to %[[ubC]] step %[[step]] {
+// CHECK:     scf.for %[[c:.*]] = %[[lb]] to %[[block]] step %[[step]] {
+// CHECK:       scf.for %[[k:.*]] = %[[lb]] to %[[block]] step %[[step]] {
+// CHECK-DAG:         %[[applyMapC:.*]] = affine.apply #[[MAP]](%[[C]], %[[c]])
+// CHECK-DAG:         %[[applyMapK:.*]] = affine.apply #[[MAP]](%[[K]], %[[k]])
+// CHECK:         %[[scalar]] = memref.load %arg0[%[[applyMapK]], %[[applyMapC]]] : memref<128x256xf32>
+// CHECK:         memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[c]], %[[k]]] : memref<8x4x32x32xf32>          
+// CHECK:       }
+// CHECK:     }
+// CHECK:   }
+// CHECK: }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -508,3 +508,19 @@ func.func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<
         } -> tensor<2x3xf32>, tensor<2x3xi32>
   return %0#0, %0#1 : tensor<2x3xf32>, tensor<2x3xi32>
 }
+
+// -----
+
+func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
+  // expected-error@+1 {{inferred type do not match provied output type}}
+  %0 = iree_linalg_ext.pack %input dims_pos = [0, 1] inner_tiles = [32, 16] interchange = [1, 0] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
+  return %0 : tensor<8x8x32x16xf32>
+}
+
+// -----
+
+func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
+  // expected-error@+1 {{interchange vector must equal blocking factors}}
+  %0 = iree_linalg_ext.pack %input dims_pos = [0, 1] inner_tiles = [32] interchange = [1, 0] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
+  return %0 : tensor<8x8x32x16xf32>
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -516,3 +516,11 @@ func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf
   %0 = iree_linalg_ext.pack %input dims_pos = [1, 0] inner_tiles = [16, 32] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
   return %0 : tensor<8x8x32x16xf32>
 }
+
+// -----
+
+func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
+  // expected-error@+1 {{invalid tile factor provided. Only full tiles are supported}}
+  %0 = iree_linalg_ext.pack %input dims_pos = [1, 0] inner_tiles = [16, 5] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
+  return %0 : tensor<8x8x32x16xf32>
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -513,14 +513,6 @@ func.func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<
 
 func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
   // expected-error@+1 {{inferred type do not match provied output type}}
-  %0 = iree_linalg_ext.pack %input dims_pos = [0, 1] inner_tiles = [32, 16] interchange = [1, 0] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
-  return %0 : tensor<8x8x32x16xf32>
-}
-
-// -----
-
-func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
-  // expected-error@+1 {{interchange vector must equal blocking factors}}
-  %0 = iree_linalg_ext.pack %input dims_pos = [0, 1] inner_tiles = [32] interchange = [1, 0] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
+  %0 = iree_linalg_ext.pack %input dims_pos = [1, 0] inner_tiles = [16, 32] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
   return %0 : tensor<8x8x32x16xf32>
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -646,13 +646,9 @@ func.func @topk_tensor_optional(%input_values: tensor<20x10x8x4xf32>) -> (tensor
 
 // -----
 
-#mapI = affine_map<(d0, d1) -> (d0, d1)>
-
 // CHECK: func.func @relayout(
 func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
   // CHECK: iree_linalg_ext.pack
-  %1 = iree_linalg_ext.pack ins(%arg0: tensor<3x3xf32>)
-                            outs(%arg1: tensor<3x3xf32>) #mapI
-    -> tensor<3x3xf32>
+  %1 = iree_linalg_ext.pack ins(%arg0: tensor<3x3xf32>) outs(%arg1: tensor<3x3xf32>) inner_tiles [0, 0] -> tensor<3x3xf32>
   return %1 : tensor<3x3xf32>
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -649,6 +649,15 @@ func.func @topk_tensor_optional(%input_values: tensor<20x10x8x4xf32>) -> (tensor
 // CHECK: func.func @relayout(
 func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
   // CHECK: iree_linalg_ext.pack
-  %1 = iree_linalg_ext.pack ins(%arg0: tensor<3x3xf32>) outs(%arg1: tensor<3x3xf32>) inner_tiles [0, 0] -> tensor<3x3xf32>
+  %1 = iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (tensor<3x3xf32> tensor<3x3xf32>) -> tensor<3x3xf32>
   return %1 : tensor<3x3xf32>
+}
+
+// -----
+
+// CHECK: func.func @relayout(
+func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+  // CHECK: iree_linalg_ext.pack
+  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (memref<3x3xf32> memref<3x3xf32>)
+  return 
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -646,18 +646,25 @@ func.func @topk_tensor_optional(%input_values: tensor<20x10x8x4xf32>) -> (tensor
 
 // -----
 
-// CHECK: func.func @relayout(
 func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32> {
-  // CHECK: iree_linalg_ext.pack
   %1 = iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [1, 1] into %arg1 : (tensor<3x3xf32> tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32>
   return %1 : tensor<3x3x1x1xf32>
 }
 
+// CHECK: func.func @relayout(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: tensor<3x3xf32>,
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32>
+// CHECK: %[[RES:.*]] = iree_linalg_ext.pack %[[ARG0]] dims_pos = [0, 1] inner_tiles = [1, 1] into %[[ARG1]] : (tensor<3x3xf32> tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32>
+// CHECK: return %[[RES]] : tensor<3x3x1x1xf32>
+
 // -----
 
-// CHECK: func.func @relayout(
 func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3x1x1xf32>) {
-  // CHECK: iree_linalg_ext.pack
   iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [1, 1] into %arg1 : (memref<3x3xf32> memref<3x3x1x1xf32>)
   return 
 }
+
+// CHECK: func.func @relayout(
+// CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: memref<3x3xf32>,
+// CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: memref<3x3x1x1xf32>) {
+// CHECK: iree_linalg_ext.pack %[[ARG0]] dims_pos = [0, 1] inner_tiles = [1, 1] into %[[ARG1]] : (memref<3x3xf32> memref<3x3x1x1xf32>)

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -647,26 +647,17 @@ func.func @topk_tensor_optional(%input_values: tensor<20x10x8x4xf32>) -> (tensor
 // -----
 
 // CHECK: func.func @relayout(
-func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32> {
   // CHECK: iree_linalg_ext.pack
-  %1 = iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (tensor<3x3xf32> tensor<3x3xf32>) -> tensor<3x3xf32>
-  return %1 : tensor<3x3xf32>
+  %1 = iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (tensor<3x3xf32> tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32>
+  return %1 : tensor<3x3x1x1xf32>
 }
 
 // -----
 
 // CHECK: func.func @relayout(
-func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3x1x1xf32>) {
   // CHECK: iree_linalg_ext.pack
-  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (memref<3x3xf32> memref<3x3xf32>)
-  return 
-}
-
-// -----
-
-// CHECK: func.func @relayout(
-func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
-  // CHECK: iree_linalg_ext.pack
-  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] interchange = [0, 1, 2, 3] into %arg1 : (memref<3x3xf32> memref<3x3xf32>)
+  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (memref<3x3xf32> memref<3x3x1x1xf32>)
   return 
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -649,7 +649,7 @@ func.func @topk_tensor_optional(%input_values: tensor<20x10x8x4xf32>) -> (tensor
 // CHECK: func.func @relayout(
 func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32> {
   // CHECK: iree_linalg_ext.pack
-  %1 = iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (tensor<3x3xf32> tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32>
+  %1 = iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [1, 1] into %arg1 : (tensor<3x3xf32> tensor<3x3x1x1xf32>) -> tensor<3x3x1x1xf32>
   return %1 : tensor<3x3x1x1xf32>
 }
 
@@ -658,6 +658,6 @@ func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3x1x1xf32>) -> tenso
 // CHECK: func.func @relayout(
 func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3x1x1xf32>) {
   // CHECK: iree_linalg_ext.pack
-  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (memref<3x3xf32> memref<3x3x1x1xf32>)
+  iree_linalg_ext.pack %arg0 dims_pos = [0, 1] inner_tiles = [1, 1] into %arg1 : (memref<3x3xf32> memref<3x3x1x1xf32>)
   return 
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -643,3 +643,16 @@ func.func @topk_tensor_optional(%input_values: tensor<20x10x8x4xf32>) -> (tensor
 //  CHECK-SAME:      outs(%[[OUT_VALUES]], %[[OUT_INDICES]]
 //       CHECK:      iree_linalg_ext.yield
 //       CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
+
+// -----
+
+#mapI = affine_map<(d0, d1) -> (d0, d1)>
+
+// CHECK: func.func @relayout(
+func.func @relayout(%arg0: tensor<3x3xf32>, %arg1: tensor<3x3xf32>) -> tensor<3x3xf32> {
+  // CHECK: iree_linalg_ext.pack
+  %1 = iree_linalg_ext.pack ins(%arg0: tensor<3x3xf32>)
+                            outs(%arg1: tensor<3x3xf32>) #mapI
+    -> tensor<3x3xf32>
+  return %1 : tensor<3x3xf32>
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -667,6 +667,6 @@ func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
 // CHECK: func.func @relayout(
 func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   // CHECK: iree_linalg_ext.pack
-  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] interchange = [1, 2, 3, 4] into %arg1 : (memref<3x3xf32> memref<3x3xf32>)
+  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] interchange = [0, 1, 2, 3] into %arg1 : (memref<3x3xf32> memref<3x3xf32>)
   return 
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -661,3 +661,12 @@ func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
   iree_linalg_ext.pack %arg0 inner_tiles [1, 1] into %arg1 : (memref<3x3xf32> memref<3x3xf32>)
   return 
 }
+
+// -----
+
+// CHECK: func.func @relayout(
+func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3xf32>) {
+  // CHECK: iree_linalg_ext.pack
+  iree_linalg_ext.pack %arg0 inner_tiles [1, 1] interchange = [1, 2, 3, 4] into %arg1 : (memref<3x3xf32> memref<3x3xf32>)
+  return 
+}


### PR DESCRIPTION
Start revisiting the `linalgx.relayout` operation in lights of the discussions we had. The semantics I would like to have is: `tensor.expand_shape + tensor.transpose`

TODO: 
1. Dropping the affine map and use attributes only?
2. Do we want to add also `tensor.pad` semantics?
3. Operation name: `pack` or `relayout`?