### PR TITLE
Add `--iree-hal-list-target-backends` flag.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -207,11 +207,11 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       "iree-llvm-list-targets",
       llvm::cl::desc("Lists all registered targets that the LLVM backend can "
                      "generate code for."),
-      llvm::cl::init(false));
-  if (clListTargets) {
-    llvm::TargetRegistry::printRegisteredTargetsForVersion(llvm::outs());
-    exit(0);
-  }
+      llvm::cl::init(false), llvm::cl::ValueDisallowed,
+      llvm::cl::callback([&](const bool &) {
+        llvm::TargetRegistry::printRegisteredTargetsForVersion(llvm::outs());
+        exit(0);
+      }));
 
   return targetOptions;
 }

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -170,6 +170,11 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
       llvm::cl::desc("Split the input file into pieces and "
                      "process each chunk independently"),
       llvm::cl::init(false));
+  llvm::cl::opt<bool> listHalTargets(
+      "iree-hal-list-target-backends",
+      llvm::cl::desc(
+          "List all registered target backends for executable compilation."),
+      llvm::cl::init(false));
 
 // Optional output formats.
 #ifdef IREE_HAVE_C_OUTPUT_FORMAT
@@ -199,6 +204,16 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
   // Default output format.
   if (outputFormat == OutputFormat::none) {
     outputFormat = OutputFormat::vm_bytecode;
+  }
+
+  // Handle help-style flags before running any compilation-related code.
+  if (listHalTargets) {
+    auto registeredTargetBackends = IREE::HAL::getRegisteredTargetBackends();
+    llvm::outs() << "Registered target backends:\n";
+    for (auto &registeredTargetBackend : registeredTargetBackends) {
+      llvm::outs() << "  " << registeredTargetBackend << "\n";
+    }
+    return 0;
   }
 
   std::string errorMessage;

--- a/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
+++ b/compiler/src/iree/compiler/Tools/iree_compile_lib.cc
@@ -173,8 +173,17 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
   llvm::cl::opt<bool> listHalTargets(
       "iree-hal-list-target-backends",
       llvm::cl::desc(
-          "List all registered target backends for executable compilation."),
-      llvm::cl::init(false));
+          "Lists all registered target backends for executable compilation."),
+      llvm::cl::init(false), llvm::cl::ValueDisallowed,
+      llvm::cl::callback([&](const bool &) {
+        auto registeredTargetBackends =
+            IREE::HAL::getRegisteredTargetBackends();
+        llvm::outs() << "Registered target backends:\n";
+        for (auto &registeredTargetBackend : registeredTargetBackends) {
+          llvm::outs() << "  " << registeredTargetBackend << "\n";
+        }
+        exit(0);
+      }));
 
 // Optional output formats.
 #ifdef IREE_HAVE_C_OUTPUT_FORMAT
@@ -204,16 +213,6 @@ int mlir::iree_compiler::runIreecMain(int argc, char **argv) {
   // Default output format.
   if (outputFormat == OutputFormat::none) {
     outputFormat = OutputFormat::vm_bytecode;
-  }
-
-  // Handle help-style flags before running any compilation-related code.
-  if (listHalTargets) {
-    auto registeredTargetBackends = IREE::HAL::getRegisteredTargetBackends();
-    llvm::outs() << "Registered target backends:\n";
-    for (auto &registeredTargetBackend : registeredTargetBackends) {
-      llvm::outs() << "  " << registeredTargetBackend << "\n";
-    }
-    return 0;
   }
 
   std::string errorMessage;


### PR DESCRIPTION
The HAL target backends are registered outside of the typical flags system, so `--help` output just appears as
```
--iree-hal-target-backends=<string>                          - Target backends for executable compilation.
```

This adds a new flag with sample usage:

```
λ iree-compile.exe --iree-hal-list-target-backends
Registered target backends:
  cuda
  llvm-cpu
  metal
  metal-spirv
  vmvx
  vmvx-inline
  vulkan
  vulkan-spirv
  webgpu
  webgpu-wgsl
```

Part of addressing https://github.com/iree-org/iree/issues/10432

---

I think we should also plumb something similar through to the Python bindings. This is what we have today:

```python
# Omit `target_backends`:
_ = compile_str(asm)

ValueError: Expected a non-empty list for 'target_backends'

# Try a backend that does not exist:
_ = compile_str(asm, target_backends=["unknown"])

CompilerToolError: Error invoking IREE compiler tool iree-compile
Diagnostics:
<stdin>:2:3: error: target backend 'unknown' not registered; registered backends: cuda, llvm-cpu, metal, metal, vmvx, vmvx-inline, vulkan, vulkan
  module @arithmetic {
  ^
compilation failed

# See a runtime helper method that we could model this after:
ireert.query_available_drivers()

['cuda', 'local-sync', 'local-task', 'vulkan']
```
