### PR TITLE
Enable & make backref warnings errors

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -144,6 +144,10 @@ build:generic_clang --copt=-Wthread-safety-beta
 build:generic_clang --copt=-Wunused-comparison
 build:generic_clang --copt=-Wvla
 
+# Treat backrefs during linking as errors.
+build:generic_clang --linkopt=-Wl,--warn-backrefs
+build:generic_clang --linkopt=-Wl,--fatal-warnings
+
 ###############################################################################
 # Additional options for MacOS based clang builds.
 # Try to keep these scoped to exclusions for third_party code and prefer

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -303,6 +303,7 @@ cc_library(
     ],
 )
 
+# TODO(#9827): Remove aliases and/or backref.
 alias(
     name = "IREELinalgExtPasses",
     actual = ":IREELinalgExtPassesAndTransforms",

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -303,40 +303,14 @@ cc_library(
     ],
 )
 
-cc_library(
+alias(
     name = "IREELinalgExtPasses",
-    srcs = glob([
-        "lib/Dialect/LinalgExt/Passes/*.cpp",
-    ]),
-    hdrs = glob([
-        "include/iree-dialects/Dialect/LinalgExt/Passes/*.h",
-    ]),
-    deps = [
-        ":IREEInputDialect",
-        ":IREELinalgExtDialect",
-        ":IREELinalgExtPassIncGen",
-        "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:AffineDialect",
-        "@llvm-project//mlir:ArithDialect",
-        "@llvm-project//mlir:ArithUtils",
-        "@llvm-project//mlir:DialectUtils",
-        "@llvm-project//mlir:FuncDialect",
-        "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:LinalgDialect",
-        "@llvm-project//mlir:LinalgTransforms",
-        "@llvm-project//mlir:LinalgUtils",
-        "@llvm-project//mlir:MathDialect",
-        "@llvm-project//mlir:MemRefDialect",
-        "@llvm-project//mlir:Parser",
-        "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:SCFDialect",
-        "@llvm-project//mlir:Support",
-        "@llvm-project//mlir:TensorDialect",
-        "@llvm-project//mlir:TensorUtils",
-        "@llvm-project//mlir:TilingInterface",
-        "@llvm-project//mlir:TransformUtils",
-        "@llvm-project//mlir:Transforms",
-    ],
+    actual = ":IREELinalgExtPassesAndTransforms",
+)
+
+alias(
+    name = "IREELinalgExtTransforms",
+    actual = ":IREELinalgExtPassesAndTransforms",
 )
 
 gentbl_cc_library(
@@ -378,18 +352,19 @@ cc_library(
 )
 
 cc_library(
-    name = "IREELinalgExtTransforms",
+    name = "IREELinalgExtPassesAndTransforms",
     srcs = glob([
+        "lib/Dialect/LinalgExt/Passes/*.cpp",
         "lib/Dialect/LinalgExt/Transforms/*.cpp",
     ]),
     hdrs = glob([
+        "include/iree-dialects/Dialect/LinalgExt/Passes/*.h",
         "include/iree-dialects/Dialect/LinalgExt/Transforms/*.h",
     ]),
     deps = [
         ":IREEInputDialect",
         ":IREELinalgExtDialect",
         ":IREELinalgExtPassIncGen",
-        ":IREELinalgExtPasses",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",


### PR DESCRIPTION
Also combine LinalgExt transforms and passes which has backref.

Makes warning default & removes failure case from #9827