### PR TITLE
Skip zero-filling accumulators, let ukernels overwrite

### DIFF
--- a/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/lower_linalg_microkernels.mlir
@@ -85,6 +85,24 @@ func.func @matmul_i8i8i32_row_major(%arg0 : memref<64x64xi32>, %arg1 : memref<64
   func.return
 }
 
+// CHECK-LABEL: @matmul_i8i8i32_row_major_clear
+//   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:2, %[[STRIDES0:.*]]:2 = vmvx.get_buffer_descriptor %arg0
+//   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:2, %[[STRIDES1:.*]]:2 = vmvx.get_buffer_descriptor %arg1
+//   CHECK-DAG: %[[BB2:.*]], %[[OFFSET2:.*]], %[[SIZES2:.*]]:2, %[[STRIDES2:.*]]:2 = vmvx.get_buffer_descriptor %arg2
+//  CHECK-NEXT: vmvx.matmul lhs(%[[BB1]] offset %[[OFFSET1]] row_stride %[[STRIDES1]]#0 : !util.buffer)
+//  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
+//  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
+//  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#1, %[[SIZES2]]#0)
+//  CHECK-SAME:   flags(0)
+func.func @matmul_i8i8i32_row_major_clear(%arg0 : memref<64x64xi32>, %arg1 : memref<64x384xi8>, %arg2 : memref<384x64xi8>) {
+  %c0 = arith.constant 0 : i32
+  linalg.fill ins(%c0 : i32) outs(%arg0 : memref<64x64xi32>)
+  linalg.matmul
+      ins(%arg1, %arg2 : memref<64x384xi8>, memref<384x64xi8>)
+      outs(%arg0 : memref<64x64xi32>)
+  func.return
+}
+
 // CHECK-LABEL: @mmt4d_f32f32f32
 //   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:4, %[[STRIDES0:.*]]:4 = vmvx.get_buffer_descriptor %arg0
 //   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:4, %[[STRIDES1:.*]]:4 = vmvx.get_buffer_descriptor %arg1
@@ -119,6 +137,43 @@ func.func @mmt4d_i8i8i32(%arg0 : memref<5x4x7x3xi32>, %arg1 : memref<5x6x7x8xi8>
   func.return
 }
 
+// CHECK-LABEL: @mmt4d_i8i8i32_clear
+//   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:4, %[[STRIDES0:.*]]:4 = vmvx.get_buffer_descriptor %arg0
+//   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:4, %[[STRIDES1:.*]]:4 = vmvx.get_buffer_descriptor %arg1
+//   CHECK-DAG: %[[BB2:.*]], %[[OFFSET2:.*]], %[[SIZES2:.*]]:4, %[[STRIDES2:.*]]:4 = vmvx.get_buffer_descriptor %arg2
+//  CHECK-NEXT: vmvx.mmt4d lhs(%[[BB1]] offset %[[OFFSET1]] row_stride %[[STRIDES1]]#0 : !util.buffer)
+//  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
+//  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
+//  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#0, %[[SIZES2]]#1)
+//  CHECK-SAME:   tile_mnk(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
+//  CHECK-SAME:   flags(0)
+func.func @mmt4d_i8i8i32_clear(%arg0 : memref<5x4x7x3xi32>, %arg1 : memref<5x6x7x8xi8>, %arg2 : memref<4x6x3x8xi8>) {
+  %c0 = arith.constant 0 : i32
+  linalg.fill ins(%c0 : i32) outs(%arg0 : memref<5x4x7x3xi32>)
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32>)
+  func.return
+}
+
+// CHECK-LABEL: @mmt4d_i8i8i32_fill_nonzero
+//   CHECK-DAG: %[[BB0:.*]], %[[OFFSET0:.*]], %[[SIZES0:.*]]:4, %[[STRIDES0:.*]]:4 = vmvx.get_buffer_descriptor %arg0
+//   CHECK-DAG: %[[BB1:.*]], %[[OFFSET1:.*]], %[[SIZES1:.*]]:4, %[[STRIDES1:.*]]:4 = vmvx.get_buffer_descriptor %arg1
+//   CHECK-DAG: %[[BB2:.*]], %[[OFFSET2:.*]], %[[SIZES2:.*]]:4, %[[STRIDES2:.*]]:4 = vmvx.get_buffer_descriptor %arg2
+//  CHECK:      vmvx.mmt4d lhs(%[[BB1]] offset %[[OFFSET1]] row_stride %[[STRIDES1]]#0 : !util.buffer)
+//  CHECK-SAME:   rhs(%[[BB2]] offset %[[OFFSET2]] row_stride %[[STRIDES2]]#0 : !util.buffer)
+//  CHECK-SAME:   out(%[[BB0]] offset %[[OFFSET0]] row_stride %[[STRIDES0]]#0 : !util.buffer)
+//  CHECK-SAME:   mnk(%[[SIZES1]]#0, %[[SIZES2]]#0, %[[SIZES2]]#1)
+//  CHECK-SAME:   tile_mnk(%[[SIZES1]]#2, %[[SIZES2]]#2, %[[SIZES2]]#3)
+//  CHECK-SAME:   flags(1)
+func.func @mmt4d_i8i8i32_fill_nonzero(%arg0 : memref<5x4x7x3xi32>, %arg1 : memref<5x6x7x8xi8>, %arg2 : memref<4x6x3x8xi8>) {
+  %c1 = arith.constant 1 : i32
+  linalg.fill ins(%c1 : i32) outs(%arg0 : memref<5x4x7x3xi32>)
+  linalg.mmt4d
+      ins(%arg1, %arg2 : memref<5x6x7x8xi8>, memref<4x6x3x8xi8>)
+      outs(%arg0 : memref<5x4x7x3xi32>)
+  func.return
+}
 
 // Now we test some variations of @mmt4d_i8i8i32 where the only thing that
 // varies is the affine_map on some memref, in order to test the logic deciding


### PR DESCRIPTION
When the accumulator argument to a `linalg.matmul` or `linalg.mmt4d` is filled with constant zeros, we can drop that fill and instead tell the `vmvx.matmul` or `vmvx.mmt4d` to overwrite the output buffer instead of loading and accumulating into the existing values.

This wasn't the top performance bottleneck --- slow packing code was --- but it was a good thing to work on independently while @MaheshRavishankar and @hanhanW are bringing up the new packing ops. And it still was significant: here this makes a 128x128, `i8` matmul over 20% faster. Okay, to put this into some perspective, we are talking about going from 1.8 Gop/s to 2.2 Gop/s (peak is 760 Gop/s, the mmt4d ukernel part does 730 Gop/s so all the remaining slowness is the packing/unpacking code. To put that in perspective, current llvmcpu does 100 Gop/s), so it's still very slow with all that packing code going down the scalar VM bytecode path, but it's good to get this out of the way so that when we turn attention to packing code, the impact of that will not be diluted in slow zero-filling code.