### PR TITLE
Activate DPS unconditionally when using the transform dialect.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -600,6 +600,10 @@ void addCPUDefaultPassPipeline(OpPassManager &passManager) {
 }
 
 void addTransformDialectInterpreterPasses(OpPassManager &passManager) {
+  auto &nestedModulePM = passManager.nest<ModuleOp>();
+  // Unconditionally convert to DPS.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createConvertToDestinationPassingStylePass());
   // Give control to the transform dialect.
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(

--- a/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
@@ -1,5 +1,8 @@
 // RUN: iree-opt %s
 
+// This is to be used with:
+//   --iree-flow-dispatch-via-region-ops \
+//   --iree-flow-dispatch-via-region-ops-generate-workload-region=false \
 transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %0 = transform.structured.match ops{["linalg.matmul"]} in %variant_op


### PR DESCRIPTION
```
 iree-transform-opt-dispatch-only  ./tests/transform_dialect/cuda/softmax.mlir  -b cuda -c tests/transform_dialect/cuda/softmax_fused_codegen_spec.mlir -d tests/transform_dialect/cuda/softmax_dispatch_spec.mlir
```

still shows a writeonly output tensor ..