### PR TITLE
Disable pattern not safe for dynamic shapes

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/mhlo_to_mhlo_preprocessing.mlir
@@ -426,3 +426,13 @@ func.func @convolution(%arg0: tensor<16x32x256xbf16>, %arg1: tensor<1x256x256xbf
   // CHECK: return %[[CONV]]
   func.return %0 : tensor<16x32x256xf32>
 }
+
+// -----
+
+// CHECK-LABEL: @dynamic_dot_general
+// This verifies non-crashing, the lowering to linalg happens elsewhere.
+func.func @dynamic_dot_general(%arg1: tensor<?x1024x16x64xf32>, %arg2: tensor<?x1024x16x64xf32>) -> tensor<?x16x1024x1024xf32> {
+  %2 = "mhlo.dot_general"(%arg2, %arg1) {dot_dimension_numbers = #mhlo.dot<lhs_batching_dimensions = [0, 2], rhs_batching_dimensions = [0, 2], lhs_contracting_dimensions = [3], rhs_contracting_dimensions = [3]>, precision_config = [#mhlo<precision DEFAULT>, #mhlo<precision DEFAULT>]} : (tensor<?x1024x16x64xf32>, tensor<?x1024x16x64xf32>) -> tensor<?x16x1024x1024xf32>
+  return %2 : tensor<?x16x1024x1024xf32>
+}
+

--- a/integrations/tensorflow/test/iree_tf_tests/layers/llvmcpu__dynamic_dims_MultiHeadAttention.run
+++ b/integrations/tensorflow/test/iree_tf_tests/layers/llvmcpu__dynamic_dims_MultiHeadAttention.run
@@ -1,3 +1,2 @@
-# XFAIL: *
 # REQUIRES: llvmcpu
 # RUN: %PYTHON -m iree_tf_tests.layers.layers_test --target_backends=iree_llvmcpu --dynamic_dims=true --training=false --test_default_kwargs_only=true --layer=MultiHeadAttention --artifacts_dir=%t

--- a/integrations/tensorflow/test/iree_tf_tests/layers/vulkan__dynamic_dims_MultiHeadAttention.run
+++ b/integrations/tensorflow/test/iree_tf_tests/layers/vulkan__dynamic_dims_MultiHeadAttention.run
@@ -1,3 +1,2 @@
-# REQUIRES: vulkan
 # RUN: %PYTHON -m iree_tf_tests.layers.layers_test --target_backends=iree_vulkan --dynamic_dims=true --training=false --test_default_kwargs_only=true --layer=MultiHeadAttention --artifacts_dir=%t
 # XFAIL: *

--- a/integrations/tensorflow/test/iree_tf_tests/layers/vulkan__dynamic_dims_MultiHeadAttention.run
+++ b/integrations/tensorflow/test/iree_tf_tests/layers/vulkan__dynamic_dims_MultiHeadAttention.run
@@ -1,2 +1,2 @@
+# REQUIRES: vulkan
 # RUN: %PYTHON -m iree_tf_tests.layers.layers_test --target_backends=iree_vulkan --dynamic_dims=true --training=false --test_default_kwargs_only=true --layer=MultiHeadAttention --artifacts_dir=%t
-# XFAIL: *


### PR DESCRIPTION
I was going to extend this to address failing case, but noticed it seems
to be redundant with pattern that comes later. Disabling for dynamic
shapes at the moment. In follow up I'll remove to verify that it is
redundant.
