### PR TITLE
Generate a page for `pip --find-links` from the GitHub releases API

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Generating release index
         run: |
           build_tools/scripts/generate_release_index.py \
-            --owner="${GITHUB_REPOSITORY}" \
+            --repo="${GITHUB_REPOSITORY}" \
             --output=docs/website/docs/pip-release-links.html
       - name: Setting git config
         run: |

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           build_tools/scripts/generate_release_index.py \
             --owner="${GITHUB_REPOSITORY}" \
-            --output=docs/website/overrides/pip-release-links.html
+            --output=docs/website/docs/pip-release-links.html
       - name: Setting git config
         run: |
           git config --local user.email "iree-github-actions-bot@google.com"

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -34,8 +34,17 @@ jobs:
         uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # v2
         with:
           python-version: 3.x
-      - name: Installing Material for MkDocs
-        run: pip install mkdocs-material
+          cache: 'pip'
+      - name: Installing dependencies
+        run: |
+          pip install \
+            mkdocs-material \
+            requests
+      - name: Generating release index
+        run: |
+          build_tools/scripts/generate_release_index.py \
+            --owner="${GITHUB_REPOSITORY}" \
+            --output=docs/website/overrides/pip-release-links.html
       - name: Setting git config
         run: |
           git config --local user.email "iree-github-actions-bot@google.com"

--- a/build_tools/scripts/generate_release_index.py
+++ b/build_tools/scripts/generate_release_index.py
@@ -20,22 +20,25 @@ import requests
 
 def parse_arguments():
   parser = argparse.ArgumentParser()
-  parser.add_argument("--owner", default="iree-org")
-  parser.add_argument("--repo", default="iree")
-  parser.add_argument("--output", default="-")
+  parser.add_argument("--repo",
+                      default="iree-org/iree",
+                      help="The GitHub repository to fetch releases from.")
+  parser.add_argument(
+      "--output",
+      default="-",
+      help="The file to write the HTML to or '-' for stdout (the default)")
   return parser.parse_args()
 
 
 class ReleaseFetcher:
 
-  def __init__(self, owner, repo, per_page=100):
+  def __init__(self, repo, per_page=100):
     self._session = requests.Session()
-    self._owner = owner
     self._repo = repo
     self._per_page = per_page
 
   def get_all(self):
-    url = f"https://api.github.com/repos/{self._owner}/{self._repo}/releases"
+    url = f"https://api.github.com/repos/{self._repo}/releases"
     page = 1
 
     while True:
@@ -52,7 +55,7 @@ class ReleaseFetcher:
 
 
 def main(args):
-  fetcher = ReleaseFetcher(owner=args.owner, repo=args.repo)
+  fetcher = ReleaseFetcher(repo=args.repo)
   with (sys.stdout if args.output == "-" else open(args.output, "w")) as f:
     f.write(
         textwrap.dedent("""\

--- a/build_tools/scripts/generate_release_index.py
+++ b/build_tools/scripts/generate_release_index.py
@@ -21,6 +21,7 @@ import requests
 def parse_arguments():
   parser = argparse.ArgumentParser()
   parser.add_argument("--repo",
+                      "--repository",
                       default="iree-org/iree",
                       help="The GitHub repository to fetch releases from.")
   parser.add_argument(

--- a/build_tools/scripts/generate_release_index.py
+++ b/build_tools/scripts/generate_release_index.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Creates an HTML page for releases for `pip install --find-links` from GitHub releases."""
+# TODO(#10479) since we're generating this we might as well create a PEP 503
+# compliant index
+import argparse
+import html
+import json
+import subprocess
+import sys
+import textwrap
+
+import requests
+
+
+def parse_arguments():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--owner", default="iree-org")
+  parser.add_argument("--repo", default="iree")
+  parser.add_argument("--output", default="-")
+  return parser.parse_args()
+
+
+class ReleaseFetcher:
+
+  def __init__(self, owner, repo, per_page=100):
+    self._session = requests.Session()
+    self._owner = owner
+    self._repo = repo
+    self._per_page = per_page
+
+  def get_all(self):
+    url = f"https://api.github.com/repos/{self._owner}/{self._repo}/releases"
+    page = 1
+
+    while True:
+      response = self._session.get(url,
+                                   params={
+                                       "page": page,
+                                       "per_page": self._per_page,
+                                   })
+      for release in response.json():
+        yield release
+      if "next" not in response.links:
+        break
+      page += 1
+
+
+def main(args):
+  fetcher = ReleaseFetcher(owner=args.owner, repo=args.repo)
+  with (sys.stdout if args.output == "-" else open(args.output, "w")) as f:
+    f.write(
+        textwrap.dedent("""\
+            <!DOCTYPE html>
+            <html>
+              <body>
+            """))
+    for release in fetcher.get_all():
+      for asset in release["assets"]:
+        url = html.escape(asset['browser_download_url'])
+        name = html.escape(asset['name'])
+        f.write(f"    <a href={url}>{name}</a>\n")
+    f.write(textwrap.dedent("""\
+      </body>
+    </html>
+    """))
+
+
+if __name__ == "__main__":
+  main(parse_arguments())

--- a/build_tools/scripts/generate_release_index.py
+++ b/build_tools/scripts/generate_release_index.py
@@ -61,6 +61,8 @@ def main(args):
               <body>
             """))
     for release in fetcher.get_all():
+      if release["draft"]:
+        continue
       for asset in release["assets"]:
         url = html.escape(asset['browser_download_url'])
         name = html.escape(asset['name'])


### PR DESCRIPTION
This is incorporated into the docs pipeline and served on the website.
This isn't really the ideal place to serve it and we should probably
create a new subdomain and host a PEP 503 compliant index there. But
this will unbreak people for now.

Part of https://github.com/iree-org/iree/issues/10479