### PR TITLE
[spirv] Add initial I64 emulation pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -510,6 +510,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createSPIRVVectorizeLoadStore();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVCreateFastSlowPathPass();
 
+/// Emulates 64-bit integer ops with 32-bit integer ops.
+std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateI64Pass();
+
 //----------------------------------------------------------------------------//
 // SPIRV Codegen Pass Pipelines.
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -489,6 +489,12 @@ def SPIRVCreateFastSlowPath :
   let constructor = "mlir::iree_compiler::createSPIRVCreateFastSlowPathPass()";
 }
 
+def SPIRVEmulateI64 :
+    Pass<"iree-spirv-emulate-i64", "ModuleOp"> {
+  let summary = "Emulate 64-bit integer opts with 32-bit integer ops";
+  let constructor = "mlir::iree_compiler::createSPIRVEmulateI64Pass()";
+}
+
 //------------------------------------------------------------------------------
 // VMVX Passes
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD
@@ -25,6 +25,7 @@ iree_compiler_cc_library(
         "Passes.cpp",
         "SPIRVCreateFastSlowPath.cpp",
         "SPIRVDistribute.cpp",
+        "SPIRVEmulateI64.cpp",
         "SPIRVLowerExecutableTargetPass.cpp",
         "SPIRVTile.cpp",
         "SPIRVTileAndDistribute.cpp",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "Passes.cpp"
     "SPIRVCreateFastSlowPath.cpp"
     "SPIRVDistribute.cpp"
+    "SPIRVEmulateI64.cpp"
     "SPIRVLowerExecutableTargetPass.cpp"
     "SPIRVTile.cpp"
     "SPIRVTileAndDistribute.cpp"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -201,6 +201,10 @@ static void addSPIRVLoweringPasses(OpPassManager &pm, bool enableFastMath) {
   pm.addPass(createCSEPass());
 
   pm.addPass(createMapMemRefStorageClassPass());
+  pm.addPass(createSPIRVEmulateI64Pass());
+  pm.addPass(createCanonicalizerPass());
+  pm.addPass(createCSEPass());
+
   pm.addPass(createConvertToSPIRVPass(enableFastMath));
 
   OpPassManager &spirvPM = pm.nest<spirv::ModuleOp>();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -1,0 +1,207 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===----------------------------------------------------------------------===//
+//
+// This file implements a pass to emulate 64-bit integer operations with 32-bit
+// ones.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/SPIRV/Utils.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/Transforms/WideIntEmulationConverter.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/DialectConversion.h"
+
+#define DEBUG_TYPE "iree-spirv-emulate-i64"
+
+namespace mlir {
+namespace iree_compiler {
+namespace {
+
+//===----------------------------------------------------------------------===//
+// Conversion patterns
+//===----------------------------------------------------------------------===//
+struct ConvertHalInterfaceBindingSubspan final
+    : OpConversionPattern<IREE::HAL::InterfaceBindingSubspanOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      IREE::HAL::InterfaceBindingSubspanOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newResultTy = getTypeConverter()->convertType(op.getType());
+    if (!newResultTy)
+      return rewriter.notifyMatchFailure(
+          op->getLoc(),
+          llvm::formatv("failed to legalize memref type: {0}", op.getType()));
+
+    auto newOp =
+        rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
+            op, newResultTy, adaptor.getSet(), adaptor.getBinding(),
+            adaptor.getDescriptorType(), adaptor.getByteOffset(),
+            adaptor.getDynamicDims(), adaptor.getAlignmentAttr());
+    LLVM_DEBUG(llvm::dbgs()
+               << "WideIntegerEmulation: new op: " << newOp << "\n");
+    (void)newOp;
+    return success();
+  }
+};
+
+// TODO(kuhar): Upstream memref conversion patterns.
+struct ConvertMemrefLoad final : OpConversionPattern<memref::LoadOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      memref::LoadOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newResTy = getTypeConverter()->convertType(op.getType());
+    if (!newResTy)
+      return rewriter.notifyMatchFailure(
+          op->getLoc(), llvm::formatv("failed to legalize memref type: {0}",
+                                      op.getMemRefType()));
+
+    auto newOp = rewriter.replaceOpWithNewOp<memref::LoadOp>(
+        op, newResTy, adaptor.getMemref(), adaptor.getIndices());
+    LLVM_DEBUG(llvm::dbgs()
+               << "WideIntegerEmulation: new op: " << newOp << "\n");
+    (void)newOp;
+    return success();
+  }
+};
+
+// TODO(kuhar): Upstream memref conversion patterns.
+struct ConvertMemrefStore final : OpConversionPattern<memref::StoreOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      memref::StoreOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    Type newTy = getTypeConverter()->convertType(op.getMemRefType());
+    if (!newTy)
+      return rewriter.notifyMatchFailure(
+          op->getLoc(), llvm::formatv("failed to legalize memref type: {0}",
+                                      op.getMemRefType()));
+
+    auto newOp = rewriter.replaceOpWithNewOp<memref::StoreOp>(
+        op, adaptor.getValue(), adaptor.getMemref(), adaptor.getIndices());
+    LLVM_DEBUG(llvm::dbgs()
+               << "WideIntegerEmulation: new op: " << newOp << "\n");
+    (void)newOp;
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
+// Helper functions
+//===----------------------------------------------------------------------===//
+
+// TODO(kuhar): Upstream memref conversion patterns.
+static void populateMemrefEmulationPatterns(
+    arith::WideIntEmulationConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<ConvertMemrefLoad, ConvertMemrefStore>(converter,
+                                                      patterns.getContext());
+}
+
+// TODO(kuhar): Upstream memref conversion patterns.
+static void populateMemrefWideIntegerEmulationConversions(
+    arith::WideIntEmulationConverter &typeConverter) {
+  typeConverter.addConversion(
+      [&typeConverter](MemRefType ty) -> Optional<Type> {
+        auto intTy = ty.getElementType().dyn_cast<IntegerType>();
+        if (!intTy) return ty;
+
+        if (intTy.getIntOrFloatBitWidth() <=
+            typeConverter.getMaxTargetIntBitWidth())
+          return ty;
+
+        Type newElemTy = typeConverter.convertType(intTy);
+        if (!newElemTy) return None;
+
+        return ty.cloneWith(None, newElemTy);
+      });
+}
+
+static void populateIreeI64EmulationPatterns(
+    arith::WideIntEmulationConverter &converter, RewritePatternSet &patterns) {
+  patterns.add<ConvertHalInterfaceBindingSubspan>(converter,
+                                                  patterns.getContext());
+}
+
+static bool supportsI64(ModuleOp op) {
+  spirv::TargetEnvAttr attr = getSPIRVTargetEnvAttr(op);
+  assert(attr && "Not a valid spirv module");
+  spirv::TargetEnv env(attr);
+  return env.allows(spirv::Capability::Int64);
+}
+
+//===----------------------------------------------------------------------===//
+// Main pass
+//===----------------------------------------------------------------------===//
+
+struct SPIRVEmulateI64Pass final
+    : public SPIRVEmulateI64Base<SPIRVEmulateI64Pass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<vector::VectorDialect>();
+  }
+
+  void runOnOperation() override {
+    ModuleOp op = getOperation();
+    if (supportsI64(op)) return;
+
+    arith::WideIntEmulationConverter typeConverter(32);
+    populateMemrefWideIntegerEmulationConversions(typeConverter);
+
+    MLIRContext *ctx = &getContext();
+    ConversionTarget target(*ctx);
+    target.addDynamicallyLegalOp<func::FuncOp>([&typeConverter](Operation *op) {
+      return typeConverter.isLegal(cast<func::FuncOp>(op).getFunctionType());
+    });
+    target.addDynamicallyLegalDialect<
+        arith::ArithDialect, func::FuncDialect, IREE::HAL::HALDialect,
+        memref::MemRefDialect, vector::VectorDialect>(
+        [&typeConverter](Operation *op) {
+          bool legal = typeConverter.isLegal(op);
+          LLVM_DEBUG(if (!legal) llvm::dbgs()
+                     << "WideIntegerEmulation: illegal op: " << *op << "\n");
+          return legal;
+        });
+
+    RewritePatternSet patterns(ctx);
+    arith::populateWideIntEmulationPatterns(typeConverter, patterns);
+    populateMemrefEmulationPatterns(typeConverter, patterns);
+    populateIreeI64EmulationPatterns(typeConverter, patterns);
+
+    if (failed(applyPartialConversion(op, target, std::move(patterns))))
+      signalPassFailure();
+  }
+};
+
+}  // namespace
+
+//===----------------------------------------------------------------------===//
+// Public interface
+//===----------------------------------------------------------------------===//
+
+std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateI64Pass() {
+  return std::make_unique<SPIRVEmulateI64Pass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -34,6 +34,7 @@ iree_lit_test_suite(
             "convert_to_spirv.mlir",
             "create_fast_slow_path.mlir",
             "distribute_to_invocations.mlir",
+            "emulate_i64.mlir",
             "pipeline_matmul_cooperative_ops.mlir",
             "pipeline_matmul_promotion.mlir",
             "pipeline_matmul_vectorization.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -30,6 +30,7 @@ iree_lit_test_suite(
     "convert_to_spirv.mlir"
     "create_fast_slow_path.mlir"
     "distribute_to_invocations.mlir"
+    "emulate_i64.mlir"
     "pipeline_matmul_cooperative_ops.mlir"
     "pipeline_matmul_promotion.mlir"
     "pipeline_matmul_vectorization.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_i64.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/emulate_i64.mlir
@@ -1,0 +1,95 @@
+// RUN: iree-opt --split-input-file \
+// RUN:   --pass-pipeline='hal.executable(hal.executable.variant(builtin.module(iree-spirv-emulate-i64)))' %s | \
+// RUN:   FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @buffer_types {
+  hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader], []>, #spirv.resource_limits<>>}> {
+    hal.executable.export @buffer_types layout(#pipeline_layout) attributes {
+      workgroup_size = [32: index, 1: index, 1: index]
+    }
+    builtin.module {
+      func.func @buffer_types() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : i64
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+
+        %3 = memref.load %0[%c0] : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+        %4 = memref.load %1[%c0] : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+        %5 = arith.addi %4, %c1 : i64
+        memref.store %5, %2[%c0] : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+
+        return
+      }
+    }
+  }
+}
+
+// Check that without the Int64 capability emulation produces expected i32 ops.
+//
+// CHECK-LABEL: func.func @buffer_types
+//       CHECK:   [[CST1:%.+]]      = arith.constant dense<[1, 0]> : vector<2xi32>
+//       CHECK:   [[REF_I32:%.+]]   = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[REF_I64_0:%.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8xvector<2xi32>, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[REF_I64_1:%.+]] = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<8xvector<2xi32>, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[VI32:%.+]]      = memref.load [[REF_I32]][{{%.+}}] : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[VI64:%.+]]      = memref.load [[REF_I64_0]][{{%.+}}] : memref<8xvector<2xi32>, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   {{%.+}}           = arith.addui_carry {{%.+}}, {{%.+}} : i32, i1
+//       CHECK:   memref.store {{%.+}}, [[REF_I64_1]][{{%.+}}] : memref<8xvector<2xi32>, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   return
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @no_emulation {
+  hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader, Int64], []>, #spirv.resource_limits<>>}> {
+    hal.executable.export @no_emulation layout(#pipeline_layout) attributes {
+      workgroup_size = [32: index, 1: index, 1: index]
+    }
+    builtin.module {
+      func.func @no_emulation() {
+        %c0 = arith.constant 0 : index
+        %c1 = arith.constant 1 : i64
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+
+        %3 = memref.load %0[%c0] : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+        %4 = memref.load %1[%c0] : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+        %5 = arith.addi %4, %c1 : i64
+        memref.store %5, %2[%c0] : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+
+        return
+      }
+    }
+  }
+}
+
+// Check that with the Int64 capability we do not emulate i64 ops.
+//
+// CHECK-LABEL: func.func @no_emulation
+//       CHECK:   [[CST1:%.+]]      = arith.constant 1 : i64
+//       CHECK:   [[REF_I32:%.+]]   = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[REF_I64_0:%.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[REF_I64_1:%.+]] = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[VI32:%.+]]      = memref.load [[REF_I32]][{{%.+}}] : memref<8xi32, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   [[VI64:%.+]]      = memref.load [[REF_I64_0]][{{%.+}}] : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   {{%.+}}           = arith.addi {{%.+}} : i64
+//       CHECK:   memref.store {{%.+}}, [[REF_I64_1]][{{%.+}}] : memref<8xi64, #spirv.storage_class<StorageBuffer>>
+//       CHECK:   return

--- a/tests/e2e/vulkan_specific/BUILD
+++ b/tests/e2e/vulkan_specific/BUILD
@@ -44,3 +44,23 @@ iree_check_single_backend_test_suite(
     driver = "vulkan",
     target_backend = "vulkan-spirv",
 )
+
+iree_check_single_backend_test_suite(
+    name = "check_vulkan-spirv_vulkan_i64_emulation",
+    srcs = [
+        "add_i64.mlir",
+        "mul_i64.mlir",
+    ],
+    compiler_flags = [
+        "--iree-input-type=mhlo",
+        "--iree-mhlo-demote-i64-to-i32=false",
+        "--iree-vulkan-target-triple=valhall-unknown-android31",
+    ],
+    driver = "vulkan",
+    tags = [
+        "manual",
+        "notap",
+        "vulkan_uses_shader_int64",
+    ],
+    target_backend = "vulkan-spirv",
+)

--- a/tests/e2e/vulkan_specific/CMakeLists.txt
+++ b/tests/e2e/vulkan_specific/CMakeLists.txt
@@ -43,4 +43,24 @@ iree_check_single_backend_test_suite(
     "--iree-vulkan-target-triple=valhall-unknown-android31"
 )
 
+iree_check_single_backend_test_suite(
+  NAME
+    check_vulkan-spirv_vulkan_i64_emulation
+  SRCS
+    "add_i64.mlir"
+    "mul_i64.mlir"
+  TARGET_BACKEND
+    "vulkan-spirv"
+  DRIVER
+    "vulkan"
+  COMPILER_FLAGS
+    "--iree-input-type=mhlo"
+    "--iree-mhlo-demote-i64-to-i32=false"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+  LABELS
+    "manual"
+    "notap"
+    "vulkan_uses_shader_int64"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/vulkan_specific/add_i64.mlir
+++ b/tests/e2e/vulkan_specific/add_i64.mlir
@@ -1,0 +1,7 @@
+func.func @add_i64() {
+  %0 = util.unfoldable_constant dense<4294967296> : tensor<3x4xi64>
+  %1 = util.unfoldable_constant dense<2> : tensor<3x4xi64>
+  %result = "mhlo.add"(%0, %1) : (tensor<3x4xi64>, tensor<3x4xi64>) -> tensor<3x4xi64>
+  check.expect_eq_const(%result, dense<4294967298> : tensor<3x4xi64>) : tensor<3x4xi64>
+  return
+}

--- a/tests/e2e/vulkan_specific/mul_i64.mlir
+++ b/tests/e2e/vulkan_specific/mul_i64.mlir
@@ -1,0 +1,7 @@
+func.func @mul_i64() {
+  %0 = util.unfoldable_constant dense<4294967296> : tensor<3x4xi64>
+  %1 = util.unfoldable_constant dense<3> : tensor<3x4xi64>
+  %result = "mhlo.multiply"(%0, %1) : (tensor<3x4xi64>, tensor<3x4xi64>) -> tensor<3x4xi64>
+  check.expect_eq_const(%result, dense<12884901888> : tensor<3x4xi64>) : tensor<3x4xi64>
+  return
+}


### PR DESCRIPTION
The pass is conditionally enabled when the SPIR-V target does not declare I64 capabilities. The `demote-i64-to-i32' needs to be disabled for Wide Integer Emulation (WIE) to have any i64 ops to emulate. These default will be changed once the WIE implementation is robust enough.

Locally, I tested this by changing the `demote-i64-to-i32` default to false and all tests passed.

Issue: #8702