### PR TITLE
Add support for GEMM e2e Test For CUDA backend on F16 input

### DIFF
--- a/runtime/src/iree/base/internal/math.h
+++ b/runtime/src/iree/base/internal/math.h
@@ -322,4 +322,10 @@ static inline uint16_t iree_math_f32_to_f16(const float f32_value) {
   return (uint16_t)(sign | exp | mantissa);
 }
 
+// Rounds of 32-bit C `float` value to nearest 16-bit value and returns
+// 32-bit `float`
+static inline float iree_math_round_to_nearest_f16(const float f32_value) {
+  return iree_math_f16_to_f32(iree_math_f32_to_f16(f32_value));
+}
+
 #endif  // IREE_BASE_INTERNAL_MATH_H_

--- a/runtime/src/iree/tooling/BUILD
+++ b/runtime/src/iree/tooling/BUILD
@@ -191,6 +191,7 @@ cc_library(
         ":yaml_util",
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/internal:file_io",
         "//runtime/src/iree/base/internal:path",
         "//runtime/src/iree/hal",

--- a/runtime/src/iree/tooling/CMakeLists.txt
+++ b/runtime/src/iree/tooling/CMakeLists.txt
@@ -211,6 +211,7 @@ iree_cc_library(
   DEPS
     ::yaml_util
     iree::base
+    iree::base::internal
     iree::base::internal::file_io
     iree::base::internal::path
     iree::base::tracing

--- a/runtime/src/iree/tooling/trace_replay.h
+++ b/runtime/src/iree/tooling/trace_replay.h
@@ -89,6 +89,133 @@ iree_status_t iree_trace_replay_event_call(iree_trace_replay_t* replay,
                                            yaml_node_t* event_node,
                                            iree_vm_list_t** out_output_list);
 
+// Defines the type of a primitive value.
+typedef enum iree_e2e_test_value_type_e {
+  // Not a value type.
+  IREE_E2E_TEST_VALUE_TYPE_NONE = 0,
+  // int8_t.
+  IREE_E2E_TEST_VALUE_TYPE_I8 = 1,
+  // int16_t.
+  IREE_E2E_TEST_VALUE_TYPE_I16 = 2,
+  // int32_t.
+  IREE_E2E_TEST_VALUE_TYPE_I32 = 3,
+  // int64_t.
+  IREE_E2E_TEST_VALUE_TYPE_I64 = 4,
+  // halft_t.
+  IREE_E2E_TEST_VALUE_TYPE_F16 = 5,
+  // float.
+  IREE_E2E_TEST_VALUE_TYPE_F32 = 6,
+  // double.
+  IREE_E2E_TEST_VALUE_TYPE_F64 = 7,
+} iree_e2e_test_value_type_t;
+
+// Maximum size, in bytes, of any value type we can represent.
+#define IREE_E2E_TEST_VALUE_STORAGE_SIZE 8
+
+// A variant value type.
+typedef struct iree_e2e_test_value_t {
+  iree_e2e_test_value_type_t type;
+  union {
+    int8_t i8;
+    int16_t i16;
+    int32_t i32;
+    int64_t i64;
+    float f32;
+    uint16_t f16_u16;
+    double f64;
+
+    uint8_t value_storage[IREE_E2E_TEST_VALUE_STORAGE_SIZE];  // max size of all
+                                                              // value types
+  };
+} iree_e2e_test_value_t;
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_none() {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_NONE;
+  return result;
+}
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_i8(int8_t value) {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_I8;
+  result.i8 = value;
+  return result;
+}
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_i16(
+    int16_t value) {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_I16;
+  result.i16 = value;
+  return result;
+}
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_i32(
+    int32_t value) {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_I32;
+  result.i32 = value;
+  return result;
+}
+
+// TODO(#5542): check the value type before accessing the union.
+static inline int32_t iree_e2e_test_value_get_i32(
+    iree_e2e_test_value_t* value) {
+  return value->i32;
+}
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_i64(
+    int64_t value) {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_I64;
+  result.i64 = value;
+  return result;
+}
+
+// TODO(#5542): check the value type before accessing the union.
+static inline int64_t iree_e2e_test_value_get_i64(
+    iree_e2e_test_value_t* value) {
+  return value->i64;
+}
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_f16(
+    uint16_t value) {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_F16;
+  result.f16_u16 = value;
+  return result;
+}
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_f32(float value) {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_F32;
+  result.f32 = value;
+  return result;
+}
+
+// TODO(#5542): check the value type before accessing the union.
+static inline float iree_e2e_test_value_get_f32(iree_e2e_test_value_t* value) {
+  return value->f32;
+}
+
+// TODO(#5542): check the value type before accessing the union.
+static inline uint16_t iree_e2e_test_value_get_f16(
+    iree_e2e_test_value_t* value) {
+  return value->f16_u16;
+}
+
+static inline iree_e2e_test_value_t iree_e2e_test_value_make_f64(double value) {
+  iree_e2e_test_value_t result;
+  result.type = IREE_E2E_TEST_VALUE_TYPE_F64;
+  result.f64 = value;
+  return result;
+}
+
+// TODO(#5542): check the value type before accessing the union.
+static inline double iree_e2e_test_value_get_f64(iree_e2e_test_value_t* value) {
+  return value->f64;
+}
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/vm/value.h
+++ b/runtime/src/iree/vm/value.h
@@ -30,10 +30,12 @@ typedef enum iree_vm_value_type_e {
   IREE_VM_VALUE_TYPE_I32 = 3,
   // int64_t.
   IREE_VM_VALUE_TYPE_I64 = 4,
+  // halft_t.
+  IREE_VM_VALUE_TYPE_F16 = 5,
   // float.
-  IREE_VM_VALUE_TYPE_F32 = 5,
+  IREE_VM_VALUE_TYPE_F32 = 6,
   // double.
-  IREE_VM_VALUE_TYPE_F64 = 6,
+  IREE_VM_VALUE_TYPE_F64 = 7,
 
   IREE_VM_VALUE_TYPE_MAX = IREE_VM_VALUE_TYPE_F64,
   IREE_VM_VALUE_TYPE_COUNT = IREE_VM_VALUE_TYPE_MAX + 1,  // used for lookup
@@ -51,6 +53,7 @@ typedef struct iree_vm_value_t {
     int32_t i32;
     int64_t i64;
     float f32;
+    uint16_t f16_u16;
     double f64;
 
     uint8_t value_storage[IREE_VM_VALUE_STORAGE_SIZE];  // max size of all value
@@ -102,6 +105,13 @@ static inline int64_t iree_vm_value_get_i64(iree_vm_value_t *value) {
   return value->i64;
 }
 
+static inline iree_vm_value_t iree_vm_value_make_f16(uint16_t value) {
+  iree_vm_value_t result;
+  result.type = IREE_VM_VALUE_TYPE_F16;
+  result.f16_u16 = value;
+  return result;
+}
+
 static inline iree_vm_value_t iree_vm_value_make_f32(float value) {
   iree_vm_value_t result;
   result.type = IREE_VM_VALUE_TYPE_F32;
@@ -112,6 +122,11 @@ static inline iree_vm_value_t iree_vm_value_make_f32(float value) {
 // TODO(#5542): check the value type before accessing the union.
 static inline float iree_vm_value_get_f32(iree_vm_value_t *value) {
   return value->f32;
+}
+
+// TODO(#5542): check the value type before accessing the union.
+static inline uint16_t iree_vm_value_get_f16(iree_vm_value_t *value) {
+  return value->f16_u16;
 }
 
 static inline iree_vm_value_t iree_vm_value_make_f64(double value) {

--- a/runtime/src/iree/vm/value.h
+++ b/runtime/src/iree/vm/value.h
@@ -30,12 +30,10 @@ typedef enum iree_vm_value_type_e {
   IREE_VM_VALUE_TYPE_I32 = 3,
   // int64_t.
   IREE_VM_VALUE_TYPE_I64 = 4,
-  // halft_t.
-  IREE_VM_VALUE_TYPE_F16 = 5,
   // float.
-  IREE_VM_VALUE_TYPE_F32 = 6,
+  IREE_VM_VALUE_TYPE_F32 = 5,
   // double.
-  IREE_VM_VALUE_TYPE_F64 = 7,
+  IREE_VM_VALUE_TYPE_F64 = 6,
 
   IREE_VM_VALUE_TYPE_MAX = IREE_VM_VALUE_TYPE_F64,
   IREE_VM_VALUE_TYPE_COUNT = IREE_VM_VALUE_TYPE_MAX + 1,  // used for lookup
@@ -53,7 +51,6 @@ typedef struct iree_vm_value_t {
     int32_t i32;
     int64_t i64;
     float f32;
-    uint16_t f16_u16;
     double f64;
 
     uint8_t value_storage[IREE_VM_VALUE_STORAGE_SIZE];  // max size of all value
@@ -105,13 +102,6 @@ static inline int64_t iree_vm_value_get_i64(iree_vm_value_t *value) {
   return value->i64;
 }
 
-static inline iree_vm_value_t iree_vm_value_make_f16(uint16_t value) {
-  iree_vm_value_t result;
-  result.type = IREE_VM_VALUE_TYPE_F16;
-  result.f16_u16 = value;
-  return result;
-}
-
 static inline iree_vm_value_t iree_vm_value_make_f32(float value) {
   iree_vm_value_t result;
   result.type = IREE_VM_VALUE_TYPE_F32;
@@ -122,11 +112,6 @@ static inline iree_vm_value_t iree_vm_value_make_f32(float value) {
 // TODO(#5542): check the value type before accessing the union.
 static inline float iree_vm_value_get_f32(iree_vm_value_t *value) {
   return value->f32;
-}
-
-// TODO(#5542): check the value type before accessing the union.
-static inline uint16_t iree_vm_value_get_f16(iree_vm_value_t *value) {
-  return value->f16_u16;
 }
 
 static inline iree_vm_value_t iree_vm_value_make_f64(double value) {

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -213,6 +213,33 @@ py_binary(
 ]]
 
 [iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f16_gpu_large_%s" % compilation_info,
+    compiler_flags = [
+        "--iree-hal-cuda-llvm-target-arch=sm_80",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f16",
+        "--shapes=gpu_large",
+        "--compilation_info=%s" % compilation_info,
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    trace_runner = "//tools:iree-e2e-matmul-test",
+) for compilation_info in [
+    "LLVMGPUMatmulTensorCore",
+]]
+
+[iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_%s_large_split_k" % lhs_rhs_type,
     compiler_flags = [
         "--iree-flow-split-matmul-reduction=4",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -300,6 +300,31 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_direct_f16_gpu_large_LLVMGPUMatmulTensorCore
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f16"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUMatmulTensorCore"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_direct_f32_large_split_k
   GENERATOR
     "generate_e2e_matmul_tests.py"

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -25,6 +25,7 @@ class MatrixElemTypeId(enum.Enum):
   I8 = "i8"
   I32 = "i32"
   F32 = "f32"
+  F16 = "f16"
 
 
 # Enumerates of the collections of shapes that we can generate tests for.
@@ -513,7 +514,7 @@ def parse_arguments():
                       required=True)
   parser.add_argument("--lhs_rhs_type",
                       type=str,
-                      choices=["i8", "f32"],
+                      choices=["i8", "f32", "f16"],
                       help="Numeric type of input matrices",
                       required=True)
   parser.add_argument("--shapes",

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -188,6 +188,7 @@ cc_binary(
         "//runtime/src/iree/base",
         "//runtime/src/iree/base:core_headers",
         "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal",
         "//runtime/src/iree/base/internal:cpu",
         "//runtime/src/iree/base/internal:flags",
         "//runtime/src/iree/base/internal:path",

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -246,8 +246,8 @@ static void write_int_to_matrix_element(int32_t value, iree_hal_dim_t m_size,
     ((float*)data)[index] = value;
     return;
   }
-  iree_status_abort(iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                                     "unhandled matmul result type"));
+  IREE_CHECK_OK(iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                 "unhandled matmul result type"));
 }
 
 // Reads an element from a mapped row-major matrix buffer.

--- a/tools/iree-e2e-matmul-test.c
+++ b/tools/iree-e2e-matmul-test.c
@@ -324,29 +324,34 @@ static iree_status_t get_matmul_sizes(
   return iree_ok_status();
 }
 
-#define IREE_TRACE_REPLAY_REFERENCE_GEMM(LHSTYPE, RHSTYPE, RESTYPE, ACCTYPE)  \
-  static void reference_matmul_##LHSTYPE##_##RHSTYPE##_##RESTYPE##_##ACCTYPE( \
-      iree_hal_dim_t m_size, iree_hal_dim_t k_size, iree_hal_dim_t n_size,    \
-      iree_hal_element_type_t lhs_type, iree_hal_element_type_t rhs_type,     \
-      iree_hal_element_type_t acc_type, LHSTYPE* lhs_data, RHSTYPE* rhs_data, \
-      ACCTYPE* acc_data, RESTYPE* result_data, iree_hal_dim_t m,              \
-      iree_hal_dim_t n) {                                                     \
-    ACCTYPE acc = acc_data[n + m * n_size];                                   \
-    for (iree_hal_dim_t k = 0; k < k_size; ++k) {                             \
-      LHSTYPE lhs_value = lhs_data[k + m * k_size];                           \
-      RHSTYPE rhs_value = rhs_data[n + k * n_size];                           \
-      acc += (ACCTYPE)lhs_value * (ACCTYPE)rhs_value;                         \
-    }                                                                         \
-    result_data[n + m * n_size] = acc;                                        \
+#define IREE_TRACE_REPLAY_REFERENCE_MATMUL(LHSTYPE, RHSTYPE, RESTYPE, ACCTYPE) \
+  static void reference_matmul_##LHSTYPE##_##RHSTYPE##_##RESTYPE##_##ACCTYPE(  \
+      iree_hal_dim_t m_size, iree_hal_dim_t k_size, iree_hal_dim_t n_size,     \
+      iree_hal_element_type_t lhs_type, iree_hal_element_type_t rhs_type,      \
+      iree_hal_element_type_t acc_type, LHSTYPE* lhs_data, RHSTYPE* rhs_data,  \
+      ACCTYPE* acc_data, RESTYPE* result_data, iree_hal_dim_t m,               \
+      iree_hal_dim_t n) {                                                      \
+    ACCTYPE acc = acc_data[n + m * n_size];                                    \
+    for (iree_hal_dim_t k = 0; k < k_size; ++k) {                              \
+      LHSTYPE lhs_value = lhs_data[k + m * k_size];                            \
+      RHSTYPE rhs_value = rhs_data[n + k * n_size];                            \
+      acc += (ACCTYPE)lhs_value * (ACCTYPE)rhs_value;                          \
+    }                                                                          \
+    result_data[n + m * n_size] = acc;                                         \
   }
 
-// Reference GEMM : float <= float * float + float
-IREE_TRACE_REPLAY_REFERENCE_GEMM(float, float, float, float)
+// Reference mamtul instantiations from macro IREE_TRACE_REPLAY_REFERENCE_MATMUL
+// for the f32 input, f32 accumlation, and f32 result.
+// [float <= float * float + float]
+IREE_TRACE_REPLAY_REFERENCE_MATMUL(float, float, float, float)
 
-// Reference GEMM : i32 <= i8 * i8 + i32
-IREE_TRACE_REPLAY_REFERENCE_GEMM(int8_t, int8_t, int32_t, int32_t)
+// Reference mamtul instantiations from macro IREE_TRACE_REPLAY_REFERENCE_MATMUL
+// for the int8_t input, int32_t accumlation, and int32_t result.
+// [i32 <= i8 * i8 + i32]
+IREE_TRACE_REPLAY_REFERENCE_MATMUL(int8_t, int8_t, int32_t, int32_t)
 
-// Reference GEMM : f16 <= f16 * f16 + f16
+// Reference mamtul for the half_t input, half_t accumlation, and half_t result.
+// [f16 <= f16 * f16 + f16]
 static void reference_matmul_f16_f16_f16_f16(
     iree_hal_dim_t m_size, iree_hal_dim_t k_size, iree_hal_dim_t n_size,
     iree_hal_element_type_t lhs_type, iree_hal_element_type_t rhs_type,
@@ -395,12 +400,6 @@ static void reference_matmul_element(
         iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                          "unhandled combination of element types in matmul"));
   }
-
-#if 0
-  reference_matmul_element_generic(m_size, k_size, n_size, lhs_type, rhs_type,
-                                   acc_type, (void*)lhs_data, (void*)rhs_data,
-                                   (void*)acc_data, (void*)result_data, m, n);
-#endif
 }
 
 // Reference matmul implementation, used to compare matmul results against.


### PR DESCRIPTION
This pull request adds support for testing e2e GEMM on a CUDA backend for F16 input and F16 accumulation. 

- Functional testing of F16 GEMMs requires setting the right tolerance value to ensure correctness checks.  
- Tolerance-based testing is fragile and finding tolerances is hard. 
- Instead we fill the buffers as small integers centered at zero and test for equivalence. 

This pull requests adds `e2e_matmul_direct_f16_gpu_large_LLVMGPUMatmulTensorCore_cuda_cuda` more e2e GEMM test to CUDA backend. We have not total 4 e2e GEMM tests on CUDA backend.

```bash
manigupta@manigupta-gpu-a100 ~/cpu_machine_workspace/repos/iree/iree_tree_1/iree-build-debug $ ctest -j96 -R e2e_matmul.*cuda

1/4 Test #41: iree/tests/e2e/matmul/e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulTensorCore_cuda_cuda ...   Passed    2.83 sec
2/4 Test #42: iree/tests/e2e/matmul/e2e_matmul_direct_f16_gpu_large_LLVMGPUMatmulTensorCore_cuda_cuda ...   Passed    3.09 sec
3/4 Test #40: iree/tests/e2e/matmul/e2e_matmul_direct_f32_gpu_large_LLVMGPUMatmulSimt_cuda_cuda .........   Passed    3.38 sec
4/4 Test #43: iree/tests/e2e/matmul/e2e_matmul_direct_f32_large_split_k_cuda_cuda .......................   Passed    4.43 sec
```
