### PR TITLE
Rework usage of testing templates

### DIFF
--- a/build_tools/github_actions/runner/README.md
+++ b/build_tools/github_actions/runner/README.md
@@ -167,7 +167,7 @@ Update the testing instance group to your new template using
 canary to the test group):
 
 ```shell
-build_tools/github_actions/runner/gcp/update_instance_group.py direct-update \
+build_tools/github_actions/runner/gcp/update_instance_groups.py direct-update \
   --env=testing --region=all --group=all --type=all --version="${VERSION?}"
 ```
 
@@ -204,7 +204,7 @@ To deploy to prod, create new prod templates. Then use the update script to
 canary to a single instance:
 
 ```shell
-build_tools/github_actions/runner/update_instance_group.py canary-update \
+build_tools/github_actions/runner/update_instance_groups.py canary-update \
   --prod --region=all --group=all --type=all --version="${VERSION}"
 ```
 
@@ -214,7 +214,7 @@ on the order of days before proceeding. When you are satisfied that your new
 configuration is good, complete the update with your new template:
 
 ```shell
-build_tools/github_actions/runner/update_instance_group.py promote-canary \
+build_tools/github_actions/runner/update_instance_groups.py promote-canary \
   --prod --region=all --group=all --type=all
 ```
 

--- a/build_tools/github_actions/runner/config/register.sh
+++ b/build_tools/github_actions/runner/config/register.sh
@@ -55,9 +55,22 @@ RUNNER_GROUP="$(get_attribute github-runner-group)"
 RUNNER_SCOPE="$(get_attribute github-runner-scope)"
 RUNNER_TRUST="$(get_attribute github-runner-trust)"
 RUNNER_VERSION="$(get_attribute github-runner-version)"
-RUNNER_ENVIRONMENT="$(get_attribute github-runner-environment)"
 TOKEN_PROXY_URL="$(get_attribute github-token-proxy-url)"
 CONFIG_REF="$(get_attribute github-runner-config-ref)"
+
+# So this is a bit of a hack, but it enables us to use the same instance
+# template regardless of environment. This means we can test a template by
+# deploying it to the testing environment and then promote *the same template*
+# to the prod environment. Otherwise it's difficult to tell the mapping between
+# prod and testing templates. Ideally, this would be explicit metadata that was
+# dynamic with the instance group itself, but instance groups don't have
+# anything like that and all the metadata on the instances has to be specified
+# in the templates.
+RUNNER_ENVIRONMENT="prod"
+if [[ "${HOSTNAME}" == *-testing-* ]]; then
+  RUNNER_ENVIRONMENT="testing"
+fi
+
 
 declare -a RUNNER_LABELS_ARRAY=(
   "os-family=${OS_FAMILY}"

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -14,34 +14,47 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
 
 TESTING="${TEMPLATE_TESTING:-0}"
+DRY_RUN="${DRY_RUN:-0}"
 
-TEMPLATE_BASE_NAME="${TEMPLATE_BASE_NAME:-github-runner}"
-TEMPLATE_CONFIG_REPO="${TEMPLATE_CONFIG_REPO:-iree-org/iree}"
-TEMPLATE_CONFIG_REF="${TEMPLATE_CONFIG_REF:-$(git rev-parse HEAD)}"
 GPU_IMAGE="github-runner-gpu-2022-09-29-1664451806"
 GPU_DISK_SIZE_GB=100
 CPU_IMAGE="github-runner-cpu-2022-09-29-1664451255"
 CPU_DISK_SIZE_GB=100
 
-if (( TESTING==0 )); then
-  if [[ "${TEMPLATE_CONFIG_REPO}" != iree-org/iree ]]; then
-    echo "Expected default settings for non-testing template, but TEMPLATE_CONFIG_REPO='${TEMPLATE_CONFIG_REPO}'. Aborting"
-    exit 1
-  fi
-  if [[ "${TEMPLATE_BASE_NAME}" != github-runner ]]; then
-    echo "Expected default settings for non-testing template, but TEMPLATE_BASE_NAME='${TEMPLATE_BASE_NAME}'. Aborting"
-    exit 1
-  fi
-  if [[ "${TEMPLATE_CONFIG_REF}" != "$(git rev-parse main)" ]]; then
-    echo "Expected default settings for non-testing template, but TEMPLATE_CONFIG_REF='${TEMPLATE_CONFIG_REF}'. Aborting"
-    exit 1
-  fi
+PROD_TEMPLATE_BASE_NAME="github-runner"
+PROD_TEMPLATE_CONFIG_REPO="iree-org/iree"
+
+TEMPLATE_CONFIG_REPO="${TEMPLATE_CONFIG_REPO:-${PROD_TEMPLATE_CONFIG_REPO}}"
+TEMPLATE_CONFIG_REF="${TEMPLATE_CONFIG_REF:-$(git rev-parse HEAD)}"
+TEMPLATE_BASE_NAME="${TEMPLATE_BASE_NAME:-${PROD_TEMPLATE_BASE_NAME}}"
+
+if (( TESTING==0 )) && ! git merge-base --is-ancestor "${TEMPLATE_CONFIG_REF}" main; then
+  echo "Creating testing template because TEMPLATE_CONFIG_REF='${TEMPLATE_CONFIG_REF}' is not on the main branch"
+  TESTING=1
+fi
+if (( TESTING==0 )) && [[ "${TEMPLATE_CONFIG_REPO}" != "${PROD_TEMPLATE_CONFIG_REPO}" ]]; then
+  echo "Creating testing template because TEMPLATE_CONFIG_REPO '${TEMPLATE_CONFIG_REPO}'!='${PROD_TEMPLATE_CONFIG_REPO}'"
+  TESTING=1
+fi
+if (( TESTING==0 )) && [[ "${TEMPLATE_BASE_NAME}" != "${PROD_TEMPLATE_BASE_NAME}" ]]; then
+  echo "Creating testing template because TEMPLATE_BASE_NAME '${TEMPLATE_BASE_NAME}'!='${PROD_TEMPLATE_BASE_NAME}'"
+  TESTING=1
 fi
 
-TIME_STRING="$(date +%Y-%m-%d-%s)"
+
+# We need something to avoid duplicate names. Occasional collisions aren't that
+# big a deal (user can just re-run), so we use few characters here, as the whole
+# template name can only be 63 characters. We used to use the unix timestamp,
+# but that's pretty long and not very human readable. We also used to include
+# the date in ISO8601 format, but again, character limits and creation date is
+# in the template metadata.
+# 3 legal characters. Note this is using bash to expand the braced sequences.
+SUFFIX="$(shuf --zero-terminated --echo --head-count=3 --repeat {a..z} {0..9})"
 SHORT_REF="${TEMPLATE_CONFIG_REF:0:10}"
-VERSION="${SHORT_REF}-${TIME_STRING}"
-STARTUP_SCRIPT_PATH="/tmp/startup_script.${SHORT_REF}.sh"
+VERSION="${SHORT_REF}-${SUFFIX}"
+if (( TESTING!=0 )); then
+  VERSION="${VERSION}-testing"
+fi
 GITHUB_RUNNER_SCOPE=iree-org
 GITHUB_RUNNER_VERSION="2.298.2"
 GITHUB_RUNNER_ARCHIVE_DIGEST="0bfd792196ce0ec6f1c65d2a9ad00215b2926ef2c416b8d97615265194477117"
@@ -55,12 +68,6 @@ declare -a METADATA=(
   "github-runner-scope=${GITHUB_RUNNER_SCOPE}"
   "github-token-proxy-url=${GITHUB_TOKEN_PROXY_URL}"
 )
-
-if (( TESTING==1 )); then
-  METADATA+=(github-runner-environment=testing)
-else
-  METADATA+=(github-runner-environment=prod)
-fi
 
 declare -a common_args=(
   --project=iree-oss
@@ -101,7 +108,8 @@ function create_template() {
   # Join on commas
   local metadata_string="$(IFS="," ; echo "${metadata[*]}")"
 
-  local -a args=(
+  local -a cmd=(
+    gcloud compute instance-templates create
     "${TEMPLATE_BASE_NAME}-${group}-${type}-${VERSION}"
     "${common_args[@]}"
     --service-account="github-runner-${trust}-trust@iree-oss.iam.gserviceaccount.com"
@@ -109,14 +117,14 @@ function create_template() {
   )
 
   if [[ "${type}" == gpu ]]; then
-    args+=(
+    cmd+=(
       --machine-type=a2-highgpu-1g
       --maintenance-policy=TERMINATE
       --accelerator=count=1,type=nvidia-tesla-a100
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=${GPU_DISK_SIZE_GB},type=pd-balanced"
     )
   elif [[ "${type}" == cpu ]]; then
-    args+=(
+    cmd+=(
       --machine-type=n1-standard-96
       --maintenance-policy=MIGRATE
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
@@ -125,8 +133,12 @@ function create_template() {
     echo "Got unrecognized type '${type}'" >2
     exit 1
   fi
-  (set -x; gcloud compute instance-templates create "${args[@]}")
-  echo
+  if (( DRY_RUN==1 )); then
+    # Prefix the command with a noop. It will still be printed by set -x
+    cmd=(":" "${cmd[@]}")
+  fi
+  (set -x; "${cmd[@]}")
+  echo ''
 }
 
 for group in presubmit postsubmit; do

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -49,7 +49,7 @@ fi
 # the date in ISO8601 format, but again, character limits and creation date is
 # in the template metadata.
 # 3 legal characters. Note this is using bash to expand the braced sequences.
-SUFFIX="$(shuf --zero-terminated --echo --head-count=3 --repeat {a..z} {0..9})"
+SUFFIX="$(shuf --echo --head-count=3 --repeat {a..z} {0..9} | tr -d '\n')"
 SHORT_REF="${TEMPLATE_CONFIG_REF:0:10}"
 VERSION="${SHORT_REF}-${SUFFIX}"
 if (( TESTING!=0 )); then

--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -96,6 +96,11 @@ def main(args):
       project=args.project,
   )
 
+  if "testing" in args.version and args.env != "testing":
+    scary_action = (f"using testing template version '{args.version}' in"
+                    f" environment '{args.env}'")
+    check_scary_action(scary_action, args.skip_confirmation)
+
   # Prod instances just have the bare name
   modifier = None if args.env == "prod" else args.env
   migs = updater.get_migs(region=args.region,


### PR DESCRIPTION
This makes it possible to run production templates on testing runners,
which is useful to enable testing of something that has already been
committed and avoids mistakes (that I've made frequently) around the
environment metadata field. It's a bit hacky, but I think will make
updating these significantly easier.

This also names templates with non-prod modifications with a "testing"
suffix. To accomplish this, I had to shorten the template names quite a
bit. I think the result is actually much more readable.

Tested: Deployed new templates to testing runners -> 
https://github.com/iree-org/iree/actions/runs/3364878153/jobs/5579737086

skip-ci: configuration of the runners themselves