### PR TITLE
[spirv] Only unify aliased resources on Apple platforms

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -205,8 +205,12 @@ static void addSPIRVLoweringPasses(OpPassManager &pm, bool enableFastMath) {
 
   pm.addPass(createConvertToSPIRVPass(enableFastMath));
 
+  auto getTargetEnv = [](spirv::ModuleOp moduleOp) {
+    return getSPIRVTargetEnvAttr(moduleOp);
+  };
+
   OpPassManager &spirvPM = pm.nest<spirv::ModuleOp>();
-  spirvPM.addPass(spirv::createUnifyAliasedResourcePass());
+  spirvPM.addPass(spirv::createUnifyAliasedResourcePass(getTargetEnv));
   spirvPM.addPass(spirv::createLowerABIAttributesPass());
   spirvPM.addPass(createCanonicalizerPass());
   spirvPM.addPass(createCSEPass());


### PR DESCRIPTION
The UnifyAliasedResourcePass is actually only necessary for targeting
Apple GPUs via MoltenVK, where we need to translate SPIR-V into MSL.
The translation has limitations--no support of aliased resources.

There is a hidden bug in the UnifyAliasedResourcePass yet to be
identified. So for now limiting it to only Apple platforms to avoid
further disruption.

Fixes https://github.com/iree-org/iree/issues/10850