### PR TITLE
Do not promote to sharemem for dynamic tensors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
@@ -23,7 +23,9 @@ static bool contractOpFilter(Operation *op) {
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
   if (!linalgOp) return false;
 
-  // Can't promote dynamic shapes.
+  // The workgroup specialization already makes static shapes available for the
+  // main tile part and makes the partial tile computation small, so promoting
+  // to shared memory for the partial tile actually hurts the performance.
   if (linalgOp.hasDynamicShape()) return false;
 
   SmallVector<unsigned> dims;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorAlloc.cpp
@@ -22,6 +22,10 @@ namespace iree_compiler {
 static bool contractOpFilter(Operation *op) {
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
   if (!linalgOp) return false;
+
+  // Can't promote dynamic shapes.
+  if (linalgOp.hasDynamicShape()) return false;
+
   SmallVector<unsigned> dims;
   linalgOp.getParallelDims(dims);
   SmallVector<int64_t, 4> shapes = linalgOp.getStaticLoopRanges();


### PR DESCRIPTION
Specialization helped the performance too and now the sharemem promotion actually slows down the partial tile portion. Needs a broad evaluation.

For example, distillbert shows improvement from 6.21ms to 5.29ms.