### PR TITLE
Add iree.compiler.query_available_targets() Python utility.

### DIFF
--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/core.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/core.py
@@ -21,6 +21,7 @@ __all__ = [
     "DEFAULT_TESTING_BACKENDS",
     "compile_file",
     "compile_str",
+    "query_available_targets",
     "CompilerOptions",
     "InputType",
     "OutputFormat",
@@ -159,12 +160,12 @@ def build_compile_command_line(input_file: str, tfs: TempFileSaver,
   Returns:
     List of strings of command line.
   """
-  iree_translate = find_tool("iree-compile")
+  iree_compile = find_tool("iree-compile")
   if not options.target_backends:
     raise ValueError("Expected a non-empty list for 'target_backends'")
 
   cl = [
-      iree_translate,
+      iree_compile,
       input_file,
       f"--iree-input-type={options.input_type.value}",
       f"--iree-vm-bytecode-module-output-format={options.output_format.value}",
@@ -283,3 +284,16 @@ def compile_str(input_str: Union[str, bytes], **kwargs):
       with open(retained_output_file, "wb") as f:
         f.write(result)
     return result
+
+
+def query_available_targets():
+  """Returns a collection of target names that are registered."""
+  iree_compile = find_tool("iree-compile")
+  cl = [iree_compile, "--iree-hal-list-target-backends"]
+  result = invoke_immediate(cl).decode("utf-8")
+
+  target_backends = result.split("\n")[1:]
+  target_backends = [target.strip() for target in target_backends]
+  target_backends = [target for target in target_backends if target]
+
+  return target_backends

--- a/compiler/src/iree/compiler/API/python/test/tools/compiler_core_test.py
+++ b/compiler/src/iree/compiler/API/python/test/tools/compiler_core_test.py
@@ -27,6 +27,12 @@ class CompilerTest(unittest.TestCase):
     if "IREE_SAVE_TEMPS" in os.environ:
       del os.environ["IREE_SAVE_TEMPS"]
 
+  def testQueryTargets(self):
+    target_names = iree.compiler.query_available_targets()
+    logging.info("Targets = %s", target_names)
+    # The VMVX target is always enabled.
+    self.assertIn("vmvx", target_names)
+
   def testNoTargetBackends(self):
     with self.assertRaisesRegex(
         ValueError, "Expected a non-empty list for 'target_backends'"):


### PR DESCRIPTION
Depends on https://github.com/iree-org/iree/pull/10629. Part of addressing https://github.com/iree-org/iree/issues/10432.

```python
# This already exists
import iree.runtime
iree.runtime.query_available_drivers()

['cuda', 'local-sync', 'local-task', 'vulkan']

# This is new
import iree.compiler
iree.compiler.query_available_targets()

['llvm-cpu', 'metal', 'metal-spirv', 'vmvx', 'vmvx-inline', 'vulkan', 'vulkan-spirv']
```

Since the Python compiler API is just a wrapper around the CLI tools, this runs `iree-compile --iree-hal-list-target-backends` and parses the output.