### PR TITLE
Relax isolatedFromAbove requirement in the ListenerGreedyPatternrewriter

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/ListenerGreedyPatternRewriteDriver.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/ListenerGreedyPatternRewriteDriver.h
@@ -21,15 +21,8 @@ struct RewriteListener;
 /// apply any patterns recursively to the regions of `op`. Accepts a listener
 /// so the caller can be notified of rewrite events.
 LogicalResult applyPatternsAndFoldGreedily(
-    MutableArrayRef<Region> regions, const FrozenRewritePatternSet &patterns,
-    const GreedyRewriteConfig &config, RewriteListener *listener);
-
-static inline LogicalResult applyPatternsAndFoldGreedily(
     Operation *op, const FrozenRewritePatternSet &patterns,
-    const GreedyRewriteConfig &config, RewriteListener *listener) {
-  return applyPatternsAndFoldGreedily(op->getRegions(), patterns, config,
-                                      listener);
-}
+    const GreedyRewriteConfig &config, RewriteListener *listener);
 
 /// Apply the given list of transformations to the regions of the
 /// isolated-from-above operation `root` greedily until convergence. Update


### PR DESCRIPTION
All known uses of applyPatternsAndFoldGreedily are on op->getRegions(). Modify the API to always operate on Operation* and use that as the root op to determine when to avoid adding new ops to the workList.

Note: This may need to be reverted in the future but I conjecture this restriction is nt really load-bearing and may bea remnant of multi-threaded parallel pass pipeline to which we do not subscribe with the transform dialect.