### PR TITLE
[spirv] Support GPU subgroup MMA ops in SPIRVVectorizeLoadStore

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -20,6 +20,7 @@
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
@@ -44,10 +45,11 @@ static bool getUsesIfAllTransferOp(Value value,
   for (Operation *userOp : value.getUsers()) {
     if (isa<memref::DeallocOp, memref::AssumeAlignmentOp>(userOp)) continue;
     // Only vectorize memref used by vector transfer ops.
-    if (!isa<vector::TransferReadOp, vector::TransferWriteOp>(userOp)) {
+    if (!isa<gpu::SubgroupMmaLoadMatrixOp, gpu::SubgroupMmaStoreMatrixOp,
+             vector::TransferReadOp, vector::TransferWriteOp>(userOp)) {
       uses.clear();
       LLVM_DEBUG(llvm::dbgs()
-                 << "failed: non-transfer user: " << *userOp << "\n");
+                 << "failed: non-transfer-like user: " << *userOp << "\n");
       return false;
     }
     uses.push_back(userOp);
@@ -73,6 +75,11 @@ static unsigned calculateMemRefVectorNumBits(
     SmallVectorImpl<Operation *> &uses) {
   unsigned minBits = kMaxVectorNumBits;
   for (Operation *op : uses) {
+    if (isa<gpu::SubgroupMmaLoadMatrixOp, gpu::SubgroupMmaStoreMatrixOp>(op)) {
+      // GPU subgroup MMA ops do not care about the memref element type. It can
+      // load from whatever memref element type.
+      continue;
+    }
     auto transferOp = dyn_cast<VectorTransferOpInterface>(op);
     if (!transferOp) return 0;
     Optional<unsigned> transferSize = getBitWidth(transferOp.getVectorType());
@@ -206,6 +213,14 @@ class MemRefConversionPattern : public OpConversionPattern<OpTy> {
  protected:
   Optional<MemRefType> getVectorizedMemRefType(
       ConversionPatternRewriter &rewriter, Value memRefValue) const;
+
+  /// Adjusts indices for vector transfer / GPU MMA load/store ops to index into
+  /// vector memref.
+  FailureOr<SmallVector<Value>> adjustIndices(
+      MemRefType scalarMemrefType, MemRefType vectorMemrefType,
+      ValueRange indices, ConversionPatternRewriter &rewriter,
+      Location loc) const;
+
   const MemRefUsageAnalysis &memrefUsageAnalysis;
 };
 
@@ -242,29 +257,18 @@ class ProcessTransferRead final
 
     Optional<unsigned> vectorMemrefElemSize =
         getBitWidth(vectorMemrefType.getElementType());
-    Optional<unsigned> scalarMemrefElemSize =
-        getBitWidth(scalarMemrefType.getElementType());
     Optional<unsigned> readVecSize = getBitWidth(readVectorType);
-    if (!vectorMemrefElemSize || !scalarMemrefElemSize || !readVecSize)
-      return failure();
 
-    MLIRContext *context = rewriter.getContext();
-    AffineExpr sym0, sym1;
-    bindSymbols(context, sym0, sym1);
-    auto divMap = AffineMap::get(0, 2, {sym0.floorDiv(sym1)}, context);
-
-    unsigned ratio = *vectorMemrefElemSize / *scalarMemrefElemSize;
-    Value valueRatio = rewriter.create<arith::ConstantIndexOp>(loc, ratio);
-    auto indices = llvm::to_vector<4>(adaptor.getIndices());
-    indices.back() = rewriter.create<AffineApplyOp>(
-        loc, divMap, ValueRange{indices.back(), valueRatio});
+    auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
+                                 adaptor.getIndices(), rewriter, loc);
+    if (failed(indices)) return failure();
 
     // If the transfer_read can be replaced by a load after vectorization use
     // LoadOp and cast back to the original type.
     if (*vectorMemrefElemSize == *readVecSize) {
       Type elemType = vectorMemrefType.getElementType();
       Value newLoad = rewriter.create<memref::LoadOp>(
-          loc, elemType, adaptor.getSource(), indices);
+          loc, elemType, adaptor.getSource(), indices.value());
       Type serializedVecType =
           VectorType::get(read.getVectorType().getNumElements(),
                           read.getVectorType().getElementType());
@@ -274,7 +278,7 @@ class ProcessTransferRead final
           read, read.getVectorType(), newLoad);
     } else {
       rewriter.replaceOpWithNewOp<vector::TransferReadOp>(
-          read, read.getVectorType(), adaptor.getSource(), indices);
+          read, read.getVectorType(), adaptor.getSource(), indices.value());
     }
     return success();
   }
@@ -303,22 +307,11 @@ class ProcessTransferWrite final
 
     Optional<unsigned> vectorMemrefElemSize =
         getBitWidth(vectorMemrefType.getElementType());
-    Optional<unsigned> scalarMemrefElemSize =
-        getBitWidth(scalarMemrefType.getElementType());
     Optional<unsigned> writeVecSize = getBitWidth(writeVectorType);
-    if (!vectorMemrefElemSize || !scalarMemrefElemSize || !writeVecSize)
-      return failure();
 
-    MLIRContext *context = rewriter.getContext();
-    AffineExpr sym0, sym1;
-    bindSymbols(context, sym0, sym1);
-    auto divMap = AffineMap::get(0, 2, {sym0.floorDiv(sym1)}, context);
-
-    unsigned ratio = *vectorMemrefElemSize / *scalarMemrefElemSize;
-    Value valueRatio = rewriter.create<arith::ConstantIndexOp>(loc, ratio);
-    SmallVector<Value, 4> indices(adaptor.getIndices());
-    indices.back() = rewriter.create<AffineApplyOp>(
-        loc, divMap, ValueRange{indices.back(), valueRatio});
+    auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
+                                 adaptor.getIndices(), rewriter, loc);
+    if (failed(indices)) return failure();
 
     // If the transfer_write can be replaced by a store after vectorization cast
     // the original value and use StoreOp.
@@ -330,10 +323,10 @@ class ProcessTransferWrite final
       data = rewriter.create<vector::BitCastOp>(
           loc, vectorMemrefType.getElementType(), data);
       rewriter.replaceOpWithNewOp<memref::StoreOp>(
-          write, data, adaptor.getSource(), indices);
+          write, data, adaptor.getSource(), indices.value());
     } else {
       rewriter.replaceOpWithNewOp<vector::TransferWriteOp>(
-          write, adaptor.getVector(), adaptor.getSource(), indices);
+          write, adaptor.getVector(), adaptor.getSource(), indices.value());
     }
     return success();
   }
@@ -376,6 +369,30 @@ Optional<MemRefType> MemRefConversionPattern<OpTy>::getVectorizedMemRefType(
   return MemRefType::get(newShape, vectorType, {}, type.getMemorySpaceAsInt());
 }
 
+template <typename OpTy>
+FailureOr<SmallVector<Value>> MemRefConversionPattern<OpTy>::adjustIndices(
+    MemRefType scalarMemrefType, MemRefType vectorMemrefType,
+    ValueRange indices, ConversionPatternRewriter &rewriter,
+    Location loc) const {
+  Optional<unsigned> vectorMemrefElemSize =
+      getBitWidth(vectorMemrefType.getElementType());
+  Optional<unsigned> scalarMemrefElemSize =
+      getBitWidth(scalarMemrefType.getElementType());
+  if (!vectorMemrefElemSize || !scalarMemrefElemSize) return failure();
+
+  MLIRContext *context = rewriter.getContext();
+  AffineExpr sym0, sym1;
+  bindSymbols(context, sym0, sym1);
+  auto divMap = AffineMap::get(0, 2, {sym0.floorDiv(sym1)}, context);
+
+  unsigned ratio = *vectorMemrefElemSize / *scalarMemrefElemSize;
+  Value valueRatio = rewriter.create<arith::ConstantIndexOp>(loc, ratio);
+  auto newIndices = llvm::to_vector(indices);
+  newIndices.back() = rewriter.create<AffineApplyOp>(
+      loc, divMap, ValueRange{indices.back(), valueRatio});
+  return newIndices;
+}
+
 class ProcessAlloc final : public MemRefConversionPattern<memref::AllocOp> {
  public:
   using MemRefConversionPattern::MemRefConversionPattern;
@@ -415,6 +432,72 @@ class ProcessInterfaceBindingSubspan final
         subspanOp, *vecMemRef, subspanOp.getSet(), subspanOp.getBinding(),
         subspanOp.getDescriptorType(), subspanOp.getByteOffset(),
         subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr());
+    return success();
+  }
+};
+
+struct ProcessSubgroupMMALoad final
+    : public MemRefConversionPattern<gpu::SubgroupMmaLoadMatrixOp> {
+  using MemRefConversionPattern::MemRefConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      gpu::SubgroupMmaLoadMatrixOp loadOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto scalarMemrefType =
+        loadOp.getSrcMemref().getType().dyn_cast<MemRefType>();
+    auto vectorMemrefType =
+        adaptor.getSrcMemref().getType().dyn_cast<MemRefType>();
+
+    if (!vectorMemrefType.getLayout().isIdentity()) {
+      return rewriter.notifyMatchFailure(loadOp,
+                                         "non-identity memref unsupported");
+    }
+
+    Location loc = loadOp.getLoc();
+    auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
+                                 adaptor.getIndices(), rewriter, loc);
+    if (failed(indices)) return failure();
+
+    auto newLeadDimSize = rewriter.getIntegerAttr(
+        loadOp.getLeadDimensionAttr().getType(),
+        vectorMemrefType.getDimSize(vectorMemrefType.getRank() - 1));
+
+    rewriter.replaceOpWithNewOp<gpu::SubgroupMmaLoadMatrixOp>(
+        loadOp, loadOp.getType(), adaptor.getSrcMemref(), indices.value(),
+        newLeadDimSize);
+    return success();
+  }
+};
+
+struct ProcessSubgroupMMAStore final
+    : public MemRefConversionPattern<gpu::SubgroupMmaStoreMatrixOp> {
+  using MemRefConversionPattern::MemRefConversionPattern;
+
+  LogicalResult matchAndRewrite(
+      gpu::SubgroupMmaStoreMatrixOp storeOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto scalarMemrefType =
+        storeOp.getDstMemref().getType().dyn_cast<MemRefType>();
+    auto vectorMemrefType =
+        adaptor.getDstMemref().getType().dyn_cast<MemRefType>();
+
+    if (!vectorMemrefType.getLayout().isIdentity()) {
+      return rewriter.notifyMatchFailure(storeOp,
+                                         "non-identity memref unsupported");
+    }
+
+    Location loc = storeOp.getLoc();
+    auto indices = adjustIndices(scalarMemrefType, vectorMemrefType,
+                                 adaptor.getIndices(), rewriter, loc);
+    if (failed(indices)) return failure();
+
+    auto newLeadDimSize = rewriter.getIntegerAttr(
+        storeOp.getLeadDimensionAttr().getType(),
+        vectorMemrefType.getDimSize(vectorMemrefType.getRank() - 1));
+
+    rewriter.replaceOpWithNewOp<gpu::SubgroupMmaStoreMatrixOp>(
+        storeOp, adaptor.getSrc(), adaptor.getDstMemref(), indices.value(),
+        newLeadDimSize);
     return success();
   }
 };
@@ -578,8 +661,8 @@ void SPIRVVectorizeLoadStorePass::runOnOperation() {
   RewritePatternSet conversionPatterns(context);
   conversionPatterns
       .add<ProcessFunctionArgument, ProcessTransferRead, ProcessTransferWrite,
-           ProcessAlloc, ProcessInterfaceBindingSubspan>(context,
-                                                         *memrefUsageAnalysis);
+           ProcessSubgroupMMALoad, ProcessSubgroupMMAStore, ProcessAlloc,
+           ProcessInterfaceBindingSubspan>(context, *memrefUsageAnalysis);
   conversionPatterns.add<PassThroughConversion<memref::DeallocOp>,
                          PassThroughConversion<memref::AssumeAlignmentOp>>(
       context);
@@ -599,6 +682,8 @@ void SPIRVVectorizeLoadStorePass::runOnOperation() {
       });
   target.markUnknownOpDynamicallyLegal([&](Operation *op) {
     if (isa<vector::TransferWriteOp, vector::TransferReadOp>(op))
+      return !memrefUsageAnalysis->shouldConvertTransfer(op);
+    if (isa<gpu::SubgroupMmaLoadMatrixOp, gpu::SubgroupMmaStoreMatrixOp>(op))
       return !memrefUsageAnalysis->shouldConvertTransfer(op);
     if (auto dealloc = dyn_cast<memref::DeallocOp>(op))
       return !memrefUsageAnalysis->shouldVectorizeMemRef(dealloc.getMemref());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -365,14 +365,14 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1024 x f16>)>, Workgroup>
+// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @generic_batch_matmul_32x128x512x64
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
-//     CHECK-DAG:     %[[C32:.+]] = spirv.Constant 32 : i32
+//     CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
+//     CHECK-DAG:     %[[C64:.+]] = spirv.Constant 64 : i32
 //     CHECK-DAG:     %[[C256:.+]] = spirv.Constant 256 : i32
-//     CHECK-DAG:     %[[C512:.+]] = spirv.Constant 512 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup>
 
@@ -380,16 +380,16 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 //         CHECK:     spirv.mlir.loop
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-8:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : f16
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-8:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : f16
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
-//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
 //         CHECK:       %[[MA0:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD2]], %{{.+}}
 //         CHECK:       %[[MA1:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD3]], %[[MA0]]
@@ -398,4 +398,4 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 //         CHECK:       spirv.mlir.merge
 
 //         CHECK:     %[[LD_FN:.+]] = spirv.Load "Function" %[[LOCAL_VAR]] : !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:     spirv.NV.CooperativeMatrixStore %{{.+}}, %[[LD_FN]], %[[C512]], %[[COL_MAJOR]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %{{.+}}, %[[LD_FN]], %[[C64]], %[[COL_MAJOR]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -76,13 +76,14 @@ hal.executable public @matmul_256x1024x128_div_add {
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1024 x f16>)>, Workgroup>
+// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @matmul_256x1024x128_div_add
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
+//     CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
 //     CHECK-DAG:     %[[C32:.+]] = spirv.Constant 32 : i32
-//     CHECK-DAG:     %[[C1024:.+]] = spirv.Constant 1024 : i32
+//     CHECK-DAG:     %[[C128:.+]] = spirv.Constant 128 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup>
 
@@ -90,16 +91,16 @@ hal.executable public @matmul_256x1024x128_div_add {
 //         CHECK:     spirv.mlir.loop
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-8:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : f16
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-8:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : f16
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
-//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
 //         CHECK:       %[[MA0:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD2]], %{{.+}}
 //         CHECK:       %[[MA1:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD3]], %[[MA0]]
@@ -108,11 +109,11 @@ hal.executable public @matmul_256x1024x128_div_add {
 //         CHECK:       spirv.mlir.merge
 
 //         CHECK:     %[[LD_FN:.+]] = spirv.Load "Function" %[[LOCAL_VAR]] : !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:     %[[LD4:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C1024]], %[[COL_MAJOR]] : !spirv.ptr<f16, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:     %[[LD5:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C1024]], %[[COL_MAJOR]] : !spirv.ptr<f16, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[LD4:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C128]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[LD5:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C128]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK:     %[[DIV:.+]] = spirv.FDiv %[[LD_FN]], %[[LD4]] : !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK:     %[[ADD:.+]] = spirv.FAdd %[[DIV]], %[[LD5]] : !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:     spirv.NV.CooperativeMatrixStore %{{.+}}, %[[ADD]], %[[C1024]], %[[COL_MAJOR]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %{{.+}}, %[[ADD]], %[[C128]], %[[COL_MAJOR]]
 
 // -----
 
@@ -184,13 +185,13 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1024 x f16>)>, Workgroup>
+// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @batch_matmul_16x128x256x512_div
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
+//     CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
 //     CHECK-DAG:     %[[C32:.+]] = spirv.Constant 32 : i32
-//     CHECK-DAG:     %[[C256:.+]] = spirv.Constant 256 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup>
 
@@ -198,16 +199,16 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 //         CHECK:     spirv.mlir.loop
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-8:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : f16
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-8:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : f16
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
-//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<f16, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
 //         CHECK:       %[[MA0:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD2]], %{{.+}}
 //         CHECK:       %[[MA1:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD3]], %[[MA0]]
@@ -216,9 +217,9 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 //         CHECK:       spirv.mlir.merge
 
 //         CHECK:     %[[LD_FN:.+]] = spirv.Load "Function" %[[LOCAL_VAR]] : !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:     %[[LD4:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C256]], %[[COL_MAJOR]] : !spirv.ptr<f16, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[LD4:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK:     %[[DIV:.+]] = spirv.FDiv %[[LD_FN]], %[[LD4]] : !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:     spirv.NV.CooperativeMatrixStore %{{.+}}, %[[DIV]], %[[C256]], %[[COL_MAJOR]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %{{.+}}, %[[DIV]], %[[C32]], %[[COL_MAJOR]]
 
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/vectorize_load_store.mlir
@@ -306,3 +306,19 @@ func.func @scalarize_indivisible_vector_transfer_write_op(%value: vector<4xf32>,
 
 // CHECK:         %[[SUBSPAN:.+]] = hal.interface.binding.subspan
 // CHECK-COUNT-4: memref.store %{{.+}}, %[[SUBSPAN]]
+
+// -----
+
+// CHECK-LABEL: func.func @vectorize_alloc_with_mma_load_store
+//  CHECK-SAME: (%[[I0:.+]]: index, %[[I1:.+]]: index)
+func.func @vectorize_alloc_with_mma_load_store(%i0: index, %i1: index) {
+  %alloc = memref.alloc() : memref<32x32xf16, 3>
+  %0 = gpu.subgroup_mma_load_matrix %alloc[%i0, %i1] {leadDimension = 32 : index} : memref<32x32xf16, 3> -> !gpu.mma_matrix<16x16xf16, "COp">
+  gpu.subgroup_mma_store_matrix %0, %alloc[%i0, %i1] {leadDimension = 32 : index} : !gpu.mma_matrix<16x16xf16, "COp">, memref<32x32xf16, 3>
+  return
+}
+
+// CHECK: %[[ALLOC:.+]] = memref.alloc() : memref<32x4xvector<4xf32>, 3>
+// CHECK: %[[IDX:.+]] = affine.apply affine_map<()[s0] -> (s0 floordiv 8)>()[%[[I1]]]
+// CHECK: %[[LD:.+]] = gpu.subgroup_mma_load_matrix %[[ALLOC]][%[[I0]], %[[IDX]]] {leadDimension = 4 : index} : memref<32x4xvector<4xf32>, 3> -> !gpu.mma_matrix<16x16xf16, "COp">
+// CHECK: gpu.subgroup_mma_store_matrix %[[LD]], %[[ALLOC]][%[[I0]], %[[IDX]]] {leadDimension = 4 : index} : !gpu.mma_matrix<16x16xf16, "COp">, memref<32x4xvector<4xf32>, 3>


### PR DESCRIPTION
This change enables vectorizing memref types used by GPU subgroup MMA ops so that we can be coherent and allow casting vector<8xf16> values into vector<4xf32> throughout.