### PR TITLE
Fix relative path to generate_release_index.py script.

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -42,7 +42,7 @@ jobs:
             requests
       - name: Generating release index
         run: |
-          build_tools/scripts/generate_release_index.py \
+          ./build_tools/scripts/generate_release_index.py \
             --repo="${GITHUB_REPOSITORY}" \
             --output=docs/website/docs/pip-release-links.html
       - name: Setting git config


### PR DESCRIPTION
Noticed on the manually triggered https://github.com/iree-org/iree/actions/runs/3147382998/jobs/5116836059 after https://github.com/iree-org/iree/pull/10581

`/home/runner/work/_temp/9c9745e9-f606-4f3a-9d32-6aab1aa7e3fa.sh: line 2: build_tools/scripts/generate_release_index.py: No such file or directory`

skip-ci