### PR TITLE
Add WebGPU compilation tests for xla_ops/ and tosa_ops/.

### DIFF
--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -215,3 +215,55 @@ iree_check_single_backend_test_suite(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_webgpu
+  SRCS
+    "abs.mlir"
+    "add.mlir"
+    "arithmetic_right_shift.mlir"
+    "bitwise_and.mlir"
+    "bitwise_or.mlir"
+    "bitwise_xor.mlir"
+    "ceil.mlir"
+    "clamp.mlir"
+    "clz.mlir"
+    "const.mlir"
+    # "equal.mlir"  # TODO(#10906): fix (i8/i16?)
+    "exp.mlir"
+    "floor.mlir"
+    "fully_connected.mlir"
+    "gather.mlir"
+    # "greater.mlir"  # TODO(#10906): fix (i8/i16?)
+    # "greater_equal.mlir"  # TODO(#10906): fix (i8/i16?)
+    "if.mlir"
+    "log.mlir"
+    "logical_left_shift.mlir"
+    "logical_right_shift.mlir"
+    "matmul.mlir"
+    # "max_pool.mlir"  # TODO(#10906): fix (i8/i16?)
+    "maximum.mlir"
+    "minimum.mlir"
+    "mul.mlir"
+    "negate.mlir"
+    "pad.mlir"
+    "reciprocal.mlir"
+    "reduce.mlir"
+    "reshape.mlir"
+    "rsqrt.mlir"
+    "select.mlir"
+    "sigmoid.mlir"
+    "sub.mlir"
+    # "table.mlir"  # TODO(#10906): fix (i8/i16?)
+    "tanh.mlir"
+    "transpose.mlir"
+    "while.mlir"
+  TARGET_BACKEND
+    "webgpu"
+  # Only test compilation for now, the WebGPU driver is not stable/tested yet.
+  # DRIVER
+  #   "webgpu"
+  COMPILER_FLAGS
+    "--iree-input-type=tosa"
+)

--- a/tests/e2e/xla_ops/CMakeLists.txt
+++ b/tests/e2e/xla_ops/CMakeLists.txt
@@ -501,3 +501,72 @@ iree_check_single_backend_test_suite(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_webgpu
+  SRCS
+    "abs.mlir"
+    "add.mlir"
+    "batch_norm_inference.mlir"
+    "bitcast_convert.mlir"
+    "broadcast.mlir"
+    "broadcast_add.mlir"
+    "broadcast_in_dim.mlir"
+    # "clamp.mlir"  # TODO(#10906): fix (i8/i16?)
+    # "compare.mlir"  # TODO(#10906): fix (i8/i16?)
+    "concatenate.mlir"
+    "constant.mlir"
+    # "convert.mlir"  # TODO(#10906): fix (i8/i16?)
+    "convolution.mlir"
+    "cosine.mlir"
+    "divide.mlir"
+    "dot.mlir"
+    "dot_general.mlir"
+    "dynamic_slice.mlir"
+    "dynamic_update_slice.mlir"
+    "exponential.mlir"
+    "exponential_fp16.mlir"
+    "exponential_minus_one.mlir"
+    # "fft.mlir"  # TODO(#9583): fix (fft codegen via spirv)
+    # "finite.mlir"  # TODO(#10906): fix (i8/i16?)
+    "floor.mlir"
+    "gather.mlir"
+    "iota.mlir"
+    "log.mlir"
+    "log_plus_one.mlir"
+    # "maximum.mlir"  # TODO(#10906): fix (i8/i16?)
+    # "minimum.mlir"  # TODO(#10906): fix (i8/i16?)
+    "multiply.mlir"
+    "negate.mlir"
+    "pad.mlir"
+    "pow.mlir"
+    "reduce.mlir"
+    "reduce_window.mlir"
+    "remainder.mlir"
+    "reshape.mlir"
+    # "reverse.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "rng_normal.mlir"
+    "rng_uniform.mlir"
+    "round.mlir"
+    "rsqrt.mlir"
+    # "scatter.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "scatter_dynamic.mlir"
+    "select.mlir"
+    "sine.mlir"
+    "slice.mlir"
+    # "sort.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "sqrt.mlir"
+    "subtract.mlir"
+    "tanh.mlir"
+    "torch_index_select.mlir"
+    "transpose.mlir"
+    "while.mlir"
+  TARGET_BACKEND
+    "webgpu"
+  # Only test compilation for now, the WebGPU driver is not stable/tested yet.
+  # DRIVER
+  #   "webgpu"
+  COMPILER_FLAGS
+    "--iree-input-type=mhlo"
+)


### PR DESCRIPTION
Copied over manually for now, but if the WebGPU target was supported in the Bazel build we could use `enforce_glob` with `exclude`.

Just compilation tests for now (like with llvm-cpu / wasm), but I'm hoping to also test execution once the WebGPU HAL is working and I have it running on CI in some form.