### PR TITLE
Fix integer overflow in summarizeDispatchWorkgroupsOp.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -35,7 +35,7 @@ static int64_t estimateLinalgOpCost(linalg::LinalgOp op) {
   if (op.hasDynamicShape()) {
     // Note: bounded dynamic shapes would be interesting, if the compiler used
     // them. For now just treat dynamic shapes as arbitrarily large.
-    return INT_MAX;
+    return INT64_MAX;
   }
 
   int64_t cost = 1;
@@ -95,7 +95,7 @@ static std::string summarizeDispatchWorkgroupsOp(
   regionOp.getBodyRegion().walk([&](Operation *op) {
     TypeSwitch<Operation *>(op)
         .Case<linalg::LinalgOp>([&](auto op) {
-          int estimatedCost = estimateLinalgOpCost(op);
+          int64_t estimatedCost = estimateLinalgOpCost(op);
           if (estimatedCost < bestEstimatedCost) return;
           bestEstimatedCost = estimatedCost;
           bestOp = op;


### PR DESCRIPTION
Noticed [on Discord here](https://discord.com/channels/689900678990135345/689906000043573354/1024146087738617906):
```
//--- summarizing 'forward_dispatch_116' ---//
// linalg.fill cost: 3906816
// new best op: 'linalg.fill', cost: 3906816
// linalg.matmul cost: 3000434688
// linalg.generic cost: 3906816
// new best op: 'linalg.generic', cost: 3906816
// best op summary: 'generic_128x30522'
//--- opSummary: 'generic_128x30522' ---//
```