### PR TITLE
Use IndexCastUIOp in pack_dispatch_operand

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -92,7 +92,7 @@ static void updateDispatchOp(IREE::Stream::CmdDispatchOp dispatchOp,
       // slower to work with on mobile GPUs. In the future we will want to flag
       // this as a global setting as well as have some heuristics for deriving
       // from target devices.
-      operand = builder.createOrFold<arith::IndexCastOp>(
+      operand = builder.createOrFold<arith::IndexCastUIOp>(
           loc, builder.getIntegerType(resourceConfig.getIndexBits()), operand);
     }
 
@@ -206,8 +206,8 @@ static void updateExportFuncOp(mlir::func::FuncOp funcOp) {
 
     // If going to index we need to insert a cast as the type changes.
     if (targetType.isIndex()) {
-      argOp = builder.create<arith::IndexCastOp>(loc, targetType,
-                                                 argOp->getResult(0));
+      argOp = builder.create<arith::IndexCastUIOp>(loc, targetType,
+                                                   argOp->getResult(0));
     }
 
     // Replace all subsequent uses with the new reconstituted value.
@@ -267,7 +267,7 @@ static void updateExportFuncOp(mlir::func::FuncOp funcOp) {
 
     // i32 or i64 -> index
     if (targetType.isIndex()) {
-      auto castOp = builder.create<arith::IndexCastOp>(
+      auto castOp = builder.create<arith::IndexCastUIOp>(
           loc, builder.getIndexType(), value);
       value.replaceAllUsesExcept(castOp.getResult(), castOp);
       value = castOp.getResult();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/pack_dispatch_operands.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/pack_dispatch_operands.mlir
@@ -113,7 +113,7 @@ stream.executable private @ex3 attributes {stream.resources = #resourceIndex32} 
     // CHECK-SAME: (%[[DEV_I32:.+]]: i32, %{{.+}}: !stream.binding)
     func.func @device_index_32(%arg0: index {stream.alignment = 16 : index, stream.values = [0 : index, 1234 : index]}, %arg1: !stream.binding) {
       // 32-bit device size fits in a push constant:
-      // CHECK: %[[DEV_INDEX:.+]] = arith.index_cast %[[DEV_I32]] {
+      // CHECK: %[[DEV_INDEX:.+]] = arith.index_castui %[[DEV_I32]] {
       // CHECK-SAME:   stream.alignment = 16 : index
       // CHECK-SAME:   stream.values = [0 : index, 1234 : index]
       // CHECK-SAME: } : i32 to index
@@ -130,7 +130,7 @@ func.func @host_index_32(%arg0: index) -> !stream.timepoint {
   %0 = stream.resource.alloc uninitialized : !stream.resource<external>{%c128}
 
   // 32-bit device size fits in a push constant:
-  // CHECK: %[[HOST_I32:.+]] = arith.index_cast %arg0 : index to i32
+  // CHECK: %[[HOST_I32:.+]] = arith.index_castui %arg0 : index to i32
   // CHECK: stream.cmd.dispatch {{.+}}(%[[HOST_I32]] : i32)
 
   %1 = stream.cmd.execute with(%0 as %arg1: !stream.resource<external>{%c128}) {
@@ -162,7 +162,7 @@ stream.executable private @ex4 attributes {stream.resources = #resourceIndex64} 
       // CHECK: %[[DEV_HI64:.+]] = arith.extui %[[DEV_HI32]] : i32 to i64
       // CHECK: %[[DEV_HISHL:.+]] = arith.shli %[[DEV_HI64]], %c32
       // CHECK: %[[DEV_I64:.+]] = arith.ori %[[DEV_LO64]], %[[DEV_HISHL]] : i64
-      // CHECK: %[[DEV_INDEX:.+]] = arith.index_cast %[[DEV_I64]] {
+      // CHECK: %[[DEV_INDEX:.+]] = arith.index_castui %[[DEV_I64]] {
       // CHECK-SAME:   stream.alignment = 16 : index
       // CHECK-SAME:   stream.values = [0 : index, 1234 : index]
       // CHECK-SAME: } : i64 to index
@@ -179,7 +179,7 @@ func.func @host_index_64(%arg0: index) -> !stream.timepoint {
   %0 = stream.resource.alloc uninitialized : !stream.resource<external>{%c128}
 
   // 64-bit device size requires splitting into lo/hi:
-  // CHECK: %[[HOST_I64:.+]] = arith.index_cast %arg0 : index to i64
+  // CHECK: %[[HOST_I64:.+]] = arith.index_castui %arg0 : index to i64
   // CHECK: %[[HOST_LO32:.+]] = arith.trunci %[[HOST_I64]] : i64 to i32
   // CHECK: %[[HOST_HI64:.+]] = arith.shrui %[[HOST_I64]], %c32
   // CHECK: %[[HOST_HI32:.+]] = arith.trunci %[[HOST_HI64]] : i64 to i32

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -765,19 +765,20 @@ class CastingOpConversion : public OpConversionPattern<StdOp> {
   }
 };
 
-class IndexCastOpConversion : public OpConversionPattern<arith::IndexCastOp> {
-  using OpConversionPattern::OpConversionPattern;
+template <typename OpTy, typename ExtOpTy>
+class IndexCastOpConversion : public OpConversionPattern<OpTy> {
+  using OpConversionPattern<OpTy>::OpConversionPattern;
   LogicalResult matchAndRewrite(
-      arith::IndexCastOp srcOp, OpAdaptor adaptor,
+      OpTy srcOp, typename OpTy::Adaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     auto srcType = adaptor.getIn().getType();
-    auto dstType = getTypeConverter()->convertType(srcOp.getResult().getType());
+    auto dstType =
+        this->getTypeConverter()->convertType(srcOp.getResult().getType());
     if (srcType == dstType) {
       rewriter.replaceOp(srcOp, adaptor.getOperands());
     } else if (srcType.getIntOrFloatBitWidth() <
                dstType.getIntOrFloatBitWidth()) {
-      rewriter.replaceOpWithNewOp<arith::ExtUIOp>(srcOp, dstType,
-                                                  adaptor.getIn());
+      rewriter.replaceOpWithNewOp<ExtOpTy>(srcOp, dstType, adaptor.getIn());
     } else {
       rewriter.replaceOpWithNewOp<arith::TruncIOp>(srcOp, dstType,
                                                    adaptor.getIn());
@@ -1085,9 +1086,10 @@ void populateStandardToVMPatterns(MLIRContext *context,
   patterns.insert<ConstantOpConversion>(context, typeConverter);
 
   patterns.insert<CastingOpConversion<UnrealizedConversionCastOp>,
-                  IndexCastOpConversion, ZeroExtendIOpConversion,
-                  SignExtendIOpConversion, TruncateIOpConversion>(typeConverter,
-                                                                  context);
+                  IndexCastOpConversion<arith::IndexCastOp, arith::ExtSIOp>,
+                  IndexCastOpConversion<arith::IndexCastUIOp, arith::ExtUIOp>,
+                  ZeroExtendIOpConversion, SignExtendIOpConversion,
+                  TruncateIOpConversion>(typeConverter, context);
 
   // Integer arithmetic ops.
   patterns


### PR DESCRIPTION
Since the offsets are unsigned value we need to do a zero extend when index is a wider type.