### PR TITLE
Add target_vector_to as a iree extension of transform dialect

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
@@ -76,5 +76,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorTransforms",
+        "@llvm-project//mlir:VectorToGPU",    
+        "@llvm-project//mlir:NVGPUDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
@@ -40,12 +40,14 @@ iree_cc_library(
     MLIRLinalgTransforms
     MLIRLinalgUtils
     MLIRMemRefDialect
+    MLIRNVGPUDialect
     MLIRPDLDialect
     MLIRPass
     MLIRSCFDialect
     MLIRTransformDialect
     MLIRTransforms
     MLIRVectorDialect
+    MLIRVectorToGPU
     MLIRVectorTransforms
     iree::compiler::Dialect::HAL::IR
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS
 #define IREE_COMPILER_CODEGEN_LLVMGPU_TRANSFORMEXTENSIONS_LLVMGPUEXTENSIONS
 
+include "mlir/IR/EnumAttr.td"
 include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
@@ -297,6 +298,45 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
 
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::Operation *target,
+        ::llvm::SmallVectorImpl<::mlir::Operation *> &results, 
+        ::mlir::transform::TransformState &state);
+  }];
+}
+def TargetVectorOp : 
+  Op<Transform_Dialect, "iree.target_vector_to",
+    [FunctionalStyleTransformOpTrait, 
+     MemoryEffectsOpInterface,
+     TransformEachOpTrait,
+     TransformOpInterface]> {
+  let description = [{
+    Specifies that the `target` operation has ops in vector dialect and 
+    lowers it to the target specific dialect. The transformation
+     only handles vector ops, otherwise it is no-op. Internally, it applies a 
+     set of rewrite patterns.
+    
+    This transformation supports the following target dialects:
+      - `gpu`: Lower the operations from the vector dialect into the 
+      general GPU dialect
+      - `nvgpu`: Lower the operations from the vector dialect into the 
+      Nvidia specific GPU dialect
+
+    #### Return modes:
+    
+    This operation produces `definiteFailure` if vectorization fails for any
+    reason.
+    The operation always returns the handle to the target op that is expected 
+    to be isolated from above.
+  }];
+
+  let arguments = (ins PDL_Operation:$target, StrAttr:$target_dialect);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target_dialect $target attr-dict";
+  let cppNamespace =  "mlir::iree_compiler::IREE::transform_dialect";
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -28,6 +28,7 @@ iree_lit_test_suite(
     srcs = [
         "reduction.mlir",
         "softmax.mlir",
+        "matmul.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,
@@ -35,6 +36,7 @@ iree_lit_test_suite(
     data = [
         "reduction_codegen_spec.mlir",
         "softmax_codegen_spec.mlir",
+        "matmul_codegen_spec.mlir",
         # FIXME: This cannot be retired yet as there is some writeonly vs readwrite
         # issue and we even end up emitting out of bounds accesses.
         "softmax_dispatch_spec.mlir",

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "matmul.mlir"
     "reduction.mlir"
     "softmax.mlir"
   TOOLS
@@ -26,6 +27,7 @@ iree_lit_test_suite(
     iree-opt
     iree-run-module
   DATA
+    matmul_codegen_spec.mlir
     reduction_codegen_spec.mlir
     softmax_codegen_spec.mlir
     softmax_dispatch_spec.mlir

--- a/tests/transform_dialect/cuda/matmul.mlir
+++ b/tests/transform_dialect/cuda/matmul.mlir
@@ -1,0 +1,40 @@
+// 16n8k16_f16
+!typeA = tensor<16x16xf16>
+!typeB = tensor<16x8xf16>
+!typeC = tensor<16x8xf16>
+
+func.func @matmul() -> !typeC {
+  %TA = linalg.init_tensor [16, 16] : !typeA
+  %TB = linalg.init_tensor [16, 8] : !typeB
+  %TC = linalg.init_tensor [16, 8] : !typeC
+  %c2 = arith.constant 2.0 : f16
+  %c3 = arith.constant 3.0 : f16
+  %c0 = arith.constant 0.0 : f16
+  %A = linalg.fill ins(%c2 : f16) outs(%TA : !typeA) -> !typeA
+  %B = linalg.fill ins(%c3 : f16) outs(%TB : !typeB) -> !typeB
+  %C = linalg.fill ins(%c0 : f16) outs(%TC : !typeC) -> !typeC
+  
+  %0 = linalg.matmul ins(%A, %B : !typeA, !typeB)
+                     outs(%C : !typeC) -> !typeC
+  return %0 : !typeC
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/matmul_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
+//     CHECK: device_target_cuda
+//     CHECK: nvgpu.mma.sync(%{{.*}}, %{{.*}}, %{{.*}}) {mmaShape = [16, 8, 16]}
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/matmul_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=matmul --device=cuda |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 16x8xf16=[96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96][96 96 96 96 96 96 96 96]

--- a/tests/transform_dialect/cuda/matmul_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/matmul_codegen_spec.mlir
@@ -1,0 +1,24 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb1(%variant_op: !pdl.operation):
+  %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op
+
+  // Create phantom loop just to start offload
+  %foreach_thread, %tiled_generic =
+    transform.iree.tile_to_foreach_thread_and_workgroup_count_region %matmul tile_sizes [16, 8]
+  
+  // Bufferize
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op   
+  %func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  
+  // Assign phantom loop to workgroups
+  %func2 = transform.iree.foreach_thread_to_workgroup %func
+
+  // Vectorize
+  %isolated = transform.get_closest_isolated_parent %func2
+  %isolated2 = transform.structured.vectorize %isolated
+  
+  // Vector -> WMMA
+  transform.iree.target_vector_to "NVGPU" %isolated2
+}


### PR DESCRIPTION
This PR adds target_vector_to op as a iree extension of transform dialect. It converts vector dialect ops into target (or architecture) specific dialects.

The op must have two arguments: target and target_dialect. target operation is supposed to have ops in vector dialect. target_vector_to converts all of the vector ops into a dialect that is given by target_dialect. The transformation only handles vector ops, otherwise it is no-op. Internally, it applies a set of rewrite patterns.

It also adds e2e simple matmul test.