### PR TITLE
Specialize partial tile path with static shape

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/workgroup_specialization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/workgroup_specialization.mlir
@@ -158,5 +158,5 @@ func.func @unaligned_partial_loop() {
 // CHECK-SAME:                  ins(%{{.+}}, %{{.+}} : tensor<2x768xf32>, tensor<768x256xf32>) outs(%{{.+}} : tensor<2x256xf32>)
 // CHECK:       } else {
 // CHECK:         linalg.matmul
-// CHECK-SAME:                  ins(%{{.+}}, %{{.+}} : tensor<2x768xf32>, tensor<768x?xf32>) outs(%{{.+}} : tensor<2x?xf32>)
+// CHECK-SAME:                  ins(%{{.+}}, %{{.+}} : tensor<2x768xf32>, tensor<768x58xf32>) outs(%{{.+}} : tensor<2x58xf32>)
 


### PR DESCRIPTION
When there is only one bounded tile size, we can get the static shape for the partial path.

This doesn't seem to improve the performance much, but it can reduce the code size by not generating code for a few bound checks. For example, distilbert's dispatch 115 has a really large transpose, it reduces the vmfb file size from 7292 to 6044 bytes. The nvptx FB size is reduced from 2680 to 1432.

