### PR TITLE
Remove Interop.h which is no longer needed

### DIFF
--- a/compiler/src/iree/compiler/API/python/IREECTransforms.cpp
+++ b/compiler/src/iree/compiler/API/python/IREECTransforms.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree/compiler/API/Compiler.h"
-#include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir/Bindings/Python/PybindAdaptors.h"
 
 namespace py = pybind11;

--- a/llvm-external-projects/iree-dialects/python/IREEDialectsModule.cpp
+++ b/llvm-external-projects/iree-dialects/python/IREEDialectsModule.cpp
@@ -6,7 +6,6 @@
 
 #include "iree-dialects-c/Dialects.h"
 #include "iree-dialects-c/Utils.h"
-#include "mlir-c/Bindings/Python/Interop.h"
 #include "mlir-c/BuiltinAttributes.h"
 #include "mlir-c/BuiltinTypes.h"
 #include "mlir-c/Diagnostics.h"


### PR DESCRIPTION
It breaks windows builds when it is included.

Similar fix went into torch-mlir https://github.com/llvm/torch-mlir/pull/1397