### PR TITLE
Enable e2e `linalg_ext.pack` test on VMVX + ukernel

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -52,6 +52,12 @@ static llvm::cl::opt<bool> clEnableMicrokernels(
     llvm::cl::desc("Enables microkernel lowering for vmvx (experimental)"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clEnableMicrokernelsDecomposeLinalgGeneric(
+    "iree-vmvx-enable-microkernels-decompose-linalg-generic",
+    llvm::cl::desc("Enables decomposition of linalg.generic ops when "
+                   "microkernels are enabled (experimental)"),
+    llvm::cl::init(true));
+
 static llvm::cl::opt<bool> clEnableReassociateFpReductions(
     "iree-llvmcpu-reassociate-fp-reductions",
     llvm::cl::desc("Enables reassociation for FP reductions"),
@@ -419,7 +425,7 @@ void addVMVXDefaultPassPipeline(OpPassManager &passManager) {
   // Tensor-level micro-kernel optimizations.
   // Note that this must be done post-tiling because it changes the structure
   // of the dispatch region such that tiling is not always possible.
-  if (clEnableMicrokernels) {
+  if (clEnableMicrokernels && clEnableMicrokernelsDecomposeLinalgGeneric) {
     passManager.nest<ModuleOp>().nest<func::FuncOp>().addPass(
         createDecomposeLinalgGenericPass());
   }

--- a/tests/e2e/linalg_ext_ops/BUILD
+++ b/tests/e2e/linalg_ext_ops/BUILD
@@ -95,6 +95,28 @@ iree_check_single_backend_test_suite(
 )
 
 iree_check_single_backend_test_suite(
+    name = "check_vmvx_ukernel_local-task",
+    srcs = [
+        "pack.mlir",
+        # TODO: Uncomment unpack.mlir when this issue is resolved:
+        # https://github.com/iree-org/iree/issues/10796
+        # "unpack.mlir",
+    ],
+    compiler_flags = [
+        "--iree-vmvx-enable-microkernels",
+        # Some testcases have linalg.generic ops with multiple ops in the body.
+        # If we don't opt out from it, DecomposeLinalgGenericPass splits those
+        # into smaller linalg.generic ops with only one op in the body. This
+        # results in the creation of temporary buffers between these split
+        # linalg.generic ops, causing:
+        # > error: failed to legalize operation 'memref.alloca' that was explicitly marked illegal
+        "--iree-vmvx-enable-microkernels-decompose-linalg-generic=false",
+    ],
+    driver = "local-task",
+    target_backend = "vmvx",
+)
+
+iree_check_single_backend_test_suite(
     name = "check_vmvx_local-task",
     srcs = enforce_glob(
         # keep sorted

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -86,6 +86,20 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
+    check_vmvx_ukernel_local-task
+  SRCS
+    "pack.mlir"
+  TARGET_BACKEND
+    "vmvx"
+  DRIVER
+    "local-task"
+  COMPILER_FLAGS
+    "--iree-vmvx-enable-microkernels"
+    "--iree-vmvx-enable-microkernels-decompose-linalg-generic=false"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
     check_vmvx_local-task
   SRCS
     "reverse.mlir"


### PR DESCRIPTION
This is in preparation for actually writing a microkernel.

This is only pack for now, not unpack, because of https://github.com/iree-org/iree/issues/10796 .

I had to introduce a new compiler command-line flag, `--iree-vmvx-enable-microkernels-decompose-linalg-generic`, defaulting to `true` (the current behavior), so that I could set it to `false` in this test. The problem is that when `--iree-vmvx-enable-microkernels` is passed, we use a DecomposeLinalgGenericPass. The `pack.mlir` test here contains `linalg.generic` which, when decomposed by this pass, are split into a chain of multiple `linalg.generic` with temporary buffers in between. These temporary buffers are `memref.alloca` in the IR, resulting in compilation failures:

```
error: failed to legalize operation 'memref.alloca' that was explicitly marked illegal
```

