### PR TITLE
Fix insertion point issue in appendDispatchRegionResult

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h
@@ -33,7 +33,8 @@ LogicalResult reifyDynamicResultDims(OpBuilder &b, Value value,
 /// Append a result to the given DispatchRegionOp. The newly created
 /// DispatchRegionOp is returned.
 FailureOr<Flow::DispatchRegionOp> appendDispatchRegionResult(
-    RewriterBase &rewriter, Flow::DispatchRegionOp regionOp, Value result);
+    RewriterBase &rewriter, Flow::DispatchRegionOp regionOp, Value result,
+    const SmallVector<Value> &dynamicDims);
 
 /// Create an empty DispatchRegionOp.
 Flow::DispatchRegionOp makeEmptyDispatchRegion(OpBuilder &builder,


### PR DESCRIPTION
This fixes a bug where a tensor dims were reified after their use (op dominance error).