### PR TITLE
Fix GCC build error with IREE_MUST_USE_RESULT attribute placement

### DIFF
--- a/runtime/src/iree/base/status_cc.h
+++ b/runtime/src/iree/base/status_cc.h
@@ -110,7 +110,7 @@ class IREE_MUST_USE_RESULT Status;
 class Status final {
  public:
   // Return a combination of the error code name and message.
-  static inline IREE_MUST_USE_RESULT std::string ToString(
+  IREE_MUST_USE_RESULT static inline std::string ToString(
       iree_status_t status) {
     if (iree_status_is_ok(status)) {
       return "OK";


### PR DESCRIPTION
Following #10946 we have this error with GCC 12.2:

```
/usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/status_cc.h:113:17: error: standard attributes in middle of decl-specifiers
  113 |   static inline IREE_MUST_USE_RESULT std::string ToString(
      |                 ^~~~~~~~~~~~~~~~~~~~
/usr/local/google/home/benoitjacob/iree/runtime/src/iree/base/status_cc.h:113:17: note: standard attributes must precede the decl-specifiers to apply to the declaration, or follow them to apply to the type
```