### PR TITLE
Extending imports to have a context pointer.

### DIFF
--- a/runtime/src/iree/hal/local/executable_library.h
+++ b/runtime/src/iree/hal/local/executable_library.h
@@ -154,14 +154,16 @@ typedef const iree_hal_executable_library_header_t** (
 // a useful failure though the HAL does not mandate that all overflows are
 // caught and only that they are not harmful - clamping byte ranges and never
 // returning a failure is sufficient.
-typedef int (*iree_hal_executable_import_v0_t)(void* import_params);
+typedef int (*iree_hal_executable_import_v0_t)(void* context, void* params,
+                                               void* reserved);
 
 // A thunk function used to call an import.
 // All imports must be called through this function by passing the import
 // function pointer as the first argument followed by the arguments of the
 // import function itself.
 typedef int (*iree_hal_executable_import_thunk_v0_t)(
-    iree_hal_executable_import_v0_t fn_ptr, void* import_params);
+    iree_hal_executable_import_v0_t fn_ptr, void* context, void* params,
+    void* reserved);
 
 // Declares imports available to the executable library at runtime.
 // To enable linker isolation, ABI shimming, and import multi-versioning we use
@@ -251,7 +253,8 @@ typedef struct iree_hal_executable_environment_v0_t {
   // Optional imported functions available for use within the executable.
   // Contains one entry per imported function. If an import was marked as weak
   // then the corresponding entry may be NULL.
-  const iree_hal_executable_import_v0_t* imports;
+  const iree_hal_executable_import_v0_t* import_funcs;
+  const void** import_contexts;
 
   // Optional architecture-specific CPU information.
   // In heterogenous processors this may represent any of the subarchitecture

--- a/runtime/src/iree/hal/local/executable_loader.c
+++ b/runtime/src/iree/hal/local/executable_loader.c
@@ -26,9 +26,11 @@ iree_hal_executable_import_provider_default(void) {
 
 iree_status_t iree_hal_executable_import_provider_resolve(
     const iree_hal_executable_import_provider_t import_provider,
-    iree_string_view_t symbol_name, void** out_fn_ptr) {
+    iree_string_view_t symbol_name, void** out_fn_ptr, void** out_fn_context) {
   IREE_ASSERT_ARGUMENT(out_fn_ptr);
+  IREE_ASSERT_ARGUMENT(out_fn_context);
   *out_fn_ptr = NULL;
+  *out_fn_context = NULL;
 
   // A `?` suffix indicates the symbol is weakly linked and can be NULL.
   bool is_weak = false;
@@ -47,8 +49,8 @@ iree_status_t iree_hal_executable_import_provider_resolve(
                             (int)symbol_name.size, symbol_name.data);
   }
 
-  iree_status_t status =
-      import_provider.resolve(import_provider.self, symbol_name, out_fn_ptr);
+  iree_status_t status = import_provider.resolve(
+      import_provider.self, symbol_name, out_fn_ptr, out_fn_context);
   if (!iree_status_is_ok(status) && is_weak) {
     status = iree_status_ignore(status);  // ok to fail on weak symbols
   }

--- a/runtime/src/iree/hal/local/executable_loader.h
+++ b/runtime/src/iree/hal/local/executable_loader.h
@@ -37,7 +37,8 @@ typedef struct iree_hal_executable_import_provider_t {
   // to the function (or its context) in |out_fn_ptr|.
   iree_status_t(IREE_API_PTR* resolve)(void* self,
                                        iree_string_view_t symbol_name,
-                                       void** out_fn_ptr);
+                                       void** out_fn_ptr,
+                                       void** out_fn_context);
 } iree_hal_executable_import_provider_t;
 
 static inline iree_hal_executable_import_provider_t
@@ -63,7 +64,7 @@ iree_hal_executable_import_provider_default(void);
 // allowed to be resolved to NULL. Such cases will always return OK.
 iree_status_t iree_hal_executable_import_provider_resolve(
     const iree_hal_executable_import_provider_t import_provider,
-    iree_string_view_t symbol_name, void** out_fn_ptr);
+    iree_string_view_t symbol_name, void** out_fn_ptr, void** out_fn_context);
 
 //===----------------------------------------------------------------------===//
 // iree_hal_executable_loader_t


### PR DESCRIPTION
This will allow for imports to carry state that doesn't require TLS or globals. Also sprinkling in a reserved pointer in case we need more stuff in the future.