### PR TITLE
Adding IREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN config.

### DIFF
--- a/runtime/src/iree/base/config.h
+++ b/runtime/src/iree/base/config.h
@@ -164,6 +164,13 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 // Enables optional HAL features. Each of these may add several KB to the final
 // binary when linked dynamically.
 
+// To use an import provider in the built-in CPU drivers define a function like:
+//   iree_hal_executable_import_provider_t my_provider(void) { ... }
+// And define it:
+//   -DIREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN=my_provider
+// This will only work for default drivers and otherwise users can explicitly
+// specify the provider when creating the executable loaders themselves.
+
 #if !defined(IREE_HAL_HEAP_BUFFER_ALIGNMENT)
 // Power of two byte alignment required on all host heap buffers.
 // Executables are compiled with alignment expectations and the runtime

--- a/runtime/src/iree/hal/drivers/local_sync/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/local_sync/registration/driver_module.c
@@ -41,7 +41,8 @@ static iree_status_t iree_hal_local_sync_driver_factory_try_create(
   iree_hal_executable_loader_t* loaders[8] = {NULL};
   iree_host_size_t loader_count = 0;
   iree_status_t status = iree_hal_create_all_available_executable_loaders(
-      IREE_ARRAYSIZE(loaders), &loader_count, loaders, host_allocator);
+      iree_hal_executable_import_provider_default(), IREE_ARRAYSIZE(loaders),
+      &loader_count, loaders, host_allocator);
 
   iree_hal_allocator_t* device_allocator = NULL;
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
+++ b/runtime/src/iree/hal/drivers/local_task/registration/driver_module.c
@@ -44,7 +44,8 @@ static iree_status_t iree_hal_local_task_driver_factory_try_create(
   iree_hal_executable_loader_t* loaders[8] = {NULL};
   iree_host_size_t loader_count = 0;
   iree_status_t status = iree_hal_create_all_available_executable_loaders(
-      IREE_ARRAYSIZE(loaders), &loader_count, loaders, host_allocator);
+      iree_hal_executable_import_provider_default(), IREE_ARRAYSIZE(loaders),
+      &loader_count, loaders, host_allocator);
 
   iree_task_executor_t* executor = NULL;
   if (iree_status_is_ok(status)) {

--- a/runtime/src/iree/hal/local/executable_library_benchmark.c
+++ b/runtime/src/iree/hal/local/executable_library_benchmark.c
@@ -141,7 +141,8 @@ static iree_status_t iree_hal_executable_library_run(
   // Register the loader used to load (or find) the executable.
   iree_hal_executable_loader_t* executable_loader = NULL;
   IREE_RETURN_IF_ERROR(iree_hal_create_executable_loader_by_name(
-      iree_make_cstring_view(FLAG_executable_format), host_allocator,
+      iree_make_cstring_view(FLAG_executable_format),
+      iree_hal_executable_import_provider_default(), host_allocator,
       &executable_loader));
 
   // Setup the specification used to perform the executable load.

--- a/runtime/src/iree/hal/local/executable_loader.c
+++ b/runtime/src/iree/hal/local/executable_loader.c
@@ -6,6 +6,24 @@
 
 #include "iree/hal/local/executable_loader.h"
 
+#if defined(IREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN)
+
+// Defined by the user and linked in to the binary:
+extern iree_hal_executable_import_provider_t
+IREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN(void);
+
+iree_hal_executable_import_provider_t
+iree_hal_executable_import_provider_default(void) {
+  return IREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN();
+}
+
+#else
+iree_hal_executable_import_provider_t
+iree_hal_executable_import_provider_default(void) {
+  return iree_hal_executable_import_provider_null();
+}
+#endif  // IREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN
+
 iree_status_t iree_hal_executable_import_provider_resolve(
     const iree_hal_executable_import_provider_t import_provider,
     iree_string_view_t symbol_name, void** out_fn_ptr) {

--- a/runtime/src/iree/hal/local/executable_loader.h
+++ b/runtime/src/iree/hal/local/executable_loader.h
@@ -41,10 +41,20 @@ typedef struct iree_hal_executable_import_provider_t {
 } iree_hal_executable_import_provider_t;
 
 static inline iree_hal_executable_import_provider_t
-iree_hal_executable_import_provider_null() {
+iree_hal_executable_import_provider_null(void) {
   iree_hal_executable_import_provider_t provider = {NULL, NULL};
   return provider;
 }
+
+// Returns the import provider specified by
+// IREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN or null.
+//
+// To use define a function like:
+//   iree_hal_executable_import_provider_t my_provider(void) { ... }
+// And define it:
+//   -DIREE_HAL_EXECUTABLE_IMPORT_PROVIDER_DEFAULT_FN=my_provider
+iree_hal_executable_import_provider_t
+iree_hal_executable_import_provider_default(void);
 
 // Resolves an import symbol with the given |symbol_name| and stores a pointer
 // to the function (or its context) in |out_fn_ptr|.

--- a/runtime/src/iree/hal/local/loaders/registration/init.c
+++ b/runtime/src/iree/hal/local/loaders/registration/init.c
@@ -24,6 +24,7 @@
 #endif  // IREE_HAVE_HAL_EXECUTABLE_LOADER_VMVX_MODULE
 
 IREE_API_EXPORT iree_status_t iree_hal_create_all_available_executable_loaders(
+    iree_hal_executable_import_provider_t import_provider,
     iree_host_size_t capacity, iree_host_size_t* out_count,
     iree_hal_executable_loader_t** loaders, iree_allocator_t host_allocator) {
   IREE_ASSERT_ARGUMENT(out_count);
@@ -52,16 +53,14 @@ IREE_API_EXPORT iree_status_t iree_hal_create_all_available_executable_loaders(
 #if defined(IREE_HAVE_HAL_EXECUTABLE_LOADER_SYSTEM_LIBRARY)
   if (iree_status_is_ok(status)) {
     status = iree_hal_system_library_loader_create(
-        iree_hal_executable_import_provider_null(), host_allocator,
-        &loaders[count++]);
+        import_provider, host_allocator, &loaders[count++]);
   }
 #endif  // IREE_HAVE_HAL_EXECUTABLE_LOADER_SYSTEM_LIBRARY
 
 #if defined(IREE_HAVE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
   if (iree_status_is_ok(status)) {
     status = iree_hal_embedded_elf_loader_create(
-        iree_hal_executable_import_provider_null(), host_allocator,
-        &loaders[count++]);
+        import_provider, host_allocator, &loaders[count++]);
   }
 #endif  // IREE_HAVE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF
 
@@ -84,21 +83,21 @@ IREE_API_EXPORT iree_status_t iree_hal_create_all_available_executable_loaders(
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_create_executable_loader_by_name(
-    iree_string_view_t name, iree_allocator_t host_allocator,
+    iree_string_view_t name,
+    iree_hal_executable_import_provider_t import_provider,
+    iree_allocator_t host_allocator,
     iree_hal_executable_loader_t** out_executable_loader) {
 #if defined(IREE_HAVE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
   if (iree_string_view_starts_with(name, IREE_SV("embedded-elf"))) {
-    return iree_hal_embedded_elf_loader_create(
-        iree_hal_executable_import_provider_null(), host_allocator,
-        out_executable_loader);
+    return iree_hal_embedded_elf_loader_create(import_provider, host_allocator,
+                                               out_executable_loader);
   }
 #endif  // IREE_HAVE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF
 
 #if defined(IREE_HAVE_HAL_EXECUTABLE_LOADER_SYSTEM_LIBRARY)
   if (iree_string_view_starts_with(name, IREE_SV("system-library"))) {
     return iree_hal_system_library_loader_create(
-        iree_hal_executable_import_provider_null(), host_allocator,
-        out_executable_loader);
+        import_provider, host_allocator, out_executable_loader);
   }
 #endif  // IREE_HAVE_HAL_EXECUTABLE_LOADER_SYSTEM_LIBRARY
 

--- a/runtime/src/iree/hal/local/loaders/registration/init.h
+++ b/runtime/src/iree/hal/local/loaders/registration/init.h
@@ -29,7 +29,9 @@ extern "C" {
 //  iree_host_size_t count = 0;
 //  iree_hal_executable_loader_t* loaders[8] = {NULL};
 //  IREE_RETURN_IF_ERROR(iree_hal_create_all_available_executable_loaders(
-//      IREE_ARRAYSIZE(loaders), &count, loaders, host_allocator));
+//      import_provider,
+//      IREE_ARRAYSIZE(loaders), &count, loaders,
+//      host_allocator));
 //  ...
 //  // use up to count loaders
 //  ...
@@ -37,13 +39,16 @@ extern "C" {
 //    iree_hal_executable_loader_release(loaders[i]);
 //  }
 IREE_API_EXPORT iree_status_t iree_hal_create_all_available_executable_loaders(
+    iree_hal_executable_import_provider_t import_provider,
     iree_host_size_t capacity, iree_host_size_t* out_count,
     iree_hal_executable_loader_t** loaders, iree_allocator_t host_allocator);
 
 // Creates an executable loader with the given |name|.
 // |out_executable_loader| must be released by the caller.
 IREE_API_EXPORT iree_status_t iree_hal_create_executable_loader_by_name(
-    iree_string_view_t name, iree_allocator_t host_allocator,
+    iree_string_view_t name,
+    iree_hal_executable_import_provider_t import_provider,
+    iree_allocator_t host_allocator,
     iree_hal_executable_loader_t** out_executable_loader);
 
 #ifdef __cplusplus

--- a/runtime/src/iree/tooling/context_util.c
+++ b/runtime/src/iree/tooling/context_util.c
@@ -210,7 +210,8 @@ static iree_status_t iree_tooling_load_hal_loader_module(
   iree_host_size_t loader_count = 0;
   iree_hal_executable_loader_t* loaders[16];
   iree_status_t status = iree_hal_create_all_available_executable_loaders(
-      IREE_ARRAYSIZE(loaders), &loader_count, loaders, host_allocator);
+      iree_hal_executable_import_provider_default(), IREE_ARRAYSIZE(loaders),
+      &loader_count, loaders, host_allocator);
 
   // Create the module; it retains the loaders for its lifetime.
   iree_vm_module_t* module = NULL;


### PR DESCRIPTION
This allows applications to specify an import provider that works in the generic driver factories. Applications wanting more control over the provider should create their executable loaders themselves and pass the provider in.