### PR TITLE
Update references to using `--find-links` for new index

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -63,7 +63,7 @@ These steps help reproduce the failures in TFLite models.
 
 1. Install `iree-import-tflite`.
    ```
-   $ python -m pip install iree-tools-tflite -f https://github.com/iree-org/iree/releases
+   $ python -m pip install iree-tools-tflite -f https://iree-org.github.io/iree/pip-release-links.html
    ```
 
 2. Expose and confirm the binary `iree-import-tflite` is in your path by running

--- a/docs/api_docs/python/requirements.txt
+++ b/docs/api_docs/python/requirements.txt
@@ -6,6 +6,6 @@ enum_tools==0.6.4
 sphinx_toolbox==2.15.0
 
 # IREE Python API
--f https://github.com/iree-org/iree/releases
+-f https://iree-org.github.io/iree/pip-release-links.html
 iree-compiler
 iree-runtime

--- a/docs/developers/debugging/tf_integrations_test_repro.md
+++ b/docs/developers/debugging/tf_integrations_test_repro.md
@@ -13,7 +13,7 @@ source iree.venv/bin/activate
 2. Install latest IREE release binaries. The importers are not expected to change much, so using the release binaries should work for most cases
 
 ```
-python -m pip install iree-compiler iree-runtime iree-tools-tf iree-tools-tflite -f https://github.com/iree-org/iree/releases/latest
+python -m pip install iree-compiler iree-runtime iree-tools-tf iree-tools-tflite --find-links https://iree-org.github.io/iree/pip-release-links.html
 ```
 
 3. Install TF nightly

--- a/docs/website/docs/bindings/python.md
+++ b/docs/website/docs/bindings/python.md
@@ -101,7 +101,7 @@ Stable release packages are published to
     run `pip install` with this extra option:
 
     ```
-    --find-links https://github.com/iree-org/iree/releases
+    --find-links https://iree-org.github.io/iree/pip-release-links.html
     ```
 
 ### Building from source

--- a/experimental/web/generate_web_metrics.sh
+++ b/experimental/web/generate_web_metrics.sh
@@ -66,7 +66,7 @@ trap "deactivate 2> /dev/null" EXIT
 # specific version when iterating on metrics is useful, and fetching is slow.
 
 python -m pip install --upgrade \
-  --find-links https://github.com/iree-org/iree/releases \
+  --find-links https://iree-org.github.io/iree/pip-release-links.html \
   iree-compiler iree-tools-tflite iree-tools-xla
 
 ###############################################################################


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/10479

skip-ci
