### PR TITLE
Switch off WARNINGS_AS_ERROR for swiftshader builds.

### DIFF
--- a/build_tools/third_party/swiftshader/build_vk_swiftshader.sh
+++ b/build_tools/third_party/swiftshader/build_vk_swiftshader.sh
@@ -78,6 +78,7 @@ fi
 cmake -B "${SWIFTSHADER_INSTALL_DIR?}" \
     -GNinja \
     -DSWIFTSHADER_BUILD_TESTS=OFF \
+    -DSWIFTSHADER_WARNINGS_AS_ERRORS=OFF \
     "${SWIFTSHADER_DIR?}"
 
 # Build the project, choosing just the vk_swiftshader target.


### PR DESCRIPTION
There seem to be a lot of deprecation warnings generated with the latest compilers during build of swiftshader. Just ignoring the warnings seems to be fine for now.