### PR TITLE
Drop unnecessary methods from `PartitionableLoopsInterface`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TestPartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TestPartitionableLoopsInterface.cpp
@@ -34,15 +34,11 @@ struct TestPartitionableLoopsInterfacePattern
     if (!interfaceOp->hasAttr(kAttributeName)) {
       return failure();
     }
-    unsigned numLoops = interfaceOp.getNumLoops();
     SmallVector<unsigned> partitionableLoops =
         interfaceOp.getPartitionableLoops(3);
-    SmallVector<int64_t> loopInfo(numLoops, 0);
-    for (auto partitionableLoop : partitionableLoops) {
-      loopInfo[partitionableLoop] = 1;
-    }
-    auto type = RankedTensorType::get(numLoops, rewriter.getIndexType());
-    auto constantAttr = DenseIntElementsAttr::get(type, loopInfo);
+    auto type =
+        RankedTensorType::get(partitionableLoops.size(), rewriter.getI32Type());
+    auto constantAttr = DenseIntElementsAttr::get(type, partitionableLoops);
     rewriter.create<IREE::Util::UnfoldableConstantOp>(interfaceOp.getLoc(),
                                                       constantAttr);
     rewriter.updateRootInPlace(

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -58,14 +58,13 @@ static FailureOr<Operation *> getRootOp(ArrayRef<Operation *> computeOps) {
 static FailureOr<unsigned> getNumWorkloadValues(
     ArrayRef<Operation *> computeOps) {
   if (computeOps.empty()) return failure();
-  PartitionableLoopsInterface tilingRoot =
-      dyn_cast<PartitionableLoopsInterface>(computeOps.back());
+  TilingInterface tilingRoot = dyn_cast<TilingInterface>(computeOps.back());
   if (!tilingRoot) {
     return tilingRoot->emitOpError(
         "expected the root of tile and fuse operations to implement the "
-        "`PartitionableLoopsInterface`");
+        "`TilingInterface`");
   }
-  return tilingRoot.getNumLoops();
+  return tilingRoot.getLoopIteratorTypes().size();
 }
 
 /// Fallback lowering of `flow.dispatch.workgroup_count_from_dag_root` to {1, 1,

--- a/compiler/src/iree/compiler/Codegen/Common/test/.#test_partitionable_loops_interface.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/.#test_partitionable_loops_interface.mlir
@@ -1,0 +1,1 @@
+ravishankarm@mrcloudtop2.c.googlers.com.145656:1664419150

--- a/compiler/src/iree/compiler/Codegen/Common/test/.#test_partitionable_loops_interface.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/.#test_partitionable_loops_interface.mlir
@@ -1,1 +1,0 @@
-ravishankarm@mrcloudtop2.c.googlers.com.145656:1664419150

--- a/compiler/src/iree/compiler/Codegen/Common/test/test_partitionable_loops_interface.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/test_partitionable_loops_interface.mlir
@@ -19,7 +19,7 @@ func.func @generic_dynamic(%arg0 : tensor<?x?x?xf32>) -> tensor<?x?xf32> {
   return %0 : tensor<?x?xf32>
 }
 // CHECK-LABEL: func.func @generic_dynamic(
-//       CHECK:   util.unfoldable_constant dense<[1, 0, 1]> : tensor<3xindex>
+//       CHECK:   util.unfoldable_constant dense<[0, 2]> : tensor<2xi32>
 
 // -----
 
@@ -40,7 +40,7 @@ func.func @generic_unit_dim(%arg0 : tensor<1x?x?xf32>) -> tensor<1x?xf32> {
   return %0 : tensor<1x?xf32>
 }
 // CHECK-LABEL: func.func @generic_unit_dim(
-//       CHECK:   util.unfoldable_constant dense<[0, 0, 1]> : tensor<3xindex>
+//       CHECK:   util.unfoldable_constant dense<2> : tensor<1xi32>
 
 // -----
 
@@ -66,7 +66,7 @@ func.func @generic_4D(%arg0: tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
   return %0 : tensor<?x?x?x?xf32>
 }
 // CHECK-LABEL: func.func @generic_4D(
-//       CHECK:   util.unfoldable_constant dense<[0, 1, 1, 1]> : tensor<4xindex>
+//       CHECK:   util.unfoldable_constant dense<[1, 2, 3]> : tensor<3xi32>
 
 // -----
 
@@ -90,7 +90,7 @@ func.func @generic_4D_unit_dim(%arg0: tensor<?x?x1x?xf32>) -> tensor<?x?x1x?xf32
   return %0 : tensor<?x?x1x?xf32>
 }
 // CHECK-LABEL: func.func @generic_4D_unit_dim(
-//       CHECK:   util.unfoldable_constant dense<[1, 1, 0, 1]> : tensor<4xindex>
+//       CHECK:   util.unfoldable_constant dense<[0, 1, 3]> : tensor<3xi32>
 
 // -----
 
@@ -102,7 +102,7 @@ func.func @named_op(%lhs : tensor<?x?xf32>, %rhs : tensor<?x?xf32>,
   return %0 : tensor<?x?xf32>
 }
 // CHECK-LABEL: func.func @named_op(
-//       CHECK:   util.unfoldable_constant dense<[1, 1, 0]> : tensor<3xindex>
+//       CHECK:   util.unfoldable_constant dense<[0, 1]> : tensor<2xi32>
 
 // -----
 
@@ -116,7 +116,7 @@ func.func @named_op_unit_dim(%lhs : tensor<1x?xf32>, %rhs : tensor<?x?xf32>,
 
 
 // CHECK-LABEL: func.func @named_op_unit_dim(
-//       CHECK:   util.unfoldable_constant dense<[0, 1, 0]> : tensor<3xindex>
+//       CHECK:   util.unfoldable_constant dense<1> : tensor<1xi32>
 
 // -----
 
@@ -128,7 +128,7 @@ func.func @mmt4d(%lhs : tensor<?x?x?x?xf32>, %rhs : tensor<?x?x?x?xf32>,
   return %0 : tensor<?x?x?x?xf32>
 }
 // CHECK-LABEL: func.func @mmt4d(
-//       CHECK:   util.unfoldable_constant dense<[1, 1, 0, 0, 0, 0]> : tensor<6xindex>
+//       CHECK:   util.unfoldable_constant dense<[0, 1]> : tensor<2xi32>
 
 // -----
 
@@ -140,7 +140,7 @@ func.func @mmt4d_unit_dim(%lhs : tensor<1x?x?x?xf32>, %rhs : tensor<?x?x?x?xf32>
   return %0 : tensor<1x?x?x?xf32>
 }
 // CHECK-LABEL: func.func @mmt4d_unit_dim(
-//       CHECK:   util.unfoldable_constant dense<[1, 1, 0, 0, 0, 0]> : tensor<6xindex>
+//       CHECK:   util.unfoldable_constant dense<[0, 1]> : tensor<2xi32>
 
 // -----
 
@@ -156,7 +156,7 @@ func.func @sort(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   return %0 : tensor<?x?xf32>
 }
 // CHECK-LABEL: func.func @sort(
-//       CHECK:   util.unfoldable_constant dense<[0, 1]> : tensor<2xindex>
+//       CHECK:   util.unfoldable_constant dense<1> : tensor<1xi32>
 
 // -----
 
@@ -172,4 +172,4 @@ func.func @sort_unit_dim(%arg0 : tensor<?x1xf32>) -> tensor<?x1xf32> {
   return %0 : tensor<?x1xf32>
 }
 // CHECK-LABEL: func.func @sort_unit_dim(
-//       CHECK:   util.unfoldable_constant dense<[0, 1]> : tensor<2xindex>
+//       CHECK:   util.unfoldable_constant dense<1> : tensor<1xi32>

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -61,20 +61,10 @@ template <typename OpTy>
 struct LinalgOpPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           LinalgOpPartitionableLoops<OpTy>, OpTy> {
-  unsigned getNumLoops(Operation *op) const {
-    auto linalgOp = cast<linalg::LinalgOp>(op);
-    return linalgOp.getNumLoops();
-  }
-
   llvm::SmallVector<unsigned> getPartitionableLoops(
       Operation *op, unsigned maxNumPartitionedLoops) const {
     auto linalgOp = cast<linalg::LinalgOp>(op);
     return getPartitionableLoopsImpl(linalgOp, maxNumPartitionedLoops);
-  }
-
-  llvm::SmallVector<utils::IteratorType> getIteratorTypes(Operation *op) const {
-    return getIteratorTypesFromAttr(
-        cast<linalg::LinalgOp>(op).iterator_types());
   }
 };
 
@@ -82,19 +72,9 @@ struct LinalgOpPartitionableLoops
 struct Mmt4DOpPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           Mmt4DOpPartitionableLoops, linalg::Mmt4DOp> {
-  unsigned getNumLoops(Operation *op) const {
-    auto linalgOp = cast<linalg::LinalgOp>(op);
-    return linalgOp.getNumLoops();
-  }
-
   llvm::SmallVector<unsigned> getPartitionableLoops(
       Operation *op, unsigned maxNumPartitionedLoops) const {
     return {0, 1};
-  }
-
-  llvm::SmallVector<utils::IteratorType> getIteratorTypes(Operation *op) const {
-    return getIteratorTypesFromAttr(
-        cast<linalg::LinalgOp>(op).iterator_types());
   }
 };
 
@@ -104,11 +84,6 @@ template <typename OpTy>
 struct OuterParallelAsPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           OuterParallelAsPartitionableLoops<OpTy>, OpTy> {
-  unsigned getNumLoops(Operation *op) const {
-    auto tiledOp = cast<OpTy>(op);
-    return tiledOp.getLoopIteratorTypes().size();
-  }
-
   llvm::SmallVector<unsigned> getPartitionableLoops(
       Operation *op, unsigned maxNumPartitionedLoops) const {
     // For now just return the loops that are returned by the
@@ -132,11 +107,6 @@ struct OuterParallelAsPartitionableLoops
     }
     return partitionableLoops;
   }
-
-  llvm::SmallVector<utils::IteratorType> getIteratorTypes(Operation *op) const {
-    auto tiledOp = cast<OpTy>(op);
-    return tiledOp.getLoopIteratorTypes();
-  }
 };
 
 /// External model implementation for operations that are to be executed
@@ -144,19 +114,9 @@ struct OuterParallelAsPartitionableLoops
 template <typename OpTy>
 struct NoPartitionableLoops : public PartitionableLoopsInterface::ExternalModel<
                                   NoPartitionableLoops<OpTy>, OpTy> {
-  unsigned getNumLoops(Operation *op) const {
-    auto tiledOp = cast<OpTy>(op);
-    return tiledOp.getLoopIteratorTypes().size();
-  }
-
   llvm::SmallVector<unsigned> getPartitionableLoops(
       Operation *op, unsigned maxNumPartitionedLoops) const {
     return {};
-  }
-
-  llvm::SmallVector<utils::IteratorType> getIteratorTypes(Operation *op) const {
-    auto tiledOp = cast<OpTy>(op);
-    return tiledOp.getLoopIteratorTypes();
   }
 };
 
@@ -164,11 +124,6 @@ struct NoPartitionableLoops : public PartitionableLoopsInterface::ExternalModel<
 struct FftOpPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           FftOpPartitionableLoops, IREE::LinalgExt::FftOp> {
-  unsigned getNumLoops(Operation *op) const {
-    auto fftOp = cast<IREE::LinalgExt::FftOp>(op);
-    return fftOp.getLoopIteratorTypes().size();
-  }
-
   llvm::SmallVector<unsigned> getPartitionableLoops(
       Operation *op, unsigned maxNumPartitionedLoops) const {
     auto fftOp = cast<IREE::LinalgExt::FftOp>(op);
@@ -186,11 +141,6 @@ struct FftOpPartitionableLoops
     }
     return partitionableLoops;
   }
-
-  llvm::SmallVector<utils::IteratorType> getIteratorTypes(Operation *op) const {
-    auto fftOp = cast<IREE::LinalgExt::FftOp>(op);
-    return fftOp.getLoopIteratorTypes();
-  }
 };
 
 /// External model implementation for making all parallel loops as
@@ -199,11 +149,6 @@ template <typename OpTy>
 struct AllParallelAsPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           AllParallelAsPartitionableLoops<OpTy>, OpTy> {
-  unsigned getNumLoops(Operation *op) const {
-    auto tiledOp = cast<OpTy>(op);
-    return tiledOp.getLoopIteratorTypes().size();
-  }
-
   llvm::SmallVector<unsigned> getPartitionableLoops(
       Operation *op, unsigned maxNumPartitionedLoops) const {
     SmallVector<unsigned> partitionableLoops;
@@ -222,11 +167,6 @@ struct AllParallelAsPartitionableLoops
                     partitionableLoops.size() - maxNumPartitionedLoops));
     }
     return partitionableLoops;
-  }
-
-  llvm::SmallVector<utils::IteratorType> getIteratorTypes(Operation *op) const {
-    auto tiledOp = cast<OpTy>(op);
-    return tiledOp.getLoopIteratorTypes();
   }
 };
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.td
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.td
@@ -22,13 +22,6 @@ def PartitionableLoopsInterface : OpInterface<"PartitionableLoopsInterface"> {
   let methods = [
     InterfaceMethod<
       /*desc=*/[{
-        Returns the total number of loops that the operation represents.
-      }],
-      /*retTy=*/"unsigned",
-      /*methodName=*/"getNumLoops"
-    >,
-    InterfaceMethod<
-      /*desc=*/[{
         Returns the loop IDs (0 being outermost) that are partitionable.
 
         The size of the vector returned is always lesser than
@@ -36,15 +29,10 @@ def PartitionableLoopsInterface : OpInterface<"PartitionableLoopsInterface"> {
       }],
       /*retTy=*/"::llvm::SmallVector<unsigned>",
       /*methodName=*/"getPartitionableLoops",
-      /*args=*/(ins "unsigned":$maxNumPartitionedLoops)
+      /*args=*/(ins "unsigned":$maxNumPartitionedLoops),
+      /*methodBody=*/"",
+      /*defaultImplementation*/"return {};"
     >,
-    InterfaceMethod<
-      /*desc=*/[{
-        Returns the iterator types for all the loops of the op.
-      }],
-      /*retTy=*/"::llvm::SmallVector<::mlir::utils::IteratorType>",
-      /*methodName=*/"getIteratorTypes"
-    >
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -157,10 +157,11 @@ LogicalResult verifyDoubleTilingExpertPassPipelineConfig(
            << loweringConfig.getTileSizes().size();
   }
 
-  auto interfaceOp = dyn_cast_or_null<PartitionableLoopsInterface>(op);
+  auto interfaceOp = dyn_cast_or_null<TilingInterface>(op);
   if (interfaceOp) {
     llvm::SmallDenseSet<unsigned> pLoopsSet;
-    for (auto iteratorType : llvm::enumerate(interfaceOp.getIteratorTypes())) {
+    for (auto iteratorType :
+         llvm::enumerate(interfaceOp.getLoopIteratorTypes())) {
       if (iteratorType.value() == utils::IteratorType::parallel) {
         pLoopsSet.insert(iteratorType.index());
       }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -76,14 +76,15 @@ static SmallVector<Value, 4> calculateDistributedTileSize(
   SmallVector<int64_t> blockTileSize = getTileSizes(operation, 0);
   SmallVector<Value, 4> tileSizesVal;
   // Use partitionedLoop to know what loop needs to be distributed.
-  auto interfaceOp = cast<PartitionableLoopsInterface>(*operation);
+  auto interfaceOp = cast<PartitionableLoopsInterface>(operation);
   auto partitionedLoops =
       interfaceOp.getPartitionableLoops(kNumMaxParallelDims);
   if (partitionedLoops.empty()) {
     return tileSizesVal;
   }
   auto zero = builder.create<arith::ConstantIndexOp>(operation->getLoc(), 0);
-  tileSizesVal.resize(interfaceOp.getNumLoops(), zero);
+  tileSizesVal.resize(
+      cast<TilingInterface>(operation).getLoopIteratorTypes().size(), zero);
 
   // partitionedLoops contains the dimensions we want to distribute.
   // We are distributing them in order onto the different workgroup
@@ -356,8 +357,8 @@ struct LLVMGPUTileAndDistributePass
     if (flatWorkgroupSize > kWarpSize) {
       RewritePatternSet promotionPatterns(&getContext());
 
-          populatePromotionPatterns(context, promotionPatterns,
-                                    contractOpFilter, {0, 1});
+      populatePromotionPatterns(context, promotionPatterns, contractOpFilter,
+                                {0, 1});
 
       if (failed(applyPatternsAndFoldGreedily(funcOp,
                                               std::move(promotionPatterns)))) {


### PR DESCRIPTION
With the `TilingInterface` being used for first-level tile and
distribute, the additional methods in `PartitionableLoopsInterface`
are no longer necessary. Drop these.