### PR TITLE
[LLVMGPU] Remove restriction on shared memory promotion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
@@ -22,8 +22,6 @@ namespace iree_compiler {
 static bool contractOpFilter(Operation *op) {
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
   if (!linalgOp) return false;
-  // Can't promote dynamic shapes.
-  if (linalgOp.hasDynamicShape()) return false;
   SmallVector<unsigned> dims;
   linalgOp.getParallelDims(dims);
   SmallVector<int64_t, 4> shapes = linalgOp.getStaticLoopRanges();


### PR DESCRIPTION
This was causing perf regression on some cases and was an unnecessary restriction.