### PR TITLE
Add requests for PyProject.toml

### DIFF
--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -9,5 +9,6 @@ requires = [
     "packaging",
     "pybind11>=2.8.0",
     "PyYAML",
+    "requests",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Just like we added to the build_requirements.txt we need requests in pyproject.toml when building release builds with CUDA on (like on Windows) without IREE docker images.