### PR TITLE
Remove unused files before archiving build dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,12 @@ jobs:
             "${BUILD_DIR}"
       # The archive step below doesn't include these files. Remove them first to
       # save disk space.
+      # TODO(#10739): This step can be removed once we enlarge the disk sapce.
       - name: "Removing unused files"
         run: |
           find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
-            -exec rm -v {} +
+            -print \
+            -delete
       # Things get more complicated here than when we're just building the
       # runtime. The build directory is way bigger. We're also using on our own
       # runners on GCE. So uploading to GitHub actions artifact storage hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,7 @@ jobs:
         env:
           BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
         run: |
-          df -h ${BUILD_DIR}
-          tar --exclude '*.a' --exclude '*.o' \
-            -I 'zstd -T0' \
+          tar -I 'zstd -T0' \
             -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
           echo "::set-output name=build-dir-archive::${BUILD_DIR_ARCHIVE}"
       - name: "Uploading build dir archive"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,7 @@ jobs:
         env:
           BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
         run: |
+          df -h ${BUILD_DIR}
           tar --exclude '*.a' --exclude '*.o' \
             -I 'zstd -T0' \
             -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,12 @@ jobs:
             gcr.io/iree-oss/base@sha256:5d43683c6b50aebe1fca6c85f2012f3b0fa153bf4dd268e8767b619b1891423a \
             ./build_tools/cmake/build_all.sh \
             "${BUILD_DIR}"
+      # The archive step below doesn't include these files. Remove them first to
+      # save disk space.
+      - name: "Removing unused files"
+        run: |
+          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
+            -exec rm -v {} +
       # Things get more complicated here than when we're just building the
       # runtime. The build directory is way bigger. We're also using on our own
       # runners on GCE. So uploading to GitHub actions artifact storage hosted


### PR DESCRIPTION
The archive step of `build_all` job uses up almost all RAM disk space. In addition to enlarging the RAM disk, we can also remove the unused files before the archive step.

This only takes 1s to run and saves about 10G disk space for the following archive step:
```
Filesystem      Size  Used Avail Use% Mounted on
tmpfs            50G   35G   16G  69% /runner-root
```