### PR TITLE
[spirv] Avoid extract/insert due to NCHW convolution transpose

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -47,6 +47,7 @@ iree_lit_test_suite(
             "tile_and_vectorize_to_cooperative_ops.mlir",
             "tile_linalg_ops.mlir",
             "vector_to_cooperative_matrix.mlir",
+            "vectorize_conv.mlir",
             "vectorize_elementwise_ops.mlir",
             "vectorize_matmul.mlir",
             "vectorize_load_store.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_lit_test_suite(
     "tile_and_vectorize_to_cooperative_ops.mlir"
     "tile_linalg_ops.mlir"
     "vector_to_cooperative_matrix.mlir"
+    "vectorize_conv.mlir"
     "vectorize_elementwise_ops.mlir"
     "vectorize_load_store.mlir"
     "vectorize_matmul.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -470,13 +470,7 @@ hal.executable private @nchw_conv_static_shape_f32 {
 //      CHECK:     scf.for %{{.*}} = %c0 to %c3 step %c1
 // CHECK-SAME:         -> (tensor<2x8x1x4xf32>)
 
-// TODO: remove these vector.extract & vector.insert pairs due to vector.transpose
-// CHECK-COUNT-96: vector.insert %{{.+}}
-
 // CHECK-COUNT-64: vector.fma
-
-// TODO: remove these vector.extract & vector.insert pairs due to vector.transpose
-// CHECK-COUNT-64: vector.insert %{{.+}}
 
 // For linalg.conv_2d_nchw_fchw
 // CHECK-COUNT-16: vector.transfer_write

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_conv.mlir
@@ -1,0 +1,21 @@
+// RUN: iree-opt --split-input-file --iree-spirv-vectorize %s | FileCheck %s
+
+func.func @ncw_conv_1d(%input: tensor<2x4x4xf32>, %filter: tensor<4x4x1xf32>, %init: tensor<2x4x4xf32>) -> tensor<2x4x4xf32> {
+  %0 = linalg.conv_1d_ncw_fcw {dilations = dense<1> : vector<1xi64>, strides = dense<1> : vector<1xi64>}
+         ins(%input, %filter : tensor<2x4x4xf32>, tensor<4x4x1xf32>)
+         outs(%init : tensor<2x4x4xf32>) -> tensor<2x4x4xf32>
+  return %0: tensor<2x4x4xf32>
+}
+
+//   CHECK-LABEL: func.func @ncw_conv_1d
+//    CHECK-SAME: (%[[INPUT:.+]]: tensor<2x4x4xf32>, %[[FILTER:.+]]: tensor<4x4x1xf32>, %[[INIT:.+]]: tensor<2x4x4xf32>)
+
+//  CHECK-COUNT-8:   vector.transfer_read %[[INPUT]]{{.+}} : tensor<2x4x4xf32>, vector<4xf32>
+// CHECK-COUNT-16:   vector.transfer_read %[[FILTER]]{{.+}} : tensor<4x4x1xf32>, vector<1xf32>
+//  CHECK-COUNT-8:   vector.transfer_read %[[INIT]]{{.+}} : tensor<2x4x4xf32>, vector<4xf32>
+// CHECK-COUNT-16:   vector.extract %{{.+}}[0] : vector<1xf32>
+//      CHECK-NOT:   vector.insert
+// CHECK-COUNT-32:   vector.fma {{.+}} : vector<4xf32>
+//      CHECK-NOT:   vector.insert
+//  CHECK-COUNT-8:   vector.transfer_write %{{.+}} : vector<4xf32>, tensor<2x4x4xf32>
+


### PR DESCRIPTION
This commit adjusts the unrolling configuration for convolution to tile the output innermost dimension by compute size. This allows to avoid generating innermost unit dimensions after unrolling NCHW convolution, which now has `affine_map<(d0, d1, d2, d3) -> (d0, d2, d1)>` after merging accumulator/result transpose ops. This cleans up the extract/insert ops generated from lowering transpose ops.

Towards https://github.com/iree-org/iree/issues/10536