### PR TITLE
Enable parallel execution of `linalg_ext.pack` operations.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -208,7 +208,7 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
                             IREE::LinalgExt::IREELinalgExtDialect *dialect) {
     IREE::LinalgExt::FftOp::attachInterface<FftOpPartitionableLoops>(*ctx);
     IREE::LinalgExt::PackOp::attachInterface<
-        NoPartitionableLoops<IREE::LinalgExt::PackOp>>(*ctx);
+        OuterParallelAsPartitionableLoops<IREE::LinalgExt::PackOp>>(*ctx);
     IREE::LinalgExt::ScanOp::attachInterface<
         AllParallelAsPartitionableLoops<IREE::LinalgExt::ScanOp>>(*ctx);
     IREE::LinalgExt::ScatterOp::attachInterface<

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtInterfaces.td
@@ -389,6 +389,33 @@ def LinalgExtInterface : OpInterface<"LinalgExtOp"> {
       }]
     >,
     //===------------------------------------------------------------------===//
+    // Non input and output operands handling
+    //===------------------------------------------------------------------===//
+    InterfaceMethod<
+      /*desc=*/[{
+        Return operands that are neither inputs nor outputs.
+      }],
+      /*retTy=*/"OpOperandVector",
+      /*methodName=*/"getNonInputOrOutputOperands",
+      /*args=*/(ins),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        int64_t numInputsAndOutputs = getNumInputsAndOutputs();
+        int64_t numOperands = this->getOperation()->getNumOperands();
+        assert(numInputsAndOutputs <= numOperands);
+        if (numInputsAndOutputs == numOperands)
+          return {};
+        OpOperandVector result;
+        result.reserve(numOperands - numInputsAndOutputs);
+        llvm::transform(
+          this->getOperation()->getOpOperands()
+            .drop_front(numInputsAndOutputs),
+          std::back_inserter(result),
+          [](OpOperand &opOperand) {return &opOperand;});
+        return result;
+      }]
+    >,
+    //===------------------------------------------------------------------===//
     // Other interface methods.
     //===------------------------------------------------------------------===//
     InterfaceMethod<

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/canonicalize.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/canonicalize.mlir
@@ -1,15 +1,11 @@
 // RUN: iree-dialects-opt --canonicalize --split-input-file %s | FileCheck %s
 
-// CHECK-LABEL: func.func @tensor.cast(
-func.func @tensor.cast(%arg0: tensor<3x5xi32>) -> tensor<3x5xi32> {
+func.func @tensor_cast(%arg0: tensor<3x5xi32>) -> tensor<3x5xi32> {
   %init = linalg.init_tensor [3, 5] : tensor<3x5xi32>
 
   %casted_arg0 = tensor.cast %arg0 : tensor<3x5xi32> to tensor<?x?xi32>
   %casted_init = tensor.cast %init : tensor<3x5xi32> to tensor<?x?xi32>
 
-// CHECK:      iree_linalg_ext.reverse
-// CHECK-SAME:   ins(%{{[a-zA-Z0-9]*}} : tensor<3x5xi32>)
-// CHECK-SAME:  outs(%{{[a-zA-Z0-9]*}} : tensor<3x5xi32>)
   %0 = iree_linalg_ext.reverse
          dimensions(dense<0> : tensor<1xi64>)
          ins(%casted_arg0 : tensor<?x?xi32>)
@@ -19,3 +15,28 @@ func.func @tensor.cast(%arg0: tensor<3x5xi32>) -> tensor<3x5xi32> {
 
   return %1: tensor<3x5xi32>
 }
+// CHECK-LABEL: func.func @tensor_cast(
+//       CHECK:      iree_linalg_ext.reverse
+//  CHECK-SAME:   ins(%{{[a-zA-Z0-9]*}} : tensor<3x5xi32>)
+//  CHECK-SAME:  outs(%{{[a-zA-Z0-9]*}} : tensor<3x5xi32>)
+
+// -----
+
+func.func @pack_canonicalize(%arg0 : tensor<?x?xi32>,
+    %arg1 : tensor<1x2x3x3xi32>) -> tensor<1x?x3x3xi32> {
+  %c0_i32 = arith.constant 0 : i32
+  %0 = tensor.cast %arg1 : tensor<1x2x3x3xi32> to tensor<1x?x3x3xi32>
+  %1 = iree_linalg_ext.pack %arg0 padding_value(%c0_i32 : i32)
+      dims_pos = [0, 1] inner_tiles = [3, 3] into %0
+      : (tensor<?x?xi32> tensor<1x?x3x3xi32>) -> tensor<1x?x3x3xi32>
+  return %1 : tensor<1x?x3x3xi32>
+}
+// CHECK-LABEL: func.func @pack_canonicalize
+//  CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xi32>
+//  CHECK-SAME:     %[[ARG1:.+]]: tensor<1x2x3x3xi32>
+//       CHECK:   %[[PAD_VALUE:.+]] = arith.constant 0 : i32
+//       CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack %[[ARG0]]
+//  CHECK-SAME:       padding_value(%[[PAD_VALUE]] : i32)
+//  CHECK-SAME:       into %[[ARG1]]
+//       CHECK:   %[[CAST:.+]] = tensor.cast %[[PACK]]
+//       CHECK:   return %[[CAST]]

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -512,7 +512,7 @@ func.func @topk_invalid(%input_values: tensor<3x10xf32>, %input_indices: tensor<
 // -----
 
 func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
-  // expected-error@+1 {{inferred type do not match provied output type}}
+  // expected-error@+1 {{infered type do not match provided output type}}
   %0 = iree_linalg_ext.pack %input dims_pos = [1, 0] inner_tiles = [16, 32] into %output : (tensor<256x128xf32> tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32>
   return %0 : tensor<8x8x32x16xf32>
 }
@@ -528,7 +528,7 @@ func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf
 // -----
 
 func.func @pad_and_pack_invalid_shape(%input: tensor<13x15xf32>, %output: tensor<3x8x8x2xf32>, %pad: f32) -> tensor<3x8x8x2xf32> {
-  // expected-error@+1 {{inferred type do not match provied output type. Expected 'tensor<2x8x8x2xf32>' but got: 'tensor<3x8x8x2xf32>}}
+  // expected-error@+1 {{infered type do not match provided output type. Expected 'tensor<2x8x8x2xf32>' but got: 'tensor<3x8x8x2xf32>}}
   %0 = iree_linalg_ext.pack %input padding_value(%pad: f32) dims_pos = [0, 1] inner_tiles = [8, 2] into %output : (tensor<13x15xf32> tensor<3x8x8x2xf32>) -> tensor<3x8x8x2xf32>
   return %0 : tensor<3x8x8x2xf32>
 }


### PR DESCRIPTION
Along the way
- Fix an error in canonicalization that generates a clone of the op without accounting for non input and output operands
- Some minor fixes to comment styles.