### PR TITLE
[fusion_heuristics] Check on fusable markers in FusionOfTensorOps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     outputs:
       should-run: ${{ steps.should-run.outputs.should-run }}
       # Variables for dependent jobs. See comment at top.
-      runner-env: prod
+      runner-env: testing
       runner-group: ${{ env._CI_STAGE }}
       # Note that we can't flip the condition here because 0 is falsey. See
       # comment at top.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     outputs:
       should-run: ${{ steps.should-run.outputs.should-run }}
       # Variables for dependent jobs. See comment at top.
-      runner-env: testing
+      runner-env: prod
       runner-group: ${{ env._CI_STAGE }}
       # Note that we can't flip the condition here because 0 is falsey. See
       # comment at top.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -99,7 +99,6 @@ struct FuseElementwiseOpsWithMultipleUses
 
   LogicalResult matchAndRewrite(linalg::GenericOp consumerOp,
                                 PatternRewriter &rewriter) const override {
-    // Check and cleanup the consumer marker.
     auto consumerMarker =
         consumerOp->getAttrOfType<IntegerAttr>(getConsumerAttributeName());
     if (!consumerMarker) return failure();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -101,7 +101,7 @@ struct FuseElementwiseOpsWithMultipleUses
                                 PatternRewriter &rewriter) const override {
     // Check and cleanup the consumer marker.
     auto consumerMarker =
-        consumerOp->removeAttr(getConsumerAttributeName()).cast<IntegerAttr>();
+        consumerOp->getAttrOfType<IntegerAttr>(getConsumerAttributeName());
     if (!consumerMarker) return failure();
 
     auto fusedOperandIt =
@@ -120,7 +120,8 @@ struct FuseElementwiseOpsWithMultipleUses
            "expected producer and consumer to be fusable");
     Operation *producerOp = fusedOperand->get().getDefiningOp();
 
-    // Cleanup the producer marker.
+    // Cleanup the markers.
+    consumerOp->removeAttr(getConsumerAttributeName());
     producerOp->removeAttr(getProducerAttributeName());
 
     FailureOr<Operation *> fusedOperation =


### PR DESCRIPTION
Previously the fuse pass didn't check if the marks on consumer and producer are the same, which will fuse incorrect ops.

This change adds the check and also removes the markers to make sure the next iteration won't see the old markers.