### PR TITLE
Update VM image setup scripting

### DIFF
--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -274,6 +274,7 @@ def parse_args():
           " https://cloud.google.com/compute/docs/instance-groups/updating-migs."
       ))
   subparser_base.add_argument("--env",
+                              "--environment",
                               default="testing",
                               help="The environment for the MIGs.",
                               choices=["prod", "testing"])


### PR DESCRIPTION
The main substantive changes have to do with the configuration of
`gcloud`. There was a recent change turning on Parallel Composite
Upload by default for large files, which unfortunately broke us. This
highlighted the need to use a stable version of gcloud on the runners
and the fact that snap makes it impossible to disable automatic
updates. gcloud is literally the only thing installed with snap for
some reason, and snap seems to kind of just suck in general, so I
purged the whole thing. I didn't use the SDK versioned archives from
https://cloud.google.com/sdk/docs/downloads-versioned-archives because
it turns out that getting something onto the path for systemd is
actually pretty tricky. I tried a few things and figured out how to do
it (in several different ways), but then decided it would be simpler if
gcloud was just installed in the same way as everything else.

There were also a few typos and such with the wrong runner user and I
fiddled with the scripting a bit to tail logs in a slightly less djanky
way and fail more gracefully.

Tested: deployed test runners with this image ->
https://github.com/iree-org/iree/actions/runs/3094322587

skip-ci