### PR TITLE
Update CI runner to ubuntu-20.04

### DIFF
--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   tag_release:
     name: "Tag candidate release"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checking out repository
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   tag_release:
     name: "Tag candidate release"
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     # Don't run this in everyone's forks.
     if: github.repository == 'iree-org/iree'
     steps:

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -19,7 +19,7 @@ jobs:
   validate_packages:
     name: "Validate packages"
     # TODO(jennik): Look into testing windows and macos builds.
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Download packages
         id: download_packages
@@ -73,7 +73,7 @@ jobs:
   publish_release:
     name: "Publish release"
     needs: validate_packages
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Publish Release
         id: publish_release


### PR DESCRIPTION
ubuntu-18.04 is going to be deprecated in Dec. 2022.