### PR TITLE
Delete non-universal binaries from macOS

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           # libzstd on GitHub Action bots is not compatible with MacOS universal.
           # https://github.com/iree-org/iree/issues/9955
-          sudo rm -rf /usr/local/lib/libzstd.*.dylib
+          sudo rm -rf /usr/local/lib/libzstd*
           sudo rm -rf /usr/local/lib/cmake/zstd/*
 
           ./main_checkout/build_tools/python_deploy/build_macos_packages.sh


### PR DESCRIPTION
This catches all variations of libzstd in the GHA runners. We noticed some runners now have an unversioned dylib https://github.com/iree-org/iree/actions/runs/3264207153/jobs/5364477219#step:9:4794 so expanding this workaround.