### PR TITLE
Increase tmpfs size for CPU runners

### DIFF
--- a/build_tools/github_actions/runner/config/register.sh
+++ b/build_tools/github_actions/runner/config/register.sh
@@ -18,9 +18,7 @@ source "${SCRIPT_DIR}/functions.sh"
 # These use OS inventory management to fetch information about the VM operating
 # system (https://cloud.google.com/compute/docs/instances/os-inventory-management).
 # For some reason, querying these at startup is unreliable. It seems like the
-# guestInventory attributes take a really long time to be populated. For now,
-# anything in here we care about needs to be injected via the
-# `github-runner-labels` custom metadata attribute.
+# guestInventory attributes take a really long time to be populated.
 # OS_ID="$(get_os_info ShortName)"
 # OS_VERSION="$(get_os_info Version)"
 # KERNEL_RELEASE="$(get_os_info KernelRelease)"
@@ -52,7 +50,7 @@ ZONE="$(get_metadata instance/zone | awk -F/ '{print $NF}')"
 CPU_PLATFORM="$(get_metadata instance/cpu-platform)"
 MACHINE_TYPE="$(get_metadata instance/machine-type | awk -F/ '{print $NF}')"
 
-RUNNER_CUSTOM_LABELS="$(get_attribute github-runner-labels)"
+RUNNER_TYPE="$(get_attribute github-runner-type)"
 RUNNER_GROUP="$(get_attribute github-runner-group)"
 RUNNER_SCOPE="$(get_attribute github-runner-scope)"
 RUNNER_TRUST="$(get_attribute github-runner-trust)"
@@ -74,6 +72,7 @@ declare -a RUNNER_LABELS_ARRAY=(
   "cpu-platform=${CPU_PLATFORM}"
   "machine-type=${MACHINE_TYPE}"
   "config-ref=${CONFIG_REF}"
+  "${RUNNER_TYPE}"
   # These labels require guest attributes. See note above.
   # "arch=${ARCH}"
   # "${ARCH}"
@@ -83,8 +82,6 @@ declare -a RUNNER_LABELS_ARRAY=(
 )
 
 RUNNER_LABELS="$(IFS="," ; echo "${RUNNER_LABELS_ARRAY[*]}")"
-# Append custom labels, taking care to only add a comma if there are any
-RUNNER_LABELS="${RUNNER_LABELS}${RUNNER_CUSTOM_LABELS:+,${RUNNER_CUSTOM_LABELS}}"
 
 INSTANCE_ID="$(get_metadata instance/id)"
 GOOGLE_CLOUD_PROJECT="$(get_metadata project/project-id)"

--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -14,9 +14,19 @@ set -xeuo pipefail
 SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
 source "${SCRIPT_DIR}/functions.sh"
 
+RUNNER_TYPE="$(get_attribute github-runner-type)"
+# The CPU machines have 360GB of RAM
+TMPFS_SIZE=100g
+if [[ "${RUNNER_TYPE}" == gpu ]]; then
+  # The GPU machines have only 85GB of RAM
+  # TODO(gcmn): Switch to using a local ssd. This is probably too much of the
+  # RAM.
+  TMPFS_SIZE=50g
+fi
+
 echo "Creating tmpfs for runner"
 mkdir /runner-root
-mount -t tmpfs -o size=50g tmpfs /runner-root
+mount -t tmpfs -o size="${TMPFS_SIZE}" tmpfs /runner-root
 cp -r "${SCRIPT_DIR}" /runner-root/config
 chown -R runner:runner /runner-root/
 

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -95,7 +95,7 @@ function create_template() {
     "${METADATA[@]}"
     "github-runner-group=${group}"
     "github-runner-trust=${trust}"
-    "github-runner-labels=${type}"
+    "github-runner-type=${type}"
   )
 
   # Join on commas


### PR DESCRIPTION
This is somewhat of a stop-gap. I think we should really switch to
using local SSD. tmpfs seemed easiest at the time because the CPU
machines had so much RAM, but I didn't realize how little the GPU
machines have.

Part of https://github.com/iree-org/iree/issues/10739 