### PR TITLE
[spirv] Enable using fp16 in matmul promotion pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -26,7 +26,13 @@ namespace detail {
 
 static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op, int subgroupSize) {
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 8};
-  const std::array<int64_t, 3> threadMNK = {8, 4, 16};
+  std::array<int64_t, 3> threadMNK;
+  auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
+  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+    threadMNK = {8, 8, 32};
+  } else {
+    threadMNK = {8, 4, 16};
+  }
   return setMatmulOpConfig(op, subgroupSize, workgroupXY, threadMNK,
                            /*useWorkgroupMemory=*/true);
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -24,7 +24,13 @@ namespace detail {
 static LogicalResult setAdrenoMatmulConfig(linalg::LinalgOp op,
                                            int subgroupSize) {
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
-  const std::array<int64_t, 3> threadMNK = {16, 4, 4};
+  std::array<int64_t, 3> threadMNK;
+  auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
+  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+    threadMNK = {16, 8, 8};
+  } else {
+    threadMNK = {16, 4, 4};
+  }
   return setMatmulOpConfig(op, subgroupSize, workgroupXY, threadMNK);
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
@@ -24,7 +24,13 @@ namespace detail {
 static LogicalResult setAppleMatmulConfig(linalg::LinalgOp op,
                                           int subgroupSize) {
   const std::array<int64_t, 2> workgroupXY = {256, 1};
-  const std::array<int64_t, 3> threadMNK = {4, 4, 4};
+  std::array<int64_t, 3> threadMNK;
+  auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
+  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+    threadMNK = {4, 8, 8};
+  } else {
+    threadMNK = {4, 4, 4};
+  }
   return setMatmulOpConfig(op, subgroupSize, workgroupXY, threadMNK);
 }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -839,7 +839,14 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
         // Try to tile and vectorize first. It's common to see 32 threads
         // per subgroup for GPUs.
         std::array<int64_t, 2> workgroupXY = {32, 2};
-        std::array<int64_t, 3> threadMNK = {8, 8, 4};
+        std::array<int64_t, 3> threadMNK;
+        auto inputType =
+            op.getInputs()[0].getType().template cast<ShapedType>();
+        if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+          threadMNK = {8, 8, 8};
+        } else {
+          threadMNK = {8, 8, 4};
+        }
         auto result = detail::setMatmulOpConfig(op, /*subgroupSize=*/32,
                                                 workgroupXY, threadMNK);
         if (failed(result)) return result;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -27,7 +27,7 @@ static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
   std::array<int64_t, 3> threadMNK;
   auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
-  if (inputType.getElementType().isF16()) {
+  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
     threadMNK = {2, 8, 8};
   } else {
     threadMNK = {6, 4, 4};

--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -112,7 +112,13 @@ static LogicalResult setOpConfig(const spirv::TargetEnv &targetEnv,
 static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
                                            int subgroupSize) {
   const std::array<int64_t, 2> workgroupXY = {subgroupSize, 8};
-  const std::array<int64_t, 3> threadMNK = {4, 4, 32};
+  std::array<int64_t, 3> threadMNK;
+  auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
+  if (inputType.getElementType().getIntOrFloatBitWidth() == 16) {
+    threadMNK = {8, 8, 32};
+  } else {
+    threadMNK = {4, 4, 32};
+  }
   return setMatmulOpConfig(op, subgroupSize, workgroupXY, threadMNK,
                            /*useWorkgroupMemory=*/true);
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -297,6 +297,7 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm) {
       createRemoveSingleIterationLoopPass());
 
   nestedModulePM.addNestedPass<func::FuncOp>(createSPIRVVectorizePass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
@@ -7,7 +7,7 @@
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-hal.executable @batch_matmul_16x4096x40x4096 {
+hal.executable @batch_matmul_f32_16x4096x40x4096 {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb", {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader], []>, AMD:DiscreteGPU, #spirv.resource_limits<
         max_compute_shared_memory_size = 65536,
@@ -15,9 +15,9 @@ hal.executable @batch_matmul_16x4096x40x4096 {
         max_compute_workgroup_size = [1024, 1024, 1024],
         subgroup_size = 64>>
     }> {
-    hal.executable.export @batch_matmul_16x4096x40x4096 layout(#pipeline_layout)
+    hal.executable.export @batch_matmul_f32_16x4096x40x4096 layout(#pipeline_layout)
     builtin.module {
-      func.func @batch_matmul_16x4096x40x4096() {
+      func.func @batch_matmul_f32_16x4096x40x4096() {
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:16x4096x4096xf32>
         %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:16x4096x40xf32>
@@ -35,10 +35,55 @@ hal.executable @batch_matmul_16x4096x40x4096 {
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1024, 8], [1, 8, 4], [0, 0, 0, 16]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
-//      CHECK: hal.executable.export public @batch_matmul_16x4096x40x4096
+//      CHECK: hal.executable.export public @batch_matmul_f32_16x4096x40x4096
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 128 : index, 1 : index]
-//      CHECK: func.func @batch_matmul_16x4096x40x4096()
+//      CHECK: func.func @batch_matmul_f32_16x4096x40x4096()
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @matmul_f16_64x1280x320 {
+  hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader, Float16], []>, AMD:DiscreteGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 65536,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 1024],
+        subgroup_size = 64>>
+    }> {
+    hal.executable.export @matmul_f16_64x1280x320 layout(#pipeline_layout)
+    builtin.module {
+      func.func @matmul_f16_64x1280x320() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:64x320xf16>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:320x1280xf16>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:64x1280xf16>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 320], strides = [1, 1] : !flow.dispatch.tensor<readonly:64x320xf16> -> tensor<64x320xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [320, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:320x1280xf16> -> tensor<320x1280xf16>
+        %5 = tensor.empty() : tensor<64x1280xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
+        %7 = linalg.matmul ins(%3, %4 : tensor<64x320xf16>, tensor<320x1280xf16>) outs(%6 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 1280], strides = [1, 1] : tensor<64x1280xf16> -> !flow.dispatch.tensor<writeonly:64x1280xf16>
+        return
+      }
+    }
+  }
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 256], [8, 8], [0, 0, 32]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
+//      CHECK: hal.executable.export public @matmul_f16_64x1280x320
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+// CHECK-SAME:   workgroup_size = [32 : index, 8 : index, 1 : index]
+//      CHECK: func.func @matmul_f16_64x1280x320()
+//      CHECK:   linalg.matmul
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_matmul.mlir
@@ -305,7 +305,7 @@ hal.executable private @matmul_pointwise_256x1024 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 256], [8, 8], [0, 0, 4]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[16, 256], [8, 8], [0, 0, 8]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @matmul_pointwise_256x1024
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_promotion.mlir
@@ -10,20 +10,20 @@
 ]>
 #map = affine_map<(d0, d1) -> (d0, d1)>
 
-hal.executable @matmul_128x256x64 {
+hal.executable @matmul_f32_128x256x64 {
   hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
     spirv.target_env = #spirv.target_env<#spirv.vce<v1.5, [Shader], []>, NVIDIA:DiscreteGPU, #spirv.resource_limits<
       max_compute_shared_memory_size = 49152,
       max_compute_workgroup_invocations = 1024,
       max_compute_workgroup_size = [65535, 65535, 65535],
       subgroup_size = 32>>}> {
-    hal.executable.export public @matmul_128x256x64 ordinal(0) layout(#pipeline_layout) {
+    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
       %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module {
-      func.func @matmul_128x256x64() {
+      func.func @matmul_f32_128x256x64() {
         %cst = arith.constant 0.000000e+00 : f32
         %c0 = arith.constant 0 : index
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:128x512xf32>
@@ -52,7 +52,7 @@ hal.executable @matmul_128x256x64 {
 // CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<256 x vector<4xf32>>)>, Workgroup>
 // CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1024 x vector<4xf32>>)>, Workgroup>
 
-// CHECK-LABEL: spirv.func @matmul_128x256x64
+// CHECK-LABEL: spirv.func @matmul_f32_128x256x64
 
 //   CHECK-COUNT-5: spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 
@@ -75,3 +75,81 @@ hal.executable @matmul_128x256x64 {
 //   CHECK-COUNT-4: spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //   CHECK-COUNT-4: spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf32>
 //   CHECK-COUNT-4: spirv.Store "StorageBuffer" %{{.+}}, %{{.+}} : vector<4xf32>
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+hal.executable @matmul_f16_128x256x64 {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<#spirv.vce<v1.5, [Shader, Float16], []>, NVIDIA:DiscreteGPU, #spirv.resource_limits<
+      max_compute_shared_memory_size = 49152,
+      max_compute_workgroup_invocations = 1024,
+      max_compute_workgroup_size = [65535, 65535, 65535],
+      subgroup_size = 32>>}> {
+    hal.executable.export public @matmul_f16_128x256x64 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_f16_128x256x64() {
+        %cst = arith.constant 0.0 : f16
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:128x512xf16>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:512x256xf16>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:128x256xf16>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:128x256xf16>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:128x512xf16> -> tensor<128x512xf16>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:512x256xf16> -> tensor<512x256xf16>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:128x256xf16> -> tensor<128x256xf16>
+        %7 = tensor.empty() : tensor<128x256xf16>
+        %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<128x256xf16>) -> tensor<128x256xf16>
+        %9 = linalg.matmul ins(%4, %5 : tensor<128x512xf16>, tensor<512x256xf16>) outs(%8 : tensor<128x256xf16>) -> tensor<128x256xf16>
+        %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+                ins(%9, %6 : tensor<128x256xf16>, tensor<128x256xf16>) outs(%7 : tensor<128x256xf16>) {
+        ^bb0(%arg0: f16, %arg1: f16, %arg2: f16):
+          %11 = arith.divf %arg0, %arg1 : f16
+          linalg.yield %11 : f16
+        } -> tensor<128x256xf16>
+        flow.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf16> -> !flow.dispatch.tensor<writeonly:128x256xf16>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<256 x vector<4xf32>>)>, Workgroup>
+// CHECK-DAG: spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1024 x vector<4xf32>>)>, Workgroup>
+
+// CHECK-LABEL: spirv.func @matmul_f16_128x256x64
+
+//   CHECK-COUNT-5: spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+
+//           CHECK: spirv.mlir.loop
+//           CHECK:   spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+//   CHECK-COUNT-5:   spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
+//           CHECK:   spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+
+//  CHECK-COUNT-64:   spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-512:   spirv.GL.Fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf16>
+//   CHECK-COUNT-5:   spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//           CHECK:   spirv.mlir.merge
+
+//           CHECK: spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+//   CHECK-COUNT-5: spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
+//           CHECK: spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+
+//  CHECK-COUNT-64: spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-512: spirv.GL.Fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf16>
+//   CHECK-COUNT-8: spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//  CHECK-COUNT-16: spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+//   CHECK-COUNT-8: spirv.Store "StorageBuffer" %{{.+}}, %{{.+}} : vector<4xf32>


### PR DESCRIPTION
This requires us to choose a tiling configuration that has some multiple of 8 as the innermost dimension, so that we can properly tile and vectorize with 8-element vectors for memory load/store. Computation still happens as `vector<4xf16>` due to SPIR-V requirements.

Towards https://github.com/iree-org/iree/issues/10718