### PR TITLE
[TF] use mlir-ir as output format by default

### DIFF
--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/tf.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/tf.py
@@ -140,6 +140,7 @@ def build_import_command_line(input_path: str, tfs: TempFileSaver,
     output_file = tfs.alloc_optional("tf-output.mlir",
                                      export_as=options.output_file)
     cl.append(f"-o={output_file}")
+    cl.append(f"--output-format=mlir-ir")
 
   # MLIR flags.
   if options.output_mlir_debuginfo:


### PR DESCRIPTION
Preserves current usage model with UTF-8. In the future we can expose other formats.