### PR TITLE
Mark iree_run_module_test in Android test as WILL_FAIL

### DIFF
--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -64,6 +64,7 @@ if((IREE_TARGET_BACKEND_VMVX OR DEFINED IREE_HOST_BINARY_ROOT) AND
       "--iree-hal-target-backends=vmvx"
   )
 
+  # TODO(hcindyl): Fix android iree_native_test flow to find required files
   iree_run_module_test(
     NAME
       iree_run_module_correctness_test
@@ -78,5 +79,7 @@ if((IREE_TARGET_BACKEND_VMVX OR DEFINED IREE_HOST_BINARY_ROOT) AND
       "f32=10"
     DEPS
       iree_tools_test_iree_run_module_bytecode_module_vmvx
+    XFAIL_PLATFORMS
+      "android-arm64-v8a"
   )
 endif()


### PR DESCRIPTION
Android on device test does not run at the directory where the CTestTestfile.cmake sits, so it can't find the module file at the current directory. Need to revisit the flow to have a proper fix.