### PR TITLE
Add a code size and no-C++ check on Android.

### DIFF
--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -12,7 +12,7 @@
 # Requires pre-compiled IREE and TF integrations host tools. Also requires that
 # ANDROID_ABI and ANDROID_NDK variables be set
 
-set -xeuo pipefail
+set -euo pipefail
 
 ROOT_DIR="${ROOT_DIR:-$(git rev-parse --show-toplevel)}"
 cd "${ROOT_DIR}"
@@ -29,22 +29,134 @@ else
   mkdir "${BUILD_ANDROID_DIR}"
 fi
 
-declare -a args=(
+declare -a common_args=(
   -G Ninja
   -B "${BUILD_ANDROID_DIR}"
   -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK}/build/cmake/android.toolchain.cmake"
   -DANDROID_ABI="${ANDROID_ABI}"
   -DANDROID_PLATFORM=android-29
   -DIREE_HOST_BINARY_ROOT="${IREE_HOST_BINARY_ROOT}"
-  -DIREE_ENABLE_ASSERTIONS=ON
   -DIREE_BUILD_COMPILER=OFF
-  -DIREE_BUILD_TESTS=ON
   -DIREE_BUILD_SAMPLES=OFF
 )
 
-# Configure towards 64-bit Android 10, then build.
-"${CMAKE_BIN}" "${args[@]}"
+# Settings for the minimal build used for code size / c++ symbols checks.
+# See "### C++ symbols checks" section below.
+declare -a minimal_build_args=(
+  -DIREE_BUILD_TESTS=OFF
+  # A bunch of instrumentation is tied to IREE_ENABLE_ASSERTIONS - this isn't
+  # just about eliding assertions.
+  -DIREE_ENABLE_ASSERTIONS=OFF
+  # The Vulkan driver is C++.
+  -DIREE_HAL_DRIVER_VULKAN=OFF
+)
 
+# These should at least undo any non-default settings in minimal_build_args.
+declare -a full_build_args=(
+  -DIREE_BUILD_TESTS=ON
+  -DIREE_ENABLE_ASSERTIONS=ON
+  -DIREE_HAL_DRIVER_VULKAN=ON
+)
+
+#############################################################################
+### C++ symbols checks
+#############################################################################
+
+# Checks that a minimal C program exercising the IREE runtime doesn't contain
+# any C++ symbols.
+#
+# This matters specifically on Android because Android does not
+# treat the C++ runtime as a "system library" --- it's up to each application to
+# distribute its own, and the CMake default, which we are using, is to
+# statically link it. See https://developer.android.com/ndk/guides/cpp-support.
+#
+# To make this worse, even though IREE C++ code is built with -fno-rtti and
+# -fno-exceptions, the libc++ that we are statically linking against in the
+# Android NDK is the same as everyone else's --- just because we have those
+# compilation flags doesn't change what we link against. As a result, a single
+# `operator new` is enough to drag in a large amount of exception-handling,
+# stack-unwinding, demangling code.
+
+echo
+echo "Start of minimal code size and symbols checks. The actual build and tests will follow below."
+echo 
+
+echo "Configuring for device (minimal build, for code size / symbols checks)"
+echo "------------"
+"${CMAKE_BIN}" "${common_args[@]}" "${minimal_build_args[@]}"
+
+TARGET="iree-minimal-invoke-module"
+
+echo "Building target ${TARGET} for device"
+echo "------------"
+"${CMAKE_BIN}" --build "${BUILD_ANDROID_DIR}" --target "${TARGET}" -- -k 0
+
+TARGET_BINARY="${BUILD_ANDROID_DIR}/tools/${TARGET}"
+
+TOOLCHAIN_TOOLS_DIR="${ANDROID_NDK}/toolchains/llvm/prebuilt/linux-x86_64/bin"
+NM_TOOL="${TOOLCHAIN_TOOLS_DIR}/llvm-nm"
+STRIP_TOOL="${TOOLCHAIN_TOOLS_DIR}/llvm-strip"
+NM_ARGS="-S --radix=d"
+NM_OUTPUT="$(${NM_TOOL} ${NM_ARGS} ${TARGET_BINARY})"
+NM_OUTPUT_ALL_CXX_SYMBOLS="$(grep '\b_Z' <<< "${NM_OUTPUT}" || true)"
+# The standard C library we're linking against has a snprintf implementation
+# that internally calls a C++ snprintf. As a result we get those C++ snprintf
+# symbols from plain C functions in .c files doing plain snprintf calls.
+# Example: iree_status_format (status.c) -> snprintf -> C++ snprintf.
+# We have no choice but to tolerate that and it's not a problem anyway as this
+# C++ code isn't dragging in any other symbol.
+NM_OUTPUT_CXX_SYMBOLS="$(grep -v '\b_ZL8snprintf' <<< "${NM_OUTPUT_ALL_CXX_SYMBOLS}"|| true)"
+
+if [[ ! -z "${NM_OUTPUT_CXX_SYMBOLS}" ]]
+then
+  CXX_SYMBOLS_SIZE="$(echo "${NM_OUTPUT_CXX_SYMBOLS}" | awk '{sum += $2} END {print sum}')"
+  echo "*********************************************************************"
+  echo "FATAL error: target ${TARGET} contains C++ symbols."
+  echo "*********************************************************************"
+  echo
+  echo "Total size of C++ symbols: ${CXX_SYMBOLS_SIZE} bytes"
+  echo
+  echo "Output of nm ${NM_ARGS} for these C++ symbols:"
+  # We could have `nm` demangle right away with -C, but that would make it
+  # harder to tell which symbols are C++. We would have to run `nm` twice.
+  echo "${NM_OUTPUT_CXX_SYMBOLS}" | c++filt
+  echo
+  exit 1
+fi
+
+${STRIP_TOOL} ${TARGET_BINARY}
+
+TARGET_BINARY_SIZE="$(size -A ${TARGET_BINARY} | grep Total | grep -o '[0-9]\+')"
+echo "File size: ${TARGET_BINARY_SIZE} bytes"
+
+# As of October 2022, the current size is 397827, so this gives 20% growth room.
+TARGET_BINARY_SIZE_LIMIT=480000
+
+if ((TARGET_BINARY_SIZE > TARGET_BINARY_SIZE_LIMIT ))
+then
+  echo "*********************************************************************"
+  echo "FATAL error: ${TARGET_BINARY} exceeds the current arbitrary limit."
+  echo "*********************************************************************"
+  echo
+  echo "Actual size:     ${TARGET_BINARY_SIZE}"
+  echo "Arbitrary limit: ${TARGET_BINARY_SIZE_LIMIT}"
+  echo
+  echo "If this is normal, feel free to bump the arbitrary limit."
+  echo
+  exit 1
+fi
+
+##############################################################################
+### End of C++ symbols checks
+##############################################################################
+
+echo
+echo "End of minimal code size and symbols checks. The actual build and tests start below."
+echo 
+
+echo "Configuring for device (full build, for actually running tests)"
+echo "------------"
+"${CMAKE_BIN}" "${common_args[@]}" "${full_build_args[@]}"
 
 echo "Building all for device"
 echo "------------"

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -168,6 +168,19 @@ cc_binary(
 )
 
 cc_binary(
+    name = "iree-minimal-invoke-module",
+    srcs = ["iree-minimal-invoke-module-main.c"],
+    deps = [
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:file_io",
+        "//runtime/src/iree/modules/hal:types",
+        "//runtime/src/iree/tooling:context_util",
+        "//runtime/src/iree/vm",
+        "//runtime/src/iree/vm:bytecode_module",
+    ],
+)
+
+cc_binary(
     name = "iree-run-trace",
     srcs = ["iree-run-trace-main.c"],
     deps = [

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -136,6 +136,21 @@ iree_cc_binary(
 
 iree_cc_binary(
   NAME
+    iree-minimal-invoke-module
+  SRCS
+    "iree-minimal-invoke-module-main.c"
+  DEPS
+    iree::base
+    iree::base::internal::file_io
+    iree::hal
+    iree::modules::hal::types
+    iree::tooling::context_util
+    iree::vm
+    iree::vm::bytecode_module
+)
+
+iree_cc_binary(
+  NAME
     iree-run-trace
   SRCS
     "iree-run-trace-main.c"

--- a/tools/iree-minimal-invoke-module-main.c
+++ b/tools/iree-minimal-invoke-module-main.c
@@ -1,0 +1,112 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Minimal C program linking in the IREE runtime. Does not even take enough
+// command-line parameters to be able to successfully run most modules. Only
+// useful for code size/symbols monitoring purposes.
+
+#include <stdio.h>
+
+// Low-level IREE VM APIs.
+// The higher-level iree/runtime/api.h can be used for more complete ML-like
+// programs using the hardware abstraction layer (HAL). This simple sample just
+// uses base VM types.
+#include "iree/base/api.h"
+#include "iree/base/internal/file_io.h"
+#include "iree/modules/hal/types.h"
+#include "iree/tooling/context_util.h"
+#include "iree/vm/api.h"
+#include "iree/vm/bytecode_module.h"
+
+// NOTE: CHECKs are dangerous but this is a sample; a real application would
+// want to handle errors gracefully. We know in this constrained case that
+// these won't fail unless something is catastrophically wrong (out of memory,
+// solar flares, etc).
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    fprintf(stderr,
+            "Usage:\n"
+            "  %s </path/to/say_hello.vmfb> <entry.point>\n",
+            argv[0]);
+    fprintf(
+        stderr,
+        "This program performs a dummy invoke without actual parameters, so "
+        "the function call will fail in general. It is only meant to be used "
+        "to inspect IREE runtime code size and internal call graph.\n");
+    return -1;
+  }
+
+  // Internally IREE does not (in general) use malloc and instead uses the
+  // provided allocator to allocate and free memory. Applications can integrate
+  // their own allocator as-needed.
+  iree_allocator_t allocator = iree_allocator_system();
+
+  // Create the root isolated VM instance that we can create contexts within.
+  iree_vm_instance_t* instance = NULL;
+  IREE_CHECK_OK(iree_vm_instance_create(allocator, &instance));
+  IREE_CHECK_OK(iree_hal_module_register_all_types(instance));
+
+  // Load the module from stdin or a file on disk.
+  // Applications can ship and load modules however they want (such as mapping
+  // them into memory instead of allocating like this). Modules can also be
+  // embedded in the binary but in those cases it makes more sense to use emitc
+  // to avoid the bytecode entirely and have a fully static build (see
+  // samples/emitc_modules/ for some examples).
+  const char* module_path = argv[1];
+  iree_file_contents_t* module_contents = NULL;
+  IREE_CHECK_OK(
+      iree_file_read_contents(module_path, allocator, &module_contents));
+
+  // Load the bytecode module from the vmfb.
+  // This module can be reused across multiple contexts.
+  // Note that we let the module retain the file contents for as long as needed.
+  iree_vm_module_t* bytecode_module = NULL;
+  IREE_CHECK_OK(iree_vm_bytecode_module_create(
+      instance, module_contents->const_buffer,
+      iree_file_contents_deallocator(module_contents), allocator,
+      &bytecode_module));
+
+  // Create the context for this invocation reusing the loaded modules.
+  // Contexts hold isolated state and can be reused for multiple calls.
+  // Note that the module order matters: the input user module is dependent on
+  // the custom module.
+  iree_vm_module_t* user_modules[] = {bytecode_module};
+  iree_tooling_module_list_t modules;
+  iree_tooling_module_list_initialize(&modules);
+  IREE_CHECK_OK(iree_tooling_resolve_modules(
+      instance, IREE_ARRAYSIZE(user_modules), user_modules,
+      /*default_device_uri=*/iree_string_view_empty(), allocator, &modules,
+      /*out_device=*/NULL, /*out_device_allocator=*/NULL));
+
+  iree_vm_context_t* context = NULL;
+  IREE_CHECK_OK(iree_vm_context_create_with_modules(
+      instance, IREE_VM_CONTEXT_FLAG_NONE, modules.count, modules.values,
+      allocator, &context));
+
+  // Lookup the function by fully-qualified name (module.func).
+  iree_vm_function_t function;
+  IREE_CHECK_OK(iree_vm_context_resolve_function(
+      context, iree_make_cstring_view(argv[2]), &function));
+
+  fprintf(stdout, "INVOKE BEGIN %s\n", argv[2]);
+  fflush(stdout);
+
+  // Synchronously invoke the requested function.
+  // We don't pass in/out anything in these simple examples so the I/O lists
+  // are not needed.
+  IREE_CHECK_OK(iree_vm_invoke(context, function, IREE_VM_INVOCATION_FLAG_NONE,
+                               /*policy=*/NULL, /*inputs=*/NULL,
+                               /*outputs=*/NULL, allocator));
+
+  fprintf(stdout, "INVOKE END\n");
+  fflush(stdout);
+
+  iree_tooling_module_list_reset(&modules);
+  iree_vm_context_release(context);
+  iree_vm_module_release(bytecode_module);
+  iree_vm_instance_release(instance);
+  return 0;
+}


### PR DESCRIPTION
This generates as CI error if any C++ makes it into the IREE runtime, at least the part of it that is linked into a minimal C program calling some `iree_vm_invoke` (adapted from samples/custom_module).

This also adds some binary size monitoring: the current sections size of that binary is ~ 397,000 bytes, so, allowing ourselves 20% growth, an arbitrary limit is set at 480,000 bytes. When we hit that limit, we will get a CI error inviting us to decide whether that's normal and we just want to bump the limit.

This matters specifically on Android because Android does not treat the C++ runtime as a "system library" --- it's up to each application to distribute its own, and the CMake default, which we are using, is to statically link it. See https://developer.android.com/ndk/guides/cpp-support.

To make this worse, even though IREE C++ code is built with `-fno-rtti` and `-fno-exceptions`, the libc++ that we are statically linking against in the Android NDK is the same as everyone else's --- just because we have those compilation flags doesn't change what we link against. As a result, a single `operator new` is enough to drag in a large amount of exception-handling, stack-unwinding, demangling code.

For example, on Android/AArch64, `iree-run-module` contains 120 kB of C++ symbols.