### PR TITLE
Passing WarpExecuteOnLane0LoweringOptions by ref.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -468,7 +468,8 @@ static void warpSyncronizationFn(Location loc, OpBuilder &builder,
 
 static void populateWarpExecuteOnLane0ToScf(
     Operation *target, RewritePatternSet &patterns,
-    vector::WarpExecuteOnLane0LoweringOptions options, PatternBenefit benefit) {
+    const vector::WarpExecuteOnLane0LoweringOptions &options,
+    PatternBenefit benefit) {
   assert(target->hasTrait<OpTrait::IsIsolatedFromAbove>());
   vector::populateWarpExecuteOnLane0OpToScfForPattern(patterns, options,
                                                       benefit);


### PR DESCRIPTION
The WarpOpToScfIfPattern captures a const& to the options but since this function takes them by value that ends up referencing a stack variable past its lifetime. This was causing stack corruption on MSVC and I confirmed this fixes it.