### PR TITLE
Loosen `linalg_ext.scatter` requirements for partial update

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -343,6 +343,27 @@ func.func @scatter_add_slice_2D(%arg0: tensor<6x3xi32>, %arg1: tensor<2x1xi32>,
 
 // -----
 
+func.func @scatter_partial(%arg0: tensor<10x5xf32>, %arg1: tensor<3x1xi32>, %arg2: tensor<3x3xf32>) -> tensor<10x5xf32> {
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<f32>, %arg4: tensor<f32>):  // no predecessors
+    %1 = mhlo.add %arg3, %arg4 : tensor<f32>
+    "mhlo.return"(%1) : (tensor<f32>) -> ()
+  }) {indices_are_sorted = false, scatter_dimension_numbers = #mhlo.scatter<update_window_dims = [1], inserted_window_dims = [0], scatter_dims_to_operand_dims = [0], index_vector_dim = 1>, unique_indices = false} : (tensor<10x5xf32>, tensor<3x1xi32>, tensor<3x3xf32>) -> tensor<10x5xf32>
+  return %0 : tensor<10x5xf32>
+}
+
+// CHECK-LABEL: func.func @scatter_partial
+// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
+// CHECK-SAME:      unique_indices(false)
+// CHECK-SAME:      ins(%[[ARG2]], %[[ARG1]] : tensor<3x3xf32>, tensor<3x1xi32>)
+// CHECK-SAME:      outs(%[[ARG0]] : tensor<10x5xf32>)
+// CHECK:         return %[[SCATTER]]
+
+// -----
+
 func.func @rfft_1d(%input: tensor<8xf32>) -> (tensor<5xf32>, tensor<5xf32>) {
   %0 = "mhlo.fft"(%input) {
     fft_length = dense<8> : tensor<1xi64>, fft_type = #mhlo<fft_type RFFT>

--- a/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/test/convert_mhlo_to_linalg_ext.mlir
@@ -353,9 +353,9 @@ func.func @scatter_partial(%arg0: tensor<10x5xf32>, %arg1: tensor<3x1xi32>, %arg
 }
 
 // CHECK-LABEL: func.func @scatter_partial
-// CHECK:         %[[ARG0:[a-zA-Z0-9]+]]
-// CHECK:         %[[ARG1:[a-zA-Z0-9]+]]
-// CHECK:         %[[ARG2:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
+// CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK:         %[[SCATTER:.+]] = iree_linalg_ext.scatter
 // CHECK-SAME:      unique_indices(false)
 // CHECK-SAME:      ins(%[[ARG2]], %[[ARG1]] : tensor<3x3xf32>, tensor<3x1xi32>)

--- a/integrations/tensorflow/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/integrations/tensorflow/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -203,16 +203,16 @@ func.func @scatter_dim_mismatch(
 
 func.func @scatter_dim_mismatch(
     %update : tensor<?x4xf32>, %indices : tensor<?x1xi32>,
-    %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{mismatch in shape of update value dim#1 and original value at dim#1}}
+    %original : tensor<?x3xf32>) -> tensor<?x3xf32> {
+  // expected-error @+1 {{op shape of update value dim#1 exceeds original value at dim#1}}
   %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x4xf32>, tensor<?x1xi32>)
-    outs(%original : tensor<?x?xf32>) {
+    outs(%original : tensor<?x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = arith.addf %arg1, %arg2 : f32
       iree_linalg_ext.yield %1 : f32
-    } -> tensor<?x?xf32>
-  return %0 : tensor<?x?xf32>
+    } -> tensor<?x3xf32>
+  return %0 : tensor<?x3xf32>
 }
 
 // -----

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -177,7 +177,7 @@ LogicalResult ScatterOp::verify() {
         "index depth and update value does not cover rank of original value");
   }
 
-  // Validate the non-indexed update dims covier the full slice size of the
+  // Validate the non-indexed update dims cover the full slice size of the
   // original tensor.
   int64_t fullSliceDims = originalType.getRank() - indexDepth;
   for (auto it :
@@ -186,10 +186,10 @@ LogicalResult ScatterOp::verify() {
                                      updateType.getRank()))) {
     int64_t originalDim = std::get<0>(it);
     int64_t updateDim = std::get<1>(it);
-    if (updateType.getDimSize(updateDim) !=
+    if (updateType.getDimSize(updateDim) >
         originalType.getDimSize(originalDim)) {
-      return op->emitOpError("mismatch in shape of update value dim#")
-             << updateDim << " and original value at dim#" << originalDim;
+      return op->emitOpError("shape of update value dim#")
+             << updateDim << " exceeds original value at dim#" << originalDim;
     }
   }
 

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -203,16 +203,16 @@ func.func @scatter_dim_mismatch(
 
 func.func @scatter_dim_mismatch(
     %update : tensor<?x4xf32>, %indices : tensor<?x1xi32>,
-    %original : tensor<?x?xf32>) -> tensor<?x?xf32> {
-  // expected-error @+1 {{mismatch in shape of update value dim#1 and original value at dim#1}}
+    %original : tensor<?x3xf32>) -> tensor<?x3xf32> {
+  // expected-error @+1 {{op shape of update value dim#1 exceeds original value at dim#1}}
   %0 = iree_linalg_ext.scatter unique_indices(true)
     ins(%update, %indices : tensor<?x4xf32>, tensor<?x1xi32>)
-    outs(%original : tensor<?x?xf32>) {
+    outs(%original : tensor<?x3xf32>) {
     ^bb0(%arg1: f32, %arg2: f32):
       %1 = arith.addf %arg1, %arg2 : f32
       iree_linalg_ext.yield %1 : f32
-    } -> tensor<?x?xf32>
-  return %0 : tensor<?x?xf32>
+    } -> tensor<?x3xf32>
+  return %0 : tensor<?x3xf32>
 }
 
 // -----

--- a/tests/e2e/xla_ops/scatter.mlir
+++ b/tests/e2e/xla_ops/scatter.mlir
@@ -87,6 +87,33 @@ func.func @scatter_update_slice_2D() {
   return
 }
 
+func.func @scatter_update_slice_partial_2D() {
+  %arg0 = util.unfoldable_constant dense<0> : tensor<6x3xi32>
+  %arg1 = util.unfoldable_constant dense<[[2], [4]]> : tensor<2x1xi32>
+  %arg2 = util.unfoldable_constant dense<[[1, 2],
+                                          [4, 5]]> : tensor<2x2xi32>
+  %0 = "mhlo.scatter"(%arg0, %arg1, %arg2) ( {
+  ^bb0(%arg3: tensor<i32>, %arg4: tensor<i32>):  // no predecessors
+    "mhlo.return"(%arg4) : (tensor<i32>) -> ()
+  }) {
+    indices_are_sorted = false,
+    scatter_dimension_numbers = #mhlo.scatter<
+      update_window_dims = [1],
+      inserted_window_dims = [0],
+      scatter_dims_to_operand_dims = [0],
+      index_vector_dim = 1,
+    >,
+    unique_indices = true
+  } : (tensor<6x3xi32>, tensor<2x1xi32>, tensor<2x2xi32>) -> tensor<6x3xi32>
+  check.expect_eq_const(%0, dense<[[0, 0, 0],
+                                   [0, 0, 0],
+                                   [1, 2, 0],
+                                   [0, 0, 0],
+                                   [4, 5, 0],
+                                   [0, 0, 0]]> : tensor<6x3xi32>) : tensor<6x3xi32>
+  return
+}
+
 func.func @scatter_add_slice_2D() {
   %arg0 = util.unfoldable_constant dense<1> : tensor<6x3xi32>
   %arg1 = util.unfoldable_constant dense<[[2], [4]]> : tensor<2x1xi32>


### PR DESCRIPTION
mhlo.scatter has implicit 0 index for the update and allows a partial update for along the destination axis.