### PR TITLE
Fold affine.min folding with scf.if

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -178,6 +178,7 @@ iree_compiler_cc_library(
     srcs = [
         "DecomposeLinalgGeneric.cpp",
         "FoldAffineMinInDistributedLoops.cpp",
+        "FoldAffineMinWithSCFIf.cpp",
         "GPUDistributeSharedMemoryCopy.cpp",
         "GPUPipelining.cpp",
         "GPUTileReduction.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -152,6 +152,7 @@ iree_cc_library(
   SRCS
     "DecomposeLinalgGeneric.cpp"
     "FoldAffineMinInDistributedLoops.cpp"
+    "FoldAffineMinWithSCFIf.cpp"
     "GPUDistributeSharedMemoryCopy.cpp"
     "GPUPipelining.cpp"
     "GPUTileReduction.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinWithSCFIf.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinWithSCFIf.cpp
@@ -113,7 +113,7 @@ struct FoldAffineMinWithSCFIf final : public OpRewritePattern<scf::IfOp> {
     } else {
       return failure();
     }
-    auto cstOp = dyn_cast<arith::ConstantIndexOp>(b.getDefiningOp());
+    auto cstOp = b.getDefiningOp<arith::ConstantIndexOp>();
     if (!cstOp) return failure();
     int64_t cstInt = cstOp.value();
 

--- a/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinWithSCFIf.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinWithSCFIf.cpp
@@ -1,0 +1,199 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===- FoldAffineMinWithSCFIf.cpp -----------------------------------------===//
+//
+// This file contains patterns to canonicalize affine.min uses inside scf::IfOp
+// by applying the condition to the affine min.
+//
+//===----------------------------------------------------------------------===//
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/IR/AffineExpr.h"
+#include "mlir/IR/AffineMap.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-codegen-fold-affinemin-with-scfif"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+static FailureOr<unsigned> findIndexOfConstResult(const AffineMap &map,
+                                                  int64_t value) {
+  for (unsigned i = 0, e = map.getNumResults(); i != e; ++i) {
+    if (auto cstExpr = map.getResult(i).dyn_cast<AffineConstantExpr>()) {
+      if (cstExpr.getValue() == value) return i;
+    }
+  }
+
+  return failure();
+}
+
+static SmallVector<OpOperand *> getUsesInRegion(Value value, Region *region) {
+  SmallVector<OpOperand *> uses;
+  for (OpOperand &use : value.getUses()) {
+    if (use.getOwner()->getParentRegion() == region) {
+      uses.push_back(&use);
+    }
+  }
+  return uses;
+}
+
+LogicalResult matchTileAndDistributionLoop(Value iv, OpFoldResult &lb,
+                                           OpFoldResult &ub,
+                                           OpFoldResult &step) {
+  scf::ForOp forOp = scf::getForInductionVarOwner(iv);
+  if (!forOp) return failure();
+
+  auto loopInfo = isTiledAndDistributedLoop(forOp);
+  if (!loopInfo) return failure();
+
+  Optional<int64_t> untiledStep = getConstantIntValue(loopInfo->untiledStep);
+  // For IREE right now the original untiled loop should have step 1..
+  if (!untiledStep || *untiledStep != 1) return failure();
+  // ..and we tile according to some static tile sizes for processors.
+  if (!loopInfo->tileSize) return failure();
+
+  lb = loopInfo->untiledLowerBound;
+  ub = loopInfo->untiledUpperBound;
+  // The "step" expected by the upstream utility is really the tiling size.
+  step = OpBuilder(iv.getContext()).getIndexAttr(loopInfo->tileSize.value());
+  return success();
+}
+
+/// Match affine.min affine_map<(d0) -> (-d0 + UB, TILESIZE)>(%iv) from a
+/// tile-and-distribution loop.
+static LogicalResult matchBoundedTileSizeOp(AffineMinOp minOp, int64_t &lb,
+                                            int64_t &ub, int64_t &tileSize) {
+  if (minOp.getNumOperands() != 1) return failure();
+
+  AffineMap map = minOp.getAffineMap();
+  if (map.getNumResults() != 2) return failure();
+
+  OpFoldResult lbOfr, ubOfr, tileSizeOfr;
+  if (failed(matchTileAndDistributionLoop(minOp.getOperand(0), lbOfr, ubOfr,
+                                          tileSizeOfr)))
+    return failure();
+
+  Optional<int64_t> lbOpt = getConstantIntValue(lbOfr);
+  if (!lbOpt) return failure();
+  Optional<int64_t> ubOpt = getConstantIntValue(ubOfr);
+  if (!ubOpt) return failure();
+  Optional<int64_t> tileSizeOpt = getConstantIntValue(tileSizeOfr);
+  if (!tileSizeOpt) return failure();
+
+  lb = *lbOpt;
+  ub = *ubOpt;
+  tileSize = *tileSizeOpt;
+  return success();
+}
+
+/// Folds `affine.min` if its constant value argument is used by scf.if,
+/// where the op is folded into one of the two values.
+///
+/// ```mlir
+/// %min = affine.min(%a, %cst)
+/// %cmp = icmp.eq %min, %cst
+/// scf.if %cmp {
+///   // expect the uses of %min are already replaced by %cst
+/// } else {
+///   // use of %min can be replaced by %a
+/// }
+/// ```
+struct FoldAffineMinWithSCFIf final : public OpRewritePattern<scf::IfOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(scf::IfOp ifOp,
+                                PatternRewriter &rewriter) const override {
+    auto cmpOp = ifOp.getCondition().getDefiningOp<arith::CmpIOp>();
+    if (!cmpOp) return failure();
+    if (cmpOp.getPredicate() != arith::CmpIPredicate::eq) return failure();
+
+    AffineMinOp minOp;
+    Value b;
+    if (isa<AffineMinOp>(cmpOp.getLhs().getDefiningOp())) {
+      minOp = cast<AffineMinOp>(cmpOp.getLhs().getDefiningOp());
+      b = cmpOp.getRhs();
+    } else if (isa<AffineMinOp>(cmpOp.getRhs().getDefiningOp())) {
+      minOp = cast<AffineMinOp>(cmpOp.getRhs().getDefiningOp());
+      b = cmpOp.getLhs();
+    } else {
+      return failure();
+    }
+    auto cstOp = dyn_cast<arith::ConstantIndexOp>(b.getDefiningOp());
+    if (!cstOp) return failure();
+    int64_t cstInt = cstOp.value();
+
+    AffineMap minMap = minOp.getAffineMap();
+    if (minMap.getNumResults() != 2) return failure();
+
+    FailureOr<unsigned> affineCstIndexOrFailure =
+        findIndexOfConstResult(minMap, cstInt);
+    if (failed(affineCstIndexOrFailure)) return failure();
+    unsigned affineCstIndex = *affineCstIndexOrFailure;
+
+    // find the uses of min in the else block.
+    SmallVector<OpOperand *> usesInElse =
+        getUsesInRegion(minOp, &ifOp.getElseRegion());
+    if (usesInElse.empty()) return failure();
+
+    OpBuilder builder(ifOp);
+    OpBuilder::InsertionGuard guard(builder);
+    int64_t lb, ub, tileSize;
+    Value valueToReplace;
+    if (succeeded(matchBoundedTileSizeOp(minOp, lb, ub, tileSize))) {
+      // The other part is the partial tile size, (ub - lb) % tileSize.
+      valueToReplace = builder.create<arith::ConstantIndexOp>(
+          minOp.getLoc(), (ub - lb) % tileSize);
+    } else {
+      // A general case. Construct a new affine map without the constant result.
+      AffineMap newMap = minMap.dropResult(affineCstIndex);
+      valueToReplace = builder.create<AffineApplyOp>(minOp.getLoc(), newMap,
+                                                     minOp.getMapOperands());
+    }
+    for (auto use : usesInElse) {
+      use->set(valueToReplace);
+    }
+    return success();
+  }
+};
+
+struct FoldAffineMinWithSCFIfPass final
+    : public FoldAffineMinWithSCFIfBase<FoldAffineMinWithSCFIfPass> {
+  void runOnOperation() override {
+    RewritePatternSet patterns(&getContext());
+    populateFoldAffineMinWithSCFIfPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(getOperation(),
+                                            std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+};
+}  // namespace
+
+void populateFoldAffineMinWithSCFIfPatterns(RewritePatternSet &patterns) {
+  patterns.add<FoldAffineMinWithSCFIf>(patterns.getContext());
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createFoldAffineMinWithSCFIfPass() {
+  return std::make_unique<FoldAffineMinWithSCFIfPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinWithSCFIf.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldAffineMinWithSCFIf.cpp
@@ -47,7 +47,7 @@ static FailureOr<unsigned> findIndexOfConstResult(const AffineMap &map,
 static SmallVector<OpOperand *> getUsesInRegion(Value value, Region *region) {
   SmallVector<OpOperand *> uses;
   for (OpOperand &use : value.getUses()) {
-    if (use.getOwner()->getParentRegion() == region) {
+    if (region->isAncestor(use.getOwner()->getParentRegion())) {
       uses.push_back(&use);
     }
   }

--- a/compiler/src/iree/compiler/Codegen/Common/test/workgroup_specialization.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/workgroup_specialization.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-codegen-enable-workgroup-specialization --iree-codegen-workgroup-specialization --canonicalize --cse --split-input-file %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-enable-workgroup-specialization --iree-codegen-workgroup-specialization --iree-codegen-fold-affinemin-with-scfif --canonicalize --cse --split-input-file %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [16, 4, 0], [0, 0, 64]]>
 #map0 = affine_map<()[s0] -> (s0 * 64)>
@@ -158,5 +158,5 @@ func.func @unaligned_partial_loop() {
 // CHECK-SAME:                  ins(%{{.+}}, %{{.+}} : tensor<2x768xf32>, tensor<768x256xf32>) outs(%{{.+}} : tensor<2x256xf32>)
 // CHECK:       } else {
 // CHECK:         linalg.matmul
-// CHECK-SAME:                  ins(%{{.+}}, %{{.+}} : tensor<2x768xf32>, tensor<768x?xf32>) outs(%{{.+}} : tensor<2x?xf32>)
+// CHECK-SAME:                  ins(%{{.+}}, %{{.+}} : tensor<2x768xf32>, tensor<768x58xf32>) outs(%{{.+}} : tensor<2x58xf32>)
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -109,6 +109,11 @@ void addGPUVectorizationPassPipeline(OpPassManager &pm) {
   nestedModulePM.addPass(createCSEPass());
 
   nestedModulePM.addNestedPass<func::FuncOp>(
+      createFoldAffineMinWithSCFIfPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
   // Distribute linalg onto threads within the workgroup.
   nestedModulePM.addNestedPass<func::FuncOp>(createLLVMGPUTileTensor(false));
@@ -143,6 +148,11 @@ void addGPUMatmulSimtPassPipeline(OpPassManager &pm) {
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
       createWorkgroupSpecializationPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createFoldAffineMinWithSCFIfPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 
@@ -253,6 +263,11 @@ void addGPUTransposePassPipeline(OpPassManager &pm) {
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
       createWorkgroupSpecializationPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createFoldAffineMinWithSCFIfPass());
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -66,6 +66,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createFlattenMemRefSubspanPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createFoldAffineMinInDistributedLoopsPass();
 
+/// Creates a pass to fold `affine.min` uses with scf.if.
+std::unique_ptr<OperationPass<func::FuncOp>> createFoldAffineMinWithSCFIfPass();
+
 /// After running the upstream TensorConstantBufferize pass, remove tensor_loads
 /// introduced for use only in tensor_extract. These can be folded to use a load
 /// of the created memref object that holds the constant values.
@@ -180,6 +183,9 @@ createConcretizePadResultShapePass();
 /// distributed loops.
 void populateFoldAffineMinInDistributedLoopsPatterns(
     RewritePatternSet &patterns);
+
+/// Populates `patterns` with patterns to fold `affine.min` uses with scf.if.
+void populateFoldAffineMinWithSCFIfPatterns(RewritePatternSet &patterns);
 
 /// Populates `patterns` with a very specific pattern that vectorizes a
 /// linalg.conv op for a single thread. The linalg.conv should compute on

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -55,6 +55,12 @@ def FoldAffineMinInDistributedLoops :
   let constructor = "mlir::iree_compiler::createFoldAffineMinInDistributedLoopsPass()";
 }
 
+def FoldAffineMinWithSCFIf :
+  Pass<"iree-codegen-fold-affinemin-with-scfif", "func::FuncOp"> {
+  let summary = "Fold `affine.min` uses in scf.if";
+  let constructor = "mlir::iree_compiler::createFoldAffineMinWithSCFIfPass()";
+}
+
 def FoldTensorExtractOp :
   Pass<"iree-codegen-fold-tensor-extract-op", ""> {
   let summary = "Fold `tensor.extract` operations prior to lowering to LLVM";

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -161,6 +161,10 @@ Optional<LoopTilingAndDistributionInfo> isTiledAndDistributedLoop(
 SmallVector<LoopTilingAndDistributionInfo> getTiledAndDistributedLoopInfo(
     func::FuncOp funcOp);
 
+/// Match a tile-and-distributed loop and get the loop bounds and step.
+LogicalResult matchTileAndDistributedLoop(Value iv, OpFoldResult &lb,
+                                          OpFoldResult &ub, OpFoldResult &step);
+
 Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
                               ArrayRef<NamedAttribute> attributes = {});
 


### PR DESCRIPTION
When there is only one bounded tile size, we can get the static shape for the partial path.

This doesn't seem to improve the performance much, but it can reduce the code size by not generating code for a few bound checks. For example, distilbert's dispatch 115 has a really large transpose, it reduces the vmfb file size from 7292 to 6044 bytes. The nvptx FB size is reduced from 2680 to 1432.