### PR TITLE
[NFC] DispatchLinalgOnTensors: Make fusion group attr an IntegerAttr

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensorsViaRegionOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensorsViaRegionOps.cpp
@@ -43,7 +43,7 @@ using namespace mlir::iree_compiler::IREE;
 static const int kInlineConstantByteLength = 256;
 static const bool kEnableMultiResultDispatches = false;
 static const char kRootOpAttr[] = "__root_op__";
-static const char kFusionGroupsAttr[] = "__fused_op__";
+static const char kFusionGroupAttr[] = "__fused_op__";
 
 //===----------------------------------------------------------------------===//
 // Helpers for fusion group formation
@@ -150,41 +150,32 @@ static int64_t getRootNumber(Operation *op) {
 }
 
 /// Returns true if an op is part of a fusion group.
-static bool hasFusionGroupsAttribute(Operation *op) {
-  return static_cast<bool>(op->getAttrOfType<ArrayAttr>(kFusionGroupsAttr));
+bool hasFusionGroupAttribute(Operation *op) {
+  return static_cast<bool>(op->getAttrOfType<IntegerAttr>(kFusionGroupAttr));
 }
 
-/// Returns the fusion groups for the given `op`.
-static SmallVector<int64_t, 1> getFusionGroups(Operation *op) {
-  SmallVector<int64_t, 1> fusionGroups = {};
-  if (auto fusionGroupsAttr = op->getAttrOfType<ArrayAttr>(kFusionGroupsAttr)) {
-    fusionGroups = llvm::to_vector<1>(llvm::map_range(
-        fusionGroupsAttr,
-        [](Attribute attr) { return attr.cast<IntegerAttr>().getInt(); }));
-  }
-  return fusionGroups;
+/// Returns the fusion group for the given `op`.
+int64_t getFusionGroup(Operation *op) {
+  auto attr = op->getAttrOfType<IntegerAttr>(kFusionGroupAttr);
+  assert(attr && "expected fusion group attr");
+  return attr.getInt();
 }
 
-/// Appends the given `op` to the `newGroups` fusion groups.
-static void appendToFusionGroup(Operation *op, ArrayRef<int64_t> newGroups) {
-  SmallVector<int64_t, 1> fusionGroups = getFusionGroups(op);
-  fusionGroups.append(newGroups.begin(), newGroups.end());
-  op->setAttr(kFusionGroupsAttr, Builder(op).getI64ArrayAttr(fusionGroups));
+/// Appends the given `op` to the `groupNumber` fusion group.
+static void setFusionGroup(Operation *op, int64_t groupNumber) {
+  assert(!hasFusionGroupAttribute(op) && "op already has fusion group attr");
+  op->setAttr(kFusionGroupAttr, Builder(op).getI64IntegerAttr(groupNumber));
 }
 
 /// Returns true if the given `op` is in the `targetGroup` fusion group.
-static bool isInFusionGroup(Operation *op, unsigned targetGroup) {
-  if (ArrayAttr opGroupAttr = op->getAttrOfType<ArrayAttr>(kFusionGroupsAttr)) {
-    return llvm::any_of(opGroupAttr, [&targetGroup](Attribute attr) {
-      return attr.cast<IntegerAttr>().getInt() == targetGroup;
-    });
-  }
-  return false;
+bool isInFusionGroup(Operation *op, int64_t targetGroup) {
+  if (!hasFusionGroupAttribute(op)) return false;
+  return getFusionGroup(op) == targetGroup;
 }
 
-/// Removes the fusion groups attribute.
-static void removeFusionGroupsAttribute(Operation *op) {
-  op->removeAttr(kFusionGroupsAttr);
+/// Removes the fusion group attribute.
+static void removeFusionGroupAttribute(Operation *op) {
+  op->removeAttr(kFusionGroupAttr);
 }
 
 //===----------------------------------------------------------------------===//
@@ -401,7 +392,7 @@ static void fuseRootsWithConsumers(MLIRContext *context,
       int64_t rootNumber = getRootNumber(currRoot);
       setRootAttribute(context, newRoot, rootNumber);
       removeRootOpAttribute(currRoot);
-      appendToFusionGroup(currRoot, rootNumber);
+      setFusionGroup(currRoot, rootNumber);
     };
 
     Optional<OpOperand *> fusableUse = getFusableUse(currRoot, dominanceInfo);
@@ -409,8 +400,7 @@ static void fuseRootsWithConsumers(MLIRContext *context,
 
     // Analyse the use to see if it is fusable.
     Operation *consumerOp = fusableUse.value()->getOwner();
-    if (hasRootOpAttribute(consumerOp) ||
-        hasFusionGroupsAttribute(consumerOp)) {
+    if (hasRootOpAttribute(consumerOp) || hasFusionGroupAttribute(consumerOp)) {
       continue;
     }
 
@@ -448,7 +438,7 @@ static void fuseRootsWithProducers(MLIRContext *context, Operation *root,
   for (OpOperand &operand : root->getOpOperands()) {
     Operation *producer = operand.get().getDefiningOp();
     if (!producer) continue;
-    if (hasFusionGroupsAttribute(producer) || hasRootOpAttribute(producer)) {
+    if (hasFusionGroupAttribute(producer) || hasRootOpAttribute(producer)) {
       continue;
     }
 
@@ -456,7 +446,7 @@ static void fuseRootsWithProducers(MLIRContext *context, Operation *root,
     if (!fusableUse || fusableUse.value()->getOwner() != root) continue;
 
     if (isFusableWithProducer(operand)) {
-      appendToFusionGroup(producer, groupNum);
+      setFusionGroup(producer, groupNum);
     }
   }
 }
@@ -465,7 +455,7 @@ static void fuseRootsWithProducers(MLIRContext *context, Operation *root,
 /// using tile + fuse. Using some heuristic, each root operation is tagged with
 /// an ID (using an IntegerAttr with name `kRootOpAttr`) and all dispatchable
 /// ops to be fused with it is tagged with the same ID (using a list of
-/// IntegerAttr with name `kFusionGroupsAttr`). Each dispatchable operation can
+/// IntegerAttr with name `kFusionGroupAttr`). Each dispatchable operation can
 /// be marked to fuse with multiple root operations (i.e. replicated). For now a
 /// very simple heuristic is used below, but the mechanism should be general
 /// enough to capture any heuristic.
@@ -483,7 +473,7 @@ static unsigned decideFusableLinalgOps(FunctionOpInterface funcOp,
     SmallVector<Operation *> roots;
     for (Operation &op : llvm::reverse(block)) {
       // Start with a root operation and fuse its producers.
-      if (hasFusionGroupsAttribute(&op) || !isRootOp(&op)) continue;
+      if (hasFusionGroupAttribute(&op) || !isRootOp(&op)) continue;
       unsigned newGroup = numRootOps++;
       setRootAttribute(context, &op, newGroup);
 
@@ -500,7 +490,7 @@ static unsigned decideFusableLinalgOps(FunctionOpInterface funcOp,
     SmallVector<Operation *> roots;
     for (Operation &op : llvm::reverse(block)) {
       // If it is part of a fusion group or root op, ignore it.
-      if (hasFusionGroupsAttribute(&op) || hasRootOpAttribute(&op)) continue;
+      if (hasFusionGroupAttribute(&op) || hasRootOpAttribute(&op)) continue;
       // Only look for Linalg ops here. Avoid moving `linalg.fill` that aren't
       // fused with anything else into their own dispatches since it is better
       // to convert them to splats.
@@ -564,9 +554,8 @@ static FailureOr<SmallVector<Flow::DispatchWorkgroupsOp>> createFusionGroups(
   // annotating fusion group IDs via attributes.
   funcOp.walk([&](Operation *op) {
     if (hasRootOpAttribute(op)) roots[getRootNumber(op)] = op;
-    if (hasFusionGroupsAttribute(op)) {
-      assert(getFusionGroups(op).size() == 1 && "expected exactly one group");
-      producers[getFusionGroups(op).front()].push_back(op);
+    if (hasFusionGroupAttribute(op)) {
+      producers[getFusionGroup(op)].push_back(op);
     }
   });
 
@@ -764,7 +753,7 @@ void DispatchLinalgOnTensorsViaRegionOpsPass::runOnOperation() {
 
   // Finally walk all the ops and remove the attributes
   funcOp.walk([](Operation *op) {
-    removeFusionGroupsAttribute(op);
+    removeFusionGroupAttribute(op);
     removeRootOpAttribute(op);
     op->removeAttr(IREE::LinalgExt::LinalgTransforms::kLinalgTransformMarker);
   });


### PR DESCRIPTION
This simplifies the code: An op is never in more than one fusion group.

The purpose of this change is make #10719 smaller and easier to review.