### PR TITLE
Switch to use emitWarning with loc variant.

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToLinalgOnTensors.cpp
@@ -348,7 +348,8 @@ struct ScatterUpdateConversion : public OpConversionPattern<mhlo::ScatterOp> {
     result = rewriter.create<arith::SelectOp>(loc, args[2].getType(), pred,
                                               args[2], result);
 
-    op.emitWarning("op is lowered to an inefficient way, which is unexpected");
+    emitWarning(loc,
+                "op is lowered to an inefficient way, which is unexpected");
     rewriter.replaceOpWithNewOp<linalg::YieldOp>(terminator, result);
     rewriter.replaceOp(op, linalgOp.getResults());
     return success();


### PR DESCRIPTION
A crash was triggered in multi-threaded mode. Switching to loc variant avoids the crash.