### PR TITLE
Fix `iree_run_module_test` setting to make it portable

### DIFF
--- a/build_tools/cmake/iree_run_module_test.cmake
+++ b/build_tools/cmake/iree_run_module_test.cmake
@@ -98,7 +98,11 @@ function(iree_run_module_test)
     message(SEND_ERROR "The DRIVER argument is required.")
   endif()
 
-  file(RELATIVE_PATH _SRC "${CMAKE_CURRENT_BINARY_DIR}" "${_RULE_MODULE_SRC}")
+  # All the file paths referred in the _RULE_RUNNER_ARGS are relative paths to
+  # make it portable, and all the paths in `_RUNNER_DATA` are absolute paths to
+  # make sure it can be checked/copied by the `iree_native_test` flow.
+  file(RELATIVE_PATH _SRC_RELATIVE_PATH
+    "${CMAKE_CURRENT_BINARY_DIR}" "${_RULE_MODULE_SRC}")
   list(APPEND _RUNNER_DATA ${_RULE_MODULE_SRC})
 
   if(_RULE_EXPECTED_OUTPUT)
@@ -108,18 +112,18 @@ function(iree_run_module_test)
     if(NOT _OUTPUT_FILE_TYPE)  # The expected output is listed in the field.
       list(APPEND _RULE_RUNNER_ARGS "--expected_output=\"${_RULE_EXPECTED_OUTPUT}\"")
     elseif(_OUTPUT_FILE_TYPE STREQUAL ".txt")
-      file(REAL_PATH "${_RULE_EXPECTED_OUTPUT}" _OUTPUT_FILE_SRC)
+      file(REAL_PATH "${_RULE_EXPECTED_OUTPUT}" _OUTPUT_FILE_ABS_PATH)
       # Process the text input to remove the line breaks.
-      file(READ "${_OUTPUT_FILE_SRC}" _EXPECTED_OUTPUT)
+      file(READ "${_OUTPUT_FILE_ABS_PATH}" _EXPECTED_OUTPUT)
       string(REPLACE "\n" " " _EXPECTED_OUTPUT_STR "${_EXPECTED_OUTPUT}")
       set(_EXPECTED_OUTPUT_STR "--expected_output=\"${_EXPECTED_OUTPUT_STR}\"")
       list(APPEND _RULE_RUNNER_ARGS ${_EXPECTED_OUTPUT_STR})
-      list(APPEND _RUNNER_DATA ${_OUTPUT_FILE_SRC})
+      list(APPEND _RUNNER_DATA ${_OUTPUT_FILE_ABS_PATH})
     elseif(_OUTPUT_FILE_TYPE STREQUAL ".npy")
       # Large npy files are not stored in the codebase. Need to download them
       # from GCS iree-model-artifacts first and store them in the following possible
       # paths.
-      find_file(_OUTPUT_FILE_SRC_PATH
+      find_file(_OUTPUT_FILE_ABS_PATH
         NAME
           "${_RULE_EXPECTED_OUTPUT}"
         PATHS
@@ -132,17 +136,17 @@ function(iree_run_module_test)
       # If the expected output npy file is not found (the large file is not
       # loaded from GCS to `IREE_BENCHMARK_SUITE_DIR` benchmark suite test),
       # report error.
-      if(NOT _OUTPUT_FILE_SRC_PATH)
+      if(NOT _OUTPUT_FILE_ABS_PATH)
         message(SEND_ERROR "${_RULE_EXPECTED_OUTPUT} is not found in\n\
           ${CMAKE_CURRENT_SOURCE_DIR}\n\
           ${CMAKE_CURRENT_BINARY_DIR}\n\
           ${IREE_BENCHMARK_SUITE_DIR}\n\
           Please check if you need to download it first.")
       else()
-        file(RELATIVE_PATH _OUTPUT_FILE_SRC
-          "${CMAKE_CURRENT_BINARY_DIR}" "${_OUTPUT_FILE_SRC_PATH}")
-        list(APPEND _RULE_RUNNER_ARGS "--expected_output=@${_OUTPUT_FILE_SRC}")
-        list(APPEND _RUNNER_DATA ${_OUTPUT_FILE_SRC_PATH})
+        file(RELATIVE_PATH _OUTPUT_FILE_RELATIVE_PATH
+          "${CMAKE_CURRENT_BINARY_DIR}" "${_OUTPUT_FILE_ABS_PATH}")
+        list(APPEND _RULE_RUNNER_ARGS "--expected_output=@${_OUTPUT_FILE_RELATIVE_PATH}")
+        list(APPEND _RUNNER_DATA ${_OUTPUT_FILE_ABS_PATH})
       endif()
     else()
       message(SEND_ERROR "Unsupported expected output file type: ${_RULE_EXPECTED_OUTPUT}")
@@ -187,7 +191,7 @@ function(iree_run_module_test)
     SRC
       "${_RUNNER_TARGET}"
     ARGS
-      "--module_file=${_SRC}"
+      "--module_file=${_SRC_RELATIVE_PATH}"
       "--flagfile=${_OUTPUT_FLAGFILE}"
     DATA
       "${_RUNNER_DATA}"

--- a/build_tools/cmake/iree_run_module_test.cmake
+++ b/build_tools/cmake/iree_run_module_test.cmake
@@ -99,6 +99,7 @@ function(iree_run_module_test)
   endif()
 
   file(RELATIVE_PATH _SRC "${CMAKE_CURRENT_BINARY_DIR}" "${_RULE_MODULE_SRC}")
+  list(APPEND _RUNNER_DATA ${_RULE_MODULE_SRC})
 
   if(_RULE_EXPECTED_OUTPUT)
     # this may be a file or a literal output. In the latter case, the
@@ -113,6 +114,7 @@ function(iree_run_module_test)
       string(REPLACE "\n" " " _EXPECTED_OUTPUT_STR "${_EXPECTED_OUTPUT}")
       set(_EXPECTED_OUTPUT_STR "--expected_output=\"${_EXPECTED_OUTPUT_STR}\"")
       list(APPEND _RULE_RUNNER_ARGS ${_EXPECTED_OUTPUT_STR})
+      list(APPEND _RUNNER_DATA ${_OUTPUT_FILE_SRC})
     elseif(_OUTPUT_FILE_TYPE STREQUAL ".npy")
       # Large npy files are not stored in the codebase. Need to download them
       # from GCS iree-model-artifacts first and store them in the following possible
@@ -140,6 +142,7 @@ function(iree_run_module_test)
         file(RELATIVE_PATH _OUTPUT_FILE_SRC
           "${CMAKE_CURRENT_BINARY_DIR}" "${_OUTPUT_FILE_SRC_PATH}")
         list(APPEND _RULE_RUNNER_ARGS "--expected_output=@${_OUTPUT_FILE_SRC}")
+        list(APPEND _RUNNER_DATA ${_OUTPUT_FILE_SRC_PATH})
       endif()
     else()
       message(SEND_ERROR "Unsupported expected output file type: ${_RULE_EXPECTED_OUTPUT}")
@@ -158,6 +161,7 @@ function(iree_run_module_test)
       CONTENT
         "${_OUTPUT_FLAGS}"
     )
+    list(APPEND _RUNNER_DATA "${CMAKE_CURRENT_BINARY_DIR}/${_RULE_NAME}_flagfile")
   endif()
 
   # A target specifically for the test.
@@ -185,6 +189,8 @@ function(iree_run_module_test)
     ARGS
       "--module_file=${_SRC}"
       "--flagfile=${_OUTPUT_FLAGFILE}"
+    DATA
+      "${_RUNNER_DATA}"
     WILL_FAIL
       ${_TEST_XFAIL}
     LABELS


### PR DESCRIPTION
Remove the absolute path in flagfile, module_file, and expected_output to make the test more portable.

Also update the `file(STRING)` --> `file(READ)` usage in the function.