### PR TITLE
Relax verifier restrictions for `outer-dims-perm`.

### DIFF
--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -1387,3 +1387,33 @@ func.func @CKkc_to_KC(%arg0: memref<128x256xf32>, %arg1: memref<32x4x32x8xf32>) 
 // CHECK: memref.store %[[VAL]], %[[ARG0]][%[[K]], %[[C]]] : memref<128x256xf32>
 // CHECK: }
 // CHECK: }
+
+// -----
+
+func.func @NPQK_to_NKPQk(%arg0: memref<1x56x56x64xf32>, %arg1: memref<1x2x56x56x32xf32>) {
+  iree_linalg_ext.pack %arg0 outer_dims_perm = [0, 3, 1, 2] inner_dims_pos = [3] inner_tiles = [32] into %arg1 : (memref<1x56x56x64xf32> memref<1x2x56x56x32xf32>)
+  return 
+}
+
+// CHECK-DAG: #[[MAP0:.+]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
+// CHECK: func.func @NPQK_to_NKPQk
+// CHECK-SAME:   %[[INPUT:[a-zA-Z0-9]+]]
+// CHECK-SAME:   %[[OUTPUT:[a-zA-Z0-9]+]]
+// CHECK-DAG: %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG: %[[C1:.+]] = arith.constant 1 : index
+// CHECK-DAG: %[[C2:.+]] = arith.constant 2 : index
+// CHECK-DAG: %[[C56:.+]] = arith.constant 56 : index
+// CHECK-DAG: %[[C32:.+]] = arith.constant 32 : index
+// CHECK: scf.for %[[N:.+]] = %[[C0]] to %[[C1]] step %[[C1]] {
+// CHECK: scf.for %[[K:.+]] = %[[C0]] to %[[C2]] step %[[C1]] {
+// CHECK: scf.for %[[P:.+]] = %[[C0]] to %[[C56]] step %[[C1]] {
+// CHECK: scf.for %[[Q:.+]] = %[[C0]] to %[[C56]] step %[[C1]] {
+// CHECK: scf.for %[[k:.+]] = %[[C0]] to %[[C32]] step %[[C1]] {
+// CHECK: %[[APPLY:.+]] = affine.apply #[[MAP0]](%[[K]], %[[k]])
+// CHECK: %[[VAL:.+]] = memref.load %[[INPUT]][%[[N]], %[[P]], %[[Q]], %[[APPLY]]] : memref<1x56x56x64xf32>
+// CHECK: memref.store %[[VAL]], %[[OUTPUT]][%[[N]], %[[K]], %[[P]], %[[Q]], %[[k]]] : memref<1x2x56x56x32xf32>
+// CHECK: }
+// CHECK: }
+// CHECK: }
+// CHECK: }
+// CHECK: }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -594,7 +594,7 @@ func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf
 
 // -----
 
-// `outer_dims_perm` and `inner_dims_pos` do not agree on the dimensions to tile and interchange.
+// `outer_dims_perm` is out of bound.
 func.func @pack_invalid(%input: tensor<256x128xf32>, %output: tensor<8x8x32x16xf32>) -> tensor<8x8x32x16xf32> {
   // expected-error@+1 {{invalid outer_dims_perm vector}}
   %0 = iree_linalg_ext.unpack %output outer_dims_perm = [2, 1] inner_dims_pos = [0, 1] inner_tiles = [2, 2] into %input : (tensor<8x8x32x16xf32> tensor<256x128xf32>) -> tensor<256x128xf32>


### PR DESCRIPTION
Originally `inner-dims-pos` and `outer-dims-perm` had to agree on the dimension to tile and interchange, meaning that the vector must have the same elements. This patch relaxes the restriction and allows `outer-dims-perms` to target any tiled loop.

We also fix a bug in the interchange routine. `outer-dims-pos` represents the new position for the tile loops. For example, given the dimension [1, 55, 56, 2] and the interchange vector [0, 3, 1, 2] we expect: [1, 2, 55, 56]. Dimension `2` in the old position `3` is now expected at position `1.