### PR TITLE
Add methods to materialize the encoding of tensor types.

### DIFF
--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -382,6 +382,7 @@ cc_library(
         "@llvm-project//mlir:LinalgUtils",
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",
+        "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -13,6 +13,10 @@
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
+
+class ConversionTarget;
+class TypeConverter;
+
 namespace iree_compiler {
 namespace IREE {
 namespace LinalgExt {
@@ -81,6 +85,26 @@ private:
 std::unique_ptr<OperationPass<func::FuncOp>> createTilingInterfaceTilingPass();
 
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgExtToLoopsPass();
+
+/// Method to populate the patterns to convert operations that have operands
+/// with tensor encodings into ops that materialize the layout specified by the
+/// encoding, as well as ops that perform the computation on the materialized
+/// layout. For now these hard-code a fixed way the lowering is encoded, but the
+/// encoding can be made backend specific. Also initializes the
+/// `conversionTarget` and `typeConverter`.
+void populateMaterializeEncodingPatterns(RewritePatternSet &patterns,
+                                         ConversionTarget &conversionTarget,
+                                         TypeConverter &typeConverter);
+
+/// Pass to apply patterns specified by `populateMaterializeEncodingPass`.
+std::unique_ptr<OperationPass<func::FuncOp>> createMaterializeEncodingPass();
+
+/// Patterns to fold operations like `tensor.pad` and `tensor.extract_slice`
+/// into `linalg_ext.pack` and `linalg_ext.unpack` operations respectively.
+void populateFoldIntoPackAndUnpackOpsPatterns(RewritePatternSet &patterns);
+
+/// Pass to apply patterns specified by `populateFoldIntoPackAndUnpackOps`.
+std::unique_ptr<OperationPass<func::FuncOp>> createFoldIntoPackAndUnpackOps();
 
 std::unique_ptr<OperationPass<>> createPadContractionToBlockSizePass();
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -21,6 +21,18 @@ def TilingInterfaceTiling :
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::createTilingInterfaceTilingPass()";
 }
 
+def MaterializeEncoding :
+    Pass<"iree-linalg-ext-materialize-encoding", "func::FuncOp"> {
+  let summary = "Test pass to materialize ops with tensor encoding into ops with explicit data movement";
+  let constructor = "mlir::iree_compiler::IREE::LinalgExt::createMaterializeEncodingPass()";
+}
+
+def FoldIntoPackAndUnpackOps :
+    Pass<"iree-linalg-ext-fold-into-pack-unpack-ops", "func::FuncOp"> {
+  let summary = "Test pass to fold operations into pack and unpacl operations";
+  let constructor = "mlir::iree_compiler::IREE::LinalgExt::createFoldIntoPackAndUnpackOps()";
+}
+
 def PadContractionToBlockSize :
     Pass<"iree-linalg-pad-contraction-to-block-size", ""> {
   let summary = "Pads contraction (matmul) ops to next multiple of block size";

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_mlir_library(IREELinalgExtPasses
   ConvertToLoops.cpp
+  FoldIntoPackAndUnpackOps.cpp
+  MaterializeEncoding.cpp
   PadContractionToBlockSize.cpp
   Passes.cpp
   SplitReduction.cpp
@@ -17,6 +19,7 @@ add_mlir_library(IREELinalgExtPasses
   MLIRLinalgTransforms
   MLIRMathDialect
   MLIRMemRefDialect
+  MLIRMemRefTransforms
   MLIRPass
   MLIRSCFDialect
   MLIRFuncDialect

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/FoldIntoPackAndUnpackOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/FoldIntoPackAndUnpackOps.cpp
@@ -36,7 +36,7 @@ struct FoldUnpackWithExtractSliceOp
                                 PatternRewriter &rewriter) const override {
     auto unpackOp = sliceOp.getSource().getDefiningOp<UnPackOp>();
     if (!unpackOp)
-      failure();
+      return failure();
 
     // Check all offsets are zeros, and all strides are 1.
     if (!areAllConstantIntValue(sliceOp.getMixedOffsets(), 0) ||
@@ -70,7 +70,9 @@ struct FoldUnpackWithExtractSliceOp
 namespace {
 struct FoldIntoPackAndUnpackOpsPass
     : public FoldIntoPackAndUnpackOpsBase<FoldIntoPackAndUnpackOpsPass> {
-  void getDependentDialects(DialectRegistry &registry) const { return; }
+  void getDependentDialects(DialectRegistry &registry) const override {
+    return;
+  }
 
   void runOnOperation() override;
 };

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/FoldIntoPackAndUnpackOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/FoldIntoPackAndUnpackOps.cpp
@@ -1,0 +1,101 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/PassDetail.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+using namespace mlir::iree_compiler::IREE::LinalgExt;
+
+//===---------------------------------------------------------------------===//
+// Patterns to fold operationsinto pack/unpack ops.
+//===---------------------------------------------------------------------===//
+
+namespace {
+/// Fold a `unpack` -> `extract_slice` into the `unpack` since it already
+/// has extract_slice semantics.
+struct FoldUnpackWithExtractSliceOp
+    : public OpRewritePattern<tensor::ExtractSliceOp> {
+  using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
+                                PatternRewriter &rewriter) const override {
+    auto unpackOp = sliceOp.getSource().getDefiningOp<UnPackOp>();
+    if (!unpackOp)
+      failure();
+
+    // Check all offsets are zeros, and all strides are 1.
+    if (llvm::any_of(
+            sliceOp.getMixedOffsets(),
+            [](OpFoldResult ofr) { return !isConstantIntValue(ofr, 0); }) ||
+        llvm::any_of(sliceOp.getMixedStrides(), [](OpFoldResult ofr) {
+          return !isConstantIntValue(ofr, 1);
+        })) {
+      return rewriter.notifyMatchFailure(
+          sliceOp, "expectes offsets to be 0s and strides to be 1s");
+    }
+
+    // Create a new empty output tensor.
+    Type elementType = unpackOp.getOutput()
+                           .getType()
+                           .cast<RankedTensorType>()
+                           .getElementType();
+    Value output = rewriter.create<linalg::InitTensorOp>(
+        sliceOp.getLoc(), sliceOp.getMixedSizes(), elementType);
+    rewriter.replaceOpWithNewOp<UnPackOp>(
+        sliceOp, output.getType(), unpackOp.getInput(), output,
+        unpackOp.getOuterDimsPerm().empty() ? nullptr
+                                            : unpackOp.getOuterDimsPerm(),
+        unpackOp.getInnerDimsPos(), unpackOp.getInnerTiles(),
+        unpackOp.getStaticInnerTiles());
+    return success();
+  }
+};
+} // namespace
+
+//===---------------------------------------------------------------------===//
+// Pass to fold operations into pack and unpack operations.
+//===---------------------------------------------------------------------===//
+
+namespace {
+struct FoldIntoPackAndUnpackOpsPass
+    : public FoldIntoPackAndUnpackOpsBase<FoldIntoPackAndUnpackOpsPass> {
+  void getDependentDialects(DialectRegistry &registry) const { return; }
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void FoldIntoPackAndUnpackOpsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  populateFoldIntoPackAndUnpackOpsPatterns(patterns);
+  if (failed(applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+    return signalPassFailure();
+}
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace LinalgExt {
+
+void populateFoldIntoPackAndUnpackOpsPatterns(RewritePatternSet &patterns) {
+  patterns.insert<FoldUnpackWithExtractSliceOp>(patterns.getContext());
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>> createFoldIntoPackAndUnpackOps() {
+  return std::make_unique<FoldIntoPackAndUnpackOpsPass>();
+}
+
+} // namespace LinalgExt
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -191,8 +191,6 @@ struct SetEncodingOpToPackOpConversion
                   ConversionPatternRewriter &rewriter) const override {
     // Pack op needs a padding value. Maybe that is an overkill. For now, just
     // use zero.
-    RankedTensorType sourceType = encodingOp.getSourceType();
-    Location loc = encodingOp.getLoc();
     auto packOp =
         lowerSetEncodingOpToPackOp(rewriter, encodingOp, adaptor.getSource());
     if (failed(packOp))
@@ -264,7 +262,9 @@ struct MaterializeTiledMatmul : public OpConversionPattern<linalg::MatmulOp> {
 
 struct MaterializeEncodingPass
     : public MaterializeEncodingBase<MaterializeEncodingPass> {
-  void getDependentDialects(DialectRegistry &registry) const { return; }
+  void getDependentDialects(DialectRegistry &registry) const override {
+    return;
+  }
 
   void runOnOperation() override;
 };

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -1,0 +1,339 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/PassDetail.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+using namespace mlir::iree_compiler::IREE::LinalgExt;
+
+//===---------------------------------------------------------------------===//
+// Methods to convert the encoding to parameters of the Pack operation
+//===---------------------------------------------------------------------===//
+
+/// Given the `encoding` return (by value) the dimensions of the input that are
+/// tiled (`innerDimsPos`), the tile size to use (`innerTileSizes`) and
+/// permutation for the outer dimensions on the pack op (`outerDimsPerm`).
+static LogicalResult getPackOpInfoFromEncoding(
+    TensorEncoding encoding, SmallVector<int64_t> &innerDimsPos,
+    SmallVector<int64_t> &innerTileSizes, SmallVector<int64_t> &outerDimsPerm) {
+  switch (encoding) {
+  case TensorEncoding::GEMM_LHS:
+    innerDimsPos = {0, 1};
+    innerTileSizes = {8, 4};
+    outerDimsPerm = {};
+    break;
+  case TensorEncoding::GEMM_RHS:
+    innerDimsPos = {0, 1};
+    innerTileSizes = {4, 8};
+    outerDimsPerm = {};
+    break;
+  case TensorEncoding::GEMM_RESULT:
+    innerDimsPos = {0, 1};
+    innerTileSizes = {8, 8};
+    outerDimsPerm = {};
+    break;
+  case TensorEncoding::GEMM_RHS_TRANSPOSE:
+    innerDimsPos = {1, 0};
+    innerTileSizes = {8, 4};
+    outerDimsPerm = {1, 0};
+    break;
+  default:
+    return failure();
+  }
+  return success();
+}
+
+//===---------------------------------------------------------------------===//
+// Utility methods
+//===---------------------------------------------------------------------===//
+
+/// Extract encoding from the `tensorType` if specified.
+static Optional<TensorEncoding> getEncoding(RankedTensorType tensorType) {
+  auto encodingAttr = tensorType.getEncoding().dyn_cast_or_null<EncodingAttr>();
+  if (!encodingAttr)
+    return llvm::None;
+  return encodingAttr.getEncoding().getValue();
+}
+
+/// For a given tensor type with an encoding, return the materialized
+/// type to use for it. If no encoding is set, then return the tensor type
+/// itself.
+static RankedTensorType getMaterializedType(RankedTensorType tensorType) {
+  Optional<TensorEncoding> encoding = getEncoding(tensorType);
+  if (!encoding)
+    return tensorType;
+  SmallVector<int64_t> innerDimsPos, innerTileSizes, outerDimsPerm;
+  if (failed(getPackOpInfoFromEncoding(encoding.value(), innerDimsPos,
+                                       innerTileSizes, outerDimsPerm))) {
+    return tensorType;
+  }
+  return PackOp::getPackedType(tensorType, innerTileSizes, innerDimsPos,
+                               outerDimsPerm)
+      .cast<RankedTensorType>();
+}
+
+/// Helper methods to get `OpFoldResult` from `int64_t` values.
+static OpFoldResult getAsOpFoldResult(OpBuilder &builder, int64_t value) {
+  return builder.getI64IntegerAttr(value);
+}
+static SmallVector<OpFoldResult> getAsOpFoldResult(OpBuilder &builder,
+                                                   ArrayRef<int64_t> values) {
+  return llvm::to_vector(llvm::map_range(
+      values, [&](int64_t v) { return getAsOpFoldResult(builder, v); }));
+}
+
+//===---------------------------------------------------------------------===//
+// Methods to convert `set_encoding` and `unset_encoding` operations
+// to `pack` and `unpack` operations respectively.
+//===---------------------------------------------------------------------===//
+
+/// Utility method to get the optional padding value to use with pack operation
+/// if source is defined using a `tensor.pad` operation. Note `source` is
+/// passed by reference. It is updated to use the source of the pad operation.
+static Optional<Value> getPaddingValue(Value &source) {
+  auto padOp = source.getDefiningOp<tensor::PadOp>();
+  if (!padOp || padOp.getNofold() || !padOp.hasZeroLowPad())
+    return llvm::None;
+
+  Value constantPaddingValue = padOp.getConstantPaddingValue();
+  if (!constantPaddingValue)
+    return llvm::None;
+
+  source = padOp.getSource();
+  return constantPaddingValue;
+}
+
+/// Utility method to convert from `set_encoding` op to `pack` operation.
+/// For now this takes a `paddingValue` as input. The source is also taken
+/// as input so that these could be used with `OpConversionPatterns`.
+static FailureOr<PackOp> lowerSetEncodingOpToPackOp(RewriterBase &rewriter,
+                                                    SetEncodingOp encodingOp,
+                                                    Value source) {
+  SmallVector<int64_t> innerDimsPos, innerTileSizes, outerDimsPerm;
+  if (failed(getPackOpInfoFromEncoding(encodingOp.getResultTensorEncoding(),
+                                       innerDimsPos, innerTileSizes,
+                                       outerDimsPerm))) {
+    return rewriter.notifyMatchFailure(encodingOp, "unhandled result encoding");
+  }
+
+  // Create `init_tensor` operation for the result of the pack operation.
+  Location loc = encodingOp.getLoc();
+  SmallVector<OpFoldResult> sourceDims = getDims(rewriter, loc, source);
+  SmallVector<OpFoldResult> innerTileSizesOfr =
+      getAsOpFoldResult(rewriter, innerTileSizes);
+  SmallVector<OpFoldResult> resultDims =
+      PackOp::getResultShape(rewriter, loc, sourceDims, innerTileSizesOfr,
+                             innerDimsPos, outerDimsPerm);
+  auto initTensor = rewriter.create<linalg::InitTensorOp>(
+      loc, resultDims, encodingOp.getSourceType().getElementType());
+  Optional<Value> paddingValue = getPaddingValue(source);
+  return rewriter.create<PackOp>(loc, source, initTensor, innerDimsPos,
+                                 innerTileSizesOfr, paddingValue,
+                                 outerDimsPerm);
+}
+
+/// Utility method to convert from `set_encoding` op to `pack` operation.
+/// The source is taken as input so that these could be used with
+/// `OpConversionPatterns`.
+static FailureOr<UnPackOp>
+lowerUnsetEncodingToUnpackOp(RewriterBase &rewriter, UnsetEncodingOp encodingOp,
+                             Value packedValue) {
+  SmallVector<int64_t> innerDimsPos, innerTileSizes, outerDimsPerm;
+  if (failed(getPackOpInfoFromEncoding(encodingOp.getSourceTensorEncoding(),
+                                       innerDimsPos, innerTileSizes,
+                                       outerDimsPerm))) {
+    return rewriter.notifyMatchFailure(encodingOp, "unhandled source encoding");
+  }
+  // Create an `init_tensor` for the result of the unpack operation.
+  Location loc = encodingOp.getLoc();
+  SmallVector<OpFoldResult> resultDims =
+      getDims(rewriter, loc, encodingOp.getSource());
+  auto initTensor = rewriter.create<linalg::InitTensorOp>(
+      loc, resultDims, encodingOp.getResultType().getElementType());
+
+  SmallVector<OpFoldResult> innerTileSizesOfr =
+      getAsOpFoldResult(rewriter, innerTileSizes);
+  return rewriter.create<UnPackOp>(loc, packedValue, initTensor, innerDimsPos,
+                                   innerTileSizesOfr, outerDimsPerm);
+}
+
+namespace {
+
+//===---------------------------------------------------------------------===//
+// Patterns to lower ops with encodings. These are written as
+// dialect conversion patterns for now. These are just drivers around
+// the core conversion utilities.
+//===---------------------------------------------------------------------===//
+
+/// Convert `set_encoding` op to `pack` op.
+struct SetEncodingOpToPackOpConversion
+    : public OpConversionPattern<SetEncodingOp> {
+  using OpConversionPattern<SetEncodingOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(SetEncodingOp encodingOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    // Pack op needs a padding value. Maybe that is an overkill. For now, just
+    // use zero.
+    RankedTensorType sourceType = encodingOp.getSourceType();
+    Location loc = encodingOp.getLoc();
+    auto packOp =
+        lowerSetEncodingOpToPackOp(rewriter, encodingOp, adaptor.getSource());
+    if (failed(packOp))
+      return rewriter.notifyMatchFailure(encodingOp,
+                                         "failed to convert to pack op");
+    rewriter.replaceOp(encodingOp, packOp->getResults());
+    return success();
+  }
+};
+
+/// Convert `unset_encoding` op to `unpack` op.
+struct UnsetEncodingOpToPackOpConversion
+    : public OpConversionPattern<UnsetEncodingOp> {
+  using OpConversionPattern<UnsetEncodingOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(UnsetEncodingOp encodingOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto unpackOp =
+        lowerUnsetEncodingToUnpackOp(rewriter, encodingOp, adaptor.getSource());
+    if (failed(unpackOp))
+      return rewriter.notifyMatchFailure(encodingOp,
+                                         "failed to convert to unpack op");
+    rewriter.replaceOp(encodingOp, unpackOp->getResults());
+    return success();
+  }
+};
+
+/// Convert a linalg.matmul with
+/// - lhs encoding of GEMM_LHS
+/// - rhs encoding of GEMM_RHS_TRANSPOSE
+/// - result encoding of GEMM_RESULT
+/// to linalg.mmt4d op.
+struct MaterializeTiledMatmul : public OpConversionPattern<linalg::MatmulOp> {
+  using OpConversionPattern<linalg::MatmulOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(linalg::MatmulOp matmulOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (!matmulOp.hasTensorSemantics())
+      return failure();
+    auto inputs = matmulOp.getInputOperands();
+    auto outputs = matmulOp.getOutputOperands();
+    Optional<TensorEncoding> lhsEncoding =
+        getEncoding(inputs[0]->get().getType().cast<RankedTensorType>());
+    Optional<TensorEncoding> rhsEncoding =
+        getEncoding(inputs[1]->get().getType().cast<RankedTensorType>());
+    Optional<TensorEncoding> resultEncoding =
+        getEncoding(outputs[0]->get().getType().cast<RankedTensorType>());
+    if (!lhsEncoding || lhsEncoding.value() != TensorEncoding::GEMM_LHS ||
+        !rhsEncoding ||
+        rhsEncoding.value() != TensorEncoding::GEMM_RHS_TRANSPOSE ||
+        !resultEncoding ||
+        resultEncoding.value() != TensorEncoding::GEMM_RESULT) {
+      return failure();
+    }
+    rewriter.replaceOpWithNewOp<linalg::Mmt4DOp>(
+        matmulOp,
+        getMaterializedType(
+            outputs[0]->get().getType().cast<RankedTensorType>()),
+        adaptor.getInputs(), adaptor.getOutputs());
+    return success();
+  }
+};
+
+//===---------------------------------------------------------------------===//
+// Pass to materialize encoding
+//===---------------------------------------------------------------------===//
+
+struct MaterializeEncodingPass
+    : public MaterializeEncodingBase<MaterializeEncodingPass> {
+  void getDependentDialects(DialectRegistry &registry) const { return; }
+
+  void runOnOperation() override;
+};
+
+void MaterializeEncodingPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+
+  {
+    RewritePatternSet patterns(context);
+    ConversionTarget target(*context);
+    TypeConverter typeConverter;
+    populateMaterializeEncodingPatterns(patterns, target, typeConverter);
+    if (failed(applyPartialConversion(getOperation(), target,
+                                      std::move(patterns))))
+      return signalPassFailure();
+  }
+
+  // Add patterns to fold pack/unpack ops with pad/extract_slice ops.
+  {
+    RewritePatternSet patterns(context);
+    populateFoldIntoPackAndUnpackOpsPatterns(patterns);
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+}
+} // namespace
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace LinalgExt {
+
+void populateMaterializeEncodingPatterns(RewritePatternSet &patterns,
+                                         ConversionTarget &target,
+                                         TypeConverter &typeConverter) {
+
+  auto typeHasEncoding = [](Type t) -> bool {
+    auto tensorType = t.dyn_cast<RankedTensorType>();
+    return tensorType && tensorType.getEncoding();
+  };
+  auto valueHasEncoding = [&](Value v) -> bool {
+    return typeHasEncoding(v.getType());
+  };
+
+  // Type converted is used to convert the unpacked tensor with tensor encoding
+  // into a packed type.
+  typeConverter.addConversion([&](RankedTensorType t) -> RankedTensorType {
+    return getMaterializedType(t);
+  });
+
+  // Mark any operation that has operands/results with encoding as
+  // illegal.
+  auto hasOperandOrResultsWithEncoding = [&](Operation *op) {
+    return llvm::any_of(op->getOperands(), valueHasEncoding) ||
+           llvm::any_of(op->getResults(), valueHasEncoding);
+  };
+  target.markUnknownOpDynamicallyLegal(
+      [&](Operation *op) { return !hasOperandOrResultsWithEncoding(op); });
+
+  // Add all patterns for converting from encoded type to the materialized type
+  patterns.insert<MaterializeTiledMatmul, SetEncodingOpToPackOpConversion,
+                  UnsetEncodingOpToPackOpConversion>(typeConverter,
+                                                     patterns.getContext());
+  ::mlir::memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>> createMaterializeEncodingPass() {
+  return std::make_unique<MaterializeEncodingPass>();
+}
+
+} // namespace LinalgExt
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fold_into_pack_unpack_ops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fold_into_pack_unpack_ops.mlir
@@ -12,7 +12,7 @@ func.func @fold_unpack_slice(%arg0 : tensor<?x?x8x4xf32>, %arg1 : tensor<?x?xf32
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
 // CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: index
-//      CHECK:   %[[INIT:.+]] = linalg.init_tensor [%[[ARG2]], %[[ARG3]]]
+//      CHECK:   %[[INIT:.+]] = tensor.empty(%[[ARG2]], %[[ARG3]]) : tensor<?x?xf32>
 //      CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [8, 4]
 // CHECK-SAME:       into %[[INIT]]
 //      CHECK:   return %[[UNPACK]]

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fold_into_pack_unpack_ops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/fold_into_pack_unpack_ops.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-dialects-opt -iree-linalg-ext-fold-into-pack-unpack-ops %s | FileCheck %s
+
+func.func @fold_unpack_slice(%arg0 : tensor<?x?x8x4xf32>, %arg1 : tensor<?x?xf32>,
+    %arg2 : index, %arg3 : index) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.unpack %arg0 inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %arg1
+      : (tensor<?x?x8x4xf32> tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = tensor.extract_slice %0[0, 0] [%arg2, %arg3] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//      CHECK: func @fold_unpack_slice(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?x8x4xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: index
+//      CHECK:   %[[INIT:.+]] = linalg.init_tensor [%[[ARG2]], %[[ARG3]]]
+//      CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [8, 4]
+// CHECK-SAME:       into %[[INIT]]
+//      CHECK:   return %[[UNPACK]]
+
+// -----
+
+func.func @nofold_unpack_slice_non_zero_offset(%arg0 : tensor<?x?x8x4xf32>, %arg1 : tensor<?x?xf32>,
+    %arg2 : index, %arg3 : index, %arg4 : index) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.unpack %arg0 inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %arg1
+      : (tensor<?x?x8x4xf32> tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = tensor.extract_slice %0[0, %arg4] [%arg2, %arg3] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @nofold_unpack_slice_non_zero_offset(
+//       CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack
+//       CHECK:   tensor.extract_slice %[[UNPACK]]
+
+// -----
+
+func.func @nofold_unpack_slice_non_unit_stride(%arg0 : tensor<?x?x8x4xf32>, %arg1 : tensor<?x?xf32>,
+    %arg2 : index, %arg3 : index, %arg4 : index) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.unpack %arg0 inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %arg1
+      : (tensor<?x?x8x4xf32> tensor<?x?xf32>) -> tensor<?x?xf32>
+  %1 = tensor.extract_slice %0[0, 0] [%arg2, %arg3] [%arg4, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @nofold_unpack_slice_non_unit_stride(
+//       CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack
+//       CHECK:   tensor.extract_slice %[[UNPACK]]

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding.mlir
@@ -1,0 +1,126 @@
+// RUN: iree-dialects-opt --iree-linalg-ext-materialize-encoding -cse -split-input-file %s | FileCheck %s
+
+func.func @pack_unpack_gemm_lhs(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//      CHECK: func @pack_unpack_gemm_lhs(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:   %[[OUTER_D0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
+//  CHECK-DAG:   %[[OUTER_D1:.+]] = affine.apply #[[MAP1]]()[%[[D1]]]
+//      CHECK:   %[[PACK_DEST:.+]] = linalg.init_tensor [%[[OUTER_D0]], %[[OUTER_D1]], 8, 4]
+//      CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[PACK_DEST]]
+//      CHECK:   %[[UNPACK_DEST:.+]] = linalg.init_tensor [%[[D0]], %[[D1]]]
+//      CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[PACK]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[UNPACK_DEST]]
+//      CHECK:   return %[[UNPACK]]
+
+// -----
+
+func.func @pack_unpack_gemm_rhs(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @pack_unpack_gemm_rhs(
+//       CHECK:   linalg_ext.pack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [4, 8]
+//       CHECK:   linalg_ext.unpack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [4, 8]
+
+// -----
+
+func.func @pack_unpack_gemm_rhs_transpose(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @pack_unpack_gemm_rhs_transpose(
+//       CHECK:   linalg_ext.pack %{{.+}} outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4]
+//       CHECK:   linalg_ext.unpack %{{.+}} outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4]
+
+// -----
+
+func.func @pack_unpack_gemm_result(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @pack_unpack_gemm_result(
+//       CHECK:   linalg_ext.pack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [8, 8]
+//       CHECK:   linalg_ext.unpack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [8, 8]
+
+// -----
+
+func.func @pack_gemm(%arg0 : tensor<100x250xf32>, %arg1 : tensor<250x500xf32>, %arg2 : tensor<100x500xf32>) -> tensor<100x500xf32> {
+  %pad_value = arith.constant 0.0 : f32
+  %pad_lhs = tensor.pad %arg0 low[0, 0] high[4, 2] {
+    ^bb0(%b0: index, %b1 : index):
+      tensor.yield %pad_value : f32
+    } : tensor<100x250xf32> to tensor<104x252xf32>
+  %lhs = iree_linalg_ext.set_encoding %pad_lhs : tensor<104x252xf32> -> tensor<104x252xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  %pad_rhs = tensor.pad %arg1 low[0, 0] high[2, 4] {
+    ^bb0(%b0: index, %b1 : index):
+      tensor.yield %pad_value : f32
+    } : tensor<250x500xf32> to tensor<252x504xf32>
+  %rhs = iree_linalg_ext.set_encoding %pad_rhs : tensor<252x504xf32> -> tensor<252x504xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>
+  %pad_output = tensor.pad %arg2 low[0, 0] high[4, 4] {
+    ^bb0(%b0: index, %b1 : index):
+      tensor.yield %pad_value : f32
+    } : tensor<100x500xf32> to tensor<104x504xf32>
+  %output = iree_linalg_ext.set_encoding %pad_output : tensor<104x504xf32> -> tensor<104x504xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  %gemm_packed = linalg.matmul ins(%lhs, %rhs : tensor<104x252xf32, #iree_linalg_ext.encoding<GEMM_LHS>>, tensor<252x504xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>)
+      outs(%output : tensor<104x504xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>) -> tensor<104x504xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  %gemm = iree_linalg_ext.unset_encoding %gemm_packed : tensor<104x504xf32, #iree_linalg_ext.encoding<GEMM_RESULT>> -> tensor<104x504xf32>
+  %result = tensor.extract_slice %gemm[0, 0] [100, 500] [1, 1] : tensor<104x504xf32> to tensor<100x500xf32>
+  return %result : tensor<100x500xf32>
+}
+//      CHECK: func @pack_gemm(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<100x250xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<250x500xf32>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<100x500xf32>
+//      CHECK:   %[[CST:.+]] = arith.constant 0.0
+//      CHECK:   %[[INIT_LHS:.+]] = linalg.init_tensor [13, 63, 8, 4]
+//      CHECK:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack %[[ARG0]] padding_value(%[[CST]] : f32)
+// CHECK-SAME:       into %[[INIT_LHS]]
+//      CHECK:   %[[INIT_RHS:.+]] = linalg.init_tensor [63, 63, 8, 4]
+//      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack %[[ARG1]] padding_value(%[[CST]] : f32)
+// CHECK-SAME:       into %[[INIT_RHS]]
+//      CHECK:   %[[INIT_RESULT:.+]] = linalg.init_tensor [13, 63, 8, 8]
+//      CHECK:   %[[PACK_RESULT:.+]] = iree_linalg_ext.pack %[[ARG2]] padding_value(%[[CST]] : f32)
+// CHECK-SAME:       into %[[INIT_RESULT]]
+//      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:       ins(%[[PACK_LHS]], %[[PACK_RHS]] :
+// CHECK-SAME:       outs(%[[PACK_RESULT]] :
+//      CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[MMT4D]]
+//      CHECK:   return %[[UNPACK]]
+
+// -----
+
+func.func @pack_gemm_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  %1 = iree_linalg_ext.set_encoding %arg1 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>
+  %2 = iree_linalg_ext.set_encoding %arg2 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  %3 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>, tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>)
+      outs(%2 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>) -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  %4 = iree_linalg_ext.unset_encoding %3 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>> -> tensor<?x?xf32>
+  return %4 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//      CHECK: func @pack_gemm_dynamic(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//      CHECK:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack %[[ARG0]]
+//      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack %[[ARG1]]
+//      CHECK:   %[[PACK_RESULT:.+]] = iree_linalg_ext.pack %[[ARG2]]
+//      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:       ins(%[[PACK_LHS]], %[[PACK_RHS]] :
+// CHECK-SAME:       outs(%[[PACK_RESULT]] :
+//      CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[MMT4D]]
+//      CHECK:   return %[[UNPACK]]

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding.mlir
@@ -15,9 +15,9 @@ func.func @pack_unpack_gemm_lhs(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
 //  CHECK-DAG:   %[[OUTER_D0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
 //  CHECK-DAG:   %[[OUTER_D1:.+]] = affine.apply #[[MAP1]]()[%[[D1]]]
-//      CHECK:   %[[PACK_DEST:.+]] = linalg.init_tensor [%[[OUTER_D0]], %[[OUTER_D1]], 8, 4]
+//      CHECK:   %[[PACK_DEST:.+]] = tensor.empty(%[[OUTER_D0]], %[[OUTER_D1]]) : tensor<?x?x8x4xf32>
 //      CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[PACK_DEST]]
-//      CHECK:   %[[UNPACK_DEST:.+]] = linalg.init_tensor [%[[D0]], %[[D1]]]
+//      CHECK:   %[[UNPACK_DEST:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32>
 //      CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[PACK]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[UNPACK_DEST]]
 //      CHECK:   return %[[UNPACK]]
 
@@ -84,13 +84,13 @@ func.func @pack_gemm(%arg0 : tensor<100x250xf32>, %arg1 : tensor<250x500xf32>, %
 // CHECK-SAME:     %[[ARG1:.+]]: tensor<250x500xf32>
 // CHECK-SAME:     %[[ARG2:.+]]: tensor<100x500xf32>
 //      CHECK:   %[[CST:.+]] = arith.constant 0.0
-//      CHECK:   %[[INIT_LHS:.+]] = linalg.init_tensor [13, 63, 8, 4]
+//      CHECK:   %[[INIT_LHS:.+]] = tensor.empty() : tensor<13x63x8x4xf32>
 //      CHECK:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack %[[ARG0]] padding_value(%[[CST]] : f32)
 // CHECK-SAME:       into %[[INIT_LHS]]
-//      CHECK:   %[[INIT_RHS:.+]] = linalg.init_tensor [63, 63, 8, 4]
+//      CHECK:   %[[INIT_RHS:.+]] = tensor.empty() : tensor<63x63x8x4xf32>
 //      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack %[[ARG1]] padding_value(%[[CST]] : f32)
 // CHECK-SAME:       into %[[INIT_RHS]]
-//      CHECK:   %[[INIT_RESULT:.+]] = linalg.init_tensor [13, 63, 8, 8]
+//      CHECK:   %[[INIT_RESULT:.+]] = tensor.empty() : tensor<13x63x8x8xf32>
 //      CHECK:   %[[PACK_RESULT:.+]] = iree_linalg_ext.pack %[[ARG2]] padding_value(%[[CST]] : f32)
 // CHECK-SAME:       into %[[INIT_RESULT]]
 //      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d


### PR DESCRIPTION
This PR adds utility methods and patterns that convert a program with ops involving encoding into programs that explicitly materialize the encoding and operations that operate on the materialized data layout. While most of the functionality is implemented as utility functions, the driver pass is written using DialectConversion framework since that avoids having to introduce fake casts for inter-op with existing ops. Ideally these patterns can be pulled in directly within IREE backend with some additional patterns for type conversion of the ABI.

Also added is a pass to fold operations like
`tensor.pad`/`tensor.extract_slice` into `linalg_ext.pack` and `linalg_ext.unpack` operations, respectively since the semantics of these ops can subsume them.