### PR TITLE
[LLVMGPU] Enable vectorization for convolution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -676,7 +676,7 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
     if (succeeded(setWarpReductionConfig(entryPointFn, linalgOp))) {
       return success();
     }
-    if (succeeded(setConvolutionConfig(linalgOp, 32, 32))) {
+    if (succeeded(setConvolutionConfig(linalgOp, 32, 16))) {
       return success();
     }
     auto genericOp = dyn_cast<linalg::GenericOp>(computeOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -557,6 +557,102 @@ static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
       workgroupSize);
 }
 
+static LogicalResult setConvolutionConfig(linalg::LinalgOp linalgOp,
+                                          const int64_t subgroupSize,
+                                          const int64_t bestTilingFactor) {
+  Type inputType = linalgOp.getInputOperand(0)->get().getType();
+  ArrayRef<int64_t> inputShape = inputType.cast<ShapedType>().getShape();
+  Type outputType = linalgOp.getOutputOperand(0)->get().getType();
+  ArrayRef<int64_t> outputShape = outputType.cast<ShapedType>().getShape();
+  if (!isa<linalg::Conv2DNhwcHwcfOp>(*linalgOp) ||
+      ShapedType::isDynamic(inputShape[3])) {
+    return failure();
+  }
+  if (llvm::any_of(outputShape.drop_front(), ShapedType::isDynamic)) {
+    return failure();
+  }
+  int64_t ic = inputShape[3];
+  int64_t oh = outputShape[1], ow = outputShape[2], oc = outputShape[3];
+  // The conversion pipeline requires the input channel dimension to be some
+  // multipler of four, or less than four.
+  if (!(ic % 4 == 0 || ic < 4)) return failure();
+  // The core idea is to distribute the convolution OH/OW/OC dimension to the
+  // workgroup Z/Y/X dimension, with each thread in a workgroup handling
+  // multiple vector elements. We try to 1) utilize all threads in a subgroup,
+  // and 2) handle an optimal tile size along each dimension.
+  int64_t residualThreads = subgroupSize;
+  int64_t residualTilingFactor = bestTilingFactor;
+  SmallVector<int64_t, 3> workgroupSize(3, 1);    // (X, Y, Z)
+  SmallVector<int64_t> workgroupTileSizes(4, 0);  // (N, OH, OW, OC)
+  // Deduce the configuration for the OC dimension.
+  for (int64_t x = residualThreads; x >= 2; x >>= 1) {
+    // Handle 4 elements per thread for the innermost dimension. We need this
+    // for vectorized load.
+    int64_t chosenTileSize = 4;
+    if (oc % (x * chosenTileSize) == 0) {
+      workgroupSize[0] = x;
+      workgroupTileSizes[3] = x * chosenTileSize;
+      residualThreads /= x;
+      residualTilingFactor /= chosenTileSize;
+      break;
+    }
+  }
+  if (workgroupTileSizes[3] == 0) return failure();
+  // Deduce the configruation for the OW and OH dimension. Try to make them even
+  // if possible given we typically have images with the same height and width.
+  bool tileToSquare = false;
+  unsigned log2Threads = llvm::Log2_64(residualThreads);
+  if (ow == oh && residualThreads != 1 && log2Threads % 2 == 0) {
+    int64_t yz = 1ll << (log2Threads / 2);
+    int64_t chosenTileSize = 1ll << (llvm::Log2_64(residualTilingFactor) / 2);
+    while (chosenTileSize >= 1 && ow % (yz * chosenTileSize) != 0) {
+      chosenTileSize >>= 1;
+    }
+    if (chosenTileSize != 0) {
+      workgroupSize[1] = workgroupSize[2] = yz;
+      workgroupTileSizes[2] = workgroupTileSizes[1] = yz * chosenTileSize;
+      tileToSquare = true;
+    }
+  }
+  // Otherwise treat OW and OH separately to allow them to have different number
+  // of threads and tiling size.
+  if (!tileToSquare) {
+    // Decide the tiling and distribution parameters for one dimension.
+    auto decideOneDim = [&](int64_t inputDim, int64_t &wgDimSize,
+                            int64_t &wgTileSize) {
+      for (int64_t dim = residualThreads; dim >= 1; dim >>= 1) {
+        int64_t chosenTileSize = 0;
+        for (int64_t t = residualTilingFactor; t >= 1; t >>= 1) {
+          if (inputDim % (dim * t) == 0) {
+            chosenTileSize = t;
+            break;
+          }
+        }
+        if (chosenTileSize) {
+          wgDimSize = dim;
+          wgTileSize = dim * chosenTileSize;
+          residualThreads /= dim;
+          residualTilingFactor /= chosenTileSize;
+          return true;
+        }
+      }
+      return false;
+    };
+    if (!decideOneDim(ow, workgroupSize[1], workgroupTileSizes[2]) ||
+        !decideOneDim(oh, workgroupSize[2], workgroupTileSizes[1])) {
+      return failure();
+    }
+  }
+  auto pipeline = IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorize;
+  TileSizesListType tileSizes;
+  // Add reduction tile sizes.
+  workgroupTileSizes.append({1, 1, 4});
+  tileSizes.push_back(workgroupTileSizes);
+  auto funcOp = linalgOp->getParentOfType<func::FuncOp>();
+  return setOpConfigAndEntryPointFnTranslation(funcOp, linalgOp, tileSizes,
+                                               pipeline, workgroupSize);
+}
+
 static LogicalResult setRootConfig(func::FuncOp entryPointFn,
                                    Operation *computeOp) {
   if (!clGPUCodegenTransformDialectTileSizes.empty()) {
@@ -582,6 +678,9 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
       return setContractConfig(entryPointFn, linalgOp);
     }
     if (succeeded(setWarpReductionConfig(entryPointFn, linalgOp))) {
+      return success();
+    }
+    if (succeeded(setConvolutionConfig(linalgOp, 32, 32))) {
       return success();
     }
     auto genericOp = dyn_cast<linalg::GenericOp>(computeOp);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -117,12 +117,20 @@ void addGPUVectorizationPassPipeline(OpPassManager &pm) {
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorizationPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createOptimizeVectorTransferPass());
 
   // tensor to memref
   addBufferizePasses(nestedModulePM);
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUDistribute());
+
+  // Post bufferization optimizations.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLoopInvariantCodeMotionPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      memref::createFoldMemRefAliasOpsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createOptimizeVectorTransferPass());
 }
 
 void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "conv_pipeline_test.mlir",
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",
             "distribute_to_thread.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "conv_pipeline_test.mlir"
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"
     "distribute_foreach.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
@@ -1,0 +1,43 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' %s | FileCheck %s
+
+#device_target_cuda = #hal.device.target<"cuda", {executable_targets = [#hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}>], legacy_sync}>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>
+module attributes {hal.device.targets = [#device_target_cuda]} {
+  hal.executable private @conv2d_1x230x230x3_7x7x3x64_dispatch_0 {
+    hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
+      hal.executable.export public @conv2d_1x230x230x3_7x7x3x64 ordinal(0) layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index, %arg5: index, %arg6: index, %arg7: index):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4, %arg5, %arg6, %arg7
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @conv2d_1x230x230x3_7x7x3x64() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant 0.000000e+00 : f32
+          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:1x230x230x3xf32>
+          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:7x7x3x64xf32>
+          %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:1x112x112x64xf32>
+          %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [1, 230, 230, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:1x230x230x3xf32> -> tensor<1x230x230x3xf32>
+          %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [7, 7, 3, 64], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:7x7x3x64xf32> -> tensor<7x7x3x64xf32>
+          %5 = linalg.init_tensor [1, 112, 112, 64] : tensor<1x112x112x64xf32>
+          %6 = linalg.fill ins(%cst : f32) outs(%5 : tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
+          %7 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%3, %4 : tensor<1x230x230x3xf32>, tensor<7x7x3x64xf32>) outs(%6 : tensor<1x112x112x64xf32>) -> tensor<1x112x112x64xf32>
+          flow.dispatch.tensor.store %7, %2, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 64], strides = [1, 1, 1, 1] : tensor<1x112x112x64xf32> -> !flow.dispatch.tensor<writeonly:1x112x112x64xf32>
+          return
+        }
+      }
+    }
+  }
+}
+
+//   CHECK-LABEL:  func.func @conv2d_1x230x230x3_7x7x3x64
+//     CHECK-NOT:    vector.transfer_write
+//     CHECK-NOT:    vector.transfer_read
+//         CHECK:    scf.for
+//         CHECK:      scf.for
+// CHECK-COUNT-2:        vector.transfer_read
+// CHECK-COUNT-7:        vector.contract
+//         CHECK:      scf.yield %{{.*}} : vector<8x4xf32>
+//         CHECK:    scf.yield %{{.*}} : vector<8x4xf32>
+//         CHECK:    vector.transfer_write {{.*}} : vector<8x4xf32>, memref<1x112x112x64xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
@@ -37,7 +37,7 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 //         CHECK:    scf.for
 //         CHECK:      scf.for
 // CHECK-COUNT-2:        vector.transfer_read
-// CHECK-COUNT-7:        vector.contract
-//         CHECK:      scf.yield %{{.*}} : vector<8x4xf32>
-//         CHECK:    scf.yield %{{.*}} : vector<8x4xf32>
-//         CHECK:    vector.transfer_write {{.*}} : vector<8x4xf32>, memref<1x112x112x64xf32>
+// CHECK-COUNT-4:        vector.contract
+//         CHECK:      scf.yield %{{.*}} : vector<4x4xf32>
+//         CHECK:    scf.yield %{{.*}} : vector<4x4xf32>
+//         CHECK:    vector.transfer_write {{.*}} : vector<4x4xf32>, memref<1x112x112x64xf32>


### PR DESCRIPTION
This enable vectorization for some convolution in order to improve performance. This will still generate very sub optimal code but gives a better baseline.