### PR TITLE
Tag runners to allow health checks

### DIFF
--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -69,6 +69,8 @@ declare -a common_args=(
   # off the VM gets no external IP and is impossible to SSH into. This knowledge
   # was hard won.
   --network-interface=network=default,address='',network-tier=PREMIUM
+  # Matches firewall rule for health check traffic
+  --tags="allow-health-checks"
   --provisioning-model=STANDARD
   --scopes=https://www.googleapis.com/auth/cloud-platform
   --no-shielded-secure-boot


### PR DESCRIPTION
This matches the firewall rule that should hopefully be coming online
soon. Health checks require a special firewall rule for...some reason.

Tested: deployed new templates to test clusters.
skip-ci: template creation for the runners