### PR TITLE
Relax UnPackOp to handle incomplete tiles.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -554,9 +554,6 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
     SmallVector<OpFoldResult> getMixedTiles();
     SmallVector<int64_t> getStaticTiles();
 
-    // Infer the output type.
-    ShapedType inferResultType();
-
     // Return a mapping from positions `dims_pos` to their tile factors.
     DenseMap<int64_t, OpFoldResult> getDimAndTileMapping();
   }];
@@ -571,7 +568,7 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
      "generateScalarImplementation"]>,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]>{
-  let summary = "unpack operation";  
+  let summary = "unpack operation";
 
   let description = [{
     The unpack operation converts a tiled and packed input to an unpacked
@@ -656,9 +653,6 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
     // Return the tile sizes.
     SmallVector<OpFoldResult> getMixedTiles();
     SmallVector<int64_t> getStaticTiles();
-
-    // Infer the output type.
-    ShapedType inferResultType();
 
     // Return a mapping from positions `dims_pos` to their tile factors.
     DenseMap<int64_t, OpFoldResult> getDimAndTileMapping();

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -568,16 +568,8 @@ func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf
 
 // -----
 
-func.func @unpack_invalid(%output: tensor<256x128xf32>, %input: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
-  // expected-error@+1 {{invalid tile factor provided. Only full tiles are supported}}
-  %0 = iree_linalg_ext.unpack %input dims_pos = [1, 0] inner_tiles = [16, 5] into %output : (tensor<8x8x32x16xf32> tensor<256x128xf32>) -> tensor<256x128xf32>
-  return %0 : tensor<256x128xf32>
-}
-
-// -----
-
 func.func @unpack_invalid(%output: tensor<256x128xf32>, %input: tensor<8x8x32x16xf32>) -> tensor<256x128xf32> {
-  // expected-error@+1 {{infered type do not match provided output type}}
+  // expected-error@+1 {{infered type do not match provided input type. Expected 'tensor<8x32x4x32xf32>' but got: 'tensor<8x8x32x16xf32>'}}
   %0 = iree_linalg_ext.unpack %input dims_pos = [1, 0] inner_tiles = [4, 32] into %output : (tensor<8x8x32x16xf32> tensor<256x128xf32>) -> tensor<256x128xf32>
   return %0 : tensor<256x128xf32>
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -734,3 +734,36 @@ func.func @relayout(%arg0: memref<3x3xf32>, %arg1: memref<3x3x1x1xf32>) {
 // CHECK-SAME: %[[ARG0:[a-zA-Z0-9]+]]: memref<3x3xf32>,
 // CHECK-SAME: %[[ARG1:[a-zA-Z0-9]+]]: memref<3x3x1x1xf32>) {
 // CHECK: iree_linalg_ext.unpack %[[ARG1]] dims_pos = [0, 1] inner_tiles = [1, 1] into %[[ARG0]] : (memref<3x3x1x1xf32> memref<3x3xf32>)
+
+// -----
+
+func.func @unpack_static(%input: tensor<8x8x32x16xf32>, %output: tensor<256x128xf32>) -> tensor<256x128xf32> {
+  %0 = iree_linalg_ext.unpack %input dims_pos = [0, 1] inner_tiles = [32, 16] into %output : (tensor<8x8x32x16xf32> tensor<256x128xf32>) -> tensor<256x128xf32>
+  return %0 : tensor<256x128xf32>
+}
+
+// CHECK:      func.func @unpack_static
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   %[[OUTPUT:[a-zA-Z0-9_]+]]
+// CHECK:        %[[UNPACK:.+]] = iree_linalg_ext.unpack
+// CHECK-SAME:     %[[INPUT]]
+// CHECK-SAME      dim_pos = [0, 1]
+// CHECK-SAME      inner_pos = [32, 16]
+// CHECK-SAME:     into %[[OUTPUT]]
+// CHECK:        return %[[UNPACK]]
+
+// ----
+
+func.func @unpack_undo_padding(%input: tensor<2x8x8x2xf32>, %output: tensor<13x15xf32>) -> tensor<13x15xf32> {
+  %0 = iree_linalg_ext.unpack %input dims_pos = [0, 1] inner_tiles = [8, 2] into %output : (tensor<2x8x8x2xf32> tensor<13x15xf32>) -> tensor<13x15xf32>
+  return %0 : tensor<13x15xf32>
+}
+// CHECK:      func.func @unpack_undo_padding
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9_]+]]
+// CHECK-SAME:   %[[OUTPUT:[a-zA-Z0-9_]+]]
+// CHECK:        %[[UNPACK:.+]] = iree_linalg_ext.unpack
+// CHECK-SAME:     %[[INPUT]]
+// CHECK-SAME      dim_pos = [0, 1]
+// CHECK-SAME      inner_pos = [32, 16]
+// CHECK-SAME:     into %[[OUTPUT]]
+// CHECK:        return %[[UNPACK]]


### PR DESCRIPTION
It also changes unpack op to verify input type against inferred type. We're able to infer packed type based on source type and inner_tiles.