### PR TITLE
Move Shared Mem Transpose Detection Logic to LinalgOpTrait

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.cpp
@@ -82,11 +82,6 @@ static SmallVector<OpOperand *> computeTransposeInfo(
     return transposeOperands;
   }
 
-  // Multiple outputs are not supported yet.
-  if (linalgOp.getNumOutputs() != 1) {
-    return transposeOperands;
-  }
-
   // Inverse map to use transfer op permutation logic.
   AffineMap outputInversedMap = inversePermutation(
       linalgOp.getTiedIndexingMap(linalgOp.getOutputOperand(0)));
@@ -101,6 +96,11 @@ static SmallVector<OpOperand *> computeTransposeInfo(
     if (isTransposeMap(inverseMap) && transposeMapFilter(inverseMap)) {
       transposeOperands.push_back(linalgOperand);
     }
+  }
+
+  // Multiple outputs are not supported yet.
+  if (linalgOp.getNumOutputs() != 1) {
+    return transposeOperands;
   }
 
   if (isTransposeMap(outputInversedMap) &&
@@ -119,21 +119,10 @@ static bool computeDynamicInfo(LinalgOp linalgOp) {
   return linalgOp.hasDynamicShape();
 }
 
-static bool computeTwoOrThreeLoopsInfo(LinalgOp linalgOp) {
-  return linalgOp.getNumParallelLoops() >= 2 &&
-         linalgOp.getNumParallelLoops() <= 3;
-}
-
-static bool computeGenericInfo(LinalgOp linalgOp) {
-  return isa<GenericOp>(linalgOp);
-}
-
 void LinalgOpInfo::computeInfo(LinalgOp linalgOp) {
   transposeOperands = computeTransposeInfo(linalgOp, transposeMapFilter);
   reductionTrait = computeReductionInfo(linalgOp);
   dynamicTrait = computeDynamicInfo(linalgOp);
-  genericTrait = computeGenericInfo(linalgOp);
-  twoOrThreeLoopsTrait = computeTwoOrThreeLoopsInfo(linalgOp);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.h
+++ b/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.h
@@ -6,6 +6,8 @@
 
 #ifndef IREE_COMPILER_CODEGEN_COMMON_LINALGOPINFO_H_
 #define IREE_COMPILER_CODEGEN_COMMON_LINALGOPINFO_H_
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Types.h"
 
 namespace mlir {
 
@@ -21,12 +23,19 @@ class LinalgOpInfo {
 
   bool isTranspose() const { return transposeTrait; }
   bool isReduction() const { return reductionTrait; }
+  bool isSharedMemTranspose() const {
+    return !sharedMemTransposeOperands.empty();
+  }
+  ArrayRef<OpOperand *> getSharedMemTransposeOperands() const {
+    return sharedMemTransposeOperands;
+  }
 
  private:
   void computeInfo(linalg::LinalgOp);
 
   bool transposeTrait;
   bool reductionTrait;
+  SmallVector<OpOperand *> sharedMemTransposeOperands;
 };
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.h
+++ b/compiler/src/iree/compiler/Codegen/Common/LinalgOpInfo.h
@@ -31,8 +31,6 @@ class LinalgOpInfo {
   bool isTranspose() const { return !transposeOperands.empty(); }
   bool isReduction() const { return reductionTrait; }
   bool isDynamic() const { return dynamicTrait; }
-  bool isGeneric() const { return genericTrait; }
-  bool isTwoThreeLoops() const { return twoOrThreeLoopsTrait; }
 
   ArrayRef<OpOperand *> getTransposeOperands() const {
     return transposeOperands;
@@ -45,8 +43,6 @@ class LinalgOpInfo {
   bool transposeTrait;
   bool reductionTrait;
   bool dynamicTrait;
-  bool genericTrait;
-  bool twoOrThreeLoopsTrait;
   SmallVector<OpOperand *> transposeOperands;
 };
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -36,6 +36,7 @@ iree_compiler_cc_library(
         "ConvertToLLVM.h",
         "KernelConfig.h",
         "TilingUtils.h",
+        "TransposeUtils.h",
     ],
     deps = [
         "//compiler/src/iree/compiler/Codegen:PassHeaders",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_cc_library(
     "ConvertToLLVM.h"
     "KernelConfig.h"
     "TilingUtils.h"
+    "TransposeUtils.h"
   SRCS
     "ConvertToLLVM.cpp"
     "ConvertToNVVM.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -9,6 +9,7 @@
 #include <numeric>
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree/compiler/Codegen/Common/LinalgOpInfo.h"
 #include "iree/compiler/Codegen/Common/UserConfig.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
@@ -511,77 +512,26 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
   return success();
 }
 
-/// Returns true if the index map represents a transpose that benefits from
-/// shared mem.
-static bool isSharedMemTranspose(AffineMap indexMap) {
-  if (!indexMap.isEmpty() && indexMap.isPermutation()) {
-    // Ensure that the fasted moving dimension (the last one) is permuted,
-    // Otherwise shared memory promotion will not benefit the operation.
-    if (indexMap.getDimPosition(indexMap.getNumDims() - 1) !=
-        indexMap.getNumDims() - 1) {
-      return true;
-    }
-  }
-  return false;
-}
-
-/// Returns true if the operation is a GenericOp implementing a 2D transpose.
-static bool checkTransposePreconditions(linalg::GenericOp linalgOp) {
-  // Check that the op has at least 2 to 3 parallel loops.
-  if (linalgOp.getNumParallelLoops() < 2 ||
-      linalgOp.getNumParallelLoops() > 3) {
-    return false;
-  }
-
-  // Check that all the iterators are parallel.
-  if (linalgOp.getNumParallelLoops() != linalgOp.getNumLoops()) {
-    return false;
-  }
-
-  // Only transpose static shapes
-  if (linalgOp.hasDynamicShape()) {
-    return false;
-  }
-  return true;
-}
-
 static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
-                                        linalg::GenericOp linalgOp) {
-  if (!checkTransposePreconditions(linalgOp)) {
+                                        linalg::LinalgOp linalgOp) {
+  LinalgOpInfo opInfo(linalgOp);
+
+  if (!opInfo.isSharedMemTranspose()) {
     return failure();
   }
 
-  // To simplify logic, we only consider linalg ops with transposes who's
-  // outputs maps are identities
-  for (OpOperand *opOperand : linalgOp.getOutputOperands()) {
-    if (!linalgOp.getTiedIndexingMap(opOperand).isIdentity()) {
-      return failure();
-    }
-  }
-
-  // Determine which operands are transposed.
-  SmallVector<int64_t, 4> transposedOperandIndices;
-  for (auto indexMapPair : llvm::enumerate(linalgOp.getIndexingMapsArray())) {
-    if (isSharedMemTranspose(indexMapPair.value())) {
-      transposedOperandIndices.push_back(indexMapPair.index());
-    }
-  }
-
-  if (transposedOperandIndices.empty()) {
-    return failure();  // No shared mem transposes.
-  }
+  ArrayRef<OpOperand *> transposedOperands =
+      opInfo.getSharedMemTransposeOperands();
 
   // Determine the fastest moving dimensions for the source/destination indices
   // of each transpose. These inform the tile sizes.
   int64_t outputFastestDim = linalgOp.getNumLoops() - 1;
-  int64_t inputFastestDim =
-      linalgOp.getIndexingMapsArray()[transposedOperandIndices[0]]
-          .getDimPosition(outputFastestDim);
+  int64_t inputFastestDim = linalgOp.getTiedIndexingMap(transposedOperands[0])
+                                .getDimPosition(outputFastestDim);
   // Ensure the other transposed operands match
-  for (int i = 1; i < transposedOperandIndices.size(); ++i) {
-    if (inputFastestDim !=
-        linalgOp.getIndexingMapsArray()[transposedOperandIndices[i]]
-            .getDimPosition(outputFastestDim)) {
+  for (int i = 1; i < transposedOperands.size(); ++i) {
+    if (inputFastestDim != linalgOp.getTiedIndexingMap(transposedOperands[i])
+                               .getDimPosition(outputFastestDim)) {
       return failure();
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -513,13 +513,18 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
   return success();
 }
 
+static bool hasTwoOrThreeLoopsInfo(linalg::LinalgOp linalgOp) {
+  return linalgOp.getNumParallelLoops() >= 2 &&
+         linalgOp.getNumParallelLoops() <= 3;
+}
+
 static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
                                         linalg::LinalgOp linalgOp) {
   LinalgOpInfo opInfo(linalgOp, sharedMemTransposeFilter);
 
   // Checks preconditions for shared mem transpose.
   if (!opInfo.isTranspose() || opInfo.isDynamic() || opInfo.isReduction() ||
-      !opInfo.isTwoThreeLoops()) {
+      !isa<linalg::GenericOp>(linalgOp) || !hasTwoOrThreeLoopsInfo(linalgOp)) {
     return failure();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransposeUtils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransposeUtils.h
@@ -1,0 +1,33 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_LLVMGPU_TRANSPOSEUTILS_H_
+#define IREE_COMPILER_CODEGEN_LLVMGPU_TRANSPOSEUTILS_H_
+
+#include "mlir/IR/Types.h"
+#include "mlir/IR/Value.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// Returns true if the index map represents a transpose that benefits from
+/// shared mem.
+static bool sharedMemTransposeFilter(AffineMap indexMap) {
+  if (!indexMap.isEmpty() && indexMap.isPermutation()) {
+    // Ensure that the fasted moving dimension (the last one) is permuted,
+    // Otherwise shared memory promotion will not benefit the operation.
+    if (indexMap.getDimPosition(indexMap.getNumDims() - 1) !=
+        indexMap.getNumDims() - 1) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_LLVMGPU_TRANSPOSEUTILS_H_


### PR DESCRIPTION
Cleanup to consolidate code and improve readability. 

Related to #10005