### PR TITLE
Add StableHLO to MHLO legalization to input pipeline

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -138,6 +138,7 @@ EXPLICIT_TARGET_MAPPING = {
         "MhloPasses",
     ],
     "@mlir-hlo//stablehlo:chlo_ops": ["ChloOps",],
+    "@mlir-hlo//:stablehlo_legalize_to_hlo_pass": ["StablehloToMhlo",],
     "@mlir-hlo//stablehlo:broadcast_utils": ["StablehloBroadcastUtils",],
 
     # Torch-MLIR.

--- a/compiler/src/iree/compiler/InputConversion/MHLO/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/BUILD
@@ -112,6 +112,7 @@ iree_compiler_cc_library(
         "@mlir-hlo//:materialize_broadcasts",
         "@mlir-hlo//:mhlo_to_mhlo_lowering_patterns",
         "@mlir-hlo//:mlir_hlo",
+        "@mlir-hlo//:stablehlo_legalize_to_hlo_pass",
         "@mlir-hlo//:unfuse_batch_norm",
         "@mlir-hlo//stablehlo:broadcast_utils",
         "@mlir-hlo//stablehlo:chlo_ops",

--- a/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/CMakeLists.txt
@@ -90,6 +90,7 @@ iree_cc_library(
     MhloToMemrefConversion
     MhloToStandard
     StablehloBroadcastUtils
+    StablehloToMhlo
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::Util::Transforms

--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -52,6 +52,7 @@ void registerMHLOConversionPassPipeline() {
 
 // Prepare HLO for use as an input to the Flow dialect.
 void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
+  passManager.addPass(mlir::mhlo::createStablehloLegalizeToHloPass());
   passManager.addNestedPass<func::FuncOp>(
       mhlo::createLegalizeControlFlowPass());
 

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/transformation_pipeline.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/transformation_pipeline.mlir
@@ -43,9 +43,9 @@ func.func @mhloElementwiseOps(%arg0 : tensor<4xf32>) -> tensor<4xf32> {
 // -----
 
 func.func @interleavedDot(%arg0 : tensor<4x4xf32>) -> tensor<4x4xf32> {
-  %0 = mhlo.add %arg0, %arg0 : tensor<4x4xf32>
-  %1 = "mhlo.dot"(%0, %arg0) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
-  %2 = mhlo.multiply %1, %arg0 : tensor<4x4xf32>
+  %0 = "stablehlo.add"(%arg0, %arg0) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+  %1 = "stablehlo.dot"(%0, %arg0) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
+  %2 = "stablehlo.multiply"(%1, %arg0) : (tensor<4x4xf32>, tensor<4x4xf32>) -> tensor<4x4xf32>
   return %2 : tensor<4x4xf32>
 }
 

--- a/compiler/src/iree/compiler/Tools/BUILD
+++ b/compiler/src/iree/compiler/Tools/BUILD
@@ -31,6 +31,7 @@ cc_library(
         "@mlir-hlo//:lhlo",
         "@mlir-hlo//:mlir_hlo",
         "@mlir-hlo//stablehlo:chlo_ops",
+        "@mlir-hlo//stablehlo:stablehlo_ops",
         "@torch-mlir-dialects//:TorchMLIRTMTensorDialect",
     ],
 )

--- a/compiler/src/iree/compiler/Tools/init_input_dialects.cc
+++ b/compiler/src/iree/compiler/Tools/init_input_dialects.cc
@@ -9,6 +9,7 @@
 #ifdef IREE_HAVE_MHLO_INPUT
 #include "mlir-hlo/Dialect/mhlo/IR/hlo_ops.h"
 #include "stablehlo/dialect/ChloOps.h"
+#include "stablehlo/dialect/StablehloOps.h"
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT
 #include "torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorDialect.h"
@@ -22,7 +23,8 @@ namespace iree_compiler {
 
 void registerInputDialects(DialectRegistry &registry) {
 #ifdef IREE_HAVE_MHLO_INPUT
-  registry.insert<mlir::chlo::ChloDialect, mlir::mhlo::MhloDialect>();
+  registry.insert<mlir::chlo::ChloDialect, mlir::mhlo::MhloDialect,
+                  mlir::stablehlo::StablehloDialect>();
 #endif  // IREE_HAVE_MHLO_INPUT
 #ifdef IREE_HAVE_TORCH_INPUT
   registry.insert<mlir::torch::TMTensor::TMTensorDialect>();


### PR DESCRIPTION
Should be NOP except where StableHLO is in input and there it should
convert to the equivalent MHLO.
