### PR TITLE
Make the iree.bufferize transform op not call the IREEComprehensiveBufferizePass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -210,14 +210,7 @@ std::unique_ptr<OperationPass<ModuleOp>> createIREEComprehensiveBufferizePass(
       allocationFn, deallocationFn, memCpyFn);
 }
 
-void addIREEComprehensiveBufferizePasses(
-    OpPassManager &passManager,
-    Optional<BufferizationOptions::AllocationFn> allocationFn,
-    Optional<BufferizationOptions::DeallocationFn> deallocationFn,
-    Optional<BufferizationOptions::MemCpyFn> memCpyFn) {
-  passManager.addPass(bufferization::createEmptyTensorToAllocTensorPass());
-  passManager.addPass(createIREEComprehensiveBufferizePass(
-      allocationFn, deallocationFn, memCpyFn));
+void addIREEPostBufferizationPasses(OpPassManager &passManager) {
   passManager.addPass(memref::createResolveShapedTypeResultDimsPass());
   passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   passManager.addNestedPass<func::FuncOp>(createCSEPass());
@@ -226,6 +219,17 @@ void addIREEComprehensiveBufferizePasses(
   // memrefs are unified in CSE pass, so we can truely remove redundant memcpy.
   passManager.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   passManager.addNestedPass<func::FuncOp>(createCleanupBufferAllocViewPass());
+}
+
+void addIREEComprehensiveBufferizePasses(
+    OpPassManager &passManager,
+    Optional<BufferizationOptions::AllocationFn> allocationFn,
+    Optional<BufferizationOptions::DeallocationFn> deallocationFn,
+    Optional<BufferizationOptions::MemCpyFn> memCpyFn) {
+  passManager.addPass(bufferization::createEmptyTensorToAllocTensorPass());
+  passManager.addPass(createIREEComprehensiveBufferizePass(
+      allocationFn, deallocationFn, memCpyFn));
+  addIREEPostBufferizationPasses(passManager);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
@@ -80,5 +80,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformDialect",
+        "@llvm-project//mlir:Transforms",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_cc_library(
     MLIRPass
     MLIRTensorDialect
     MLIRTransformDialect
+    MLIRTransforms
     iree::compiler::Codegen::Common::CommonPasses
     iree::compiler::Codegen::Interfaces::BufferizationInterfaces
     iree::compiler::Codegen::PassHeaders

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -36,6 +36,11 @@ LogicalResult verifyLoweringConfiguration(
 // Misc/common conversions
 //------------------------------------------------------------------------------
 
+/// Post-bufferization passes run to cleanup the IR
+/// (ResolveShapedTypeResultDims, Canonicalization/CSE and
+/// CleanupBufferAllocView).
+void addIREEPostBufferizationPasses(OpPassManager &passManager);
+
 using bufferization::BufferizationOptions;
 void addIREEComprehensiveBufferizePasses(
     OpPassManager &passManager,
@@ -47,9 +52,9 @@ void addIREEComprehensiveBufferizePasses(
 /// allocations and view operations.
 std::unique_ptr<OperationPass<func::FuncOp>> createCleanupBufferAllocViewPass();
 
-/// Pass to bufferize dispatches that are copying from one interface to another.
-/// This will create a `linalg.generic` op which is a copy that can then be
-/// used by backends to handle appropriately.
+/// Pass to bufferize dispatches that are copying from one interface to
+/// another. This will create a `linalg.generic` op which is a copy that can
+/// then be used by backends to handle appropriately.
 std::unique_ptr<OperationPass<ModuleOp>>
 createBufferizeCopyOnlyDispatchesPass();
 
@@ -57,32 +62,33 @@ createBufferizeCopyOnlyDispatchesPass();
 // one op in the body.
 std::unique_ptr<Pass> createDecomposeLinalgGenericPass();
 
-/// Flattens n-D MemRef subspan ops to 1-D MemRef and folds the byte offsets on
-/// subspan ops to the consumer load/store ops, in preparation for lowering to
-/// backends that require linearized access.
+/// Flattens n-D MemRef subspan ops to 1-D MemRef and folds the byte offsets
+/// on subspan ops to the consumer load/store ops, in preparation for lowering
+/// to backends that require linearized access.
 std::unique_ptr<OperationPass<ModuleOp>> createFlattenMemRefSubspanPass();
 
 /// Creates a pass to fold `affine.min` ops in tiled and distributed loops.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createFoldAffineMinInDistributedLoopsPass();
 
-/// After running the upstream TensorConstantBufferize pass, remove tensor_loads
-/// introduced for use only in tensor_extract. These can be folded to use a load
-/// of the created memref object that holds the constant values.
+/// After running the upstream TensorConstantBufferize pass, remove
+/// tensor_loads introduced for use only in tensor_extract. These can be
+/// folded to use a load of the created memref object that holds the constant
+/// values.
 std::unique_ptr<OperationPass<>> createFoldTensorExtractOpPass();
 
 /// An ad-hoc pass to canonicalize selected loop carried dependencies on
 /// scf.for.
 std::unique_ptr<OperationPass<func::FuncOp>> createForOpCanonicalizationPass();
 
-/// Pass to perform linalg on tensor bufferization. The function passed into the
-/// pass through the `allocationFn` argument is invoked whenever a new buffer is
-/// to be created. The callback will be passed the Values for the dynamic
-/// dimensions in the memref type that is to be allocated.  The callback is
-/// expected to return a MemRefType Value.  When no `allocationFn` is specified,
-/// the default allocator generates an `std.alloc` instruction with the
-/// allocated MemRefType having no stride map (i.e. default row-major striding)
-/// and default memory space.
+/// Pass to perform linalg on tensor bufferization. The function passed into
+/// the pass through the `allocationFn` argument is invoked whenever a new
+/// buffer is to be created. The callback will be passed the Values for the
+/// dynamic dimensions in the memref type that is to be allocated.  The
+/// callback is expected to return a MemRefType Value.  When no `allocationFn`
+/// is specified, the default allocator generates an `std.alloc` instruction
+/// with the allocated MemRefType having no stride map (i.e. default row-major
+/// striding) and default memory space.
 std::unique_ptr<OperationPass<ModuleOp>> createIREEComprehensiveBufferizePass(
     Optional<BufferizationOptions::AllocationFn> allocationFn = None,
     Optional<BufferizationOptions::DeallocationFn> deallocationFn = None,
@@ -261,20 +267,20 @@ void populateUnfusedFMAOpsPassPatterns(MLIRContext *context,
 //----------------------------------------------------------------------------//
 
 /// Populates the passes to lower to scalars operations for linalg based
-/// code-generation. This pipeline does not vectorize, but instead just converts
-/// to memrefs
+/// code-generation. This pipeline does not vectorize, but instead just
+/// converts to memrefs
 void addCPUDefaultPassPipeline(OpPassManager &passManager);
 
 /// Populates the passes to lower ops through data tiling transformations.
 void addCPUDataTilingPipeline(OpPassManager &passManager);
 
-/// Populates the passes to lower to tiled/distributed/bufferized ops, suitable
-/// for library call dispatch and lowering to loops.
+/// Populates the passes to lower to tiled/distributed/bufferized ops,
+/// suitable for library call dispatch and lowering to loops.
 void addVMVXDefaultPassPipeline(OpPassManager &passManager);
 
-/// Populates the passes to lower linalg ops on buffers. Currenly this pipeline
-/// is only used for dispatches that just copy data from input interfaces to
-/// output interface.
+/// Populates the passes to lower linalg ops on buffers. Currenly this
+/// pipeline is only used for dispatches that just copy data from input
+/// interfaces to output interface.
 void addCPUBufferOpsTileAndVectorizePipeline(OpPassManager &passManager);
 
 /// Populates the passes needed to multi level tile and lowering of linalg ops
@@ -305,13 +311,13 @@ LogicalResult verifyConvTileAndDecomposeExpertConfig(
     ArrayRef<int64_t> workgroupSize = {});
 void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager);
 
-/// Populates the passes from Sandbox for testing transformations from sandbox.
-/// Unlike other pipelines this pass mangaer is nested at the
+/// Populates the passes from Sandbox for testing transformations from
+/// sandbox. Unlike other pipelines this pass mangaer is nested at the
 /// `hal.executable.variant` op.
 void addTransformDialectInterpreterPasses(OpPassManager &passManager);
 
-/// Populates the passes needed to multi level tile, fuse and vectorize lowering
-/// of linalg ops on tensors to vectors operations.
+/// Populates the passes needed to multi level tile, fuse and vectorize
+/// lowering of linalg ops on tensors to vectors operations.
 void addCPUAArchDoubleTilingExpertPassPipeline(OpPassManager &passManager);
 
 //----------------------------------------------------------------------------//
@@ -380,13 +386,13 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm);
 void addGPUTransformDialectInterpreterPasses(OpPassManager &pm);
 
 /// Simple lowering only distributute linalg ops on blocks and threads. This
-/// will result in scalar operations. Expects pass manager to be a module-level
-/// pass manager.
+/// will result in scalar operations. Expects pass manager to be a
+/// module-level pass manager.
 void addGPUSimpleDistributePassPipeline(OpPassManager &pm);
 
-/// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via the
-/// structured ops path. The pass manager `pm` in here should operate on the
-/// module within the IREE::HAL::ExecutableOp.
+/// Populates passes needed to lower a XLA HLO op to NVVM/ROCDL dialect via
+/// the structured ops path. The pass manager `pm` in here should operate on
+/// the module within the IREE::HAL::ExecutableOp.
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM);
 
 /// Performs the final conversion to NNVM+LLVM dialect.
@@ -480,16 +486,17 @@ createSPIRVFoldProcessorIDUsesPass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createSPIRVLowerExecutableTargetPass();
 
-/// Pass to tile and distribute Linalg ops with buffer semantics to invocations.
+/// Pass to tile and distribute Linalg ops with buffer semantics to
+/// invocations.
 std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTileAndDistributePass();
 
-/// Pass to promote Linalg ops with buffer semantics to use workgroup memory and
-/// then tile to invocations.
+/// Pass to promote Linalg ops with buffer semantics to use workgroup memory
+/// and then tile to invocations.
 std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTileAndPromotePass(
     bool skipThreadLevel = false);
 
-/// Pass to tile Linalg ops with buffer semantics to subgroups and vectorize to
-/// vector ops suitable for lowering to SPIR-V cooperative ops.
+/// Pass to tile Linalg ops with buffer semantics to subgroups and vectorize
+/// to vector ops suitable for lowering to SPIR-V cooperative ops.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVTileAndVectorizeToCooperativeOpsPass();
 
@@ -513,7 +520,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createSPIRVVectorizeLoadStore();
 
 // Uses `tensor.pad` ops as anchors to create separate fast and slow paths
 // inside the kernel. The fast path is for inner tiles where we don't need
-// padding, while the slow path is for boundary tiles where we do need padding.
+// padding, while the slow path is for boundary tiles where we do need
+// padding.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVCreateFastSlowPathPass();
 
@@ -524,8 +532,8 @@ std::unique_ptr<OperationPass<ModuleOp>> createSPIRVEmulateI64Pass();
 // SPIRV Codegen Pass Pipelines.
 //----------------------------------------------------------------------------//
 
-/// Populates passes needed to lower linalg/arith/math ops to SPIR-V ops via the
-/// structured ops path. The pass manager `pm` here operate on the module
+/// Populates passes needed to lower linalg/arith/math ops to SPIR-V ops via
+/// the structured ops path. The pass manager `pm` here operate on the module
 /// within the IREE::HAL::ExecutableOp.
 void buildSPIRVCodegenPassPipeline(OpPassManager &pm, bool enableFastMath);
 

--- a/tests/e2e/linalg_transform/BUILD
+++ b/tests/e2e/linalg_transform/BUILD
@@ -25,6 +25,7 @@ iree_lit_test_suite(
         "hostonly",
     ],
     tools = [
+        "//tools:iree-opt",
         "//tools:iree-run-mlir",
         "@llvm-project//lld",
         "@llvm-project//llvm:FileCheck",

--- a/tests/e2e/linalg_transform/CMakeLists.txt
+++ b/tests/e2e/linalg_transform/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck
+    iree-opt
     iree-run-mlir
   DATA
     iree::tests::e2e::linalg_transform::transform_dialect_codegen_spec.mlir

--- a/tests/e2e/linalg_transform/linalg_transform.mlir
+++ b/tests/e2e/linalg_transform/linalg_transform.mlir
@@ -1,9 +1,15 @@
-// RUN: iree-run-mlir --iree-hal-target-backends=llvm-cpu \
+// R-UN: iree-run-mlir --iree-hal-target-backends=llvm-cpu \
 /// Specify the dispatch region formation with the transform dialect.
-// RUN:   --iree-flow-dispatch-use-transform-dialect=%p/transform_dialect_dispatch_spec.mlir \
+// R-UN:   --iree-flow-dispatch-use-transform-dialect=%p/transform_dialect_dispatch_spec.mlir \
 /// Specify the codegen strategy with the transform dialect.
-// RUN:   --iree-codegen-llvmcpu-use-transform-dialect=%p/transform_dialect_codegen_spec.mlir \
-// RUN: %s | FileCheck %s
+// R-UN:   --iree-codegen-llvmcpu-use-transform-dialect=%p/transform_dialect_codegen_spec.mlir \
+// R-UN: %s | FileCheck %s
+
+
+// RUN: iree-opt %s \
+// RUN:   --iree-abi-transformation-pipeline \
+// RUN:   --iree-flow-transformation-pipeline \
+// RUN:   --iree-flow-dispatch-use-transform-dialect=%p/transform_dialect_dispatch_spec.mlir
 
 func.func @matmul_static() -> tensor<5x5xf32> {
   %res = flow.tensor.constant dense<[

--- a/tests/transform_dialect/cpu/BUILD
+++ b/tests/transform_dialect/cpu/BUILD
@@ -15,7 +15,7 @@ package(
 
 iree_lit_test_suite(
     name = "lit",
-    srcs = [],  # ["matmul.mlir"], disable failing test
+    srcs = ["matmul.mlir"],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.

--- a/tests/transform_dialect/cpu/CMakeLists.txt
+++ b/tests/transform_dialect/cpu/CMakeLists.txt
@@ -13,6 +13,8 @@ iree_add_all_subdirs()
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "matmul.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -26,11 +26,11 @@ endif()
 iree_lit_test_suite(
     name = "lit",
     srcs = [
-        #"reduction.mlir",
-        #"softmax.mlir",
-        #"softmax_v2.mlir",
+        "reduction.mlir",
+        "softmax.mlir",
+        "softmax_v2.mlir",
         # First few ops of softmax only, acts as a proxy example.
-        #"softmax_partial.mlir",
+        "softmax_partial.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -17,6 +17,11 @@ endif()
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "reduction.mlir"
+    "softmax.mlir"
+    "softmax_partial.mlir"
+    "softmax_v2.mlir"
   TOOLS
     FileCheck
     iree-compile


### PR DESCRIPTION
The nested pass pipeline and extra level of transform op indirection creates significant and
unnecessary registration complexities.
    
Instead, just make the transform op do what it needs.
    
This will need to be factored out better in the future to reuse code.