### PR TITLE
NFC: Move FlattenTransferReadOp in preparation for reuse

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -195,6 +195,7 @@ iree_compiler_cc_library(
         "WorkGroupSwizzle.cpp",
     ],
     hdrs = [
+        "GPUPatterns.h",
         "LinalgOpInfo.h",
         "UserConfig.h",
     ],

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -179,6 +179,7 @@ iree_compiler_cc_library(
         "DecomposeLinalgGeneric.cpp",
         "FoldAffineMinInDistributedLoops.cpp",
         "GPUDistributeSharedMemoryCopy.cpp",
+        "GPUPatterns.cpp",
         "GPUPipelining.cpp",
         "GPUTileReduction.cpp",
         "GPUVectorization.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -153,6 +153,7 @@ iree_cc_library(
     "DecomposeLinalgGeneric.cpp"
     "FoldAffineMinInDistributedLoops.cpp"
     "GPUDistributeSharedMemoryCopy.cpp"
+    "GPUPatterns.cpp"
     "GPUPipelining.cpp"
     "GPUTileReduction.cpp"
     "GPUVectorization.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -147,6 +147,7 @@ iree_cc_library(
   NAME
     Common
   HDRS
+    "GPUPatterns.h"
     "LinalgOpInfo.h"
     "UserConfig.h"
   SRCS

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPatterns.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPatterns.cpp
@@ -1,0 +1,149 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/GPUPatterns.h"
+
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/PatternMatch.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+/// Applies tranformation to drop unit dims in destination vector.transfer_read
+/// destination so that the resulting vector is 2D.
+//
+/// Example:
+/// ```
+/// %cst = arith.constant 0.000000e+00 : f32
+/// %c2 = arith.constant 2 : index
+/// %c3 = arith.constant 3 : index
+/// %c4 = arith.constant 4 : index
+/// %0 = vector.transfer_read %a[%c2, %c3, %c4], %cst
+///        {in_bounds = [true, true, true]}
+///      : memref<128x16x256xf32>, vector<16x1x8xf32>
+/// ```
+/// Will be converted into:
+/// ```
+/// #map = affine_map<(d0, d1) -> (d0 * 4096 + d1 + 8964)>
+/// %c0 = arith.constant 0 : index
+/// %cst = arith.constant 0.000000e+00 : f32
+/// %0 = memref.subview %arg0[2, 3, 4] [16, 1, 8] [1, 1, 1]
+///      : memref<128x16x256xf32> to memref<16x8xf32, #map>
+/// %1 = vector.transfer_read %0[%c0, %c0], %cst {in_bounds = [true, true]}
+///      : memref<16x8xf32, #map>, vector<16x8xf32>
+/// %2 = vector.broadcast %1 : vector<16x8xf32> to  vector<1x16x8xf32>
+/// %3 = vector.transpose %2, [1, 0, 2]
+///      : vector<1x16x8xf32> to vector<16x1x8xf32>
+/// ```
+struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(vector::TransferReadOp transferReadOp,
+                                PatternRewriter &rewriter) const override {
+    auto loc = transferReadOp.getLoc();
+    Value vector = transferReadOp.getVector();
+    VectorType vectorType = vector.getType().cast<VectorType>();
+    Value source = transferReadOp.getSource();
+    MemRefType sourceType = source.getType().dyn_cast<MemRefType>();
+    // Contiguity check is valid on tensors only.
+    if (!sourceType) return failure();
+    // Already 2D or lower nothing to do.
+    if (vectorType.getRank() < 3) return failure();
+    // The innermost dim is always considered non-unit as it wont be dropped
+    // Therefore, we initialize `numberOfNonUnitDims` to 1 and not 0
+    int numberOfNonUnitDims = 1;
+    // Track of the location of the outer non-unit dim in the source
+    // vector e.g if vector<1x16x1x32> -> vector<16x32> here the outer non-unit
+    // dim is the one with size 16 at index 1 in the source vector. We
+    // initialize as: `indexOfOuterNonUnitDim` = vectorType.getRank() - 2 = 2,
+    // which is the highest index it can have for any 4D shape, we then traverse
+    // the source vector shape to update this value to `indexOfOuterNonUnitDim`
+    // = 1. This works out nicely for a case like vector<1x1x1x32> ->
+    // vector<1x32> where `numberOfNonUnitDims` is desired to be 2, as the unit
+    // dim adjacent to the innermost dim is considered the outermost non-unit
+    // dim for the rest of the pattern if an actual outer non-unit dim does not
+    // exist
+    int indexOfOuterNonUnitDim = vectorType.getRank() - 2;
+    for (int i = 0; i < vectorType.getRank() - 1; i++) {
+      if (vectorType.getShape()[i] != 1) {
+        numberOfNonUnitDims++;
+        indexOfOuterNonUnitDim = i;
+      }
+    }
+    // Bail out if 2D vector cannot be formed
+    if (numberOfNonUnitDims > 2) {
+      return failure();
+    }
+    int rankOfCollapsedVector = 2;
+    // TODO: generalize this pattern, relax the requirements here.
+    if (transferReadOp.hasOutOfBoundsDim()) return failure();
+    if (!transferReadOp.getPermutationMap().isMinorIdentity()) return failure();
+    if (transferReadOp.getMask()) return failure();
+    ArrayAttr newInBoundsAttr = rewriter.getBoolArrayAttr(
+        SmallVector<bool>(rankOfCollapsedVector, true));
+    auto newidentityMap =
+        rewriter.getMultiDimIdentityMap(rankOfCollapsedVector);
+
+    SmallVector<int64_t> vectorShapeCollapse = {
+        vectorType.getShape()[indexOfOuterNonUnitDim],
+        vectorType.getShape()[vectorType.getRank() - 1]};
+    SmallVector<int64_t> vectorShapeBroadcast = vectorShapeCollapse;
+    for (int i = 0; i < vectorType.getRank() - rankOfCollapsedVector; i++) {
+      vectorShapeBroadcast.insert(vectorShapeBroadcast.begin(), 1);
+    }
+
+    VectorType vectorTypeCollapse =
+        VectorType::get(vectorShapeCollapse, vectorType.getElementType());
+    VectorType vectorTypeBroadcast =
+        VectorType::get(vectorShapeBroadcast, vectorType.getElementType());
+
+    SmallVector<OpFoldResult> subViewOffsets, subViewSizes, subViewStrides;
+    subViewSizes.append(sourceType.getRank() - vectorType.getRank(),
+                        rewriter.getIndexAttr(1));
+    for (int64_t dim : vectorType.getShape())
+      subViewSizes.push_back(rewriter.getIndexAttr(dim));
+    for (int i = 0; i < sourceType.getRank(); i++) {
+      subViewOffsets.push_back(transferReadOp.getIndices()[i]);
+      subViewStrides.push_back(rewriter.getIndexAttr(1));
+    }
+    MemRefType resultType = memref::SubViewOp::inferRankReducedResultType(
+                                vectorShapeCollapse, sourceType, subViewOffsets,
+                                subViewSizes, subViewStrides)
+                                .cast<MemRefType>();
+    Value subView = rewriter.create<memref::SubViewOp>(
+        loc, resultType, source, subViewOffsets, subViewSizes, subViewStrides);
+    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value readCollapse = rewriter.create<vector::TransferReadOp>(
+        loc, vectorTypeCollapse, subView, ValueRange{c0, c0}, newidentityMap,
+        transferReadOp.getPadding(), transferReadOp.getMask(), newInBoundsAttr);
+
+    Value readBroadcast = rewriter.create<vector::BroadcastOp>(
+        loc, vectorTypeBroadcast, readCollapse);
+    SmallVector<int64_t> tranposePermutation;
+    for (int i = 0; i < vectorType.getRank(); i++) {
+      if (i == vectorType.getRank() - 2) continue;
+      tranposePermutation.push_back(i);
+    }
+    tranposePermutation.insert(
+        tranposePermutation.begin() + indexOfOuterNonUnitDim,
+        vectorType.getRank() - 2);
+    rewriter.replaceOpWithNewOp<vector::TransposeOp>(
+        transferReadOp, readBroadcast, tranposePermutation);
+    return success();
+  }
+};
+}  // namespace
+
+void populateVectorTransferToGPUMMAPreparationPatterns(
+    RewritePatternSet &patterns) {
+  patterns.add<FlattenTransferReadOp>(patterns.getContext());
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPatterns.h
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPatterns.h
@@ -1,0 +1,22 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_COMMON_GPUPATTERNS_H_
+#define IREE_COMPILER_CODEGEN_COMMON_GPUPATTERNS_H_
+
+#include "mlir/IR/PatternMatch.h"
+namespace mlir {
+namespace iree_compiler {
+
+/// Adds patterns for preparing vector transfer ops for converting to GPU
+/// subgroup MMA load/store ops.
+void populateVectorTransferToGPUMMAPreparationPatterns(
+    RewritePatternSet &patterns);
+
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_COMMON_GPUPATTERNS_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUVectorToGPU.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/Common/GPUPatterns.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "llvm/ADT/SetVector.h"
@@ -121,126 +122,6 @@ static void swizzleSharedMemory(func::FuncOp funcOp) {
 }
 
 namespace {
-/// Apply tranformation to drop unit dims in destination of vector.transfer_read
-/// Ops such that the resulting vector is 2D
-/// Example:
-/// ```
-/// %cst = arith.constant 0.000000e+00 : f32
-/// %c2 = arith.constant 2 : index
-/// %c3 = arith.constant 3 : index
-/// %c4 = arith.constant 4 : index
-/// %0 = vector.transfer_read %a[%c2, %c3, %c4], %cst {in_bounds = [true, true,
-/// true]} : memref<128x16x256xf32>, vector<16x1x8xf32>
-/// To:
-/// ```
-/// #map = affine_map<(d0, d1) -> (d0 * 4096 + d1 + 8964)>
-/// %c0 = arith.constant 0 : index
-/// %cst = arith.constant 0.000000e+00 : f32
-/// %0 = memref.subview %arg0[2, 3, 4] [16, 1, 8] [1, 1, 1] :
-/// memref<128x16x256xf32> to memref<16x8xf32, #map> %1 = vector.transfer_read
-/// %0[%c0, %c0], %cst {in_bounds = [true, true]} : memref<16x8xf32, #map>,
-/// vector<16x8xf32> %2 = vector.broadcast %1 : vector<16x8xf32> to
-/// vector<1x16x8xf32> %3 = vector.transpose %2, [1, 0, 2] : vector<1x16x8xf32>
-/// to vector<16x1x8xf32>
-/// ```
-struct FlattenTransferReadOp : public OpRewritePattern<vector::TransferReadOp> {
-  using OpRewritePattern<vector::TransferReadOp>::OpRewritePattern;
-
-  LogicalResult matchAndRewrite(vector::TransferReadOp transferReadOp,
-                                PatternRewriter& rewriter) const override {
-    auto loc = transferReadOp.getLoc();
-    Value vector = transferReadOp.getVector();
-    VectorType vectorType = vector.getType().cast<VectorType>();
-    Value source = transferReadOp.getSource();
-    MemRefType sourceType = source.getType().dyn_cast<MemRefType>();
-    // Contiguity check is valid on tensors only.
-    if (!sourceType) return failure();
-    // Already 2D or lower nothing to do.
-    if (vectorType.getRank() < 3) return failure();
-    // The innermost dim is always considered non-unit as it wont be dropped
-    // Therefore, we initialize `numberOfNonUnitDims` to 1 and not 0
-    int numberOfNonUnitDims = 1;
-    // Track of the location of the outer non-unit dim in the source
-    // vector e.g if vector<1x16x1x32> -> vector<16x32> here the outer non-unit
-    // dim is the one with size 16 at index 1 in the source vector. We
-    // initialize as: `indexOfOuterNonUnitDim` = vectorType.getRank() - 2 = 2,
-    // which is the highest index it can have for any 4D shape, we then traverse
-    // the source vector shape to update this value to `indexOfOuterNonUnitDim`
-    // = 1. This works out nicely for a case like vector<1x1x1x32> ->
-    // vector<1x32> where `numberOfNonUnitDims` is desired to be 2, as the unit
-    // dim adjacent to the innermost dim is considered the outermost non-unit
-    // dim for the rest of the pattern if an actual outer non-unit dim does not
-    // exist
-    int indexOfOuterNonUnitDim = vectorType.getRank() - 2;
-    for (int i = 0; i < vectorType.getRank() - 1; i++) {
-      if (vectorType.getShape()[i] != 1) {
-        numberOfNonUnitDims++;
-        indexOfOuterNonUnitDim = i;
-      }
-    }
-    // Bail out if 2D vector cannot be formed
-    if (numberOfNonUnitDims > 2) {
-      return failure();
-    }
-    int rankOfCollapsedVector = 2;
-    // TODO: generalize this pattern, relax the requirements here.
-    if (transferReadOp.hasOutOfBoundsDim()) return failure();
-    if (!transferReadOp.getPermutationMap().isMinorIdentity()) return failure();
-    if (transferReadOp.getMask()) return failure();
-    ArrayAttr newInBoundsAttr = rewriter.getBoolArrayAttr(
-        SmallVector<bool>(rankOfCollapsedVector, true));
-    auto newidentityMap =
-        rewriter.getMultiDimIdentityMap(rankOfCollapsedVector);
-
-    SmallVector<int64_t> vectorShapeCollapse = {
-        vectorType.getShape()[indexOfOuterNonUnitDim],
-        vectorType.getShape()[vectorType.getRank() - 1]};
-    SmallVector<int64_t> vectorShapeBroadcast = vectorShapeCollapse;
-    for (int i = 0; i < vectorType.getRank() - rankOfCollapsedVector; i++) {
-      vectorShapeBroadcast.insert(vectorShapeBroadcast.begin(), 1);
-    }
-
-    VectorType vectorTypeCollapse =
-        VectorType::get(vectorShapeCollapse, vectorType.getElementType());
-    VectorType vectorTypeBroadcast =
-        VectorType::get(vectorShapeBroadcast, vectorType.getElementType());
-
-    SmallVector<OpFoldResult> subViewOffsets, subViewSizes, subViewStrides;
-    subViewSizes.append(sourceType.getRank() - vectorType.getRank(),
-                        rewriter.getIndexAttr(1));
-    for (int64_t dim : vectorType.getShape())
-      subViewSizes.push_back(rewriter.getIndexAttr(dim));
-    for (int i = 0; i < sourceType.getRank(); i++) {
-      subViewOffsets.push_back(transferReadOp.getIndices()[i]);
-      subViewStrides.push_back(rewriter.getIndexAttr(1));
-    }
-    MemRefType resultType = memref::SubViewOp::inferRankReducedResultType(
-                                vectorShapeCollapse, sourceType, subViewOffsets,
-                                subViewSizes, subViewStrides)
-                                .cast<MemRefType>();
-    Value subView = rewriter.create<memref::SubViewOp>(
-        loc, resultType, source, subViewOffsets, subViewSizes, subViewStrides);
-    Value c0 = rewriter.create<arith::ConstantIndexOp>(loc, 0);
-    Value readCollapse = rewriter.create<vector::TransferReadOp>(
-        loc, vectorTypeCollapse, subView, ValueRange{c0, c0}, newidentityMap,
-        transferReadOp.getPadding(), transferReadOp.getMask(), newInBoundsAttr);
-
-    Value readBroadcast = rewriter.create<vector::BroadcastOp>(
-        loc, vectorTypeBroadcast, readCollapse);
-    SmallVector<int64_t> tranposePermutation;
-    for (int i = 0; i < vectorType.getRank(); i++) {
-      if (i == vectorType.getRank() - 2) continue;
-      tranposePermutation.push_back(i);
-    }
-    tranposePermutation.insert(
-        tranposePermutation.begin() + indexOfOuterNonUnitDim,
-        vectorType.getRank() - 2);
-    rewriter.replaceOpWithNewOp<vector::TransposeOp>(
-        transferReadOp, readBroadcast, tranposePermutation);
-    return success();
-  }
-};
-
 struct LLVMGPUVectorToGPUPass
     : public LLVMGPUVectorToGPUBase<LLVMGPUVectorToGPUPass> {
   void getDependentDialects(DialectRegistry& registry) const override {
@@ -251,7 +132,7 @@ struct LLVMGPUVectorToGPUPass
   void runOnOperation() override {
     auto funcOp = getOperation();
     RewritePatternSet flatternpatterns(funcOp.getContext());
-    flatternpatterns.insert<FlattenTransferReadOp>(funcOp.getContext());
+    populateVectorTransferToGPUMMAPreparationPatterns(flatternpatterns);
     if (failed(applyPatternsAndFoldGreedily(funcOp,
                                             std::move(flatternpatterns)))) {
       return signalPassFailure();


### PR DESCRIPTION
This commit moves FlattenTransferReadOp to a common place in preparation for reuse in the SPIR-V CodeGen pipeline.