### PR TITLE
[LLVMCPU] Adjust convolution CodeGen pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -510,11 +510,11 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
     nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   }
 
-  addBufferizePasses(nestedModulePM);
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createOptimizeVectorTransferPass(/*flatten=*/true));
+      createOptimizeVectorTransferPass(/*flatten=*/false));
+  addBufferizePasses(nestedModulePM);
 
   // Run IREE specific passes before vector lowering expert.
   nestedModulePM.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/pipeline_tests.mlir
@@ -277,6 +277,7 @@ hal.executable private @vectorize_fill_conv2d_generic {
 }
 
 // CHECK:      func.func @vectorize_fill_conv2d_generic
+// CHECK-NOT:    memref.alloca
 // CHECK-NOT:    linalg.fill
 // CHECK:        vector.outerproduct %{{.+}}, %{{.+}}, %{{.+}} {kind = #vector.kind<add>}
 // CHECK-NOT:    linalg.generic


### PR DESCRIPTION
This moves the bufferization after OptimizeVector pass. The pass is intended to remove leading unit dimensions; it removes redundant memref.alloca ops. It also disable flatten in the OptimizeVector pass because this kind of optimization is done at vector lowering strategies.

Fixes https://github.com/iree-org/iree/issues/9201