### PR TITLE
Integrate TensorPadPass into the TransposeSharedMem Pipeline. 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -620,22 +620,12 @@ static LogicalResult setTransposeConfig(func::FuncOp entryPoint,
     }
   }
 
-  int32_t tileM = 32;
-  int32_t tileN = 32;
   TileSizesListType tileSizes;
   // Set all tile sizes to 1 except for fastest moving dimensions.
   SmallVector<int64_t> tileSizesTemp(linalgOp.getNumLoops(), 1);
   tileSizesTemp[outputFastestDim] = 32;
   tileSizesTemp[inputFastestDim] = 32;
   tileSizes.push_back(tileSizesTemp);
-
-  // Check alignment with tile size for each transpose. Only the fastest moving
-  // dims need to match the transpose tile.
-  auto loopRanges = linalgOp.getStaticLoopRanges();
-  if (loopRanges[outputFastestDim] % tileM != 0 ||
-      loopRanges[inputFastestDim] % tileN != 0) {
-    return failure();
-  }
 
   // Workgroup size contains 8 warps. Configured with 8 threads on fastest
   // moving dimension so each thread can execute a vectorized copy of 4

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorPad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorPad.cpp
@@ -125,7 +125,7 @@ struct LLVMGPUTensorPadPass
       // dynamic.
       if (!opInfo.isTranspose() || !opInfo.isDynamic() ||
           !hasTwoOrThreeLoopsInfo(linalgOp)) {
-        funcOp.emitWarning("failed preconditions");
+        // funcOp.emitWarning("failed preconditions");
         return;
       }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -263,10 +263,10 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
 void addGPUTransposePassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createWorkgroupSpecializationPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
+
+  nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUTensorPadPass());
 
   nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/tensor_pad.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/tensor_pad.mlir
@@ -64,3 +64,117 @@ func.func @transpose_no_align_dispatch_0_generic_48x32() {
 //       CHECK:      } -> tensor<32x32xf32>
 //       CHECK:      %[[D13:.*]] = tensor.extract_slice %[[D12:.*]][0, 0] {{\[}}%[[D4]], 32] [1, 1] : tensor<32x32xf32> to tensor<?x32xf32>
 //       CHECK:      flow.dispatch.tensor.store %[[D13]], %[[D1]], offsets = {{\[}}%[[ARG0]], %[[ARG1]]], sizes = {{\[}}%[[D4]], 32], strides = [1, 1] : tensor<?x32xf32> -> !flow.dispatch.tensor<writeonly:tensor<48x32xf32>>
+
+
+// -----
+
+func.func @transpose_no_align_3d_dispatch_0_generic_10x48x2048() {
+  %c10 = arith.constant 10 : index
+  %c48 = arith.constant 48 : index
+  %c2048 = arith.constant 2048 : index
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:10x2048x48xf32>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:10x48x2048xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %workgroup_id_z = hal.interface.workgroup.id[2] : index
+  %workgroup_count_z = hal.interface.workgroup.count[2] : index
+  scf.for %arg0 = %workgroup_id_z to %c10 step %workgroup_count_z {
+    %2 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_y]
+    %3 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_y]
+    scf.for %arg1 = %2 to %c48 step %3 {
+      %4 = affine.min affine_map<(d0) -> (-d0 + 48, 32)>(%arg1)
+      %5 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
+      %6 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
+      scf.for %arg2 = %5 to %c2048 step %6 {
+        %7 = flow.dispatch.tensor.load %1, offsets = [%arg0, %arg1, %arg2], sizes = [1, %4, 32], strides = [1, 1, 1] : !flow.dispatch.tensor<writeonly:10x48x2048xf32> -> tensor<1x?x32xf32>
+        %8 = flow.dispatch.tensor.load %0, offsets = [%arg0, %arg2, %arg1], sizes = [1, 32, %4], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:10x2048x48xf32> -> tensor<1x32x?xf32>
+        %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%8 : tensor<1x32x?xf32>) outs(%7 : tensor<1x?x32xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 32, 32]]>} {
+        ^bb0(%arg3: f32, %arg4: f32):
+          linalg.yield %arg3 : f32
+        } -> tensor<1x?x32xf32>
+        flow.dispatch.tensor.store %9, %1, offsets = [%arg0, %arg1, %arg2], sizes = [1, %4, 32], strides = [1, 1, 1] : tensor<1x?x32xf32> -> !flow.dispatch.tensor<writeonly:10x48x2048xf32>
+      }
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:  func.func @transpose_no_align_3d_dispatch_0_generic_10x48x2048
+//       CHECK:  %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+//       CHECK:  %[[C10:.*]] = arith.constant 10 : index
+//       CHECK:  %[[C48:.*]] = arith.constant 48 : index
+//       CHECK:  %[[C2048:.*]] = arith.constant 2048 : index
+//       CHECK:  %[[C0:.*]] = arith.constant 0 : index
+//       CHECK:  %[[D0:.*]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[C0]]) alignment(64) : !flow.dispatch.tensor<readonly:10x2048x48xf32>
+//       CHECK:  %[[D1:.*]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%[[C0]]) alignment(64) : !flow.dispatch.tensor<writeonly:10x48x2048xf32>
+//       CHECK:  %[[WORKGROUP_ID_X:.*]] = hal.interface.workgroup.id[0] : index
+//       CHECK:  %[[WORKGROUP_COUNT_X:.*]] = hal.interface.workgroup.count[0] : index
+//       CHECK:  %[[WORKGROUP_ID_Y:.*]] = hal.interface.workgroup.id[1] : index
+//       CHECK:  %[[WORKGROUP_COUNT_Y:.*]] = hal.interface.workgroup.count[1] : index
+//       CHECK:  %[[WORKGROUP_ID_Z:.*]] = hal.interface.workgroup.id[2] : index
+//       CHECK:  %[[WORKGROUP_COUNT_Z:.*]] = hal.interface.workgroup.count[2] : index
+//       CHECK:  scf.for %[[ARG0:.*]] = %[[WORKGROUP_ID_Z]] to %[[C10]] step %[[WORKGROUP_COUNT_Z]] {
+//       CHECK:    %[[D2:.*]] = affine.apply #{{.*}}(){{\[}}%[[WORKGROUP_ID_Y]]]
+//       CHECK:    %[[D3:.*]] = affine.apply #{{.*}}(){{\[}}%[[WORKGROUP_COUNT_Y]]]
+//       CHECK:    scf.for %[[ARG1:.*]] = %[[D2]] to %[[C48]] step %[[D3]] {
+//       CHECK:      %[[D4:.*]] = affine.min #{{.*}}(%[[ARG1]])
+//       CHECK:      %[[D5:.*]] = affine.apply #{{.*}}(){{\[}}%[[WORKGROUP_ID_X]]]
+//       CHECK:      %[[D6:.*]] = affine.apply #{{.*}}(){{\[}}%[[WORKGROUP_COUNT_X]]]
+//       CHECK:      scf.for %[[ARG2:.*]] = %[[D5]] to %[[C2048]] step %[[D6]] {
+//       CHECK:        %[[D7:.*]] = flow.dispatch.tensor.load %[[D1]], offsets = {{\[}}%[[ARG0]], %[[ARG1]], %[[ARG2]]], sizes = [1, %[[D4]], 32], strides = [1, 1, 1] : !flow.dispatch.tensor<writeonly:10x48x2048xf32> -> tensor<1x?x32xf32>
+//       CHECK:        %[[D8:.*]] = flow.dispatch.tensor.load %[[D0]], offsets = {{\[}}%[[ARG0]], %[[ARG2]], %[[ARG1]]], sizes = [1, 32, %[[D4]]], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:10x2048x48xf32> -> tensor<1x32x?xf32>
+//       CHECK:        %[[D9:.*]] = affine.apply #{{.*}}(%[[D4]])
+//       CHECK:        %[[D10:.*]] = tensor.pad %[[D8]] low{{\[}}%[[C0]], %[[C0]], %[[C0]]] high{{\[}}%[[C0]], %[[C0]], %[[D9]]] {
+//       CHECK:        ^bb0(%[[ARG3:.*]]: index, %[[ARG4:.*]]: index, %[[ARG5:.*]]: index):
+//       CHECK:          tensor.yield %[[CST]] : f32
+//       CHECK:        } : tensor<1x32x?xf32> to tensor<1x32x32xf32>
+//       CHECK:        %[[D11:.*]] = tensor.pad %[[D7]] low{{\[}}%[[C0]], %[[C0]], %[[C0]]] high{{\[}}%[[C0]], %[[D9]], %[[C0]]] {
+//       CHECK:        ^bb0(%[[ARG3:.*]]: index, %[[ARG4:.*]]: index, %[[ARG5:.*]]: index):
+//       CHECK:          tensor.yield %[[CST]] : f32
+//       CHECK:        } : tensor<1x?x32xf32> to tensor<1x32x32xf32>
+//       CHECK:        %[[D12:.*]] = linalg.generic {indexing_maps = [#{{.*}}, #{{.*}}], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[D10:.*]] : tensor<1x32x32xf32>) outs(%[[D11:.*]] : tensor<1x32x32xf32>) attrs =  {lowering_config = #config} {
+//       CHECK:        ^bb0(%[[ARG3:.*]]: f32, %[[ARG4:.*]]: f32):
+//       CHECK:          linalg.yield %[[ARG3]] : f32
+//       CHECK:        } -> tensor<1x32x32xf32>
+//       CHECK:        %[[D13:.*]] = tensor.extract_slice %[[D12:.*]][0, 0, 0] [1, %[[D4]], 32] [1, 1, 1] : tensor<1x32x32xf32> to tensor<1x?x32xf32>
+//       CHECK:        flow.dispatch.tensor.store %[[D13]], %[[D1]], offsets = {{\[}}%[[ARG0]], %[[ARG1]], %[[ARG2]]], sizes = [1, %[[D4]], 32], strides = [1, 1, 1] : tensor<1x?x32xf32> -> !flow.dispatch.tensor<writeonly:10x48x2048xf32>
+
+
+// -----
+
+
+func.func @transpose_align_dispatch_0_generic_64x32() {
+  %c64 = arith.constant 64 : index
+  %c32 = arith.constant 32 : index
+  %c0 = arith.constant 0 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:32x64xf32>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:64x32xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %workgroup_count_x = hal.interface.workgroup.count[0] : index
+  %workgroup_id_y = hal.interface.workgroup.id[1] : index
+  %workgroup_count_y = hal.interface.workgroup.count[1] : index
+  %2 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_y]
+  %3 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_y]
+  scf.for %arg0 = %2 to %c64 step %3 {
+    %4 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
+    %5 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
+    scf.for %arg1 = %4 to %c32 step %5 {
+      %6 = flow.dispatch.tensor.load %1, offsets = [%arg0, %arg1], sizes = [32, 32], strides = [1, 1] : !flow.dispatch.tensor<writeonly:64x32xf32> -> tensor<32x32xf32>
+      %7 = flow.dispatch.tensor.load %0, offsets = [%arg1, %arg0], sizes = [32, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:32x64xf32> -> tensor<32x32xf32>
+      %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1, d0)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%7 : tensor<32x32xf32>) outs(%6 : tensor<32x32xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[32, 32]]>} {
+      ^bb0(%arg2: f32, %arg3: f32):
+        linalg.yield %arg2 : f32
+      } -> tensor<32x32xf32>
+      flow.dispatch.tensor.store %8, %1, offsets = [%arg0, %arg1], sizes = [32, 32], strides = [1, 1] : tensor<32x32xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x32xf32>
+    }
+  }
+  return
+}
+
+// CHECK-LABEL:  func.func @transpose_align_dispatch_0_generic_64x32
+//   CHECK-NOT:  tensor.pad
+
+// -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transpose_pipeline_test.mlir
@@ -31,6 +31,7 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 }
 
 // CHECK-LABEL:  hal.executable public @transpose_dispatch_0
+//   CHECK-NOT:  tensor.pad
 //   CHECK-DAG:  %[[CST:.*]] = arith.constant 0.000000e+00 : f32
 //   CHECK-DAG:  %[[C0:.*]] = arith.constant 0 : index
 //   CHECK-DAG:  %[[D0:.*]] = gpu.thread_id  x
@@ -94,6 +95,7 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 }
 
 // CHECK-LABEL:  hal.executable public @transpose_single_operand_dispatch_0_generic_768x2048
+//   CHECK-NOT:  tensor.pad
 //       CHECK:  %[[CST:.*]] = arith.constant 0.000000e+00 : f32
 //       CHECK:  %[[C0:.*]] = arith.constant 0 : index
 //       CHECK:  %[[D0:.*]] = gpu.thread_id  x
@@ -200,6 +202,7 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 }
 
 // CHECK-LABEL:   hal.executable public @transpose_3d_yes_dispatch_0_generic_10x768x2048 {
+//   CHECK-NOT:   tensor.pad
 //       CHECK:   %[[CST:.*]] = arith.constant 0.000000e+00 : f32
 //       CHECK:   %[[C0:.*]] = arith.constant 0 : index
 //       CHECK:   %[[D0:.*]] = gpu.thread_id  x
@@ -267,6 +270,7 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 }
 
 // CHECK-LABEL:   hal.executable public @transpose_3d_trans_out_dispatch_0_generic_10x2048x768 {
+//   CHECK-NOT:   tensor.pad
 //       CHECK:   %[[CST:.*]] = arith.constant 0.000000e+00 : f32
 //       CHECK:   %[[C0:.*]] = arith.constant 0 : index
 //       CHECK:   %[[D0:.*]] = gpu.thread_id  x
@@ -361,3 +365,88 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 //   CHECK-NOT:   gpu.barrier
 //   CHECK-NOT:   memref.alloc
 //       CHECK:   return
+
+// -----
+
+#device_target_cuda = #hal.device.target<"cuda", {executable_targets = [#hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>], legacy_sync}>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>
+module attributes {hal.device.targets = [#device_target_cuda]} {
+  hal.executable @transpose_no_align_3d_dispatch_0_generic_10x48x2048 {
+    hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
+      hal.executable.export public @transpose_no_align_3d_dispatch_0_generic_10x48x2048 ordinal(0) layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @transpose_no_align_3d_dispatch_0_generic_10x48x2048() {
+          %c0 = arith.constant 0 : index
+          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:10x2048x48xf32>
+          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:10x48x2048xf32>
+          %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [10, 2048, 48], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:10x2048x48xf32> -> tensor<10x2048x48xf32>
+          %3 = linalg.init_tensor [10, 48, 2048] : tensor<10x48x2048xf32>
+          %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%2 : tensor<10x2048x48xf32>) outs(%3 : tensor<10x48x2048xf32>) {
+          ^bb0(%arg0: f32, %arg1: f32):
+            linalg.yield %arg0 : f32
+          } -> tensor<10x48x2048xf32>
+          flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0], sizes = [10, 48, 2048], strides = [1, 1, 1] : tensor<10x48x2048xf32> -> !flow.dispatch.tensor<writeonly:10x48x2048xf32>
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL:   hal.executable public @transpose_no_align_3d_dispatch_0_generic_10x48x2048 {
+//   CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C32:.*]] = arith.constant 32 : index
+//   CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[CST:.*]] = arith.constant 0.000000e+00 : f32
+//   CHECK-DAG:   %[[D0:.*]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[C0]]) alignment(64) : memref<10x2048x48xf32>
+//       CHECK:   memref.assume_alignment %[[D0]], 64 : memref<10x2048x48xf32>
+//       CHECK:   %[[D1:.*]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%[[C0]]) alignment(64) : memref<10x48x2048xf32>
+//       CHECK:   memref.assume_alignment %[[D1]], 64 : memref<10x48x2048xf32>
+//       CHECK:   %[[D2:.*]] = affine.apply #{{.*}}(){{\[}}%{{.*}}]
+//       CHECK:   %[[D3:.*]] = affine.min #{{.*}}(){{\[}}%{{.*}}]
+//       CHECK:   %[[D4:.*]] = affine.apply #{{.*}}(){{\[}}%{{.*}}]
+//       CHECK:   %[[D5:.*]] = memref.subview %[[D1]]{{\[}}%{{.*}}, %[[D2]], %[[D4]]] [1, %[[D3]], 32] [1, 1, 1] : memref<10x48x2048xf32> to memref<1x?x32xf32, strided<[98304, 2048, 1], offset: ?>>
+//       CHECK:   %[[D6:.*]] = memref.subview %[[D0]]{{\[}}%{{.*}}, %[[D4]], %[[D2]]] [1, 32, %[[D3]]] [1, 1, 1] : memref<10x2048x48xf32> to memref<1x32x?xf32, strided<[98304, 48, 1], offset: ?>>
+//       CHECK:   %[[D7:.*]] = memref.alloc() : memref<1x32x33xf32, 3>
+//       CHECK:   %[[D8:.*]] = memref.subview %[[D7]][0, 0, 0] [1, 32, 32] [1, 1, 1] : memref<1x32x33xf32, 3> to memref<1x32x32xf32, strided<[1056, 33, 1]>, 3>
+//       CHECK:   %[[D9:.*]] = bufferization.to_tensor %[[D8]] : memref<1x32x32xf32, strided<[1056, 33, 1]>, 3>
+//       CHECK:   %[[D10:.*]] = bufferization.to_memref %[[D9]] : memref<1x32x32xf32>
+//       CHECK:   scf.parallel (%[[ARG0:.*]], %[[ARG1:.*]]) = (%[[C0]], %[[C0]]) to (%[[C32]], %[[C32]]) step (%[[C1]], %[[C1]]) {
+//       CHECK:     memref.store %[[CST]], %[[D10]]{{\[}}%[[C0]], %[[ARG0]], %[[ARG1]]] : memref<1x32x32xf32>
+//       CHECK:     scf.yield
+//       CHECK:   }
+//       CHECK:   %[[D11:.*]] = memref.subview %[[D10]][0, 0, 0] [1, 32, %[[D3]]] [1, 1, 1] : memref<1x32x32xf32> to memref<1x32x?xf32, strided<[1024, 32, 1]>>
+//       CHECK:   linalg.generic {indexing_maps = [#{{.*}}, #{{.*}}], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[D6]] : memref<1x32x?xf32, strided<[98304, 48, 1], offset: ?>>) outs(%[[D11]] : memref<1x32x?xf32, strided<[1024, 32, 1]>>) {
+//       CHECK:   ^bb0(%[[ARG0:.*]]: f32, %[[ARG1:.*]]: f32):
+//       CHECK:     linalg.yield %[[ARG0]] : f32
+//       CHECK:   }
+//       CHECK:   %[[D12:.*]] = memref.alloc() : memref<1x32x33xf32, 3>
+//       CHECK:   %[[D13:.*]] = memref.subview %[[D12]][0, 0, 0] [1, 32, 32] [1, 1, 1] : memref<1x32x33xf32, 3> to memref<1x32x32xf32, strided<[1056, 33, 1]>, 3>
+//       CHECK:   %[[D14:.*]] = bufferization.to_tensor %[[D13]] : memref<1x32x32xf32, strided<[1056, 33, 1]>, 3>
+//       CHECK:   %[[D15:.*]] = bufferization.to_memref %[[D14]] : memref<1x32x32xf32>
+//       CHECK:   scf.parallel (%[[ARG0:.*]], %[[ARG1:.*]]) = (%[[C0]], %[[C0]]) to (%[[C32]], %[[C32]]) step (%[[C1]], %[[C1]]) {
+//       CHECK:     memref.store %[[CST]], %[[D15]]{{\[}}%[[C0]], %[[ARG0]], %[[ARG1]]] : memref<1x32x32xf32>
+//       CHECK:     scf.yield
+//       CHECK:   }
+//       CHECK:   %[[D16:.*]] = memref.subview %[[D15]][0, 0, 0] [1, %[[D3]], 32] [1, 1, 1] : memref<1x32x32xf32> to memref<1x?x32xf32, strided<[1024, 32, 1]>>
+//       CHECK:   linalg.generic {indexing_maps = [#{{.*}}, #{{.*}}], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[D5]] : memref<1x?x32xf32, strided<[98304, 2048, 1], offset: ?>>) outs(%[[D16]] : memref<1x?x32xf32, strided<[1024, 32, 1]>>) {
+//       CHECK:   ^bb0(%[[ARG0:.*]]: f32, %[[ARG1:.*]]: f32):
+//       CHECK:     linalg.yield %[[ARG0]] : f32
+//       CHECK:   }
+//       CHECK:   %[[D17:.*]] = gpu.thread_id  x
+//       CHECK:   %[[D18:.*]] = gpu.thread_id  y
+//       CHECK:   %[[D19:.*]] = affine.apply #{{.*}}(){{\[}}%[[D17]]]
+//       CHECK:   %[[D20:.*]] = vector.transfer_read %[[D10]]{{\[}}%[[C0]], %[[D19]], %[[D18]]], %[[CST]] {in_bounds = [true, true]} : memref<1x32x32xf32>, vector<4x1xf32>
+//       CHECK:   %[[D21:.*]] = vector.broadcast %[[D20]] : vector<4x1xf32> to vector<1x4x1xf32>
+//       CHECK:   %[[D22:.*]] = vector.shape_cast %[[D21]] : vector<1x4x1xf32> to vector<1x1x4xf32>
+//       CHECK:   %[[D23:.*]] = vector.extract %[[D22]][0, 0] : vector<1x1x4xf32>
+//       CHECK:   vector.transfer_write %[[D23]], %[[D15]]{{\[}}%[[C0]], %[[D18]], %[[D19]]] {in_bounds = [true]} : vector<4xf32>, memref<1x32x32xf32>
+//       CHECK:   linalg.generic {indexing_maps = [#{{.*}}, #{{.*}}], iterator_types = ["parallel", "parallel", "parallel"]} ins(%[[D16]] : memref<1x?x32xf32, strided<[1024, 32, 1]>>) outs(%[[D5]] : memref<1x?x32xf32, strided<[98304, 2048, 1], offset: ?>>) {
+//       CHECK:   ^bb0(%[[ARG0:.*]]: f32, %[[ARG1:.*]]: f32):
+//       CHECK:     linalg.yield %[[ARG0]] : f32
+//       CHECK:   }


### PR DESCRIPTION
This removes specialization from the transpose pipeline as it is redundant since padding handles non-alignment. 

Updated TensorAllocPass to account for padded tensors during transpose. These are skipped during allocation. 

Note: Transpose padding is currently not distributed, hence the inclusion of `linalg.generic` in the padded test output. 

Part of https://github.com/iree-org/iree/issues/10005