### PR TITLE
Make elementwise parallel operations use in-place updates only for non-vectorizable ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -276,8 +276,7 @@ static LogicalResult duplicateInitTensorOps(OpBuilder &b,
   return success();
 }
 
-static SmallVector<NamedAttribute> PruneAttributeList(
-    linalg::GenericOp op, bool useWARForCooperativeMatrixCodegen = false) {
+static SmallVector<NamedAttribute> PruneAttributeList(linalg::GenericOp op) {
   auto opAttributes = op.getAttributeNames();
   llvm::StringSet<> elidedAttrs;
   elidedAttrs.insert(opAttributes.begin(), opAttributes.end());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -103,7 +103,7 @@ static void tileAndDistributeToWorkgroup(
 }
 
 static void tileAndBufferize(OpPassManager &pm) {
-  tileAndDistributeToWorkgroup(pm, /*useWARForCooperativeMatrixCodegen =*/true);
+  tileAndDistributeToWorkgroup(pm, /*useWARForCooperativeMatrixCodegen=*/true);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   addBufferizePasses(nestedModulePM);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -90,18 +90,20 @@ static void addBufferizePasses(OpPassManager &passManager) {
       createEraseHALDescriptorTypeFromMemRefPass());
 }
 
-static void tileAndDistributeToWorkgroup(OpPassManager &pm) {
+static void tileAndDistributeToWorkgroup(
+    OpPassManager &pm, bool useWARForCooperativeMatrixCodegen = false) {
   pm.addPass(createTileAndDistributeToWorkgroupsPass());
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createConvertToDestinationPassingStylePass());
+      createConvertToDestinationPassingStylePass(
+          useWARForCooperativeMatrixCodegen));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 }
 
 static void tileAndBufferize(OpPassManager &pm) {
-  tileAndDistributeToWorkgroup(pm);
+  tileAndDistributeToWorkgroup(pm, /*useWARForCooperativeMatrixCodegen =*/true);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   addBufferizePasses(nestedModulePM);

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -106,7 +106,8 @@ createRemoveSingleIterationLoopPass();
 /// destination-passing style, which is better suited for the upstream
 /// comprehensive bufferization pass.
 std::unique_ptr<OperationPass<func::FuncOp>>
-createConvertToDestinationPassingStylePass();
+createConvertToDestinationPassingStylePass(
+    bool useWARForCooperativeMatrixCodegen = false);
 
 /// Creates a pass to vectorize a very specific form of tensor.pad ops with
 /// control flows.

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -28,7 +28,7 @@ def ConvertToDestinationPassingStyle :
   let options = [
     Option<"useWARForCooperativeMatrixCodegen", "use-war-for-cooperative-matrix-codegen",
            "bool", /*default=*/"false",
-           "WAR for failure in Cooperative matrix codegen pipelines">
+           "WAR for failure in Cooperative matrix codegen pipelines. See #10648.">
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -25,6 +25,11 @@ def ConvertToDestinationPassingStyle :
   let summary =
       "Transforms the code to make the dispatch use destination-passing style";
   let constructor = "mlir::iree_compiler::createConvertToDestinationPassingStylePass()";
+  let options = [
+    Option<"useWARForCooperativeMatrixCodegen", "use-war-for-cooperative-matrix-codegen",
+           "bool", /*default=*/"false",
+           "WAR for failure in Cooperative matrix codegen pipelines">
+  ];
 }
 
 def DecomposeLinalgGeneric :

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -276,8 +276,8 @@ void addSPIRVBaseVectorizePassPipeline(OpPassManager &pm) {
 
 void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm) {
   addTileAndDistributeToWorkgroupsPasses(
-      pm, /*useFuseTensorPadWithConsumerPass = */ false,
-      /*useWARForCooperativeMatrixCodegen = */ true);
+      pm, /*useFuseTensorPadWithConsumerPass=*/false,
+      /*useWARForCooperativeMatrixCodegen=*/true);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
 
@@ -324,8 +324,8 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
                                                 unsigned pipelineDepth) {
   LLVM_DEBUG(llvm::dbgs() << "Pipeline Depth: " << pipelineDepth << "\n");
   addTileAndDistributeToWorkgroupsPasses(
-      pm, /*useFuseTensorPadWithConsumerPass = */ false,
-      /*useWARForCooperativeMatrixCodegen = */ true);
+      pm, /*useFuseTensorPadWithConsumerPass=*/false,
+      /*useWARForCooperativeMatrixCodegen=*/true);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   addBufferizePasses(nestedModulePM, gpuAllocateWorkgroupMemoryFn);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -117,7 +117,8 @@ static void addBufferizePasses(OpPassManager &passManager,
 //===----------------------------------------------------------------------===//
 
 static void addTileAndDistributeToWorkgroupsPasses(
-    OpPassManager &passManager, bool useFuseTensorPadWithConsumerPass = false) {
+    OpPassManager &passManager, bool useFuseTensorPadWithConsumerPass = false,
+    bool useWARForCooperativeMatrixCodegen = false) {
   passManager.addPass(createTileAndDistributeToWorkgroupsPass());
   auto &nestedModulePM = passManager.nest<ModuleOp>();
   if (useFuseTensorPadWithConsumerPass) {
@@ -125,7 +126,8 @@ static void addTileAndDistributeToWorkgroupsPasses(
         createFuseTensorPadWithConsumerPass());
   }
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createConvertToDestinationPassingStylePass());
+      createConvertToDestinationPassingStylePass(
+          useWARForCooperativeMatrixCodegen));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 }
@@ -273,7 +275,9 @@ void addSPIRVBaseVectorizePassPipeline(OpPassManager &pm) {
 }
 
 void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm) {
-  addTileAndDistributeToWorkgroupsPasses(pm);
+  addTileAndDistributeToWorkgroupsPasses(
+      pm, /*useFuseTensorPadWithConsumerPass = */ false,
+      /*useWARForCooperativeMatrixCodegen = */ true);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
 
@@ -319,7 +323,9 @@ void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm) {
 void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
                                                 unsigned pipelineDepth) {
   LLVM_DEBUG(llvm::dbgs() << "Pipeline Depth: " << pipelineDepth << "\n");
-  addTileAndDistributeToWorkgroupsPasses(pm);
+  addTileAndDistributeToWorkgroupsPasses(
+      pm, /*useFuseTensorPadWithConsumerPass = */ false,
+      /*useWARForCooperativeMatrixCodegen = */ true);
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   addBufferizePasses(nestedModulePM, gpuAllocateWorkgroupMemoryFn);


### PR DESCRIPTION
The `ConvertToDestinationPassingStyle` pass converts elementwise operations fused with named op producers to use the result of the named ops as the `outs` operands, i.e.

```
%conv = linalg.conv
%result = linalg.generic ins(%conv, ... : ...) outs(...) -> ...
```

would be converted to

```
%conv = linalg.conv
%result = linalg.generic ins(... : ...) outs(%conv : ) -> ...
```

This avoids using intermediate buffers during bufferization to carry the dependence. This is only needed when the producer and consumer are not vectorized since in those cases the dependence is carried through registers. Make this transformation only when ops dont vectorize.

The CUDA/SPIR-V pipelines that bufferize early will have an allocation post this change. So adding a flag as a WAR to guard this change on those pipelines. See #11325 .