### PR TITLE
[CPU] Enable peeling by default on RISC-V

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -29,8 +29,7 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 #define DEBUG_TYPE "kernel-dispatch"
-#define DBGS() (llvm::dbgs())
-#define KD_DBGS() (DBGS() << '[' << DEBUG_TYPE << "] ")
+#define KD_DBGS() (llvm::dbgs() << '[' << DEBUG_TYPE << "] ")
 
 namespace mlir {
 namespace iree_compiler {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -189,12 +189,7 @@ static VectorPreProcStrategy getVectorPreProcStrategy(
   //   * Contractions: Peeling.
   //   * Rest: None.
 
-  if (isRISCV(variantOp) && enableVectorPeeling &&
-      isa<linalg::ContractionOpInterface>(*linalgOp)) {
-    return VectorPreProcStrategy::Peeling;
-  }
-
-  return VectorPreProcStrategy::None;
+  return VectorPreProcStrategy::Peeling;
 }
 
 /// Looks for the `native_vector_size` attribute in the hal.executable.variant

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
@@ -40,7 +40,7 @@ hal.executable private @matmul_riscv  {
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] =  #iree_codegen.lowering_config<tile_sizes = {{\[}}[128, 64, 0], [8, 32, 0], [0, 0, 1]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
 //      CHECK: hal.executable.export public @matmul_riscv
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul


### PR DESCRIPTION
This PR enables peeling for matmul and element-wise ops on RISC-V. Now that we have most of the unrolling limits in place, peeling becomes beneficial on RISC-V! This PR improves DeepLabV3 performance by 43%.

Along the way, this patch also introduces debug dumps in KernelDispatch.cpp that is useful to follow how the tile size computation evolves. I used them to study the current tile size computation and I also tried to improve the code a bit while figuring out what it does.