### PR TITLE
Fixing stream resource usage refinement to properly reject invalid state.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -340,7 +340,9 @@ class PackDispatchOperandsPass
       auto exportOp =
           symbolTable.lookupNearestSymbolFrom<IREE::Stream::ExecutableExportOp>(
               dispatchOp, dispatchOp.getEntryPoint());
-      updateDispatchOp(dispatchOp, exportOp);
+      if (exportOp) {
+        updateDispatchOp(dispatchOp, exportOp);
+      }
       return WalkResult::advance();
     });
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -1189,6 +1189,9 @@ static LogicalResult allocateExecutionRegion(
   auto resultAllocation = reserveResultAllocation(resultReservations);
   for (auto &reservationSet : resultAllocation.reservationSets) {
     // Allocate and tie an operand to the result.
+    // TODO(benvanik): change this to an alloca. We may need a higher-level
+    // analysis to decide when to deallocate, or just leave it to be deallocated
+    // as part of garbage collection.
     auto allocOp = externalBuilder.create<IREE::Stream::ResourceAllocOp>(
         externalBuilder.getFusedLoc(reservationSet.reservationLocs),
         reservationSet.reservationTypes, reservationSet.reservationSizes,


### PR DESCRIPTION
Due to the missing override the solver would mark states as resolved even when invalid and then later consumers of the analysis results would get really confused.