### PR TITLE
Fix a bug in tiling pack op that has outer_dim_perms attribute.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -38,6 +38,16 @@ SmallVector<T> interchange(ArrayRef<T> elements,
   }
   return vec;
 }
+template <typename T>
+SmallVector<T> undoInterchange(ArrayRef<T> elements,
+                               ArrayRef<int64_t> interchangeVector,
+                               int offset = 0) {
+  SmallVector<T> vec = llvm::to_vector(elements);
+  for (auto en : llvm::enumerate(interchangeVector)) {
+    vec[en.value() + offset] = elements[en.index() + offset];
+  }
+  return vec;
+}
 
 } // namespace LinalgExt
 } // namespace IREE


### PR DESCRIPTION
The iteration space is on the leading dimensions of output, where there are inputRank loops. The tiling sizes are set to tile on the order of iteration space. In this context, the input of getTiledImplementation is interchanged. We have to undo it before creating the slice for input.

This PR also adds an e2e test for the pack op with outer_dim_perms.

Fixes https://github.com/iree-org/iree/issues/10902