### PR TITLE
Accept EINTR (interrupted by signal) futex return code

### DIFF
--- a/runtime/src/iree/base/internal/synchronization.c
+++ b/runtime/src/iree/base/internal/synchronization.c
@@ -178,7 +178,7 @@ static inline iree_status_code_t iree_futex_wait(void* address,
   int rc = syscall(
       SYS_futex, address, FUTEX_WAIT | FUTEX_PRIVATE_FLAG, expected_value,
       timeout_ms == IREE_INFINITE_TIMEOUT_MS ? NULL : &timeout, NULL, 0);
-  if (IREE_LIKELY(rc == 0) || errno == EAGAIN) {
+  if (IREE_LIKELY(rc == 0) || errno == EAGAIN || errno == EINTR) {
     return IREE_STATUS_OK;
   } else if (errno == ETIMEDOUT) {
     return IREE_STATUS_DEADLINE_EXCEEDED;


### PR DESCRIPTION
This loop is already handling EAGAIN. It looks like it should handle EINTR the same way.

I'm trying to guess what might cause the intermittent crash #10337. One thing that would explain it is if the iree_task_scope_wait_idle done at the end of SubmitTasksAndWaitIdle wasn't doing its job. It calls iree_notification_await, which assumes that
iree_notification_commit_wait never returns false unless the deadline is exceeded. But iree_notification_commit_wait does return false if the futex syscall returns an expected error code, so we need to handle the exhaustive list of return codes that might come out of this syscall. The manual page lists only very few possible return codes for the particular FUTEX_WAIT op we're doing here (there are plenty of error cases, but few apply to FUTEX_WAIT). EINTR is the only one that I could see us missing here.