### PR TITLE
Rename label buildkite:benchmark to buildkite:benchmark-android

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -5,7 +5,7 @@ benchmarks suite. Benchmark results are posted to https://perf.iree.dev.
 
 The https://buildkite.com/iree/iree-benchmark Buildkite pipeline runs on each
 commit to the `main` branch and posts those results to the dashboard. The
-pipeline also runs on pull requests with the `buildkite:benchmark` label,
+pipeline also runs on pull requests with the `buildkite:benchmark-*` label,
 posting results compared against their base commit as comments.
 
 ## Types of benchmarks
@@ -44,7 +44,7 @@ posting results compared against their base commit as comments.
    your desired benchmark configuration with the `iree_mlir_benchmark_suite`
    function. You can test your change by running the
    https://buildkite.com/iree/iree-benchmark pipeline on a GitHub pull request
-   with the `buildkite:benchmark` label.
+   with the `buildkite:benchmark-*` label.
 
 5. Once your changes are merged to the `main` branch, results will start to
    appear on the benchmarks dashboard at https://perf.iree.dev.

--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -13,7 +13,7 @@ steps:
       - "tar --exclude='*.tar.gz' --exclude='*.tgz' --exclude='*.mlir' --exclude='*.tflite' --exclude='*tf-model' -czvf benchmark-suites-${BUILDKITE_BUILD_NUMBER}.tgz build-host/benchmark_suites"
       - "find build-host/benchmark_suites -name '*.mlir' | tar -czvf source-mlir-models-${BUILDKITE_BUILD_NUMBER}.tgz -T -"
       - "tar -czvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz build-android/tools/iree-benchmark-module build-android-trace/tools/iree-benchmark-module build-android/tools/build_config.txt"
-    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
+    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark' || build.pull_request.labels includes 'buildkite:benchmark-android')"
     agents:
       - "queue=build"
     env:
@@ -35,7 +35,7 @@ steps:
       - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf tracy-capture-eeffb6d2.tgz"
       - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/tools/ --traced_benchmark_tool_dir=build-android-trace/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-pixel-4-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-pixel-4-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='(?!vulkan).*' --verbose build-host/"
-    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
+    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark' || build.pull_request.labels includes 'buildkite:benchmark-android')"
     agents:
       - "android-soc=snapdragon-855"
       - "android-version=12"
@@ -55,7 +55,7 @@ steps:
       - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf tracy-capture-eeffb6d2.tgz"
       - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/tools/ --traced_benchmark_tool_dir=build-android-trace/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-pixel6-pro-${BUILDKITE_BUILD_NUMBER}.tgz --verbose build-host/"
-    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
+    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark' || build.pull_request.labels includes 'buildkite:benchmark-android')"
     agents:
       - "android-soc=google-tensor"
       - "android-version=12"
@@ -75,7 +75,7 @@ steps:
       - "tar -xzvf iree-android-tools-${BUILDKITE_BUILD_NUMBER}.tgz"
       - "tar -xzvf tracy-capture-eeffb6d2.tgz"
       - "python3 build_tools/benchmarks/run_benchmarks_on_android.py --pin-cpu-freq --pin-gpu-freq --normal_benchmark_tool_dir=build-android/tools/ --traced_benchmark_tool_dir=build-android-trace/tools/ --trace_capture_tool=tracy-capture -o benchmark-results-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.json --capture_tarball=trace-captures-moto-edge-x30-${BUILDKITE_BUILD_NUMBER}.tgz --driver_filter_regex='vulkan' --verbose build-host/"
-    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark')"
+    if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark' || build.pull_request.labels includes 'buildkite:benchmark-android')"
     agents:
       - "android-soc=snapdragon-8gen1"
       - "android-version=12"
@@ -93,7 +93,7 @@ steps:
       - "buildkite-agent artifact download benchmark-results-*.json ./"
       - "python3 build_tools/benchmarks/post_benchmarks_as_pr_comment.py --verbose --query-base --benchmark_files benchmark-results-*.json"
     key: "post-on-pr"
-    if: "build.pull_request.id != null && (build.pull_request.labels includes 'buildkite:benchmark')"
+    if: "build.pull_request.id != null && (build.pull_request.labels includes 'buildkite:benchmark' || build.pull_request.labels includes 'buildkite:benchmark-android')"
     agents:
       - "queue=report"
 


### PR DESCRIPTION
Rename the historical `buildkite:benchmark` to `buildkite:benchmark-android`.
Github label will be renamed once this change is merged. The condition on old `buildkite:benchmark` isn't removed to avoid interruption during the migration.

Was planning to get rid of these when migrating to the Github-based benchmark CI, but this seems to be too confusing and easy to fix.