### PR TITLE
Publish release pip index as part of website

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -12,6 +12,7 @@ on:
       - main
     paths:
       - "docs/website/**"
+      - "build_tools/scripts/generate_release_index.py"
   # Regenerate the release pip index when a regular or pre-release is created or
   # deleted.
   release:

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -19,8 +19,6 @@ on:
 
 jobs:
   publish_website:
-    # Don't run this in everyone's forks.
-    if: github.repository == 'iree-org/iree'
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout out repository

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -12,16 +12,16 @@ on:
       - main
     paths:
       - "docs/website/**"
-
-defaults:
-  run:
-    working-directory: docs/website
+  # Regenerate the release pip index when a regular or pre-release is created or
+  # deleted.
+  release:
+    types: [published, unpublished]
 
 jobs:
   publish_website:
     # Don't run this in everyone's forks.
     if: github.repository == 'iree-org/iree'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout out repository
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -34,11 +34,21 @@ jobs:
         uses: actions/setup-python@7f80679172b057fc5e90d70d197929d454754a5a # v2
         with:
           python-version: 3.x
-      - name: Installing Material for MkDocs
-        run: pip install mkdocs-material
+          cache: 'pip'
+      - name: Installing dependencies
+        run: |
+          pip install \
+            mkdocs-material \
+            requests
+      - name: Generating release index
+        run: |
+          ./build_tools/scripts/generate_release_index.py \
+            --repo="${GITHUB_REPOSITORY}" \
+            --output=docs/website/docs/pip-release-links.html
       - name: Setting git config
         run: |
           git config --local user.email "iree-github-actions-bot@google.com"
           git config --local user.name "Website Publish Action"
       - name: Deploying to gh-pages
+        working-directory: docs/website
         run: mkdocs gh-deploy


### PR DESCRIPTION
This is incorporated into the docs pipeline and served on the website.
This isn't really the ideal place to serve it and we should probably
create a new subdomain and host a PEP 503 compliant index there. But
this will unbreak people for now.

Note that this includes a change to make docs publication run on forks.
I did this initially to enable testing, but I actually think it's a
reasonable change to make. The workflow is fast and cheap and this
makes testing it easier. GitHub already provides a way for people to
disable all actions or specific actions in their repository and I think
it makes more sense to let them handle it that way. I am open to being
convinced otherwise though. The fork most likely to be doing something
else with their gh-pages branch is Nod, and I've checked that they
aren't (nothing here: https://nod-ai.github.io/SHARK/). The workflow
requires that the repo have a `WRITE_ACCESS_TOKEN` secret and will fail
otherwise. We could also condition running it on the existence of that. 

Another attempt at https://github.com/iree-org/iree/pull/10581 and
https://github.com/iree-org/iree/pull/10585

Supersedes https://github.com/iree-org/iree/pull/10583.

Part of https://github.com/iree-org/iree/issues/10479.

Tested:
https://github.com/GMNGeoffrey/iree/actions/runs/3150453503 ->
https://gmngeoffrey.github.io/iree/pip-release-links.html

I didn't test the release trigger because doing an actual release is
very time-consuming.

skip-ci
