### PR TITLE
Decompose linalg.conv_2d_q to linalg.conv_2d

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD
@@ -48,6 +48,7 @@ iree_compiler_cc_library(
         "IREEImportPublic.cpp",
         "ImportMLProgram.cpp",
         "Passes.cpp",
+        "QuantizedConvToConv.cpp",
         "QuantizedMatmulToMatmul.cpp",
         "SanitizeModuleNames.cpp",
         "TopLevelSCFToCFG.cpp",

--- a/compiler/src/iree/compiler/InputConversion/Common/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/Common/BUILD
@@ -52,9 +52,11 @@ iree_compiler_cc_library(
         "QuantizedMatmulToMatmul.cpp",
         "SanitizeModuleNames.cpp",
         "TopLevelSCFToCFG.cpp",
+        "Utils.cpp",
     ],
     hdrs = [
         "Passes.h",
+        "Utils.h",
     ],
     deps = [
         ":PassHeaders",

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_cc_library(
     "QuantizedMatmulToMatmul.cpp"
     "SanitizeModuleNames.cpp"
     "TopLevelSCFToCFG.cpp"
+    "Utils.cpp"
   DEPS
     ::PassHeaders
     ::PassesIncGen

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -26,7 +26,6 @@ iree_cc_library(
     "PassDetail.h"
     "Passes.h"
     "Passes.h.inc"
-    "Utils.h"
   DEPS
     ::PassesIncGen
     MLIRPass
@@ -39,6 +38,7 @@ iree_cc_library(
     Common
   HDRS
     "Passes.h"
+    "Utils.h"
   SRCS
     "IREEImportPublic.cpp"
     "ImportMLProgram.cpp"

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     "IREEImportPublic.cpp"
     "ImportMLProgram.cpp"
     "Passes.cpp"
+    "QuantizedConvToConv.cpp"
     "QuantizedMatmulToMatmul.cpp"
     "SanitizeModuleNames.cpp"
     "TopLevelSCFToCFG.cpp"

--- a/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_cc_library(
     "PassDetail.h"
     "Passes.h"
     "Passes.h.inc"
+    "Utils.h"
   DEPS
     ::PassesIncGen
     MLIRPass

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.h
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.h
@@ -29,6 +29,8 @@ void buildCommonInputConversionPassPipeline(OpPassManager &passManager);
 std::unique_ptr<OperationPass<ModuleOp>> createIREEImportPublicPass();
 std::unique_ptr<OperationPass<ModuleOp>> createImportMLProgramPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
+createLinalgQuantizedConvToConvPass();
+std::unique_ptr<OperationPass<func::FuncOp>>
 createLinalgQuantizedMatmulToMatmulPass();
 std::unique_ptr<OperationPass<ModuleOp>> createSanitizeModuleNamesPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createTopLevelSCFToCFGPass();

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.td
@@ -21,6 +21,13 @@ def ImportMLProgram :
   let constructor = "mlir::iree_compiler::createImportMLProgramPass()";
 }
 
+def LinalgQuantizedConvToConvPass
+    : Pass<"iree-linalg-quantized-conv-to-conv", "func::FuncOp"> {
+  let summary = "lower quantized_conv to conv";
+  let constructor = "mlir::iree_compiler::createLinalgQuantizedConvToConvPass()";
+  // let dependentDialects = ["mlir::linalg::LinalgDialect"];
+}
+
 def LinalgQuantizedMatmulToMatmulPass
     : Pass<"iree-linalg-quantized-matmul-to-matmul", "func::FuncOp"> {
   let summary = "lower quantized_matmul to matmul";

--- a/compiler/src/iree/compiler/InputConversion/Common/Passes.td
+++ b/compiler/src/iree/compiler/InputConversion/Common/Passes.td
@@ -25,14 +25,12 @@ def LinalgQuantizedConvToConvPass
     : Pass<"iree-linalg-quantized-conv-to-conv", "func::FuncOp"> {
   let summary = "lower quantized_conv to conv";
   let constructor = "mlir::iree_compiler::createLinalgQuantizedConvToConvPass()";
-  // let dependentDialects = ["mlir::linalg::LinalgDialect"];
 }
 
 def LinalgQuantizedMatmulToMatmulPass
     : Pass<"iree-linalg-quantized-matmul-to-matmul", "func::FuncOp"> {
   let summary = "lower quantized_matmul to matmul";
   let constructor = "mlir::iree_compiler::createLinalgQuantizedMatmulToMatmulPass()";
-  // let dependentDialects = ["mlir::linalg::LinalgDialect"];
 }
 
 def SanitizeModuleNames :

--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
@@ -1,0 +1,320 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/InputConversion/Common/PassDetail.h"
+#include "iree/compiler/InputConversion/Common/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/FoldUtils.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+Value makeLinalgInit(PatternRewriter &rewriter, Location loc, Value value) {
+  RankedTensorType ty = value.getType().cast<RankedTensorType>();
+  Type eTy = ty.getElementType();
+
+  SmallVector<Value> dynSizes;
+  for (int i = 0, s = ty.getRank(); i < s; i++) {
+    if (ty.isDynamicDim(i)) {
+      dynSizes.push_back(rewriter.create<tensor::DimOp>(loc, value, i));
+    }
+  }
+
+  return rewriter.create<tensor::EmptyOp>(loc, ty.getShape(), eTy, dynSizes);
+}
+
+Value applyZeroPoint(PatternRewriter &rewriter, Location loc, Value conv,
+                     Value sum, Value zp, ArrayRef<int> affine_map) {
+  auto context = rewriter.getContext();
+  auto convTy = conv.getType().cast<RankedTensorType>();
+
+  llvm::SmallVector<AffineExpr> sumExprs;
+  for (auto i : affine_map) {
+    sumExprs.push_back(rewriter.getAffineDimExpr(i));
+  }
+
+  SmallVector<StringRef> iterators(convTy.getRank(),
+                                   getParallelIteratorTypeName());
+
+  auto convMap = rewriter.getMultiDimIdentityMap(convTy.getRank());
+  auto sumMap = AffineMap::get(convTy.getRank(), 0, sumExprs, context);
+
+  SmallVector<AffineMap> affineMaps{convMap, sumMap, convMap};
+
+  Value init = makeLinalgInit(rewriter, loc, conv);
+  return rewriter
+      .create<linalg::GenericOp>(
+          loc, init.getType(), ValueRange{conv, sum}, ValueRange{init},
+          affineMaps, iterators,
+          [=](OpBuilder &b, Location loc, ValueRange args) {
+            Value mul = b.create<arith::MulIOp>(loc, args[1], zp);
+            Value sum = b.create<arith::SubIOp>(loc, args[0], mul);
+            b.create<linalg::YieldOp>(loc, sum);
+          })
+      .getResult(0);
+}
+
+// Reduce the input value along the reduction dimensions
+Value reduceDims(PatternRewriter &rewriter, Location loc, Value val,
+                 Type accETy, ArrayRef<bool> is_reduction) {
+  auto context = val.getContext();
+  RankedTensorType ty = val.getType().cast<RankedTensorType>();
+
+  llvm::SmallVector<int64_t> staticSizes;
+  SmallVector<Value> dynSizes;
+  for (int i = 0, s = is_reduction.size(); i < s; i++) {
+    if (is_reduction[i]) continue;
+
+    staticSizes.push_back(ty.getDimSize(i));
+    if (ty.isDynamicDim(i)) {
+      dynSizes.push_back(rewriter.create<tensor::DimOp>(loc, val, i));
+    }
+  }
+
+  // Create a zero-filled accumulator.
+  Value initAcc =
+      rewriter.create<tensor::EmptyOp>(loc, staticSizes, accETy, dynSizes);
+  Value zeroInt =
+      rewriter.create<arith::ConstantIntOp>(loc, 0, accETy).getResult();
+  Value zeroAcc =
+      rewriter.create<linalg::FillOp>(loc, zeroInt, initAcc).getResult(0);
+
+  SmallVector<AffineExpr> filterExprs(ty.getRank());
+  SmallVector<AffineExpr> outputExprs;
+  SmallVector<StringRef> iterators;
+
+  for (int i = 0, s = ty.getRank(); i < s; i++) {
+    if (!is_reduction[i]) {
+      auto expr = rewriter.getAffineDimExpr(iterators.size());
+      iterators.push_back(getParallelIteratorTypeName());
+
+      outputExprs.push_back(expr);
+      filterExprs[i] = expr;
+    }
+  }
+
+  for (int i = 0, s = filterExprs.size(); i < s; i++) {
+    if (!filterExprs[i]) {
+      auto expr = mlir::getAffineDimExpr(iterators.size(), context);
+      iterators.push_back(getReductionIteratorTypeName());
+      filterExprs[i] = expr;
+    }
+  }
+
+  SmallVector<AffineMap> affineMaps{AffineMap::get(4, 0, filterExprs, context),
+                                    AffineMap::get(4, 0, outputExprs, context)};
+
+  return rewriter
+      .create<linalg::GenericOp>(
+          loc, zeroAcc.getType(), ValueRange{val}, ValueRange{zeroAcc},
+          affineMaps, iterators,
+          [=](OpBuilder &b, Location loc, ValueRange args) {
+            Value ext = b.create<arith::ExtSIOp>(loc, accETy, args[0]);
+            Value sum = b.create<arith::AddIOp>(loc, ext, args[1]);
+            b.create<linalg::YieldOp>(loc, sum);
+          })
+      .getResult(0);
+}
+
+// Pattern lowering conv_2d_nhwc_hwcf_q to conv_2d_nhwc_hwcf.
+//
+// This is implementing the math explained in Section 2.3 of
+// https://arxiv.org/abs/1712.05877.
+struct QuantizedConvToConv
+    : public OpRewritePattern<linalg::Conv2DNhwcHwcfQOp> {
+  using OpRewritePattern<linalg::Conv2DNhwcHwcfQOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Conv2DNhwcHwcfQOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto input = op.getInputs()[0];
+    auto filter = op.getInputs()[1];
+    auto iZp = op.getInputs()[2];
+    auto fZp = op.getInputs()[3];
+    auto inputTy = input.getType().cast<RankedTensorType>();
+    auto filterTy = filter.getType().cast<RankedTensorType>();
+    auto resultTy = op.getType(0).cast<ShapedType>();
+    auto accETy = resultTy.getElementType();
+
+    auto strides = op.getStrides();
+    auto dilations = op.getDilations();
+
+    IntegerAttr iZpConst;
+    IntegerAttr fZpConst;
+    bool iZpIsZero = matchPattern(iZp, m_Constant(&iZpConst)) &&
+                     iZpConst.getValue().isZero();
+    bool fZpIsZero = matchPattern(fZp, m_Constant(&fZpConst)) &&
+                     fZpConst.getValue().isZero();
+
+    // First implement the convolution without the zero point.
+    Value newConv = rewriter
+                        .create<linalg::Conv2DNhwcHwcfOp>(
+                            loc, resultTy, ValueRange{input, filter},
+                            op.getOutputs(), strides, dilations)
+                        .getResult(0);
+    RankedTensorType newConvTy = newConv.getType().cast<RankedTensorType>();
+
+    // If the zero pointer value is zero we can just replace.
+    if (iZpIsZero && fZpIsZero) {
+      rewriter.replaceOp(op, newConv);
+      return success();
+    }
+
+    // Compute the summation and correction for the filter zero point:
+    //  sum(d) = filter(a, b, c, d)
+    //  conv(a, b, c, d) -= iZp * filter(d)
+    if (!iZpIsZero) {
+      Value filterSum =
+          reduceDims(rewriter, loc, filter, accETy, {true, true, true, false});
+      newConv = applyZeroPoint(rewriter, loc, newConv, filterSum, iZp, {3});
+    }
+
+    if (!fZpIsZero) {
+      // Reduce along the input feature dimension.
+      Value inputSum =
+          reduceDims(rewriter, loc, input, accETy, {false, false, false, true});
+
+      // Materialize a length-1 dimension at the end of the summation.
+      SmallVector<ReassociationExprs, 4> reassociationMap(3);
+      for (int i = 0; i < 3; i++)
+        reassociationMap[i].push_back(rewriter.getAffineDimExpr(i));
+      reassociationMap.back().push_back(rewriter.getAffineDimExpr(3));
+
+      auto expandTy =
+          RankedTensorType::get({inputTy.getDimSize(0), inputTy.getDimSize(1),
+                                 inputTy.getDimSize(2), 1},
+                                accETy);
+      inputSum = rewriter.create<tensor::ExpandShapeOp>(loc, expandTy, inputSum,
+                                                        reassociationMap);
+
+      // Perform a summing operation across the kernel width and height.
+      auto poolTy = RankedTensorType::get(
+          {expandTy.getDimSize(0), newConvTy.getDimSize(1),
+           newConvTy.getDimSize(2), expandTy.getDimSize(3)},
+          accETy);
+
+      llvm::SmallVector<Value> poolDynDims;
+      if (expandTy.isDynamicDim(0))
+        poolDynDims.push_back(rewriter.create<tensor::DimOp>(loc, inputSum, 0));
+
+      if (newConvTy.isDynamicDim(1))
+        poolDynDims.push_back(rewriter.create<tensor::DimOp>(loc, newConv, 1));
+
+      if (newConvTy.isDynamicDim(2))
+        poolDynDims.push_back(rewriter.create<tensor::DimOp>(loc, newConv, 2));
+
+      if (expandTy.isDynamicDim(3))
+        poolDynDims.push_back(rewriter.create<tensor::DimOp>(loc, inputSum, 3));
+
+      Value poolTensor = rewriter.create<tensor::EmptyOp>(
+          loc, poolTy.getShape(), accETy, poolDynDims);
+
+      Attribute initialAttr = rewriter.getZeroAttr(accETy);
+      Value initialValue = rewriter.create<arith::ConstantOp>(loc, initialAttr);
+      poolTensor = rewriter
+                       .create<linalg::FillOp>(loc, ValueRange{initialValue},
+                                               ValueRange{poolTensor})
+                       .result();
+
+      llvm::SmallVector<int64_t> kernel{filterTy.getDimSize(0),
+                                        filterTy.getDimSize(1)};
+      llvm::SmallVector<Value> kernelDynDims;
+      for (int i = 0; i < 2; i++) {
+        if (filterTy.isDynamicDim(i))
+          kernelDynDims.push_back(
+              rewriter.create<tensor::DimOp>(loc, filter, i));
+      }
+
+      Value poolDims =
+          rewriter.create<tensor::EmptyOp>(loc, kernel, accETy, kernelDynDims);
+      inputSum =
+          rewriter
+              .create<linalg::PoolingNhwcSumOp>(loc, ArrayRef<Type>{poolTy},
+                                                ValueRange{inputSum, poolDims},
+                                                poolTensor, strides, dilations)
+              .getResult(0);
+
+      // Collapse the length-1 ending dimension away.
+      auto collapseTy =
+          RankedTensorType::get(poolTy.getShape().drop_back(), accETy);
+      inputSum = rewriter.create<tensor::CollapseShapeOp>(
+          loc, collapseTy, inputSum, reassociationMap);
+
+      // Apply the zero-point update based on the input sum.
+      newConv =
+          applyZeroPoint(rewriter, loc, newConv, inputSum, fZp, {0, 1, 2});
+    }
+
+    // Apply the final update that occurs when there are multiple zero-points.
+    if (!iZpIsZero && !fZpIsZero) {
+      Value dim0 = rewriter.create<tensor::DimOp>(loc, filter, 0);
+      Value dim1 = rewriter.create<tensor::DimOp>(loc, filter, 1);
+      Value dim2 = rewriter.create<tensor::DimOp>(loc, filter, 2);
+      Value mul1 = rewriter.create<arith::MulIOp>(loc, dim0, dim1);
+      Value mul2 = rewriter.create<arith::MulIOp>(loc, mul1, dim2);
+      Value cast = rewriter.create<arith::IndexCastOp>(loc, accETy, mul2);
+
+      auto convTy = newConv.getType().cast<RankedTensorType>();
+      SmallVector<StringRef> iterators(convTy.getRank(),
+                                       getParallelIteratorTypeName());
+      auto convMap = rewriter.getMultiDimIdentityMap(convTy.getRank());
+      SmallVector<AffineMap> affineMaps{convMap, convMap};
+
+      Value init = makeLinalgInit(rewriter, loc, newConv);
+      newConv = rewriter
+                    .create<linalg::GenericOp>(
+                        loc, init.getType(), ValueRange{newConv},
+                        ValueRange{init}, affineMaps, iterators,
+                        [=](OpBuilder &b, Location loc, ValueRange args) {
+                          Value mul1 = b.create<arith::MulIOp>(loc, iZp, fZp);
+                          Value mul2 = b.create<arith::MulIOp>(loc, mul1, cast);
+                          Value sum =
+                              b.create<arith::AddIOp>(loc, args[0], mul2);
+                          b.create<linalg::YieldOp>(loc, sum);
+                        })
+                    .getResult(0);
+    }
+
+    rewriter.replaceOp(op, newConv);
+    return success();
+  }
+};
+
+/// Pass that lowers quantized_conv to conv.
+struct LinalgQuantizedConvToConvPass
+    : public LinalgQuantizedConvToConvPassBase<LinalgQuantizedConvToConvPass> {
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    MLIRContext *context = op->getContext();
+    RewritePatternSet patterns(context);
+    patterns.add<QuantizedConvToConv>(context);
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
+      signalPassFailure();
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLinalgQuantizedConvToConvPass() {
+  return std::make_unique<LinalgQuantizedConvToConvPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedMatmulToMatmul.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/InputConversion/Common/PassDetail.h"
 #include "iree/compiler/InputConversion/Common/Passes.h"
+#include "iree/compiler/InputConversion/Common/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
@@ -14,6 +15,7 @@
 #include "mlir/IR/AffineExpr.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Transforms/FoldUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -21,65 +23,6 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
-
-// Returns the add-reduction of the input 2D tensor `matrix` along one of the
-// two dimensions. The `parallelDim` argument specifies which of the two
-// dimensions (0 or 1) is the parallel (i.e. not reduction) dimension.
-// The input `matrix`'s element type is assumed to be signless integer.
-// The result's element type is `accElTy`. The input elements are sign-extended
-// to `accElTy` before being added.
-Value additiveReductionLeaving1ParallelDim(PatternRewriter &rewriter,
-                                           Location loc, Value matrix,
-                                           int parallelDim, Type accElTy) {
-  RankedTensorType matrixType = matrix.getType().cast<RankedTensorType>();
-  assert(matrixType.getRank() == 2);
-  assert(parallelDim == 0 || parallelDim == 1);
-  // Create the accumulator.
-  int64_t dstStaticSize = matrixType.getShape()[parallelDim];
-  SmallVector<Value> dstDynSizes;
-  if (dstStaticSize == ShapedType::kDynamicSize) {
-    dstDynSizes.push_back(
-        rewriter.create<tensor::DimOp>(loc, matrix, parallelDim));
-  }
-  Value initAcc =
-      rewriter
-          .create<tensor::EmptyOp>(loc, ArrayRef<int64_t>{dstStaticSize},
-                                   accElTy, dstDynSizes)
-          .getResult();
-  // Zero-fill the accumulator.
-  Value zeroInt =
-      rewriter.create<arith::ConstantIntOp>(loc, 0, accElTy).getResult();
-  Value zeroAcc =
-      rewriter.create<linalg::FillOp>(loc, zeroInt, initAcc).getResult(0);
-  // Create the indexing maps for the generic.
-  MLIRContext *context = rewriter.getContext();
-  AffineExpr expr[2];
-  bindDims(context, expr[0], expr[1]);
-  AffineExpr parallelExpr = expr[parallelDim];
-  AffineMap mapIdentity = AffineMap::get(2, 0, expr, context);
-  AffineMap mapToParallelDim = AffineMap::get(2, 0, parallelExpr, context);
-  SmallVector<AffineMap> indexingMaps{mapIdentity, mapToParallelDim};
-  // Create the iterators for the generic.
-  auto iterator = [=](int dim) -> StringRef {
-    return dim == parallelDim ? "parallel" : "reduction";
-  };
-  SmallVector<StringRef> iterators{iterator(0), iterator(1)};
-  // Create the generic.
-  return rewriter
-      .create<linalg::GenericOp>(
-          loc, zeroAcc.getType(), ValueRange{matrix}, ValueRange{zeroAcc},
-          indexingMaps, iterators,
-          [=](OpBuilder &b, Location loc, ValueRange args) {
-            Value matrixEl = args[0];
-            // Sign-extend the input matrix elem to accElTy before adding.
-            Value promotedMatrixEl =
-                b.create<arith::ExtSIOp>(loc, accElTy, matrixEl);
-            Value accEl = args[1];
-            Value sum = b.create<arith::AddIOp>(loc, promotedMatrixEl, accEl);
-            b.create<linalg::YieldOp>(loc, sum);
-          })
-      .getResult(0);
-}
 
 bool isConstantZero(Value val) {
   auto constIntOp = val.getDefiningOp<arith::ConstantIntOp>();
@@ -98,6 +41,7 @@ struct QuantizedMatmulToMatmul
   LogicalResult matchAndRewrite(linalg::QuantizedMatmulOp quantizedMatmulOp,
                                 PatternRewriter &rewriter) const override {
     Location loc = quantizedMatmulOp.getLoc();
+    ImplicitLocOpBuilder builder(loc, rewriter);
     ValueRange inputs = quantizedMatmulOp.getInputs();
     assert(inputs.size() == 4);
     Value lhs = inputs[0];
@@ -107,10 +51,9 @@ struct QuantizedMatmulToMatmul
     ValueRange outputs = quantizedMatmulOp.getOutputs();
     // Compute the matmul part.
     Value acc = outputs[0];
-    Value matmul = rewriter
-                       .create<linalg::MatmulOp>(loc, ValueRange{lhs, rhs},
-                                                 ValueRange{acc})
-                       .getResult(0);
+    Value matmul =
+        builder.create<linalg::MatmulOp>(ValueRange{lhs, rhs}, ValueRange{acc})
+            .getResult(0);
     bool lhsZpIsConstantZero = isConstantZero(lhsZp);
     bool rhsZpIsConstantZero = isConstantZero(rhsZp);
     if (lhsZpIsConstantZero && rhsZpIsConstantZero) {
@@ -122,8 +65,8 @@ struct QuantizedMatmulToMatmul
     // Create the result. No need to zero-fill it as we will overwrite it.
     ShapedType accType = acc.getType().cast<ShapedType>();
     auto accDynShape = linalg::getDynOperands(loc, acc, rewriter);
-    Value initResult = rewriter.create<tensor::EmptyOp>(
-        loc, accType.getShape(), accType.getElementType(), accDynShape);
+    Value initResult = builder.create<tensor::EmptyOp>(
+        accType.getShape(), accType.getElementType(), accDynShape);
     // Create the indexing maps for the generic.
     MLIRContext *context = rewriter.getContext();
     AffineExpr m, n;
@@ -147,23 +90,23 @@ struct QuantizedMatmulToMatmul
     int indexOfLhsZpTimesRhsZpTimesKSizeInput = 0;
     Type accElTy = accType.getElementType();
     if (!rhsZpIsConstantZero) {
-      Value lhsSums =
-          additiveReductionLeaving1ParallelDim(rewriter, loc, lhs, 0, accElTy);
+      Value lhsSums = sumReduceDimensionSubset(builder, lhs, accElTy,
+                                               /*is_reduction=*/{false, true});
       indexOfLhsSumsInput = addInput(lhsSums, mapToRowDim);
       indexOfRhsZpInput = addInput(rhsZp, mapToNone);
     }
     if (!lhsZpIsConstantZero) {
-      Value rhsSums =
-          additiveReductionLeaving1ParallelDim(rewriter, loc, rhs, 1, accElTy);
+      Value rhsSums = sumReduceDimensionSubset(builder, rhs, accElTy,
+                                               /*is_reduction=*/{true, false});
       indexOfRhsSumsInput = addInput(rhsSums, mapToColumnDim);
       indexOfLhsZpInput = addInput(lhsZp, mapToNone);
     }
     if (!lhsZpIsConstantZero && !rhsZpIsConstantZero) {
-      Value lhsZpTimesRhsZp = rewriter.create<arith::MulIOp>(loc, lhsZp, rhsZp);
+      Value lhsZpTimesRhsZp = builder.create<arith::MulIOp>(lhsZp, rhsZp);
       Value kSize = rewriter.create<arith::IndexCastOp>(
-          loc, accElTy, rewriter.create<tensor::DimOp>(loc, lhs, 1));
+          loc, accElTy, builder.create<tensor::DimOp>(lhs, 1));
       Value lhsZpTimesRhsZpTimesKSize =
-          rewriter.create<arith::MulIOp>(loc, lhsZpTimesRhsZp, kSize);
+          builder.create<arith::MulIOp>(lhsZpTimesRhsZp, kSize);
       indexOfLhsZpTimesRhsZpTimesKSizeInput =
           addInput(lhsZpTimesRhsZpTimesKSize, mapToNone);
     }

--- a/compiler/src/iree/compiler/InputConversion/Common/Utils.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/Utils.cpp
@@ -1,0 +1,87 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/InputConversion/Common/Utils.h"
+
+#include "iree/compiler/InputConversion/Common/PassDetail.h"
+#include "iree/compiler/InputConversion/Common/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Utils/Utils.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+// Reduce the input value along the reduction dimensions
+Value sumReduceDimensionSubset(ImplicitLocOpBuilder &rewriter, Value val,
+                               Type accETy, ArrayRef<bool> is_reduction) {
+  auto context = val.getContext();
+  RankedTensorType ty = val.getType().cast<RankedTensorType>();
+
+  llvm::SmallVector<int64_t> staticSizes;
+  SmallVector<Value> dynSizes;
+  for (int i = 0, s = is_reduction.size(); i < s; i++) {
+    if (is_reduction[i]) continue;
+
+    staticSizes.push_back(ty.getDimSize(i));
+    if (ty.isDynamicDim(i)) {
+      dynSizes.push_back(rewriter.create<tensor::DimOp>(val, i));
+    }
+  }
+
+  // Create a zero-filled accumulator.
+  Value initAcc =
+      rewriter.create<tensor::EmptyOp>(staticSizes, accETy, dynSizes);
+  Value zeroInt = rewriter.create<arith::ConstantIntOp>(0, accETy).getResult();
+  Value zeroAcc =
+      rewriter.create<linalg::FillOp>(zeroInt, initAcc).getResult(0);
+
+  SmallVector<AffineExpr> filterExprs(ty.getRank());
+  SmallVector<AffineExpr> outputExprs;
+  SmallVector<StringRef> iterators;
+
+  for (int i = 0, s = ty.getRank(); i < s; i++) {
+    if (!is_reduction[i]) {
+      auto expr = rewriter.getAffineDimExpr(iterators.size());
+      iterators.push_back(getParallelIteratorTypeName());
+
+      outputExprs.push_back(expr);
+      filterExprs[i] = expr;
+    }
+  }
+
+  for (int i = 0, s = filterExprs.size(); i < s; i++) {
+    if (!filterExprs[i]) {
+      auto expr = mlir::getAffineDimExpr(iterators.size(), context);
+      iterators.push_back(getReductionIteratorTypeName());
+      filterExprs[i] = expr;
+    }
+  }
+
+  SmallVector<AffineMap> affineMaps{
+      AffineMap::get(ty.getRank(), 0, filterExprs, context),
+      AffineMap::get(ty.getRank(), 0, outputExprs, context)};
+
+  return rewriter
+      .create<linalg::GenericOp>(
+          zeroAcc.getType(), ValueRange{val}, ValueRange{zeroAcc}, affineMaps,
+          iterators,
+          [=](OpBuilder &b, Location loc, ValueRange args) {
+            Value ext = b.create<arith::ExtSIOp>(loc, accETy, args[0]);
+            Value sum = b.create<arith::AddIOp>(loc, ext, args[1]);
+            b.create<linalg::YieldOp>(loc, sum);
+          })
+      .getResult(0);
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/InputConversion/Common/Utils.h
+++ b/compiler/src/iree/compiler/InputConversion/Common/Utils.h
@@ -1,0 +1,17 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+Value sumReduceDimensionSubset(ImplicitLocOpBuilder &rewriter, Value val,
+                               Type accETy, ArrayRef<bool> is_reduction);
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/InputConversion/Common/test/BUILD
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "import_ml_program.mlir",
             "iree_import_public.mlir",
+            "linalg_quantized_conv_to_conv.mlir",
             "linalg_quantized_matmul_to_matmul.mlir",
             "sanitize_module_names.mlir",
             "top_level_scf_to_cfg.mlir",

--- a/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "import_ml_program.mlir"
     "iree_import_public.mlir"
+    "linalg_quantized_conv_to_conv.mlir"
     "linalg_quantized_matmul_to_matmul.mlir"
     "sanitize_module_names.mlir"
     "top_level_scf_to_cfg.mlir"

--- a/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
@@ -1,0 +1,238 @@
+// RUN: iree-opt --iree-linalg-quantized-conv-to-conv -split-input-file %s | FileCheck %s
+
+// CHECK-LABEL: func.func @conv2d_zp
+func.func @conv2d_zps(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<3x4x5x1024xi8>, %arg2: tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32> {
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 0 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf 
+  // CHECK-SAME:  dilations = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  strides = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  ins(%arg0, %arg1 : tensor<1x14x16x5xi8>, tensor<3x4x5x1024xi8>)
+  // CHECK-SAME:  outs(%arg2 : tensor<1x12x13x1024xi32>)
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x14x16x5xi8>, tensor<3x4x5x1024xi8>, i32, i32) outs(%arg2 : tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32>
+
+  // CHECK: return %[[CONV]]
+  return %0 : tensor<1x12x13x1024xi32>
+}
+
+// -----
+
+// CHECK: #map0 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3, d0)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0)>
+// CHECK: #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map3 = affine_map<(d0, d1, d2, d3) -> (d3)>
+
+// CHECK-LABEL: func.func @conv2d_filter_zp
+func.func @conv2d_filter_zp(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<3x4x5x1024xi8>, %arg2: tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32> {
+  %iZp = arith.constant 42 : i32
+  %fZp = arith.constant 0 : i32
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42
+  // CHECK-DAG: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf 
+  // CHECK-DAG: %[[SUM_INIT:.+]] = tensor.empty() : tensor<1024xi32>
+  // CHECK-DAG: %[[SUM_FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%1 : tensor<1024xi32>) -> tensor<1024xi32>
+
+  // CHECK: %[[SUM:.+]] = linalg.generic 
+  // CHECK-SAME:  indexing_maps = [#map0, #map1]
+  // CHECK-SAME:  iterator_types = ["parallel", "reduction", "reduction", "reduction"]}
+  // CHECK-SAME:  ins(%arg1 : tensor<3x4x5x1024xi8>)
+  // CHECK-SAME:  outs(%[[SUM_FILL]] : tensor<1024xi32>)
+  // CHECK:   ^bb0(%[[IN:.+]]: i8, %[[OUT:.+]]: i32):
+  // CHECK:   %[[EXT:.+]] = arith.extsi %[[IN]] : i8 to i32
+  // CHECK:   %[[ADD:.+]] = arith.addi %[[EXT]], %[[OUT]] : i32
+  // CHECK:   linalg.yield %[[ADD]]
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x12x13x1024xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic 
+  // CHECK-SAME:  indexing_maps = [#map2, #map3, #map2]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME:  ins(%[[CONV]], %[[SUM]] : tensor<1x12x13x1024xi32>, tensor<1024xi32>)
+  // CHECK-SAME:  outs(%[[INIT]] : tensor<1x12x13x1024xi32>)
+  // CHECK:   ^bb0(%[[A0:.+]]: i32, %[[A1:.+]]: i32, %[[A2:.+]]: i32):
+  // CHECK:   %[[MUL:.+]] = arith.muli %[[A1]], %[[C42]] : i32
+  // CHECK:   %[[SUB:.+]] = arith.subi %[[A0]], %[[MUL]] : i32
+  // CHECK:   linalg.yield %[[SUB]]
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x14x16x5xi8>, tensor<3x4x5x1024xi8>, i32, i32) outs(%arg2 : tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32>
+
+  // CHECK: return %[[GENERIC]] : tensor<1x12x13x1024xi32>
+  return %0 : tensor<1x12x13x1024xi32>
+}
+
+// -----
+
+// CHECK: #map0 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+
+// CHECK-LABEL: func.func @conv2d_input_zp
+func.func @conv2d_input_zp(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<3x4x5x1024xi8>, %arg2: tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32> {
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 42 : i32
+
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-DAG: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf 
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x14x16xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT]] : tensor<1x14x16xi32>)
+  // CHECK: %[[SUM:.+]] = linalg.generic
+  // CHECK-SAME:  indexing_maps = [#map0, #map1]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "reduction"]
+  // CHECK-SAME:  ins(%arg0 : tensor<1x14x16x5xi8>)
+  // CHECK-SAME:  outs(%[[FILL]] : tensor<1x14x16xi32>)
+
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[SUM]] {{\[\[}}0], [1], [2, 3]] : tensor<1x14x16xi32> into tensor<1x14x16x1xi32>
+  // CHECK: %[[INIT:.+]] = tensor.empty()
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT]] : tensor<1x12x13x1xi32>)
+  // CHECK: %[[KERNEL:.+]] = tensor.empty() : tensor<3x4xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nhwc_sum 
+  // CHECK-SAME:  dilations = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  strides = dense<1> : tensor<2xi64>
+  // CHECK-SAME:  ins(%[[EXPAND]], %[[KERNEL]] : tensor<1x14x16x1xi32>, tensor<3x4xi32>)
+  // CHECK-SAME:  outs(%[[FILL]] : tensor<1x12x13x1xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]] {{\[\[}}0], [1], [2, 3]]
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x12x13x1024xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic 
+  // CHECK-SAME:  indexing_maps = [#map0, #map1, #map0]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME:  ins(%[[CONV]], %[[COLLAPSE]] : tensor<1x12x13x1024xi32>, tensor<1x12x13xi32>)
+  // CHECK-SAME:  outs(%[[INIT]] : tensor<1x12x13x1024xi32>)
+  // CHECK:   ^bb0(%[[A0:.+]]: i32, %[[A1:.+]]: i32, %[[A2:.+]]: i32):
+  // CHECK:   %[[MUL:.+]] = arith.muli %[[A1]], %[[C42]]
+  // CHECK:   %[[SUB:.+]] = arith.subi %[[A0]], %[[MUL]]
+  // CHECK:   linalg.yield %[[SUB]]
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x14x16x5xi8>, tensor<3x4x5x1024xi8>, i32, i32) outs(%arg2 : tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32>
+
+  // CHECK: return %[[GENERIC]]
+  return %0 : tensor<1x12x13x1024xi32>
+}
+
+// -----
+
+// CHECK: #map0 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3, d0)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0)>
+// CHECK: #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map3 = affine_map<(d0, d1, d2, d3) -> (d3)>
+// CHECK: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+func.func @conv2d_full(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<3x4x5x1024xi8>, %arg2: tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32> {
+  %iZp = arith.constant 17 : i32
+  %fZp = arith.constant 42 : i32
+
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C42840:.+]] = arith.constant 42840 : i32
+  // CHECK-DAG: %[[C17:.+]] = arith.constant 17 : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf 
+
+  // CHECK: %[[SUM:.+]] = linalg.generic 
+  // CHECK-SAME:  ins(%arg1 : tensor<3x4x5x1024xi8>)
+  // CHECK: %[[IZP:.+]] = linalg.generic 
+  // CHECK-SAME:  ins(%[[CONV]], %[[SUM]] : tensor<1x12x13x1024xi32>, tensor<1024xi32>)
+
+  // CHECK: %[[SUM:.+]] = linalg.generic
+  // CHECK-SAME:  ins(%arg0 : tensor<1x14x16x5xi8>)
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[SUM]]
+  // CHECK: %[[KERNEL:.+]] = tensor.empty() : tensor<3x4xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nhwc_sum 
+  // CHECK-SAME:  ins(%[[EXPAND]], %[[KERNEL]] : tensor<1x14x16x1xi32>, tensor<3x4xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]]
+  // CHECK: %[[FZP:.+]] = linalg.generic 
+  // CHECK-SAME:  ins(%[[IZP]], %[[COLLAPSE]] : tensor<1x12x13x1024xi32>, tensor<1x12x13xi32>)
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x12x13x1024xi32>
+  // CHECK: %[[FINAL:.+]] = linalg.generic {indexing_maps = [#map2, #map2]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME:  ins(%[[FZP]] : tensor<1x12x13x1024xi32>)
+  // CHECK-SAME:  outs(%[[INIT]] : tensor<1x12x13x1024xi32>)
+  // CHECK:   ^bb0(%[[A0:.+]]: i32, %[[A1:.+]]: i32):
+  // CHECK:   %[[ADD:.+]] = arith.addi %[[A0]], %[[C42840]] : i32
+  // CHECK:   linalg.yield %[[ADD]]
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x14x16x5xi8>, tensor<3x4x5x1024xi8>, i32, i32) outs(%arg2 : tensor<1x12x13x1024xi32>) -> tensor<1x12x13x1024xi32>
+
+  // CHECK: return %[[FINAL]]
+  return %0 : tensor<1x12x13x1024xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @conv2d_dyn
+func.func @conv2d_dyn(%arg0: tensor<?x?x?x5xi8>, %arg1: tensor<3x4x5x1024xi8>, %arg2: tensor<?x?x?x1024xi32>) -> tensor<?x?x?x1024xi32> {
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 0 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<?x?x?x5xi8>, tensor<3x4x5x1024xi8>, i32, i32) outs(%arg2 : tensor<?x?x?x1024xi32>) -> tensor<?x?x?x1024xi32>
+
+  // CHECK: return %[[CONV]]
+  return %0 : tensor<?x?x?x1024xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @conv2d_dyn_filter_zp
+func.func @conv2d_dyn_filter_zp(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<?x?x5x1024xi8>, %arg2: tensor<1x?x?x1024xi32>) -> tensor<1x?x?x1024xi32> {
+  // CHECK: %[[C1:.+]] = arith.constant 1 : index
+  // CHECK: %[[C2:.+]] = arith.constant 2 : index
+
+  %iZp = arith.constant 42 : i32
+  %fZp = arith.constant 0 : i32
+
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf 
+  // CHECK: %[[SUM:.+]] = linalg.generic
+  // CHECK-SAME: ins(%arg1 : tensor<?x?x5x1024xi8>) 
+
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %c1 : tensor<1x?x?x1024xi32>
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %c2 : tensor<1x?x?x1024xi32>
+  // CHECK: %[[INIT:.+]] = tensor.empty(%[[DIM1]], %[[DIM2]]) : tensor<1x?x?x1024xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic
+  // CHECK-SAME: ins(%[[CONV]], %[[SUM]] : tensor<1x?x?x1024xi32>, tensor<1024xi32>)
+  // CHECK-SAME: outs(%[[INIT]] : tensor<1x?x?x1024xi32>)
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x14x16x5xi8>, tensor<?x?x5x1024xi8>, i32, i32) outs(%arg2 : tensor<1x?x?x1024xi32>) -> tensor<1x?x?x1024xi32>
+
+  // CHECK: return %[[GENERIC]]
+  return %0 : tensor<1x?x?x1024xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @conv2d_dyn_input_zp
+func.func @conv2d_dyn_input_zp(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<?x?x5x1024xi8>, %arg2: tensor<1x?x?x1024xi32>) -> tensor<1x?x?x1024xi32> {
+  %fZp = arith.constant 42 : i32
+  %iZp = arith.constant 0 : i32
+
+  // CHECK: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK: %[[I1:.+]] = arith.constant 1 : index
+  // CHECK: %[[I2:.+]] = arith.constant 2 : index
+  // CHECK: %[[I0:.+]] = arith.constant 0 : index
+  // CHECK: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf
+
+  // CHECK: %[[INIT:.+]] = tensor.empty() : tensor<1x14x16xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT]] : tensor<1x14x16xi32>)
+  // CHECK: %[[GENERIC:.+]] = linalg.generic 
+  // CHECK-SAME: ins(%arg0 : tensor<1x14x16x5xi8>) outs(%[[FILL]] : tensor<1x14x16xi32>)
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[GENERIC]]
+
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK: %[[INIT:.+]] = tensor.empty(%[[DIM1]], %[[DIM2]]) : tensor<1x?x?x1xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[INIT]] : tensor<1x?x?x1xi32>)
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg1, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg1, %[[I1]]
+  // CHECK: %[[KERNEL:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nhwc_sum 
+  // CHECK-SAME: ins(%[[EXPAND]], %[[KERNEL]] : tensor<1x14x16x1xi32>, tensor<?x?xi32>)
+  // CHECK-SAME: outs(%[[FILL]] : tensor<1x?x?x1xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]]
+
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK: %[[INIT:.+]] = tensor.empty(%[[DIM1]], %[[DIM2]]) : tensor<1x?x?x1024xi32>
+  // CHECK: %[[GENERIC:.+]] = linalg.generic 
+  // CHECK-SAME: ins(%[[CONV]], %[[COLLAPSE]] : tensor<1x?x?x1024xi32>, tensor<1x?x?xi32>)
+  // CHECK-SAME: outs(%[[INIT]] : tensor<1x?x?x1024xi32>)
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<1x14x16x5xi8>, tensor<?x?x5x1024xi8>, i32, i32) outs(%arg2 : tensor<1x?x?x1024xi32>) -> tensor<1x?x?x1024xi32>
+
+  // CHECK: return %[[GENERIC]]
+  return %0 : tensor<1x?x?x1024xi32>
+}

--- a/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
@@ -236,3 +236,108 @@ func.func @conv2d_dyn_input_zp(%arg0: tensor<1x14x16x5xi8>, %arg1: tensor<?x?x5x
   // CHECK: return %[[GENERIC]]
   return %0 : tensor<1x?x?x1024xi32>
 }
+
+// -----
+
+// CHECK: #map0 = affine_map<(d0, d1, d2, d3) -> (d1, d2, d3, d0)>
+// CHECK: #map1 = affine_map<(d0, d1, d2, d3) -> (d0)>
+// CHECK: #map2 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+// CHECK: #map3 = affine_map<(d0, d1, d2, d3) -> (d3)>
+// CHECK: #map4 = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>
+
+// CHECK-LABEL: @conv2d_all_dyn
+func.func @conv2d_all_dyn(%arg0: tensor<?x?x?x?xi8>, %arg1: tensor<?x?x?x?xi8>, %arg2: tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32> {
+  %fZp = arith.constant 42 : i32
+  %iZp = arith.constant 13 : i32
+
+  // CHECK-DAG: %[[I3:.+]] = arith.constant 3 : index
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[I0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[I1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[I2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[C546:.+]] = arith.constant 546 : i32
+  // CHECK-DAG: %[[C42:.+]] = arith.constant 42 : i32
+  // CHECK-DAG: %[[C13:.+]] = arith.constant 13 : i32
+  // CHECK: %[[CONV:.+]] = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+  // CHECK-SAME:  ins(%arg0, %arg1 : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>)
+  // CHECK-SAME:  outs(%arg2 : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM3:.+]] = tensor.dim %arg1, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM3]]) : tensor<?xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<?xi32>)
+  // CHECK: %[[FSUM:.+]] = linalg.generic 
+  // CHECK-SAME:  indexing_maps = [#map0, #map1]
+  // CHECK-SAME:  iterator_types = ["parallel", "reduction", "reduction", "reduction"]
+  // CHECK-SAME:  ins(%arg1 : tensor<?x?x?x?xi8>)
+  // CHECK-SAME:  outs(%[[FILL]] : tensor<?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK: %[[DIM3:.+]] = tensor.dim %arg1, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]])
+  // CHECK: %[[CONV_SUMF:.+]] = linalg.generic 
+  // CHECK-SAME:  indexing_maps = [#map2, #map3, #map2]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "parallel"]
+  // CHECK-SAME:  ins(%[[CONV]], %[[FSUM]] : tensor<?x?x?x?xi32>, tensor<?xi32>)
+  // CHECK-SAME:  outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg0, %[[I1]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg0, %[[I2]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]])
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<?x?x?xi32>)
+  // CHECK: %[[SUMI:.+]] = linalg.generic 
+  // CHECK-SAME:  indexing_maps = [#map2, #map4]
+  // CHECK-SAME:  iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+  // CHECK-SAME:  ins(%arg0 : tensor<?x?x?x?xi8>)
+  // CHECK-SAME:  outs(%[[FILL]] : tensor<?x?x?xi32>)
+  // CHECK: %[[EXPAND:.+]] = tensor.expand_shape %[[SUMI]] {{\[\[}}0], [1], [2, 3]]
+
+  // CHECK-DAG: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]])
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%9 : tensor<?x?x?x1xi32>)
+  // CHECK-DAG: %[[DIM0:.+]] = tensor.dim %arg1, %[[I0]] : tensor<?x?x?x?xi8>
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg1, %[[I1]] : tensor<?x?x?x?xi8>
+  // CHECK: %[[KERNEL:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nhwc_sum 
+  // CHECK-SAME: dilations = dense<1> : tensor<2xi64>
+  // CHECK-SAME: strides = dense<1> : tensor<2xi64>}
+  // CHECK-SAME: ins(%[[EXPAND]], %[[KERNEL]] : tensor<?x?x?x1xi32>, tensor<?x?xi32>)
+  // CHECK-SAME: outs(%[[FILL]] : tensor<?x?x?x1xi32>)
+  // CHECK: %[[COLLAPSE:.+]] = tensor.collapse_shape %[[POOL]] {{\[\[}}0], [1], [2, 3]]
+
+  // CHECK-DAG: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK-DAG: %[[DIM3:.+]] = tensor.dim %arg1, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]])
+  // CHECK: %[[CONV_SUMIF:.+]] = linalg.generic 
+  // CHECK-SAME: indexing_maps = [#map2, #map4, #map2]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME: ins(%[[CONV_SUMF]], %[[COLLAPSE]] : tensor<?x?x?x?xi32>, tensor<?x?x?xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg1, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg1, %[[I1]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg1, %[[I2]]
+  // CHECK: %[[MUL_DIM0_DIM1:.+]] = arith.muli %[[DIM0]], %[[DIM1]]
+  // CHECK: %[[MUL_DIM0_DIM1_DIM2:.+]] = arith.muli %[[MUL_DIM0_DIM1]], %[[DIM2]]
+  // CHECK: %[[CAST:.+]] = arith.index_cast %[[MUL_DIM0_DIM1_DIM2]] : index to i32
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK: %[[DIM3:.+]] = tensor.dim %arg1, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]) : tensor<?x?x?x?xi32>
+  // CHECK: %[[RESULT:.+]] = linalg.generic 
+  // CHECK-SAME: indexing_maps = [#map2, #map2]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME: ins(%[[CONV_SUMIF]] : tensor<?x?x?x?xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+  %0 = linalg.conv_2d_nhwc_hwcf_q {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>} ins(%arg0, %arg1, %iZp, %fZp : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>, i32, i32) outs(%arg2 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+
+  // CHECK: return %[[RESULT]]
+  return %0 : tensor<?x?x?x?xi32>
+}

--- a/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_matmul_to_matmul.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_matmul_to_matmul.mlir
@@ -61,7 +61,7 @@ func.func @quantized_matmul_rhs_zp_0_dynamic(%lhs : tensor<?x?xi8>, %rhs : tenso
 // CHECK-SAME:    ins(%[[C0_I32]] :
 // CHECK-SAME:    outs(%[[INIT_RHS_SUMS_ACC]] :
 // CHECK:       %[[RHS_SUMS:.+]] = linalg.generic
-// CHECK-SAME:    "reduction", "parallel"
+// CHECK-SAME:    "parallel", "reduction"
 // CHECK-SAME:    ins(%[[RHS]] : tensor<?x?xi8>)
 // CHECK-SAME:    outs(%[[ZERO_RHS_SUMS_ACC]] : tensor<?xi32>)
 // CHECK:       %[[RESULT:.+]] = linalg.generic
@@ -96,7 +96,7 @@ func.func @quantized_matmul_neither_zp_0_dynamic(%lhs : tensor<?x?xi8>, %rhs : t
 // CHECK-SAME:    ins(%[[C0_I32]] :
 // CHECK-SAME:    outs(%[[INIT_RHS_SUMS_ACC]] :
 // CHECK:       %[[RHS_SUMS:.+]] = linalg.generic
-// CHECK-SAME:    "reduction", "parallel"
+// CHECK-SAME:    "parallel", "reduction"
 // CHECK-SAME:    ins(%[[RHS]] : tensor<?x?xi8>)
 // CHECK-SAME:    outs(%[[ZERO_RHS_SUMS_ACC]] : tensor<?xi32>)
 // CHECK:       %[[LHS_ZP_TIMES_RHS_ZP:.+]] = arith.muli %[[LHS_ZP]], %[[RHS_ZP]]
@@ -135,7 +135,7 @@ func.func @quantized_matmul_neither_zp_0_3x4x5(%lhs : tensor<3x4xi8>, %rhs : ten
 // CHECK-SAME:    ins(%[[C0_I32]] :
 // CHECK-SAME:    outs(%[[INIT_RHS_SUMS_ACC]] :
 // CHECK:       %[[RHS_SUMS:.+]] = linalg.generic
-// CHECK-SAME:    "reduction", "parallel"
+// CHECK-SAME:    "parallel", "reduction"
 // CHECK-SAME:    ins(%[[RHS]] : tensor<4x5xi8>)
 // CHECK-SAME:    outs(%[[ZERO_RHS_SUMS_ACC]] : tensor<5xi32>)
 // CHECK:       %[[LHS_ZP_TIMES_RHS_ZP:.+]] = arith.muli %[[LHS_ZP]], %[[RHS_ZP]]


### PR DESCRIPTION
linalg.conv_2d_nhwc_hwcf_q includes the zeropoint modification within the inner loop. This can be decomposed to series of generic and pooling computations. This allows the tiling/vectorization code to run on the quantized variants and decreases the total additions / sums.