### PR TITLE
Support large reduction in group reduction path

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -180,6 +180,7 @@ iree_compiler_cc_library(
         "FoldAffineMinInDistributedLoops.cpp",
         "GPUDistributeSharedMemoryCopy.cpp",
         "GPUPipelining.cpp",
+        "GPUTileReduction.cpp",
         "GPUVectorization.cpp",
         "LinalgOpInfo.cpp",
         "MemrefCopyToLinalg.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -154,6 +154,7 @@ iree_cc_library(
     "FoldAffineMinInDistributedLoops.cpp"
     "GPUDistributeSharedMemoryCopy.cpp"
     "GPUPipelining.cpp"
+    "GPUTileReduction.cpp"
     "GPUVectorization.cpp"
     "LinalgOpInfo.cpp"
     "MemrefCopyToLinalg.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPUTileReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUTileReduction.cpp
@@ -1,0 +1,84 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Utils/MarkerUtils.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "mlir/Transforms/Passes.h"
+
+#define DEBUG_TYPE "iree-codegen-gpu-tile-reduction"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+/// A simple pattern rewriter that implements no special logic.
+class SimpleRewriter : public PatternRewriter {
+ public:
+  SimpleRewriter(MLIRContext *context) : PatternRewriter(context) {}
+};
+}  // namespace
+
+namespace {
+
+static LogicalResult tileReduction(linalg::GenericOp op) {
+  // First split the reduction.
+  SimpleRewriter rewriter(op.getContext());
+  rewriter.setInsertionPoint(op);
+  auto control = [](linalg::LinalgOp op) {
+    linalg::SplitReductionOptions option;
+    SmallVector<int64_t> tileSize = getTileSizes(op, 1);
+    if (tileSize.empty()) return option;
+    option.ratio = tileSize.back();
+    option.innerParallel = true;
+    option.index = op.getNumLoops() - 1;
+    return option;
+  };
+  FailureOr<linalg::SplitReductionResult> result =
+      linalg::splitReduction(rewriter, op, control);
+  if (failed(result)) return failure();
+
+  unsigned numLoops = result->splitLinalgOp.getNumLoops();
+  // Then tile the new dimension to 1.
+  SmallVector<int64_t> tileSizes(numLoops, 0);
+  tileSizes[numLoops - 2] = 1;
+  linalg::LinalgTilingOptions tileOption;
+  tileOption.setTileSizes(tileSizes);
+  FailureOr<linalg::TiledLinalgOp> tiledOps =
+      linalg::tileLinalgOp(rewriter, result->splitLinalgOp, tileOption);
+  if (failed(tiledOps)) return failure();
+  rewriter.replaceOp(result->splitLinalgOp, tiledOps->tensorResults);
+  return success();
+}
+struct GPUTileReductionPass
+    : public GPUTileReductionBase<GPUTileReductionPass> {
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    SmallVector<linalg::GenericOp> genericOps;
+    funcOp.walk([&](linalg::GenericOp op) { genericOps.push_back(op); });
+    for (linalg::GenericOp op : genericOps) {
+      if (op.getNumReductionLoops() > 0) {
+        if (failed(tileReduction(op))) {
+          return signalPassFailure();
+        }
+      }
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>> createGPUTileReductionPass() {
+  return std::make_unique<GPUTileReductionPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/GPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUVectorization.cpp
@@ -105,6 +105,8 @@ struct GPUVectorizationPass
             funcOp, std::move(vectorizationPatterns)))) {
       return signalPassFailure();
     }
+
+    linalg::hoistRedundantVectorTransfersOnTensor(funcOp);
   }
 };
 }  // namespace

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "swizzle_workgroup.mlir",
             "test_partitionable_loops_interface.mlir",
             "tile_and_distribute_to_workgroups.mlir",
+            "tile_reduction.mlir",
             "transform_dialect_apply_pattern_op.mlir",
             "transpose_canonicalization.mlir",
             "type_propagation.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_lit_test_suite(
     "swizzle_workgroup.mlir"
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_to_workgroups.mlir"
+    "tile_reduction.mlir"
     "transform_dialect_apply_pattern_op.mlir"
     "transpose_canonicalization.mlir"
     "type_propagation.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_reduction.mlir
@@ -1,0 +1,46 @@
+// RUN: iree-opt -iree-codegen-gpu-tile-reduction --split-input-file -canonicalize -canonicalize -cse %s | FileCheck %s
+
+
+func.func @warp_reduction_dispatch() {
+  %cst = arith.constant 1.000000e+00 : f32
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:512x10240xf32>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:512xf32>
+  %workgroup_id_x = hal.interface.workgroup.id[0] : index
+  %2 = flow.dispatch.tensor.load %1, offsets = [%workgroup_id_x], sizes = [1], strides = [1] : !flow.dispatch.tensor<writeonly:512xf32> -> tensor<1xf32>
+  %3 = flow.dispatch.tensor.load %0, offsets = [%workgroup_id_x, 0], sizes = [1, 10240], strides = [1, 1] : !flow.dispatch.tensor<readonly:512x10240xf32> -> tensor<1x10240xf32>
+  %4 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1], [0, 2048]]>} ins(%cst : f32) outs(%2 : tensor<1xf32>) -> tensor<1xf32>
+  %5 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%3 : tensor<1x10240xf32>) outs(%4 : tensor<1xf32>)
+    attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1], [0, 2048]]>} {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<1xf32>
+  flow.dispatch.tensor.store %5, %1, offsets = [%workgroup_id_x], sizes = [1], strides = [1] : tensor<1xf32> -> !flow.dispatch.tensor<writeonly:512xf32>
+  return
+}
+
+//   CHECK-DAG: #[[$MAP0:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+//   CHECK-DAG: #[[$MAP1:.+]] = affine_map<(d0, d1, d2) -> (d0, d2)>
+//   CHECK-DAG: #[[$MAP2:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+//   CHECK-DAG: #[[$MAP3:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-LABEL: warp_reduction_dispatch()
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C5:.+]] = arith.constant 5 : index
+//   CHECK-DAG:   %[[IDEN:.+]] = arith.constant 0.000000e+00 : f32
+//       CHECK:   %[[F0:.+]] = linalg.fill
+//       CHECK:   %[[F1:.+]] = linalg.fill ins(%[[IDEN]] : f32) outs(%5 : tensor<1x2048xf32>) -> tensor<1x2048xf32>
+//       CHECK:   %[[A1:.*]] = scf.for %[[IV:.+]] = %[[C0]] to %[[C5]] step %[[C1]] iter_args(%[[A0:.+]] = %[[F1]]) -> (tensor<1x2048xf32>) {
+//       CHECK:     %[[S:.+]] = tensor.extract_slice %{{.*}}[0, %[[IV]], 0] [1, 1, 2048] [1, 1, 1] : tensor<1x5x2048xf32> to tensor<1x1x2048xf32>
+//       CHECK:     %[[A2:.+]] = linalg.generic {indexing_maps = [#[[$MAP0]], #[[$MAP1]]], iterator_types = ["parallel", "reduction", "parallel"]} ins(%[[S]] : tensor<1x1x2048xf32>) outs(%[[A0]] : tensor<1x2048xf32>) {
+//       CHECK:       arith.addf {{.*}} : f32
+//       CHECK:     } -> tensor<1x2048xf32>
+//       CHECK:     scf.yield %[[A2]] : tensor<1x2048xf32>
+//       CHECK:   }
+//       CHECK:   %[[A3:.+]] = linalg.generic {indexing_maps = [#[[$MAP2]], #[[$MAP3]]], iterator_types = ["parallel", "reduction"]} ins(%[[A1]] : tensor<1x2048xf32>) outs(%[[F0]] : tensor<1xf32>) {
+//       CHECK:     arith.addf %in, %out : f32
+//       CHECK:   } -> tensor<1xf32>
+//       CHECK:   flow.dispatch.tensor.store %[[A3]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -296,6 +296,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
 
   nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createGPUTileReductionPass());
 
   // Linalg -> vector
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUVectorizationPass(
@@ -316,6 +317,8 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
       createLoopInvariantCodeMotionPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createCSEPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
 
   // vector -> simt gpu + vector
   nestedModulePM.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -26,6 +26,7 @@ iree_lit_test_suite(
             "gpu_set_num_workgroups.mlir",
             "nvvm_pipeline_test.mlir",
             "reduce_bank_conflicts.mlir",
+            "reduction_pipeline.mlir",
             "rocdl_pipeline_test.mlir",
             "illegal_configuration.mlir",
             "linalg_transform.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_lit_test_suite(
     "linalg_transform.mlir"
     "nvvm_pipeline_test.mlir"
     "reduce_bank_conflicts.mlir"
+    "reduction_pipeline.mlir"
     "rocdl_pipeline_test.mlir"
     "tensor_alloc.mlir"
     "tensor_pad.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/conv_pipeline_test.mlir
@@ -38,8 +38,8 @@ module attributes {hal.device.targets = [#device_target_cuda]} {
 //         CHECK:      scf.for
 // CHECK-COUNT-2:        vector.transfer_read
 // CHECK-COUNT-4:        vector.contract
-//         CHECK:      scf.yield %{{.*}} : vector<4x4xf32>
-//         CHECK:    scf.yield %{{.*}} : vector<4x4xf32>
+//         CHECK:      scf.yield %{{.*}} : vector<1x4x4xf32>
+//         CHECK:    scf.yield %{{.*}} : vector<1x4x4xf32>
 //         CHECK:    vector.transfer_write {{.*}} : vector<4x4xf32>, memref<1x112x112x64xf32>
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
@@ -1,0 +1,140 @@
+
+// RUN: iree-opt --split-input-file --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable @warp_reduction_dispatch {
+hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
+  hal.executable.export @warp_reduction_dispatch layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @warp_reduction_dispatch() {
+      %c0 = arith.constant 0 : index
+      %c10240 = arith.constant 10240 : index
+      %cst = arith.constant 1.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:512x10240xf32>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:512xf32>
+      %5 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 10240], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:512x10240xf32> -> tensor<512x10240xf32>
+      %8 = tensor.empty() : tensor<512xf32>
+      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<512xf32>) -> tensor<512xf32>
+      %10 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]}
+          ins(%5 : tensor<512x10240xf32>) outs(%9 : tensor<512xf32>) {
+        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+          %11 = arith.addf %arg1, %arg2 : f32
+          linalg.yield %11 : f32
+        } -> tensor<512xf32>
+      flow.dispatch.tensor.store %10, %1, offsets = [0], sizes = [512], strides = [1]
+          : tensor<512xf32> -> !flow.dispatch.tensor<writeonly:512xf32>
+      return
+    }
+  }
+}
+}
+
+//   CHECK-LABEL:  func.func @warp_reduction_dispatch
+//     CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+//     CHECK-DAG:    %[[C1i:.+]] = arith.constant 1 : index
+//     CHECK-DAG:    %[[C5:.+]] = arith.constant 5 : index
+//     CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : i32
+//     CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : i32
+//     CHECK-DAG:    %[[C4:.+]] = arith.constant 4 : i32
+//     CHECK-DAG:    %[[C8:.+]] = arith.constant 8 : i32
+//     CHECK-DAG:    %[[C16:.+]] = arith.constant 16 : i32
+//     CHECK-DAG:    %[[C32:.+]] = arith.constant 32 : i32
+//     CHECK-DAG:    %[[CF:.+]] = arith.constant 1.000000e+00 : f32
+//     CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+//     CHECK-DAG:    %[[TID:.+]] = gpu.thread_id  x
+//         CHECK:    %[[R0:.+]] = scf.for %{{.*}} = %[[C0]] to %[[C5]] step %[[C1i]] iter_args(%[[A0:.+]] = %[[CST]]) -> (vector<4xf32>) {
+//         CHECK:      %[[V:.+]] = vector.transfer_read {{.*}} {in_bounds = [true]} : memref<1x5x2048xf32, strided<[10240, 2048, 1], offset: ?>>, vector<4xf32>
+//         CHECK:      %[[A1:.+]] = arith.addf %[[A0]], %[[V]] : vector<4xf32>
+//         CHECK:      scf.yield %[[A1]] : vector<4xf32>
+//         CHECK:    }
+//         CHECK:    %[[R1:.+]] = vector.reduction <add>, %[[R0]] : vector<4xf32> into f32
+//         CHECK:    %[[S0:.+]], %{{.*}} = gpu.shuffle  xor %[[R1]], %[[C1]], %[[C32]] : f32
+//         CHECK:    %[[R2:.+]] = arith.addf %[[R1]], %[[S0]] : f32
+//         CHECK:    %[[S1:.+]], %{{.*}} = gpu.shuffle  xor %[[R2]], %[[C2]], %[[C32]] : f32
+//         CHECK:    %[[R3:.+]] = arith.addf %[[R2]], %[[S1]] : f32
+//         CHECK:    %[[S2:.+]], %{{.*}} = gpu.shuffle  xor %[[R3]], %[[C4]], %[[C32]] : f32
+//         CHECK:    %[[R4:.+]] = arith.addf %[[R3]], %[[S2]] : f32
+//         CHECK:    %[[S3:.+]], %{{.*}} = gpu.shuffle  xor %[[R4]], %[[C8]], %[[C32]] : f32
+//         CHECK:    %[[R5:.+]] = arith.addf %[[R4]], %[[S3]] : f32
+//         CHECK:    %[[S4:.+]], %{{.*}} = gpu.shuffle  xor %[[R5]], %[[C16]], %[[C32]] : f32
+//         CHECK:    %[[R6:.+]] = arith.addf %[[R5]], %[[S4]] : f32
+//         CHECK:    %[[ALLOC:.+]] = memref.alloc() : memref<16xf32, 3>
+//         CHECK:    %[[WID:.+]] = arith.divui %{{.*}}, %{{.*}} : index
+//         CHECK:    memref.store %[[R6]], %[[ALLOC]][%[[WID]]] : memref<16xf32, 3>
+//         CHECK:    gpu.barrier
+//         CHECK:    %[[B:.+]] = vector.transfer_read %[[ALLOC]][%[[C0]]], %{{.*}} {in_bounds = [true]} : memref<16xf32, 3>, vector<16xf32>
+//         CHECK:    %[[R7:.+]] = vector.reduction <add>, %[[B]] : vector<16xf32> into f32
+//         CHECK:    %[[R8:.+]] = arith.addf %[[R7]], %[[CF]] : f32
+//         CHECK:    %[[R9:.+]] = vector.broadcast %[[R8]] : f32 to vector<1xf32>
+//         CHECK:    %[[TID0:.+]] = arith.cmpi eq, %[[TID]], %[[C0]] : index
+//         CHECK:    scf.if %[[TID0]] {
+//         CHECK:      vector.transfer_write %[[R9]], %{{.*}}[%{{.*}}] {in_bounds = [true]} : vector<1xf32>, memref<512xf32>
+//         CHECK:    }
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable @warp_reduction_broadcast_dispatch {
+hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
+  hal.executable.export @warp_reduction_broadcast_dispatch layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @warp_reduction_broadcast_dispatch() {
+      %c0 = arith.constant 0 : index
+      %c10240 = arith.constant 10240 : index
+      %cst_0 = arith.constant 3.840000e+02 : f32
+      %cst = arith.constant 1.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:512x10240xf32>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:512x10240xf32>
+      %5 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 1024], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:512x10240xf32> -> tensor<512x10240xf32>
+      %8 = tensor.empty() : tensor<512xf32>
+      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<512xf32>) -> tensor<512xf32>
+      %10 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>],
+          iterator_types = ["parallel", "reduction"]}
+          ins(%5 : tensor<512x10240xf32>) outs(%9 : tensor<512xf32>) {
+        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+          %11 = arith.addf %arg1, %arg2 : f32
+          linalg.yield %11 : f32
+        } -> tensor<512xf32>
+      %i = tensor.empty() : tensor<512x10240xf32>
+      %11 = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%10 : tensor<512xf32>) outs(%i : tensor<512x10240xf32>) {
+          ^bb0(%arg0: f32, %arg1: f32):
+            %12 = arith.divf %arg0, %cst_0 : f32
+            linalg.yield %12 : f32
+          } -> tensor<512x10240xf32>
+      flow.dispatch.tensor.store %11, %1, offsets = [0, 0], sizes = [512, 10240], strides = [1, 1]
+          : tensor<512x10240xf32> -> !flow.dispatch.tensor<writeonly:512x10240xf32>
+      return
+    }
+  }
+}
+}
+
+// TODO: enable group reduce for large reduction + broadcast fused.
+//   CHECK-LABEL:  func.func @warp_reduction_broadcast_dispatch
+//     CHECK-NOT:    gpu.shuffle
+//         CHECK:    return

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -152,6 +152,9 @@ std::unique_ptr<Pass> createTransformDialectInterpreterPass(
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUVectorizationPass(
     bool generateContract = true);
 
+/// Tile reductions and generate serial loops around reductions.
+std::unique_ptr<OperationPass<func::FuncOp>> createGPUTileReductionPass();
+
 // Distributes vector ops to all threads/warps in a GPU workgroup.
 // `getWarpSize` is for deciding the warp size to use; it takes the
 // current function containing those vector ops as the argument.

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -210,6 +210,12 @@ def GPUVectorization :
   ];
 }
 
+def GPUTileReduction :
+    Pass<"iree-codegen-gpu-tile-reduction", "func::FuncOp"> {
+  let summary = "Pass to tile linalg reduction dimensions.";
+  let constructor = "mlir::iree_compiler::createGPUTileReductionPass()";
+}
+
 def VectorReduceToGPU :
     Pass<"iree-codegen-reduction-to-gpu", "func::FuncOp"> {
   let summary = "Convert vector reduction to gpu ops.";

--- a/tests/e2e/regression/large_reduction.mlir
+++ b/tests/e2e/regression/large_reduction.mlir
@@ -31,3 +31,21 @@ func.func @reduction_unaligned() {
   check.expect_eq_const(%result, dense<384.0> : tensor<129xf32>) : tensor<129xf32>
   return
 }
+
+// Reduction dimension larger than the max number of threads per group on a gpu.
+func.func @reduction_aligned_larger() {
+  %in = util.unfoldable_constant dense<0.001> : tensor<2x40960xf32>
+  %cst = arith.constant 0.0 : f32
+  %init = tensor.empty() : tensor<2xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<2xf32>) -> tensor<2xf32>
+  %result = linalg.generic {indexing_maps = [
+    affine_map<(d0, d1) -> (d0, d1)>,affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%in : tensor<2x40960xf32>) outs(%fill : tensor<2xf32>) {
+    ^bb0(%arg3: f32, %arg4: f32):  // no predecessors
+      %2 = arith.addf %arg3, %arg4 : f32
+      linalg.yield %2 : f32
+    } -> tensor<2xf32>
+  check.expect_eq_const(%result, dense<40.96> : tensor<2xf32>) : tensor<2xf32>
+  return
+}


### PR DESCRIPTION
Add a pass to tile reductions when the dimension is larger than the maximum number of threads in a group. This allows supporting larger reductions efficiently.
Currently we disable the case where the reduction is fused with a broadcast as we need to improve distribution to handle it.