### PR TITLE
Re-enable iree_static_linker_test for cross compile

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -109,20 +109,9 @@ function(iree_bytecode_module)
     list(APPEND _OUTPUT_FILES "${_RULE_STATIC_LIB_PATH}" "${_STATIC_HDR_PATH}")
   endif()
 
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64" AND
-     CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-     NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
-    # RV64 Linux crosscompile toolchain can support iree-compile with
-    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
-    # llvm-target-triple is not specified.
-    list(APPEND _ARGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
-  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv32" AND
-         CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-         NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
-    # RV32 Linux crosscompile toolchain can support iree-compile with
-    # specific CPU flags. Add the llvm flags to support RV32 RVV codegen if
-    # llvm-target-triple is not specified.
-    list(APPEND _ARGS ${RISCV32_TEST_DEFAULT_LLVM_FLAGS})
+  iree_compile_flags_for_platform(_PLATFORM_FLAGS "${_RULE_FLAGS}")
+  if(_PLATFORM_FLAGS)
+    list(APPEND _ARGS ${_PLATFORM_FLAGS})
   endif()
 
   if(_RULE_FRIENDLY_NAME)

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -81,6 +81,11 @@ function(iree_c_module)
     list(APPEND _OUTPUT_FILES "${_RULE_STATIC_LIB_PATH}" "${_STATIC_HDR_PATH}")
   endif()
 
+  iree_compile_flags_for_platform(_PLATFORM_FLAGS "${_RULE_FLAGS}")
+  if(_PLATFORM_FLAGS)
+    list(APPEND _ARGS "${_PLATFORM_FLAGS}")
+  endif()
+
   add_custom_command(
     OUTPUT ${_OUTPUT_FILES}
     COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -28,37 +28,6 @@ function(iree_bytecode_module_for_iree_check_test_and_friends)
     ${ARGN}
   )
 
-  if(ANDROID AND NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
-    # Android's CMake toolchain defines some variables that we can use to infer
-    # the appropriate target triple from the configured settings:
-    # https://developer.android.com/ndk/guides/cmake#android_platform
-    #
-    # In typical CMake fashion, the various strings are pretty fuzzy and can
-    # have multiple values like "latest", "android-25"/"25"/"android-N-MR1".
-    #
-    # From looking at the toolchain file, ANDROID_PLATFORM_LEVEL seems like it
-    # should pretty consistently be just a number we can use for target triple.
-    set(_TARGET_TRIPLE "aarch64-none-linux-android${ANDROID_PLATFORM_LEVEL}")
-    list(APPEND _RULE_FLAGS "--iree-llvm-target-triple=${_TARGET_TRIPLE}")
-  endif()
-
-  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64" AND
-     CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-     _RULE_TARGET_BACKEND STREQUAL "llvm-cpu" AND
-     NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
-    # RV64 Linux crosscompile toolchain can support iree_check_test with
-    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
-    # llvm-target-triple is not specified.
-    list(APPEND _RULE_FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
-  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv32" AND
-         CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
-         NOT _RULE_FLAGS MATCHES "iree-llvm-target-triple")
-    # RV32 Linux crosscompile toolchain can support iree-compile with
-    # specific CPU flags. Add the llvm flags to support RV32 RVV codegen if
-    # llvm-target-triple is not specified.
-    list(APPEND _RULE_FLAGS ${RISCV32_TEST_DEFAULT_LLVM_FLAGS})
-  endif()
-
   if(_RULE_TARGET_CPU_FEATURES)
     if(NOT _RULE_TARGET_BACKEND IN_LIST IREE_TARGET_BACKENDS_SUPPORTING_TARGET_CPU_FEATURES)
       message(SEND_ERROR "TARGET_CPU_FEATURES should be empty when \

--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -84,18 +84,6 @@ function(iree_hal_cts_test_suite)
       "--compile-mode=hal-executable"
       "--iree-hal-target-backends=${_RULE_COMPILER_TARGET_BACKEND}"
     )
-    if(ANDROID)
-      set(_TARGET_TRIPLE "aarch64-none-linux-android${ANDROID_PLATFORM_LEVEL}")
-      list(APPEND _TRANSLATE_FLAGS "--iree-llvm-target-triple=${_TARGET_TRIPLE}")
-    endif()
-
-    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64" AND
-       CMAKE_SYSTEM_NAME STREQUAL "Linux")
-      list(APPEND  _TRANSLATE_FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
-    elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv32" AND
-           CMAKE_SYSTEM_NAME STREQUAL "Linux")
-      list(APPEND _TRANSLATE_FLAGS ${RISCV32_TEST_DEFAULT_LLVM_FLAGS})
-    endif()
 
     # Skip if already created (multiple suites using the same compiler setting).
     iree_package_name(_PACKAGE_NAME)

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -359,3 +359,52 @@ function(iree_validate_required_arguments
     endif()
   endforeach()
 endfunction()
+
+# iree_compile_flags_for_patform
+#
+# Helper function to add necessary compile flags based on platform-specific
+# configurations. Note the flags are added for cpu backends only.
+function(iree_compile_flags_for_platform OUT_FLAGS IN_FLAGS)
+  if(NOT (IN_FLAGS MATCHES "iree-hal-target-backends=llvm-cpu" OR
+          IN_FLAGS MATCHES "iree-hal-target-backends=vmvx"))
+    set(${OUT_FLAGS} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  if(ANDROID AND NOT IN_FLAGS MATCHES "iree-llvm-target-triple")
+    # Android's CMake toolchain defines some variables that we can use to infer
+    # the appropriate target triple from the configured settings:
+    # https://developer.android.com/ndk/guides/cmake#android_platform
+    #
+    # In typical CMake fashion, the various strings are pretty fuzzy and can
+    # have multiple values like "latest", "android-25"/"25"/"android-N-MR1".
+    #
+    # From looking at the toolchain file, ANDROID_PLATFORM_LEVEL seems like it
+    # should pretty consistently be just a number we can use for target triple.
+    set(_TARGET_TRIPLE "aarch64-none-linux-android${ANDROID_PLATFORM_LEVEL}")
+    list(APPEND _FLAGS "--iree-llvm-target-triple=${_TARGET_TRIPLE}")
+  endif()
+
+  if(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv64" AND
+     CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+     NOT IN_FLAGS MATCHES "iree-llvm-target-triple")
+    # RV64 Linux crosscompile toolchain can support iree-compile with
+    # specific CPU flags. Add the llvm flags to support RV64 RVV codegen if
+    # llvm-target-triple is not specified.
+    list(APPEND _FLAGS ${RISCV64_TEST_DEFAULT_LLVM_FLAGS})
+  elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "riscv32" AND
+         CMAKE_SYSTEM_NAME STREQUAL "Linux" AND
+         NOT IN_FLAGS MATCHES "iree-llvm-target-triple")
+    # RV32 Linux crosscompile toolchain can support iree-compile with
+    # specific CPU flags. Add the llvm flags to support RV32 RVV codegen if
+    # llvm-target-triple is not specified.
+    list(APPEND _FLAGS ${RISCV32_TEST_DEFAULT_LLVM_FLAGS})
+  endif()
+
+  if(EMSCRIPTEN AND NOT IN_FLAGS MATCHES "iree-llvm-target-triple")
+    list(APPEND _FLAGS "--iree-llvm-target-triple=wasm32-unknown-emscripten")
+    list(APPEND _FLAGS "--iree-llvm-target-cpu-features=+atomics,+bulk-memory")
+  endif()
+
+  set(${OUT_FLAGS} "${_FLAGS}" PARENT_SCOPE)
+endfunction()

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -402,8 +402,10 @@ function(iree_compile_flags_for_platform OUT_FLAGS IN_FLAGS)
   endif()
 
   if(EMSCRIPTEN AND NOT IN_FLAGS MATCHES "iree-llvm-target-triple")
-    list(APPEND _FLAGS "--iree-llvm-target-triple=wasm32-unknown-emscripten")
-    list(APPEND _FLAGS "--iree-llvm-target-cpu-features=+atomics,+bulk-memory")
+    set(_EMSCRIPTEN_TEST_DEFAULT_FLAGS
+      "--iree-llvm-target-triple=wasm32-unknown-emscripten"
+    )
+    list(APPEND _FLAGS ${_EMSCRIPTEN_TEST_DEFAULT_FLAGS})
   endif()
 
   set(${OUT_FLAGS} "${_FLAGS}" PARENT_SCOPE)

--- a/build_tools/cmake/iree_static_linker_test.cmake
+++ b/build_tools/cmake/iree_static_linker_test.cmake
@@ -52,7 +52,8 @@ function(iree_static_linker_test)
     return()
   endif()
 
-  if(NOT IREE_TARGET_BACKEND_LLVM_CPU OR NOT IREE_HAL_DRIVER_LOCAL_SYNC)
+  if(NOT (IREE_TARGET_BACKEND_LLVM_CPU OR DEFINED IREE_HOST_BINARY_ROOT) OR
+     NOT IREE_HAL_DRIVER_LOCAL_SYNC)
     return()
   endif()
 
@@ -64,7 +65,8 @@ function(iree_static_linker_test)
     ${ARGN}
   )
 
-  if(_RULE_EMITC AND NOT IREE_OUTPUT_FORMAT_C)
+  if(_RULE_EMITC AND
+     NOT (IREE_OUTPUT_FORMAT_C OR DEFINED IREE_HOST_BINARY_ROOT))
     return()
   endif()
 

--- a/docs/developers/developing_iree/testing_guide.md
+++ b/docs/developers/developing_iree/testing_guide.md
@@ -13,7 +13,7 @@ components and use different tooling depending on the needs of that component.
 |                 | iree_trace_runner_test                          | Bazel/CMake  | Host/Device         |
 |                 | iree_single_backend_generated_trace_runner_test | Bazel/CMake  | Host/Device         |
 |                 | iree_generated_trace_runner_test                | Bazel/CMake  | Host/Device         |
-|                 | iree_static_linker_test                         | CMake        | Host                |
+|                 | iree_static_linker_test                         | CMake        | Host/Device         |
 
 There are also more `*_test_suite` targets that groups test targets with the
 same configuration together.


### PR DESCRIPTION
Reverts https://github.com/iree-org/iree/pull/10620 and re-introduce https://github.com/iree-org/iree/pull/10589

Enable cross compile flags in `iree_bytecode_module` and `iree_c_module`, and allow `iree_static_linker_test` to build and test in cross compile platforms.