### PR TITLE
Fix parsing trailers when they're the only thing in the PR body

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
       # The commit being checked out is the merge commit for the PR. Its first
       # parent will be the tip of main.
       BASE_REF: HEAD^
-      PR_DESCRIPTION: ${{ github.event.pull_request.body }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
     outputs:
       should-run: ${{ steps.configure.outputs.should-run }}
       ci-stage: ${{ steps.configure.outputs.ci-stage }}

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -12,7 +12,8 @@ jobs:
       # The commit being checked out is the merge commit for the PR. Its first
       # parent will be the tip of main.
       BASE_REF: HEAD^
-      PR_DESCRIPTION: ${{ github.event.pull_request.body }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
     outputs:
       should-run: ${{ steps.configure.outputs.should-run }}
       ci-stage: ${{ steps.configure.outputs.ci-stage }}

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -60,7 +60,13 @@ def set_output(d: Mapping[str, str]):
 
 
 def get_trailers() -> Mapping[str, str]:
-  description = os.environ.get("PR_DESCRIPTION", "")
+  title = os.environ["PR_TITLE"]
+  body = os.environ.get("PR_BODY", "")
+
+  description = f"{title}" "\n\n" f"{body}"
+
+  print("Parsing PR description:", description, sep="\n")
+
   trailer_lines = subprocess.run(["git", "interpret-trailers", "--parse"],
                                  input=description,
                                  stdout=subprocess.PIPE,


### PR DESCRIPTION
We already generally treat the PR description as a commit description
with title and body in this way (e.g. in our [squash and] merge commit
messages). I could've added any dummy title string, but this seemed
more understandable. We could also write our own parsing instead of
relying on interpret-trailers, but I think it's good to use a standard
tool.

Tested: https://github.com/iree-org/iree/actions/runs/3364878153/jobs/5579737086