### PR TITLE
Fix mmt4d_test: actually dont use unsupported instructions.

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_tile_arm_64_i8mm.S
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_tile_arm_64_i8mm.S
@@ -144,7 +144,7 @@ BEGIN_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm
         stp q0, q1, [x0, 128]
         stp q2, q3, [x0, 160]
         stp q4, q5, [x0, 192]
-        stp q7, q7, [x0, 224]
+        stp q6, q7, [x0, 224]
         ret
 
 END_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
@@ -253,25 +253,27 @@ static void mmt4d_test(iree_ukernel_mmt4d_type_t type, int M0, int N0, int K0,
   params.M0 = M0;
   params.N0 = N0;
   params.K0 = K0;
-  const uint64_t local_cpu_data[IREE_CPU_DATA_FIELD_COUNT] = {
-      cpu_data_field_0_bit};
-  params.cpu_data = local_cpu_data;
+  const uint64_t local_cpu_data_default[IREE_CPU_DATA_FIELD_COUNT] = {0};
+  params.cpu_data = local_cpu_data_default;
   // First try without any optional CPU feature. This matters even when the
   // feature is supported by the CPU because we want to test the fallback to
   // architecture-default or generic code.
   test_matmuls_for_various_MNK_shapes_and_flags(params, engine);
   // If this is nonzero, we are asked to test again with this CPU feature.
   if (cpu_data_field_0_bit) {
+    const uint64_t local_cpu_data_with_bit[IREE_CPU_DATA_FIELD_COUNT] = {
+        cpu_data_field_0_bit};
+    params.cpu_data = local_cpu_data_with_bit;
     // Check if the CPU supports the feature (otherwise, we crash).
     bool supported = iree_cpu_data_field(0) & params.cpu_data[0];
     if (supported) {
       // Run with the optional CPU feature.
-      fprintf(stderr, "Device supports CPU feature: %s\n",
-              get_cpu_features_str(&params));
+      printf("Device supports CPU feature: %s\n",
+             get_cpu_features_str(&params));
       test_matmuls_for_various_MNK_shapes_and_flags(params, engine);
     } else {
-      fprintf(stderr, "Skipped: device does not support CPU feature: %s\n",
-              get_cpu_features_str(&params));
+      printf("Skipped: device does not support CPU feature: %s\n",
+             get_cpu_features_str(&params));
     }
   }
   iree_mmt4d_test_random_engine_destroy(engine);


### PR DESCRIPTION
This was regressed by #10485.

Also, report the skipped/ran status on stdout not stderr, because GTest output goes there so that's how we get it consistently interleaved.

Also, fix a numerical bug in the i8mm kernel introduced in #10476. It was caught by mmt4d_test, not sure how I didn't notice.