### PR TITLE
Make default pipeline depth 1 when not available in the configuration

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -106,7 +106,7 @@ def IREECodegen_TranslationInfoAttr :
   let parameters = (ins
     AttrParameter<"IREE::Codegen::DispatchLoweringPassPipelineAttr",
         "Name of the pipeline to be invoked on the translation unit.">:$passPipeline,
-    OptionalParameter<"unsigned",
+    DefaultValuedParameter<"unsigned", "1",
         "The software pipeline depth to be used">:$softwarePipelineDepth
   );
   let builders = [


### PR DESCRIPTION
This avoids confusion as it used to be the behavior before.