### PR TITLE
[iree-dialects][transform] drop unnecessary handle associations

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
@@ -44,6 +44,10 @@ public:
     return failure(hadErrors);
   }
 
+  /// Remove the mappings between the given operation and any handle that may be
+  /// associated with it in the transform op.
+  void removeMappings(Operation *op);
+
 private:
   InFlightDiagnostic emitError(Operation *op, const llvm::Twine &message = {}) {
     mayFail(failure());

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -1,6 +1,4 @@
 // RUN: iree-dialects-opt --transform-dialect-interpreter %s | FileCheck %s
-// REQUIRES: dont-run
-// FIXME(#10785): Fix an un-XFAIL this test.
 
 // CHECK-LABEL: func @matmul_tensors
 // CHECK-NOT: linalg


### PR DESCRIPTION
Canonicalization in the canonicalized sequence transform op may replace payload operations associated with the transform dialect handles. Post-canonicalize reassociation is fragile and may fail. To make this less likely, drop any association that are no longer necessary, i.e., if the operand is no longer used in the sequence or elsewhere or if the result is never read. This is a more robust but IREE-specific alternative to the obsolete functionality in upstream MLIR that wouldn't associate unread results.

Closes #10785