### PR TITLE
dispatch-on-tensors-via-region-ops: Generate tensor.update ops

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/BUILD
@@ -16,9 +16,11 @@ iree_compiler_cc_library(
     name = "TensorToFlow",
     srcs = [
         "Patterns.cpp",
+        "Utils.cpp",
     ],
     hdrs = [
         "Patterns.h",
+        "Utils.h",
     ],
     deps = [
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
@@ -28,5 +30,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TensorUtils",
     ],
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/CMakeLists.txt
@@ -15,8 +15,10 @@ iree_cc_library(
     TensorToFlow
   HDRS
     "Patterns.h"
+    "Utils.h"
   SRCS
     "Patterns.cpp"
+    "Utils.cpp"
   DEPS
     MLIRArithDialect
     MLIRFuncDialect
@@ -24,6 +26,7 @@ iree_cc_library(
     MLIRLinalgDialect
     MLIRMemRefTransforms
     MLIRTensorDialect
+    MLIRTensorUtils
     iree::compiler::Dialect::Flow::IR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -6,6 +6,7 @@
 
 #include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.h"
 
+#include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -13,97 +14,12 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
 namespace Flow {
-
-/// An operation that uses `offsets`, `sizes` and `strides` (i.e. implements the
-/// `OffsetSizeAndStrideInterface`) can be mapped to flow operations that
-/// eventually map to DMA operations if the offsets/sizes/strides represent a
-/// contiguous memory.
-static bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
-                                                ArrayRef<OpFoldResult> sizes,
-                                                ArrayRef<OpFoldResult> strides,
-                                                ArrayRef<int64_t> baseShape) {
-  if (offsets.size() != baseShape.size()) {
-    // Unhanded rank-reducing case.
-    return false;
-  }
-  auto getVal = [](OpFoldResult valueOrAttr, int64_t dynamicVal) -> int64_t {
-    auto attr = valueOrAttr.dyn_cast<Attribute>();
-    return attr ? attr.cast<IntegerAttr>().getInt() : dynamicVal;
-  };
-  /// To ensure contiguity, start from the least signficant dimension. As long
-  /// as the inner slices are "full slices", the current slice can be any offset
-  /// and size. If the inner slices are not "full slices", the current slice
-  /// must be of size 1. All strides must be one.
-
-  bool fullSlices = true;
-  for (size_t dim = offsets.size(); dim > 0; dim--) {
-    int64_t staticOffset =
-        getVal(offsets[dim - 1], ShapedType::kDynamicStrideOrOffset);
-    int64_t staticSize = getVal(sizes[dim - 1], ShapedType::kDynamicSize);
-    int64_t staticStride =
-        getVal(strides[dim - 1], ShapedType::kDynamicStrideOrOffset);
-
-    if (staticStride != 1) return false;
-    // The offsets and sizes dont have to be static for all dimensions. When
-    // `fullSlices` is true, the offset and sizes can be dynamic. But many
-    // cases, the dynamic offset/size value is obtained by computing from
-    // another tensor which lives on the device. To avoid host-round tripping
-    // enforce that offset/size is also static.
-    if (staticSize == ShapedType::kDynamicSize) return false;
-    if (staticOffset == ShapedType::kDynamicStrideOrOffset) return false;
-
-    if (fullSlices == false) {
-      if (staticSize != 1) return false;
-    } else {
-      if (!(staticOffset == 0 && staticSize != ShapedType::kDynamicSize &&
-            baseShape[dim - 1] != ShapedType::kDynamicSize &&
-            staticSize == baseShape[dim - 1])) {
-        fullSlices = false;
-      }
-    }
-  }
-  return true;
-}
-
-/// Gets the list of non-static values from a list of `OpFoldResult`.
-static SmallVector<Value, 4> getDynamicValues(
-    ArrayRef<OpFoldResult> valueOrAttrList) {
-  SmallVector<Value, 4> dynamicDims;
-  for (auto valueOrAttr : valueOrAttrList) {
-    if (auto value = valueOrAttr.dyn_cast<Value>()) {
-      dynamicDims.push_back(value);
-    }
-  }
-  return dynamicDims;
-}
-
-/// Get shape of the tensor given the sizes as a list of `OpFoldResult`.
-static SmallVector<int64_t, 4> getShapeFromSizes(
-    ArrayRef<OpFoldResult> valueOrAttrList) {
-  return llvm::to_vector<4>(llvm::map_range(
-      valueOrAttrList, [&](OpFoldResult valueOrAttr) -> int64_t {
-        if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
-          return attr.cast<IntegerAttr>().getInt();
-        }
-        return ShapedType::kDynamicSize;
-      }));
-}
-
-/// Generates `memref.dim` operations to get the dynamic sizes of a value `v`.
-static SmallVector<Value, 4> getDynamicDimValues(OpBuilder &b, Location loc,
-                                                 Value v) {
-  SmallVector<Value, 4> dynamicDims;
-  for (auto dim : llvm::enumerate(v.getType().cast<ShapedType>().getShape())) {
-    if (dim.value() != ShapedType::kDynamicSize) continue;
-    dynamicDims.push_back(b.createOrFold<tensor::DimOp>(loc, v, dim.index()));
-  }
-  return dynamicDims;
-}
 
 namespace {
 
@@ -113,42 +29,7 @@ struct ConvertTensorInsertSlicePattern
   using OpRewritePattern<tensor::InsertSliceOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::InsertSliceOp insertOp,
                                 PatternRewriter &rewriter) const override {
-    if (insertOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
-      return failure();
-    }
-
-    SmallVector<OpFoldResult, 4> offsets = insertOp.getMixedOffsets();
-    SmallVector<OpFoldResult, 4> sizes = insertOp.getMixedSizes();
-    SmallVector<OpFoldResult, 4> strides = insertOp.getMixedStrides();
-    ArrayRef<int64_t> dstShape = insertOp.getType().getShape();
-    if (!isOffsetSizeAndStrideMappableToFlow(offsets, sizes, strides,
-                                             dstShape)) {
-      return failure();
-    }
-
-    Location loc = insertOp.getLoc();
-    auto sourceDynamicDims = getDynamicValues(sizes);
-    Value source = insertOp.getSource();
-    ShapedType sourceType = insertOp.getSourceType();
-    ShapedType destType = insertOp.getType();
-
-    // Handle rank-reduced version.
-    if (sourceType.getRank() < destType.getRank()) {
-      // Get the un-rank-reduced shape of the source.
-      auto unreducedShape = getShapeFromSizes(sizes);
-      sourceType =
-          RankedTensorType::get(unreducedShape, sourceType.getElementType());
-      source = rewriter.create<IREE::Flow::TensorReshapeOp>(
-          loc, sourceType, source, sourceDynamicDims, sourceDynamicDims);
-    }
-
-    auto offsetVals = getAsValues(rewriter, loc, insertOp.getMixedOffsets());
-    Value dest = insertOp.getDest();
-    auto destDynamicDims = getDynamicDimValues(rewriter, loc, dest);
-    rewriter.replaceOpWithNewOp<TensorUpdateOp>(
-        insertOp, insertOp.getType(), dest, destDynamicDims, offsetVals, source,
-        sourceDynamicDims, rewriter.getIndexArrayAttr({0}));
-    return success();
+    return convertInsertSliceOpToFlowUpdateOp(rewriter, insertOp);
   }
 };
 
@@ -158,47 +39,7 @@ struct ConvertTensorExtractSlicePattern
   using OpRewritePattern<tensor::ExtractSliceOp>::OpRewritePattern;
   LogicalResult matchAndRewrite(tensor::ExtractSliceOp sliceOp,
                                 PatternRewriter &rewriter) const override {
-    if (sliceOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
-      return failure();
-    }
-
-    SmallVector<OpFoldResult, 4> offsets = sliceOp.getMixedOffsets();
-    SmallVector<OpFoldResult, 4> sizes = sliceOp.getMixedSizes();
-    SmallVector<OpFoldResult, 4> strides = sliceOp.getMixedStrides();
-    ArrayRef<int64_t> srcShape = sliceOp.getSourceType().getShape();
-    if (!isOffsetSizeAndStrideMappableToFlow(offsets, sizes, strides,
-                                             srcShape)) {
-      return failure();
-    }
-
-    Location loc = sliceOp.getLoc();
-
-    ShapedType sourceType = sliceOp.getSourceType();
-    ShapedType resultType = sliceOp.getType();
-
-    // Handle rank reduced version.
-    if (resultType.getRank() < sourceType.getRank()) {
-      // Get the un-rank-reduced shape of the result.
-      auto unreducedShape = getShapeFromSizes(sizes);
-      resultType =
-          RankedTensorType::get(unreducedShape, sourceType.getElementType());
-    }
-
-    auto offsetVals = getAsValues(rewriter, loc, offsets);
-    auto sizeVals = getAsValues(rewriter, loc, sizes);
-    auto sourceDynamicDims =
-        getDynamicDimValues(rewriter, loc, sliceOp.getSource());
-    auto resultDynamicDims = getDynamicValues(sizes);
-    Value replacement = rewriter.create<TensorSliceOp>(
-        loc, resultType, sliceOp.getSource(), sourceDynamicDims, offsetVals,
-        sizeVals, resultDynamicDims);
-    if (resultType.getRank() > sliceOp.getType().getRank()) {
-      replacement = rewriter.create<IREE::Flow::TensorReshapeOp>(
-          loc, sliceOp.getType(), replacement, resultDynamicDims,
-          resultDynamicDims);
-    }
-    rewriter.replaceOp(sliceOp, replacement);
-    return success();
+    return convertExtractSliceOpToFlowSliceOp(rewriter, sliceOp);
   }
 };
 
@@ -356,8 +197,8 @@ struct ConvertLinalgFillPattern final
       return failure();
     }
 
-    SmallVector<Value, 4> dynamicDims =
-        getDynamicDimValues(rewriter, fillOp.getLoc(), fillOp.output());
+    SmallVector<Value, 4> dynamicDims = tensor::createDynamicDimValues(
+        rewriter, fillOp.getLoc(), fillOp.output());
     rewriter.replaceOpWithNewOp<TensorSplatOp>(
         fillOp, fillOp.output().getType(), fillOp.value(), dynamicDims);
     return success();

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.cpp
@@ -1,0 +1,183 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h"
+
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+/// Gets the list of non-static values from a list of `OpFoldResult`.
+static SmallVector<Value, 4> getDynamicValues(
+    ArrayRef<OpFoldResult> valueOrAttrList) {
+  SmallVector<Value, 4> dynamicDims;
+  for (auto valueOrAttr : valueOrAttrList) {
+    if (auto value = valueOrAttr.dyn_cast<Value>()) {
+      dynamicDims.push_back(value);
+    }
+  }
+  return dynamicDims;
+}
+
+/// Get shape of the tensor given the sizes as a list of `OpFoldResult`.
+static SmallVector<int64_t, 4> getShapeFromSizes(
+    ArrayRef<OpFoldResult> valueOrAttrList) {
+  return llvm::to_vector<4>(llvm::map_range(
+      valueOrAttrList, [&](OpFoldResult valueOrAttr) -> int64_t {
+        if (auto attr = valueOrAttr.dyn_cast<Attribute>()) {
+          return attr.cast<IntegerAttr>().getInt();
+        }
+        return ShapedType::kDynamicSize;
+      }));
+}
+
+/// An operation that uses `offsets`, `sizes` and `strides` (i.e. implements the
+/// `OffsetSizeAndStrideInterface`) can be mapped to flow operations that
+/// eventually map to DMA operations if the offsets/sizes/strides represent a
+/// contiguous memory.
+static bool isOffsetSizeAndStrideMappableToFlow(ArrayRef<OpFoldResult> offsets,
+                                                ArrayRef<OpFoldResult> sizes,
+                                                ArrayRef<OpFoldResult> strides,
+                                                ArrayRef<int64_t> baseShape) {
+  if (offsets.size() != baseShape.size()) {
+    // Unhanded rank-reducing case.
+    return false;
+  }
+  auto getVal = [](OpFoldResult valueOrAttr, int64_t dynamicVal) -> int64_t {
+    auto attr = valueOrAttr.dyn_cast<Attribute>();
+    return attr ? attr.cast<IntegerAttr>().getInt() : dynamicVal;
+  };
+  /// To ensure contiguity, start from the least signficant dimension. As long
+  /// as the inner slices are "full slices", the current slice can be any offset
+  /// and size. If the inner slices are not "full slices", the current slice
+  /// must be of size 1. All strides must be one.
+
+  bool fullSlices = true;
+  for (size_t dim = offsets.size(); dim > 0; dim--) {
+    int64_t staticOffset =
+        getVal(offsets[dim - 1], ShapedType::kDynamicStrideOrOffset);
+    int64_t staticSize = getVal(sizes[dim - 1], ShapedType::kDynamicSize);
+    int64_t staticStride =
+        getVal(strides[dim - 1], ShapedType::kDynamicStrideOrOffset);
+
+    if (staticStride != 1) return false;
+    // The offsets and sizes dont have to be static for all dimensions. When
+    // `fullSlices` is true, the offset and sizes can be dynamic. But many
+    // cases, the dynamic offset/size value is obtained by computing from
+    // another tensor which lives on the device. To avoid host-round tripping
+    // enforce that offset/size is also static.
+    if (staticSize == ShapedType::kDynamicSize) return false;
+    if (staticOffset == ShapedType::kDynamicStrideOrOffset) return false;
+
+    if (fullSlices == false) {
+      if (staticSize != 1) return false;
+    } else {
+      if (!(staticOffset == 0 && staticSize != ShapedType::kDynamicSize &&
+            baseShape[dim - 1] != ShapedType::kDynamicSize &&
+            staticSize == baseShape[dim - 1])) {
+        fullSlices = false;
+      }
+    }
+  }
+  return true;
+}
+
+LogicalResult convertInsertSliceOpToFlowUpdateOp(
+    RewriterBase &rewriter, tensor::InsertSliceOp insertOp) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(insertOp);
+
+  if (insertOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    return failure();
+  }
+
+  SmallVector<OpFoldResult, 4> offsets = insertOp.getMixedOffsets();
+  SmallVector<OpFoldResult, 4> sizes = insertOp.getMixedSizes();
+  SmallVector<OpFoldResult, 4> strides = insertOp.getMixedStrides();
+  ArrayRef<int64_t> dstShape = insertOp.getType().getShape();
+  if (!isOffsetSizeAndStrideMappableToFlow(offsets, sizes, strides, dstShape)) {
+    return failure();
+  }
+
+  Location loc = insertOp.getLoc();
+  auto sourceDynamicDims = getDynamicValues(sizes);
+  Value source = insertOp.getSource();
+  ShapedType sourceType = insertOp.getSourceType();
+  ShapedType destType = insertOp.getType();
+
+  // Handle rank-reduced version.
+  if (sourceType.getRank() < destType.getRank()) {
+    // Get the un-rank-reduced shape of the source.
+    auto unreducedShape = getShapeFromSizes(sizes);
+    sourceType =
+        RankedTensorType::get(unreducedShape, sourceType.getElementType());
+    source = rewriter.create<IREE::Flow::TensorReshapeOp>(
+        loc, sourceType, source, sourceDynamicDims, sourceDynamicDims);
+  }
+
+  auto offsetVals = getAsValues(rewriter, loc, insertOp.getMixedOffsets());
+  Value dest = insertOp.getDest();
+  auto destDynamicDims = tensor::createDynamicDimValues(rewriter, loc, dest);
+  rewriter.replaceOpWithNewOp<TensorUpdateOp>(
+      insertOp, insertOp.getType(), dest, destDynamicDims, offsetVals, source,
+      sourceDynamicDims, rewriter.getIndexArrayAttr({0}));
+  return success();
+}
+
+LogicalResult convertExtractSliceOpToFlowSliceOp(
+    RewriterBase &rewriter, tensor::ExtractSliceOp sliceOp) {
+  if (sliceOp->getParentOfType<Flow::DispatchWorkgroupsOp>()) {
+    return failure();
+  }
+
+  SmallVector<OpFoldResult, 4> offsets = sliceOp.getMixedOffsets();
+  SmallVector<OpFoldResult, 4> sizes = sliceOp.getMixedSizes();
+  SmallVector<OpFoldResult, 4> strides = sliceOp.getMixedStrides();
+  ArrayRef<int64_t> srcShape = sliceOp.getSourceType().getShape();
+  if (!isOffsetSizeAndStrideMappableToFlow(offsets, sizes, strides, srcShape)) {
+    return failure();
+  }
+
+  Location loc = sliceOp.getLoc();
+
+  ShapedType sourceType = sliceOp.getSourceType();
+  ShapedType resultType = sliceOp.getType();
+
+  // Handle rank reduced version.
+  if (resultType.getRank() < sourceType.getRank()) {
+    // Get the un-rank-reduced shape of the result.
+    auto unreducedShape = getShapeFromSizes(sizes);
+    resultType =
+        RankedTensorType::get(unreducedShape, sourceType.getElementType());
+  }
+
+  auto offsetVals = getAsValues(rewriter, loc, offsets);
+  auto sizeVals = getAsValues(rewriter, loc, sizes);
+  auto sourceDynamicDims =
+      tensor::createDynamicDimValues(rewriter, loc, sliceOp.getSource());
+  auto resultDynamicDims = getDynamicValues(sizes);
+  Value replacement = rewriter.create<TensorSliceOp>(
+      loc, resultType, sliceOp.getSource(), sourceDynamicDims, offsetVals,
+      sizeVals, resultDynamicDims);
+  if (resultType.getRank() > sliceOp.getType().getRank()) {
+    replacement = rewriter.create<IREE::Flow::TensorReshapeOp>(
+        loc, sliceOp.getType(), replacement, resultDynamicDims,
+        resultDynamicDims);
+  }
+  rewriter.replaceOp(sliceOp, replacement);
+  return success();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Utils.h
@@ -1,0 +1,41 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_DIALECT_FLOW_CONVERSION_TENSORTOFLOW_UTILS_H_
+#define IREE_COMPILER_DIALECT_FLOW_CONVERSION_TENSORTOFLOW_UTILS_H_
+
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+class Location;
+class LogicalResult;
+class OpBuilder;
+class RewriterBase;
+class Value;
+
+namespace tensor {
+class ExtractSliceOp;
+class InsertSliceOp;
+}  // namespace tensor
+
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+/// Rewrite the given InsertSliceOp into a Flow::TensorUpdateOp.
+LogicalResult convertInsertSliceOpToFlowUpdateOp(
+    RewriterBase &rewriter, tensor::InsertSliceOp insertOp);
+
+/// Rewrite the given ExtractSliceOp into a Flow::TensorSliceOp.
+LogicalResult convertExtractSliceOpToFlowSliceOp(
+    RewriterBase &rewriter, tensor::ExtractSliceOp sliceOp);
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_DIALECT_FLOW_CONVERSION_TENSORTOFLOW_UTILS_H_

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="func.func(iree-flow-dispatch-linalg-on-tensors-pass{aggressive-fusion=true}), cse, canonicalize, cse" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --iree-flow-dispatch-via-region-ops --pass-pipeline="func.func(iree-flow-dispatch-linalg-on-tensors-pass{aggressive-fusion=true}), cse, canonicalize, cse" %s | FileCheck %s --check-prefix=CHECK-VIA-REGIONS
 
 func.func @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
              %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
@@ -1291,6 +1292,7 @@ func.func @concat_pattern(%src1 : tensor<2x40xf32>, %src2 : tensor<3x40xf32>,
       : tensor<3x40xf32> into tensor<5x40xf32>
   return %1 : tensor<5x40xf32>
 }
+
 //      CHECK: func.func @concat_pattern
 // CHECK-SAME:     %[[SRC1:.+]]: tensor<2x40xf32>
 // CHECK-SAME:     %[[SRC2:.+]]: tensor<3x40xf32>
@@ -1298,6 +1300,14 @@ func.func @concat_pattern(%src1 : tensor<2x40xf32>, %src2 : tensor<3x40xf32>,
 //      CHECK:   %[[UPDATE1:.+]] = flow.tensor.update %[[SRC1]], %[[DEST]]
 //      CHECK:   %[[UPDATE2:.+]] = flow.tensor.update %[[SRC2]], %[[UPDATE1]]
 //      CHECK:   return %[[UPDATE2]]
+
+//      CHECK-VIA-REGIONS: func.func @concat_pattern
+// CHECK-VIA-REGIONS-SAME:     %[[SRC1:.+]]: tensor<2x40xf32>
+// CHECK-VIA-REGIONS-SAME:     %[[SRC2:.+]]: tensor<3x40xf32>
+// CHECK-VIA-REGIONS-SAME:     %[[DEST:.+]]: tensor<5x40xf32>
+//      CHECK-VIA-REGIONS:   %[[UPDATE1:.+]] = flow.tensor.update %[[SRC1]], %[[DEST]]
+//      CHECK-VIA-REGIONS:   %[[UPDATE2:.+]] = flow.tensor.update %[[SRC2]], %[[UPDATE1]]
+//      CHECK-VIA-REGIONS:   return %[[UPDATE2]]
 
 // -----
 


### PR DESCRIPTION
This is an improvement to DispatchLinalgOnTensorsViaRegionOps.cpp: Certain tensor.insert_slice ops are lowered to flow.tensor.update ops. (Same as DispatchLinalgOnTensors.cpp.)

This is in preparation of #10719.