### PR TITLE
Making >1B wide VM buffer load/stores implicitly scale.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/buffer_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/UtilToVM/test/buffer_ops.mlir
@@ -177,11 +177,12 @@ func.func @buffer_fill_index(%arg0: !util.buffer, %arg1: index, %arg2: index) {
 
 // CHECK-LABEL: @buffer_load_i1
 func.func @buffer_load_i32(%arg0: !util.buffer, %arg1: index) -> i1 {
-  %c100 = arith.constant 100 : index
-  // CHECK-32-DAG: %[[C100:.+]] = vm.const.i64 100
-  // CHECK-32: %[[VALUE:.+]] = vm.buffer.load.i8.s %arg0[%[[C100]]] : !vm.buffer -> i32
-  // CHECK-64: %[[VALUE:.+]] = vm.buffer.load.i8.s %arg0[%c100] : !vm.buffer -> i32
-  %0 = util.buffer.load %arg0[%c100] : !util.buffer{%arg1} -> i1
+  %byte_offset = arith.constant 128 : index
+  // CHECK-32-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 128
+  // CHECK-32: %[[VALUE:.+]] = vm.buffer.load.i8.s %arg0[%[[ELEMENT_OFFSET]]] : !vm.buffer -> i32
+  // CHECK-64-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 128
+  // CHECK-64: %[[VALUE:.+]] = vm.buffer.load.i8.s %arg0[%[[ELEMENT_OFFSET]]] : !vm.buffer -> i32
+  %0 = util.buffer.load %arg0[%byte_offset] : !util.buffer{%arg1} -> i1
   // CHECK: return %[[VALUE]]
   return %0 : i1
 }
@@ -190,11 +191,12 @@ func.func @buffer_load_i32(%arg0: !util.buffer, %arg1: index) -> i1 {
 
 // CHECK-LABEL: @buffer_load_i32
 func.func @buffer_load_i32(%arg0: !util.buffer, %arg1: index) -> i32 {
-  %c100 = arith.constant 100 : index
-  // CHECK-32-DAG: %[[C100:.+]] = vm.const.i64 100
-  // CHECK-32: %[[VALUE:.+]] = vm.buffer.load.i32 %arg0[%[[C100]]] : !vm.buffer -> i32
-  // CHECK-64: %[[VALUE:.+]] = vm.buffer.load.i32 %arg0[%c100] : !vm.buffer -> i32
-  %0 = util.buffer.load %arg0[%c100] : !util.buffer{%arg1} -> i32
+  %byte_offset = arith.constant 128 : index
+  // CHECK-32-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 32
+  // CHECK-32: %[[VALUE:.+]] = vm.buffer.load.i32 %arg0[%[[ELEMENT_OFFSET]]] : !vm.buffer -> i32
+  // CHECK-64-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 32
+  // CHECK-64: %[[VALUE:.+]] = vm.buffer.load.i32 %arg0[%[[ELEMENT_OFFSET]]] : !vm.buffer -> i32
+  %0 = util.buffer.load %arg0[%byte_offset] : !util.buffer{%arg1} -> i32
   // CHECK: return %[[VALUE]]
   return %0 : i32
 }
@@ -203,11 +205,12 @@ func.func @buffer_load_i32(%arg0: !util.buffer, %arg1: index) -> i32 {
 
 // CHECK-LABEL: @buffer_load_i64
 func.func @buffer_load_i64(%arg0: !util.buffer, %arg1: index) -> i64 {
-  %c100 = arith.constant 100 : index
-  // CHECK-32-DAG: %[[C100:.+]] = vm.const.i64 100
-  // CHECK-32: %[[VALUE:.+]] = vm.buffer.load.i64 %arg0[%[[C100]]] : !vm.buffer -> i64
-  // CHECK-64: %[[VALUE:.+]] = vm.buffer.load.i64 %arg0[%c100] : !vm.buffer -> i64
-  %0 = util.buffer.load %arg0[%c100] : !util.buffer{%arg1} -> i64
+  %byte_offset = arith.constant 128 : index
+  // CHECK-32-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 16
+  // CHECK-32: %[[VALUE:.+]] = vm.buffer.load.i64 %arg0[%[[ELEMENT_OFFSET]]] : !vm.buffer -> i64
+  // CHECK-64-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 16
+  // CHECK-64: %[[VALUE:.+]] = vm.buffer.load.i64 %arg0[%[[ELEMENT_OFFSET]]] : !vm.buffer -> i64
+  %0 = util.buffer.load %arg0[%byte_offset] : !util.buffer{%arg1} -> i64
   // CHECK: return %[[VALUE]]
   return %0 : i64
 }
@@ -216,10 +219,10 @@ func.func @buffer_load_i64(%arg0: !util.buffer, %arg1: index) -> i64 {
 
 // CHECK-LABEL: @buffer_load_index
 func.func @buffer_load_index(%arg0: !util.buffer, %arg1: index) -> index {
-  %c100 = arith.constant 100 : index
+  %byte_offset = arith.constant 100 : index
   // CHECK-32: vm.buffer.load.i32
   // CHECK-64: vm.buffer.load.i64
-  %0 = util.buffer.load %arg0[%c100] : !util.buffer{%arg1} -> index
+  %0 = util.buffer.load %arg0[%byte_offset] : !util.buffer{%arg1} -> index
   return %0 : index
 }
 
@@ -227,11 +230,12 @@ func.func @buffer_load_index(%arg0: !util.buffer, %arg1: index) -> index {
 
 // CHECK-LABEL: @buffer_store_i1
 func.func @buffer_store_i1(%arg0: !util.buffer, %arg1: index, %arg2: i1) {
-  %c100 = arith.constant 100 : index
-  // CHECK-32-DAG: %[[C100:.+]] = vm.const.i64 100
-  // CHECK-32: vm.buffer.store.i8 %arg2, %arg0[%[[C100]]] : i32 -> !vm.buffer
-  // CHECK-64: vm.buffer.store.i8 %arg2, %arg0[%c100] : i32 -> !vm.buffer
-  util.buffer.store %arg2, %arg0[%c100] : i1 -> !util.buffer{%arg1}
+  %byte_offset = arith.constant 128 : index
+  // CHECK-32-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 128
+  // CHECK-32: vm.buffer.store.i8 %arg2, %arg0[%[[ELEMENT_OFFSET]]] : i32 -> !vm.buffer
+  // CHECK-64-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 128
+  // CHECK-64: vm.buffer.store.i8 %arg2, %arg0[%[[ELEMENT_OFFSET]]] : i32 -> !vm.buffer
+  util.buffer.store %arg2, %arg0[%byte_offset] : i1 -> !util.buffer{%arg1}
   return
 }
 
@@ -239,11 +243,12 @@ func.func @buffer_store_i1(%arg0: !util.buffer, %arg1: index, %arg2: i1) {
 
 // CHECK-LABEL: @buffer_store_i32
 func.func @buffer_store_i32(%arg0: !util.buffer, %arg1: index, %arg2: i32) {
-  %c100 = arith.constant 100 : index
-  // CHECK-32-DAG: %[[C100:.+]] = vm.const.i64 100
-  // CHECK-32: vm.buffer.store.i32 %arg2, %arg0[%[[C100]]] : i32 -> !vm.buffer
-  // CHECK-64: vm.buffer.store.i32 %arg2, %arg0[%c100] : i32 -> !vm.buffer
-  util.buffer.store %arg2, %arg0[%c100] : i32 -> !util.buffer{%arg1}
+  %byte_offset = arith.constant 128 : index
+  // CHECK-32-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 32
+  // CHECK-32: vm.buffer.store.i32 %arg2, %arg0[%[[ELEMENT_OFFSET]]] : i32 -> !vm.buffer
+  // CHECK-64-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 32
+  // CHECK-64: vm.buffer.store.i32 %arg2, %arg0[%[[ELEMENT_OFFSET]]] : i32 -> !vm.buffer
+  util.buffer.store %arg2, %arg0[%byte_offset] : i32 -> !util.buffer{%arg1}
   return
 }
 
@@ -251,11 +256,12 @@ func.func @buffer_store_i32(%arg0: !util.buffer, %arg1: index, %arg2: i32) {
 
 // CHECK-LABEL: @buffer_store_i64
 func.func @buffer_store_i64(%arg0: !util.buffer, %arg1: index, %arg2: i64) {
-  %c100 = arith.constant 100 : index
-  // CHECK-32-DAG: %[[C100:.+]] = vm.const.i64 100
-  // CHECK-32: vm.buffer.store.i64 %arg2, %arg0[%[[C100]]] : i64 -> !vm.buffer
-  // CHECK-64: vm.buffer.store.i64 %arg2, %arg0[%c100] : i64 -> !vm.buffer
-  util.buffer.store %arg2, %arg0[%c100] : i64 -> !util.buffer{%arg1}
+  %byte_offset = arith.constant 128 : index
+  // CHECK-32-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 16
+  // CHECK-32: vm.buffer.store.i64 %arg2, %arg0[%[[ELEMENT_OFFSET]]] : i64 -> !vm.buffer
+  // CHECK-64-DAG: %[[ELEMENT_OFFSET:.+]] = vm.const.i64 16
+  // CHECK-64: vm.buffer.store.i64 %arg2, %arg0[%[[ELEMENT_OFFSET]]] : i64 -> !vm.buffer
+  util.buffer.store %arg2, %arg0[%byte_offset] : i64 -> !util.buffer{%arg1}
   return
 }
 
@@ -263,9 +269,9 @@ func.func @buffer_store_i64(%arg0: !util.buffer, %arg1: index, %arg2: i64) {
 
 // CHECK-LABEL: @buffer_store_index
 func.func @buffer_store_index(%arg0: !util.buffer, %arg1: index, %arg2: index) {
-  %c100 = arith.constant 100 : index
+  %byte_offset = arith.constant 100 : index
   // CHECK-32: vm.buffer.store.i32
   // CHECK-64: vm.buffer.store.i64
-  util.buffer.store %arg2, %arg0[%c100] : index -> !util.buffer{%arg1}
+  util.buffer.store %arg2, %arg0[%byte_offset] : index -> !util.buffer{%arg1}
   return
 }

--- a/compiler/src/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/test/arithmetic_folding.mlir
@@ -5,7 +5,7 @@
 // CHECK-LABEL: @add_i32_folds
 vm.module @add_i32_folds {
   // CHECK-LABEL: @add_i32_0_y
-  vm.func @add_i32_0_y(%arg0 : i32) -> i32 {
+  vm.func @add_i32_0_y(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %zero = vm.const.i32.zero
     %0 = vm.add.i32 %zero, %arg0 : i32
@@ -13,7 +13,7 @@ vm.module @add_i32_folds {
   }
 
   // CHECK-LABEL: @add_i32_x_0
-  vm.func @add_i32_x_0(%arg0 : i32) -> i32 {
+  vm.func @add_i32_x_0(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %zero = vm.const.i32.zero
     %0 = vm.add.i32 %arg0, %zero : i32
@@ -36,7 +36,7 @@ vm.module @add_i32_folds {
 // CHECK-LABEL: @sub_i32_folds
 vm.module @sub_i32_folds {
   // CHECK-LABEL: @sub_i32_x_0
-  vm.func @sub_i32_x_0(%arg0 : i32) -> i32 {
+  vm.func @sub_i32_x_0(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %zero = vm.const.i32.zero
     %0 = vm.sub.i32 %arg0, %zero : i32
@@ -59,14 +59,14 @@ vm.module @sub_i32_folds {
 // CHECK-LABEL: @add_sub_i32_folds
 vm.module @add_sub_i32_folds {
   // CHECK-LABEL: @add_sub_x
-  vm.func @add_sub_x(%arg0 : i32, %arg1 : i32) -> i32 {
+  vm.func @add_sub_x(%arg0: i32, %arg1: i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0
     %0 = vm.add.i32 %arg0, %arg1 : i32
     %1 = vm.sub.i32 %0, %arg1 : i32
     vm.return %1 : i32
   }
   // CHECK-LABEL: @add_sub_x_rev
-  vm.func @add_sub_x_rev(%arg0 : i32, %arg1 : i32) -> i32 {
+  vm.func @add_sub_x_rev(%arg0: i32, %arg1: i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0
     %0 = vm.add.i32 %arg1, %arg0 : i32
     %1 = vm.sub.i32 %arg1, %0 : i32
@@ -74,14 +74,14 @@ vm.module @add_sub_i32_folds {
   }
 
   // CHECK-LABEL: @sub_add_x
-  vm.func @sub_add_x(%arg0 : i32, %arg1 : i32) -> i32 {
+  vm.func @sub_add_x(%arg0: i32, %arg1: i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0
     %0 = vm.sub.i32 %arg0, %arg1 : i32
     %1 = vm.add.i32 %0, %arg1 : i32
     vm.return %1 : i32
   }
   // CHECK-LABEL: @sub_add_x_rev
-  vm.func @sub_add_x_rev(%arg0 : i32, %arg1 : i32) -> i32 {
+  vm.func @sub_add_x_rev(%arg0: i32, %arg1: i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0
     %0 = vm.sub.i32 %arg0, %arg1 : i32
     %1 = vm.add.i32 %arg1, %0 : i32
@@ -94,7 +94,7 @@ vm.module @add_sub_i32_folds {
 // CHECK-LABEL: @mul_i32_folds
 vm.module @mul_i32_folds {
   // CHECK-LABEL: @mul_i32_by_0
-  vm.func @mul_i32_by_0(%arg0 : i32) -> i32 {
+  vm.func @mul_i32_by_0(%arg0: i32) -> i32 {
     // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %zero = vm.const.i32.zero
@@ -103,7 +103,7 @@ vm.module @mul_i32_folds {
   }
 
   // CHECK-LABEL: @mul_i32_1_y
-  vm.func @mul_i32_1_y(%arg0 : i32) -> i32 {
+  vm.func @mul_i32_1_y(%arg0: i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0 : i32
     %c1 = vm.const.i32 1
     %0 = vm.mul.i32 %c1, %arg0 : i32
@@ -111,7 +111,7 @@ vm.module @mul_i32_folds {
   }
 
   // CHECK-LABEL: @mul_i32_x_1
-  vm.func @mul_i32_x_1(%arg0 : i32) -> i32 {
+  vm.func @mul_i32_x_1(%arg0: i32) -> i32 {
     // CHECK-NEXT: vm.return %arg0 : i32
     %c1 = vm.const.i32 1
     %0 = vm.mul.i32 %arg0, %c1 : i32
@@ -134,7 +134,7 @@ vm.module @mul_i32_folds {
 // CHECK-LABEL: @mul_mul_i32_folds
 vm.module @mul_mul_i32_folds {
   // CHECK-LABEL: @mul_mul_i32_const
-  vm.func @mul_mul_i32_const(%arg0 : i32) -> i32 {
+  vm.func @mul_mul_i32_const(%arg0: i32) -> i32 {
     // CHECK: %c40 = vm.const.i32 40
     %c4 = vm.const.i32 4
     %c10 = vm.const.i32 10
@@ -151,7 +151,7 @@ vm.module @mul_mul_i32_folds {
 // CHECK-LABEL: @div_i32_folds
 vm.module @div_i32_folds {
   // CHECK-LABEL: @div_i32_0_y
-  vm.func @div_i32_0_y(%arg0 : i32) -> i32 {
+  vm.func @div_i32_0_y(%arg0: i32) -> i32 {
     // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %zero = vm.const.i32.zero
@@ -160,7 +160,7 @@ vm.module @div_i32_folds {
   }
 
   // CHECK-LABEL: @div_i32_x_1
-  vm.func @div_i32_x_1(%arg0 : i32) -> i32 {
+  vm.func @div_i32_x_1(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %c1 = vm.const.i32 1
     %0 = vm.div.i32.s %arg0, %c1 : i32
@@ -176,6 +176,14 @@ vm.module @div_i32_folds {
     %0 = vm.div.i32.s %c15, %c5 : i32
     vm.return %0 : i32
   }
+
+  // CHECK-LABEL: @mul_div_i32
+  vm.func @mul_div_i32(%arg0: i32, %arg1: i32) -> i32 {
+    %0 = vm.mul.i32 %arg0, %arg1 : i32
+    %1 = vm.div.i32.s %0, %arg1 : i32
+    // CHECK-NEXT: vm.return %arg0
+    vm.return %1 : i32
+  }
 }
 
 // -----
@@ -183,7 +191,7 @@ vm.module @div_i32_folds {
 // CHECK-LABEL: @rem_i32_folds
 vm.module @rem_i32_folds {
   // CHECK-LABEL: @rem_i32_x_1
-  vm.func @rem_i32_x_1(%arg0 : i32) -> i32 {
+  vm.func @rem_i32_x_1(%arg0: i32) -> i32 {
     // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %c1 = vm.const.i32 1
@@ -192,7 +200,7 @@ vm.module @rem_i32_folds {
   }
 
   // CHECK-LABEL: @rem_i32_0_y
-  vm.func @rem_i32_0_y(%arg0 : i32) -> i32 {
+  vm.func @rem_i32_0_y(%arg0: i32) -> i32 {
     // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %zero = vm.const.i32.zero
@@ -244,7 +252,7 @@ vm.module @not_i32_folds {
 // CHECK-LABEL: @and_i32_folds
 vm.module @and_i32_folds {
   // CHECK-LABEL: @and_i32_zero
-  vm.func @and_i32_zero(%arg0 : i32) -> i32 {
+  vm.func @and_i32_zero(%arg0: i32) -> i32 {
     // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %zero = vm.const.i32.zero
@@ -253,7 +261,7 @@ vm.module @and_i32_folds {
   }
 
   // CHECK-LABEL: @and_i32_eq
-  vm.func @and_i32_eq(%arg0 : i32) -> i32 {
+  vm.func @and_i32_eq(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %0 = vm.and.i32 %arg0, %arg0 : i32
     vm.return %0 : i32
@@ -275,7 +283,7 @@ vm.module @and_i32_folds {
 // CHECK-LABEL: @or_i32_folds
 vm.module @or_i32_folds {
   // CHECK-LABEL: @or_i32_0_y
-  vm.func @or_i32_0_y(%arg0 : i32) -> i32 {
+  vm.func @or_i32_0_y(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %zero = vm.const.i32.zero
     %0 = vm.or.i32 %zero, %arg0 : i32
@@ -283,7 +291,7 @@ vm.module @or_i32_folds {
   }
 
   // CHECK-LABEL: @or_i32_x_0
-  vm.func @or_i32_x_0(%arg0 : i32) -> i32 {
+  vm.func @or_i32_x_0(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %zero = vm.const.i32.zero
     %0 = vm.or.i32 %arg0, %zero : i32
@@ -291,7 +299,7 @@ vm.module @or_i32_folds {
   }
 
   // CHECK-LABEL: @or_i32_x_x
-  vm.func @or_i32_x_x(%arg0 : i32) -> i32 {
+  vm.func @or_i32_x_x(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %0 = vm.or.i32 %arg0, %arg0 : i32
     vm.return %0 : i32
@@ -313,7 +321,7 @@ vm.module @or_i32_folds {
 // CHECK-LABEL: @xor_i32_folds
 vm.module @xor_i32_folds {
   // CHECK-LABEL: @xor_i32_0_y
-  vm.func @xor_i32_0_y(%arg0 : i32) -> i32 {
+  vm.func @xor_i32_0_y(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %zero = vm.const.i32.zero
     %0 = vm.xor.i32 %zero, %arg0 : i32
@@ -321,7 +329,7 @@ vm.module @xor_i32_folds {
   }
 
   // CHECK-LABEL: @xor_i32_x_0
-  vm.func @xor_i32_x_0(%arg0 : i32) -> i32 {
+  vm.func @xor_i32_x_0(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %zero = vm.const.i32.zero
     %0 = vm.xor.i32 %arg0, %zero : i32
@@ -329,7 +337,7 @@ vm.module @xor_i32_folds {
   }
 
   // CHECK-LABEL: @xor_i32_x_x
-  vm.func @xor_i32_x_x(%arg0 : i32) -> i32 {
+  vm.func @xor_i32_x_x(%arg0: i32) -> i32 {
     // CHECK: %zero = vm.const.i32.zero
     // CHECK-NEXT: vm.return %zero : i32
     %0 = vm.xor.i32 %arg0, %arg0 : i32
@@ -392,7 +400,7 @@ vm.module @shl_i32_folds {
   }
 
   // CHECK-LABEL: @shl_i32_x_by_0
-  vm.func @shl_i32_x_by_0(%arg0 : i32) -> i32 {
+  vm.func @shl_i32_x_by_0(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %c0 = vm.const.i32 0
     %0 = vm.shl.i32 %arg0, %c0 : i32
@@ -425,7 +433,7 @@ vm.module @shr_i32_s_folds {
   }
 
   // CHECK-LABEL: @shr_i32_s_x_by_0
-  vm.func @shr_i32_s_x_by_0(%arg0 : i32) -> i32 {
+  vm.func @shr_i32_s_x_by_0(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %c0 = vm.const.i32.zero
     %0 = vm.shr.i32.s %arg0, %c0 : i32
@@ -458,7 +466,7 @@ vm.module @shr_i32_u_folds {
   }
 
   // CHECK-LABEL: @shr_i32_u_x_by_0
-  vm.func @shr_i32_u_x_by_0(%arg0 : i32) -> i32 {
+  vm.func @shr_i32_u_x_by_0(%arg0: i32) -> i32 {
     // CHECK: vm.return %arg0 : i32
     %c0 = vm.const.i32 0
     %0 = vm.shr.i32.u %arg0, %c0 : i32

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.h
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeEncoder.h
@@ -32,7 +32,7 @@ struct EncodedBytecodeFunction {
 class BytecodeEncoder : public VMFuncEncoder {
  public:
   // Matches IREE_VM_BYTECODE_VERSION_MAJOR.
-  static constexpr uint32_t kVersionMajor = 12;
+  static constexpr uint32_t kVersionMajor = 13;
   // Matches IREE_VM_BYTECODE_VERSION_MINOR.
   static constexpr uint32_t kVersionMinor = 0;
   static constexpr uint32_t kVersion = (kVersionMajor << 16) | kVersionMinor;

--- a/runtime/src/iree/vm/bytecode_dispatch.c
+++ b/runtime/src/iree/vm/bytecode_dispatch.c
@@ -1158,8 +1158,9 @@ static iree_status_t iree_vm_bytecode_dispatch(
       iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
       uint32_t* result_ptr = VM_DecResultRegI32("result");
       uint16_t result_x16 = 0;
-      IREE_RETURN_IF_ERROR(iree_vm_buffer_read_elements(
-          buffer, offset, &result_x16, 1, sizeof(result_x16)));
+      IREE_RETURN_IF_ERROR(
+          iree_vm_buffer_read_elements(buffer, offset * sizeof(result_x16),
+                                       &result_x16, 1, sizeof(result_x16)));
       *result_ptr = vm_ext_i16i32u(result_x16);
     });
     DISPATCH_OP(CORE, BufferLoadI16S, {
@@ -1174,8 +1175,9 @@ static iree_status_t iree_vm_bytecode_dispatch(
       iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
       uint32_t* result_ptr = VM_DecResultRegI32("result");
       int16_t result_x16 = 0;
-      IREE_RETURN_IF_ERROR(iree_vm_buffer_read_elements(
-          buffer, offset, &result_x16, 1, sizeof(result_x16)));
+      IREE_RETURN_IF_ERROR(
+          iree_vm_buffer_read_elements(buffer, offset * sizeof(result_x16),
+                                       &result_x16, 1, sizeof(result_x16)));
       *result_ptr = vm_ext_i16i32s(result_x16);
     });
     DISPATCH_OP(CORE, BufferLoadI32, {
@@ -1189,8 +1191,8 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
       iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
       uint32_t* result = VM_DecResultRegI32("result");
-      IREE_RETURN_IF_ERROR(iree_vm_buffer_read_elements(buffer, offset, result,
-                                                        1, sizeof(*result)));
+      IREE_RETURN_IF_ERROR(iree_vm_buffer_read_elements(
+          buffer, offset * sizeof(*result), result, 1, sizeof(*result)));
     });
     DISPATCH_OP(CORE, BufferLoadI64, {
       bool buffer_is_move;
@@ -1203,8 +1205,8 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
       iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
       uint64_t* result = VM_DecResultRegI64("result");
-      IREE_RETURN_IF_ERROR(iree_vm_buffer_read_elements(buffer, offset, result,
-                                                        1, sizeof(*result)));
+      IREE_RETURN_IF_ERROR(iree_vm_buffer_read_elements(
+          buffer, offset * sizeof(*result), result, 1, sizeof(*result)));
     });
 
     // TODO(benvanik): rework dispatch so that the StoreI* ops can share the
@@ -1235,8 +1237,8 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
       iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
       uint16_t value = (uint16_t)VM_DecOperandRegI32("value");
-      IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(&value, buffer, offset,
-                                                         1, sizeof(uint16_t)));
+      IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(
+          &value, buffer, offset * sizeof(value), 1, sizeof(value)));
     });
     DISPATCH_OP(CORE, BufferStoreI32, {
       bool buffer_is_move;
@@ -1249,8 +1251,8 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
       iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
       uint32_t value = VM_DecOperandRegI32("value");
-      IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(&value, buffer, offset,
-                                                         1, sizeof(uint32_t)));
+      IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(
+          &value, buffer, offset * sizeof(value), 1, sizeof(value)));
     });
     DISPATCH_OP(CORE, BufferStoreI64, {
       bool buffer_is_move;
@@ -1263,8 +1265,8 @@ static iree_status_t iree_vm_bytecode_dispatch(
       }
       iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
       uint64_t value = (uint64_t)VM_DecOperandRegI64("value");
-      IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(&value, buffer, offset,
-                                                         1, sizeof(uint64_t)));
+      IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(
+          &value, buffer, offset * sizeof(value), 1, sizeof(value)));
     });
 
     //===------------------------------------------------------------------===//
@@ -2124,7 +2126,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
         iree_host_size_t offset = VM_DecOperandRegI64HostSize("source_offset");
         float* result = VM_DecResultRegF32("result");
         IREE_RETURN_IF_ERROR(iree_vm_buffer_read_elements(
-            buffer, offset, result, 1, sizeof(*result)));
+            buffer, offset * sizeof(*result), result, 1, sizeof(*result)));
       });
 
       DISPATCH_OP(EXT_F32, BufferStoreF32, {
@@ -2139,7 +2141,7 @@ static iree_status_t iree_vm_bytecode_dispatch(
         iree_host_size_t offset = VM_DecOperandRegI64HostSize("target_offset");
         float value = VM_DecOperandRegF32("value");
         IREE_RETURN_IF_ERROR(iree_vm_buffer_write_elements(
-            &value, buffer, offset, 1, sizeof(float)));
+            &value, buffer, offset * sizeof(value), 1, sizeof(value)));
       });
     }
     END_DISPATCH_PREFIX();

--- a/runtime/src/iree/vm/bytecode_module_benchmark.mlir
+++ b/runtime/src/iree/vm/bytecode_module_benchmark.mlir
@@ -82,20 +82,20 @@ vm.module @bytecode_module_benchmark {
   vm.func @buffer_reduce(%count : i32) -> i32 {
     %c0 = vm.const.i64.zero
     %c0_i32 = vm.const.i32.zero
-    %c1 = vm.const.i32 1
-    %c4 = vm.const.i32 4
-    %max = vm.mul.i32 %count, %c4 : i32
-    %max_i64 = vm.ext.i32.i64.u %max : i32 -> i64
-    %buf = vm.buffer.alloc %max_i64 : !vm.buffer
-    vm.buffer.fill.i32 %buf, %c0, %max_i64, %c1 : i32 -> !vm.buffer
-    vm.br ^loop(%c0_i32, %c0_i32 : i32, i32)
-  ^loop(%i : i32, %sum : i32):
-    %i_i64 = vm.ext.i32.i64.u %i : i32 -> i64
-    %element = vm.buffer.load.i32 %buf[%i_i64] : !vm.buffer -> i32
+    %pattern = vm.const.i32 1
+    %c1 = vm.const.i64 1
+    %c4 = vm.const.i64 4
+    %count_i64 = vm.ext.i32.i64.u %count : i32 -> i64
+    %max = vm.mul.i64 %count_i64, %c4 : i64
+    %buf = vm.buffer.alloc %max : !vm.buffer
+    vm.buffer.fill.i32 %buf, %c0, %max, %pattern : i32 -> !vm.buffer
+    vm.br ^loop(%c0, %c0_i32 : i64, i32)
+  ^loop(%i : i64, %sum : i32):
+    %element = vm.buffer.load.i32 %buf[%i] : !vm.buffer -> i32
     %new_sum = vm.add.i32 %sum, %element : i32
-    %ip4 = vm.add.i32 %i, %c4 : i32
-    %cmp = vm.cmp.lt.i32.s %ip4, %max : i32
-    vm.cond_br %cmp, ^loop(%ip4, %new_sum : i32, i32), ^loop_exit(%new_sum : i32)
+    %ip1 = vm.add.i64 %i, %c1 : i64
+    %cmp = vm.cmp.lt.i64.s %ip1, %count_i64 : i64
+    vm.cond_br %cmp, ^loop(%ip1, %new_sum : i64, i32), ^loop_exit(%new_sum : i32)
   ^loop_exit(%result : i32):
     vm.return %result : i32
   }
@@ -105,30 +105,31 @@ vm.module @bytecode_module_benchmark {
   vm.export @buffer_reduce_unrolled
   vm.func @buffer_reduce_unrolled(%count : i32) -> i32 {
     %c0 = vm.const.i64.zero
-    %c1 = vm.const.i32 1
+    %pattern = vm.const.i32 1
+    %c1 = vm.const.i64 1
     %c4 = vm.const.i64 4
     %count_i64 = vm.ext.i32.i64.u %count : i32 -> i64
     %max = vm.mul.i64 %count_i64, %c4 : i64
     %buf = vm.buffer.alloc %max : !vm.buffer
-    vm.buffer.fill.i32 %buf, %c0, %max, %c1 : i32 -> !vm.buffer
+    vm.buffer.fill.i32 %buf, %c0, %max, %pattern : i32 -> !vm.buffer
     %sum_init = vm.const.i32.zero
     vm.br ^loop(%c0, %sum_init : i64, i32)
   ^loop(%i0 : i64, %sum : i32):
     // TODO(#5544): add addressing modes to load/store.
     %e0 = vm.buffer.load.i32 %buf[%i0] : !vm.buffer -> i32
-    %i1 = vm.add.i64 %i0, %c4 : i64
+    %i1 = vm.add.i64 %i0, %c1 : i64
     %e1 = vm.buffer.load.i32 %buf[%i1] : !vm.buffer -> i32
-    %i2 = vm.add.i64 %i1, %c4 : i64
+    %i2 = vm.add.i64 %i1, %c1 : i64
     %e2 = vm.buffer.load.i32 %buf[%i2] : !vm.buffer -> i32
-    %i3 = vm.add.i64 %i2, %c4 : i64
+    %i3 = vm.add.i64 %i2, %c1 : i64
     %e3 = vm.buffer.load.i32 %buf[%i3] : !vm.buffer -> i32
-    %i4 = vm.add.i64 %i3, %c4 : i64
+    %i4 = vm.add.i64 %i3, %c1 : i64
     %e4 = vm.buffer.load.i32 %buf[%i4] : !vm.buffer -> i32
-    %i5 = vm.add.i64 %i4, %c4 : i64
+    %i5 = vm.add.i64 %i4, %c1 : i64
     %e5 = vm.buffer.load.i32 %buf[%i5] : !vm.buffer -> i32
-    %i6 = vm.add.i64 %i5, %c4 : i64
+    %i6 = vm.add.i64 %i5, %c1 : i64
     %e6 = vm.buffer.load.i32 %buf[%i6] : !vm.buffer -> i32
-    %i7 = vm.add.i64 %i6, %c4 : i64
+    %i7 = vm.add.i64 %i6, %c1 : i64
     %e7 = vm.buffer.load.i32 %buf[%i7] : !vm.buffer -> i32
     // If we do reductions like this we could add a horizontal-add op.
     %new_sum0 = vm.add.i32 %sum, %e0 : i32
@@ -139,8 +140,8 @@ vm.module @bytecode_module_benchmark {
     %new_sum5 = vm.add.i32 %new_sum4, %e5 : i32
     %new_sum6 = vm.add.i32 %new_sum5, %e6 : i32
     %new_sum7 = vm.add.i32 %new_sum6, %e7 : i32
-    %next_i = vm.add.i64 %i7, %c4 : i64
-    %cmp = vm.cmp.lt.i64.s %next_i, %max : i64
+    %next_i = vm.add.i64 %i7, %c1 : i64
+    %cmp = vm.cmp.lt.i64.s %next_i, %count_i64 : i64
     vm.cond_br %cmp, ^loop(%next_i, %new_sum7 : i64, i32), ^loop_exit(%new_sum7 : i32)
   ^loop_exit(%result : i32):
     vm.return %result : i32

--- a/runtime/src/iree/vm/bytecode_module_impl.h
+++ b/runtime/src/iree/vm/bytecode_module_impl.h
@@ -33,7 +33,7 @@ extern "C" {
 // Major bytecode version; mismatches on this will fail in either direction.
 // This allows coarse versioning of completely incompatible versions.
 // Matches BytecodeEncoder::kVersionMajor in the compiler.
-#define IREE_VM_BYTECODE_VERSION_MAJOR 12
+#define IREE_VM_BYTECODE_VERSION_MAJOR 13
 // Minor bytecode version; lower versions are allowed to enable newer runtimes
 // to load older serialized files when there are backwards-compatible changes.
 // Higher versions are disallowed as they occur when new ops are added that

--- a/runtime/src/iree/vm/test/buffer_ops.mlir
+++ b/runtime/src/iree/vm/test/buffer_ops.mlir
@@ -417,24 +417,24 @@ vm.module @buffer_ops {
   vm.export @test_load_i16u attributes {emitc.exclude}
   vm.func private @test_load_i16u() {
     %c0 = vm.const.i64 0
+    %c1 = vm.const.i64 1
     %c2 = vm.const.i64 2
+    %c3 = vm.const.i64 3
     %c4 = vm.const.i64 4
-    %c6 = vm.const.i64 6
-    %c8 = vm.const.i64 8
     %rodata = vm.const.ref.rodata @test_load_i16_data : !vm.buffer
     %v0 = vm.buffer.load.i16.u %rodata[%c0] : !vm.buffer -> i32
     %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
-    %v1 = vm.buffer.load.i16.u %rodata[%c2] : !vm.buffer -> i32
+    %v1 = vm.buffer.load.i16.u %rodata[%c1] : !vm.buffer -> i32
     %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
-    %v2 = vm.buffer.load.i16.u %rodata[%c4] : !vm.buffer -> i32
+    %v2 = vm.buffer.load.i16.u %rodata[%c2] : !vm.buffer -> i32
     %e2 = vm.const.i32 0x7FFF
     vm.check.eq %v2, %e2, "0x7FFF" : i32
-    %v3 = vm.buffer.load.i16.u %rodata[%c6] : !vm.buffer -> i32
+    %v3 = vm.buffer.load.i16.u %rodata[%c3] : !vm.buffer -> i32
     %e3 = vm.const.i32 0x8000
     vm.check.eq %v3, %e3, "0x8000" : i32
-    %v4 = vm.buffer.load.i16.u %rodata[%c8] : !vm.buffer -> i32
+    %v4 = vm.buffer.load.i16.u %rodata[%c4] : !vm.buffer -> i32
     %e4 = vm.const.i32 0xFFFF
     vm.check.eq %v4, %e4, "0xFFFF" : i32
     vm.return
@@ -443,24 +443,24 @@ vm.module @buffer_ops {
   vm.export @test_load_i16s attributes {emitc.exclude}
   vm.func private @test_load_i16s() {
     %c0 = vm.const.i64 0
+    %c1 = vm.const.i64 1
     %c2 = vm.const.i64 2
+    %c3 = vm.const.i64 3
     %c4 = vm.const.i64 4
-    %c6 = vm.const.i64 6
-    %c8 = vm.const.i64 8
     %rodata = vm.const.ref.rodata @test_load_i16_data : !vm.buffer
     %v0 = vm.buffer.load.i16.s %rodata[%c0] : !vm.buffer -> i32
     %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
-    %v1 = vm.buffer.load.i16.s %rodata[%c2] : !vm.buffer -> i32
+    %v1 = vm.buffer.load.i16.s %rodata[%c1] : !vm.buffer -> i32
     %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
-    %v2 = vm.buffer.load.i16.s %rodata[%c4] : !vm.buffer -> i32
+    %v2 = vm.buffer.load.i16.s %rodata[%c2] : !vm.buffer -> i32
     %e2 = vm.const.i32 0x7FFF
     vm.check.eq %v2, %e2, "0x7FFF" : i32
-    %v3 = vm.buffer.load.i16.s %rodata[%c6] : !vm.buffer -> i32
+    %v3 = vm.buffer.load.i16.s %rodata[%c3] : !vm.buffer -> i32
     %e3 = vm.const.i32 -32768
     vm.check.eq %v3, %e3, "-32768" : i32
-    %v4 = vm.buffer.load.i16.s %rodata[%c8] : !vm.buffer -> i32
+    %v4 = vm.buffer.load.i16.s %rodata[%c4] : !vm.buffer -> i32
     %e4 = vm.const.i32 -1
     vm.check.eq %v4, %e4, "-1" : i32
     vm.return
@@ -471,42 +471,26 @@ vm.module @buffer_ops {
   vm.export @test_load_i32 attributes {emitc.exclude}
   vm.func private @test_load_i32() {
     %c0 = vm.const.i64 0
+    %c1 = vm.const.i64 1
+    %c2 = vm.const.i64 2
+    %c3 = vm.const.i64 3
     %c4 = vm.const.i64 4
-    %c8 = vm.const.i64 8
-    %c12 = vm.const.i64 12
-    %c16 = vm.const.i64 16
     %rodata = vm.const.ref.rodata @test_load_i32_data : !vm.buffer
     %v0 = vm.buffer.load.i32 %rodata[%c0] : !vm.buffer -> i32
     %e0 = vm.const.i32 0
     vm.check.eq %v0, %e0, "0" : i32
-    %v1 = vm.buffer.load.i32 %rodata[%c4] : !vm.buffer -> i32
+    %v1 = vm.buffer.load.i32 %rodata[%c1] : !vm.buffer -> i32
     %e1 = vm.const.i32 1
     vm.check.eq %v1, %e1, "1" : i32
-    %v2 = vm.buffer.load.i32 %rodata[%c8] : !vm.buffer -> i32
+    %v2 = vm.buffer.load.i32 %rodata[%c2] : !vm.buffer -> i32
     %e2 = vm.const.i32 0x7FFFFFFF
     vm.check.eq %v2, %e2, "0x7FFFFFFF" : i32
-    %v3 = vm.buffer.load.i32 %rodata[%c12] : !vm.buffer -> i32
+    %v3 = vm.buffer.load.i32 %rodata[%c3] : !vm.buffer -> i32
     %e3 = vm.const.i32 0x80000000
     vm.check.eq %v3, %e3, "0x80000000" : i32
-    %v4 = vm.buffer.load.i32 %rodata[%c16] : !vm.buffer -> i32
+    %v4 = vm.buffer.load.i32 %rodata[%c4] : !vm.buffer -> i32
     %e4 = vm.const.i32 0xFFFFFFFF
     vm.check.eq %v4, %e4, "0xFFFFFFFF" : i32
-    vm.return
-  }
-
-  vm.rodata private @test_load_i32_unaligned_data dense<[0x00112233, 0x44556677, 0x8899AABB, 0xCCDDEEFF]> : tensor<4xui32>
-
-  // Unaligned loads are not supported and offsets will be rounded down.
-  vm.export @test_load_i32_unaligned attributes {emitc.exclude}
-  vm.func private @test_load_i32_unaligned() {
-    %rodata = vm.const.ref.rodata @test_load_i32_unaligned_data : !vm.buffer
-
-    // Byte offset 5 rounded to byte offset 4 (element 1).
-    %c5 = vm.const.i64 5
-    %v1 = vm.buffer.load.i32 %rodata[%c5] : !vm.buffer -> i32
-    %e1 = vm.const.i32 0x44556677
-    vm.check.eq %v1, %e1, "0x44556677" : i32
-
     vm.return
   }
 
@@ -561,18 +545,18 @@ vm.module @buffer_ops {
     %c0 = vm.const.i64 0
     %e0 = vm.const.i32 0
     vm.buffer.store.i16 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
-    %c2 = vm.const.i64 2
+    %c1 = vm.const.i64 1
     %e1 = vm.const.i32 1
-    vm.buffer.store.i16 %e1, %buf_dno[%c2] : i32 -> !vm.buffer
-    %c4 = vm.const.i64 4
+    vm.buffer.store.i16 %e1, %buf_dno[%c1] : i32 -> !vm.buffer
+    %c2 = vm.const.i64 2
     %e2 = vm.const.i32 0x7FFF
-    vm.buffer.store.i16 %e2, %buf_dno[%c4] : i32 -> !vm.buffer
-    %c6 = vm.const.i64 6
+    vm.buffer.store.i16 %e2, %buf_dno[%c2] : i32 -> !vm.buffer
+    %c3 = vm.const.i64 3
     %e3 = vm.const.i32 0x8000
-    vm.buffer.store.i16 %e3, %buf_dno[%c6] : i32 -> !vm.buffer
-    %c8 = vm.const.i64 8
+    vm.buffer.store.i16 %e3, %buf_dno[%c3] : i32 -> !vm.buffer
+    %c4 = vm.const.i64 4
     %e4 = vm.const.i32 0xFFFF
-    vm.buffer.store.i16 %e4, %buf_dno[%c8] : i32 -> !vm.buffer
+    vm.buffer.store.i16 %e4, %buf_dno[%c4] : i32 -> !vm.buffer
 
     %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
     vm.check.nz %cmp, "source and target match" : i32
@@ -594,41 +578,21 @@ vm.module @buffer_ops {
     %c0 = vm.const.i64 0
     %e0 = vm.const.i32 0
     vm.buffer.store.i32 %e0, %buf_dno[%c0] : i32 -> !vm.buffer
-    %c4 = vm.const.i64 4
+    %c1 = vm.const.i64 1
     %e1 = vm.const.i32 1
-    vm.buffer.store.i32 %e1, %buf_dno[%c4] : i32 -> !vm.buffer
-    %c8 = vm.const.i64 8
+    vm.buffer.store.i32 %e1, %buf_dno[%c1] : i32 -> !vm.buffer
+    %c2 = vm.const.i64 2
     %e2 = vm.const.i32 0x7FFFFFFF
-    vm.buffer.store.i32 %e2, %buf_dno[%c8] : i32 -> !vm.buffer
-    %c12 = vm.const.i64 12
+    vm.buffer.store.i32 %e2, %buf_dno[%c2] : i32 -> !vm.buffer
+    %c3 = vm.const.i64 3
     %e3 = vm.const.i32 0x80000000
-    vm.buffer.store.i32 %e3, %buf_dno[%c12] : i32 -> !vm.buffer
-    %c16 = vm.const.i64 16
+    vm.buffer.store.i32 %e3, %buf_dno[%c3] : i32 -> !vm.buffer
+    %c4 = vm.const.i64 4
     %e4 = vm.const.i32 0xFFFFFFFF
-    vm.buffer.store.i32 %e4, %buf_dno[%c16] : i32 -> !vm.buffer
+    vm.buffer.store.i32 %e4, %buf_dno[%c4] : i32 -> !vm.buffer
 
     %cmp = vm.buffer.compare %ref_dno, %c0, %buf_dno, %c0, %ref_length : !vm.buffer, !vm.buffer
     vm.check.nz %cmp, "source and target match" : i32
-
-    vm.return
-  }
-
-  // Unaligned stores are not supported and offsets will be rounded down.
-  vm.export @test_store_i32_unaligned attributes {emitc.exclude}
-  vm.func private @test_store_i32_unaligned() {
-    %c12 = vm.const.i64 12
-    %buf = vm.buffer.alloc %c12 : !vm.buffer
-    %buf_dno = util.do_not_optimize(%buf) : !vm.buffer
-
-    // Byte offset 5 rounded to byte offset 4 (element 1).
-    %c5 = vm.const.i64 5
-    %e1 = vm.const.i32 0x44556677
-    vm.buffer.store.i32 %e1, %buf_dno[%c5] : i32 -> !vm.buffer
-
-    // Read back at offset 4 (where the data should be).
-    %c4 = vm.const.i64 4
-    %a1 = vm.buffer.load.i32 %buf_dno[%c4] : !vm.buffer -> i32
-    vm.check.eq %a1, %e1, "0x44556677" : i32
 
     vm.return
   }


### PR DESCRIPTION
This should remove a lot of the *4 ops we need whenever we access buffers and prevents the opportunity for unaligned accesses.

In combination with #10510 this speeds things up quite a bit, for example in resnet (where we are running all convs with scalar vm code):
![image](https://user-images.githubusercontent.com/75337/192049509-b3c8c887-5161-4dcb-b53a-0b8d8d8e9652.png)
