### PR TITLE
Expand list of community projects on the website.

### DIFF
--- a/docs/website/docs/community/index.md
+++ b/docs/website/docs/community/index.md
@@ -1,17 +1,34 @@
 # Community projects
 
+Projects built by community members:
+
+*   The [SHARK](https://github.com/nod-ai/SHARK) project from
+    [nod.ai](https://nod.ai/) uses a forked version of IREE
+    ([SHARK-Runtime](https://github.com/nod-ai/SHARK-Runtime)), offering
+    highly tuned performance on a large corpus of machine learning programs.
+
 *   The [IREE Bare-Metal Arm Sample](https://github.com/iml130/iree-bare-metal-arm)
-    demonstrates how build IREE with the
+    shows how to build IREE with the
     [Arm GNU Toolchain](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain)
     for bare-metal Arm targets using the open-source firmware libraries
     [CMSIS](https://github.com/ARM-software/CMSIS_5) and
     [libopencm3](https://github.com/libopencm3/libopencm3).
 
 *   The [IREE C++ Template](https://github.com/iml130/iree-template-cpp)
-    demonstrates how to integrate IREE into a third-party project with CMake.
-    The project demonstrates the usage of runtime support.
+    shows one way to integrate IREE's runtime into a project with CMake.
 
-*   The [IREE LLVM Sandbox](https://github.com/iree-org/iree-llvm-sandbox)
+Official repositories:
+
+*   [iree-jax](https://github.com/iree-org/iree-jax) is home to
+    IREE's support for [JAX](https://github.com/google/jax) programs.
+
+*   [iree-torch](https://github.com/iree-org/iree-torch) contains
+    IREE's [PyTorch](https://pytorch.org/) frontend, leveraging the
+    [torch-mlir](https://github.com/llvm/torch-mlir) project.
+
+*   [iree-samples](https://github.com/iree-org/iree-samples)
+    includes various samples and prototypes built with IREE.
+
+*   [iree-llvm-sandbox](https://github.com/iree-org/iree-llvm-sandbox)
     contains experimental work by the IREE team closely related to LLVM and
-    MLIR, usually with the aim of contributing back to those upstream projects
-    in some form.
+    MLIR, usually with the aim of contributing back to those upstream projects.


### PR DESCRIPTION
Adding a few projects that I'm aware of (both "official" and community driven). Trying to connect more dots between frontends (e.g. JAX, PyTorch) and other projects, where lots of exciting work is happening, and the core project. We're split across so many repositories, forums, mailing lists, etc. that having an index page is nice :)