### PR TITLE
Add IREE imported model layer to e2e test framework

### DIFF
--- a/build_tools/python/benchmark_suites/iree/adreno_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/adreno_benchmarks.py
@@ -52,23 +52,26 @@ class Android_Adreno_Benchmarks(object):
     ]
     default_gen_configs = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.DEFAULT_COMPILE_CONFIG, model=model)
+            compile_config=self.DEFAULT_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in default_models
     ]
     fuse_padding_gen_configs = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.FUSE_PADDING_COMPILE_CONFIG, model=model)
+            compile_config=self.FUSE_PADDING_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in default_models
     ]
     fuse_padding_repeated_kernel_gen_configs = [
         iree_definitions.ModuleGenerationConfig(
             compile_config=self.FUSE_PADDING_REPEATED_KERNEL_COMPILE_CONFIG,
-            model=model) for model in [
-                tflite_models.MOBILESSD_FP32,
-                tflite_models.POSENET_FP32,
-                tflite_models.MOBILENET_V2,
-                tflite_models.MOBILENET_V3SMALL,
-            ]
+            imported_model=iree_definitions.ImportedModel.from_model(model))
+        for model in [
+            tflite_models.MOBILESSD_FP32,
+            tflite_models.POSENET_FP32,
+            tflite_models.MOBILENET_V2,
+            tflite_models.MOBILENET_V3SMALL,
+        ]
     ]
 
     adreno_devices = device_collections.DEFAULT_DEVICE_COLLECTION.query_device_specs(

--- a/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
@@ -66,16 +66,19 @@ class Android_ARMv8_A_Benchmarks(object):
 
     default_gen_confings = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.DEFAULT_COMPILE_CONFIG, model=model)
+            compile_config=self.DEFAULT_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in self.NONQUANT_MODELS + self.QUANT_MODELS
     ]
     experimental_gen_confings = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.MMT4D_COMPILE_CONFIG, model=model)
+            compile_config=self.MMT4D_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in self.NONQUANT_MODELS
     ] + [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.MMT4D_AND_DOTPROD_COMPILE_CONFIG, model=model)
+            compile_config=self.MMT4D_AND_DOTPROD_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in self.QUANT_MODELS
     ]
 

--- a/build_tools/python/benchmark_suites/iree/cuda_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/cuda_benchmarks.py
@@ -34,7 +34,8 @@ class Linux_CUDA_Benchmarks(object):
 
     gen_configs = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.SM_80_COMPILE_CONFIG, model=model)
+            compile_config=self.SM_80_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in model_groups.LARGE
     ]
     sm80_devices = device_collections.DEFAULT_DEVICE_COLLECTION.query_device_specs(

--- a/build_tools/python/benchmark_suites/iree/mali_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/mali_benchmarks.py
@@ -105,11 +105,13 @@ class Android_Mali_Benchmarks(object):
         extra_flags=compile_config.extra_flags +
         ["--iree-flow-demote-f32-to-f16"])
     return [
-        iree_definitions.ModuleGenerationConfig(compile_config=compile_config,
-                                                model=model)
+        iree_definitions.ModuleGenerationConfig(
+            compile_config=compile_config,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in fp32_models
     ] + [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=demote_compile_config, model=model)
+            compile_config=demote_compile_config,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in fp16_models
     ]

--- a/build_tools/python/benchmark_suites/iree/riscv_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/riscv_benchmarks.py
@@ -38,7 +38,8 @@ class Linux_RV64_Benchmarks(object):
     """Generates IREE compile and run configs."""
     gen_configs = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.DEFAULT_COMPILE_CONFIG, model=model)
+            compile_config=self.DEFAULT_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in self.MODELS
     ]
     return (gen_configs, [])
@@ -67,7 +68,8 @@ class Linux_RV32_Benchmarks(object):
     """Generates IREE compile and run configs."""
     gen_configs = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.DEFAULT_COMPILE_CONFIG, model=model)
+            compile_config=self.DEFAULT_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in self.MODELS
     ]
     return (gen_configs, [])

--- a/build_tools/python/benchmark_suites/iree/vmvx_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/vmvx_benchmarks.py
@@ -34,8 +34,9 @@ class Android_VMVX_Benchmarks(object):
 
     gen_configs = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.DEFAULT_COMPILE_CONFIG, model=model) for model
-        in [tflite_models.MOBILENET_V2, tflite_models.MOBILENET_V3SMALL]
+            compile_config=self.DEFAULT_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model)) for
+        model in [tflite_models.MOBILENET_V2, tflite_models.MOBILENET_V3SMALL]
     ]
     default_execution_configs = [
         benchmark_suites.iree.module_execution_configs.

--- a/build_tools/python/benchmark_suites/iree/x86_64_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/x86_64_benchmarks.py
@@ -36,7 +36,8 @@ class Linux_x86_64_Benchmarks(object):
 
     gen_configs = [
         iree_definitions.ModuleGenerationConfig(
-            compile_config=self.CASCADELAKE_COMPILE_CONFIG, model=model)
+            compile_config=self.CASCADELAKE_COMPILE_CONFIG,
+            imported_model=iree_definitions.ImportedModel.from_model(model))
         for model in model_groups.SMALL + model_groups.LARGE
     ]
     default_execution_configs = [

--- a/build_tools/python/e2e_test_framework/cmake_rule_generator_test.py
+++ b/build_tools/python/e2e_test_framework/cmake_rule_generator_test.py
@@ -59,17 +59,44 @@ class CommonRuleFactoryTest(unittest.TestCase):
 
 class IreeRuleFactoryTest(unittest.TestCase):
 
+  TFLITE_MODEL = common_definitions.Model(
+      id="1234",
+      name="abcd",
+      tags=[],
+      source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
+      source_url="https://example.com/xyz.tflite",
+      entry_function="main",
+      input_types=["1xf32"])
+  TF_MODEL = common_definitions.Model(
+      id="5678",
+      name="efgh",
+      tags=[],
+      source_type=common_definitions.ModelSourceType.EXPORTED_TF,
+      source_url="https://example.com/xyz_saved_model",
+      entry_function="predict",
+      input_types=["2xf32"])
+  LINALG_MODEL = common_definitions.Model(
+      id="9012",
+      name="ijkl",
+      tags=[],
+      source_type=common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR,
+      source_url="https://example.com/xyz.mlir",
+      entry_function="main",
+      input_types=["3xf32"])
+
   def setUp(self):
     self._factory = cmake_rule_generator.IreeRuleFactory("root/iree")
 
   def test_add_import_model_rule_import_model(self):
+    model_rule = cmake_rule_generator.ModelRule(target_name="model-1234",
+                                                file_path="aaa",
+                                                cmake_rule="bbb")
+
     rule = self._factory.add_import_model_rule(
-        model_id="1234",
-        model_name="abcd",
-        model_source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
-        model_entry_function="main",
-        source_model_rule=cmake_rule_generator.ModelRule(
-            target_name="model-1234", file_path="aaa", cmake_rule="bbb"))
+        imported_model=iree_definitions.ImportedModel(
+            model=self.TFLITE_MODEL,
+            dialect_type=iree_definitions.MLIRDialectType.TOSA),
+        source_model_rule=model_rule)
 
     self.assertEqual(rule.target_name, "iree-import-model-1234")
     self.assertEqual(rule.mlir_dialect_type, "tosa")
@@ -77,16 +104,14 @@ class IreeRuleFactoryTest(unittest.TestCase):
 
   def test_add_import_model_rule_forward_mlir(self):
     model_rule = cmake_rule_generator.ModelRule(
-        target_name="model-1234",
-        file_path="root/models/1234.mlir",
-        cmake_rule="bbb")
+        target_name="model-0912",
+        file_path="root/models/0912.mlir",
+        cmake_rule="ccc")
 
     rule = self._factory.add_import_model_rule(
-        model_id="1234",
-        model_name="abcd",
-        model_source_type=common_definitions.ModelSourceType.
-        EXPORTED_LINALG_MLIR,
-        model_entry_function="main",
+        imported_model=iree_definitions.ImportedModel(
+            model=self.LINALG_MODEL,
+            dialect_type=iree_definitions.MLIRDialectType.LINALG),
         source_model_rule=model_rule)
 
     self.assertEqual(rule.target_name, model_rule.target_name)
@@ -121,17 +146,15 @@ class IreeRuleFactoryTest(unittest.TestCase):
 
   def test_generate_cmake_rules(self):
     import_rule_1 = self._factory.add_import_model_rule(
-        model_id="1234",
-        model_name="abcd",
-        model_source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
-        model_entry_function="main",
+        imported_model=iree_definitions.ImportedModel(
+            model=self.TFLITE_MODEL,
+            dialect_type=iree_definitions.MLIRDialectType.TOSA),
         source_model_rule=cmake_rule_generator.ModelRule(
             target_name="model-1234", file_path="aaa", cmake_rule="bbb"))
     import_rule_2 = self._factory.add_import_model_rule(
-        model_id="5678",
-        model_name="efgh",
-        model_source_type=common_definitions.ModelSourceType.EXPORTED_TF,
-        model_entry_function="main",
+        imported_model=iree_definitions.ImportedModel(
+            model=self.TF_MODEL,
+            dialect_type=iree_definitions.MLIRDialectType.MHLO),
         source_model_rule=cmake_rule_generator.ModelRule(
             target_name="model-5678", file_path="ccc", cmake_rule="eee"))
     compile_config = iree_definitions.CompileConfig(

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
@@ -73,11 +73,43 @@ class ModuleExecutionConfig(object):
   extra_flags: List[str] = dataclasses.field(default_factory=list)
 
 
+class MLIRDialectType(Enum):
+  """Imported MLIR dialect type."""
+  LINALG = "linalg"
+  TOSA = "tosa"
+  MHLO = "mhlo"
+
+
+MODEL_SOURCE_TO_DIALECT_TYPE_MAP = {
+    common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR:
+        MLIRDialectType.LINALG,
+    common_definitions.ModelSourceType.EXPORTED_TFLITE:
+        MLIRDialectType.TOSA,
+    common_definitions.ModelSourceType.EXPORTED_TF:
+        MLIRDialectType.MHLO,
+}
+
+
+@dataclass(frozen=True)
+class ImportedModel(object):
+  """Describes an imported MLIR model."""
+  model: common_definitions.Model
+  dialect_type: MLIRDialectType
+
+  @staticmethod
+  def from_model(model: common_definitions.Model):
+    # Currently we assume the model source type and its imported dialect is an
+    # 1-1 mapping.
+    return ImportedModel(
+        model=model,
+        dialect_type=MODEL_SOURCE_TO_DIALECT_TYPE_MAP[model.source_type])
+
+
 @dataclass(frozen=True)
 class ModuleGenerationConfig(object):
   """Describes a compile target to generate the module."""
+  imported_model: ImportedModel
   compile_config: CompileConfig
-  model: common_definitions.Model
 
 
 @dataclass(frozen=True)

--- a/build_tools/python/e2e_test_framework/iree_tf_import_template.cmake
+++ b/build_tools/python/e2e_test_framework/iree_tf_import_template.cmake
@@ -1,9 +1,0 @@
-# Import the Tensorflow model "$__SOURCE_MODEL_PATH"
-iree_import_tf_model(
-  TARGET_NAME "$${_PACKAGE_NAME}_$__TARGET_NAME"
-  SOURCE "$__SOURCE_MODEL_PATH"
-  ENTRY_FUNCTION "$__ENTRY_FUNCTION"
-  OUTPUT_MLIR_FILE "$__OUTPUT_PATH"
-)
-# Mark dependency so users can import models without compiling them.
-add_dependencies(iree-benchmark-import-models "$${_PACKAGE_NAME}_$__TARGET_NAME")


### PR DESCRIPTION
Add an extra layer to represent the model importing step when generating e2e test modules.

This provides a place to put the MLIR dialect information of imported model.