### PR TITLE
NFC: Add static method to `Pack` op to get result shape.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h
@@ -29,6 +29,7 @@ Value getDimValue(OpBuilder &builder, Location loc, Value v, int64_t dim);
 /// Returns a `memref.dim` or `tensor.dim` operation to get the shape of `v` at
 /// `dim`. If the shape is constant, returns the shape as an `IntegerAttr`.
 OpFoldResult getDim(OpBuilder &builder, Location loc, Value v, int64_t dim);
+SmallVector<OpFoldResult> getDims(OpBuilder &builder, Location loc, Value v);
 
 } // namespace LinalgExt
 } // namespace IREE

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -575,11 +575,15 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
     // Return a mapping from positions `dims_pos` to their tile factors.
     DenseMap<int64_t, OpFoldResult> getDimAndTileMapping();
 
-    // Method to get the shape of the result as `SmallVector<OpFoldResult>`
+    // Method to get the shape of the result as `SmallVector<OpFoldResult>`.
+    // This is a static method to allow getting the shape of the destination
+    // expected while creating a `pack` op.
     static SmallVector<OpFoldResult> getResultShape(OpBuilder &builder,
         Location loc, ArrayRef<OpFoldResult> sourceDims,
         ArrayRef<OpFoldResult> innerTileDims, ArrayRef<int64_t> innerDimsPos,
         ArrayRef<int64_t> outerDimsPerm = {});
+
+    // Method to return the shape of the result as `SmallVector<OpFoldResult>`.
     SmallVector<OpFoldResult> getResultShape(OpBuilder &builder);
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -494,7 +494,7 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
   let arguments = (ins Variadic<AnyShaped>:$inputs,
     Variadic<AnyShaped>:$outputs,
     DefaultValuedOptionalAttr<I64ArrayAttr, "{}">:$outer_dims_perm,
-    DefaultValuedAttr<I64ArrayAttr, "{}">:$inner_dims_pos,
+    I64ArrayAttr:$inner_dims_pos,
     Variadic<Index>:$inner_tiles,
     I64ArrayAttr:$static_inner_tiles,
     Optional<AnyType>:$padding_value);
@@ -512,6 +512,14 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
     `into` $outputs `:` `(` type($inputs) type($outputs) `)`
      (`->` type($results)^)?
   }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$source, "Value":$output,
+      "ArrayRef<int64_t>":$innerDimsPos,
+      "ArrayRef<OpFoldResult>":$innerTiles, 
+      CArg<"Optional<Value>", "llvm::None">:$paddingValue,
+      CArg<"ArrayRef<int64_t>", "{}">:$outerDimsPerm)>
+  ];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
 
@@ -566,6 +574,13 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
 
     // Return a mapping from positions `dims_pos` to their tile factors.
     DenseMap<int64_t, OpFoldResult> getDimAndTileMapping();
+
+    // Method to get the shape of the result as `SmallVector<OpFoldResult>`
+    static SmallVector<OpFoldResult> getResultShape(OpBuilder &builder,
+        Location loc, ArrayRef<OpFoldResult> sourceDims,
+        ArrayRef<OpFoldResult> innerTileDims, ArrayRef<int64_t> innerDimsPos,
+        ArrayRef<int64_t> outerDimsPerm = {});
+    SmallVector<OpFoldResult> getResultShape(OpBuilder &builder);
   }];
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -96,8 +96,7 @@ Value IREE::LinalgExt::getDimValue(OpBuilder &builder, Location loc, Value v,
       })
       .Case<MemRefType>([&](MemRefType t) -> Value {
         return builder.create<memref::DimOp>(loc, v, dim);
-      })
-      .Default([&](Type t) { return Value(); });
+      });
 }
 
 OpFoldResult IREE::LinalgExt::getDim(OpBuilder &builder, Location loc, Value v,
@@ -107,6 +106,14 @@ OpFoldResult IREE::LinalgExt::getDim(OpBuilder &builder, Location loc, Value v,
     return getDimValue(builder, loc, v, dim);
   }
   return builder.getI64IntegerAttr(t.getDimSize(dim));
+}
+SmallVector<OpFoldResult> IREE::LinalgExt::getDims(OpBuilder &builder,
+                                                   Location loc,
+                                                   Value shapedTypeValue) {
+  return llvm::to_vector(llvm::map_range(
+      llvm::seq<int64_t>(
+          0, shapedTypeValue.getType().cast<ShapedType>().getRank()),
+      [&](int64_t dim) { return getDim(builder, loc, shapedTypeValue, dim); }));
 }
 
 //===----------------------------------------------------------------------===//
@@ -1770,6 +1777,31 @@ inferPackedType(ShapedType sourceType, ArrayRef<int64_t> innerTiles,
 // PackOp
 //===----------------------------------------------------------------------===//
 
+/// Custom builder methods for pack ops.
+void PackOp::build(OpBuilder &builder, OperationState &state, Value source,
+                   Value output, ArrayRef<int64_t> innerDimsPos,
+                   ArrayRef<OpFoldResult> innerTiles,
+                   Optional<Value> paddingValue,
+                   ArrayRef<int64_t> outerDimsPerm) {
+  assert(innerDimsPos.size() == innerTiles.size());
+  DenseMap<int64_t, OpFoldResult> tileAndPosMapping;
+  for (auto it : llvm::zip(innerDimsPos, innerTiles))
+    tileAndPosMapping[std::get<0>(it)] = std::get<1>(it);
+  SmallVector<int64_t> staticTileSizes;
+  SmallVector<Value> dynamicTileSizes;
+  dispatchIndexOpFoldResults(innerTiles, dynamicTileSizes, staticTileSizes,
+                             ShapedType::kDynamicSize);
+  ShapedType resultType =
+      inferPackedType(source.getType().cast<ShapedType>(), staticTileSizes,
+                      tileAndPosMapping, outerDimsPerm);
+  build(builder, state, resultType, source, output,
+        outerDimsPerm.empty() ? nullptr
+                              : builder.getI64ArrayAttr(outerDimsPerm),
+        builder.getI64ArrayAttr(innerDimsPos), dynamicTileSizes,
+        builder.getI64ArrayAttr(staticTileSizes),
+        (paddingValue ? paddingValue.value() : nullptr));
+}
+
 /// verifier for the pack operation.
 LogicalResult PackOp::verify() {
   Operation *op = getOperation();
@@ -1830,6 +1862,39 @@ SmallVector<OpFoldResult> PackOp::getMixedTiles() {
 
 SmallVector<int64_t> PackOp::getStaticTiles() {
   return ::getStaticTiles(*this);
+}
+
+SmallVector<OpFoldResult> PackOp::getResultShape(
+    OpBuilder &builder, Location loc, ArrayRef<OpFoldResult> sourceDims,
+    ArrayRef<OpFoldResult> innerTileSizes, ArrayRef<int64_t> innerDimsPos,
+    ArrayRef<int64_t> outerDimsPerm) {
+  SmallVector<OpFoldResult> resultDims = llvm::to_vector(sourceDims);
+
+  AffineExpr s0, s1;
+  bindSymbols(builder.getContext(), s0, s1);
+  AffineExpr ceilDivExpr = s0.ceilDiv(s1);
+  for (auto tiledDim : llvm::enumerate(innerDimsPos)) {
+    resultDims[tiledDim.value()] = makeComposedFoldedAffineApply(
+        builder, loc, ceilDivExpr,
+        {resultDims[tiledDim.value()], innerTileSizes[tiledDim.index()]});
+  }
+  if (!outerDimsPerm.empty()) {
+    resultDims =
+        interchange<OpFoldResult>(resultDims, outerDimsPerm, /*offset = */ 0);
+  }
+  resultDims.append(innerTileSizes.begin(), innerTileSizes.end());
+  return resultDims;
+}
+SmallVector<OpFoldResult> PackOp::getResultShape(OpBuilder &builder) {
+  auto getAsIntVector = [](ArrayAttr arrayAttr) {
+    return llvm::to_vector(llvm::map_range(arrayAttr, [](Attribute attr) {
+      return attr.cast<IntegerAttr>().getInt();
+    }));
+  };
+  return getResultShape(builder, getLoc(),
+                        getDims(builder, getLoc(), getInput()), getMixedTiles(),
+                        getAsIntVector(getInnerDimsPos()),
+                        getAsIntVector(getOuterDimsPerm()));
 }
 
 SmallVector<utils::IteratorType> PackOp::getLoopIteratorTypes() {
@@ -2100,39 +2165,9 @@ PackOp::reifyResultShapes(OpBuilder &builder,
                           ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
   OpBuilder::InsertionGuard g(builder);
   builder.setInsertionPoint(getOperation());
-  Location loc = getLoc();
-  SmallVector<OpFoldResult> mixedTiles = getMixedTiles();
-  DenseMap<int64_t, OpFoldResult> dimAndTileMapping = getDimAndTileMapping();
-
-  // Build the output dimension at pos `dimIdx`.
-  auto buildOutputDim = [&](OpBuilder &builder, size_t dimIdx) -> OpFoldResult {
-    ArrayRef<int64_t> outputShape = getOutputShape();
-    if (!ShapedType::isDynamic(outputShape[dimIdx])) {
-      return builder.getI64IntegerAttr(outputShape[dimIdx]);
-    }
-
-    // Inner tile sizes can be derived from inner_tiles.
-    if (dimIdx >= getInputRank()) {
-      return mixedTiles[dimIdx - getInputRank()];
-    }
-
-    OpFoldResult dimBound = getDim(builder, loc, getInput(), dimIdx);
-    if (dimAndTileMapping.count(dimIdx)) {
-      AffineExpr dim = builder.getAffineSymbolExpr(0);
-      AffineExpr tile = builder.getAffineSymbolExpr(1);
-      dimBound = makeComposedFoldedAffineApply(
-          builder, loc, dim.ceilDiv(tile),
-          ArrayRef<OpFoldResult>{dimBound, dimAndTileMapping[dimIdx]});
-    }
-    return dimBound;
-  };
-
   reifiedReturnShapes.resize(1);
-  reifiedReturnShapes[0].reserve(getOutputRank());
-  for (auto dimIdx : llvm::seq<int64_t>(0, getOutputRank())) {
-    reifiedReturnShapes[0].push_back(getValueOrCreateConstantIndexOp(
-        builder, loc, buildOutputDim(builder, dimIdx)));
-  }
+  reifiedReturnShapes[0] = getValueOrCreateConstantIndexOp(
+      builder, getLoc(), getResultShape(builder));
   return success();
 }
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -1322,10 +1322,10 @@ func.func @unpack_undo_padding(%input: memref<2x8x8x2xf32>, %output: memref<13x1
 // CHECK-DAG:    %[[C15:.+]] = arith.constant 15 : index
 // CHECK:        scf.for %[[I:.+]] = %[[C0]] to %[[C13]] step %[[C1]] {
 // CHECK:          scf.for %[[J:.+]] = %[[C0]] to %[[C15]] step %[[C1]] {
-// CHECK-DAG:        %[[OUTER_I:.+]] = affine.apply #[[MAP0]](%[[I]])
-// CHECK-DAG:        %[[INNER_I:.+]] = affine.apply #[[MAP1]](%[[I]])
-// CHECK-DAG:        %[[OUTER_J:.+]] = affine.apply #[[MAP2]](%[[J]])
-// CHECK-DAG:        %[[INNER_J:.+]] = affine.apply #[[MAP3]](%[[J]])
+// CHECK-DAG:        %[[OUTER_I:.+]] = affine.apply #[[MAP_FLOORI]](%[[I]])
+// CHECK-DAG:        %[[INNER_I:.+]] = affine.apply #[[MAP_MODI]](%[[I]])
+// CHECK-DAG:        %[[OUTER_J:.+]] = affine.apply #[[MAP_FLOORJ]](%[[J]])
+// CHECK-DAG:        %[[INNER_J:.+]] = affine.apply #[[MAP_MODJ]](%[[J]])
 // CHECK:            %[[VAL:.+]] = memref.load %[[INPUT]][%[[OUTER_I]], %[[OUTER_J]], %[[INNER_I]], %[[INNER_J]]]
 // CHECK:            memref.store %[[VAL]], %[[OUTPUT]][%[[I]], %[[J]]]
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
@@ -1020,10 +1020,10 @@ func.func @pad_and_pack_partially_dynamic(%input: tensor<?x?xf32>, %output: tens
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[C2:.*]] = arith.constant 2 : index
 // CHECK-DAG:       %[[C4:.*]] = arith.constant 4 : index
-// CHECK:           %[[IN_D0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?xf32>
-// CHECK:           %[[OUT_D0:.*]] = affine.apply #[[MAP0]]()[%[[IN_D0]]]
-// CHECK:           %[[IN_D1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?xf32>
-// CHECK:           %[[OUT_D1:.*]] = affine.apply #[[MAP1]]()[%[[IN_D1]]]
+// CHECK-DAG:       %[[IN_D0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?xf32>
+// CHECK-DAG:       %[[IN_D1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?xf32>
+// CHECK-DAG:       %[[OUT_D0:.*]] = affine.apply #[[MAP0]]()[%[[IN_D0]]]
+// CHECK-DAG:       %[[OUT_D1:.*]] = affine.apply #[[MAP1]]()[%[[IN_D1]]]
 // CHECK:           %[[RES0:.*]] = scf.for %[[I:.*]] = %[[C0]] to %[[OUT_D0]] step %[[C2]] iter_args(%[[ITER0:.*]] = %[[OUT]]) -> (tensor<?x?x8x2xf32>) {
 // CHECK-DAG:         %[[OUT_I_SZ:.*]] = affine.min #[[MAP2]](%[[I]])[%[[C2]], %[[OUT_D0]]]
 // CHECK:             %[[RES1:.*]] = scf.for %[[J:.*]] = %[[C0]] to %[[OUT_D1]] step %[[C4]] iter_args(%[[ITER1:.*]] = %[[ITER0]]) -> (tensor<?x?x8x2xf32>) {
@@ -1069,10 +1069,10 @@ func.func @pad_and_pack_fully_dynamic(%input: tensor<?x?xf32>, %output: tensor<?
 // CHECK-DAG:       %[[C1:.*]] = arith.constant 1 : index
 // CHECK-DAG:       %[[C2:.*]] = arith.constant 2 : index
 // CHECK-DAG:       %[[C4:.*]] = arith.constant 4 : index
-// CHECK:           %[[IN_D0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?xf32>
-// CHECK:           %[[OUT_D0:.*]] = affine.apply #[[MAP0]]()[%[[IN_D0]], %[[TILE_0]]]
-// CHECK:           %[[IN_D1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?xf32>
-// CHECK:           %[[OUT_D1:.*]] = affine.apply #[[MAP0]]()[%[[IN_D1]], %[[TILE_1]]]
+// CHECK-DAG:       %[[IN_D0:.*]] = tensor.dim %[[IN]], %[[C0]] : tensor<?x?xf32>
+// CHECK-DAG:       %[[IN_D1:.*]] = tensor.dim %[[IN]], %[[C1]] : tensor<?x?xf32>
+// CHECK-DAG:       %[[OUT_D0:.*]] = affine.apply #[[MAP0]]()[%[[IN_D0]], %[[TILE_0]]]
+// CHECK-DAG:       %[[OUT_D1:.*]] = affine.apply #[[MAP0]]()[%[[IN_D1]], %[[TILE_1]]]
 // CHECK:           %[[RES0:.*]] = scf.for %[[I:.*]] = %[[C0]] to %[[OUT_D0]] step %[[C2]] iter_args(%[[ITER0:.*]] = %[[OUT]]) -> (tensor<?x?x?x?xf32>) {
 // CHECK:             %[[OUT_I_SZ:.*]] = affine.min #[[MAP1]](%[[I]])[%[[C2]], %[[OUT_D0]]]
 // CHECK:             %[[RES1:.*]] = scf.for %[[J:.*]] = %[[C0]] to %[[OUT_D1]] step %[[C4]] iter_args(%[[ITER1:.*]] = %[[ITER0]]) -> (tensor<?x?x?x?xf32>) {


### PR DESCRIPTION
Add a static class method to `Pack` operation that allows getting the shape of the expected result. Such methods helps to lower into pack operations that is destination passing style.
Also add a custom `build` method to `Pack` ops to hide a lot of bioler plate.
Fix a lit test along the way.