### PR TITLE
Use new VM image for runner CPU VMs

### DIFF
--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -19,7 +19,12 @@ TEMPLATE_BASE_NAME="${TEMPLATE_BASE_NAME:-github-runner}"
 TEMPLATE_CONFIG_REPO="${TEMPLATE_CONFIG_REPO:-iree-org/iree}"
 TEMPLATE_CONFIG_REF="${TEMPLATE_CONFIG_REF:-$(git rev-parse HEAD)}"
 GPU_IMAGE="github-runner-gpu-2022-08-15-1660603500"
-CPU_IMAGE="github-runner-2022-07-28-1659048799"
+# Due to an early misconfiguration, this boot image is really large (1TB), so we
+# need a 1TB boot disk.
+# TODO(gcmn): Shrink the image and disk size.
+GPU_DISK_SIZE_GB=1000
+CPU_IMAGE="github-runner-cpu-2022-09-22-1663865258"
+CPU_DISK_SIZE_GB=100
 
 if (( TESTING==0 )); then
   if [[ "${TEMPLATE_CONFIG_REPO}" != iree-org/iree ]]; then
@@ -111,13 +116,13 @@ function create_template() {
       --machine-type=a2-highgpu-1g
       --maintenance-policy=TERMINATE
       --accelerator=count=1,type=nvidia-tesla-a100
-      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=1000,type=pd-balanced"
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=${GPU_DISK_SIZE_GB},type=pd-balanced"
     )
   elif [[ "${type}" == cpu ]]; then
     args+=(
       --machine-type=n1-standard-96
       --maintenance-policy=MIGRATE
-      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=1000,type=pd-balanced"
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
     )
   else
     echo "Got unrecognized type '${type}'" >2

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -24,6 +24,7 @@ GPU_IMAGE="github-runner-gpu-2022-08-15-1660603500"
 # TODO(gcmn): Shrink the image and disk size.
 GPU_DISK_SIZE_GB=1000
 CPU_IMAGE="github-runner-cpu-2022-09-22-1663865258"
+# The image is only 10GB, but we need some space for Docker images and such.
 CPU_DISK_SIZE_GB=100
 
 if (( TESTING==0 )); then


### PR DESCRIPTION
This is the image created by `create_image.sh`. It's one-hundredth the
size of the current image, created from scratch by a documented script,
and has other goodies, like turning off apt auto-update (see the
script for everything the image does).

Tested: deployed in test cluster ->
https://github.com/iree-org/iree/actions/runs/3107500759

skip-ci