### PR TITLE
[spirv] NFC: Refactor SPIRVTilePass to be more readable

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -40,8 +40,74 @@ namespace mlir {
 namespace iree_compiler {
 
 //===----------------------------------------------------------------------===//
-// Tiling patterns
+// Tiling and fusion utilities
 //===----------------------------------------------------------------------===//
+
+/// Collects computation ops which we will use as anchor to tile and fuse.
+static LogicalResult collectComputeOps(
+    func::FuncOp funcOp, SmallVectorImpl<Operation *> &computeOps) {
+  // If there are `scf.if` ops, we have both a fast and slow paths for
+  // padding handling. Then we need to scan both regions to discover such
+  // computation ops so that we can tile and fuse both regions.
+  SmallVector<scf::IfOp, 1> ifOps;
+  funcOp.walk([&ifOps](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
+
+  if (ifOps.empty()) {
+    if (failed(getComputeOps(funcOp, computeOps))) {
+      return funcOp.emitOpError("does not contain compute ops");
+    }
+    while (computeOps.size() > 1) computeOps.erase(computeOps.begin());
+    return success();
+  }
+
+  if (ifOps.size() > 1) {
+    return funcOp.emitError("expected to contain no more than one scf.if ops");
+  }
+
+  for (Operation &op : llvm::reverse(*ifOps.front().thenBlock())) {
+    if (isa<linalg::LinalgOp, TilingInterface>(op)) {
+      computeOps.push_back(&op);
+      break;
+    }
+  }
+  if (Block *elseBlock = ifOps.front().elseBlock()) {
+    for (Operation &op : llvm::reverse(*elseBlock)) {
+      if (isa<linalg::LinalgOp, TilingInterface>(op)) {
+        computeOps.push_back(&op);
+        break;
+      }
+    }
+  }
+  return success();
+}
+
+static LogicalResult tileAndDistributeToThreads(linalg::LinalgOp consumerOp) {
+  MLIRContext *context = consumerOp.getContext();
+  OpBuilder builder(context);
+  SmallVector<int64_t> tileSizes = getTileSizes(consumerOp, 1);
+  auto identityLoopOrder =
+      llvm::to_vector<4>(llvm::seq<int64_t>(0, tileSizes.size()));
+
+  FailureOr<linalg::TileLoopNest> loopNest =
+      linalg::tileConsumerAndFuseProducers(builder, consumerOp, tileSizes,
+                                           identityLoopOrder, llvm::None);
+  if (failed(loopNest)) {
+    return consumerOp.emitOpError("failed tiling and fusing producers");
+  }
+
+  consumerOp->replaceAllUsesWith(loopNest->getRootOpReplacementResults());
+
+  // We don't distribute here; instead, it will be done in a later step
+  // after bufferization. So add attributes to the tiled loop nest to
+  // indicate that they should be distributed to invocations.
+  ArrayRef<scf::ForOp> loops = loopNest->getLoopOps();
+  assert(loops.size() <= kNumGPUDims);
+  const char *attrName = getSPIRVDistributeAttrName();
+  for (int i = loops.size() - 1, dim = 0; i >= 0; --i) {
+    loops[i]->setAttr(attrName, builder.getIndexAttr(dim++));
+  }
+  return success();
+}
 
 /// Populates `patterns` with patterns that tiles convolution/matmul ops with
 /// markers.
@@ -63,6 +129,114 @@ static void populateTilingReductionPatterns(RewritePatternSet &patterns) {
                                                               filter);
 }
 
+/// Tiles reduction dimensions.
+static LogicalResult tileReduction(func::FuncOp funcOp) {
+  MLIRContext *context = funcOp.getContext();
+
+  // Set markers to drive tiling reduction dimensions.
+  OpBuilder builder(context);
+  auto marker = builder.getStringAttr(getTileReductionMarker());
+  funcOp.walk([&](linalg::LinalgOp op) {
+    if (isa<linalg::ContractionOpInterface>(*op) ||
+        isa<linalg::ConvolutionOpInterface>(*op) ||
+        isa<linalg::GenericOp>(*op)) {
+      op->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker, marker);
+    }
+  });
+
+  RewritePatternSet patterns(context);
+  populateTilingReductionPatterns(patterns);
+  if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+    return funcOp.emitError("failed tiling reduction dimensions");
+  }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "--- After tiling reduction dimensions  ---\n";
+    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+  return success();
+}
+
+/// Fuses `tensor.pad` ops into the the materalized loop nests containing
+/// their consumer ops.
+static void fusePadIntoConsumer(func::FuncOp funcOp) {
+  MLIRContext *context = funcOp.getContext();
+  RewritePatternSet patterns(context);
+  patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
+      context, [](tensor::ExtractSliceOp) { return false; });
+  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "--- After fusing padding into consumers ---\n";
+    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+};
+
+/// Concretizes `tensor.pad` ops' result shapes.
+static void concretizePadShape(func::FuncOp funcOp) {
+  MLIRContext *context = funcOp.getContext();
+  RewritePatternSet patterns(context);
+  populateConcretizePadResultShapePatterns(context, patterns);
+  (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "--- After concretizing pad result shape ---\n";
+    funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+}
+
+/// Tiles one of the convolution output window dimensions with size 1 to prepare
+/// for downsizing 2-D convolution ops into 1-D ones.
+static LogicalResult tileAndUnrollConvWindow(func::FuncOp funcOp) {
+  SmallVector<linalg::ConvolutionOpInterface, 1> convOps;
+  funcOp.walk([&convOps](linalg::ConvolutionOpInterface convOp) {
+    convOps.push_back(convOp);
+  });
+
+  for (linalg::ConvolutionOpInterface convOp : convOps) {
+    auto consumerOp = cast<linalg::LinalgOp>(*convOp);
+    OpBuilder builder(funcOp.getContext());
+    SmallVector<int64_t> tileSizes = getTileSizes(consumerOp, 3);
+    auto identityLoopOrder =
+        llvm::to_vector<4>(llvm::seq<int64_t>(0, tileSizes.size()));
+
+    FailureOr<linalg::TileLoopNest> loopNest =
+        linalg::tileConsumerAndFuseProducers(builder, consumerOp, tileSizes,
+                                             identityLoopOrder, llvm::None);
+    if (failed(loopNest)) {
+      return consumerOp.emitOpError("failed tiling and fusing producers");
+    }
+
+    consumerOp->replaceAllUsesWith(loopNest->getRootOpReplacementResults());
+
+    // Fully unroll the generated loop. This allows us to remove the loop
+    // for parallel output window dimension, so it helps future vector
+    // transformations.
+    if (!loopNest->getLoopOps().empty()) {
+      assert(loopNest->getLoopOps().size() == 1);
+      scf::ForOp loopOp = loopNest->getLoopOps().front();
+      IntegerAttr ub;
+      if (!matchPattern(loopOp.getUpperBound(), m_Constant(&ub))) {
+        return loopOp.emitOpError("upper bound should be a constant");
+      }
+      if (failed(mlir::loopUnrollByFactor(loopOp, ub.getInt()))) {
+        return loopOp.emitOpError("failed unrolling by factor 1");
+      }
+    }
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "--- After tiling convolution output window ---\n";
+      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+      llvm::dbgs() << "\n\n";
+    });
+  }
+
+  return success();
+}
+
 //===----------------------------------------------------------------------===//
 // Main pass
 //===----------------------------------------------------------------------===//
@@ -78,71 +252,18 @@ class SPIRVTilePass final : public SPIRVTileBase<SPIRVTilePass> {
     MLIRContext *context = &getContext();
     func::FuncOp funcOp = getOperation();
 
-    // Try to find computation ops which we will use as anchor to tile and fuse
-    // again. If there are `scf.if` ops, we have both a fast and slow paths for
-    // padding handling. Then we need to scan both regions to discover such
-    // computation ops so that we can tile and fuse both regions.
+    // Try to find computation ops which we will use as anchor to tile and fuse.
     SmallVector<Operation *> computeOps;
-    SmallVector<scf::IfOp, 1> ifOps;
-    funcOp.walk([&ifOps](scf::IfOp ifOp) { ifOps.push_back(ifOp); });
-    if (ifOps.empty()) {
-      if (failed(getComputeOps(funcOp, computeOps))) {
-        funcOp.emitOpError("does not contain compute ops");
-        return signalPassFailure();
-      }
-      while (computeOps.size() > 1) computeOps.erase(computeOps.begin());
-    } else {
-      if (ifOps.size() > 1) {
-        funcOp.emitError("expected to contain no more than one scf.if ops");
-        return signalPassFailure();
-      }
-
-      for (Operation &op : llvm::reverse(*ifOps.front().thenBlock())) {
-        if (isa<linalg::LinalgOp, TilingInterface>(op)) {
-          computeOps.push_back(&op);
-          break;
-        }
-      }
-      if (Block *elseBlock = ifOps.front().elseBlock()) {
-        for (Operation &op : llvm::reverse(*elseBlock)) {
-          if (isa<linalg::LinalgOp, TilingInterface>(op)) {
-            computeOps.push_back(&op);
-            break;
-          }
-        }
-      }
-    }
+    if (failed(collectComputeOps(funcOp, computeOps)))
+      return signalPassFailure();
     assert(computeOps.size() <= 2);
 
     // Now tile the last computation op to invocations and fuse all operand
     // computation ops into the materialized loop nest.
     for (Operation *computeOp : computeOps) {
       auto consumerOp = dyn_cast<linalg::LinalgOp>(computeOp);
-
-      OpBuilder builder(context);
-      SmallVector<int64_t> tileSizes = getTileSizes(consumerOp, 1);
-      auto identityLoopOrder =
-          llvm::to_vector<4>(llvm::seq<int64_t>(0, tileSizes.size()));
-
-      FailureOr<linalg::TileLoopNest> loopNest =
-          linalg::tileConsumerAndFuseProducers(builder, consumerOp, tileSizes,
-                                               identityLoopOrder, llvm::None);
-      if (failed(loopNest)) {
-        consumerOp.emitOpError("failed tiling and fusing producers");
+      if (failed(tileAndDistributeToThreads(consumerOp)))
         return signalPassFailure();
-      }
-
-      consumerOp->replaceAllUsesWith(loopNest->getRootOpReplacementResults());
-
-      // We don't distribute here; instead, it will be done in a later step
-      // after bufferization. So add attributes to the tiled loop nest to
-      // indicate that they should be distributed to invocations.
-      ArrayRef<scf::ForOp> loops = loopNest->getLoopOps();
-      assert(loops.size() <= kNumGPUDims);
-      const char *attrName = getSPIRVDistributeAttrName();
-      for (int i = loops.size() - 1, dim = 0; i >= 0; --i) {
-        loops[i]->setAttr(attrName, builder.getIndexAttr(dim++));
-      }
     }
 
     LLVM_DEBUG({
@@ -151,130 +272,17 @@ class SPIRVTilePass final : public SPIRVTileBase<SPIRVTilePass> {
       llvm::dbgs() << "\n\n";
     });
 
-    {  // Fuse `tensor.pad` op inside the materalized loop nest too.
-      RewritePatternSet patterns(context);
-      patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
-          context, [](tensor::ExtractSliceOp) { return false; });
-      (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+    fusePadIntoConsumer(funcOp);
 
-      LLVM_DEBUG({
-        llvm::dbgs() << "--- After fusing padding into consumers ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
-    }
+    concretizePadShape(funcOp);
 
-    {
-      RewritePatternSet patterns(context);
-      populateConcretizePadResultShapePatterns(context, patterns);
-      (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
+    if (failed(tileReduction(funcOp))) return signalPassFailure();
 
-      LLVM_DEBUG({
-        llvm::dbgs() << "--- After tiling canonicalization ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
-    }
+    fusePadIntoConsumer(funcOp);
 
-    {  // Set markers to drive tiling reduction dimensions.
-      OpBuilder builder(context);
-      auto marker = builder.getStringAttr(getTileReductionMarker());
-      funcOp.walk([&](linalg::LinalgOp op) {
-        if (isa<linalg::ContractionOpInterface>(*op) ||
-            isa<linalg::ConvolutionOpInterface>(*op) ||
-            isa<linalg::GenericOp>(*op)) {
-          op->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker, marker);
-        }
-      });
-    }
+    if (failed(tileAndUnrollConvWindow(funcOp))) return signalPassFailure();
 
-    {  // Tile reduction dimensions.
-      RewritePatternSet tilingPatterns(context);
-      populateTilingReductionPatterns(tilingPatterns);
-      if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                              std::move(tilingPatterns)))) {
-        funcOp.emitError("failed tiling reduction dimensions");
-        return signalPassFailure();
-      }
-
-      LLVM_DEBUG({
-        llvm::dbgs() << "--- After tiling reduction dimensions  ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
-    }
-
-    {  // Fuse `tensor.pad` op inside the materalized loop nest too.
-      RewritePatternSet patterns(context);
-      patterns.insert<linalg::ExtractSliceOfPadTensorSwapPattern>(
-          context, [](tensor::ExtractSliceOp) { return false; });
-      (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
-
-      LLVM_DEBUG({
-        llvm::dbgs() << "--- After fusing padding into consumers ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
-    }
-
-    {  // Tile convolution output window dimension by 1 to prepare downsizing.
-      SmallVector<linalg::ConvolutionOpInterface, 1> convOps;
-      funcOp.walk([&convOps](linalg::ConvolutionOpInterface convOp) {
-        convOps.push_back(convOp);
-      });
-      for (linalg::ConvolutionOpInterface convOp : convOps) {
-        auto consumerOp = cast<linalg::LinalgOp>(*convOp);
-        OpBuilder builder(context);
-        SmallVector<int64_t> tileSizes = getTileSizes(consumerOp, 3);
-        auto identityLoopOrder =
-            llvm::to_vector<4>(llvm::seq<int64_t>(0, tileSizes.size()));
-
-        FailureOr<linalg::TileLoopNest> loopNest =
-            linalg::tileConsumerAndFuseProducers(builder, consumerOp, tileSizes,
-                                                 identityLoopOrder, llvm::None);
-        if (failed(loopNest)) {
-          consumerOp.emitOpError("failed tiling and fusing producers");
-          return signalPassFailure();
-        }
-
-        consumerOp->replaceAllUsesWith(loopNest->getRootOpReplacementResults());
-
-        // Fully unroll the generated loop. This allows us to remove the loop
-        // for parallel output window dimension, so it helps future vector
-        // transformations.
-        if (!loopNest->getLoopOps().empty()) {
-          assert(loopNest->getLoopOps().size() == 1);
-          scf::ForOp loopOp = loopNest->getLoopOps().front();
-          IntegerAttr ub;
-          if (!matchPattern(loopOp.getUpperBound(), m_Constant(&ub))) {
-            loopOp.emitOpError("upper bound should be a constant");
-            return signalPassFailure();
-          }
-          if (failed(mlir::loopUnrollByFactor(loopOp, ub.getInt()))) {
-            loopOp.emitOpError("failed unrolling by factor 1");
-            return signalPassFailure();
-          }
-        }
-
-        LLVM_DEBUG({
-          llvm::dbgs() << "--- After tiling convolution output window ---\n";
-          funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-          llvm::dbgs() << "\n\n";
-        });
-      }
-    }
-
-    {
-      RewritePatternSet patterns(context);
-      populateConcretizePadResultShapePatterns(context, patterns);
-      (void)applyPatternsAndFoldGreedily(funcOp, std::move(patterns));
-
-      LLVM_DEBUG({
-        llvm::dbgs() << "--- After tiling canonicalization ---\n";
-        funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-        llvm::dbgs() << "\n\n";
-      });
-    }
+    concretizePadShape(funcOp);
 
     {  // Downsize n-D (n > 1) convolutions to 1-D.
       RewritePatternSet patterns(context);


### PR DESCRIPTION
Breaking down the long function into multiple smaller utility functions to make the logic clear and easier to read.