### PR TITLE
Re-enable Shark post-submit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,8 +455,7 @@ jobs:
   ##############################################################################
   test_shark_model_suite:
     needs: [setup, build_all, build_tf_integrations]
-    # Disabled while failing, see https://github.com/nod-ai/SHARK/issues/373
-    if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}


### PR DESCRIPTION
Now that https://github.com/nod-ai/SHARK/pull/374 is merged, re-enable SHARK.