### PR TITLE
[spirv] Add barrier when performing copy involving workgroup memory

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -17,6 +17,7 @@
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
+#include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/MemRefToSPIRV/MemRefToSPIRV.h"
@@ -26,6 +27,7 @@
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVEnums.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/Dialect/SPIRV/Transforms/Passes.h"
 #include "mlir/Dialect/SPIRV/Transforms/SPIRVConversion.h"
@@ -78,7 +80,18 @@ static LogicalResult gpuDeallocationFn(OpBuilder &builder, Location loc,
 
 static LogicalResult gpuCopyFn(OpBuilder &builder, Location loc, Value from,
                                Value to) {
-  createLinalgCopyOp(builder, loc, from, to);
+  Optional<unsigned> workgroupSpace =
+      spirv::mapVulkanStorageClassToMemorySpace(spirv::StorageClass::Workgroup);
+  auto fromType = from.getType().cast<MemRefType>();
+  auto toType = to.getType().cast<MemRefType>();
+  bool isWorkgroupMemory = fromType.getMemorySpaceAsInt() == workgroupSpace ||
+                           toType.getMemorySpaceAsInt() == workgroupSpace;
+  if (isWorkgroupMemory) builder.create<gpu::BarrierOp>(loc);
+  Operation *copy = createLinalgCopyOp(builder, loc, from, to);
+  if (isWorkgroupMemory) {
+    setMarker(copy, getCopyToWorkgroupMemoryMarker());
+    builder.create<gpu::BarrierOp>(loc);
+  }
   return success();
 }
 


### PR DESCRIPTION
We don't actually use workgroup memory for mobile GPUs; so no copy there. For desktop GPUs where we may use workgroup memory, the pass pipeline handles barrier already. However there are cases allocation might be generated unexpectedly; just be conservative to avoid numeric issues.