### PR TITLE
Make iree-benchmark-suites buildable with some backends disabled.

### DIFF
--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -185,6 +185,19 @@ function(iree_benchmark_suite)
     "BENCHMARK_MODES;BENCHMARK_TOOL;MODULES"
   )
 
+  # Try to check if the compiler supports the TARGET_BACKEND. If
+  # IREE_HOST_BINARY_ROOT is defined, we are using a compiler binary, in which
+  # case we can't check it's supported backend just by looking at this build
+  # dir's cmake variables --- we would have to implement a configure-check
+  # executing that compiler.
+  if (NOT DEFINED IREE_HOST_BINARY_ROOT)
+    string(TOUPPER ${_RULE_TARGET_BACKEND} _UPPERCASE_TARGET_BACKEND)
+    string(REPLACE "-" "_" _NORMALIZED_TARGET_BACKEND ${_UPPERCASE_TARGET_BACKEND})
+    if(NOT IREE_TARGET_BACKEND_${_NORMALIZED_TARGET_BACKEND})
+      return()
+    endif()
+  endif()
+
   iree_package_name(_PACKAGE_NAME)
 
   # Add the benchmark suite target.


### PR DESCRIPTION
Note: the reason why iree-test-deps wasn't failing similarly was that `iree_single_backend_generated_trace_runner_test` and `iree_check_single_backend_test_suite` were already performing a similar check, but they do it on the `DRIVER`, not on the `TARGET_BACKEND`. They can do so because these targets are built in the device build dir, where `IREE_HAL_DRIVER_*` variables are set and drivers are built, because drivers are part of the runtime, so they're built in the device build dir.

Unlike those targets, `iree-benchmark-suites` is built in the host build dir, so we shouldn't enable or disable benchmarks based on `IREE_HAL_DRIVER_*` here. Instead, what is relevant (and to the point of fixing the module compile error that caused me to look into this) is a check on `IREE_TARGET_BACKEND_*`.

Possibly these could be unified by switching also `iree-test-deps` to this `IREE_TARGET_BACKEND_*` check.