### PR TITLE
Fix setting of workgroup size for `tile_to_foreach_thread_and_workgroup_count_region` 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -599,16 +599,13 @@ static LogicalResult lowerWorkgroupCountComputingRegion(
   }
   workgroupCount.resize(3, rewriter.getIndexAttr(1));
   permutedWorkgroupCount.resize(3, rewriter.getIndexAttr(1));
-  int dimId = 0;
+  int mappingId = 0;
   for (auto map : mapping->getValue()) {
-    auto id = map.cast<mlir::gpu::GPUBlockMappingAttr>().getBlock();
-    if (id == mlir::gpu::Blocks::DimX)
-      permutedWorkgroupCount[0] = workgroupCount[dimId];
-    if (id == mlir::gpu::Blocks::DimY)
-      permutedWorkgroupCount[1] = workgroupCount[dimId];
-    if (id == mlir::gpu::Blocks::DimZ)
-      permutedWorkgroupCount[2] = workgroupCount[dimId];
-    dimId++;
+    int64_t dimId = map.cast<DeviceMappingAttrInterface>().getMappingId();
+    permutedWorkgroupCount[dimId] = workgroupCount[mappingId];
+    permutedWorkgroupCount[dimId] = workgroupCount[mappingId];
+    permutedWorkgroupCount[dimId] = workgroupCount[mappingId];
+    mappingId++;
   }
   rewriter.replaceOp(
       workgroupCountOp,

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -536,7 +536,8 @@ void transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::build(
 /// pdl::OperationType handles on the fly.
 static LogicalResult lowerWorkgroupCountComputingRegion(
     transform::TransformState &state, RewriterBase &rewriter, Location loc,
-    HAL::ExecutableExportOp exportOp, ArrayRef<OpFoldResult> tileSizes) {
+    HAL::ExecutableExportOp exportOp, ArrayRef<OpFoldResult> tileSizes,
+    Optional<ArrayAttr> mapping) {
   Region &r = exportOp.getWorkgroupCount();
   if (!r.hasOneBlock()) {
     return rewriter.notifyMatchFailure(exportOp,
@@ -579,7 +580,7 @@ static LogicalResult lowerWorkgroupCountComputingRegion(
         "number of tile sizes overflow the dimension from the workload");
   }
 
-  SmallVector<OpFoldResult> workgroupCount;
+  SmallVector<OpFoldResult> workgroupCount, permutedWorkgroupCount;
   OpBuilder::InsertionGuard g(rewriter);
   rewriter.setInsertionPoint(workgroupCountOp);
   loc = workgroupCountOp.getLoc();
@@ -596,10 +597,22 @@ static LogicalResult lowerWorkgroupCountComputingRegion(
         ArrayRef<OpFoldResult>{workload[tileSize.index()], tileSize.value()});
     workgroupCount.push_back(count);
   }
-  workgroupCount = llvm::to_vector(llvm::reverse(workgroupCount));
   workgroupCount.resize(3, rewriter.getIndexAttr(1));
-  rewriter.replaceOp(workgroupCountOp, getValueOrCreateConstantIndexOp(
-                                           rewriter, loc, workgroupCount));
+  permutedWorkgroupCount.resize(3, rewriter.getIndexAttr(1));
+  int dimId = 0;
+  for (auto map : mapping->getValue()) {
+    auto id = map.cast<mlir::gpu::GPUBlockMappingAttr>().getBlock();
+    if (id == mlir::gpu::Blocks::DimX)
+      permutedWorkgroupCount[0] = workgroupCount[dimId];
+    if (id == mlir::gpu::Blocks::DimY)
+      permutedWorkgroupCount[1] = workgroupCount[dimId];
+    if (id == mlir::gpu::Blocks::DimZ)
+      permutedWorkgroupCount[2] = workgroupCount[dimId];
+    dimId++;
+  }
+  rewriter.replaceOp(
+      workgroupCountOp,
+      getValueOrCreateConstantIndexOp(rewriter, loc, permutedWorkgroupCount));
   return success();
 }
 
@@ -646,7 +659,8 @@ transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::apply(
   /// regions are created by default in IREEs compilation flow.
   IRRewriter rewriter(getContext());
   if (failed(lowerWorkgroupCountComputingRegion(
-          state, rewriter, getLoc(), exportOp.value(), getMixedTileSizes()))) {
+          state, rewriter, getLoc(), exportOp.value(), getMixedTileSizes(),
+          getMapping()))) {
     return mlir::emitDefiniteFailure(exportOp.value(),
                                      "failed to lower workgroup count region");
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -597,7 +597,7 @@ static LogicalResult lowerWorkgroupCountComputingRegion(
         ArrayRef<OpFoldResult>{workload[tileSize.index()], tileSize.value()});
     workgroupCount.push_back(count);
   }
-  // Make sure to fill unused dimensions with a 1
+  // Make sure to fill unused dimensions with 1
   workgroupCount.resize(3, rewriter.getIndexAttr(1));
   permutedWorkgroupCount.resize(3, rewriter.getIndexAttr(1));
   int mappingId = 0;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -597,15 +597,12 @@ static LogicalResult lowerWorkgroupCountComputingRegion(
         ArrayRef<OpFoldResult>{workload[tileSize.index()], tileSize.value()});
     workgroupCount.push_back(count);
   }
+  // Make sure to fill unused dimensions with a 1
   workgroupCount.resize(3, rewriter.getIndexAttr(1));
   permutedWorkgroupCount.resize(3, rewriter.getIndexAttr(1));
   int mappingId = 0;
-  for (auto map : mapping->getValue()) {
-    int64_t dimId = map.cast<DeviceMappingAttrInterface>().getMappingId();
-    permutedWorkgroupCount[dimId] = workgroupCount[mappingId];
-    permutedWorkgroupCount[dimId] = workgroupCount[mappingId];
-    permutedWorkgroupCount[dimId] = workgroupCount[mappingId];
-    mappingId++;
+  for (DeviceMappingAttrInterface map : mapping->getValue()) {
+    permutedWorkgroupCount[map.getMappingId()] = workgroupCount[mappingId++];
   }
   rewriter.replaceOp(
       workgroupCountOp,

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -31,6 +31,7 @@ iree_lit_test_suite(
         "softmax_v2.mlir",
         # First few ops of softmax only, acts as a proxy example.
         "softmax_partial.mlir",
+        "vecadd2d.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,
@@ -47,6 +48,7 @@ iree_lit_test_suite(
         "softmax_dispatch_spec.mlir",
         # First few ops of softmax only, acts as a proxy example.
         "softmax_partial_codegen_spec.mlir",
+        "vecadd2d_codegen_spec.mlir",
     ],
     tags = [
         # CUDA cuInit fails with sanitizer on.

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -22,6 +22,7 @@ iree_lit_test_suite(
     "softmax.mlir"
     "softmax_partial.mlir"
     "softmax_v2.mlir"
+    "vecadd2d.mlir"
   TOOLS
     FileCheck
     iree-compile
@@ -33,6 +34,7 @@ iree_lit_test_suite(
     softmax_dispatch_spec.mlir
     softmax_partial_codegen_spec.mlir
     softmax_v2_codegen_spec.mlir
+    vecadd2d_codegen_spec.mlir
   LABELS
     "noasan"
     "nomsan"

--- a/tests/transform_dialect/cuda/vecadd2d.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d.mlir
@@ -1,0 +1,52 @@
+!type = tensor<512x16xf32>
+
+func.func @vecadd2d() -> (!type) {
+  %cst0 = arith.constant 0.000000e+00 : f32
+  %cst1 = arith.constant 2.000000e+00 : f32
+  %0 = tensor.empty() : !type
+  %x = linalg.fill ins(%cst1 : f32) outs(%0 : !type) ->   !type
+  %1 = tensor.empty() : !type
+  %y = linalg.fill ins(%cst0 : f32) outs(%1 : !type) ->   !type
+
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%x : !type) outs(%y : !type) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !type
+
+  return %2 : !type
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/vecadd2d_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/vecadd2d_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=vecadd2d --device=cuda |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+//     CHECK:  hal.executable.export 
+//     CHECK:  bb0(%[[DEV:.*]]: !hal.device, %[[A1:.*]]: index, %[[A2:.*]]: index):
+//     CHECK:  %[[Dim2:.*]] = arith.constant 1 : index
+//     CHECK:  %[[Dim3:.*]] = affine.apply #map()[%[[A1]]]                          
+//     CHECK:  %[[Dim1:.*]] = affine.apply #map1()[%[[A2]]]
+//     CHECK:  hal.return %[[Dim1]], %[[Dim2]], %[[Dim3]] : index, index, index
+
+//     CHECK:  %[[BLKZ:.*]] = hal.interface.workgroup.id[2] : index
+//     CHECK:  %[[BLKX:.*]] = hal.interface.workgroup.id[0] : index
+//     CHECK:  memref.subview %0[%[[BLKZ:.*]], %[[BLKX:.*]]]
+
+
+//      EXEC: EXEC @vecadd2d
+//      EXEC: result[0]: hal.buffer_view
+//      EXEC: 512x16xf32=[2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2][2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2]

--- a/tests/transform_dialect/cuda/vecadd2d.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d.mlir
@@ -1,16 +1,24 @@
-!type = tensor<512x16xf32>
-
+!type = tensor<512x9xf32>
+#trait = { indexing_maps = [affine_map<(d0,d1) -> (d0,d1)>],
+           iterator_types = ["parallel", "parallel"]}
 func.func @vecadd2d() -> (!type) {
   %cst0 = arith.constant 0.000000e+00 : f32
   %cst1 = arith.constant 2.000000e+00 : f32
   %0 = tensor.empty() : !type
-  %x = linalg.fill ins(%cst1 : f32) outs(%0 : !type) ->   !type
   %1 = tensor.empty() : !type
-  %y = linalg.fill ins(%cst0 : f32) outs(%1 : !type) ->   !type
-
+  %x = linalg.generic #trait
+    outs(%0 : !type) {
+      ^bb0(%arg: f32):        
+        linalg.yield %cst1 : f32
+      } -> !type
+  %y = linalg.generic #trait
+    outs(%0 : !type) {
+      ^bb0(%arg: f32):        
+        linalg.yield %cst0 : f32
+      } -> !type
   %2 = linalg.generic {
-    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
-                     affine_map<(d0, d1) -> (d0, d1)>],
+    indexing_maps = [affine_map<(d0,d1) -> (d0,d1)>,
+                     affine_map<(d0,d1) -> (d0,d1)>],
     iterator_types = ["parallel", "parallel"]}
     ins(%x : !type) outs(%y : !type) {
       ^bb0(%arg3: f32, %arg4: f32):
@@ -49,4 +57,4 @@ func.func @vecadd2d() -> (!type) {
 
 //      EXEC: EXEC @vecadd2d
 //      EXEC: result[0]: hal.buffer_view
-//      EXEC: 512x16xf32=[2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2][2 2 2 2 2 2 2 2 2 2 2 2 2 2 2 2]
+//      EXEC: 512x9xf32=[2 2 2 2 2 2 2 2 2][2 2 2 2 2 2 2 2 2]

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
@@ -1,10 +1,17 @@
 transform.structured.canonicalized_sequence failures(propagate) {
-^bb1(%varop: !pdl.operation):
-  %generic = transform.structured.match ops{["linalg.generic"]} in %varop
-  %foreach, %tiled = transform.iree.tile_to_foreach_thread_and_workgroup_count_region %generic tile_sizes [5, 3] ( mapping = [#gpu.block<z>, #gpu.block<x>] )
-  %funcx = transform.structured.match ops{["func.func"]} in %varop
-  transform.iree.apply_patterns %funcx { rank_reducing }
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %varop
-  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
-  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4  
+^bb1(%variant_op: !pdl.operation):
+  // Step 1. Find three linalg.generics and tile to GPU thread blocks
+  // ===========================================================================
+  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op
+  transform.iree.tile_to_foreach_thread_and_workgroup_count_region %generics 
+                  tile_sizes [5, 3] ( mapping = [#gpu.block<z>, #gpu.block<x>])
+  // Step 2. Rank reduce and bufferize
+  // ===========================================================================
+  %func = transform.structured.match ops{["func.func"]} in %variant_op
+  transform.iree.apply_patterns %func { rank_reducing }
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+  // Step 3. Map to GPU thread blocks
+  // ===========================================================================
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  transform.iree.foreach_thread_to_workgroup %func_2
 }

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
@@ -1,7 +1,7 @@
 transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%varop: !pdl.operation):
   %generic = transform.structured.match ops{["linalg.generic"]} in %varop
-  %foreach, %tiled = transform.iree.tile_to_foreach_thread_and_workgroup_count_region %generic tile_sizes [16, 4] ( mapping = [#gpu.block<z>, #gpu.block<x>] )
+  %foreach, %tiled = transform.iree.tile_to_foreach_thread_and_workgroup_count_region %generic tile_sizes [5, 3] ( mapping = [#gpu.block<z>, #gpu.block<x>] )
   %funcx = transform.structured.match ops{["func.func"]} in %varop
   transform.iree.apply_patterns %funcx { rank_reducing }
   %variant_op_2 = transform.iree.bufferize { target_gpu } %varop

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
@@ -1,0 +1,10 @@
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb1(%varop: !pdl.operation):
+  %generic = transform.structured.match ops{["linalg.generic"]} in %varop
+  %foreach, %tiled = transform.iree.tile_to_foreach_thread_and_workgroup_count_region %generic tile_sizes [16, 4] ( mapping = [#gpu.block<z>, #gpu.block<x>] )
+  %funcx = transform.structured.match ops{["func.func"]} in %varop
+  transform.iree.apply_patterns %funcx { rank_reducing }
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %varop
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4  
+}


### PR DESCRIPTION
`tile_to_foreach_thread_and_workgroup_count_region` explicitly maps dimensions to GPU thread blocks via attribute. This PR assigns workgroup size according to given dimensions of `scf.foreach_thread`

Take a look at a 2D vectoradd example with 'linalg.generic' and transform dialect.
```
linalg.generic {...} ins(%x: tensor<512x4xf32>) outs(%y: tensor<512x4xf32>) {...}
```
here is the transform dialect
```
transform.iree.tile_to_foreach_thread_and_workgroup_count_region %generic tile_sizes [4, 2] (
mapping = [#gpu.block<z>, #gpu.block<y>] )
```

Current iree launches the following which is wrong.
```
CUDA kernel <<< (gridDim.x=2, gridDim.y=128, gridDim.z=1), ...>>> -> Wrong!
```
This PR changes the kernel launch as below:
```
CUDA kernel <<< (gridDim.x=1, gridDim.y=2, gridDim.z=128), ...>>> -> Correct
```