### PR TITLE
[mlir][transform] Use MLIR's GPU transform dialect

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -68,6 +68,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:GPUToNVVMTransforms",
         "@llvm-project//mlir:GPUToROCDLTransforms",
+        "@llvm-project//mlir:GPUTransformOps",
         "@llvm-project//mlir:GPUTransforms",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LLVMCommonConversion",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -56,6 +56,7 @@ iree_cc_library(
     MLIRGPUOps
     MLIRGPUToNVVMTransforms
     MLIRGPUToROCDLTransforms
+    MLIRGPUTransformOps
     MLIRGPUTransforms
     MLIRIR
     MLIRLLVMCommonConversion

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
@@ -65,6 +65,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:GPUDialect",
+        "@llvm-project//mlir:GPUTransformOps",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:LinalgUtils",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
     MLIRArithDialect
     MLIRFuncDialect
     MLIRGPUOps
+    MLIRGPUTransformOps
     MLIRIR
     MLIRLinalgTransforms
     MLIRLinalgUtils

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/GPU/TransformOps/GPUTransformOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
@@ -66,19 +67,19 @@ transform_dialect::MapNestedForeachThreadToGpuThreads::applyToOne(
       extractFromI64ArrayAttr(getWorkgroupSize());
   // TODO: no magic constant but IREE uses this extensively.
   workgroupSize.resize(/*size=*/3, /*value=*/1);
+
+  auto transformOp = cast<transform::TransformOpInterface>(getOperation());
   SimplePatternRewriter rewriter(target);
-  auto walkResult = mlir::linalg::rewriteMapNestedForeachThreadToGpuThreads(
-      rewriter, target, workgroupSize, true);
-
-  if (walkResult.wasInterrupted())
-    return DiagnosedSilenceableFailure(reportUnknownTransformError(target));
-
-  auto newAttr = rewriter.getIndexArrayAttr(workgroupSize);
-  // TODO: should really be: exportOp.setWorkgroupSizeAttr(newAttr);
-  exportOp->setAttr(exportOp.getWorkgroupSizeAttrName(), newAttr);
-
+  DiagnosedSilenceableFailure diag =
+      mlir::transform::gpu::mapNestedForeachToThreadsImpl(
+          rewriter, target, workgroupSize, true, transformOp);
+  if (diag.succeeded()) {
+    auto newAttr = rewriter.getIndexArrayAttr(workgroupSize);
+    // TODO: should really be: exportOp.setWorkgroupSizeAttr(newAttr);
+    exportOp->setAttr(exportOp.getWorkgroupSizeAttrName(), newAttr);
+  }
   results.assign({target});
-  return DiagnosedSilenceableFailure(success());
+  return diag;
 }
 
 //===---------------------------------------------------------------------===//


### PR DESCRIPTION
MLIR added GPU transform dialect. The functionality existed before but lived in linalg. IREE was using functions of the transform dialect from linalg. https://reviews.llvm.org/D134800 actually created a gpu transform dialect and moved gpu related fucntions there.

This PR make IREE use of GPU transform dialect. We do not expect any functionality changes.

The PR includes the cherry pick llvm below:
```
[mlir][transform][nfc] typo fix
78305720f387ba5c86810a02155bd6c58d22c97c

[mlir][transform] Create GPU transform dialect
89bb0cae46f85bdfb04075b24f75064864708e78
```