### PR TITLE
Cleanup PyTorch getting started page.

### DIFF
--- a/docs/website/docs/getting-started/pytorch.md
+++ b/docs/website/docs/getting-started/pytorch.md
@@ -1,7 +1,8 @@
 # PyTorch Integration
 
 IREE supports compiling and running PyTorch programs represented as
-`nn.Module` [classes](https://pytorch.org/docs/stable/generated/torch.nn.Module.html) as well as models defined using [`functorch`](https://pytorch.org/functorch/).
+`nn.Module` [classes](https://pytorch.org/docs/stable/generated/torch.nn.Module.html)
+as well as models defined using [`functorch`](https://pytorch.org/functorch/).
 
 ## Prerequisites
 
@@ -14,13 +15,15 @@ pip install \
   iree-runtime
 ```
 
-Install [`torch-mlir`](https://github.com/llvm/torch-mlir), necessary for compiling PyTorch models to a format IREE is able to execute:
+Install [`torch-mlir`](https://github.com/llvm/torch-mlir), necessary for
+compiling PyTorch models to a format IREE is able to execute:
 
 ```shell
 pip install -f https://llvm.github.io/torch-mlir/package-index/ torch-mlir
 ```
 
-A special `iree_torch` package is available to make it easy to compile PyTorch programs and run them on IREE:
+A special `iree_torch` package makes it easy to compile PyTorch programs and
+run them on IREE:
 
 ```shell
 pip install git+https://github.com/iree-org/iree-torch.git
@@ -28,14 +31,18 @@ pip install git+https://github.com/iree-org/iree-torch.git
 
 ## Running a model
 
-Going from a loaded PyTorch model to one that's executing on IREE happens in four steps:
+Going from a loaded PyTorch model to one that's executing on IREE happens in
+four steps:
 
- 1) Compile the model to [MLIR](https://mlir.llvm.org)
- 2) Compile the MLIR to IREE VM flatbuffer
- 3) Load the VM flatbuffer into IREE
- 4) Execute the model via IREE
+1. Compile the model to [MLIR](https://mlir.llvm.org)
+2. Compile the MLIR to IREE VM flatbuffer
+3. Load the VM flatbuffer into IREE
+4. Execute the model via IREE
 
-!!! note In the following steps, we'll be borrowing the model from [this BERT colab](https://github.com/iree-org/iree-torch/blob/main/examples/bert.ipynb) and assuming it is available as `model`.
+!!! note
+    In the following steps, we'll be borrowing the model from
+    [this BERT colab](https://github.com/iree-org/iree-torch/blob/main/examples/bert.ipynb)
+    and assuming it is available as `model`.
 
 ### Compile the model to MLIR
 
@@ -51,24 +58,30 @@ mlir = torch_mlir.compile(
     use_tracing=True)
 ```
 
-The full list of available output types can be found [here](https://github.com/llvm/torch-mlir/blob/6403c0e56f0e93e231df1c8d3dc78df7dd721b80/python/torch_mlir/__init__.py#L19) and includes linalg on tensors, mhlo, and tosa.
+The full list of available output types can be found
+[here](https://github.com/llvm/torch-mlir/blob/6403c0e56f0e93e231df1c8d3dc78df7dd721b80/python/torch_mlir/__init__.py#L19)
+and includes linalg on tensors, mhlo, and tosa.
 
-### Compile the MLIR to IREE VM flatbuffer
+### Compile the MLIR to an IREE VM flatbuffer
 
-Next, we compile the resulting MLIR to IREE VM flatbuffer: 
+Next, we compile the resulting MLIR to IREE's deployable file format:
 
 ```python
 iree_backend = "llvm-cpu"
 iree_vmfb = iree_torch.compile_to_vmfb(mlir, iree_backend)
 ```
 
-Here we have a choice of backend we want to target. See [IREE Deployment Configurations](https://iree-org.github.io/iree/deployment-configurations/) for a full list of targets.
+Here we have a choice of backend we want to target. See the
+[Deployment Configurations](https://iree-org.github.io/iree/deployment-configurations/)
+section of this site for a full list of targets and configurations.
 
-The generated flatbuffer can now be serialized and stored for another time or loaded and executed immediately.
+The generated flatbuffer can now be serialized and stored for another time or
+loaded and executed immediately.
 
 ### Load the VM flatbuffer into IREE
 
-Next, we load the flatbuffer into the IREE runtime. `iree_torch` provides a convenience method for loading this flatbuffer:
+Next, we load the flatbuffer into the IREE runtime. `iree_torch` provides a
+convenience method for loading this flatbuffer from Python:
 
 ```python
 invoker = iree_torch.load_vmfb(iree_vmfb, iree_backend)
@@ -76,7 +89,7 @@ invoker = iree_torch.load_vmfb(iree_vmfb, iree_backend)
 
 ### Execute the model via IREE
 
-Finally, we can execute the loaded model on IREE:
+Finally, we can execute the loaded model:
 
 ```python
 result = invoker.forward(example_input)
@@ -84,9 +97,13 @@ result = invoker.forward(example_input)
 
 ## Training
 
-Training with PyTorch in IREE is supported via `functorch`. The steps for loading the model, once defined, into IREE, is nearly identical to the above example.
+Training with PyTorch in IREE is supported via `functorch`. The steps for
+loading the model into IREE, once defined, are nearly identical to the above
+example.
 
-You can find a full end-to-end example of defining a basic regression model, training with it, and running inference on it [here](https://github.com/iree-org/iree-torch/blob/main/examples/regression.py).
+You can find a full end-to-end example of defining a basic regression model,
+training with it, and running inference on it
+[here](https://github.com/iree-org/iree-torch/blob/main/examples/regression.py).
 
 ## Samples
 
@@ -96,4 +113,4 @@ Inference on BERT | [![Open in Colab](https://colab.research.google.com/assets/c
 
 | Example scripts |
 | -- |
-[Basic Inference and Training Example](https://github.com/iree-org/iree-torch/blob/main/examples/regression.py)
+| [Basic Inference and Training Example](https://github.com/iree-org/iree-torch/blob/main/examples/regression.py) |


### PR DESCRIPTION
Follow-up to https://github.com/iree-org/iree/pull/10757

* Fix table formatting (single column table needs `| text here |` instead of `text here`)
* Fix note formatting (https://squidfunk.github.io/mkdocs-material/reference/admonitions/)
* Fix numbered list formatting (https://squidfunk.github.io/mkdocs-material/reference/lists/#using-ordered-lists)
* Wrap some lines at 80 characters (purely a style choice, some formatters do this automatically)
* Tweak some phrasing / grammar

(steps to preview changes to the website locally are here: https://github.com/iree-org/iree/tree/main/docs/website)