### PR TITLE
[LLVMGPU] Tile extra parallel dimensions not distributed

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
@@ -76,7 +76,7 @@ struct LLVMGPUTensorAllocPass
     auto funcOp = getOperation();
 
     // Tile the reduction first to reduce the alloc size.
-    if (failed(tileReduction(funcOp))) {
+    if (failed(tileToSerialLoops(funcOp))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileAndDistribute.cpp
@@ -338,7 +338,7 @@ struct LLVMGPUTileAndDistributePass
     // Tile again at the workgroup level since reduction dimension were
     // ignored. Dimensions already tiled will be ignore since we tile to the
     // same size.
-    if (failed(tileReduction(funcOp))) {
+    if (failed(tileToSerialLoops(funcOp))) {
       return signalPassFailure();
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TilingUtils.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TilingUtils.h
@@ -16,7 +16,7 @@ class FuncOp;
 namespace iree_compiler {
 
 /// Apply tiling to reduction dimensions based on op attributes.
-LogicalResult tileReduction(func::FuncOp funcOp);
+LogicalResult tileToSerialLoops(func::FuncOp funcOp, bool onlyReduction = true);
 
 }  // namespace iree_compiler
 }  // namespace mlir


### PR DESCRIPTION
This prevents vectorizing large linalg ops. We tile with serial loops the extra dimension that are not handled by tileAndDistribute to workgroup.