### PR TITLE
Add mmperf workflow

### DIFF
--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -15,7 +15,6 @@ name: mmperf
 
 on:
   workflow_dispatch:
-  pull_request:
 
 env:
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
@@ -80,7 +79,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
-          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cpu"
+          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cpu" "${IREE_SHA}"
       - name: "Running mmperf on CPU"
         run: |
           mkdir ${RESULTS_DIR}
@@ -115,7 +114,7 @@ jobs:
         run: |
           ./build_tools/github_actions/docker_run.sh \
             gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
-          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cuda"
+          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cuda" "${IREE_SHA}"
       - name: "Removing unused files"
         run: |
           find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -51,7 +51,7 @@ jobs:
           git log --oneline --graph --max-count=3
           ./build_tools/github_actions/configure_ci.py
 
-  build_cpu:
+  benchmark_cpu:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
@@ -63,10 +63,8 @@ jobs:
     env:
       MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
       BUILD_DIR: mmperf-build-cpu
-    outputs:
-      build-dir: ${{ env.BUILD_DIR }}
-      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
+      RESULTS_DIR: mmperf-results-cpu
+      RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cpu"
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -75,31 +73,21 @@ jobs:
       - name: "Building mmperf for CPU"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
+            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
           ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cpu"
-      - name: "Removing unused files"
+      - name: "Running mmperf on CPU"
         run: |
-          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
-            -print \
-            -delete
-      - name: "Creating build dir archive"
-        id: archive
-        env:
-          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
+          mkdir ${RESULTS_DIR}
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${RESULTS_DIR}"
+      - name: "Uploading results"
         run: |
-          tar -I 'zstd -T0' \
-            -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
-          echo "::set-output name=build-dir-archive::${BUILD_DIR_ARCHIVE}"
-      - name: "Uploading build dir archive"
-        id: upload
-        env:
-          BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
-          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
-        run: |
-          gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
-          echo "::set-output name=build-dir-gcs-artifact::${BUILD_DIR_GCS_ARTIFACT}"
+          export GCS_DIR_NAME="$(date +'%Y-%m-%d').$(date +'%s')"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/**" "${RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/matmul.png" "${RESULTS_GCS_UPLOAD_DIR}/matmul.png"
 
-  build_cuda:
+  benchmark_cuda:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
@@ -111,10 +99,8 @@ jobs:
     env:
       MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
       BUILD_DIR: mmperf-build-cuda
-    outputs:
-      build-dir: ${{ env.BUILD_DIR }}
-      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
+      RESULTS_DIR: mmperf-results-cuda
+      RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cuda"
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -123,100 +109,18 @@ jobs:
       - name: "Building mmperf for CUDA"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
+          --gpus all \
+            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
           ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cuda"
-      - name: "Removing unused files"
-        run: |
-          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
-            -print \
-            -delete
-      - name: "Creating build dir archive"
-        id: archive
-        env:
-          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
-        run: |
-          tar -I 'zstd -T0' \
-            -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
-          echo "::set-output name=build-dir-archive::${BUILD_DIR_ARCHIVE}"
-      - name: "Uploading build dir archive"
-        id: upload
-        env:
-          BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
-          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
-        run: |
-          gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
-          echo "::set-output name=build-dir-gcs-artifact::${BUILD_DIR_GCS_ARTIFACT}"
-
-  benchmark_cpu:
-    needs: [setup, build_cpu]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
-      MMPERF_RESULTS_DIR: mmperf-results-cpu
-      MMPERF_RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cpu"
-      BUILD_DIR: ${{ needs.build_cpu.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_cpu.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_cpu.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
-        with:
-          submodules: true
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Running mmperf on CPU"
-        run: |
-          mkdir ${MMPERF_RESULTS_DIR}
-          ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${MMPERF_RESULTS_DIR}"
-      - name: "Uploading results"
-        run: |
-          export GCS_DIR_NAME="$(date +'%Y-%m-%d').$(date +'%s')"
-          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/**" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
-          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/matmul.png" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/matmul.png"
-
-  benchmark_cuda:
-    needs: [setup, build_cuda]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
-      - os-family=Linux
-    env:
-      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
-      MMPERF_RESULTS_DIR: mmperf-results-cuda
-      MMPERF_RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cuda"
-      BUILD_DIR: ${{ needs.build_cuda.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_cuda.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_cuda.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
-        with:
-          submodules: true
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Running mmperf on CUDA"
         run: |
-          mkdir ${MMPERF_RESULTS_DIR}
+          mkdir ${RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${MMPERF_RESULTS_DIR}"
+          --gpus all \
+            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${RESULTS_DIR}"
       - name: "Uploading results"
         run: |
           export GCS_DIR_NAME="$(date +'%Y-%m-%d').$(date +'%s')"
-          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/**" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
-          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/matmul.png" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/matmul.png"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/**" "${RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/matmul.png" "${RESULTS_GCS_UPLOAD_DIR}/matmul.png"

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -1,3 +1,16 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Workflow for running `mmperf` (https://github.com/mmperf/mmperf).
+# `mmperf` benchmarks matrix-multiply workloads on IREE and other backends such
+# as RUY, TVM, Halide, CuBLAS, etc.
+#
+# The workflow runs benchmarks on CPU and GPU and uploads results to the
+# `mmperf-benchmark-artifacts` GC bucket.
+
 name: mmperf
 
 on:

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -29,9 +29,9 @@ jobs:
       BASE_REF: HEAD^
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
-      MMPERF_REPO_DIR: "/usr/local/src/mmperf/mmperf"
     outputs:
-      mmperf-repo-dir: ${{ env.MMPERF_REPO_DIR }}
+      iree-sha: ${{ steps.iree.outputs.iree-sha }}
+      artifact-upload-dir: ${{ steps.iree.outputs.artifact-upload-dir }}
       should-run: ${{ steps.configure.outputs.should-run }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
@@ -50,6 +50,13 @@ jobs:
           # https://github.com/nektos/act where there will be more.
           git log --oneline --graph --max-count=3
           ./build_tools/github_actions/configure_ci.py
+      - name: "Calculating version info"
+        id: iree
+        run: |
+          export IREE_SHA=$(git rev-parse --short=4 HEAD)
+          echo "iree-sha=${IREE_SHA}" >> $GITHUB_OUTPUT
+          export GCS_ARTIFACT_DIR="$(date +'%Y-%m-%d').sha_${IREE_SHA}.timestamp_$(date +'%s')"
+          echo "artifact-upload-dir=${GCS_ARTIFACT_DIR}" >> $GITHUB_OUTPUT
 
   build_and_benchmark_cpu:
     needs: setup
@@ -61,31 +68,29 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
+      IREE_SHA: ${{ needs.setup.outputs.iree-sha }}
       BUILD_DIR: mmperf-build-cpu
       RESULTS_DIR: mmperf-results-cpu
-      RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cpu"
+      GCS_UPLOAD_PARENT_DIR: "gs://mmperf-benchmark-artifacts/cpu"
+      GCS_UPLOAD_DIR_NAME: ${{ needs.setup.outputs.artifact-upload-dir }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
-        with:
-          submodules: true
       - name: "Building mmperf for CPU"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
-          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cpu"
+            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cpu"
       - name: "Running mmperf on CPU"
         run: |
           mkdir ${RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${RESULTS_DIR}"
+            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${BUILD_DIR}" "${RESULTS_DIR}"
       - name: "Uploading results"
         run: |
-          export GCS_DIR_NAME="$(date +'%Y-%m-%d').$(date +'%s')"
-          gcloud alpha storage cp "${RESULTS_DIR}/latest/**" "${RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
-          gcloud alpha storage cp "${RESULTS_DIR}/latest/matmul.png" "${RESULTS_GCS_UPLOAD_DIR}/matmul.png"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/**" "${GCS_UPLOAD_PARENT_DIR}/${GCS_UPLOAD_DIR_NAME}/"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/matmul.png" "${GCS_UPLOAD_PARENT_DIR}/matmul.png"
 
   build_cuda:
     needs: setup
@@ -97,7 +102,7 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
+      IREE_SHA: ${{ needs.setup.outputs.iree-sha }}
       BUILD_DIR: mmperf-build-cuda
     outputs:
       build-dir: ${{ env.BUILD_DIR }}
@@ -106,13 +111,11 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
-        with:
-          submodules: true
       - name: "Building mmperf for CUDA"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
-          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cuda"
+            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cuda"
       - name: "Removing unused files"
         run: |
           find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
@@ -145,17 +148,15 @@ jobs:
       - gpu
       - os-family=Linux
     env:
-      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
       RESULTS_DIR: mmperf-results-cuda
-      RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cuda"
+      GCS_UPLOAD_PARENT_DIR: "gs://mmperf-benchmark-artifacts/cuda"
+      GCS_UPLOAD_DIR_NAME: ${{ needs.setup.outputs.artifact-upload-dir }}
       BUILD_DIR: ${{ needs.build_cuda.outputs.build-dir }}
       BUILD_DIR_ARCHIVE: ${{ needs.build_cuda.outputs.build-dir-archive }}
       BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_cuda.outputs.build-dir-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
-        with:
-          submodules: true
       - name: "Downloading build dir archive"
         run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting build dir archive"
@@ -165,10 +166,10 @@ jobs:
           mkdir ${RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
           --gpus all \
-            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${RESULTS_DIR}"
+            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${BUILD_DIR}" "${RESULTS_DIR}"
       - name: "Uploading results"
         run: |
           export GCS_DIR_NAME="$(date +'%Y-%m-%d').$(date +'%s')"
-          gcloud alpha storage cp "${RESULTS_DIR}/latest/**" "${RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
-          gcloud alpha storage cp "${RESULTS_DIR}/latest/matmul.png" "${RESULTS_GCS_UPLOAD_DIR}/matmul.png"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/**" "${GCS_UPLOAD_PARENT_DIR}/${GCS_UPLOAD_DIR_NAME}/"
+          gcloud alpha storage cp "${RESULTS_DIR}/latest/matmul.png" "${GCS_UPLOAD_PARENT_DIR}/matmul.png"

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -51,7 +51,7 @@ jobs:
           git log --oneline --graph --max-count=3
           ./build_tools/github_actions/configure_ci.py
 
-  benchmark_cpu:
+  build_and_benchmark_cpu:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
@@ -87,8 +87,56 @@ jobs:
           gcloud alpha storage cp "${RESULTS_DIR}/latest/**" "${RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
           gcloud alpha storage cp "${RESULTS_DIR}/latest/matmul.png" "${RESULTS_GCS_UPLOAD_DIR}/matmul.png"
 
-  benchmark_cuda:
+  build_cuda:
     needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
+      BUILD_DIR: mmperf-build-cuda
+    outputs:
+      build-dir: ${{ env.BUILD_DIR }}
+      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
+      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          submodules: true
+      - name: "Building mmperf for CUDA"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
+          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cuda"
+      - name: "Removing unused files"
+        run: |
+          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
+            -print \
+            -delete
+      - name: "Creating build dir archive"
+        id: archive
+        env:
+          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
+        run: |
+          tar -I 'zstd -T0' \
+            -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
+          echo "::set-output name=build-dir-archive::${BUILD_DIR_ARCHIVE}"
+      - name: "Uploading build dir archive"
+        id: upload
+        env:
+          BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
+          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
+        run: |
+          gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
+          echo "::set-output name=build-dir-gcs-artifact::${BUILD_DIR_GCS_ARTIFACT}"
+
+  benchmark_cuda:
+    needs: [setup, build_cuda]
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
@@ -98,20 +146,20 @@ jobs:
       - os-family=Linux
     env:
       MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
-      BUILD_DIR: mmperf-build-cuda
       RESULTS_DIR: mmperf-results-cuda
       RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cuda"
+      BUILD_DIR: ${{ needs.build_cuda.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_cuda.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_cuda.outputs.build-dir-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
-      - name: "Building mmperf for CUDA"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-          --gpus all \
-            gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced \
-          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cuda"
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
       - name: "Running mmperf on CUDA"
         run: |
           mkdir ${RESULTS_DIR}

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -28,10 +28,8 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
     outputs:
       should-run: ${{ steps.configure.outputs.should-run }}
-      ci-stage: ${{ steps.configure.outputs.ci-stage }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
-      write-caches: ${{ steps.configure.outputs.write-caches }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -58,8 +56,10 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      MMPERF_RESULTS_DIR: mmperf-results
-      GCS_UPLOAD_DIR: gs://mmperf-benchmark-artifacts
+      MMPERF_REPO_DIR: "/usr/local/src/mmperf/mmperf"
+      MMPERF_BUILD_DIR: "/usr/local/src/mmperf/mmperf-build-cpu"
+      MMPERF_RESULTS_DIR: "mmperf-results-cpu"
+      GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cpu"
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -69,12 +69,15 @@ jobs:
         run: |
           mkdir ${MMPERF_RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:e563ead2db6f7c28a4fb815fe14444d38e40c49ba5b37b0d6dba741825570632 \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_RESULTS_DIR}" "cpu"
+            gcr.io/iree-oss/mmperf@sha256:804448959a4045f390d349cd8913d26556d7b93164aa6e85c2d1b4747a43b9ca \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${MMPERF_BUILD_DIR}" "${MMPERF_RESULTS_DIR}" "cpu"
       - name: "Uploading artifacts"
         run: |
-          export DIR_NAME=`ls -lat ${MMPERF_RESULTS_DIR}/latest | awk '{print $NF}'`
-          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/${DIR_NAME}/**" "${GCS_UPLOAD_DIR}/cpu/${DIR_NAME}/"
+          pushd ${MMPERF_REPO_DIR}/external/iree
+          export IREE_SHA="$(git rev-parse --short=4 HEAD)"
+          popd
+          export GCS_DIR_NAME="$(date +'%Y-%m-%d').sha_${IREE_SHA}.timestamp_$(date +'%s')"
+          gcloud storage cp ${MMPERF_RESULTS_DIR}/latest/**" "${GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
 
   benchmark_cuda:
     needs: setup
@@ -86,8 +89,10 @@ jobs:
       - gpu
       - os-family=Linux
     env:
-      MMPERF_RESULTS_DIR: mmperf-results
-      GCS_UPLOAD_DIR: gs://mmperf-benchmark-artifacts
+      MMPERF_REPO_DIR: "/usr/local/src/mmperf/mmperf"
+      MMPERF_BUILD_DIR: "/usr/local/src/mmperf/mmperf-build-cuda"
+      MMPERF_RESULTS_DIR: "mmperf-results-cuda"
+      GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cuda"
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -98,9 +103,12 @@ jobs:
           mkdir ${MMPERF_RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
             --gpus all \
-            gcr.io/iree-oss/mmperf@sha256:e563ead2db6f7c28a4fb815fe14444d38e40c49ba5b37b0d6dba741825570632 \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_RESULTS_DIR}" "cuda"
+            gcr.io/iree-oss/mmperf@sha256:804448959a4045f390d349cd8913d26556d7b93164aa6e85c2d1b4747a43b9ca \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${MMPERF_BUILD_DIR}" "${MMPERF_RESULTS_DIR}" "cuda"
       - name: "Uploading artifacts"
         run: |
-          export DIR_NAME=`ls -lat ${MMPERF_RESULTS_DIR}/latest | awk '{print $NF}'`
-          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/${DIR_NAME}/**" "${GCS_UPLOAD_DIR}/cuda/${DIR_NAME}/"
+          pushd ${MMPERF_REPO_DIR}/external/iree
+          export IREE_SHA="$(git rev-parse --short=4 HEAD)"
+          popd
+          export GCS_DIR_NAME="$(date +'%Y-%m-%d').sha_${IREE_SHA}.timestamp_$(date +'%s')"
+          gcloud alpha storage cp ${MMPERF_RESULTS_DIR}/latest/**" "${GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -17,6 +17,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+env:
+  GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
+
 jobs:
   setup:
     runs-on: ubuntu-20.04
@@ -26,7 +29,9 @@ jobs:
       BASE_REF: HEAD^
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
+      MMPERF_REPO_DIR: "/usr/local/src/mmperf/mmperf"
     outputs:
+      mmperf-repo-dir: ${{ env.MMPERF_REPO_DIR }}
       should-run: ${{ steps.configure.outputs.should-run }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
@@ -46,7 +51,7 @@ jobs:
           git log --oneline --graph --max-count=3
           ./build_tools/github_actions/configure_ci.py
 
-  benchmark_cpu:
+  build_cpu:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
@@ -56,30 +61,45 @@ jobs:
       - cpu
       - os-family=Linux
     env:
-      MMPERF_REPO_DIR: "/usr/local/src/mmperf/mmperf"
-      MMPERF_BUILD_DIR: "/usr/local/src/mmperf/mmperf-build-cpu"
-      MMPERF_RESULTS_DIR: "mmperf-results-cpu"
-      GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cpu"
+      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
+      BUILD_DIR: mmperf-build-cpu
+    outputs:
+      build-dir: ${{ env.BUILD_DIR }}
+      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
+      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
-      - name: "Running mmperf on CPU"
+      - name: "Building mmperf for CPU"
         run: |
-          mkdir ${MMPERF_RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:804448959a4045f390d349cd8913d26556d7b93164aa6e85c2d1b4747a43b9ca \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${MMPERF_BUILD_DIR}" "${MMPERF_RESULTS_DIR}" "cpu"
-      - name: "Uploading artifacts"
+            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
+          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cpu"
+      - name: "Removing unused files"
         run: |
-          pushd ${MMPERF_REPO_DIR}/external/iree
-          export IREE_SHA="$(git rev-parse --short=4 HEAD)"
-          popd
-          export GCS_DIR_NAME="$(date +'%Y-%m-%d').sha_${IREE_SHA}.timestamp_$(date +'%s')"
-          gcloud storage cp ${MMPERF_RESULTS_DIR}/latest/**" "${GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
+          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
+            -print \
+            -delete
+      - name: "Creating build dir archive"
+        id: archive
+        env:
+          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
+        run: |
+          tar -I 'zstd -T0' \
+            -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
+          echo "::set-output name=build-dir-archive::${BUILD_DIR_ARCHIVE}"
+      - name: "Uploading build dir archive"
+        id: upload
+        env:
+          BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
+          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
+        run: |
+          gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
+          echo "::set-output name=build-dir-gcs-artifact::${BUILD_DIR_GCS_ARTIFACT}"
 
-  benchmark_cuda:
+  build_cuda:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
@@ -89,26 +109,114 @@ jobs:
       - gpu
       - os-family=Linux
     env:
-      MMPERF_REPO_DIR: "/usr/local/src/mmperf/mmperf"
-      MMPERF_BUILD_DIR: "/usr/local/src/mmperf/mmperf-build-cuda"
-      MMPERF_RESULTS_DIR: "mmperf-results-cuda"
-      GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cuda"
+      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
+      BUILD_DIR: mmperf-build-cuda
+    outputs:
+      build-dir: ${{ env.BUILD_DIR }}
+      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
+      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
         with:
           submodules: true
-      - name: "Running mmperf on GPU"
+      - name: "Building mmperf for CUDA"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
+          ./build_tools/benchmarks/mmperf/build_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "cuda"
+      - name: "Removing unused files"
+        run: |
+          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
+            -print \
+            -delete
+      - name: "Creating build dir archive"
+        id: archive
+        env:
+          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
+        run: |
+          tar -I 'zstd -T0' \
+            -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
+          echo "::set-output name=build-dir-archive::${BUILD_DIR_ARCHIVE}"
+      - name: "Uploading build dir archive"
+        id: upload
+        env:
+          BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
+          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
+        run: |
+          gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
+          echo "::set-output name=build-dir-gcs-artifact::${BUILD_DIR_GCS_ARTIFACT}"
+
+  benchmark_cpu:
+    needs: [setup, build_cpu]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
+      MMPERF_RESULTS_DIR: mmperf-results-cpu
+      MMPERF_RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cpu"
+      BUILD_DIR: ${{ needs.build_cpu.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_cpu.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_cpu.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          submodules: true
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Running mmperf on CPU"
         run: |
           mkdir ${MMPERF_RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
-            --gpus all \
-            gcr.io/iree-oss/mmperf@sha256:804448959a4045f390d349cd8913d26556d7b93164aa6e85c2d1b4747a43b9ca \
-          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${MMPERF_BUILD_DIR}" "${MMPERF_RESULTS_DIR}" "cuda"
-      - name: "Uploading artifacts"
+            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${MMPERF_RESULTS_DIR}"
+      - name: "Uploading results"
         run: |
-          pushd ${MMPERF_REPO_DIR}/external/iree
-          export IREE_SHA="$(git rev-parse --short=4 HEAD)"
-          popd
-          export GCS_DIR_NAME="$(date +'%Y-%m-%d').sha_${IREE_SHA}.timestamp_$(date +'%s')"
-          gcloud alpha storage cp ${MMPERF_RESULTS_DIR}/latest/**" "${GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
+          export GCS_DIR_NAME="$(date +'%Y-%m-%d').$(date +'%s')"
+          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/**" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
+          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/matmul.png" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/matmul.png"
+
+  benchmark_cuda:
+    needs: [setup, build_cuda]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - gpu
+      - os-family=Linux
+    env:
+      MMPERF_REPO_DIR: ${{ needs.setup.outputs.mmperf-repo-dir }}
+      MMPERF_RESULTS_DIR: mmperf-results-cuda
+      MMPERF_RESULTS_GCS_UPLOAD_DIR: "gs://mmperf-benchmark-artifacts/cuda"
+      BUILD_DIR: ${{ needs.build_cuda.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_cuda.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_cuda.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          submodules: true
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Running mmperf on CUDA"
+        run: |
+          mkdir ${MMPERF_RESULTS_DIR}
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_REPO_DIR}" "${BUILD_DIR}" "${MMPERF_RESULTS_DIR}"
+      - name: "Uploading results"
+        run: |
+          export GCS_DIR_NAME="$(date +'%Y-%m-%d').$(date +'%s')"
+          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/**" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/${GCS_DIR_NAME}/"
+          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/latest/matmul.png" "${MMPERF_RESULTS_GCS_UPLOAD_DIR}/matmul.png"

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -1,0 +1,93 @@
+name: mmperf
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  setup:
+    runs-on: ubuntu-20.04
+    env:
+      # The commit being checked out is the merge commit for the PR. Its first
+      # parent will be the tip of main.
+      BASE_REF: HEAD^
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+    outputs:
+      should-run: ${{ steps.configure.outputs.should-run }}
+      ci-stage: ${{ steps.configure.outputs.ci-stage }}
+      runner-env: ${{ steps.configure.outputs.runner-env }}
+      runner-group: ${{ steps.configure.outputs.runner-group }}
+      write-caches: ${{ steps.configure.outputs.write-caches }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          # We need the parent commit to do a diff
+          fetch-depth: 2
+      - name: "Configuring CI options"
+        id: configure
+        run: |
+          # Just informative logging. There should only be two commits in the
+          # history here, but limiting the depth helps when copying from a local
+          # repo instead of using checkout, e.g. with
+          # https://github.com/nektos/act where there will be more.
+          git log --oneline --graph --max-count=3
+          ./build_tools/github_actions/configure_ci.py
+
+  benchmark_cpu:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      MMPERF_RESULTS_DIR: mmperf-results
+      GCS_UPLOAD_DIR: gs://mmperf-benchmark-artifacts
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          submodules: true
+      - name: "Running mmperf on CPU"
+        run: |
+          mkdir ${MMPERF_RESULTS_DIR}
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/mmperf@sha256:e563ead2db6f7c28a4fb815fe14444d38e40c49ba5b37b0d6dba741825570632 \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_RESULTS_DIR}" "cpu"
+      - name: "Uploading artifacts"
+        run: |
+          export DIR_NAME=`ls -lat ${MMPERF_RESULTS_DIR}/latest | awk '{print $NF}'`
+          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/${DIR_NAME}/**" "${GCS_UPLOAD_DIR}/cpu/${DIR_NAME}/"
+
+  benchmark_cuda:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - gpu
+      - os-family=Linux
+    env:
+      MMPERF_RESULTS_DIR: mmperf-results
+      GCS_UPLOAD_DIR: gs://mmperf-benchmark-artifacts
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+        with:
+          submodules: true
+      - name: "Running mmperf on GPU"
+        run: |
+          mkdir ${MMPERF_RESULTS_DIR}
+          ./build_tools/github_actions/docker_run.sh \
+            --gpus all \
+            gcr.io/iree-oss/mmperf@sha256:e563ead2db6f7c28a4fb815fe14444d38e40c49ba5b37b0d6dba741825570632 \
+          ./build_tools/benchmarks/mmperf/run_mmperf.sh "${MMPERF_RESULTS_DIR}" "cuda"
+      - name: "Uploading artifacts"
+        run: |
+          export DIR_NAME=`ls -lat ${MMPERF_RESULTS_DIR}/latest | awk '{print $NF}'`
+          gcloud alpha storage cp "${MMPERF_RESULTS_DIR}/${DIR_NAME}/**" "${GCS_UPLOAD_DIR}/cuda/${DIR_NAME}/"

--- a/build_tools/benchmarks/mmperf/build_mmperf.sh
+++ b/build_tools/benchmarks/mmperf/build_mmperf.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Builds `mmperf` (https://github.com/mmperf/mmperf).
+#
+# `mmperf` benchmarks matrix-multiply workloads on IREE and other backends such
+# as RUY, TVM, Halide, CuBLAS, etc. Some backends are included as submodules
+# in the `mmperf` repo and built from source, and other backends are expected
+# to already be installed.
+#
+# Please refer to `build_tools/docker/mmperf/Dockerfile` for commands on
+# installing various backends.
+#
+# Currently x86 CPU and CUDA are supported.
+#
+# Usage:
+#    ./run_mmperf.sh \
+#        <mmperf repo dir> \
+#        <mmperf build dir> \
+#        <backend> e.g. "cpu", "cuda".
+
+set -xeuo pipefail
+
+export REPO_DIR=$1
+export BUILD_DIR=$2
+# Either `cpu` or `cuda`.
+export BACKEND=$3
+
+pushd ${REPO_DIR}
+
+# Set all repos as a safe directory. Since this repo was created in the
+# DockerFile under `root`, git will not run commands on this repo as a
+# non-root user unless it is marked safe.
+for i in $(find ${REPO_DIR} -name '.git' | xargs dirname); do
+  git config --global --add safe.directory $i
+done
+
+source mmperf.venv/bin/activate
+
+# Update IREE.
+pushd external/iree
+git restore .
+git submodule foreach --recursive git restore .
+git fetch
+git checkout origin/main
+git submodule update --init --jobs 8 --depth 1
+popd
+
+popd
+
+# Build mmperf.
+if [ ${BACKEND} == "cuda" ]; then
+  cmake \
+    -GNinja \
+    -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+    -DCMAKE_C_COMPILER=/usr/bin/clang \
+    -DUSE_IREE=ON \
+    -DIREE_CUDA=ON \
+    -DUSE_CUBLAS=ON \
+    -B ${BUILD_DIR} ${REPO_DIR}
+else
+  MKL_DIR=/opt/intel/mkl BLIS_DIR=/opt/blis cmake \
+    -GNinja \
+    -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+    -DCMAKE_C_COMPILER=/usr/bin/clang \
+    -DMKL_DIR=/opt/intel/mkl \
+    -DBLIS_DIR=/opt/blis \
+    -DUSE_MKL=ON \
+    -DUSE_RUY=ON \
+    -DUSE_IREE=ON \
+    -DIREE_LLVMCPU=ON \
+    -DUSE_HALIDE=ON \
+    -DUSE_OPENBLAS=ON \
+    -DUSE_BLIS=ON \
+    -DUSE_TVM=ON \
+    -B ${BUILD_DIR} ${REPO_DIR}
+fi
+
+cmake --build ${BUILD_DIR} --verbose

--- a/build_tools/benchmarks/mmperf/run_mmperf.sh
+++ b/build_tools/benchmarks/mmperf/run_mmperf.sh
@@ -73,7 +73,7 @@ MKL_DIR=/opt/intel/mkl BLIS_DIR=/opt/blis cmake \
   -DUSE_TVM=ON \
   -B ../mmperf-build .
 fi
-cmake --build ../mmperf-build -j32 --verbose
+cmake --build ../mmperf-build --verbose
 
 # Run benchmark.
 popd

--- a/build_tools/benchmarks/mmperf/run_mmperf.sh
+++ b/build_tools/benchmarks/mmperf/run_mmperf.sh
@@ -18,15 +18,15 @@
 #
 # Usage:
 #    ./run_mmperf.sh \
-#        <mmperf repo dir> \
 #        <mmperf build dir> \
-#        <results directory>
+#        <results directory> \
+#        <mmperf repo dir> (optional)
 
 set -xeuo pipefail
 
-export REPO_DIR=$1
-export BUILD_DIR=$2
-export REPORT_DIR=$3
+export BUILD_DIR=$1
+export REPORT_DIR=$2
+export REPO_DIR=${3:-${MMPERF_REPO_DIR}}
 
 source ${REPO_DIR}/mmperf.venv/bin/activate
 

--- a/build_tools/benchmarks/mmperf/run_mmperf.sh
+++ b/build_tools/benchmarks/mmperf/run_mmperf.sh
@@ -31,4 +31,4 @@ export REPORT_DIR=$3
 source ${REPO_DIR}/mmperf.venv/bin/activate
 
 # Run benchmark.
-python3 ${REPO_DIR}/mmperf.py ${BUILD_DIR}/matmul ${REPORT_DIR}
+python3 ${REPO_DIR}/mmperf.py ${BUILD_DIR}/matmul/ ${REPORT_DIR}

--- a/build_tools/benchmarks/mmperf/run_mmperf.sh
+++ b/build_tools/benchmarks/mmperf/run_mmperf.sh
@@ -16,69 +16,19 @@
 # Please refer to `build_tools/docker/mmperf/Dockerfile` for commands on
 # installing various backends.
 #
-# Currently x86 CPU and CUDA are supported. Benchmarks are run directly on the
-# machine the script is executed on.
-#
 # Usage:
 #    ./run_mmperf.sh \
 #        <mmperf repo dir> \
 #        <mmperf build dir> \
-#        <results directory> \
-#        <backend> e.g. "cpu", "cuda".
+#        <results directory>
 
 set -xeuo pipefail
 
 export REPO_DIR=$1
 export BUILD_DIR=$2
 export REPORT_DIR=$3
-# Either `cpu` or `cuda`.
-export BACKEND=$4
 
-pushd ${REPO_DIR}
-# Set all repos as a safe directory.
-for i in $(find ${REPO_DIR} -name '.git' | xargs dirname); do
-  git config --global --add safe.directory $i
-done
-
-source mmperf.venv/bin/activate
-
-# Update IREE.
-pushd external/iree
-git restore .
-git submodule foreach --recursive git restore .
-git fetch
-git checkout origin/main
-git submodule update --init --jobs 8 --depth 1
-popd
-
-# Build mmperf.
-if [ ${BACKEND} == "cuda" ]; then
-  cmake \
-    -GNinja \
-    -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
-    -DCMAKE_C_COMPILER=/usr/bin/clang \
-    -DUSE_IREE=ON \
-    -DIREE_CUDA=ON \
-    -DUSE_CUBLAS=ON \
-    -B ${BUILD_DIR} .
-else
-  MKL_DIR=/opt/intel/mkl BLIS_DIR=/opt/blis cmake \
-    -GNinja \
-    -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
-    -DCMAKE_C_COMPILER=/usr/bin/clang \
-    -DMKL_DIR=/opt/intel/mkl \
-    -DBLIS_DIR=/opt/blis \
-    -DUSE_MKL=ON \
-    -DUSE_RUY=ON \
-    -DUSE_IREE=ON \
-    -DIREE_LLVMCPU=ON \
-    -DUSE_HALIDE=ON \
-    -DUSE_OPENBLAS=ON \
-    -DUSE_BLIS=ON \
-    -DUSE_TVM=ON \
-    -B ${BUILD_DIR} .
-fi
-cmake --build ${BUILD_DIR} --verbose
+source ${REPO_DIR}/mmperf.venv/bin/activate
 
 # Run benchmark.
-python3 mmperf.py ${BUILD_DIR}/matmul ${REPORT_DIR}
+python3 ${REPO_DIR}/mmperf.py ${BUILD_DIR}/matmul ${REPORT_DIR}

--- a/build_tools/benchmarks/mmperf/run_mmperf.sh
+++ b/build_tools/benchmarks/mmperf/run_mmperf.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Runs SHARK tank using both SHARK-Runtime and IREE-Runtime, producing benchmark
+# numbers.
+#
+# Usage:
+#    ./run_shark.sh \
+#        <SHA of https://github.com/nod-ai/SHARK.git to pin to> \
+#        <pytest regex> e.g. "cpu", "cuda", "cuda and torch".
+#        <driver> e.g. "cpu", "cuda", "vulkan"
+#        <output directory>
+
+set -xeuo pipefail
+
+export REPORT_DIR=$1
+# Either `cpu` or `cuda`.
+export BACKEND=$2
+
+git clone https://github.com/mmperf/mmperf.git
+cd mmperf
+
+# Update IREE.
+cd external/iree
+git fetch --all
+git checkout origin/main
+git submodule update --init --recursive
+cd -
+
+# Create virtual environment.
+python3 -m venv mmperf.venv
+source mmperf.venv/bin/activate
+pip install -r requirements.txt
+pip install -r ./external/llvm-project/mlir/python/requirements.txt
+pip install requests
+
+# Build mmperf.
+if [ ${BACKEND} == "cuda" ]; then
+cmake \
+  -GNinja \
+  -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+  -DCMAKE_C_COMPILER=/usr/bin/clang \
+  -DUSE_IREE=ON \
+  -DIREE_CUDA=ON \
+  -DUSE_CUBLAS=ON \
+  -B ../mmperf-build .
+else
+MKL_DIR=/opt/intel/mkl BLIS_DIR=/opt/blis cmake \
+  -GNinja \
+  -DCMAKE_CXX_COMPILER=/usr/bin/clang++ \
+  -DCMAKE_C_COMPILER=/usr/bin/clang \
+  -DMKL_DIR=/opt/intel/mkl \
+  -DBLIS_DIR=/opt/blis \
+  -DUSE_MKL=ON \
+  -DUSE_RUY=ON \
+  -DUSE_IREE=ON \
+  -DIREE_LLVMCPU=ON \
+  -DUSE_HALIDE=ON \
+  -DUSE_OPENBLAS=ON \
+  -DUSE_BLIS=ON \
+  -DUSE_TVM=ON \
+  -B ../mmperf-build .
+fi
+cmake --build ../mmperf-build -j32 --verbose
+
+# Run benchmark.
+cd ../
+python3 mmperf/mmperf.py ./mmperf-build/matmul/ ${REPORT_DIR}

--- a/build_tools/docker/context/setup_mmperf.sh
+++ b/build_tools/docker/context/setup_mmperf.sh
@@ -15,15 +15,20 @@
 #
 # Usage:
 #    ./setup_mmperf.sh \
-#        <mmperf repo dir>
+#        <mmperf repo dir> \
+#        <mmperf sha>
 
 set -xeuo pipefail
 
 export REPO_DIR=$1
+export REPO_SHA=$2
 
 pushd ${REPO_DIR}
 git clone --recurse-submodules https://github.com/mmperf/mmperf.git
 pushd mmperf
+
+# Checkout a specific commit.
+git checkout ${REPO_SHA}
 
 # Create virtual environment.
 python3 -m venv mmperf.venv

--- a/build_tools/docker/context/setup_mmperf.sh
+++ b/build_tools/docker/context/setup_mmperf.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# Sets up `mmperf` (https://github.com/mmperf/mmperf).
+#
+# `mmperf` benchmarks matrix-multiply workloads on IREE and other backends such
+# as RUY, TVM, Halide, CuBLAS, etc. Some backends are included as submodules
+# in the `mmperf` repo and built from source, and other backends are expected
+# to already be installed.
+#
+# Usage:
+#    ./setup_mmperf.sh \
+#        <mmperf repo dir>
+
+set -xeuo pipefail
+
+export REPO_DIR=$1
+
+pushd ${REPO_DIR}
+git clone --recurse-submodules https://github.com/mmperf/mmperf.git
+pushd mmperf
+
+# Create virtual environment.
+python3 -m venv mmperf.venv
+source mmperf.venv/bin/activate
+pip install -r requirements.txt
+pip install -r ./external/llvm-project/mlir/python/requirements.txt
+
+# Since we are updating the IREE repo at each run, make sure there are no local changes.
+pushd external/iree
+git restore .
+git submodule foreach --recursive git restore .
+popd
+
+popd
+
+# Since the root user is used to clone the mmperf repo, we update permissions
+# so that a runner can access this repo.
+chmod -R 777 .

--- a/build_tools/docker/dockerfiles/mmperf.Dockerfile
+++ b/build_tools/docker/dockerfiles/mmperf.Dockerfile
@@ -117,4 +117,4 @@ COPY build_tools/docker/context/setup_mmperf.sh /usr/local/bin
 RUN mkdir -p "/usr/local/src/mmperf" \
     && /usr/local/bin/setup_mmperf.sh "/usr/local/src/mmperf" "ae523a3"
 
-##############
+############## \

--- a/build_tools/docker/dockerfiles/mmperf.Dockerfile
+++ b/build_tools/docker/dockerfiles/mmperf.Dockerfile
@@ -114,6 +114,7 @@ ENV BLIS_DIR="/opt/blis"
 COPY build_tools/docker/context/setup_mmperf.sh /usr/local/bin
 
 # Generate a version of mmperf for CPU.
-RUN mkdir -p "/usr/local/src/mmperf" && /usr/local/bin/setup_mmperf.sh "/usr/local/src/mmperf"
+RUN mkdir -p "/usr/local/src/mmperf" \
+    && /usr/local/bin/setup_mmperf.sh "/usr/local/src/mmperf" "ae523a3"
 
 ##############

--- a/build_tools/docker/dockerfiles/mmperf.Dockerfile
+++ b/build_tools/docker/dockerfiles/mmperf.Dockerfile
@@ -48,21 +48,13 @@ RUN apt-get update \
 ##############
 
 ######## Python ########
-RUN apt-get update \
-  && apt-get install -y \
-    python3.10 \
-    python3.10-dev \
-  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
-  && apt-get install -y \
-    python3-pip \
-    python3-setuptools \
-    python3-distutils \
-    python3-venv \
-    python3.10-venv \
-  && python3 -m pip install --upgrade pip>=21.3 \
-  && python3 -m pip install --upgrade setuptools \
-  && python3 -m pip install --ignore-installed \
-    requests
+WORKDIR /install-python
+
+ARG PYTHON_VERSION=3.10
+
+COPY runtime/bindings/python/iree/runtime/build_requirements.txt build_tools/docker/context/install_python_deps.sh ./
+RUN ./install_python_deps.sh "${PYTHON_VERSION}" \
+  && rm -rf /install-python
 
 ENV PYTHON_BIN /usr/bin/python3
 ##############
@@ -113,8 +105,11 @@ ENV BLIS_DIR="/opt/blis"
 ######## MMPERF ########
 COPY build_tools/docker/context/setup_mmperf.sh /usr/local/bin
 
+ARG MMPERF_SHA="ae523a3"
+
 # Generate a version of mmperf for CPU.
 RUN mkdir -p "/usr/local/src/mmperf" \
-    && /usr/local/bin/setup_mmperf.sh "/usr/local/src/mmperf" "ae523a3"
+    && /usr/local/bin/setup_mmperf.sh "/usr/local/src/mmperf" "${MMPERF_SHA}"
 
+ENV MMPERF_REPO_DIR="/usr/local/src/mmperf/mmperf"
 ############## \

--- a/build_tools/docker/dockerfiles/mmperf.Dockerfile
+++ b/build_tools/docker/dockerfiles/mmperf.Dockerfile
@@ -13,7 +13,8 @@
 # mmperf repo. Later versions of Clang, LLVM, Python and Ubuntu are needed
 # to satisfy the dependency requirements of the backends.
 
-FROM ubuntu:22.04
+# Ubuntu 22.04.
+FROM ubuntu@sha256:817cfe4672284dcbfee885b1a66094fd907630d610cab329114d036716be49ba
 
 ######## Basic ########
 RUN apt-get update \
@@ -87,12 +88,12 @@ RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCT
 WORKDIR /
 
 ENV MKL_DIR="/opt/intel/mkl"
-############## \
+##############
 
 ######## OPENBLAS ########
 RUN apt-get update \
   && apt-get install -y libopenblas-dev
-############## \
+##############
 
 ######## BLIS ########
 WORKDIR /install-blis
@@ -107,4 +108,12 @@ RUN git clone --recurse-submodules https://github.com/flame/blis \
 WORKDIR /
 
 ENV BLIS_DIR="/opt/blis"
-############## \
+##############
+
+######## MMPERF ########
+COPY build_tools/docker/context/setup_mmperf.sh /usr/local/bin
+
+# Generate a version of mmperf for CPU.
+RUN mkdir -p "/usr/local/src/mmperf" && /usr/local/bin/setup_mmperf.sh "/usr/local/src/mmperf"
+
+##############

--- a/build_tools/docker/manage_images.py
+++ b/build_tools/docker/manage_images.py
@@ -50,6 +50,7 @@ IMAGES_TO_DEPENDENCIES = {
     "riscv": ["base"],
     "gradle-android": ["base"],
     "frontends": ["android"],
+    "mmperf": [],
     "shark": [],
     "swiftshader": ["base"],
     "samples": ["swiftshader"],

--- a/build_tools/docker/mmperf/Dockerfile
+++ b/build_tools/docker/mmperf/Dockerfile
@@ -4,7 +4,14 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# An image for running SHARK tank: https://github.com/nod-ai/SHARK.
+# An image for running mmperf: https://github.com/mmperf/mmperf.
+#
+# mmperf benchmarks matrix-multiplication workloads on IREE and various backends
+# such as OpenBLAS, MKL, TVM, Halide, CuBLAS, etc.
+#
+# These backends are included either in this image or as a submodule in the
+# mmperf repo. Later versions of Clang, LLVM, Python and Ubuntu are needed
+# to satisfy the dependency requirements of the backends.
 
 FROM ubuntu:22.04
 

--- a/build_tools/docker/mmperf/Dockerfile
+++ b/build_tools/docker/mmperf/Dockerfile
@@ -1,0 +1,103 @@
+# Copyright 2021 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# An image for running SHARK tank: https://github.com/nod-ai/SHARK.
+
+FROM ubuntu:22.04
+
+######## Basic ########
+RUN apt-get update \
+  && apt-get install -y \
+    git \
+    wget \
+    cmake \
+    curl \
+    ninja-build
+##############
+
+######## Clang/LLVM ########
+RUN apt-get update \
+  && apt-get install -y \
+    llvm-14 \
+    llvm-14-dev \
+    clang-14 \
+    clang-tools-14 \
+    libclang-common-14-dev \
+    libclang-14-dev \
+    libclang1-14 \
+    clang-format-14 \
+    clangd-14 \
+    clang-tidy-14 \
+    lldb-14 \
+    lld-14 \
+    libmlir-14-dev \
+    mlir-14-tools \
+  && ln -s /usr/lib/llvm-14/bin/clang /usr/bin/clang \
+  && ln -s /usr/lib/llvm-14/bin/clang++ /usr/bin/clang++
+##############
+
+######## Python ########
+RUN apt-get update \
+  && apt-get install -y \
+    python3.10 \
+    python3.10-dev \
+  && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 \
+  && apt-get install -y \
+    python3-pip \
+    python3-setuptools \
+    python3-distutils \
+    python3-venv \
+    python3.10-venv \
+  && python3 -m pip install --upgrade pip>=21.3 \
+  && python3 -m pip install --upgrade setuptools \
+  && python3 -m pip install --ignore-installed \
+    requests
+
+ENV PYTHON_BIN /usr/bin/python3
+##############
+
+######## CUDA ########
+RUN apt-get update \
+  && apt-get install -y \
+    nvidia-cuda-toolkit \
+  && mkdir -p "/usr/nvvm/libdevice" \
+  && ln -s "/usr/lib/nvidia-cuda-toolkit/libdevice/libdevice.10.bc" "/usr/nvvm/libdevice/libdevice.10.bc"
+##############
+
+######## MKL ########
+WORKDIR /install-mkl
+
+RUN wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB \
+    && apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB \
+    && sh -c 'echo deb https://apt.repos.intel.com/mkl all main > /etc/apt/sources.list.d/intel-mkl.list' \
+    && apt-get update \
+    && apt-get install -y intel-mkl-64bit-2018.2-046 \
+    && rm -rf /install-mkl
+
+WORKDIR /
+
+ENV MKL_DIR="/opt/intel/mkl"
+############## \
+
+######## OPENBLAS ########
+RUN apt-get update \
+  && apt-get install -y libopenblas-dev
+############## \
+
+######## BLIS ########
+WORKDIR /install-blis
+
+RUN git clone --recurse-submodules https://github.com/flame/blis \
+  && cd blis \
+  && ./configure --prefix=/opt/blis --enable-cblas -c amd64 \
+  && make -j 32 \
+  && make install \
+  && rm -rf /install-blis
+
+WORKDIR /
+
+ENV BLIS_DIR="/opt/blis"
+############## \

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -13,3 +13,4 @@ gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:b3b096e4b96746c3ae4cc52e8800
 gcr.io/iree-oss/shark@sha256:c72ef54dcb6ec485e8a96b0dfc43307875f4c4c7619f7fdc60bf5220a5672259
 gcr.io/iree-oss/base-bleeding-edge@sha256:99a5d6324b464bac19f78cd7fe50c8d5068dde9bf96af18686e91f1356ed586a
 gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:50301f9ccc0bf63c4d498c225444cc5585218612d15b83d06e4f4672ab2dfc03
+gcr.io/iree-oss/mmperf@sha256:e563ead2db6f7c28a4fb815fe14444d38e40c49ba5b37b0d6dba741825570632

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -13,4 +13,4 @@ gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:b3b096e4b96746c3ae4cc52e8800
 gcr.io/iree-oss/shark@sha256:c72ef54dcb6ec485e8a96b0dfc43307875f4c4c7619f7fdc60bf5220a5672259
 gcr.io/iree-oss/base-bleeding-edge@sha256:99a5d6324b464bac19f78cd7fe50c8d5068dde9bf96af18686e91f1356ed586a
 gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:50301f9ccc0bf63c4d498c225444cc5585218612d15b83d06e4f4672ab2dfc03
-gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd
+gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -13,4 +13,4 @@ gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:b3b096e4b96746c3ae4cc52e8800
 gcr.io/iree-oss/shark@sha256:c72ef54dcb6ec485e8a96b0dfc43307875f4c4c7619f7fdc60bf5220a5672259
 gcr.io/iree-oss/base-bleeding-edge@sha256:99a5d6324b464bac19f78cd7fe50c8d5068dde9bf96af18686e91f1356ed586a
 gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:50301f9ccc0bf63c4d498c225444cc5585218612d15b83d06e4f4672ab2dfc03
-gcr.io/iree-oss/mmperf@sha256:804448959a4045f390d349cd8913d26556d7b93164aa6e85c2d1b4747a43b9ca
+gcr.io/iree-oss/mmperf@sha256:1ffc9bfa4618c38d3c2a4ecbf6c4d825106736ff1602bd139bb1cf2005ec23dd

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -13,4 +13,4 @@ gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:b3b096e4b96746c3ae4cc52e8800
 gcr.io/iree-oss/shark@sha256:c72ef54dcb6ec485e8a96b0dfc43307875f4c4c7619f7fdc60bf5220a5672259
 gcr.io/iree-oss/base-bleeding-edge@sha256:99a5d6324b464bac19f78cd7fe50c8d5068dde9bf96af18686e91f1356ed586a
 gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:50301f9ccc0bf63c4d498c225444cc5585218612d15b83d06e4f4672ab2dfc03
-gcr.io/iree-oss/mmperf@sha256:f1b458cb9570e5e70ffbd59d64d365ed818cb3b308d6e42a4cf5807f2c1a9ced
+gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -13,4 +13,4 @@ gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:b3b096e4b96746c3ae4cc52e8800
 gcr.io/iree-oss/shark@sha256:c72ef54dcb6ec485e8a96b0dfc43307875f4c4c7619f7fdc60bf5220a5672259
 gcr.io/iree-oss/base-bleeding-edge@sha256:99a5d6324b464bac19f78cd7fe50c8d5068dde9bf96af18686e91f1356ed586a
 gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:50301f9ccc0bf63c4d498c225444cc5585218612d15b83d06e4f4672ab2dfc03
-gcr.io/iree-oss/mmperf@sha256:e563ead2db6f7c28a4fb815fe14444d38e40c49ba5b37b0d6dba741825570632
+gcr.io/iree-oss/mmperf@sha256:804448959a4045f390d349cd8913d26556d7b93164aa6e85c2d1b4747a43b9ca


### PR DESCRIPTION
Adds a Github workflow and Docker image for running mmperf (https://github.com/mmperf/mmperf). mmperf benchmarks matrix-multiply workloads on IREE and other frameworks such as RUY, TVM, Halide, etc. Reports are uploaded to the mmperf-benchmark-artifacts GC bucket.