### PR TITLE
Add helper build methods to `pack` and `unpack`.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -586,8 +586,8 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
     SmallVector<OpFoldResult> getResultShape(OpBuilder &builder);
 
     // Method to get the `ShapedType` of the result. This is a static method
-    // to allow getting the type of the destination operation expected while
-    // creating the `pack` op.
+    // to allow getting the type of the destination while creating the `pack`
+    // op.
     static ShapedType getPackedType(ShapedType sourceType,
         ArrayRef<int64_t> innerTileSizes, ArrayRef<int64_t> innerDimsPos,
         ArrayRef<int64_t> outerDimsPerm = {});

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -584,6 +584,13 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
         ArrayRef<int64_t> outerDimsPerm = {});
     // Method to return the shape of the result as `SmallVector<OpFoldResult>`.
     SmallVector<OpFoldResult> getResultShape(OpBuilder &builder);
+
+    // Method to get the `ShapedType` of the result. This is a static method
+    // to allow getting the type of the destination operation expected while
+    // creating the `pack` op.
+    static ShapedType getPackedType(ShapedType sourceType,
+        ArrayRef<int64_t> innerTileSizes, ArrayRef<int64_t> innerDimsPos,
+        ArrayRef<int64_t> outerDimsPerm = {});
   }];
 }
 
@@ -607,14 +614,14 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
     Example KCck_to_KC:
 
     ```mlir
-    iree_linalg_ext.pack %arg0 dims_pos = [1, 0]
+    iree_linalg_ext.unpack %arg0 dims_pos = [1, 0]
       inner_tiles = [32, 8] into %arg1 : (memref<16x8x32x8xf32> memref<128x256xf32>)
     ```
 
     Example NCnc_to_NC:
 
     ```mlir
-    iree_linalg_ext.pack %arg0 dims_pos = [0, 1]
+    iree_linalg_ext.unpack %arg0 dims_pos = [0, 1]
       inner_tiles = [8, 32] into %arg1 : (memref<16x8x8x32xf32> memref<128x256xf32>)
     ```
 
@@ -645,6 +652,13 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
     `into` $outputs `:` `(` type($inputs) type($outputs) `)`
      (`->` type($results)^)?
   }];
+
+  let builders = [
+    OpBuilder<(ins "Value":$source, "Value":$output,
+    "ArrayRef<int64_t>":$innerDimsPos,
+    "ArrayRef<OpFoldResult>":$innerTiles,
+    CArg<"ArrayRef<int64_t>", "{}">:$outerDimsPerm)>
+  ];
 
   let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1732,50 +1732,6 @@ static LogicalResult commonVerifierPackAndUnPackOp(OpTy packOrUnPack) {
   return success();
 }
 
-static ShapedType
-inferPackedType(ShapedType sourceType, ArrayRef<int64_t> innerTiles,
-                const DenseMap<int64_t, OpFoldResult> &tileAndPosMapping,
-                ArrayRef<int64_t> outerDimPerm) {
-  SmallVector<int64_t> inferredShape;
-  int64_t rank = sourceType.getRank();
-
-  // tile loop.
-  for (auto dim : llvm::seq<int64_t>(0, rank)) {
-    if (tileAndPosMapping.count(dim)) {
-      Optional<int64_t> tileSize =
-          getConstantIntValue(tileAndPosMapping.lookup(dim));
-      if (sourceType.isDynamicDim(dim) || !tileSize) {
-        inferredShape.push_back(ShapedType::kDynamicSize);
-      } else {
-        int64_t sizeTiledDim = ceilDiv(sourceType.getDimSize(dim), *tileSize);
-        inferredShape.push_back(sizeTiledDim);
-      }
-    } else {
-      inferredShape.push_back(sourceType.getShape()[dim]);
-    }
-  }
-
-  // swap tile loops if `outer_dims_perm` is available.
-  inferredShape =
-      interchange<int64_t>(inferredShape, outerDimPerm, /*offset=*/0);
-
-  // point loop.
-  inferredShape.append(innerTiles.begin(), innerTiles.end());
-
-  return TypeSwitch<Type, ShapedType>(sourceType)
-      .Case<RankedTensorType>([&](RankedTensorType t) -> ShapedType {
-        return RankedTensorType::get(inferredShape,
-                                     sourceType.getElementType());
-      })
-      .Case<MemRefType>([&](MemRefType t) -> ShapedType {
-        return MemRefType::get(inferredShape, sourceType.getElementType());
-      })
-      .Default([&](Type t) {
-        llvm_unreachable("unexpected type");
-        return nullptr;
-      });
-}
-
 //===----------------------------------------------------------------------===//
 // PackOp
 //===----------------------------------------------------------------------===//
@@ -1789,16 +1745,13 @@ void PackOp::build(OpBuilder &builder, OperationState &state, Value source,
   assert(innerDimsPos.size() == innerTiles.size() &&
          "number of tile sizes specified must match the specified number of "
          "original dimensions to be tiled");
-  DenseMap<int64_t, OpFoldResult> tileAndPosMapping;
-  for (auto it : llvm::zip(innerDimsPos, innerTiles))
-    tileAndPosMapping[std::get<0>(it)] = std::get<1>(it);
   SmallVector<int64_t> staticTileSizes;
   SmallVector<Value> dynamicTileSizes;
   dispatchIndexOpFoldResults(innerTiles, dynamicTileSizes, staticTileSizes,
                              ShapedType::kDynamicSize);
   ShapedType resultType =
-      inferPackedType(source.getType().cast<ShapedType>(), staticTileSizes,
-                      tileAndPosMapping, outerDimsPerm);
+      getPackedType(source.getType().cast<ShapedType>(), staticTileSizes,
+                    innerDimsPos, outerDimsPerm);
   build(builder, state, resultType, source, output,
         outerDimsPerm.empty() ? nullptr
                               : builder.getI64ArrayAttr(outerDimsPerm),
@@ -1841,9 +1794,8 @@ LogicalResult PackOp::verify() {
   // Verify result type against inferred type.
   SmallVector<int64_t> outerDimPerm =
       extractFromI64ArrayAttr(getOuterDimsPerm());
-  DenseMap<int64_t, OpFoldResult> tileAndPosMapping = getDimAndTileMapping();
-  ShapedType expectedOutputType = inferPackedType(
-      getInputType(), getStaticTiles(), tileAndPosMapping, outerDimPerm);
+  ShapedType expectedOutputType = getPackedType(
+      getInputType(), getStaticTiles(), innerDimsPos, outerDimPerm);
   if (!isCompatible(expectedOutputType, getOutputType())) {
     return op->emitError(
                "infered type do not match provided output type. Expected ")
@@ -1896,6 +1848,36 @@ SmallVector<OpFoldResult> PackOp::getResultShape(OpBuilder &builder) {
                         getDims(builder, getLoc(), getInput()), getMixedTiles(),
                         extractFromI64ArrayAttr(getInnerDimsPos()),
                         extractFromI64ArrayAttr(getOuterDimsPerm()));
+}
+
+ShapedType PackOp::getPackedType(ShapedType sourceType,
+                                 ArrayRef<int64_t> innerTileSizes,
+                                 ArrayRef<int64_t> innerDimsPos,
+                                 ArrayRef<int64_t> outerDimsPerm) {
+  SmallVector<int64_t> resultShape = llvm::to_vector(sourceType.getShape());
+  for (auto tiledDim : llvm::enumerate(innerDimsPos)) {
+    if (ShapedType::isDynamic(resultShape[tiledDim.value()]))
+      continue;
+    if (ShapedType::isDynamic(innerTileSizes[tiledDim.index()])) {
+      resultShape[tiledDim.value()] = ShapedType::kDynamicSize;
+      continue;
+    }
+    resultShape[tiledDim.value()] = ceilDiv(resultShape[tiledDim.value()],
+                                            innerTileSizes[tiledDim.index()]);
+  }
+  resultShape = interchange<int64_t>(resultShape, outerDimsPerm, /*offset=*/0);
+  resultShape.append(innerTileSizes.begin(), innerTileSizes.end());
+  return TypeSwitch<ShapedType, ShapedType>(sourceType)
+      .Case<RankedTensorType>([&](auto shapedType) {
+        return RankedTensorType::get(resultShape, shapedType.getElementType());
+      })
+      .Case<MemRefType>([&](auto shapedType) {
+        return MemRefType::get(resultShape, shapedType.getElementType());
+      })
+      .Default([&](Type t) {
+        assert(0 && "unexpected type");
+        return nullptr;
+      });
 }
 
 SmallVector<utils::IteratorType> PackOp::getLoopIteratorTypes() {
@@ -2176,6 +2158,22 @@ PackOp::reifyResultShapes(OpBuilder &builder,
 // UnPackOp
 //===----------------------------------------------------------------------===//
 
+/// Custom builder methods for unpack ops.
+void UnPackOp::build(OpBuilder &builder, OperationState &state, Value source,
+                     Value output, ArrayRef<int64_t> innerDimsPos,
+                     ArrayRef<OpFoldResult> innerTiles,
+                     ArrayRef<int64_t> outerDimsPerm) {
+  SmallVector<int64_t> staticTileSizes;
+  SmallVector<Value> dynamicTileSizes;
+  dispatchIndexOpFoldResults(innerTiles, dynamicTileSizes, staticTileSizes,
+                             ShapedType::kDynamicSize);
+  build(builder, state, output.getType(), source, output,
+        outerDimsPerm.empty() ? nullptr
+                              : builder.getI64ArrayAttr(outerDimsPerm),
+        builder.getI64ArrayAttr(innerDimsPos), dynamicTileSizes,
+        builder.getI64ArrayAttr(staticTileSizes));
+}
+
 SmallVector<OpFoldResult> UnPackOp::getMixedTiles() {
   return ::getMixedTiles(*this);
 }
@@ -2284,9 +2282,8 @@ LogicalResult UnPackOp::verify() {
   // incompilete tiles. We allow to `undo` the padding done in the pack.
   SmallVector<int64_t> outerDimPerm =
       extractFromI64ArrayAttr(getOuterDimsPerm());
-  DenseMap<int64_t, OpFoldResult> tileAndPosMapping = getDimAndTileMapping();
-  ShapedType expectedInputType = inferPackedType(
-      getOutputType(), getStaticTiles(), tileAndPosMapping, outerDimPerm);
+  ShapedType expectedInputType = PackOp::getPackedType(
+      getOutputType(), getStaticTiles(), innerDimsPos, outerDimPerm);
   if (!isCompatible(expectedInputType, getInputType())) {
     return op->emitError(
                "infered type do not match provided input type. Expected ")

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1865,7 +1865,11 @@ ShapedType PackOp::getPackedType(ShapedType sourceType,
     resultShape[tiledDim.value()] = ceilDiv(resultShape[tiledDim.value()],
                                             innerTileSizes[tiledDim.index()]);
   }
+
+  // Swap tile loops if outer_dims_perm is available.
   resultShape = interchange<int64_t>(resultShape, outerDimsPerm, /*offset=*/0);
+
+  // Append the inner tile dimensions.
   resultShape.append(innerTileSizes.begin(), innerTileSizes.end());
   return TypeSwitch<ShapedType, ShapedType>(sourceType)
       .Case<RankedTensorType>([&](auto shapedType) {
@@ -1875,7 +1879,7 @@ ShapedType PackOp::getPackedType(ShapedType sourceType,
         return MemRefType::get(resultShape, shapedType.getElementType());
       })
       .Default([&](Type t) {
-        assert(0 && "unexpected type");
+        assert(false && "unexpected type");
         return nullptr;
       });
 }


### PR DESCRIPTION
Also add a static method, `getPackedType`, to `pack` op to get the
type of the result based on the pack op parameters.