### PR TITLE
Update `iree_run_module_test` to set flags for on-device tests

### DIFF
--- a/build_tools/cmake/iree_run_module_test.cmake
+++ b/build_tools/cmake/iree_run_module_test.cmake
@@ -98,14 +98,21 @@ function(iree_run_module_test)
     message(SEND_ERROR "The DRIVER argument is required.")
   endif()
 
+  iree_package_path(_PACKAGE_PATH)
+
   # All the file paths referred in the _RULE_RUNNER_ARGS are relative paths to
   # make it portable, and all the paths in `_RUNNER_DATA` are absolute paths to
   # make sure it can be checked/copied by the `iree_native_test` flow.
-  file(RELATIVE_PATH _SRC_RELATIVE_PATH
-    "${CMAKE_CURRENT_BINARY_DIR}" "${_RULE_MODULE_SRC}")
   list(APPEND _RUNNER_DATA ${_RULE_MODULE_SRC})
-
-  iree_package_path(_PACKAGE_PATH)
+  # Android test runs on device and needs to set the file location properly.
+  # TODO(#10744): Move it into `iree_native_test`
+  if(ANDROID)
+    cmake_path(GET _RULE_MODULE_SRC FILENAME _SRC_FILE_BASE)
+    set(_SRC_PATH "${_PACKAGE_PATH}/${_RULE_NAME}/${_SRC_FILE_BASE}")
+  else()
+    file(RELATIVE_PATH _SRC_PATH
+      "${CMAKE_CURRENT_BINARY_DIR}" "${_RULE_MODULE_SRC}")
+  endif()
 
   if(_RULE_EXPECTED_OUTPUT)
     # this may be a file or a literal output. In the latter case, the
@@ -145,14 +152,15 @@ function(iree_run_module_test)
           ${IREE_BENCHMARK_SUITE_DIR}\n\
           Please check if you need to download it first.")
       else()
-        file(RELATIVE_PATH _OUTPUT_FILE_RELATIVE_PATH
-          "${CMAKE_CURRENT_BINARY_DIR}" "${_OUTPUT_FILE_ABS_PATH}")
         # Android runs on device and pushs the file into a different path.
+        # TODO(#10744): Move it into `iree_native_test`
         if(ANDROID)
           cmake_path(GET _OUTPUT_FILE_ABS_PATH FILENAME _OUTPUT_FILE_BASE)
           list(APPEND
             _RULE_RUNNER_ARGS "--expected_output=@${_PACKAGE_PATH}/${_RULE_NAME}/${_OUTPUT_FILE_BASE}")
         else()
+          file(RELATIVE_PATH _OUTPUT_FILE_RELATIVE_PATH
+            "${CMAKE_CURRENT_BINARY_DIR}" "${_OUTPUT_FILE_ABS_PATH}")
           list(APPEND _RULE_RUNNER_ARGS "--expected_output=@${_OUTPUT_FILE_RELATIVE_PATH}")
         endif()
         list(APPEND _RUNNER_DATA ${_OUTPUT_FILE_ABS_PATH})
@@ -165,16 +173,22 @@ function(iree_run_module_test)
   # Dump the flags into a flag file to avoid CMake's naive handling of spaces
   # in expected output. `--module_file` is coded separatedly to make it portable.
   if(_RULE_RUNNER_ARGS)
-    set(_OUTPUT_FLAGFILE "${_RULE_NAME}_flagfile")
     # Write each argument in a new line.
     string(REPLACE ";" "\n" _OUTPUT_FLAGS "${_RULE_RUNNER_ARGS}")
     file(CONFIGURE
       OUTPUT
-        "${_OUTPUT_FLAGFILE}"
+        "${_RULE_NAME}_flagfile"
       CONTENT
         "${_OUTPUT_FLAGS}"
     )
     list(APPEND _RUNNER_DATA "${CMAKE_CURRENT_BINARY_DIR}/${_RULE_NAME}_flagfile")
+    # Android test runs on device and needs to set the file location properly.
+    # TODO(#10744): Move it into `iree_native_test`
+    if(ANDROID)
+      set(_OUTPUT_FLAGFILE "${_PACKAGE_PATH}/${_RULE_NAME}/${_RULE_NAME}_flagfile")
+    else()
+      set(_OUTPUT_FLAGFILE "${_RULE_NAME}_flagfile")
+    endif()
   endif()
 
   # A target specifically for the test.
@@ -190,13 +204,6 @@ function(iree_run_module_test)
     set(_TEST_XFAIL TRUE)
   endif()
 
-  # Android test runs on device and needs to set the file location properly.
-  if(ANDROID)
-    cmake_path(GET _RULE_MODULE_SRC FILENAME _SRC_FILE_BASE)
-    set(_SRC_RELATIVE_PATH "${_PACKAGE_PATH}/${_RULE_NAME}/${_SRC_FILE_BASE}")
-    set(_OUTPUT_FLAGFILE "${_PACKAGE_PATH}/${_RULE_NAME}/${_OUTPUT_FLAGFILE}")
-  endif()
-
   set(_RUNNER_TARGET "iree-run-module")
 
   iree_native_test(
@@ -207,7 +214,7 @@ function(iree_run_module_test)
     SRC
       "${_RUNNER_TARGET}"
     ARGS
-      "--module_file=${_SRC_RELATIVE_PATH}"
+      "--module_file=${_SRC_PATH}"
       "--flagfile=${_OUTPUT_FLAGFILE}"
     DATA
       "${_RUNNER_DATA}"

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -64,7 +64,6 @@ if((IREE_TARGET_BACKEND_VMVX OR DEFINED IREE_HOST_BINARY_ROOT) AND
       "--iree-hal-target-backends=vmvx"
   )
 
-  # TODO(hcindyl): Fix android iree_native_test flow to find required files
   iree_run_module_test(
     NAME
       iree_run_module_correctness_test
@@ -79,7 +78,5 @@ if((IREE_TARGET_BACKEND_VMVX OR DEFINED IREE_HOST_BINARY_ROOT) AND
       "f32=10"
     DEPS
       iree_tools_test_iree_run_module_bytecode_module_vmvx
-    XFAIL_PLATFORMS
-      "android-arm64-v8a"
   )
 endif()


### PR DESCRIPTION
Android test pushes the files to the device to the test-specific directory w.r.t the top temp IREE directory. We need to update the `iree-run-module` file flags with such.