### PR TITLE
mmt4d ukernel: early return paths for degenerate cases

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
@@ -220,8 +220,25 @@ static void test_matmuls_for_various_MNK_shapes_and_flags(
     int m, n, k;
   };
   std::vector<shape_mnk_t> shapes{
-      {1, 1, 1}, {1, 1, 2}, {1, 1, 10}, {1, 1, 1000},
-      {2, 1, 1}, {1, 2, 1}, {2, 2, 2},  {5, 7, 13},
+      // Degenerate case M==0. Vacuous.
+      {0, 1, 1},
+      {0, 5, 7},
+      // Degenerate case N==0. Vacuous.
+      {1, 0, 1},
+      {5, 0, 7},
+      // Degenerate case K==0. Vacuous if flags have ACCUMULATE. Zeroing the
+      // output buffer otherwise.
+      {1, 1, 0},
+      {5, 7, 0},
+      // Non-degenerate cases.
+      {1, 1, 1},
+      {1, 1, 2},
+      {1, 1, 10},
+      {1, 1, 1000},
+      {2, 1, 1},
+      {1, 2, 1},
+      {2, 2, 2},
+      {5, 7, 13},
   };
   for (shape_mnk_t shape : shapes) {
     params.M = shape.m;


### PR DESCRIPTION
Take care of cases where one of the M, N or K dimension is 0, in early-return paths.

This is motivated by loop pipelining optimizations that I want to do soon in asm kernels, which will have to either assume K>=1 or add an additional conditional branch for that case.

The compiler might help optimize away those degenerate cases with static shapes, but not with dynamic shapes anyway.

The other motivation here, alluded to in a comment, is that conversations with hardware folks suggest that there's a need to specialize the whole mmt4d loop nest, not just the innermost loop as we are currently doing with the tile_func on CPU. This provides an explicit placeholder for that.