### PR TITLE
[spirv] RFC: Pass in the entire resource limits for matmul

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -22,7 +22,8 @@ namespace iree_compiler {
 namespace detail {
 
 static LogicalResult setAdrenoMatmulConfig(linalg::LinalgOp op,
-                                           int subgroupSize) {
+                                           spirv::ResourceLimitsAttr limits) {
+  const int subgroupSize = limits.getSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
   std::array<int64_t, 3> threadMNK;
   auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
@@ -31,7 +32,7 @@ static LogicalResult setAdrenoMatmulConfig(linalg::LinalgOp op,
   } else {
     threadMNK = {16, 4, 4};
   }
-  return setMatmulOpConfig(op, subgroupSize, workgroupXY, threadMNK);
+  return setMatmulOpConfig(limits, op, workgroupXY, threadMNK);
 }
 
 //===----------------------------------------------------------------------===//
@@ -40,17 +41,17 @@ static LogicalResult setAdrenoMatmulConfig(linalg::LinalgOp op,
 
 LogicalResult setAdrenoCodeGenConfig(const spirv::TargetEnv &targetEnv,
                                      Operation *rootOp) {
-  int subgroupSize = targetEnv.getResourceLimits().getSubgroupSize();
+  spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
+  int subgroupSize = limits.getSubgroupSize();
 
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp)) {
     if (isMatmulOrBatchMatmul(linalgOp))
-      return setAdrenoMatmulConfig(linalgOp, subgroupSize);
+      return setAdrenoMatmulConfig(linalgOp, limits);
   }
 
   return TypeSwitch<Operation *, LogicalResult>(rootOp)
-      .Case<linalg::BatchMatmulOp, linalg::MatmulOp>([subgroupSize](auto op) {
-        return setAdrenoMatmulConfig(op, subgroupSize);
-      })
+      .Case<linalg::BatchMatmulOp, linalg::MatmulOp>(
+          [limits](auto op) { return setAdrenoMatmulConfig(op, limits); })
       .Case<linalg::Conv2DNchwFchwOp, linalg::Conv2DNhwcHwcfOp>(
           [subgroupSize](auto op) {
             return setConvOpConfig(op, subgroupSize,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -34,6 +34,8 @@
 namespace mlir {
 namespace iree_compiler {
 
+using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
+
 //===----------------------------------------------------------------------===//
 // Utility Functions
 //===----------------------------------------------------------------------===//
@@ -204,8 +206,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
     threadTileSizes[i] = workgroupTileSizes[i] / workgroupSize[3 - i];
   }
 
-  auto pipeline =
-      IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseVectorize;
+  auto pipeline = CodeGenPipeline::SPIRVBaseVectorize;
   TileSizesListType tileSizes;
   tileSizes.push_back(workgroupTileSizes);
   tileSizes.push_back(threadTileSizes);
@@ -344,10 +345,11 @@ static bool tileMatmulMToWorkgroupY(const int64_t dimM,
 
 namespace detail {
 
-LogicalResult setMatmulOpConfig(linalg::LinalgOp op, int64_t subgroupSize,
+LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
+                                linalg::LinalgOp op,
                                 std::array<int64_t, 2> bestWorkgroupSizeXY,
                                 std::array<int64_t, 3> bestThreadTileSizeMNK,
-                                bool useWorkgroupMemory) {
+                                bool enablePromotion) {
   LLVM_DEBUG(llvm::dbgs() << "trying to deduce config as matmul...\n");
   OpOperand *lhs = op.getInputOperand(0);
   OpOperand *rhs = op.getInputOperand(1);
@@ -432,16 +434,15 @@ LogicalResult setMatmulOpConfig(linalg::LinalgOp op, int64_t subgroupSize,
   }
   if (reductionTileSizes[kIndex] == 0) return success();
 
+  const int subgroupSize = limits.getSubgroupSize();
   int64_t totalThreads = workgroupSize[0] * workgroupSize[1] * workgroupSize[2];
   LLVM_DEBUG({
     llvm::dbgs() << "total thread count = " << totalThreads << "\n";
     llvm::dbgs() << "subgroup size = " << subgroupSize << "\n";
   });
-  auto pipeline =
-      (useWorkgroupMemory && totalThreads > subgroupSize)
-          ? IREE::Codegen::DispatchLoweringPassPipeline::
-                SPIRVMatmulPromoteVectorize
-          : IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseVectorize;
+  auto pipeline = (enablePromotion && totalThreads > subgroupSize)
+                      ? CodeGenPipeline::SPIRVMatmulPromoteVectorize
+                      : CodeGenPipeline::SPIRVBaseVectorize;
 
   SmallVector<int64_t> threadTileSizes(numLoops, 0);
   if (isBM) {
@@ -472,8 +473,7 @@ static LogicalResult setFftOpConfig(spirv::ResourceLimitsAttr limits,
                                     IREE::LinalgExt::FftOp op) {
   LLVM_DEBUG(llvm::dbgs() << "trying to deduce config as fft...\n");
   const int subgroupSize = limits.getSubgroupSize();
-  auto pipeline =
-      IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseDistribute;
+  auto pipeline = CodeGenPipeline::SPIRVBaseDistribute;
 
   std::array<int64_t, 3> workgroupSize = {subgroupSize, 1, 1};
 
@@ -573,8 +573,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
 
   return setOpConfigAndEntryPointFnTranslation(
       op->getParentOfType<func::FuncOp>(), op, tileSizes,
-      IREE::Codegen::DispatchLoweringPassPipeline::SPIRVSubgroupReduce,
-      workgroupSize);
+      CodeGenPipeline::SPIRVSubgroupReduce, workgroupSize);
 }
 
 //===----------------------------------------------------------------------===//
@@ -594,8 +593,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
   if (partitionedLoops.empty()) {
     // No tiled loops means we cannot tile (and distribute) at all. Use just one
     // single thread to run everything.
-    auto pipeline =
-        IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseDistribute;
+    auto pipeline = CodeGenPipeline::SPIRVBaseDistribute;
     std::array<int64_t, 3> workgroupSize = {1, 1, 1};
     return setOpConfigAndEntryPointFnTranslation(funcOp, op, {}, pipeline,
                                                  workgroupSize);
@@ -627,8 +625,7 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
   // Special case for non-linalg ops.
   auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
   if (!linalgOp || linalgOp.getNumOutputs() != 1) {
-    auto pipeline =
-        IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseDistribute;
+    auto pipeline = CodeGenPipeline::SPIRVBaseDistribute;
 
     initConfiguration();
     TileSizesListType tileSizes;
@@ -763,10 +760,8 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
     }
   }
 
-  auto pipeline =
-      vectorizable
-          ? IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseVectorize
-          : IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseDistribute;
+  auto pipeline = vectorizable ? CodeGenPipeline::SPIRVBaseVectorize
+                               : CodeGenPipeline::SPIRVBaseDistribute;
 
   TileSizesListType tileSizes;
   tileSizes.push_back(workgroupTileSizes);
@@ -855,8 +850,8 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
         } else {
           threadMNK = {8, 8, 4};
         }
-        auto result = detail::setMatmulOpConfig(op, /*subgroupSize=*/32,
-                                                workgroupXY, threadMNK);
+        auto result =
+            detail::setMatmulOpConfig(limits, op, workgroupXY, threadMNK);
         if (failed(result)) return result;
         if (getLoweringConfig(op)) return result;
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
@@ -35,10 +35,11 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
 
 /// Sets CodeGen configurations via attributes to the given matmul `linalgOp`
 /// with the given best workgroup size and tile size hints.
-LogicalResult setMatmulOpConfig(linalg::LinalgOp linalgOp, int64_t subgroupSize,
+LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
+                                linalg::LinalgOp linalgOp,
                                 std::array<int64_t, 2> bestWorkgroupSizeXY,
                                 std::array<int64_t, 3> bestThreadTileSizeMNK,
-                                bool useWorkgroupMemory = false);
+                                bool enablePromotion = false);
 
 /// Sets CodeGen configuration for GPUs from a specific vendor.
 ///

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -23,7 +23,8 @@ namespace iree_compiler {
 namespace detail {
 
 static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
-                                         int subgroupSize) {
+                                         spirv::ResourceLimitsAttr limits) {
+  const int subgroupSize = limits.getSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize / 2, 2};
   std::array<int64_t, 3> threadMNK;
   auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
@@ -32,7 +33,7 @@ static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
   } else {
     threadMNK = {6, 4, 4};
   }
-  return setMatmulOpConfig(op, subgroupSize, workgroupXY, threadMNK);
+  return setMatmulOpConfig(limits, op, workgroupXY, threadMNK);
 }
 
 //===----------------------------------------------------------------------===//
@@ -41,17 +42,17 @@ static LogicalResult setMaliMatmulConfig(linalg::LinalgOp op,
 
 LogicalResult setMaliCodeGenConfig(const spirv::TargetEnv &targetEnv,
                                    Operation *rootOp) {
-  int subgroupSize = targetEnv.getResourceLimits().getSubgroupSize();
+  spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
+  int subgroupSize = limits.getSubgroupSize();
 
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp)) {
     if (isMatmulOrBatchMatmul(linalgOp))
-      return setMaliMatmulConfig(linalgOp, subgroupSize);
+      return setMaliMatmulConfig(linalgOp, limits);
   }
 
   return TypeSwitch<Operation *, LogicalResult>(rootOp)
-      .Case<linalg::BatchMatmulOp, linalg::MatmulOp>([subgroupSize](auto op) {
-        return setMaliMatmulConfig(op, subgroupSize);
-      })
+      .Case<linalg::BatchMatmulOp, linalg::MatmulOp>(
+          [limits](auto op) { return setMaliMatmulConfig(op, limits); })
       .Case<linalg::Conv2DNchwFchwOp, linalg::Conv2DNhwcHwcfOp>(
           [subgroupSize](auto op) {
             bool hasPaddedInput =

--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -15,6 +15,7 @@
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/IR/BuiltinOps.h"
 
 #define DEBUG_TYPE "iree-spirv-nvidia-config"
@@ -110,7 +111,8 @@ static LogicalResult setOpConfig(const spirv::TargetEnv &targetEnv,
 }
 
 static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
-                                           int subgroupSize) {
+                                           spirv::ResourceLimitsAttr limits) {
+  const int subgroupSize = limits.getSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize, 8};
   std::array<int64_t, 3> threadMNK;
   auto inputType = op.getInputs()[0].getType().cast<ShapedType>();
@@ -119,8 +121,8 @@ static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
   } else {
     threadMNK = {4, 4, 32};
   }
-  return setMatmulOpConfig(op, subgroupSize, workgroupXY, threadMNK,
-                           /*useWorkgroupMemory=*/true);
+  return setMatmulOpConfig(limits, op, workgroupXY, threadMNK,
+                           /*enablePromotion=*/true);
 }
 
 // Volta architecture:
@@ -155,7 +157,7 @@ static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
 
 LogicalResult setNVIDIACodeGenConfig(const spirv::TargetEnv &targetEnv,
                                      Operation *rootOp) {
-  int subgroupSize = targetEnv.getResourceLimits().getSubgroupSize();
+  spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
 
   // First try to see if we can use tensor cores.
   if (auto matmulOp = dyn_cast<linalg::MatmulOp>(rootOp)) {
@@ -165,13 +167,12 @@ LogicalResult setNVIDIACodeGenConfig(const spirv::TargetEnv &targetEnv,
 
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(rootOp)) {
     if (isMatmulOrBatchMatmul(linalgOp))
-      return setNVIDIAMatmulConfig(linalgOp, subgroupSize);
+      return setNVIDIAMatmulConfig(linalgOp, limits);
   }
 
   return TypeSwitch<Operation *, LogicalResult>(rootOp)
-      .Case<linalg::BatchMatmulOp, linalg::MatmulOp>([subgroupSize](auto op) {
-        return setNVIDIAMatmulConfig(op, subgroupSize);
-      })
+      .Case<linalg::BatchMatmulOp, linalg::MatmulOp>(
+          [limits](auto op) { return setNVIDIAMatmulConfig(op, limits); })
       .Default([](Operation *) { return success(); });
 }
 


### PR DESCRIPTION
This is just a preliminary refactoring step for upcoming changes to better utilize shared memory for matmul. Keep it separate to make code reviews easier.