### PR TITLE
Defaulting Vulkan dispatch workloads to graphics+compute queues.

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -153,6 +153,13 @@ typedef struct iree_hal_vulkan_queue_set_t {
 // TODO(benvanik): replace with flag list (easier to version).
 enum iree_hal_vulkan_device_flag_bits_t {
   IREE_HAL_VULKAN_DEVICE_FLAG_NONE = 0u,
+
+  // Prefer choosing a dedicated VK_QUEUE_COMPUTE_BIT without
+  // VK_QUEUE_GRAPHICS_BIT capabilities. When integrating into an application
+  // that makes heavy use of the primary graphics/compute queue this can allow
+  // IREE execution to run asynchronously with the graphics workloads.
+  // See: https://gpuopen.com/learn/concurrent-execution-asynchronous-queues/
+  IREE_HAL_VULKAN_DEVICE_FLAG_DEDICATED_COMPUTE_QUEUE = 1u << 0,
 };
 typedef uint32_t iree_hal_vulkan_device_flags_t;
 

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -31,6 +31,10 @@ IREE_FLAG(int32_t, vulkan_debug_verbosity, 2,
 IREE_FLAG(bool, vulkan_tracing, true,
           "Enables Vulkan tracing (if IREE tracing is enabled).");
 
+IREE_FLAG(
+    bool, vulkan_dedicated_compute_queue, false,
+    "Use a dedicated queue with VK_QUEUE_COMPUTE_BIT for dispatch workloads.");
+
 static iree_status_t iree_hal_vulkan_create_driver_with_flags(
     iree_string_view_t identifier, iree_allocator_t host_allocator,
     iree_hal_driver_t** out_driver) {
@@ -62,6 +66,11 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
   }
   if (FLAG_vulkan_tracing) {
     driver_options.requested_features |= IREE_HAL_VULKAN_FEATURE_ENABLE_TRACING;
+  }
+
+  if (FLAG_vulkan_dedicated_compute_queue) {
+    driver_options.device_options.flags |=
+        IREE_HAL_VULKAN_DEVICE_FLAG_DEDICATED_COMPUTE_QUEUE;
   }
 
   // Load the Vulkan library. This will fail if the library cannot be found or

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -298,6 +298,7 @@ static uint32_t iree_hal_vulkan_find_first_queue_family_with_flags(
 // Note that both queue families may be the same if there is only one family
 // available.
 static iree_status_t iree_hal_vulkan_select_queue_families(
+    const iree_hal_vulkan_device_options_t* options,
     VkPhysicalDevice physical_device, iree::hal::vulkan::DynamicSymbols* syms,
     iree_hal_vulkan_queue_family_info_t* out_family_info) {
   // Enumerate queue families available on the device.
@@ -316,13 +317,21 @@ static iree_status_t iree_hal_vulkan_select_queue_families(
   out_family_info->transfer_index = IREE_HAL_VULKAN_INVALID_QUEUE_FAMILY_INDEX;
   out_family_info->transfer_queue_count = 0;
 
-  // Try to find a dedicated compute queue (no graphics caps).
-  // Some may support both transfer and compute. If that fails then fallback
-  // to any queue that supports compute.
-  out_family_info->dispatch_index =
-      iree_hal_vulkan_find_first_queue_family_with_flags(
-          queue_family_count, queue_family_properties, VK_QUEUE_COMPUTE_BIT,
-          VK_QUEUE_GRAPHICS_BIT);
+  // By default we choose graphics+compute as on most current GPUs this is a
+  // primary queue and may run at the fastest clock speed.
+  // If the user is integrating into applications with existing graphics
+  // workloads then they can request that we instead try to find a dedicated
+  // compute-only queue such that we can run async with the rest of their
+  // existing workload.
+  if (iree_all_bits_set(options->flags,
+                        IREE_HAL_VULKAN_DEVICE_FLAG_DEDICATED_COMPUTE_QUEUE)) {
+    // Try to find a dedicated compute queue. If this fails then we'll fall back
+    // to any queue supporting compute.
+    out_family_info->dispatch_index =
+        iree_hal_vulkan_find_first_queue_family_with_flags(
+            queue_family_count, queue_family_properties, VK_QUEUE_COMPUTE_BIT,
+            VK_QUEUE_GRAPHICS_BIT);
+  }
   if (out_family_info->dispatch_index ==
       IREE_HAL_VULKAN_INVALID_QUEUE_FAMILY_INDEX) {
     out_family_info->dispatch_index =
@@ -392,13 +401,14 @@ static iree_status_t iree_hal_vulkan_select_queue_families(
 // Builds a set of compute and transfer queues based on the queues available on
 // the device and some magic heuristical goo.
 static iree_status_t iree_hal_vulkan_build_queue_sets(
+    const iree_hal_vulkan_device_options_t* options,
     VkPhysicalDevice physical_device, iree::hal::vulkan::DynamicSymbols* syms,
     iree_hal_vulkan_queue_set_t* out_compute_queue_set,
     iree_hal_vulkan_queue_set_t* out_transfer_queue_set) {
   // Select which queues to use (and fail the implementation can't handle them).
   iree_hal_vulkan_queue_family_info_t queue_family_info;
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_select_queue_families(
-      physical_device, syms, &queue_family_info));
+      options, physical_device, syms, &queue_family_info));
 
   // Build queue indices for the selected queue families.
   memset(out_compute_queue_set, 0, sizeof(*out_compute_queue_set));
@@ -814,7 +824,7 @@ iree_status_t iree_hal_vulkan_device_create(
   // Find queue families we will expose as HAL queues.
   iree_hal_vulkan_queue_family_info_t queue_family_info;
   IREE_RETURN_IF_ERROR(iree_hal_vulkan_select_queue_families(
-      physical_device, instance_syms, &queue_family_info));
+      options, physical_device, instance_syms, &queue_family_info));
 
   bool has_dedicated_transfer_queues =
       queue_family_info.transfer_queue_count > 0;
@@ -920,8 +930,8 @@ iree_status_t iree_hal_vulkan_device_create(
   iree_hal_vulkan_queue_set_t transfer_queue_set;
   if (iree_status_is_ok(status)) {
     status = iree_hal_vulkan_build_queue_sets(
-        physical_device, logical_device->syms().get(), &compute_queue_set,
-        &transfer_queue_set);
+        options, physical_device, logical_device->syms().get(),
+        &compute_queue_set, &transfer_queue_set);
   }
 
   // Allocate and initialize the device.


### PR DESCRIPTION
Added the `--vulkan_dedicated_compute_queue` flag for the existing behavior that preferred a dedicated compute-only queue if available.