### PR TITLE
Enable group reduction on SPIRV for large reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -38,6 +38,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -292,7 +293,13 @@ static Value linearizeIndices(Value sourceValue, ValueRange indices,
     } else if (auto allocaOp = dyn_cast<memref::AllocaOp>(sourceOp)) {
       getDimValues(sourceType, allocaOp.getDynamicSizes());
     } else {
-      return nullptr;
+      if (sourceType.hasStaticShape()) {
+        for (int64_t dim : sourceType.getShape()) {
+          dims.push_back(builder.create<arith::ConstantIndexOp>(loc, dim));
+        }
+      } else {
+        return nullptr;
+      }
     }
   }
 
@@ -308,6 +315,37 @@ static Value linearizeIndices(Value sourceValue, ValueRange indices,
   }
   return linearIndex;
 }
+
+/// Flattens memref subspan ops with more than 1 dimensions to 1 dimension.
+struct FlattenSubView final : public OpConversionPattern<memref::SubViewOp> {
+  using OpConversionPattern::OpConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      memref::SubViewOp op, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    if (!isRankOneMemRef(adaptor.getSource().getType())) {
+      return rewriter.notifyMatchFailure(
+          op, "expected converted memref of rank == 1");
+    }
+    Type neededResultType =
+        getTypeConverter()->convertType(op.getResult().getType());
+    if (!neededResultType || !isRankOneMemRef(neededResultType))
+      return failure();
+    Value size = createTotalElementCountValue(op.getType(), op.sizes(),
+                                              op.getLoc(), rewriter);
+    SmallVector<Value> offsets = mlir::getValueOrCreateConstantIndexOp(
+        rewriter, op.getLoc(), op.getMixedOffsets());
+    Value linearOffset =
+        linearizeIndices(op.getSource(), offsets, op.getLoc(), rewriter);
+    Value stride = rewriter.create<arith::ConstantIndexOp>(op.getLoc(), 1);
+    Value newSubView = rewriter.create<memref::SubViewOp>(
+        op.getLoc(), adaptor.getSource(), ValueRange({linearOffset}),
+        ValueRange({size}), ValueRange({stride}));
+    rewriter.replaceOpWithNewOp<memref::CastOp>(op, neededResultType,
+                                                newSubView);
+    return success();
+  }
+};
 
 /// Linearizes indices in memref.load ops.
 struct LinearizeLoadIndices final : public OpConversionPattern<memref::LoadOp> {
@@ -632,7 +670,7 @@ struct FlattenMemRefSubspanPass
              FlattenGlobal, FlattenGetGlobal, LinearizeLoadIndices,
              LinearizeStoreIndices, LinearizeTransferReadIndices,
              LinearizeTransferWriteIndices, AdjustConversionCast,
-             FoldMemRefReshape<memref::CollapseShapeOp>,
+             FlattenSubView, FoldMemRefReshape<memref::CollapseShapeOp>,
              FoldMemRefReshape<memref::ExpandShapeOp>>(
             only1DStaticTypeConverter, &context);
 
@@ -679,6 +717,8 @@ struct FlattenMemRefSubspanPass
           Type inputType = castOp->getOperandTypes().front();
           return !inputType.isa<BaseMemRefType>() || isRankOneMemRef(inputType);
         });
+    target.addDynamicallyLegalOp<memref::SubViewOp>(
+        [](memref::SubViewOp op) { return isRankOneMemRef(op.getType()); });
 
     // Use partial conversion here so that we can ignore allocations created by
     // promotion and their load/store ops.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
@@ -43,7 +44,8 @@ class SPIRVLowerExecutableTargetPass
         .insert<IREE::Codegen::IREECodegenDialect, AffineDialect,
                 gpu::GPUDialect, IREE::HAL::HALDialect, linalg::LinalgDialect,
                 IREE::LinalgExt::IREELinalgExtDialect, memref::MemRefDialect,
-                scf::SCFDialect, spirv::SPIRVDialect, vector::VectorDialect>();
+                bufferization::BufferizationDialect, scf::SCFDialect,
+                spirv::SPIRVDialect, vector::VectorDialect>();
   }
 
   void runOnOperation() override;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -38,6 +38,7 @@ iree_lit_test_suite(
             "pipeline_matmul_promotion.mlir",
             "pipeline_matmul_vectorization.mlir",
             "pipeline_reduction_subgroup.mlir",
+            "reduction_lowering.mlir",
             "tile_and_distribute.mlir",
             "tile_and_distribute_scatter.mlir",
             "tile_and_distribute_sort.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -34,6 +34,7 @@ iree_lit_test_suite(
     "pipeline_matmul_promotion.mlir"
     "pipeline_matmul_vectorization.mlir"
     "pipeline_reduction_subgroup.mlir"
+    "reduction_lowering.mlir"
     "tile_and_distribute.mlir"
     "tile_and_distribute_scatter.mlir"
     "tile_and_distribute_sort.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_reduction.mlir
@@ -43,7 +43,7 @@ hal.executable private @subgroup_reduce_f32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1], [0, 512]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVSubgroupReduce>
 //      CHECK: hal.executable.export public @subgroup_reduce_f32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/reduction_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/reduction_lowering.mlir
@@ -1,0 +1,79 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='hal.executable(hal.executable.variant(iree-spirv-lower-executable-target-pass))' %s | FileCheck %s
+
+#device_target_vulkan = #hal.device.target<"vulkan", {executable_targets = [#hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative], [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU, #spirv.resource_limits<max_compute_workgroup_size = [128, 128, 64], subgroup_size = 32, cooperative_matrix_properties_nv = []>>}>], legacy_sync}>
+#executable_target_vulkan_spirv_fb = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {spirv.target_env = #spirv.target_env<#spirv.vce<v1.3, [Shader, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative], [SPV_KHR_storage_buffer_storage_class]>, SwiftShader:CPU, #spirv.resource_limits<max_compute_workgroup_size = [128, 128, 64], subgroup_size = 32, cooperative_matrix_properties_nv = []>>}>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>
+  hal.executable private @warp_reduction_dispatch {
+    hal.executable.variant public @vulkan_spirv_fb, target = #executable_target_vulkan_spirv_fb {
+      hal.executable.export public @warp_reduction_dispatch ordinal(0) layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+        hal.return %x, %y, %z : index, index, index
+      }
+  builtin.module {
+    func.func @warp_reduction_dispatch() {
+      %c0 = arith.constant 0 : index
+      %c10240 = arith.constant 10240 : index
+      %cst = arith.constant 1.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:512x10240xf32>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<writeonly:512xf32>
+      %5 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [512, 10240], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:512x10240xf32> -> tensor<512x10240xf32>
+      %8 = tensor.empty() : tensor<512xf32>
+      %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<512xf32>) -> tensor<512xf32>
+      %10 = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]}
+          ins(%5 : tensor<512x10240xf32>) outs(%9 : tensor<512xf32>) {
+        ^bb0(%arg1: f32, %arg2: f32):  // no predecessors
+          %11 = arith.addf %arg1, %arg2 : f32
+          linalg.yield %11 : f32
+        } -> tensor<512xf32>
+      flow.dispatch.tensor.store %10, %1, offsets = [0], sizes = [512], strides = [1]
+          : tensor<512xf32> -> !flow.dispatch.tensor<writeonly:512xf32>
+      return
+    }
+  }
+}
+}
+
+//   CHECK-LABEL:  func.func @warp_reduction_dispatch
+//     CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
+//     CHECK-DAG:    %[[C1i:.+]] = arith.constant 1 : index
+//     CHECK-DAG:    %[[C20:.+]] = arith.constant 20 : index
+//     CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : i32
+//     CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : i32
+//     CHECK-DAG:    %[[C4:.+]] = arith.constant 4 : i32
+//     CHECK-DAG:    %[[C8:.+]] = arith.constant 8 : i32
+//     CHECK-DAG:    %[[C16:.+]] = arith.constant 16 : i32
+//     CHECK-DAG:    %[[C32:.+]] = arith.constant 32 : i32
+//     CHECK-DAG:    %[[CF:.+]] = arith.constant 1.000000e+00 : f32
+//     CHECK-DAG:    %[[CST:.+]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+//     CHECK-DAG:    %[[TID:.+]] = gpu.thread_id  x
+//         CHECK:    %[[R0:.+]] = scf.for %{{.*}} = %[[C0]] to %[[C20]] step %[[C1i]] iter_args(%[[A0:.+]] = %[[CST]]) -> (vector<4xf32>) {
+//         CHECK:      %[[V:.+]] = vector.transfer_read {{.*}} {in_bounds = [true]} : memref<1x20x512xf32, strided<[10240, 512, 1], offset: ?>>, vector<4xf32>
+//         CHECK:      %[[A1:.+]] = arith.addf %[[A0]], %[[V]] : vector<4xf32>
+//         CHECK:      scf.yield %[[A1]] : vector<4xf32>
+//         CHECK:    }
+//         CHECK:    %[[R1:.+]] = vector.reduction <add>, %[[R0]] : vector<4xf32> into f32
+//         CHECK:    %[[S0:.+]], %{{.*}} = gpu.shuffle  xor %[[R1]], %[[C1]], %[[C32]] : f32
+//         CHECK:    %[[R2:.+]] = arith.addf %[[R1]], %[[S0]] : f32
+//         CHECK:    %[[S1:.+]], %{{.*}} = gpu.shuffle  xor %[[R2]], %[[C2]], %[[C32]] : f32
+//         CHECK:    %[[R3:.+]] = arith.addf %[[R2]], %[[S1]] : f32
+//         CHECK:    %[[S2:.+]], %{{.*}} = gpu.shuffle  xor %[[R3]], %[[C4]], %[[C32]] : f32
+//         CHECK:    %[[R4:.+]] = arith.addf %[[R3]], %[[S2]] : f32
+//         CHECK:    %[[S3:.+]], %{{.*}} = gpu.shuffle  xor %[[R4]], %[[C8]], %[[C32]] : f32
+//         CHECK:    %[[R5:.+]] = arith.addf %[[R4]], %[[S3]] : f32
+//         CHECK:    %[[S4:.+]], %{{.*}} = gpu.shuffle  xor %[[R5]], %[[C16]], %[[C32]] : f32
+//         CHECK:    %[[R6:.+]] = arith.addf %[[R5]], %[[S4]] : f32
+//         CHECK:    %[[ALLOC:.+]] = memref.alloc() : memref<4xf32, 3>
+//         CHECK:    %[[WID:.+]] = arith.divui %{{.*}}, %{{.*}} : index
+//         CHECK:    memref.store %[[R6]], %[[ALLOC]][%[[WID]]] : memref<4xf32, 3>
+//         CHECK:    gpu.barrier
+//         CHECK:    %[[B:.+]] = vector.transfer_read %[[ALLOC]][%[[C0]]], %{{.*}} {in_bounds = [true]} : memref<4xf32, 3>, vector<4xf32>
+//         CHECK:    %[[R7:.+]] = vector.reduction <add>, %[[B]] : vector<4xf32> into f32
+//         CHECK:    %[[R8:.+]] = arith.addf %[[R7]], %[[CF]] : f32
+//         CHECK:    %[[R9:.+]] = vector.splat %[[R8]] : vector<1xf32>
+//         CHECK:    %[[TID0:.+]] = arith.cmpi eq, %[[TID]], %[[C0]] : index
+//         CHECK:    scf.if %[[TID0]] {
+//         CHECK:      vector.transfer_write %[[R9]], %{{.*}}[%{{.*}}] {in_bounds = [true]} : vector<1xf32>, memref<512xf32>
+//         CHECK:    }


### PR DESCRIPTION
Add pass to tile reduction dimension when it is bigger than the workgroup size.

This requires relaxing flatten memref pass.