### PR TITLE
Don't fuse linalg.fill with multi uses

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -847,6 +847,10 @@ static Optional<OpOperand *> getFusableUse(Operation *op,
                                            bool fuseMultiUse) {
   if (!fuseMultiUse && !op->hasOneUse()) return llvm::None;
 
+  // Don't fuse `linalg.fill` if it has multi uses. This might result in a
+  // dispatch with multi results just to return the filled tensors.
+  if (isa<linalg::FillOp>(op) && !op->hasOneUse()) return llvm::None;
+
   for (auto &use : op->getUses()) {
     Operation *user = use.getOwner();
     if (llvm::all_of(op->getUsers(), [&](Operation *c) {


### PR DESCRIPTION
When the aggressive fusion is enabled, avoid fusing lingalg.fill into a dispatch when it has multi uses; otherwise it might result in a multi-results dispatch, which is just to return the filled tensor. For example:
```
  %4:2 = flow.dispatch.workgroups[%c1, %c112, %c112, %c32](%3, %cst_93) : (tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) -> (tensor<1x112x112x32xf32>, tensor<1x112x112x32xf32>) =
      (%arg1: !flow.dispatch.tensor<readonly:1x225x225x3xf32>, %arg2: !flow.dispatch.tensor<readonly:3x3x3x32xf32>, %arg3: !flow.dispatch.tensor<writeonly:1x112x112x32xf32>, %arg4: !flow.dispatch.tensor<writeonly:1x112x112x32xf32>) {
    %cst_94 = arith.constant 0.000000e+00 : f32
    %cst_95 = arith.constant 6.000000e+00 : f32
    %cst_96 = arith.constant dense_resource<__elided__> : tensor<32xf32>
    %124 = flow.dispatch.tensor.load %arg1, offsets = [0, 0, 0, 0], sizes = [1, 225, 225, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:1x225x225x3xf32> -> tensor<1x225x225x3xf32>
    %125 = flow.dispatch.tensor.load %arg2, offsets = [0, 0, 0, 0], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:3x3x3x32xf32> -> tensor<3x3x3x32xf32>
    %126 = linalg.init_tensor [1, 112, 112, 32] : tensor<1x112x112x32xf32>
    %127 = linalg.fill ins(%cst_94 : f32) outs(%126 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
    %128 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<2> : tensor<2xi64>} ins(%124, %125 : tensor<1x225x225x3xf32>, tensor<3x3x3x32xf32>) outs(%127 : tensor<1x112x112x32xf32>) -> tensor<1x112x112x32xf32>
    %129 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%cst_96, %128 : tensor<32xf32>, tensor<1x112x112x32xf32>) outs(%126 : tensor<1x112x112x32xf32>) {
    ^bb0(%arg5: f32, %arg6: f32, %arg7: f32):
      %130 = arith.addf %arg5, %arg6 : f32
      %131 = arith.minf %130, %cst_95 : f32
      %132 = arith.maxf %131, %cst_94 : f32
      linalg.yield %132 : f32
    } -> tensor<1x112x112x32xf32>
    flow.dispatch.tensor.store %129, %arg3, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf32> -> !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
    flow.dispatch.tensor.store %127, %arg4, offsets = [0, 0, 0, 0], sizes = [1, 112, 112, 32], strides = [1, 1, 1, 1] : tensor<1x112x112x32xf32> -> !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
    flow.return
  } count(%arg1: index, %arg2: index, %arg3: index, %arg4: index) -> (index, index, index) {
    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4
    flow.return %x, %y, %z : index, index, index
  }
```

`flow.dispatch.tensor.store %127, %arg4` simply returns the filled tensor. This will prevent the `lingalg.fill` from being eliminated (as its value is returned) and generate extra loops for it later, like this: (then breaks the bufferization in some ways)
```
// -----// IR Dump After LinalgStrategyTileAndFusePass (iree-linalg-strategy-tile-and-fuse-pass) //----- //
func.func @main_dispatch_1_conv_2d_nhwc_hwcf_1x112x112x32x3x3x3() {
  %c1 = arith.constant 1 : index
  %c4 = arith.constant 4 : index
  %c8 = arith.constant 8 : index
  %c28 = arith.constant 28 : index
  %c112 = arith.constant 112 : index
  %c32 = arith.constant 32 : index
  %c0 = arith.constant 0 : index
  %c13951040 = arith.constant 13951040 : index
  %c607552 = arith.constant 607552 : index
  %c2213184 = arith.constant 2213184 : index
  %cst = arith.constant 0.000000e+00 : f32
  %cst_0 = arith.constant 6.000000e+00 : f32
  %cst_1 = arith.constant dense_resource<__elided__> : tensor<32xf32>
  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:1x225x225x3xf32>
  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c13951040) alignment(64) : !flow.dispatch.tensor<readonly:3x3x3x32xf32>
  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c607552) alignment(64) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
  %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) offset(%c2213184) alignment(64) : !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
  %workgroup_id_x = hal.interface.workgroup.id[0] : index
  %workgroup_count_x = hal.interface.workgroup.count[0] : index
  %workgroup_id_y = hal.interface.workgroup.id[1] : index
  %workgroup_count_y = hal.interface.workgroup.count[1] : index
  %workgroup_id_z = hal.interface.workgroup.id[2] : index
  %workgroup_count_z = hal.interface.workgroup.count[2] : index
  %4 = affine.apply affine_map<()[s0] -> (s0 * 28)>()[%workgroup_id_z]
  %5 = affine.apply affine_map<()[s0] -> (s0 * 28)>()[%workgroup_count_z]
  scf.for %arg0 = %4 to %c112 step %5 {
    %6 = affine.apply affine_map<()[s0] -> (s0 * 28)>()[%workgroup_id_y]
    %7 = affine.apply affine_map<()[s0] -> (s0 * 28)>()[%workgroup_count_y]
    scf.for %arg1 = %6 to %c112 step %7 {
      %8 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
      %9 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
      scf.for %arg2 = %8 to %c32 step %9 {
        %10 = flow.dispatch.tensor.load %2, offsets = [0, %arg0, %arg1, %arg2], sizes = [1, 28, 28, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<writeonly:1x112x112x32xf32> -> tensor<1x28x28x32xf32>
        %11 = tensor.extract_slice %cst_1[%arg2] [32] [1] : tensor<32xf32> to tensor<32xf32>
        %12 = affine.apply affine_map<(d0) -> (d0 * 2)>(%arg0)
        %13 = affine.apply affine_map<(d0) -> (d0 * 2)>(%arg1)
        %14 = flow.dispatch.tensor.load %0, offsets = [0, %12, %13, 0], sizes = [1, 57, 57, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:1x225x225x3xf32> -> tensor<1x57x57x3xf32>
        %15 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, %arg2], sizes = [3, 3, 3, 32], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:3x3x3x32xf32> -> tensor<3x3x3x32xf32>
        %16 = linalg.init_tensor [1, 28, 28, 32] : tensor<1x28x28x32xf32>
        %17 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg4 = %16) -> (tensor<1x28x28x32xf32>) {
          %19 = scf.for %arg5 = %c0 to %c28 step %c1 iter_args(%arg6 = %arg4) -> (tensor<1x28x28x32xf32>) {
            %20 = scf.for %arg7 = %c0 to %c28 step %c4 iter_args(%arg8 = %arg6) -> (tensor<1x28x28x32xf32>) {
              %21 = scf.for %arg9 = %c0 to %c32 step %c8 iter_args(%arg10 = %arg8) -> (tensor<1x28x28x32xf32>) {
                %22 = tensor.extract_slice %arg10[%arg3, %arg5, %arg7, %arg9] [1, 1, 4, 8] [1, 1, 1, 1] : tensor<1x28x28x32xf32> to tensor<1x1x4x8xf32>
                %23 = linalg.fill {__internal_linalg_transform__ = "1"} ins(%cst : f32) outs(%22 : tensor<1x1x4x8xf32>) -> tensor<1x1x4x8xf32>
                %24 = tensor.insert_slice %23 into %arg10[%arg3, %arg5, %arg7, %arg9] [1, 1, 4, 8] [1, 1, 1, 1] : tensor<1x1x4x8xf32> into tensor<1x28x28x32xf32>
                scf.yield %24 : tensor<1x28x28x32xf32>
              }
              scf.yield %21 : tensor<1x28x28x32xf32>
            }
            scf.yield %20 : tensor<1x28x28x32xf32>
          }
          scf.yield %19 : tensor<1x28x28x32xf32>
        }
        %18 = scf.for %arg3 = %c0 to %c1 step %c1 iter_args(%arg4 = %10) -> (tensor<1x28x28x32xf32>) {
          %19 = scf.for %arg5 = %c0 to %c28 step %c1 iter_args(%arg6 = %arg4) -> (tensor<1x28x28x32xf32>) {
            %20 = scf.for %arg7 = %c0 to %c28 step %c4 iter_args(%arg8 = %arg6) -> (tensor<1x28x28x32xf32>) {
              %21 = scf.for %arg9 = %c0 to %c32 step %c8 iter_args(%arg10 = %arg8) -> (tensor<1x28x28x32xf32>) {
                %22 = tensor.extract_slice %11[%arg9] [8] [1] : tensor<32xf32> to tensor<8xf32>
                %23 = affine.apply affine_map<(d0) -> (d0 * 2)>(%arg5)
                %24 = affine.apply affine_map<(d0) -> (d0 * 2)>(%arg7)
                %25 = tensor.extract_slice %14[%arg3, %23, %24, 0] [1, 3, 9, 3] [1, 1, 1, 1] : tensor<1x57x57x3xf32> to tensor<1x3x9x3xf32>
                %26 = tensor.extract_slice %15[0, 0, 0, %arg9] [3, 3, 3, 8] [1, 1, 1, 1] : tensor<3x3x3x32xf32> to tensor<3x3x3x8xf32>
                %27 = tensor.extract_slice %16[%arg3, %arg5, %arg7, %arg9] [1, 1, 4, 8] [1, 1, 1, 1] : tensor<1x28x28x32xf32> to tensor<1x1x4x8xf32>
                %28 = linalg.fill {__internal_linalg_transform__ = "1"} ins(%cst : f32) outs(%27 : tensor<1x1x4x8xf32>) -> tensor<1x1x4x8xf32>
                %29 = linalg.conv_2d_nhwc_hwcf {__internal_linalg_transform__ = "1", dilations = dense<1> : tensor<2xi64>, lowering_config = #iree_codegen.lowering_config<tile_sizes = [[0, 28, 28, 32, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>, strides = dense<2> : tensor<2xi64>} ins(%25, %26 : tensor<1x3x9x3xf32>, tensor<3x3x3x8xf32>) outs(%28 : tensor<1x1x4x8xf32>) -> tensor<1x1x4x8xf32>
                %30 = tensor.extract_slice %arg10[%arg3, %arg5, %arg7, %arg9] [1, 1, 4, 8] [1, 1, 1, 1] : tensor<1x28x28x32xf32> to tensor<1x1x4x8xf32>
                %31 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%22, %29 : tensor<8xf32>, tensor<1x1x4x8xf32>) outs(%30 : tensor<1x1x4x8xf32>) attrs =  {__internal_linalg_transform__ = "1"} {
                ^bb0(%arg11: f32, %arg12: f32, %arg13: f32):
                  %33 = arith.addf %arg11, %arg12 : f32
                  %34 = arith.minf %33, %cst_0 : f32
                  %35 = arith.maxf %34, %cst : f32
                  linalg.yield %35 : f32
                } -> tensor<1x1x4x8xf32>
                %32 = tensor.insert_slice %31 into %arg10[%arg3, %arg5, %arg7, %arg9] [1, 1, 4, 8] [1, 1, 1, 1] : tensor<1x1x4x8xf32> into tensor<1x28x28x32xf32>
                scf.yield %32 : tensor<1x28x28x32xf32>
              }
              scf.yield %21 : tensor<1x28x28x32xf32>
            }
            scf.yield %20 : tensor<1x28x28x32xf32>
          }
          scf.yield %19 : tensor<1x28x28x32xf32>
        }
        flow.dispatch.tensor.store %18, %2, offsets = [0, %arg0, %arg1, %arg2], sizes = [1, 28, 28, 32], strides = [1, 1, 1, 1] : tensor<1x28x28x32xf32> -> !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
        flow.dispatch.tensor.store %17, %3, offsets = [0, %arg0, %arg1, %arg2], sizes = [1, 28, 28, 32], strides = [1, 1, 1, 1] : tensor<1x28x28x32xf32> -> !flow.dispatch.tensor<writeonly:1x112x112x32xf32>
      }
    }
  }
  return
}
```

Ideally we can fuse the multi-uses fill op if all of its users are in the same dispatch. This is the simple fix for now and allows models to compile e2e with the aggressive fusion.