### PR TITLE
Revert inclusion of pip index generation in docs publication workflow

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -34,17 +34,8 @@ jobs:
         uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # v2
         with:
           python-version: 3.x
-          cache: 'pip'
-      - name: Installing dependencies
-        run: |
-          pip install \
-            mkdocs-material \
-            requests
-      - name: Generating release index
-        run: |
-          ./build_tools/scripts/generate_release_index.py \
-            --repo="${GITHUB_REPOSITORY}" \
-            --output=docs/website/docs/pip-release-links.html
+      - name: Installing Material for MkDocs
+        run: pip install mkdocs-material
       - name: Setting git config
         run: |
           git config --local user.email "iree-github-actions-bot@google.com"


### PR DESCRIPTION
I messed up the action part of this with the paths. Going to revert and
iterate by triggering the publication on my fork.

This partially reverts commits 7d53e568109d19ca00427e399a4c95f8191b75fa
(https://github.com/iree-org/iree/pull/10581) and
10a3b04950528af67dfba8f9ac125be37959c597
(https://github.com/iree-org/iree/pull/10585).

Part of https://github.com/iree-org/iree/issues/10479

skip-ci
