### PR TITLE
[spirv] Use 8 as the innermost tile size for fp16 convolution

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -82,8 +82,12 @@ LogicalResult setAMDCodeGenConfig(const spirv::TargetEnv &targetEnv,
   }
 
   if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
+    auto type = convOp.image().getType().cast<ShapedType>();
+    const int bitwidth = type.getElementTypeBitWidth();
+    if (bitwidth > 32) return failure();
+    const int multipler = 32 / bitwidth;
     bool hasPaddedInput = convOp.image().getDefiningOp<tensor::PadOp>();
-    int bestTilingFactor = hasPaddedInput ? 16 : 32;
+    int bestTilingFactor = (hasPaddedInput ? 16 : 32) * multipler;
     return setConvOpConfig(rootOp, subgroupSize, bestTilingFactor);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -82,12 +82,12 @@ LogicalResult setAMDCodeGenConfig(const spirv::TargetEnv &targetEnv,
   }
 
   if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
-    auto type = convOp.image().getType().cast<ShapedType>();
+    auto type = cast<ShapedType>(convOp.image().getType());
     const int bitwidth = type.getElementTypeBitWidth();
     if (bitwidth > 32) return failure();
     const int multipler = 32 / bitwidth;
     bool hasPaddedInput = convOp.image().getDefiningOp<tensor::PadOp>();
-    int bestTilingFactor = (hasPaddedInput ? 16 : 32) * multipler;
+    const int bestTilingFactor = (hasPaddedInput ? 16 : 32) * multipler;
     return setConvOpConfig(rootOp, subgroupSize, bestTilingFactor);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -49,10 +49,14 @@ LogicalResult setAdrenoCodeGenConfig(const spirv::TargetEnv &targetEnv,
       return setAdrenoMatmulConfig(linalgOp, limits);
   }
 
-  if (isa<linalg::ConvolutionOpInterface>(rootOp)) {
+  if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
+    auto type = convOp.image().getType().cast<ShapedType>();
+    const int bitwidth = type.getElementTypeBitWidth();
+    if (bitwidth > 32) return failure();
+    const int multipler = 32 / bitwidth;
     linalg::detail::ConvolutionDimensions convDims;
     linalg::detail::isConvolutionInterfaceImpl(rootOp, &convDims);
-    const int bestTilingFactor = convDims.depth.empty() ? 32 : 16;
+    const int bestTilingFactor = (convDims.depth.empty() ? 32 : 16) * multipler;
     return setConvOpConfig(rootOp, subgroupSize, bestTilingFactor);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -50,7 +50,7 @@ LogicalResult setAdrenoCodeGenConfig(const spirv::TargetEnv &targetEnv,
   }
 
   if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
-    auto type = convOp.image().getType().cast<ShapedType>();
+    auto type = cast<ShapedType>(convOp.image().getType());
     const int bitwidth = type.getElementTypeBitWidth();
     if (bitwidth > 32) return failure();
     const int multipler = 32 / bitwidth;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
@@ -49,9 +49,13 @@ LogicalResult setAppleCodeGenConfig(const spirv::TargetEnv &targetEnv,
       return setAppleMatmulConfig(linalgOp, limits);
   }
 
-  if (isa<linalg::ConvolutionOpInterface>(rootOp)) {
-    return setConvOpConfig(rootOp, subgroupSize,
-                           /*bestTilingFactor=*/16);
+  if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
+    auto type = convOp.image().getType().cast<ShapedType>();
+    const int bitwidth = type.getElementTypeBitWidth();
+    if (bitwidth > 32) return failure();
+    const int multipler = 32 / bitwidth;
+    int bestTilingFactor = 16 * multipler;
+    return setConvOpConfig(rootOp, subgroupSize, bestTilingFactor);
   }
 
   return failure();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
@@ -50,11 +50,11 @@ LogicalResult setAppleCodeGenConfig(const spirv::TargetEnv &targetEnv,
   }
 
   if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
-    auto type = convOp.image().getType().cast<ShapedType>();
+    auto type = cast<ShapedType>(convOp.image().getType());
     const int bitwidth = type.getElementTypeBitWidth();
     if (bitwidth > 32) return failure();
     const int multipler = 32 / bitwidth;
-    int bestTilingFactor = 16 * multipler;
+    const int bestTilingFactor = 16 * multipler;
     return setConvOpConfig(rootOp, subgroupSize, bestTilingFactor);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -96,16 +96,16 @@ static bool fusedOpMayUseExtraSharedMemory(linalg::LinalgOp matmul) {
 /// - `wgDimSize` will be updated with the decided workgroup dimension size.
 /// - `wgTileSize` will be updated with the decided workgroup tile size.
 static bool tileConvOneDim(const int64_t inputDim, const bool isInnerMostDim,
-                           int64_t &residualThreads,
+                           int vectorSize, int64_t &residualThreads,
                            int64_t &residualTilingFactor, int64_t &wgDimSize,
                            int64_t &wgTileSize) {
   const int64_t lb = isInnerMostDim ? 2 : 1;
   for (int64_t dim = residualThreads; dim >= lb; dim >>= 1) {
     int64_t chosenTileSize = 0;
     if (isInnerMostDim) {
-      // Handle 4 elements per thread for the innermost dimension. We need
-      // this for vectorized load.
-      chosenTileSize = 4;
+      // Handle `vectorSize` elements per thread for the innermost dimension.
+      // We need this for the best utilization of memory.
+      chosenTileSize = vectorSize;
       if (inputDim % (dim * chosenTileSize) != 0) continue;
     } else {
       for (int64_t t = residualTilingFactor; t >= 1; t >>= 1)
@@ -230,6 +230,9 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
   // multipler of four, or less than four.
   if (ic && !(*ic % 4 == 0 || *ic < 4)) return failure();
 
+  const int bitwidth = outputType.cast<ShapedType>().getElementTypeBitWidth();
+  const int vectorSize = kMaxVectorNumBits / bitwidth;
+
   // The core idea is to distribute the convolution dimensions to the workgroup
   // Z/Y/X dimensions, with each thread in a workgroup handling multiple vector
   // elements. We try to 1) utilize all threads in a subgroup, and 2) handle an
@@ -244,21 +247,21 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
   const bool isNCHW = ocIndex < ohIndex;
   if (isNCHW) {
     // OW -> x, OH -> y, OC -> z
-    if (!tileConvOneDim(ow, /*isInnerMostDim=*/true, residualThreads,
-                        residualTilingFactor, workgroupSize[0],
+    if (!tileConvOneDim(ow, /*isInnerMostDim=*/true, vectorSize,
+                        residualThreads, residualTilingFactor, workgroupSize[0],
                         workgroupTileSizes[3]) ||
-        !tileConvOneDim(oh, /*isInnerMostDim=*/false, residualThreads,
-                        residualTilingFactor, workgroupSize[1],
+        !tileConvOneDim(oh, /*isInnerMostDim=*/false, vectorSize,
+                        residualThreads, residualTilingFactor, workgroupSize[1],
                         workgroupTileSizes[2]) ||
-        !tileConvOneDim(oc, /*isInnerMostDim=*/false, residualThreads,
-                        residualTilingFactor, workgroupSize[2],
+        !tileConvOneDim(oc, /*isInnerMostDim=*/false, vectorSize,
+                        residualThreads, residualTilingFactor, workgroupSize[2],
                         workgroupTileSizes[1])) {
       return failure();
     }
   } else {
     // OC -> x
-    if (!tileConvOneDim(oc, /*isInnerMostDim=*/true, residualThreads,
-                        residualTilingFactor, workgroupSize[0],
+    if (!tileConvOneDim(oc, /*isInnerMostDim=*/true, vectorSize,
+                        residualThreads, residualTilingFactor, workgroupSize[0],
                         workgroupTileSizes[3]))
       return failure();
 
@@ -273,18 +276,19 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
     // Otherwise treat OW and OH separately to allow them to have different
     // number of threads and tiling size.
     if (!tileToSquare) {
-      if (!tileConvOneDim(ow, /*isInnerMostDim=*/false, residualThreads,
-                          residualTilingFactor, workgroupSize[1],
-                          workgroupTileSizes[2]) ||
-          !tileConvOneDim(oh, /*isInnerMostDim=*/false, residualThreads,
-                          residualTilingFactor, workgroupSize[2],
-                          workgroupTileSizes[1])) {
+      if (!tileConvOneDim(ow, /*isInnerMostDim=*/false, vectorSize,
+                          residualThreads, residualTilingFactor,
+                          workgroupSize[1], workgroupTileSizes[2]) ||
+          !tileConvOneDim(oh, /*isInnerMostDim=*/false, vectorSize,
+                          residualThreads, residualTilingFactor,
+                          workgroupSize[2], workgroupTileSizes[1])) {
         return failure();
       }
     }
   }
 
   SmallVector<int64_t> threadTileSizes(4, 0);
+  threadTileSizes[0] = 1;  // Tile along the N dimension with size 1
   for (int i = 1; i <= 3; ++i) {
     threadTileSizes[i] = workgroupTileSizes[i] / workgroupSize[3 - i];
   }
@@ -1447,12 +1451,16 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
         return setDefaultOpConfig(limits, op);
       })
       .Case<linalg::ConvolutionOpInterface>([limits](auto op) {
-        // Try to tile and vectorize first. It's common to see 32 threads
-        // per subgroup for GPUs.
-        auto result = detail::setConvOpConfig(cast<linalg::LinalgOp>(*op),
-                                              /*subgroupSize=*/32,
-                                              /*bestTilingFactor=*/32);
-        if (succeeded(result)) return success();
+        auto type = op.image().getType().template cast<ShapedType>();
+        const int bitwidth = type.getElementTypeBitWidth();
+        if (bitwidth <= 32) {
+          const int multipler = 32 / bitwidth;
+          const int bestTilingFactor = 32 * multipler;
+          const int subgroupSize = 32;
+          auto result = detail::setConvOpConfig(cast<linalg::LinalgOp>(*op),
+                                                subgroupSize, bestTilingFactor);
+          if (succeeded(result)) return success();
+        }
 
         // If unsuccessful, try to tile and distribute/vectorize.
         return setDefaultOpConfig(limits, op);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -231,7 +231,7 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
 
   // We use `vectorSize` as the tile size along IC dimension. If smaller than
   // 4, it will be unrolled into size 1.
-  if (ic && !(*ic % vectorSize == 0 || *ic < 4)) return success();
+  if (ic && !(*ic % vectorSize == 0 || *ic < 4)) return failure();
 
   // The core idea is to distribute the convolution dimensions to the workgroup
   // Z/Y/X dimensions, with each thread in a workgroup handling multiple vector

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1451,7 +1451,7 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
         return setDefaultOpConfig(limits, op);
       })
       .Case<linalg::ConvolutionOpInterface>([limits](auto op) {
-        auto type = op.image().getType().template cast<ShapedType>();
+        auto type = cast<ShapedType>(op.image().getType());
         const int bitwidth = type.getElementTypeBitWidth();
         if (bitwidth <= 32) {
           const int multipler = 32 / bitwidth;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -53,12 +53,12 @@ LogicalResult setMaliCodeGenConfig(const spirv::TargetEnv &targetEnv,
   }
 
   if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
-    auto type = convOp.image().getType().cast<ShapedType>();
+    auto type = cast<ShapedType>(convOp.image().getType());
     const int bitwidth = type.getElementTypeBitWidth();
     if (bitwidth > 32) return failure();
     const int multipler = 32 / bitwidth;
     bool hasPaddedInput = convOp.image().getDefiningOp<tensor::PadOp>();
-    int bestTilingFactor = (hasPaddedInput ? 8 : 16) * multipler;
+    const int bestTilingFactor = (hasPaddedInput ? 8 : 16) * multipler;
     return setConvOpConfig(rootOp, subgroupSize, bestTilingFactor);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -53,8 +53,12 @@ LogicalResult setMaliCodeGenConfig(const spirv::TargetEnv &targetEnv,
   }
 
   if (auto convOp = dyn_cast<linalg::ConvolutionOpInterface>(rootOp)) {
+    auto type = convOp.image().getType().cast<ShapedType>();
+    const int bitwidth = type.getElementTypeBitWidth();
+    if (bitwidth > 32) return failure();
+    const int multipler = 32 / bitwidth;
     bool hasPaddedInput = convOp.image().getDefiningOp<tensor::PadOp>();
-    int bestTilingFactor = hasPaddedInput ? 8 : 16;
+    int bestTilingFactor = (hasPaddedInput ? 8 : 16) * multipler;
     return setConvOpConfig(rootOp, subgroupSize, bestTilingFactor);
   }
 

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -136,8 +136,8 @@ static LogicalResult tileAndDistributeToThreads(linalg::LinalgOp consumerOp,
   const char *attrName = getSPIRVDistributeAttrName();
   // We can have more than 3 dimensions being tiled (e.g., for convolutions with
   // non-1 batch). But only the innermost 3 dimensions are distributed.
-  for (int i = loops.size() - 1, dim = 0; i >= 0 && dim < 3; --i) {
-    loops[i]->setAttr(attrName, rewriter.getIndexAttr(dim++));
+  for (auto [dim, loop] : zip(llvm::seq(0, 3), llvm::reverse(loops))) {
+    loop->setAttr(attrName, rewriter.getIndexAttr(dim++));
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -133,9 +133,10 @@ static LogicalResult tileAndDistributeToThreads(linalg::LinalgOp consumerOp,
   // after bufferization. So add attributes to the tiled loop nest to
   // indicate that they should be distributed to invocations.
   ArrayRef<scf::ForOp> loops = tileAndFuseResult.value().loops;
-  assert(loops.size() <= kNumGPUDims);
   const char *attrName = getSPIRVDistributeAttrName();
-  for (int i = loops.size() - 1, dim = 0; i >= 0; --i) {
+  // We can have more than 3 dimensions being tiled (e.g., for convolutions with
+  // non-1 batch). But only the innermost 3 dimensions are distributed.
+  for (int i = loops.size() - 1, dim = 0; i >= 0 && dim < 3; --i) {
     loops[i]->setAttr(attrName, rewriter.getIndexAttr(dim++));
   }
   return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD.bazel
@@ -22,6 +22,7 @@ iree_lit_test_suite(
             "break_down_large_vector.mlir",
             "config_adreno_conv.mlir",
             "config_adreno_matmul.mlir",
+            "config_amd_conv.mlir",
             "config_amd_matmul.mlir",
             "config_amd_matmul_cooperative_ops.mlir",
             "config_default_conv.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "break_down_large_vector.mlir"
     "config_adreno_conv.mlir"
     "config_adreno_matmul.mlir"
+    "config_amd_conv.mlir"
     "config_amd_matmul.mlir"
     "config_amd_matmul_cooperative_ops.mlir"
     "config_default_conv.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_adreno_conv.mlir
@@ -43,7 +43,7 @@ hal.executable @conv_112x112x512 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 256], [0, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 256], [1, 1, 8, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @conv_112x112x512
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -97,7 +97,7 @@ hal.executable @conv_112x112x32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 16, 32], [0, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 16, 32], [1, 4, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @conv_112x112x32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -150,7 +150,7 @@ hal.executable @conv_16x16x16 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 8, 8, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 8, 8, 16], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @conv_16x16x16
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -205,7 +205,7 @@ hal.executable @dwconv_28x28x144 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @dwconv_28x28x144
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -258,7 +258,7 @@ hal.executable @dwconv_4x4x8 {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 8], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @dwconv_4x4x8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_conv.mlir
@@ -1,0 +1,58 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-spirv-lower-executable-target-pass{test-lowering-configuration=true})))' %s | FileCheck %s
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+
+hal.executable private @nhwc_conv_pointwise_2x64x64x320 {
+  hal.executable.variant public @vulkan_spirv_fb, target = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader], []>, AMD:DiscreteGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 65536,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 1024],
+        subgroup_size = 64>>
+    }> {
+    hal.executable.export public @nhwc_conv_pointwise_2x64x64x320 layout(#pipeline_layout)
+    builtin.module {
+      func.func @nhwc_conv_pointwise_2x64x64x320() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<2x66x66x320xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<3x3x320x320xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<2x64x64x320xf16>>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x64x64x320xf16>>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 66, 66, 320], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x66x66x320xf16>> -> tensor<2x66x66x320xf16>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, 0], sizes = [3, 3, 320, 320], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x320x320xf16>> -> tensor<3x3x320x320xf16>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0, 0], sizes = [2, 64, 64, 320], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x64x64x320xf16>> -> tensor<2x64x64x320xf16>
+        %7 = tensor.empty() : tensor<2x64x64x320xf16>
+        %8 = linalg.fill ins(%cst : f16) outs(%7 : tensor<2x64x64x320xf16>) -> tensor<2x64x64x320xf16>
+        %9 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64>}
+          ins(%4, %5 : tensor<2x66x66x320xf16>, tensor<3x3x320x320xf16>) outs(%8 : tensor<2x64x64x320xf16>) -> tensor<2x64x64x320xf16>
+        %10 = linalg.generic {
+            indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+            iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+          ins(%9, %6 : tensor<2x64x64x320xf16>, tensor<2x64x64x320xf16>) outs(%7 : tensor<2x64x64x320xf16>) {
+        ^bb0(%in: f16, %in_0: f16, %out: f16):
+          %11 = arith.divf %in, %in_0 : f16
+          linalg.yield %11 : f16
+        } -> tensor<2x64x64x320xf16>
+        flow.dispatch.tensor.store %10, %3, offsets = [0, 0, 0, 0], sizes = [2, 64, 64, 320], strides = [1, 1, 1, 1] : tensor<2x64x64x320xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x64x64x320xf16>>
+        return
+      }
+    }
+  }
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 64, 64], [1, 1, 8, 8], [0, 0, 0, 0, 1, 1, 8], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
+//      CHECK: hal.executable.export public @nhwc_conv_pointwise_2x64x64x320
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+// CHECK-SAME:   workgroup_size = [8 : index, 8 : index, 1 : index]
+//      CHECK: func.func @nhwc_conv_pointwise_2x64x64x320()
+//      CHECK:   linalg.conv_2d_nhwc_hwcf
+// CHECK-SAME:     lowering_config = #[[CONFIG]]
+

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_conv.mlir
@@ -62,7 +62,7 @@ hal.executable private @nhwc_conv_pointwise_112x112x32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 32], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 32], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @nhwc_conv_pointwise_112x112x32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -107,7 +107,7 @@ hal.executable private @nchw_conv_2x1280x8x8 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 16, 8, 8], [0, 8, 1, 4], [0, 0, 0, 0, 4, 1, 1], [0, 0, 1, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 16, 8, 8], [1, 8, 1, 4], [0, 0, 0, 0, 4, 1, 1], [0, 0, 1, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @nchw_conv_2x1280x8x8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -129,7 +129,7 @@ hal.executable @avg_pool {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 2, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 2, 8], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @avg_pool
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -184,7 +184,7 @@ hal.executable @avg_pool {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 1, 128], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 1, 128], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @avg_pool
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_mali_conv.mlir
@@ -44,7 +44,7 @@ hal.executable @conv_112x112x512 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 4, 64], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 4, 64], [1, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @conv_112x112x512
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -98,7 +98,7 @@ hal.executable @conv_112x112x32 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 32], [0, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 8, 32], [1, 1, 4, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @conv_112x112x32
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -151,7 +151,7 @@ hal.executable @conv_16x16x16 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @conv_16x16x16
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -205,7 +205,7 @@ hal.executable @dwconv_28x28x144 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [0, 2, 2, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 4, 4, 16], [1, 2, 2, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @dwconv_28x28x144
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
@@ -260,7 +260,7 @@ hal.executable @dwconv_1x2x8 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 2, 8], [0, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 2, 8], [1, 1, 1, 4], [0, 0, 0, 0, 1, 1], [0, 1, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 //      CHECK: hal.executable.export public @dwconv_1x2x8
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_conv.mlir
@@ -456,3 +456,101 @@ hal.executable private @nchw_conv_static_shape_f32 {
 // CHECK-COUNT-16: vector.transfer_write
 
 //  CHECK-COUNT-3: scf.yield %{{.+}} : tensor<2x16x8x8xf32>
+
+// -----
+
+#config = #iree_codegen.lowering_config<tile_sizes = [[0, 1, 32, 64], [1, 1, 4, 8], [0, 0, 0, 0, 1, 1, 4], [0, 1, 0, 0]]>
+#translation = #iree_codegen.translation_info<SPIRVBaseVectorize>
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+
+hal.executable private @nhwc_conv_static_shape_f16_batch2 {
+  hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb"> {
+    hal.executable.export @nhwc_conv_static_shape_f16_batch2 layout(#pipeline_layout) attributes {
+      workgroup_size = [8: index, 8: index, 1: index],
+      translation_info = #translation
+    }
+    builtin.module  {
+      func.func @nhwc_conv_static_shape_f16_batch2() {
+        %c64 = arith.constant 64 : index
+        %c320 = arith.constant 320 : index
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<2x66x66x320xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<3x3x320x320xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<2x64x64x320xf16>>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<2x64x64x320xf16>>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        scf.for %arg0 = %workgroup_id_z to %c64 step %workgroup_count_z {
+          %4 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_y]
+          %5 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_y]
+          scf.for %arg1 = %4 to %c64 step %5 {
+            %6 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+            %7 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_x]
+            scf.for %arg2 = %6 to %c320 step %7 {
+              %8 = flow.dispatch.tensor.load %3, offsets = [0, %arg0, %arg1, %arg2], sizes = [2, 1, 32, 64], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<writeonly:tensor<2x64x64x320xf16>> -> tensor<2x1x32x64xf16>
+              %9 = flow.dispatch.tensor.load %0, offsets = [0, %arg0, %arg1, 0], sizes = [2, 3, 34, 320], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x66x66x320xf16>> -> tensor<2x3x34x320xf16>
+              %10 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0, %arg2], sizes = [3, 3, 320, 64], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x3x320x320xf16>> -> tensor<3x3x320x64xf16>
+              %11 = linalg.fill {lowering_config = #config}
+                ins(%cst : f16) outs(%8 : tensor<2x1x32x64xf16>) -> tensor<2x1x32x64xf16>
+              %12 = linalg.conv_2d_nhwc_hwcf {dilations = dense<1> : tensor<2xi64>, lowering_config = #config, strides = dense<1> : tensor<2xi64>}
+                ins(%9, %10 : tensor<2x3x34x320xf16>, tensor<3x3x320x64xf16>) outs(%11 : tensor<2x1x32x64xf16>) -> tensor<2x1x32x64xf16>
+              %13 = flow.dispatch.tensor.load %2, offsets = [0, %arg0, %arg1, %arg2], sizes = [2, 1, 32, 64], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x64x64x320xf16>> -> tensor<2x1x32x64xf16>
+              %14 = linalg.generic {
+                  indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>],
+                  iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+                ins(%13 : tensor<2x1x32x64xf16>) outs(%12 : tensor<2x1x32x64xf16>) attrs =  {lowering_config = #config} {
+              ^bb0(%in: f16, %out: f16):
+                %15 = arith.divf %out, %in : f16
+                linalg.yield %15 : f16
+              } -> tensor<2x1x32x64xf16>
+              flow.dispatch.tensor.store %14, %3, offsets = [0, %arg0, %arg1, %arg2], sizes = [2, 1, 32, 64], strides = [1, 1, 1, 1] : tensor<2x1x32x64xf16> -> !flow.dispatch.tensor<writeonly:tensor<2x64x64x320xf16>>
+            }
+          }
+        }
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @nhwc_conv_static_shape_f16_batch2()
+
+// No vector transfer write ops generated for the linalg.fill op: initial values are forwarded to loops.
+// CHECK-NOT: vector.transfer
+
+// Check additional loops generated from tiling along N dimension
+// CHECK: scf.for %{{.+}} = %c0 to %c2 step %c1
+
+// CHECK:   scf.for %{{.+}} = %c0 to %c32 step %c4
+// CHECK:     scf.for %{{.+}} = %c0 to %c64 step %c8
+
+// Check tiling loop along filter height/width and input channel
+//      CHECK: scf.for %{{.*}} = %c0 to %c3 step %c1
+// CHECK-SAME:     -> (vector<8xf16>, vector<8xf16>, vector<8xf16>, vector<8xf16>)
+//      CHECK:   scf.for %{{.*}} = %c0 to %c3 step %c1
+// CHECK-SAME:       -> (vector<8xf16>, vector<8xf16>, vector<8xf16>, vector<8xf16>)
+//      CHECK:     scf.for %{{.*}} = %c0 to %c320 step %c4
+// CHECK-SAME:         -> (vector<8xf16>, vector<8xf16>, vector<8xf16>, vector<8xf16>)
+
+// CHECK-COUNT-32: vector.fma
+
+// CHECK-COUNT-3: scf.yield
+
+// CHECK-COUNT-4: vector.transfer_read {{.+}} vector<8xf16>
+// CHECK-COUNT-8: arith.divf {{.+}} : vector<4xf16>
+// CHECK-COUNT-4: vector.transfer_write {{.+}} : vector<8xf16>
+
+// CHECK-COUNT-3: scf.yield


### PR DESCRIPTION
To achieve the best memory transaction pattern, we need to load/store 128-bits each time. For 32-bit values, that means 4 elements. But for 16-bit values, we'd want to increase to 8 elements.

This commit adjust convolution configuration deduction to factor in elementwise bitwidth and use 8 elements for fp16.

Also to handle non-unit batch cases better, we extend tiling at the thread level to materialize a loop for the N dimension. This avoids seeing rank reducing slices where we have inner unit dimensions dropped.