### PR TITLE
Drop LinalgVectorizationOptions and ensure code compiles and runs pro…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
@@ -252,12 +252,11 @@ static void populateTilingAndDistribute(RewritePatternSet &patterns,
 
 static void populateVectorizationPatterns(RewritePatternSet &patterns) {
   VectorizationPatterns<linalg::GenericOp>::insert(
-      patterns, linalg::LinalgVectorizationOptions(),
-      IREE::LinalgExt::LinalgTransformationFilter(
-          {StringAttr::get(patterns.getContext(),
-                           getCopyToWorkgroupMemoryMarker()),
-           StringAttr::get(patterns.getContext(), kCopyDistributed)},
-          llvm::None));
+      patterns, IREE::LinalgExt::LinalgTransformationFilter(
+                    {StringAttr::get(patterns.getContext(),
+                                     getCopyToWorkgroupMemoryMarker()),
+                     StringAttr::get(patterns.getContext(), kCopyDistributed)},
+                    llvm::None));
 }
 
 /// Return a flattened Id Value by combining the 3D gpu thread IDs.

--- a/compiler/src/iree/compiler/Codegen/Common/GPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUVectorization.cpp
@@ -36,7 +36,6 @@ static constexpr int64_t kMaxVectorSize = 4096;
 
 static void populateVectorizationPatterns(RewritePatternSet &patterns) {
   MLIRContext *ctx = patterns.getContext();
-  linalg::LinalgVectorizationOptions opt;
   IREE::LinalgExt::LinalgTransformationFilter f(
       {StringAttr::get(ctx, getWorkgroupKTiledMarker()),
        StringAttr::get(ctx, getVectorizeMarker())},
@@ -59,10 +58,10 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns) {
   });
   VectorizationPatterns<linalg::FillOp, linalg::GenericOp,
                         linalg::Conv1DNwcWcfOp,
-                        linalg::Conv1DNcwFcwOp>::insert(patterns, opt, f);
+                        linalg::Conv1DNcwFcwOp>::insert(patterns, f);
   patterns.add<linalg::CopyVectorizationPattern>(ctx);
   patterns.add<LinalgVectorizationPattern>(
-      ctx, f.addOpFilter<linalg::ContractionOpInterface>(), opt);
+      ctx, f.addOpFilter<linalg::ContractionOpInterface>());
 }
 
 namespace {

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -283,8 +283,8 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
 
     // Add a marker to the last operation in the list.
     auto marker = StringAttr::get(context, "__workgroup_tiling__");
-    computeOps.back()->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker,
-                               marker);
+    computeOps.back()->setAttr(
+        IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker, marker);
 
     // Configure the linalg options.
     // Tile size selection function.
@@ -324,7 +324,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
     // potentially left with a marker that will confuse the following passes so
     // we remove the intermediate markers.
     funcOp->walk([&](Operation *op) {
-      op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+      op->removeAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
     });
 
     LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/VerifyLinalgTransformLegality.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/VerifyLinalgTransformLegality.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
@@ -25,7 +26,8 @@ void VerifyLinalgTransformLegalityPass::runOnOperation() {
   auto moduleOp = getOperation();
   // For now only check that there are no Linalg transform markers.
   auto walkResult = moduleOp.walk([](linalg::LinalgOp op) -> WalkResult {
-    if (op->hasAttr(linalg::LinalgTransforms::kLinalgTransformMarker)) {
+    if (op->hasAttr(
+            IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker)) {
       return op.emitError("expected no Linalg transform markers");
     }
     return WalkResult::advance();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -29,14 +29,11 @@ extern llvm::cl::opt<bool> llvmgpuUseMMASync;
 //====---------------------------------------------------------------------===//
 
 static void populateVectorizationPatterns(RewritePatternSet &patterns) {
-  linalg::LinalgVectorizationOptions opt;
   IREE::LinalgExt::LinalgTransformationFilter f(
       StringAttr::get(patterns.getContext(), getVectorizeMarker()));
-  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns,
-                                                                   opt, f);
+  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns, f);
   patterns.add<LinalgVectorizationPattern>(
-      patterns.getContext(), f.addOpFilter<linalg::ContractionOpInterface>(),
-      opt);
+      patterns.getContext(), f.addOpFilter<linalg::ContractionOpInterface>());
   vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
   vector::populateVectorReductionToContractPatterns(patterns);
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileTensor.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileTensor.cpp
@@ -201,7 +201,7 @@ struct LLVMGPUTileTensorPass
     if (!isEntryPoint(funcOp)) return;
 
     funcOp->walk([&](linalg::LinalgOp op) {
-      op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+      op->removeAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
     });
 
     auto workgroupSize = llvm::to_vector<4>(llvm::map_range(

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -141,7 +141,8 @@ static LogicalResult tileReduction(func::FuncOp funcOp) {
     if (isa<linalg::ContractionOpInterface>(*op) ||
         isa<linalg::ConvolutionOpInterface>(*op) ||
         isa<linalg::GenericOp>(*op)) {
-      op->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker, marker);
+      op->setAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker,
+                  marker);
     }
   });
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -190,7 +190,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
 
   funcOp.walk([&](Operation *op) {
     if (isa<linalg::FillOp, linalg::GenericOp>(op)) {
-      op->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker,
+      op->setAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker,
                   StringAttr::get(context, getWorkgroupMemoryMarker()));
     } else if (isa<linalg::BatchMatmulOp, linalg::MatmulOp>(op)) {
       auto lhsShape = op->getOperand(0).getType().cast<ShapedType>().getShape();
@@ -208,7 +208,7 @@ void SPIRVTileAndPromotePass::runOnOperation() {
       } else if (canPromoteRHS) {
         promoteMarker = StringAttr::get(context, promoteRHSMarker);
       }
-      op->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker,
+      op->setAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker,
                   promoteMarker);
     }
     return WalkResult::advance();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -147,13 +147,11 @@ static void populateTilingToSubgroupPatterns(ArrayRef<int64_t> subgroupCounts,
 /// Adds patterns to vectorize Linalg ops with vectorization markers.
 void populateVectorizationPatterns(MLIRContext *context,
                                    RewritePatternSet &patterns) {
-  linalg::LinalgVectorizationOptions opt;
   IREE::LinalgExt::LinalgTransformationFilter f(
       StringAttr::get(context, getVectorizeMarker()));
-  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns,
-                                                                   opt, f);
+  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns, f);
   patterns.add<LinalgVectorizationPattern>(
-      context, f.addOpFilter<linalg::ContractionOpInterface>(), opt);
+      context, f.addOpFilter<linalg::ContractionOpInterface>());
   vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
   vector::populateVectorReductionToContractPatterns(patterns);
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -120,14 +120,11 @@ Optional<SmallVector<int64_t, 4>> getNativeVectorShape(Operation *op) {
 
 /// Add patterns to vectorize any supported Linalg ops.
 void populateVectorizationPatterns(RewritePatternSet &patterns) {
-  linalg::LinalgVectorizationOptions opt;
   IREE::LinalgExt::LinalgTransformationFilter f;
-  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns,
-                                                                   opt, f);
+  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns, f);
   linalg::populateConvolutionVectorizationPatterns(patterns);
   patterns.add<LinalgVectorizationPattern>(
-      patterns.getContext(), f.addOpFilter<linalg::ContractionOpInterface>(),
-      opt);
+      patterns.getContext(), f.addOpFilter<linalg::ContractionOpInterface>());
 }
 
 /// Adds patterns to unroll vector ops to SPIR-V native vector size.

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD
@@ -34,6 +34,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     "Utils.cpp"
   DEPS
     IREELinalgExtDialect
+    IREELinalgExtPasses
     LLVMSupport
     MLIRAffineDialect
     MLIRArithDialect

--- a/compiler/src/iree/compiler/Codegen/Utils/MarkerUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/MarkerUtils.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Operation.h"
@@ -47,14 +48,14 @@ StringRef getDeleteMarker() { return "delete"; }
 
 StringRef getMarkerOrNull(Operation *op) {
   StringAttr attr = op->getAttrOfType<StringAttr>(
-      linalg::LinalgTransforms::kLinalgTransformMarker);
+      IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
   if (!attr) return "";
   return attr.getValue();
 }
 
 bool hasMarker(Operation *op, ArrayRef<StringRef> marker) {
   StringAttr attr = op->getAttrOfType<StringAttr>(
-      linalg::LinalgTransforms::kLinalgTransformMarker);
+      IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
   return attr && (marker.empty() ||
                   llvm::any_of(marker, [&attr](StringRef markerValue) {
                     return attr.getValue() == markerValue;
@@ -62,7 +63,7 @@ bool hasMarker(Operation *op, ArrayRef<StringRef> marker) {
 }
 
 void setMarker(Operation *op, StringRef marker) {
-  op->setAttr(linalg::LinalgTransforms::kLinalgTransformMarker,
+  op->setAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker,
               StringAttr::get(op->getContext(), marker));
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -1248,7 +1248,7 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
   funcOp.walk([](Operation *op) {
     removeFusionGroupsAttribute(op);
     removeRootOpAttribute(op);
-    op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+    op->removeAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
   });
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensorsViaRegionOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensorsViaRegionOps.cpp
@@ -11,6 +11,7 @@
 // Note: The heuristic part of the implementation is unchanged and copied from
 // DispatchLinalgOnTensors.cpp.
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/ConvertTensorToFlow.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
@@ -764,7 +765,7 @@ void DispatchLinalgOnTensorsViaRegionOpsPass::runOnOperation() {
   funcOp.walk([](Operation *op) {
     removeFusionGroupsAttribute(op);
     removeRootOpAttribute(op);
-    op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+    op->removeAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
   });
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SplitReduction.cpp
@@ -126,10 +126,10 @@ struct SplitReductionPass : public SplitReductionBase<SplitReductionPass> {
     // Remove all the markers at the end.
     auto funcOp = getOperation();
     funcOp->walk([&](linalg::LinalgOp op) {
-      op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+      op->removeAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
     });
     funcOp->walk([&](LinalgExt::LinalgExtOp op) {
-      op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+      op->removeAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
       op->removeAttr(
           mlir::iree_compiler::IREE::LinalgExt::kSplitReductionDepthMarker);
     });

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -174,8 +174,6 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyPeelPass(
 /// Create a LinalgStrategyVectorizePass.
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyVectorizePass(
     StringRef opName = "",
-    linalg::LinalgVectorizationOptions opt =
-        linalg::LinalgVectorizationOptions(),
     const LinalgExt::LinalgTransformationFilter &filter =
         LinalgExt::LinalgTransformationFilter(),
     bool padVectorize = false);

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/CodegenStrategy.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/CodegenStrategy.h
@@ -128,28 +128,24 @@ private:
 /// Represent one application of createLinalgStrategyVectorizePass.
 struct Vectorize : public Transformation {
   explicit Vectorize(
-      linalg::LinalgVectorizationOptions options,
       LinalgExt::LinalgTransformationFilter::FilterFunction f = nullptr,
       bool padVectorize = false)
-      : Transformation(std::move(f)), options(options),
-        vectorizePadding(padVectorize) {}
+      : Transformation(std::move(f)), vectorizePadding(padVectorize) {}
 
-  Vectorize(StringRef name, linalg::LinalgVectorizationOptions options,
+  Vectorize(StringRef name,
             LinalgExt::LinalgTransformationFilter::FilterFunction f = nullptr,
             bool padVectorize = false)
-      : Transformation(std::move(f)), opName(name), options(options),
+      : Transformation(std::move(f)), opName(name),
         vectorizePadding(padVectorize) {}
 
   void
   addToPassPipeline(OpPassManager &pm,
                     LinalgExt::LinalgTransformationFilter m) const override {
-    pm.addPass(createLinalgStrategyVectorizePass(opName, options, m,
-                                                 vectorizePadding));
+    pm.addPass(createLinalgStrategyVectorizePass(opName, m, vectorizePadding));
   }
 
 private:
   std::string opName;
-  linalg::LinalgVectorizationOptions options;
   bool vectorizePadding;
 };
 
@@ -257,8 +253,8 @@ struct CodegenStrategy {
       StringRef opName,
       const LinalgExt::LinalgTransformationFilter::FilterFunction &f = nullptr,
       bool vectorizePadding = false) {
-    transformationSequence.emplace_back(std::make_unique<Vectorize>(
-        opName, linalg::LinalgVectorizationOptions(), f, vectorizePadding));
+    transformationSequence.emplace_back(
+        std::make_unique<Vectorize>(opName, f, vectorizePadding));
     return *this;
   }
   /// Conditionally append a pattern to rewrite `LinalgOpType` as a vector

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
@@ -195,15 +195,11 @@ struct LinalgVectorizationPattern
   LinalgVectorizationPattern(
       MLIRContext *context,
       LinalgTransformationFilter f = LinalgTransformationFilter(),
-      linalg::LinalgVectorizationOptions options =
-          linalg::LinalgVectorizationOptions(),
       PatternBenefit benefit = 1);
 
   /// Construct a pattern specifically applied to `opName`.
   LinalgVectorizationPattern(
       StringRef opName, MLIRContext *context,
-      linalg::LinalgVectorizationOptions options =
-          linalg::LinalgVectorizationOptions(),
       LinalgTransformationFilter f = LinalgTransformationFilter(),
       PatternBenefit benefit = 1);
 
@@ -222,7 +218,6 @@ template <>
 class VectorizationPatterns<> {
 public:
   static void insert(RewritePatternSet &patterns,
-                     const linalg::LinalgVectorizationOptions &options,
                      const LinalgTransformationFilter &f) {}
 };
 
@@ -230,11 +225,10 @@ template <typename OpTy, typename... OpTypes>
 class VectorizationPatterns<OpTy, OpTypes...> {
 public:
   static void insert(RewritePatternSet &patterns,
-                     const linalg::LinalgVectorizationOptions &options,
                      const LinalgTransformationFilter &f) {
     patterns.add<LinalgVectorizationPattern>(OpTy::getOperationName(),
-                                             patterns.getContext(), options, f);
-    VectorizationPatterns<OpTypes...>::insert(patterns, options, f);
+                                             patterns.getContext(), f);
+    VectorizationPatterns<OpTypes...>::insert(patterns, f);
   }
 };
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
@@ -409,7 +409,7 @@ struct TopkSplitReductionPass
     // Remove all the markers at the end.
     auto funcOp = getOperation();
     funcOp->walk([&](TopkOp op) {
-      op->removeAttr(linalg::LinalgTransforms::kLinalgTransformMarker);
+      op->removeAttr(LinalgTransforms::kLinalgTransformMarker);
       op->removeAttr(kSplitReductionDepthMarker);
     });
   }


### PR DESCRIPTION
…perly at LLVM f4ad1b6f697cc80b1a72b3b24fdae5a4db54e304

With these last patch ups #10760 is green.

We can land these changes ahead of time to simplify future integration.