### PR TITLE
rename iree_ukernel_size_t to iree_ukernel_ssize_t

### DIFF
--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -103,15 +103,14 @@ typedef unsigned long long uint64_t;
 
 #endif  // !INT8_MIN
 
-// Use iree_ukernel_size_t for all sizes that may need pointer width.
+// Use iree_ukernel_ssize_t for all sizes that may need pointer width.
 // For any argument that is known to fit in a specific size prefer that to
 // ensure this code operates well on systems with small/weird widths (x32/ilp32,
 // etc).
-// TODO: it's probably too surprising that a type named *_size_t is signed.
 #if IREE_UKERNEL_POINTER_SIZE == 4
-typedef int32_t iree_ukernel_size_t;
+typedef int32_t iree_ukernel_ssize_t;
 #elif IREE_UKERNEL_POINTER_SIZE == 8
-typedef int64_t iree_ukernel_size_t;
+typedef int64_t iree_ukernel_ssize_t;
 #else
 #error Unexpected pointer size
 #endif

--- a/runtime/src/iree/builtins/ukernel/elementwise.h
+++ b/runtime/src/iree/builtins/ukernel/elementwise.h
@@ -32,13 +32,13 @@ typedef int (*iree_ukernel_x32b_2d_func_t)(
 // Declares a binary 2d microkernel with the following signature:
 //   int iree_ukernel_{category}_{opcode}_2d(...)
 // of function type iree_ukernel_{category}_2d_func_t.
-#define DECLARE_UKERNEL_BINARY_2D(opcode, dtype, category)              \
-  IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(      \
-      const dtype* lhs, iree_ukernel_ssize_t lhs_offset,                 \
+#define DECLARE_UKERNEL_BINARY_2D(opcode, dtype, category)                \
+  IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(        \
+      const dtype* lhs, iree_ukernel_ssize_t lhs_offset,                  \
       iree_ukernel_ssize_t lhs_stride0, iree_ukernel_ssize_t lhs_stride1, \
-      const dtype* rhs, iree_ukernel_ssize_t rhs_offset,                 \
+      const dtype* rhs, iree_ukernel_ssize_t rhs_offset,                  \
       iree_ukernel_ssize_t rhs_stride0, iree_ukernel_ssize_t rhs_stride1, \
-      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,         \
+      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,          \
       iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1, \
       iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1)
 
@@ -76,11 +76,11 @@ typedef int (*iree_ukernel_x32u_2d_func_t)(
 //   int iree_ukernel_{category}_{opcode}_2d(...)
 // It takes lhs, rhs, out buffers and size, returning 0 on success and !0 on
 // error.
-#define DECLARE_UKERNEL_UNARY_2D(opcode, dtype, category)               \
-  IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(      \
-      const dtype* in, iree_ukernel_ssize_t in_offset,                   \
+#define DECLARE_UKERNEL_UNARY_2D(opcode, dtype, category)                 \
+  IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(        \
+      const dtype* in, iree_ukernel_ssize_t in_offset,                    \
       iree_ukernel_ssize_t in_stride0, iree_ukernel_ssize_t in_stride1,   \
-      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,         \
+      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,          \
       iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1, \
       iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1)
 

--- a/runtime/src/iree/builtins/ukernel/elementwise.h
+++ b/runtime/src/iree/builtins/ukernel/elementwise.h
@@ -21,26 +21,26 @@ extern "C" {
 // It takes lhs, rhs, out buffers and size, returning 0 on success and !0 on
 // error.
 typedef int (*iree_ukernel_x32b_2d_func_t)(
-    const uint32_t* lhs, iree_ukernel_size_t lhs_offset,
-    iree_ukernel_size_t lhs_stride0, iree_ukernel_size_t lhs_stride1,
-    const uint32_t* rhs, iree_ukernel_size_t rhs_offset,
-    iree_ukernel_size_t rhs_stride0, iree_ukernel_size_t rhs_stride1,
-    uint32_t* out, iree_ukernel_size_t out_offset,
-    iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1,
-    iree_ukernel_size_t size0, iree_ukernel_size_t size1);
+    const uint32_t* lhs, iree_ukernel_ssize_t lhs_offset,
+    iree_ukernel_ssize_t lhs_stride0, iree_ukernel_ssize_t lhs_stride1,
+    const uint32_t* rhs, iree_ukernel_ssize_t rhs_offset,
+    iree_ukernel_ssize_t rhs_stride0, iree_ukernel_ssize_t rhs_stride1,
+    uint32_t* out, iree_ukernel_ssize_t out_offset,
+    iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1,
+    iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1);
 
 // Declares a binary 2d microkernel with the following signature:
 //   int iree_ukernel_{category}_{opcode}_2d(...)
 // of function type iree_ukernel_{category}_2d_func_t.
 #define DECLARE_UKERNEL_BINARY_2D(opcode, dtype, category)              \
   IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(      \
-      const dtype* lhs, iree_ukernel_size_t lhs_offset,                 \
-      iree_ukernel_size_t lhs_stride0, iree_ukernel_size_t lhs_stride1, \
-      const dtype* rhs, iree_ukernel_size_t rhs_offset,                 \
-      iree_ukernel_size_t rhs_stride0, iree_ukernel_size_t rhs_stride1, \
-      dtype* IREE_RESTRICT out, iree_ukernel_size_t out_offset,         \
-      iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1, \
-      iree_ukernel_size_t size0, iree_ukernel_size_t size1)
+      const dtype* lhs, iree_ukernel_ssize_t lhs_offset,                 \
+      iree_ukernel_ssize_t lhs_stride0, iree_ukernel_ssize_t lhs_stride1, \
+      const dtype* rhs, iree_ukernel_ssize_t rhs_offset,                 \
+      iree_ukernel_ssize_t rhs_stride0, iree_ukernel_ssize_t rhs_stride1, \
+      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,         \
+      iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1, \
+      iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1)
 
 DECLARE_UKERNEL_BINARY_2D(addf, uint32_t, x32b);
 DECLARE_UKERNEL_BINARY_2D(addi, uint32_t, x32b);
@@ -66,11 +66,11 @@ DECLARE_UKERNEL_BINARY_2D(xori, uint32_t, x32b);
 // It takes in, out buffers and size, returning 0 on success and !0 on
 // error.
 typedef int (*iree_ukernel_x32u_2d_func_t)(
-    const uint32_t* in, iree_ukernel_size_t in_offset,
-    iree_ukernel_size_t in_stride0, iree_ukernel_size_t in_stride1,
-    uint32_t* out, iree_ukernel_size_t out_offset,
-    iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1,
-    iree_ukernel_size_t size0, iree_ukernel_size_t size1);
+    const uint32_t* in, iree_ukernel_ssize_t in_offset,
+    iree_ukernel_ssize_t in_stride0, iree_ukernel_ssize_t in_stride1,
+    uint32_t* out, iree_ukernel_ssize_t out_offset,
+    iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1,
+    iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1);
 
 // Declares a binary 2d microkernel with the following signature:
 //   int iree_ukernel_{category}_{opcode}_2d(...)
@@ -78,11 +78,11 @@ typedef int (*iree_ukernel_x32u_2d_func_t)(
 // error.
 #define DECLARE_UKERNEL_UNARY_2D(opcode, dtype, category)               \
   IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(      \
-      const dtype* in, iree_ukernel_size_t in_offset,                   \
-      iree_ukernel_size_t in_stride0, iree_ukernel_size_t in_stride1,   \
-      dtype* IREE_RESTRICT out, iree_ukernel_size_t out_offset,         \
-      iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1, \
-      iree_ukernel_size_t size0, iree_ukernel_size_t size1)
+      const dtype* in, iree_ukernel_ssize_t in_offset,                   \
+      iree_ukernel_ssize_t in_stride0, iree_ukernel_ssize_t in_stride1,   \
+      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,         \
+      iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1, \
+      iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1)
 
 DECLARE_UKERNEL_UNARY_2D(absf, uint32_t, x32u);
 DECLARE_UKERNEL_UNARY_2D(ceilf, uint32_t, x32u);

--- a/runtime/src/iree/builtins/ukernel/elementwise_impl.c.inc
+++ b/runtime/src/iree/builtins/ukernel/elementwise_impl.c.inc
@@ -111,13 +111,13 @@ static inline int iree_ukernel_count_leading_zeros_u32(const uint32_t n) {
 // Corresponds to the header macro DECLARE_UKERNEL_BINARY_2D.
 #define DISPATCH_UKERNEL_BINARY_2D(opcode, opcode_t, dtype, category)         \
   IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(            \
-      const dtype* lhs, iree_ukernel_size_t lhs_offset,                       \
-      iree_ukernel_size_t lhs_stride0, iree_ukernel_size_t lhs_stride1,       \
-      const dtype* rhs, iree_ukernel_size_t rhs_offset,                       \
-      iree_ukernel_size_t rhs_stride0, iree_ukernel_size_t rhs_stride1,       \
-      dtype* IREE_RESTRICT out, iree_ukernel_size_t out_offset,               \
-      iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1,       \
-      iree_ukernel_size_t size0, iree_ukernel_size_t size1) {                 \
+      const dtype* lhs, iree_ukernel_ssize_t lhs_offset,                       \
+      iree_ukernel_ssize_t lhs_stride0, iree_ukernel_ssize_t lhs_stride1,       \
+      const dtype* rhs, iree_ukernel_ssize_t rhs_offset,                       \
+      iree_ukernel_ssize_t rhs_stride0, iree_ukernel_ssize_t rhs_stride1,       \
+      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,               \
+      iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1,       \
+      iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1) {                 \
     return iree_ukernel_generic_##category##_2d(                              \
         opcode_t, lhs, lhs_offset, lhs_stride0, lhs_stride1, rhs, rhs_offset, \
         rhs_stride0, rhs_stride1, out, out_offset, out_stride0, out_stride1,  \
@@ -129,11 +129,11 @@ static inline int iree_ukernel_count_leading_zeros_u32(const uint32_t n) {
 // Corresponds to the header macro DECLARE_UKERNEL_BINARY_2D.
 #define DISPATCH_UKERNEL_UNARY_2D(opcode, opcode_t, dtype, category)      \
   IREE_UKERNEL_EXPORT int iree_ukernel_##category##_##opcode##_2d(        \
-      const dtype* in, iree_ukernel_size_t in_offset,                     \
-      iree_ukernel_size_t in_stride0, iree_ukernel_size_t in_stride1,     \
-      dtype* IREE_RESTRICT out, iree_ukernel_size_t out_offset,           \
-      iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1,   \
-      iree_ukernel_size_t size0, iree_ukernel_size_t size1) {             \
+      const dtype* in, iree_ukernel_ssize_t in_offset,                     \
+      iree_ukernel_ssize_t in_stride0, iree_ukernel_ssize_t in_stride1,     \
+      dtype* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,           \
+      iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1,   \
+      iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1) {             \
     return iree_ukernel_generic_##category##_2d(                          \
         opcode_t, in, in_offset, in_stride0, in_stride1, out, out_offset, \
         out_stride0, out_stride1, size0, size1);                          \
@@ -242,20 +242,20 @@ static void iree_ukernel_generic_x32u_op(iree_ukernel_x32u_opcode_t opcode,
 static int iree_ukernel_generic_x32b_2d(
     iree_ukernel_x32b_opcode_t opcode,
     // LHS.
-    const uint32_t* lhs, iree_ukernel_size_t lhs_offset,
-    iree_ukernel_size_t lhs_stride0, iree_ukernel_size_t lhs_stride1,
+    const uint32_t* lhs, iree_ukernel_ssize_t lhs_offset,
+    iree_ukernel_ssize_t lhs_stride0, iree_ukernel_ssize_t lhs_stride1,
     // RHS
-    const uint32_t* rhs, iree_ukernel_size_t rhs_offset,
-    iree_ukernel_size_t rhs_stride0, iree_ukernel_size_t rhs_stride1,
+    const uint32_t* rhs, iree_ukernel_ssize_t rhs_offset,
+    iree_ukernel_ssize_t rhs_stride0, iree_ukernel_ssize_t rhs_stride1,
     // OUT.
-    uint32_t* IREE_RESTRICT out, iree_ukernel_size_t out_offset,
-    iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1,
+    uint32_t* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,
+    iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1,
     // Sizes.
-    iree_ukernel_size_t size0, iree_ukernel_size_t size1) {
+    iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1) {
   int result_code = 0;
   // TODO: Manually unroll to x4 to trigger vectorization.
-  for (iree_ukernel_size_t i = 0; i < size0; ++i) {
-    for (iree_ukernel_size_t j = 0; j < size1; ++j) {
+  for (iree_ukernel_ssize_t i = 0; i < size0; ++i) {
+    for (iree_ukernel_ssize_t j = 0; j < size1; ++j) {
       iree_ukernel_generic_x32b_op(opcode, &result_code,
                                    &lhs[i * lhs_stride0 + j * lhs_stride1],
                                    &rhs[i * rhs_stride0 + j * rhs_stride1],
@@ -269,17 +269,17 @@ static int iree_ukernel_generic_x32b_2d(
 static int iree_ukernel_generic_x32u_2d(
     iree_ukernel_x32u_opcode_t opcode,
     // IN.
-    const uint32_t* in, iree_ukernel_size_t in_offset,
-    iree_ukernel_size_t in_stride0, iree_ukernel_size_t in_stride1,
+    const uint32_t* in, iree_ukernel_ssize_t in_offset,
+    iree_ukernel_ssize_t in_stride0, iree_ukernel_ssize_t in_stride1,
     // OUT.
-    uint32_t* IREE_RESTRICT out, iree_ukernel_size_t out_offset,
-    iree_ukernel_size_t out_stride0, iree_ukernel_size_t out_stride1,
+    uint32_t* IREE_RESTRICT out, iree_ukernel_ssize_t out_offset,
+    iree_ukernel_ssize_t out_stride0, iree_ukernel_ssize_t out_stride1,
     // Sizes.
-    iree_ukernel_size_t size0, iree_ukernel_size_t size1) {
+    iree_ukernel_ssize_t size0, iree_ukernel_ssize_t size1) {
   int result_code = 0;
   // TODO: Manually unroll to x4 to trigger vectorization.
-  for (iree_ukernel_size_t i = 0; i < size0; ++i) {
-    for (iree_ukernel_size_t j = 0; j < size1; ++j) {
+  for (iree_ukernel_ssize_t i = 0; i < size0; ++i) {
+    for (iree_ukernel_ssize_t j = 0; j < size1; ++j) {
       iree_ukernel_generic_x32u_op(opcode, &result_code,
                                    &in[i * in_stride0 + j * in_stride1],
                                    &out[i * out_stride0 + j * out_stride1]);

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -74,9 +74,9 @@ static void iree_ukernel_mmt4d_using_tile_func(
   const char* lhs_panel = params->lhs_buffer;
   int32_t out_tile_size = (M0 * N0) << out_elem_size_log2;
   iree_ukernel_ssize_t lhs_panel_stride = params->lhs_stride
-                                         << lhs_elem_size_log2;
+                                          << lhs_elem_size_log2;
   iree_ukernel_ssize_t rhs_panel_stride = params->rhs_stride
-                                         << rhs_elem_size_log2;
+                                          << rhs_elem_size_log2;
   iree_ukernel_ssize_t out_stride = params->out_stride << out_elem_size_log2;
   for (int32_t i = 0; i < M; ++i) {
     char* out_tile = out_tile_row;

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -73,11 +73,11 @@ static void iree_ukernel_mmt4d_using_tile_func(
   char* out_tile_row = params->out_buffer;
   const char* lhs_panel = params->lhs_buffer;
   int32_t out_tile_size = (M0 * N0) << out_elem_size_log2;
-  iree_ukernel_size_t lhs_panel_stride = params->lhs_stride
+  iree_ukernel_ssize_t lhs_panel_stride = params->lhs_stride
                                          << lhs_elem_size_log2;
-  iree_ukernel_size_t rhs_panel_stride = params->rhs_stride
+  iree_ukernel_ssize_t rhs_panel_stride = params->rhs_stride
                                          << rhs_elem_size_log2;
-  iree_ukernel_size_t out_stride = params->out_stride << out_elem_size_log2;
+  iree_ukernel_ssize_t out_stride = params->out_stride << out_elem_size_log2;
   for (int32_t i = 0; i < M; ++i) {
     char* out_tile = out_tile_row;
     const char* rhs_panel = params->rhs_buffer;

--- a/runtime/src/iree/builtins/ukernel/mmt4d_select_tile_generic.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_select_tile_generic.c
@@ -43,10 +43,10 @@ static void iree_ukernel_mmt4d_tile_i8i8i32_generic(
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_ukernel_size_t k = 0; k < K; ++k) {
-    for (iree_ukernel_size_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_ukernel_size_t j0 = 0; j0 < N0; ++j0) {
-        for (iree_ukernel_size_t k0 = 0; k0 < K0; ++k0) {
+  for (iree_ukernel_ssize_t k = 0; k < K; ++k) {
+    for (iree_ukernel_ssize_t i0 = 0; i0 < M0; ++i0) {
+      for (iree_ukernel_ssize_t j0 = 0; j0 < N0; ++j0) {
+        for (iree_ukernel_ssize_t k0 = 0; k0 < K0; ++k0) {
           int32_t lhs_val_int32 = lhs_panel[i0 * K0 + k0];
           int32_t rhs_val_int32 = rhs_panel[j0 * K0 + k0];
           acc[i0 * N0 + j0] += lhs_val_int32 * rhs_val_int32;
@@ -79,10 +79,10 @@ static void iree_ukernel_mmt4d_tile_f32f32f32_generic(
     for (int i = 0; i < M0 * N0; ++i) acc[i] = 0;
   }
   // Accumulation loop.
-  for (iree_ukernel_size_t k = 0; k < K; ++k) {
-    for (iree_ukernel_size_t i0 = 0; i0 < M0; ++i0) {
-      for (iree_ukernel_size_t j0 = 0; j0 < N0; ++j0) {
-        for (iree_ukernel_size_t k0 = 0; k0 < K0; ++k0) {
+  for (iree_ukernel_ssize_t k = 0; k < K; ++k) {
+    for (iree_ukernel_ssize_t i0 = 0; i0 < M0; ++i0) {
+      for (iree_ukernel_ssize_t j0 = 0; j0 < N0; ++j0) {
+        for (iree_ukernel_ssize_t k0 = 0; k0 < K0; ++k0) {
           float lhs_val = lhs_panel[i0 * K0 + k0];
           float rhs_val = rhs_panel[j0 * K0 + k0];
           acc[i0 * N0 + j0] += lhs_val * rhs_val;

--- a/runtime/src/iree/builtins/ukernel/mmt4d_types.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_types.h
@@ -25,12 +25,12 @@ struct iree_ukernel_mmt4d_params_t {
   const void* lhs_buffer;
   const void* rhs_buffer;
   void* out_buffer;
-  iree_ukernel_size_t lhs_stride;
-  iree_ukernel_size_t rhs_stride;
-  iree_ukernel_size_t out_stride;
-  iree_ukernel_size_t M;
-  iree_ukernel_size_t N;
-  iree_ukernel_size_t K;
+  iree_ukernel_ssize_t lhs_stride;
+  iree_ukernel_ssize_t rhs_stride;
+  iree_ukernel_ssize_t out_stride;
+  iree_ukernel_ssize_t M;
+  iree_ukernel_ssize_t N;
+  iree_ukernel_ssize_t K;
   int32_t M0;
   int32_t N0;
   int32_t K0;

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -62,11 +62,11 @@ static iree_status_t iree_mmt4d_benchmark(
   params.lhs_stride = params.K * params.M0 * params.K0;
   params.rhs_stride = params.K * params.N0 * params.K0;
   params.out_stride = params.N * params.M0 * params.N0;
-  iree_ukernel_size_t lhs_buffer_size =
+  iree_ukernel_ssize_t lhs_buffer_size =
       iree_ukernel_mmt4d_lhs_buffer_size(&params);
-  iree_ukernel_size_t rhs_buffer_size =
+  iree_ukernel_ssize_t rhs_buffer_size =
       iree_ukernel_mmt4d_rhs_buffer_size(&params);
-  iree_ukernel_size_t out_buffer_size =
+  iree_ukernel_ssize_t out_buffer_size =
       iree_ukernel_mmt4d_out_buffer_size(&params);
   void* lhs_buffer = malloc(lhs_buffer_size);
   void* rhs_buffer = malloc(lhs_buffer_size);

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
@@ -60,25 +60,25 @@
 template <typename lhs_t, typename rhs_t, typename out_t>
 static void iree_mmt4d_reference(const iree_ukernel_mmt4d_params_t& params) {
   bool accumulate = params.flags & IREE_VMVX_MATMUL_FLAG_ACCUMULATE;
-  iree_ukernel_size_t lhs_tile_size = params.M0 * params.K0;
-  iree_ukernel_size_t rhs_tile_size = params.N0 * params.K0;
-  iree_ukernel_size_t out_tile_size = params.M0 * params.N0;
-  for (iree_ukernel_size_t i = 0; i < params.M; ++i) {
-    for (iree_ukernel_size_t j = 0; j < params.N; ++j) {
+  iree_ukernel_ssize_t lhs_tile_size = params.M0 * params.K0;
+  iree_ukernel_ssize_t rhs_tile_size = params.N0 * params.K0;
+  iree_ukernel_ssize_t out_tile_size = params.M0 * params.N0;
+  for (iree_ukernel_ssize_t i = 0; i < params.M; ++i) {
+    for (iree_ukernel_ssize_t j = 0; j < params.N; ++j) {
       out_t* out_tile_ptr = ((out_t*)params.out_buffer) +
                             i * params.out_stride + j * out_tile_size;
       const lhs_t* lhs_panel_ptr =
           ((const lhs_t*)params.lhs_buffer) + i * params.lhs_stride;
       const rhs_t* rhs_panel_ptr =
           ((const rhs_t*)params.rhs_buffer) + j * params.rhs_stride;
-      for (iree_ukernel_size_t i0 = 0; i0 < params.M0; ++i0) {
-        for (iree_ukernel_size_t j0 = 0; j0 < params.N0; ++j0) {
+      for (iree_ukernel_ssize_t i0 = 0; i0 < params.M0; ++i0) {
+        for (iree_ukernel_ssize_t j0 = 0; j0 < params.N0; ++j0) {
           const lhs_t* lhs_tile_ptr = lhs_panel_ptr;
           const rhs_t* rhs_tile_ptr = rhs_panel_ptr;
           out_t* out_ptr = out_tile_ptr + i0 * params.N0 + j0;
           out_t acc = accumulate ? *out_ptr : 0.f;
-          for (iree_ukernel_size_t k = 0; k < params.K; ++k) {
-            for (iree_ukernel_size_t k0 = 0; k0 < params.K0; ++k0) {
+          for (iree_ukernel_ssize_t k = 0; k < params.K; ++k) {
+            for (iree_ukernel_ssize_t k0 = 0; k0 < params.K0; ++k0) {
               out_t lhs_val = lhs_tile_ptr[i0 * params.K0 + k0];
               out_t rhs_val = rhs_tile_ptr[j0 * params.K0 + k0];
               acc += lhs_val * rhs_val;
@@ -113,7 +113,7 @@ static void test_one_matmul_using_given_lhs_rhs(
 
   iree_ukernel_mmt4d_params_t reference_params;
   memcpy(&reference_params, &shared_params, sizeof shared_params);
-  iree_ukernel_size_t out_buffer_size =
+  iree_ukernel_ssize_t out_buffer_size =
       iree_ukernel_mmt4d_out_buffer_size(&shared_params);
   reference_params.out_buffer = malloc(out_buffer_size);
   iree_mmt4d_scalar_type_t out_type =
@@ -190,9 +190,9 @@ static void test_one_matmul_creating_lhs_rhs_for_given_shape(
                       iree_mmt4d_test_random_engine_get_0_or_1(engine);
   params.out_stride = params.N * params.M0 * params.N0 +
                       iree_mmt4d_test_random_engine_get_0_or_1(engine);
-  iree_ukernel_size_t lhs_buffer_size =
+  iree_ukernel_ssize_t lhs_buffer_size =
       iree_ukernel_mmt4d_lhs_buffer_size(&params);
-  iree_ukernel_size_t rhs_buffer_size =
+  iree_ukernel_ssize_t rhs_buffer_size =
       iree_ukernel_mmt4d_rhs_buffer_size(&params);
   iree_mmt4d_scalar_type_t lhs_type = iree_ukernel_mmt4d_lhs_type(&params);
   iree_mmt4d_scalar_type_t rhs_type = iree_ukernel_mmt4d_rhs_type(&params);

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test_utils.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test_utils.cc
@@ -43,19 +43,19 @@ iree_mmt4d_scalar_type_t iree_ukernel_mmt4d_out_type(
   }
 }
 
-iree_ukernel_size_t iree_ukernel_mmt4d_lhs_buffer_size(
+iree_ukernel_ssize_t iree_ukernel_mmt4d_lhs_buffer_size(
     const iree_ukernel_mmt4d_params_t* params) {
   return params->M * params->lhs_stride *
          iree_ukernel_mmt4d_lhs_elem_size(params->type);
 }
 
-iree_ukernel_size_t iree_ukernel_mmt4d_rhs_buffer_size(
+iree_ukernel_ssize_t iree_ukernel_mmt4d_rhs_buffer_size(
     const iree_ukernel_mmt4d_params_t* params) {
   return params->N * params->rhs_stride *
          iree_ukernel_mmt4d_rhs_elem_size(params->type);
 }
 
-iree_ukernel_size_t iree_ukernel_mmt4d_out_buffer_size(
+iree_ukernel_ssize_t iree_ukernel_mmt4d_out_buffer_size(
     const iree_ukernel_mmt4d_params_t* params) {
   return params->M * params->out_stride *
          iree_ukernel_mmt4d_out_elem_size(params->type);
@@ -94,11 +94,11 @@ int iree_mmt4d_test_random_engine_get_between_minus16_and_plus15(
 }
 
 template <typename T>
-static void write_random_buffer(T* buffer, iree_ukernel_size_t size_in_bytes,
+static void write_random_buffer(T* buffer, iree_ukernel_ssize_t size_in_bytes,
                                 iree_mmt4d_test_random_engine_t* engine) {
-  iree_ukernel_size_t size_in_elems = size_in_bytes / sizeof(T);
+  iree_ukernel_ssize_t size_in_elems = size_in_bytes / sizeof(T);
   assert(size_in_elems * sizeof(T) == size_in_bytes && "bad size");
-  for (iree_ukernel_size_t i = 0; i < size_in_elems; ++i) {
+  for (iree_ukernel_ssize_t i = 0; i < size_in_elems; ++i) {
     // Small integers, should work for now for all the types we currently have
     // and enable exact float arithmetic, allowing to keep tests simpler for
     // now. Watch out for when we'll do float16!
@@ -108,7 +108,7 @@ static void write_random_buffer(T* buffer, iree_ukernel_size_t size_in_bytes,
   }
 }
 
-void write_random_buffer(void* buffer, iree_ukernel_size_t size_in_bytes,
+void write_random_buffer(void* buffer, iree_ukernel_ssize_t size_in_bytes,
                          iree_mmt4d_scalar_type_t type,
                          iree_mmt4d_test_random_engine_t* engine) {
   switch (type) {

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test_utils.h
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test_utils.h
@@ -33,11 +33,11 @@ iree_mmt4d_scalar_type_t iree_ukernel_mmt4d_rhs_type(
 iree_mmt4d_scalar_type_t iree_ukernel_mmt4d_out_type(
     const iree_ukernel_mmt4d_params_t* params);
 
-iree_ukernel_size_t iree_ukernel_mmt4d_lhs_buffer_size(
+iree_ukernel_ssize_t iree_ukernel_mmt4d_lhs_buffer_size(
     const iree_ukernel_mmt4d_params_t* params);
-iree_ukernel_size_t iree_ukernel_mmt4d_rhs_buffer_size(
+iree_ukernel_ssize_t iree_ukernel_mmt4d_rhs_buffer_size(
     const iree_ukernel_mmt4d_params_t* params);
-iree_ukernel_size_t iree_ukernel_mmt4d_out_buffer_size(
+iree_ukernel_ssize_t iree_ukernel_mmt4d_out_buffer_size(
     const iree_ukernel_mmt4d_params_t* params);
 
 struct iree_mmt4d_test_random_engine_t;
@@ -49,7 +49,7 @@ int iree_mmt4d_test_random_engine_get_0_or_1(
 int iree_mmt4d_test_random_engine_get_between_minus16_and_plus15(
     iree_mmt4d_test_random_engine_t* e);
 
-void write_random_buffer(void* buffer, iree_ukernel_size_t size_in_bytes,
+void write_random_buffer(void* buffer, iree_ukernel_ssize_t size_in_bytes,
                          iree_mmt4d_scalar_type_t type,
                          iree_mmt4d_test_random_engine_t* engine);
 


### PR DESCRIPTION
This type is rightly signed, so its name shouldn't end in `_size_t`.