### PR TITLE
Fix bug in flatten memref pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
@@ -367,12 +367,11 @@ func.func @subview(%offset : index, %i0: index, %i1: index) -> f32 {
   return %value : f32
 }
 
-//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1] -> (s0 * 128 + s1)>
+//      CHECK: #[[MAP:.+]] = affine_map<()[s0, s1, s2] -> (s0 * 128 + s1 + s2 floordiv 4)>
 //      CHECK: func.func @subview
 // CHECK-SAME: (%[[OFFSET:.+]]: index, %[[I0:.+]]: index, %[[I1:.+]]: index)
 //  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //  CHECK-DAG:   %[[SIZE:.+]] = arith.constant 4096 : index
-//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[OFFSET]]) : memref<?xf32>{%[[SIZE]]}
-//      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[I0]], %[[I1]]]
-//      CHECK:   %[[SUBVIEW:.+]] = memref.subview %[[SUBSPAN]][%[[INDEX]]] [128] [1] : memref<?xf32> to memref<128xf32, strided<[1], offset: ?>>
-//      CHECK:   memref.load %[[SUBVIEW]][%[[C0]]]
+//      CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[C0]]) : memref<?xf32>{%[[SIZE]]}
+//      CHECK:   %[[INDEX:.+]] = affine.apply #[[MAP]]()[%[[I0]], %[[I1]], %[[OFFSET]]]
+//      CHECK:   memref.load %[[SUBSPAN]][%[[INDEX]]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -37,6 +37,7 @@
 #include "mlir/Conversion/TosaToArith/TosaToArith.h"
 #include "mlir/Conversion/VectorToSPIRV/VectorToSPIRV.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -235,7 +236,13 @@ struct HALInterfaceBindingSubspanConverter final
       return subspanOp.emitError()
              << "failed to convert SPIR-V type: " << resultType;
     }
-
+    assert(
+        (subspanOp.getByteOffset() == Value() ||
+         (subspanOp.getByteOffset().getDefiningOp<arith::ConstantIndexOp>() &&
+          subspanOp.getByteOffset()
+                  .getDefiningOp<arith::ConstantIndexOp>()
+                  .value() == 0)) &&
+        "subspan expects a 0 offset or no offset.");
     auto varOp = interfaceToResourceVars.lookup(subspanOp);
     // Fix up the variable's type.
     varOp.setTypeAttr(TypeAttr::get(convertedType));

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -187,8 +187,6 @@ static void addMemRefLoweringPasses(OpPassManager &pm) {
   // Turn multi-dimension memref into one-dimension. This is needed for SPIR-V
   // because we don't use upstream memref descriptors.
   pm.addPass(createFlattenMemRefSubspanPass());
-  // Flatten memref may expose more opportunities to fold subview ops.
-  pm.addPass(memref::createFoldMemRefAliasOpsPass());
 }
 
 /// Adds passes to perform the final SPIR-V conversion.


### PR DESCRIPTION
The subspan op is expected to have an offset of 0 after the pass. Add an assert in convertion to SPIRV since the pass makes the assumption.