### PR TITLE
Remove dead references to `LoopTilingAndDistributionInfo`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1573,10 +1573,9 @@ LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
     }
 
     SmallVector<Operation *> computeOps;
-    SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
 
     // If there are no linalg ops, not using Linalg based lowering.
-    if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
+    if (failed(getComputeOps(funcOp, computeOps))) {
       return failure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -705,8 +705,7 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
     if (!exportOp) continue;
     if (getTranslationInfo(exportOp)) continue;
     SmallVector<Operation *> computeOps;
-    SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
-    if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
+    if (failed(getComputeOps(funcOp, computeOps))) {
       return funcOp.emitOpError("failed to get compute ops");
     }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -854,8 +854,7 @@ LogicalResult initSPIRVLaunchConfig(ModuleOp module) {
     if (!exportOp) continue;
 
     SmallVector<Operation *> computeOps;
-    SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
-    if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
+    if (failed(getComputeOps(funcOp, computeOps))) {
       return funcOp.emitOpError("failed to get compute ops");
     }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -86,8 +86,7 @@ class SPIRVTilePass final : public SPIRVTileBase<SPIRVTilePass> {
     SmallVector<scf::IfOp, 1> ifOps;
     funcOp.walk([&ifOps](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
     if (ifOps.empty()) {
-      SmallVector<LoopTilingAndDistributionInfo> loopInfos;
-      if (failed(getComputeOps(funcOp, computeOps, loopInfos))) {
+      if (failed(getComputeOps(funcOp, computeOps))) {
         funcOp.emitOpError("does not contain compute ops");
         return signalPassFailure();
       }

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -146,6 +146,11 @@ LogicalResult getFilteredOps(
 LogicalResult getComputeOps(
     func::FuncOp funcOp, SmallVectorImpl<Operation *> &computeOps,
     SmallVectorImpl<LoopTilingAndDistributionInfo> &tiledLoops);
+inline LogicalResult getComputeOps(func::FuncOp funcOp,
+                                   SmallVectorImpl<Operation *> &computeOps) {
+  SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
+  return getComputeOps(funcOp, computeOps, tiledLoops);
+}
 
 /// If the given `forOp` is a tiled and distributed loop, returns its tiling and
 /// distribution information.


### PR DESCRIPTION
This limits the references to this to place that only need it.