### PR TITLE
Extend PadLinalgOps to support batch matmul

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/PadLinalgOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/PadLinalgOps.cpp
@@ -6,8 +6,10 @@
 
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -20,18 +22,22 @@ namespace Flow {
 namespace {
 /// A pattern to pad statically shaped matmul operands to the next integer
 /// multiple of padSize.
-class PadMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
+class PadMatmulOp : public OpInterfaceRewritePattern<linalg::LinalgOp> {
  public:
   PadMatmulOp(MLIRContext *context, int size, PatternBenefit benefit = 1)
-      : OpRewritePattern<linalg::MatmulOp>(context, benefit),
-        paddingSize(size) {}
+      : OpInterfaceRewritePattern(context, benefit), paddingSize(size) {}
 
-  LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
+  LogicalResult matchAndRewrite(linalg::LinalgOp linalgOp,
                                 PatternRewriter &rewriter) const override {
-    auto loc = matmulOp.getLoc();
-    auto lhs = matmulOp.getInputs()[0];
-    auto rhs = matmulOp.getInputs()[1];
-    auto result = matmulOp.getOutputs()[0];
+    Operation *op = linalgOp.getOperation();
+    const bool isBatchMatmul = isa<linalg::BatchMatmulOp>(op);
+    const bool isMatmul = isa<linalg::MatmulOp>(op);
+    if (!isBatchMatmul && !isMatmul) return failure();
+
+    Location loc = linalgOp.getLoc();
+    Value lhs = linalgOp.getInputs()[0];
+    Value rhs = linalgOp.getInputs()[1];
+    Value result = linalgOp.getOutputs()[0];
 
     auto lhsType = lhs.getType().dyn_cast<RankedTensorType>();
     auto rhsType = rhs.getType().dyn_cast<RankedTensorType>();
@@ -45,7 +51,9 @@ class PadMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
     auto lhsShape = lhsType.getShape();
     auto rhsShape = rhsType.getShape();
 
-    int M = lhsShape[0], K = lhsShape[1], N = rhsShape[1];
+    const int B = isBatchMatmul ? lhsShape[0] : -1;
+    const int M = isBatchMatmul ? lhsShape[1] : lhsShape[0];
+    const int K = lhsShape.back(), N = rhsShape.back();
 
     int newMSize = std::ceil(float(M) / paddingSize) * paddingSize;
     int newNSize = std::ceil(float(N) / paddingSize) * paddingSize;
@@ -58,11 +66,18 @@ class PadMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
     if (paddingForM == 0 && paddingForN == 0 && paddingForK == 0)
       return failure();
 
-    auto lhsPaddedType =
-        RankedTensorType::get({newMSize, newKSize}, lhsType.getElementType());
+    auto getFullShape = [&](ArrayRef<int> dims) {
+      SmallVector<int64_t, 3> shape;
+      if (isBatchMatmul) shape.push_back(B);
+      llvm::append_range(shape, dims);
+      return shape;
+    };
 
-    auto rhsPaddedType =
-        RankedTensorType::get({newKSize, newNSize}, rhsType.getElementType());
+    auto lhsPaddedType = RankedTensorType::get(
+        getFullShape({newMSize, newKSize}), lhsType.getElementType());
+
+    auto rhsPaddedType = RankedTensorType::get(
+        getFullShape({newKSize, newNSize}), rhsType.getElementType());
 
     Value lhsPaddingValue = rewriter.create<arith::ConstantOp>(
         loc, rewriter.getZeroAttr(lhsType.getElementType()));
@@ -72,38 +87,40 @@ class PadMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
 
     auto createPadding = [&](ArrayRef<int64_t> padding) {
       SmallVector<OpFoldResult> result;
+      if (isBatchMatmul) {
+        result.push_back(rewriter.getI64IntegerAttr(0));
+      }
       for (auto pad : padding) {
         result.push_back(rewriter.getI64IntegerAttr(pad));
       }
       return result;
     };
 
-    Value paddedLhs =
-        (paddingForM > 0 || paddingForK > 0)
-            ? tensor::createPadScalarOp(
-                  lhsPaddedType, lhs, lhsPaddingValue, createPadding({0, 0}),
-                  createPadding({paddingForM, paddingForK}), /*nofold=*/false,
-                  loc, rewriter)
-            : lhs;
+    Value paddedLhs = lhs;
+    if (paddingForM > 0 || paddingForK > 0) {
+      paddedLhs = tensor::createPadScalarOp(
+          lhsPaddedType, lhs, lhsPaddingValue, createPadding({0, 0}),
+          createPadding({paddingForM, paddingForK}), /*nofold=*/false, loc,
+          rewriter);
+    }
 
-    Value paddedRhs =
-        (paddingForK > 0 || paddingForN > 0)
-            ? tensor::createPadScalarOp(
-                  rhsPaddedType, rhs, rhsPaddingValue, createPadding({0, 0}),
-                  createPadding({paddingForK, paddingForN}), /*nofold=*/false,
-                  loc, rewriter)
-            : rhs;
+    Value paddedRhs = rhs;
+    if (paddingForK > 0 || paddingForN > 0) {
+      paddedRhs = tensor::createPadScalarOp(
+          rhsPaddedType, rhs, rhsPaddingValue, createPadding({0, 0}),
+          createPadding({paddingForK, paddingForN}),
+          /*nofold=*/false, loc, rewriter);
+    }
 
     // Padding for K-dim doesn't change result size.
     if (paddingForM == 0 && paddingForN == 0) {
       auto paddedMatmulOp =
-          cast<linalg::LinalgOp>(matmulOp.getOperation())
-              .clone(rewriter, loc, {resultType},
-                     ArrayRef<Value>{paddedLhs, paddedRhs, result});
-      rewriter.replaceOp(matmulOp, paddedMatmulOp->getResults());
+          linalgOp.clone(rewriter, loc, {resultType},
+                         ArrayRef<Value>{paddedLhs, paddedRhs, result});
+      rewriter.replaceOp(linalgOp, paddedMatmulOp->getResults());
     } else {
-      auto newResultType = RankedTensorType::get({newMSize, newNSize},
-                                                 resultType.getElementType());
+      auto newResultType = RankedTensorType::get(
+          getFullShape({newMSize, newNSize}), resultType.getElementType());
       auto resultPaddingValue = rewriter.create<arith::ConstantOp>(
           loc, rewriter.getZeroAttr(resultType.getElementType()));
       Value paddedResult = tensor::createPadScalarOp(
@@ -111,16 +128,25 @@ class PadMatmulOp : public OpRewritePattern<linalg::MatmulOp> {
           createPadding({paddingForM, paddingForN}), /*nofold=*/false, loc,
           rewriter);
       auto paddedMatmulOp =
-          cast<linalg::LinalgOp>(matmulOp.getOperation())
-              .clone(rewriter, loc, {newResultType},
-                     ArrayRef<Value>{paddedLhs, paddedRhs, paddedResult});
+          linalgOp.clone(rewriter, loc, {newResultType},
+                         ArrayRef<Value>{paddedLhs, paddedRhs, paddedResult});
 
-      SmallVector<OpFoldResult> offsets(2, rewriter.getI64IntegerAttr(0));
-      SmallVector<OpFoldResult> strides(2, rewriter.getI64IntegerAttr(1));
-      SmallVector<OpFoldResult> sizes = {rewriter.getIndexAttr(M),
-                                         rewriter.getIndexAttr(N)};
+      auto zero = rewriter.getI64IntegerAttr(0);
+      auto one = rewriter.getI64IntegerAttr(1);
+      auto mAttr = rewriter.getIndexAttr(M);
+      auto nAttr = rewriter.getIndexAttr(N);
+      SmallVector<OpFoldResult> offsets, strides, sizes;
+      if (isBatchMatmul) {
+        offsets.assign(3, zero);
+        strides.assign(3, one);
+        sizes = {rewriter.getIndexAttr(B), mAttr, nAttr};
+      } else {
+        offsets.assign(2, zero);
+        strides.assign(2, one);
+        sizes = {mAttr, nAttr};
+      }
       rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
-          matmulOp, paddedMatmulOp->getResults()[0], offsets, sizes, strides);
+          linalgOp, paddedMatmulOp->getResults()[0], offsets, sizes, strides);
     }
 
     return success();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pad_linalg_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/pad_linalg_ops.mlir
@@ -53,3 +53,37 @@ func.func @matmul_i8_i8_i32_2x2x4(%lhs: tensor<2x4xi8>, %rhs: tensor<4x2xi8>, %d
 //  CHECK-SAME:         outs(%[[PADDED_DST]] : tensor<4x4xi32>)
 //       CHECK:      %[[RESULT:.+]] = tensor.extract_slice %[[PADDED_RESULT]]
 //       CHECK:      return %[[RESULT]] : tensor<2x2xi32>
+
+// -----
+
+func.func @batch_matmul_f32_7x11x13x17(%lhs: tensor<7x11x17xf32>, %rhs: tensor<7x17x13xf32>, %init: tensor<7x11x13xf32>) -> tensor<7x11x13xf32> {
+    %result = linalg.batch_matmul ins(%lhs, %rhs : tensor<7x11x17xf32>, tensor<7x17x13xf32>) outs(%init : tensor<7x11x13xf32>) -> tensor<7x11x13xf32>
+    return %result : tensor<7x11x13xf32>
+}
+
+// CHECK-LABEL: func.func @batch_matmul_f32_7x11x13x17
+//  CHECK-SAME: (%[[LHS:.+]]: tensor<7x11x17xf32>, %[[RHS:.+]]: tensor<7x17x13xf32>, %[[DST:.+]]: tensor<7x11x13xf32>)
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[LHS]] low[0, 0, 0] high[0, 1, 3]
+//       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[RHS]] low[0, 0, 0] high[0, 3, 3]
+//       CHECK:   %[[PADDED_DST:.+]] = tensor.pad %[[DST]] low[0, 0, 0] high[0, 1, 3]
+//       CHECK:   %[[BM:.+]] = linalg.batch_matmul
+//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<7x12x20xf32>, tensor<7x20x16xf32>)
+//  CHECK-SAME:     outs(%[[PADDED_DST]] : tensor<7x12x16xf32>)
+//       CHECK:   %[[EXTRACT:.+]] = tensor.extract_slice %[[BM]][0, 0, 0] [7, 11, 13] [1, 1, 1]
+//       CHECK:   return %[[EXTRACT]]
+
+// -----
+
+func.func @batch_matmul_f32_7x12x12x17(%lhs: tensor<7x12x17xf32>, %rhs: tensor<7x17x12xf32>, %init: tensor<7x12x12xf32>) -> tensor<7x12x12xf32> {
+    %result = linalg.batch_matmul ins(%lhs, %rhs : tensor<7x12x17xf32>, tensor<7x17x12xf32>) outs(%init : tensor<7x12x12xf32>) -> tensor<7x12x12xf32>
+    return %result : tensor<7x12x12xf32>
+}
+
+// CHECK-LABEL: func.func @batch_matmul_f32_7x12x12x17
+//  CHECK-SAME: (%[[LHS:.+]]: tensor<7x12x17xf32>, %[[RHS:.+]]: tensor<7x17x12xf32>, %[[DST:.+]]: tensor<7x12x12xf32>)
+//       CHECK:   %[[PADDED_LHS:.+]] = tensor.pad %[[LHS]] low[0, 0, 0] high[0, 0, 3]
+//       CHECK:   %[[PADDED_RHS:.+]] = tensor.pad %[[RHS]] low[0, 0, 0] high[0, 3, 0]
+//       CHECK:   %[[BM:.+]] = linalg.batch_matmul
+//  CHECK-SAME:     ins(%[[PADDED_LHS]], %[[PADDED_RHS]] : tensor<7x12x20xf32>, tensor<7x20x12xf32>)
+//  CHECK-SAME:     outs(%[[DST]] : tensor<7x12x12xf32>)
+//       CHECK:   return %[[BM]]


### PR DESCRIPTION
For linalg.batch_matmul we still only pad along M, N, K dimensions.