### PR TITLE
Adding CPU import conversion and ordinal assignment machinery.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -19,6 +19,7 @@ iree_compiler_cc_library(
         "KernelDispatch.cpp",
         "LLVMCPUAArch64VectorLowering.cpp",
         "LLVMCPUAssignConstantOrdinals.cpp",
+        "LLVMCPUAssignImportOrdinals.cpp",
         "LLVMCPUCheckIRBeforeLLVMConversion.cpp",
         "LLVMCPUEmitVectorizationRemarks.cpp",
         "LLVMCPULinkExecutables.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_cc_library(
     "KernelDispatch.cpp"
     "LLVMCPUAArch64VectorLowering.cpp"
     "LLVMCPUAssignConstantOrdinals.cpp"
+    "LLVMCPUAssignImportOrdinals.cpp"
     "LLVMCPUCheckIRBeforeLLVMConversion.cpp"
     "LLVMCPUEmitVectorizationRemarks.cpp"
     "LLVMCPULinkExecutables.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -538,32 +538,62 @@ class HALDispatchABI {
     return castValueToType(loc, constantValue, resultType, builder);
   }
 
+  // Loads the ordinal of the import with the given |importName|.
+  // A placeholder global will be inserted that will be updated with the
+  // assigned ordinal after linking.
+  Value loadImportOrdinal(Location loc, StringRef importName, bool weak,
+                          OpBuilder &builder) {
+    // Create top-level global placeholder.
+    // The magic attribute is used by future assignment passes.
+    std::string globalName = ("__import_ordinal_" + importName).str();
+    auto moduleOp =
+        builder.getInsertionPoint()->getParentOfType<mlir::ModuleOp>();
+    LLVM::GlobalOp globalOp;
+    if (!(globalOp = moduleOp.lookupSymbol<LLVM::GlobalOp>(globalName))) {
+      auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
+      globalOp = moduleBuilder.create<LLVM::GlobalOp>(loc, builder.getI32Type(),
+                                                      /*isConstant=*/false,
+                                                      LLVM::Linkage::Internal,
+                                                      globalName, Attribute{});
+      globalOp->setAttr("hal.executable.import.key",
+                        builder.getStringAttr(importName));
+      if (weak) {
+        globalOp->setAttr("hal.executable.import.weak", builder.getUnitAttr());
+      }
+    }
+
+    // Load the placeholder global ordinal.
+    Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, globalOp);
+    return builder.create<LLVM::LoadOp>(loc, globalPtr);
+  }
+
   // Loads the import function pointer of the import |ordinal|.
   // Equivalent to:
   //   iree_hal_executable_import_v0_t fn_ptr = state->import_funcs[ordinal];
   //   void* context = state->import_contexts[ordinal];
-  std::pair<Value, Value> loadImportFunc(Location loc, int64_t ordinal,
+  std::pair<Value, Value> loadImportFunc(Location loc, Value importOrdinal,
                                          OpBuilder &builder) {
-    auto ordinalValue = getIndexValue(loc, ordinal, builder);
     auto funcPtrsValue =
         loadFieldValue(loc, EnvironmentField::import_funcs, builder);
     auto funcPtrValue = builder.createOrFold<LLVM::GEPOp>(
-        loc, funcPtrsValue.getType(), funcPtrsValue, ordinalValue);
+        loc, funcPtrsValue.getType(), funcPtrsValue, importOrdinal);
     auto contextPtrsValue =
         loadFieldValue(loc, EnvironmentField::import_contexts, builder);
     auto contextPtrValue = builder.createOrFold<LLVM::GEPOp>(
-        loc, contextPtrsValue.getType(), contextPtrsValue, ordinalValue);
+        loc, contextPtrsValue.getType(), contextPtrsValue, importOrdinal);
     return std::make_pair(
         builder.createOrFold<LLVM::LoadOp>(loc, funcPtrValue),
         builder.createOrFold<LLVM::LoadOp>(loc, contextPtrValue));
   }
 
-  // Returns an i1 indicating whether the optional import with |ordinal| is
+  // Returns an i1 indicating whether the optional import with |importName| is
   // defined. Equivalent to:
   //   state->import_funcs[ordinal] != NULL
-  Value isImportFuncAvailable(Location loc, int64_t ordinal,
+  Value isImportFuncAvailable(Location loc, StringRef importName,
                               OpBuilder &builder) {
-    auto importFunc = loadImportFunc(loc, ordinal, builder);
+    auto importOrdinal =
+        loadImportOrdinal(loc, importName, /*weak=*/true, builder);
+    auto importFunc = loadImportFunc(loc, importOrdinal, builder);
     Value nullPtrValue =
         builder.create<LLVM::NullOp>(loc, importFunc.first.getType());
     return builder.create<LLVM::ICmpOp>(loc, builder.getI1Type(),
@@ -571,15 +601,22 @@ class HALDispatchABI {
                                         importFunc.first, nullPtrValue);
   }
 
-  // Emits a call to the import with the given |importOrdinal|.
+  // Emits a call to the import with the given |importName|.
   // The provided |params| struct containing the function-specific arguments
   // is passed without modification.
   // Returns 0 on success and non-zero otherwise.
-  Value callImport(Location loc, unsigned importOrdinal, Value params,
+  Value callImport(Location loc, StringRef importName, bool weak, Value params,
                    OpBuilder &builder) {
+    auto importOrdinal = loadImportOrdinal(loc, importName, weak, builder);
     auto thunkPtrValue =
         loadFieldValue(loc, EnvironmentField::import_thunk, builder);
     auto importFunc = loadImportFunc(loc, importOrdinal, builder);
+
+    // TODO(benvanik): if weak is set then we should bail if the import is not
+    // found. Since we've loaded the import func here we can just compare for
+    // null as in isImportFuncAvailable but we'll need to make the control flow.
+    assert(!weak && "calls to weak imports not yet implemented");
+
     Value nullPtrValue = builder.create<LLVM::NullOp>(
         loc, LLVM::LLVMPointerType::get(builder.getI8Type()));
     auto callOp =
@@ -592,6 +629,85 @@ class HALDispatchABI {
                                          /*reserved=*/nullPtrValue,
                                      });
     return callOp.getResult();
+  }
+
+  // Emits a call to a dynamically linked import using the given |importName|
+  // as a template.
+  // The provided |resultTypes| and |args| are packed in a struct and transit
+  // through memory so that we can expose a single void* argument.
+  // Returns 0 on success and non-zero otherwise.
+  SmallVector<Value> wrapAndCallImport(Location loc, StringRef importName,
+                                       bool weak, TypeRange resultTypes,
+                                       ValueRange args, OpBuilder &builder) {
+    // Struct types are ordered [results..., args...].
+    SmallVector<Type> types(resultTypes);
+    types.reserve(resultTypes.size() + args.size());
+    for (Value arg : args) {
+      types.push_back(typeConverter->convertType(arg.getType()));
+    }
+
+    // Pack parameter structure.
+    Type structType;
+    Value paramsPtr, voidPtr;
+    auto voidPtrTy = LLVM::LLVMPointerType::get(builder.getI8Type());
+    if (!types.empty()) {
+      // TODO(benvanik): set specific layout to match runtime.
+      structType =
+          LLVM::LLVMStructType::getLiteral(builder.getContext(), types);
+      auto ptrStructType = LLVM::LLVMPointerType::get(structType);
+      Value one = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
+                                                   builder.getIndexAttr(1));
+      paramsPtr = builder.create<LLVM::AllocaOp>(loc, ptrStructType, one,
+                                                 /*alignment=*/0);
+      Value structVal = builder.create<LLVM::UndefOp>(loc, structType);
+      for (int64_t i = 0, e = args.size(); i < e; ++i) {
+        structVal = builder.create<LLVM::InsertValueOp>(loc, structVal, args[i],
+                                                        i + resultTypes.size());
+      }
+      // Store into the alloca'ed descriptor.
+      builder.create<LLVM::StoreOp>(loc, structVal, paramsPtr);
+      voidPtr = builder.create<LLVM::BitcastOp>(loc, voidPtrTy, paramsPtr);
+    } else {
+      voidPtr = builder.create<LLVM::UndefOp>(loc, voidPtrTy);
+    }
+
+    // Calls return 0 (success) or non-zero (failure).
+    auto callResult = callImport(loc, importName, weak, voidPtr, builder);
+    Block *trueDest =
+        builder.getInsertionBlock()->splitBlock(++builder.getInsertionPoint());
+    Block *falseDest = builder.createBlock(trueDest);
+
+    // Check the call results and branch to exit if it failed.
+    // Note that we weight the true branch (call successful) higher.
+    builder.setInsertionPointAfterValue(callResult);
+    Value zeroI32 = builder.create<LLVM::ConstantOp>(
+        loc, builder.getI32Type(), builder.getI32IntegerAttr(0));
+    Value cmpZero = builder.create<LLVM::ICmpOp>(
+        loc, builder.getI1Type(), LLVM::ICmpPredicate::eq, callResult, zeroI32);
+    builder.create<LLVM::CondBrOp>(loc, cmpZero, trueDest, ValueRange{},
+                                   falseDest, ValueRange{callResult},
+                                   std::make_pair(1u, 0u));
+
+    // Failure return block.
+    // Return the call result to the runtime.
+    builder.setInsertionPointToStart(falseDest);
+    builder.create<LLVM::ReturnOp>(
+        loc, falseDest->addArgument(builder.getI32Type(), loc));
+
+    // Successful continuation block.
+    // Marshal results out of the params struct.
+    builder.setInsertionPointToStart(trueDest);
+    SmallVector<Value> results;
+    if (!resultTypes.empty()) {
+      results.reserve(resultTypes.size());
+      Value structVal =
+          builder.create<LLVM::LoadOp>(loc, structType, paramsPtr);
+      for (int64_t i = 0, e = resultTypes.size(); i < e; ++i) {
+        results.push_back(
+            builder.create<LLVM::ExtractValueOp>(loc, structVal, i));
+      }
+    }
+    return results;
   }
 
  private:
@@ -929,6 +1045,53 @@ class ConvertHALInterfaceBindingSubspanOp : public ConvertToLLVMPattern {
   }
 };
 
+/// Rewrites calls to extern functions to dynamic library import calls.
+/// The parent LLVMFuncOp must be compatible with HALDispatchABI.
+///
+/// Note: this is an LLVM::CallOp -> LLVM::CallOp rewrite that is introduced
+/// after all conversions are done. Importantly, this is not a conversion
+/// pattern.
+class RewriteExternCallOpToDynamicImportCallOp
+    : public OpRewritePattern<LLVM::CallOp> {
+ public:
+  explicit RewriteExternCallOpToDynamicImportCallOp(
+      MLIRContext *context, LLVMTypeConverter &converter)
+      : OpRewritePattern<LLVM::CallOp>(context), typeConverter(converter) {}
+
+  LogicalResult matchAndRewrite(LLVM::CallOp callOp,
+                                PatternRewriter &rewriter) const override {
+    auto llvmFuncOp = callOp->getParentOfType<LLVM::LLVMFuncOp>();
+    if (!llvmFuncOp) return failure();
+    HALDispatchABI abi(llvmFuncOp, &typeConverter);
+
+    // Ignore indirect calls (they're probably already converted imports).
+    auto symbol = callOp.getCallableForCallee().dyn_cast<SymbolRefAttr>();
+    auto flatSymbol = symbol.dyn_cast_or_null<FlatSymbolRefAttr>();
+    if (!flatSymbol) return failure();
+
+    // Ensure the target function is extern.
+    // To support conversion inserting calls in local patterns that can't add
+    // global function symbols we assume any missing callee is extern.
+    auto calleeOp = SymbolTable::lookupNearestSymbolFrom<LLVM::LLVMFuncOp>(
+        llvmFuncOp, symbol);
+    if (calleeOp && !calleeOp.isExternal()) return failure();
+
+    // TODO(benvanik): way to determine if weak (maybe via linkage?).
+    bool weak = false;
+
+    // Rewrite the call to a dynamic import call.
+    SmallVector<Value> results = abi.wrapAndCallImport(
+        callOp->getLoc(), flatSymbol.getValue(), weak, callOp->getResultTypes(),
+        callOp->getOperands(), rewriter);
+
+    rewriter.replaceOp(callOp, results);
+    return success();
+  }
+
+ private:
+  LLVMTypeConverter &typeConverter;
+};
+
 class ConvertToLLVMPass : public ConvertToLLVMBase<ConvertToLLVMPass> {
  public:
   ConvertToLLVMPass(bool reassociateFpReductions)
@@ -1076,6 +1239,15 @@ void ConvertToLLVMPass::runOnOperation() {
   if (failed(applyPartialConversion(module, target, std::move(patterns)))) {
     signalPassFailure();
     return;
+  }
+
+  // Rewrite any extern calls emitted to dynamic library imports.
+  {
+    RewritePatternSet patterns(&getContext());
+    patterns.insert<RewriteExternCallOpToDynamicImportCallOp>(&getContext(),
+                                                              converter);
+    if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))
+      return signalPassFailure();
   }
 
   // Post conversion patterns.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignImportOrdinals.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUAssignImportOrdinals.cpp
@@ -1,0 +1,86 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "llvm/ADT/MapVector.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+struct LLVMCPUAssignImportOrdinalsPass
+    : public LLVMCPUAssignImportOrdinalsBase<LLVMCPUAssignImportOrdinalsPass> {
+  LLVMCPUAssignImportOrdinalsPass() = default;
+  void runOnOperation() override {
+    auto variantOp = getOperation();
+
+    // Ignore non-LLVMCPU variants.
+    // TODO(benvanik): a way to nest this in the pipeline via dynamic passes.
+    if (variantOp.getTarget().getBackend().getValue() != "llvm-cpu") return;
+
+    auto *context = variantOp.getContext();
+    auto unitAttr = UnitAttr::get(context);
+    auto importKeyAttr = StringAttr::get(context, "hal.executable.import.key");
+    auto importWeakAttr =
+        StringAttr::get(context, "hal.executable.import.weak");
+
+    // Scan the module for the used imports and sort by name.
+    // This allows us to assign ordinals deterministically regardless of what
+    // order the imports are declared which may not always be stable.
+    SetVector<StringAttr> uniqueKeys;
+    DenseMap<StringAttr, SmallVector<LLVM::GlobalOp>> ordinalGlobals;
+    auto moduleOp = variantOp.getInnerModule();
+    for (auto globalOp :
+         llvm::make_early_inc_range(moduleOp.getOps<LLVM::GlobalOp>())) {
+      auto keyAttr = globalOp->getAttrOfType<StringAttr>(importKeyAttr);
+      if (!keyAttr) continue;
+      uniqueKeys.insert(keyAttr);
+      ordinalGlobals[keyAttr].push_back(globalOp);
+    }
+    if (uniqueKeys.empty()) return;
+    auto sortedKeys = uniqueKeys.takeVector();
+    llvm::stable_sort(sortedKeys, [](auto lhs, auto rhs) {
+      return lhs.getValue() < rhs.getValue();
+    });
+
+    // Build the attribute used during serialization to emit the import table.
+    SmallVector<Attribute> importAttrs;
+    for (auto keyAttr : sortedKeys) {
+      auto anyGlobalOp = ordinalGlobals[keyAttr].front();
+      bool isWeak = anyGlobalOp->hasAttr(importWeakAttr);
+      auto isWeakAttr = BoolAttr::get(context, isWeak);
+      importAttrs.push_back(ArrayAttr::get(context, {keyAttr, isWeakAttr}));
+    }
+    variantOp->setAttr("hal.executable.imports",
+                       ArrayAttr::get(context, importAttrs));
+
+    // Update placeholders to hold the concrete ordinal values.
+    // Eventually MLIR or LLVM will inline them.
+    for (auto [ordinal, keyAttr] : llvm::enumerate(sortedKeys)) {
+      for (auto globalOp : ordinalGlobals[keyAttr]) {
+        globalOp->removeAttr(importKeyAttr);
+        globalOp->removeAttr(importWeakAttr);
+        globalOp.setConstantAttr(unitAttr);
+        globalOp.setValueAttr(IntegerAttr::get(
+            IntegerType::get(globalOp.getContext(), 32), ordinal));
+      }
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createLLVMCPUAssignImportOrdinalsPass() {
+  return std::make_unique<LLVMCPUAssignImportOrdinalsPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -712,10 +712,11 @@ void buildLLVMCPULinkingPassPipeline(OpPassManager &passManager) {
   passManager.addNestedPass<IREE::HAL::ExecutableOp>(
       mlir::createCanonicalizerPass());
 
-  // Assign final executable constant ordinals.
-  passManager.nest<IREE::HAL::ExecutableOp>()
-      .addNestedPass<IREE::HAL::ExecutableVariantOp>(
-          createLLVMCPUAssignConstantOrdinalsPass());
+  // Assign final executable constant and import ordinals.
+  auto &variantPM = passManager.nest<IREE::HAL::ExecutableOp>()
+                        .nest<IREE::HAL::ExecutableVariantOp>();
+  variantPM.addPass(createLLVMCPUAssignConstantOrdinalsPass());
+  variantPM.addPass(createLLVMCPUAssignImportOrdinalsPass());
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "aarch64_vector_lowering.mlir",
             "apply_scale_lowering.mlir",
             "assign_constant_ordinals.mlir",
+            "assign_import_ordinals.mlir",
             "check_ir_before_llvm_conversion.mlir",
             "convert_to_llvm.mlir",
             "emit_vectorization_remarks.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "aarch64_vector_lowering.mlir"
     "apply_scale_lowering.mlir"
     "assign_constant_ordinals.mlir"
+    "assign_import_ordinals.mlir"
     "check_ir_before_llvm_conversion.mlir"
     "convert_to_llvm.mlir"
     "emit_vectorization_remarks.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_import_ordinals.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/assign_import_ordinals.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt --pass-pipeline="hal.executable(hal.executable.variant(iree-llvmcpu-assign-import-ordinals))" --split-input-file %s | FileCheck %s
+
+// Tests that duplicate keys get the same ordinal and that ordinals are assigned
+// in alphabetical order.
+
+hal.executable private @executable {
+  // CHECK: hal.executable.variant
+  // CHECK-SAME: hal.executable.imports = {{.+}}["bar", true], ["foo", false]{{.+}}
+  hal.executable.variant public @variant, target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64"> {
+    builtin.module {
+      // CHECK: llvm.mlir.global internal constant @__import_ordinal_foo_a(1 : i32)
+      llvm.mlir.global internal @__import_ordinal_foo_a() {
+        hal.executable.import.key = "foo"
+      } : i32
+      // CHECK: llvm.mlir.global internal constant @__import_ordinal_foo_b(1 : i32)
+      llvm.mlir.global internal @__import_ordinal_foo_b() {
+        hal.executable.import.key = "foo"
+      } : i32
+      // CHECK: llvm.mlir.global internal constant @__import_ordinal_bar(0 : i32)
+      llvm.mlir.global internal @__import_ordinal_bar() {
+        hal.executable.import.key = "bar",
+        hal.executable.import.weak
+      } : i32
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_executable_constants.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_executable_constants.mlir
@@ -12,4 +12,6 @@ func.func @constant_values() {
   llvm.call @sink(%v0) : (i32) -> ()
   return
 }
-llvm.func @sink(i32)
+llvm.func @sink(%arg0: i32) {
+  llvm.return
+}

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_bindings.mlir
@@ -1,48 +1,33 @@
-// RUN: iree-opt --allow-unregistered-dialect --iree-convert-to-llvm --split-input-file %s | FileCheck %s
-
-llvm.func @sink(f32)
+// RUN: iree-opt --iree-convert-to-llvm --split-input-file %s | FileCheck %s --dump-input=always
 
 // CHECK-LABEL: llvm.func @binding_ptrs
 func.func @binding_ptrs() {
-  // CHECK-DAG: %[[C72:.+]] = llvm.mlir.constant(72 : index) : i64
-  %c72 = arith.constant 72 : index
+  // CHECK-DAG: %[[C1:.+]] = llvm.mlir.constant(1
+  // CHECK-DAG: %[[C2:.+]] = llvm.mlir.constant(2
+  // CHECK-DAG: %[[C5:.+]] = llvm.mlir.constant(5
 
-  // CHECK: %[[STATE:.+]] = llvm.load %arg1 : !llvm.ptr<struct<[[DISPATCH_STATE_TYPE:.+]]>>
-  // CHECK: %[[PC:.+]] = llvm.extractvalue %[[STATE]][9]
-  // CHECK: %[[C2:.+]] = llvm.mlir.constant(2 : i64) : i64
-  // CHECK: %[[DIM_PTR:.+]] = llvm.getelementptr %[[PC]][%[[C2]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
-  // CHECK: %[[DIM_I32:.+]] = llvm.load %[[DIM_PTR]] : !llvm.ptr<i32>
-  // CHECK: %[[DIM:.+]] = llvm.zext %[[DIM_I32]] : i32 to i64
-  %dim = hal.interface.constant.load[2] : index
-
-  // CHECK: %[[STATE:.+]] = llvm.load %arg1 : !llvm.ptr<struct<[[DISPATCH_STATE_TYPE]]>>
+  // CHECK: %[[STATE:.+]] = llvm.load %arg1
   // CHECK: %[[BINDING_PTRS:.+]] = llvm.extractvalue %[[STATE]][10]
-  // CHECK: %[[C1:.+]] = llvm.mlir.constant(1 : i64) : i64
   // CHECK: %[[ARRAY_PTR:.+]] = llvm.getelementptr %[[BINDING_PTRS]][1] : (!llvm.ptr<ptr<i8>>) -> !llvm.ptr<ptr<i8>>
   // CHECK: %[[BASE_PTR_I8:.+]] = llvm.load %[[ARRAY_PTR]] : !llvm.ptr<ptr<i8>>
   // CHECK: %[[BUFFER_I8:.+]] = llvm.getelementptr %[[BASE_PTR_I8]][72] : (!llvm.ptr<i8>) -> !llvm.ptr<i8>
   // CHECK: %[[BUFFER_F32:.+]] = llvm.bitcast %[[BUFFER_I8]] : !llvm.ptr<i8> to !llvm.ptr<f32>
-  // CHECK: %[[DESC_A:.+]] = llvm.mlir.undef : !llvm.struct<(ptr<f32>, ptr<f32>, i64, array<2 x i64>, array<2 x i64>)>
-  // CHECK: %[[DESC_B:.+]] = llvm.insertvalue %[[BUFFER_F32]], %[[DESC_A]][0]
-  // CHECK: %[[DESC_C:.+]] = llvm.insertvalue %[[BUFFER_F32]], %[[DESC_B]][1]
-  // CHECK: %[[C0:.+]] = llvm.mlir.constant(0 : index) : i64
-  // CHECK: %[[DESC_D:.+]] = llvm.insertvalue %[[C0]], %[[DESC_C]][2]
-  // CHECK: %[[DESC_E:.+]] = llvm.insertvalue %[[DIM]], %[[DESC_D]][3, 0]
-  // CHECK: %[[C2:.+]] = llvm.mlir.constant(2 : index) : i64
-  // CHECK: %[[DESC_F:.+]] = llvm.insertvalue %[[C2]], %[[DESC_E]][3, 1]
-  // CHECK: %[[C1:.+]] = llvm.mlir.constant(1 : index) : i64
-  // CHECK: %[[DESC_G:.+]] = llvm.insertvalue %[[C1]], %[[DESC_F]][4, 1]
-  // CHECK: %[[STRIDE1:.+]] = llvm.extractvalue %[[DESC_G]][4, 1]
-  // CHECK: %[[DIM1:.+]] = llvm.extractvalue %[[DESC_G]][3, 1]
-  // CHECK: %[[STRIDE0:.+]] = llvm.mul %[[STRIDE1]], %[[DIM1]]  : i64
-  // CHECK: %[[DESC_H:.+]] = llvm.insertvalue %[[STRIDE0]], %[[DESC_G]][4, 0]
-  %memref = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c72) : memref<?x2xf32>{%dim}
+  %c72 = arith.constant 72 : index
+  %c128 = arith.constant 128 : index
+  %memref = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c72) : memref<?x2xf32>{%c128}
 
-  // CHECK: %[[VAL:.+]] = llvm.load
-  %c0 = arith.constant 0 : index
-  %val = memref.load %memref[%c0, %c0] : memref<?x2xf32>
+  // CHECK: %[[OFFSET_D0:.+]] = llvm.mul %[[C5]], %[[C2]]
+  // CHECK: %[[OFFSET_D1:.+]] = llvm.add %[[OFFSET_D0]], %[[C1]]
+  // CHECK: %[[OFFSET_PTR:.+]] = llvm.getelementptr %[[BUFFER_F32]][%[[OFFSET_D1]]]
+  // CHECK: %[[VALUE:.+]] = llvm.load %[[OFFSET_PTR]]
+  %c1 = arith.constant 1 : index
+  %c5 = arith.constant 5 : index
+  %value = memref.load %memref[%c5, %c1] : memref<?x2xf32>
 
-  // CHECK: llvm.call @sink(%[[VAL]])
-  llvm.call @sink(%val) : (f32) -> ()
+  // CHECK: llvm.call @sink(%[[VALUE]])
+  llvm.call @sink(%value) : (f32) -> ()
   return
+}
+llvm.func @sink(%arg0: f32) {
+  llvm.return
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_constants.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_constants.mlir
@@ -1,13 +1,10 @@
 // RUN: iree-opt --allow-unregistered-dialect --iree-convert-to-llvm --split-input-file %s | FileCheck %s
 
-llvm.func @sink(i64)
-
 // CHECK-LABEL: llvm.func @constant_values
 func.func @constant_values() {
   // CHECK: %[[STATE:.+]] = llvm.load %arg1 : !llvm.ptr<struct<"iree_hal_executable_dispatch_state_v0_t"
   // CHECK: %[[PTR_BASE:.+]] = llvm.extractvalue %[[STATE]][9]
-  // CHECK: %[[C1:.+]] = llvm.mlir.constant(1
-  // CHECK: %[[VPTR:.+]] = llvm.getelementptr %[[PTR_BASE]][%[[C1]]] : (!llvm.ptr<i32>, i64) -> !llvm.ptr<i32>
+  // CHECK: %[[VPTR:.+]] = llvm.getelementptr %[[PTR_BASE]][1] : (!llvm.ptr<i32>) -> !llvm.ptr<i32>
   // CHECK: %[[V32:.+]] = llvm.load %[[VPTR]] : !llvm.ptr<i32>
   // CHECK: %[[V64:.+]] = llvm.zext %[[V32]] : i32 to i64
   %v1 = hal.interface.constant.load[1] : index
@@ -17,3 +14,7 @@ func.func @constant_values() {
   llvm.call @sink(%v2) : (i64) -> ()
   return
 }
+llvm.func @sink(%arg0: i64) {
+  llvm.return
+}
+

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_workgroup_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_workgroup_info.mlir
@@ -1,7 +1,5 @@
 // RUN: iree-opt --allow-unregistered-dialect --iree-convert-to-llvm --split-input-file %s | FileCheck %s
 
-llvm.func @sink(i64)
-
 // CHECK-LABEL: llvm.func @workgroup_id
 func.func @workgroup_id() {
   // CHECK: %[[STATE:.+]] = llvm.load %arg2 : !llvm.ptr<struct<"iree_hal_executable_workgroup_state_v0_t"
@@ -13,10 +11,11 @@ func.func @workgroup_id() {
   llvm.call @sink(%val) : (i64) -> ()
   return
 }
+llvm.func @sink(%arg0: i64) {
+  llvm.return
+}
 
 // -----
-
-llvm.func @sink(i64)
 
 // CHECK-LABEL: llvm.func @workgroup_size
 func.func @workgroup_size() {
@@ -29,10 +28,11 @@ func.func @workgroup_size() {
   llvm.call @sink(%val) : (i64) -> ()
   return
 }
+llvm.func @sink(%arg0: i64) {
+  llvm.return
+}
 
 // -----
-
-llvm.func @sink(i64)
 
 // CHECK-LABEL: llvm.func @workgroup_count
 func.func @workgroup_count() {
@@ -44,4 +44,7 @@ func.func @workgroup_count() {
   %val = arith.index_cast %workgroup_count_z : index to i64
   llvm.call @sink(%val) : (i64) -> ()
   return
+}
+llvm.func @sink(%arg0: i64) {
+  llvm.return
 }

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -332,6 +332,10 @@ createLLVMCPULinkExecutablesPass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createLLVMCPUAssignConstantOrdinalsPass();
 
+/// Assigns executable import ordinals across all LLVMCPU variants.
+std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
+createLLVMCPUAssignImportOrdinalsPass();
+
 /// Populates passes needed to link HAL executables across LLVMCPU targets.
 void buildLLVMCPULinkingPassPipeline(OpPassManager &passManager);
 

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -328,6 +328,12 @@ def LLVMCPUAssignConstantOrdinals :
   let constructor = "mlir::iree_compiler::createLLVMCPUAssignConstantOrdinalsPass()";
 }
 
+def LLVMCPUAssignImportOrdinals :
+    Pass<"iree-llvmcpu-assign-import-ordinals", "IREE::HAL::ExecutableVariantOp"> {
+  let summary = "Assigns executable import ordinals across all LLVMCPU variants.";
+  let constructor = "mlir::iree_compiler::createLLVMCPUAssignImportOrdinalsPass()";
+}
+
 //------------------------------------------------------------------------------
 // LLVMGPU
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -239,6 +239,21 @@ class LLVMCPUTargetBackend final : public TargetBackend {
         }
       } break;
     }
+
+    // Declare dynamically imported functions.
+    auto importsAttrName =
+        StringAttr::get(variantOp.getContext(), "hal.executable.imports");
+    if (auto importsAttr =
+            variantOp->getAttrOfType<ArrayAttr>(importsAttrName)) {
+      for (auto importAttr : importsAttr.getAsValueRange<ArrayAttr>()) {
+        auto nameAttr = importAttr[0].cast<StringAttr>();
+        auto weakAttr = importAttr[1].cast<BoolAttr>();
+        libraryBuilder.addImport(nameAttr.getValue(), weakAttr.getValue());
+      }
+      variantOp->removeAttr(importsAttrName);
+    }
+
+    // Declare exported entry points.
     auto align16 = llvm::Attribute::getWithAlignment(context, llvm::Align(16));
     for (auto exportOp : variantOp.getBlock().getOps<ExecutableExportOp>()) {
       // Find the matching function in the LLVM module.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LibraryBuilder.h
@@ -104,10 +104,10 @@ class LibraryBuilder {
     this->sanitizerKind = sanitizerKind;
   }
 
-  // Defines a new runtime import function and returns its ordinal.
-  unsigned addImport(StringRef name, bool weak) {
+  // Defines a new runtime import function.
+  // The declared ordinal of the import matches the order they are declared.
+  void addImport(StringRef name, bool weak) {
     imports.push_back({name.str(), weak});
-    return imports.size() - 1;
   }
 
   // Defines a new entry point on the library implemented by |func|.

--- a/runtime/src/iree/hal/local/elf/arch.h
+++ b/runtime/src/iree/hal/local/elf/arch.h
@@ -59,7 +59,7 @@ int iree_elf_call_i_p(const void* symbol_ptr, void* a0);
 // Host -> ELF: int(*)(void*, void*, void*)
 int iree_elf_call_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2);
 
-// ELF -> Host: int(*)(void*)
-int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0);
+// ELF -> Host: int(*)(void*, void*, void*)
+int iree_elf_thunk_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2);
 
 #endif  // IREE_HAL_LOCAL_ELF_ARCH_H_

--- a/runtime/src/iree/hal/local/elf/arch/arm_32.c
+++ b/runtime/src/iree/hal/local/elf/arch/arm_32.c
@@ -144,9 +144,9 @@ int iree_elf_call_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
   return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
-int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0) {
-  typedef int (*ptr_t)(void*);
-  return ((ptr_t)symbol_ptr)(a0);
+int iree_elf_thunk_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
+  typedef int (*ptr_t)(void*, void*, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
 #endif  // IREE_ARCH_ARM_32

--- a/runtime/src/iree/hal/local/elf/arch/arm_64.c
+++ b/runtime/src/iree/hal/local/elf/arch/arm_64.c
@@ -141,9 +141,9 @@ int iree_elf_call_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
   return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
-int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0) {
-  typedef int (*ptr_t)(void*);
-  return ((ptr_t)symbol_ptr)(a0);
+int iree_elf_thunk_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
+  typedef int (*ptr_t)(void*, void*, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
 #endif  // IREE_ARCH_ARM_64

--- a/runtime/src/iree/hal/local/elf/arch/riscv.c
+++ b/runtime/src/iree/hal/local/elf/arch/riscv.c
@@ -184,9 +184,9 @@ int iree_elf_call_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
   return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
-int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0) {
-  typedef int (*ptr_t)(void*);
-  return ((ptr_t)symbol_ptr)(a0);
+int iree_elf_thunk_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
+  typedef int (*ptr_t)(void*, void*, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
 #endif  // IREE_ARCH_RISCV_*

--- a/runtime/src/iree/hal/local/elf/arch/x86_32.c
+++ b/runtime/src/iree/hal/local/elf/arch/x86_32.c
@@ -158,9 +158,9 @@ int iree_elf_call_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
   return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
-int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0) {
-  typedef int (*ptr_t)(void*);
-  return ((ptr_t)symbol_ptr)(a0);
+int iree_elf_thunk_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
+  typedef int (*ptr_t)(void*, void*, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
 #endif  // IREE_ARCH_X86_32

--- a/runtime/src/iree/hal/local/elf/arch/x86_64.c
+++ b/runtime/src/iree/hal/local/elf/arch/x86_64.c
@@ -206,9 +206,9 @@ int iree_elf_call_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
   return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
-int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0) {
-  typedef int (*ptr_t)(void*);
-  return ((ptr_t)symbol_ptr)(a0);
+int iree_elf_thunk_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2) {
+  typedef int (*ptr_t)(void*, void*, void*);
+  return ((ptr_t)symbol_ptr)(a0, a1, a2);
 }
 
 #endif  // IREE_PLATFORM_WINDOWS

--- a/runtime/src/iree/hal/local/elf/arch/x86_64_msvc.asm
+++ b/runtime/src/iree/hal/local/elf/arch/x86_64_msvc.asm
@@ -173,9 +173,9 @@ iree_elf_call_i_ppp PROC FRAME
   _sysv_interop_prolog
 
   ; RCX = symbol_ptr
-  ; RDX = a0
-  ; R8 = a1
-  ; R9 = a2
+  ; RDX = a0         <- RDI
+  ; R8  = a1         <- RSI
+  ; R9  = a2         <- RDX
   mov rdi, rdx
   mov rsi, r8
   mov rdx, r9
@@ -185,18 +185,21 @@ iree_elf_call_i_ppp PROC FRAME
   ret
 iree_elf_call_i_ppp ENDP
 
-; int iree_elf_thunk_i_p(const void* symbol_ptr, void* a0)
-iree_elf_thunk_i_p PROC FRAME
+; int iree_elf_thunk_i_ppp(const void* symbol_ptr, void* a0, void* a1, void* a2)
+iree_elf_thunk_i_ppp PROC FRAME
   _sysv_interop_prolog
 
   ; RDI = symbol_ptr
-  ; RSI = a0
+  ; RSI = a0         -> RCX
+  ; RDX = a1         -> RDX
+  ; RCX = a2         -> R8
+  mov r8, rcx
   mov rcx, rsi
   call rdi
 
   _sysv_interop_epilog
   ret
-iree_elf_thunk_i_p ENDP
+iree_elf_thunk_i_ppp ENDP
 
 _TEXT ENDS
 END

--- a/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
+++ b/runtime/src/iree/hal/local/loaders/embedded_elf_loader.c
@@ -98,7 +98,7 @@ static iree_status_t iree_hal_elf_executable_resolve_imports(
   // All calls from the loaded ELF route through our thunk function so that we
   // can adapt to ABI differences.
   executable->base.environment.import_thunk =
-      (iree_hal_executable_import_thunk_v0_t)iree_elf_call_i_ppp;
+      (iree_hal_executable_import_thunk_v0_t)iree_elf_thunk_i_ppp;
 
   // Allocate storage for the imports.
   // TODO(benvanik): allocate both as one block.


### PR DESCRIPTION
During conversion to the LLVM dialect any `func.call` to an extern function or a function emitted during conversion will be lowered into an import call with a placeholder ordinal. This uses a technique like executable constants whereby imports get an attributed global placeholder for the ordinal that is assigned in the new LLVMCPUAssignImportOrdinals pass after linking. During serialization the import table built during assignment is used to declare the imports on the executable library data structure.

The automatic conversion comes courtesy of @nicolasvasilache and should handle most basic arg/result packing.
Minor fixes were required in the runtime for MSVC compatibility with embedded ELFs.

Fixes #7504.