### PR TITLE
simple streaming kernel for the i8mm case

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_tile_arm_64_i8mm.S
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_tile_arm_64_i8mm.S
@@ -13,9 +13,15 @@
 
 BEGIN_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm
 
+        // Save callee-saved NEON registers
+        stp d8, d9, [sp, -64]!
+        stp d10, d11, [sp, 16]
+        stp d12, d13, [sp, 32]
+        stp d14, d15, [sp, 48]
+
         // Do we accumulate into or clear the accumulator tile?
         tbnz w4, ACCUMULATE_FLAG_BIT_POS, 1f
-
+        
     0:
         // No-accumulate case. Clear the 8x8 accumulator tile.
         movi v16.16b, 0
@@ -38,16 +44,18 @@ BEGIN_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm
   
     1:
         // Accumulate case. Load the 8x8 accumulator tile from row-major
-        // out_tile and swizzle it into 2x2 tiled layout. To avoid having to
-        // save the callee-saved registers v8--v15 (their bottom 64bit halves),
-        // we process 4 rows at a time so we only need temporary registers
-        // v0--v7.
+        // out_tile and swizzle it into 2x2 tiled layout.
         //
         // Load rows 0--3.
         ldp q0, q1, [x0, 0]
         ldp q2, q3, [x0, 32]
         ldp q4, q5, [x0, 64]
         ldp q6, q7, [x0, 96]
+        // Load rows 4--7.
+        ldp q8, q9, [x0, 128]
+        ldp q10, q11, [x0, 160]
+        ldp q12, q13, [x0, 192]
+        ldp q14, q15, [x0, 224]
         // Swizzle in 2x2 tiles for smmla, rows 0--1.
         zip1 v16.2d, v0.2d, v2.2d
         zip2 v17.2d, v0.2d, v2.2d
@@ -58,26 +66,157 @@ BEGIN_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm
         zip2 v21.2d, v4.2d, v6.2d
         zip1 v22.2d, v5.2d, v7.2d
         zip2 v23.2d, v5.2d, v7.2d
-        //
-        // Load rows 4--7.
-        ldp q0, q1, [x0, 128]
-        ldp q2, q3, [x0, 160]
-        ldp q4, q5, [x0, 192]
-        ldp q6, q7, [x0, 224]
         // Swizzle in 2x2 tiles for smmla, rows 4--5.
-        zip1 v24.2d, v0.2d, v2.2d
-        zip2 v25.2d, v0.2d, v2.2d
-        zip1 v26.2d, v1.2d, v3.2d
-        zip2 v27.2d, v1.2d, v3.2d
+        zip1 v24.2d, v8.2d, v10.2d
+        zip2 v25.2d, v8.2d, v10.2d
+        zip1 v26.2d, v9.2d, v11.2d
+        zip2 v27.2d, v9.2d, v11.2d
         // Swizzle in 2x2 tiles for smmla, rows 6--7.
-        zip1 v28.2d, v4.2d, v6.2d
-        zip2 v29.2d, v4.2d, v6.2d
-        zip1 v30.2d, v5.2d, v7.2d
-        zip2 v31.2d, v5.2d, v7.2d
-        
+        zip1 v28.2d, v12.2d, v14.2d
+        zip2 v29.2d, v12.2d, v14.2d
+        zip1 v30.2d, v13.2d, v15.2d
+        zip2 v31.2d, v13.2d, v15.2d
+    
     2:
-        // Loop body. Decrement the loop counter K.
+
+        // Start of math work. If K==1, jump over the whole main loop.
         subs w3, w3, 1
+        b.eq 6f
+
+    3:
+        // Prologue of main loop, 2x partially unrolled, for when K>=2.
+        //
+        // Decrement the loop counter K.
+        subs w3, w3, 2
+        // Pre-load data for first loop iteration
+        //
+        // Load 8x8 LHS tile
+        ldp q0, q1, [x1], 32
+        ldp q2, q3, [x1], 32
+        // Load 8x8 RHS tile
+        ldp q4, q5, [x2], 32
+        ldp q6, q7, [x2], 32
+        // Load 8x8 LHS tile
+        ldp q8, q9, [x1], 32
+        ldp q10, q11, [x1], 32
+        // Load 8x8 RHS tile...
+        ldp q12, q13, [x2], 32
+        // ...second half loads is kept inside the loop below.
+        //
+        // Multiply-accumulate, rows 0--1.
+        smmla v16.4s, v0.16b, v4.16b
+        smmla v17.4s, v0.16b, v5.16b
+        smmla v18.4s, v0.16b, v6.16b
+        smmla v19.4s, v0.16b, v7.16b
+
+        // If K==2, jump to the epilogue.
+        b.le 5f
+
+    4:
+        // Body of main loop, 2x partially unrolled, for when K>2.
+        //
+        // Multiply-accumulate, rows 2--3.
+        smmla v20.4s, v1.16b, v4.16b
+        smmla v21.4s, v1.16b, v5.16b
+        smmla v22.4s, v1.16b, v6.16b
+        smmla v23.4s, v1.16b, v7.16b
+        ldp q14, q15, [x2], 32
+        // Multiply-accumulate, rows 4--5.
+        smmla v24.4s, v2.16b, v4.16b
+        smmla v25.4s, v2.16b, v5.16b
+        smmla v26.4s, v2.16b, v6.16b
+        smmla v27.4s, v2.16b, v7.16b
+        ldp q0, q1, [x1], 32
+        // Multiply-accumulate, rows 6--7.
+        smmla v28.4s, v3.16b, v4.16b
+        smmla v29.4s, v3.16b, v5.16b
+        smmla v30.4s, v3.16b, v6.16b
+        smmla v31.4s, v3.16b, v7.16b
+        ldp q2, q3, [x1], 32
+        // Multiply-accumulate, rows 0--1.
+        smmla v16.4s, v8.16b, v12.16b
+        smmla v17.4s, v8.16b, v13.16b
+        smmla v18.4s, v8.16b, v14.16b
+        smmla v19.4s, v8.16b, v15.16b
+        ldp q4, q5, [x2], 32
+        // Multiply-accumulate, rows 2--3.
+        smmla v20.4s, v9.16b, v12.16b
+        smmla v21.4s, v9.16b, v13.16b
+        smmla v22.4s, v9.16b, v14.16b
+        smmla v23.4s, v9.16b, v15.16b
+        ldp q6, q7, [x2], 32
+        // Multiply-accumulate, rows 4--5.
+        smmla v24.4s, v10.16b, v12.16b
+        smmla v25.4s, v10.16b, v13.16b
+        smmla v26.4s, v10.16b, v14.16b
+        smmla v27.4s, v10.16b, v15.16b
+        ldp q8, q9, [x1], 32
+        // Multiply-accumulate, rows 6--7.
+        smmla v28.4s, v11.16b, v12.16b
+        smmla v29.4s, v11.16b, v13.16b
+        smmla v30.4s, v11.16b, v14.16b
+        smmla v31.4s, v11.16b, v15.16b
+        ldp q10, q11, [x1], 32
+        // Multiply-accumulate, rows 0--1.
+        smmla v16.4s, v0.16b, v4.16b
+        smmla v17.4s, v0.16b, v5.16b
+        ldp q12, q13, [x2], 32
+        smmla v18.4s, v0.16b, v6.16b
+        subs w3, w3, 2
+        smmla v19.4s, v0.16b, v7.16b
+        b.gt 4b
+
+    5:
+        // Epilogue of main loop, 2x partially unrolled, for when K>2.
+        //
+        // Load last chunk of last RHS tile.
+        ldp q14, q15, [x2], 32
+
+        // Multiply-accumulate, rows 2--3.
+        smmla v20.4s, v1.16b, v4.16b
+        smmla v21.4s, v1.16b, v5.16b
+        smmla v22.4s, v1.16b, v6.16b
+        smmla v23.4s, v1.16b, v7.16b
+        // Multiply-accumulate, rows 4--5.
+        smmla v24.4s, v2.16b, v4.16b
+        smmla v25.4s, v2.16b, v5.16b
+        smmla v26.4s, v2.16b, v6.16b
+        smmla v27.4s, v2.16b, v7.16b
+        // Multiply-accumulate, rows 6--7.
+        smmla v28.4s, v3.16b, v4.16b
+        smmla v29.4s, v3.16b, v5.16b
+        smmla v30.4s, v3.16b, v6.16b
+        smmla v31.4s, v3.16b, v7.16b
+
+        // Multiply-accumulate, rows 0--1.
+        smmla v16.4s, v8.16b, v12.16b
+        smmla v17.4s, v8.16b, v13.16b
+        smmla v18.4s, v8.16b, v14.16b
+        smmla v19.4s, v8.16b, v15.16b
+        // Multiply-accumulate, rows 2--3.
+        smmla v20.4s, v9.16b, v12.16b
+        smmla v21.4s, v9.16b, v13.16b
+        smmla v22.4s, v9.16b, v14.16b
+        smmla v23.4s, v9.16b, v15.16b
+        // Multiply-accumulate, rows 4--5.
+        smmla v24.4s, v10.16b, v12.16b
+        smmla v25.4s, v10.16b, v13.16b
+        smmla v26.4s, v10.16b, v14.16b
+        smmla v27.4s, v10.16b, v15.16b
+        // Multiply-accumulate, rows 6--7.
+        smmla v28.4s, v11.16b, v12.16b
+        smmla v29.4s, v11.16b, v13.16b
+        smmla v30.4s, v11.16b, v14.16b
+        smmla v31.4s, v11.16b, v15.16b
+
+        // Finished accumulating? Then jump to final store.
+        b.lt 7f
+        // Fall through.
+
+    6:
+        // Accumulate for a single K-value - used for either the K==1 case or
+        // final value of K for odd K>1.
+
         // Load 8x8 LHS tile
         ldp q0, q1, [x1, 0]
         ldp q2, q3, [x1, 32]
@@ -106,14 +245,11 @@ BEGIN_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm
         smmla v29.4s, v3.16b, v5.16b
         smmla v30.4s, v3.16b, v6.16b
         smmla v31.4s, v3.16b, v7.16b
-        // Loop if K != 0.
-        b.ne 2b
 
-    3:
-        // Swizzle back to row-major and store to destination. To avoid having
-        // to save the callee-saved registers v8--v15 (their bottom 64bit
-        // halves), we process 4 rows at a time so we only need temporary
-        // registers v0--v7.
+    7:
+        // Done accumulating.
+        //
+        // Swizzle back to row-major and store to destination.
         //
         // Swizzle back to row-major, rows 0--1.
         uzp1 v0.2d, v16.2d, v17.2d
@@ -125,26 +261,31 @@ BEGIN_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm
         uzp1 v5.2d, v22.2d, v23.2d
         uzp2 v6.2d, v20.2d, v21.2d
         uzp2 v7.2d, v22.2d, v23.2d
+        // Swizzle back to row-major, rows 4--5.
+        uzp1 v8.2d, v24.2d, v25.2d
+        uzp1 v9.2d, v26.2d, v27.2d
+        uzp2 v10.2d, v24.2d, v25.2d
+        uzp2 v11.2d, v26.2d, v27.2d
+        // Swizzle back to row-major, rows 6--7.
+        uzp1 v12.2d, v28.2d, v29.2d
+        uzp1 v13.2d, v30.2d, v31.2d
+        uzp2 v14.2d, v28.2d, v29.2d
+        uzp2 v15.2d, v30.2d, v31.2d
         // Store rows 0--3 to destination.
         stp q0, q1, [x0, 0]
         stp q2, q3, [x0, 32]
         stp q4, q5, [x0, 64]
         stp q6, q7, [x0, 96]
-        // Swizzle back to row-major, rows 4--5.
-        uzp1 v0.2d, v24.2d, v25.2d
-        uzp1 v1.2d, v26.2d, v27.2d
-        uzp2 v2.2d, v24.2d, v25.2d
-        uzp2 v3.2d, v26.2d, v27.2d
-        // Swizzle back to row-major, rows 6--7.
-        uzp1 v4.2d, v28.2d, v29.2d
-        uzp1 v5.2d, v30.2d, v31.2d
-        uzp2 v6.2d, v28.2d, v29.2d
-        uzp2 v7.2d, v30.2d, v31.2d
-        // Store the accumulator tile to the destination.
-        stp q0, q1, [x0, 128]
-        stp q2, q3, [x0, 160]
-        stp q4, q5, [x0, 192]
-        stp q6, q7, [x0, 224]
+        stp q8, q9, [x0, 128]
+        stp q10, q11, [x0, 160]
+        stp q12, q13, [x0, 192]
+        stp q14, q15, [x0, 224]
+
+        // Restore callee-saved NEON registers
+        ldp d14, d15, [sp, 48]
+        ldp d12, d13, [sp, 32]
+        ldp d10, d11, [sp, 16]
+        ldp d8, d9, [sp], 64
         ret
 
 END_FUNCTION iree_ukernel_mmt4d_i8i8i32_tile_8x8x8_arm_64_i8mm


### PR DESCRIPTION
@silvasean you were right, the "max streaming" idea from ruy kernels still helps, even on big OOO cores that "should" be able to make that optimization by themselves.

This is a 2x partial unrolling + pipelining of the inner loop that allows using all of the available registers to maximize load-to-use distance.

It might be counterproductive on cores that care foremost about minimum loop code size such as the Cortex-X1, but I don't have one here to test. Will be a good use case for tuning.

On the 3 core types in the Snapdragon 8gen1 in my Moto Edge x30:

  | Gop/s before | Gop/s after | Gop/s peak | Speedup | %peak before | %peak after
-- | -- | -- | -- | -- | -- | --
Cortex-A510 | 83.4 | 103.0 | 114.24 | 1.24 | 73% | 90%
Cortex-A710 | 307.7 | 308.0 | 319.49 | 1.00 | 96% | 96%
Cortex-X2 | 675.4 | 732.3 | 766.77 | 1.08 | 88% | 96%

