### PR TITLE
Disable iree/tests/e2e/regression/globals.mlir.test under ASan.

### DIFF
--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -130,6 +130,7 @@ declare -a excluded_tests=(
   "iree/tests/e2e/models/mnist_fake_weights.mlir.test"
   "iree/tests/e2e/models/resnet50_fake_weights.mlir.test"
   "iree/tests/e2e/models/unidirectional_lstm.mlir.test"
+  "iree/tests/e2e/regression/globals.mlir.test"
   # TODO(#5715): Fix these
   "iree/samples/simple_embedding/simple_embedding_vulkan_test"
   "iree/tools/test/iree-benchmark-module.mlir.test"


### PR DESCRIPTION
Seeing this test flake on a few presubmits:
https://github.com/iree-org/iree/actions/runs/3316089449/jobs/5477477103
https://github.com/iree-org/iree/actions/runs/3316263166/jobs/5477856081

Looks like https://github.com/iree-org/iree/issues/5716

```
FAIL: IREE :: e2e/regression/globals.mlir (1 of 1)
******************** TEST 'IREE :: e2e/regression/globals.mlir' FAILED ********************
Script:
--
: 'RUN: at line 1';   iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=vmvx /work/tests/e2e/regression/globals.mlir | FileCheck /work/tests/e2e/regression/globals.mlir
: 'RUN: at line 2';   [[ $IREE_VULKAN_DISABLE == 1 ]] || (iree-run-mlir --iree-input-type=mhlo --iree-hal-target-backends=vulkan-spirv /work/tests/e2e/regression/globals.mlir | FileCheck /work/tests/e2e/regression/globals.mlir)
--
Exit Code: 1

Command Output (stderr):
--
Tracer caught signal 11: addr=0x0 pc=0x624e79 sp=0x7f87b02e3d30
==39757==LeakSanitizer has encountered a fatal error.
==39757==HINT: For debugging, try setting environment variable LSAN_OPTIONS=verbosity=1:log_threads=1
==39757==HINT: LeakSanitizer does not work under ptrace (strace, gdb, etc)

--

********************
********************
Failed Tests (1):
  IREE :: e2e/regression/globals.mlir
```

The other tests in that suite either don't use Vulkan or can lower to just VM calls (no HAL): https://github.com/iree-org/iree/blob/87c5f3f353f9b733f137004c01673f6385515823/tests/e2e/regression/CMakeLists.txt#L16-L22

skip-ci