### PR TITLE
Reenable transform dialect tests.

### DIFF
--- a/tests/transform_dialect/cpu/BUILD
+++ b/tests/transform_dialect/cpu/BUILD
@@ -15,7 +15,7 @@ package(
 
 iree_lit_test_suite(
     name = "lit",
-    srcs = [],  # ["matmul.mlir"], disable failing test
+    srcs = ["matmul.mlir"],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.

--- a/tests/transform_dialect/cpu/CMakeLists.txt
+++ b/tests/transform_dialect/cpu/CMakeLists.txt
@@ -13,6 +13,8 @@ iree_add_all_subdirs()
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "matmul.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -26,11 +26,11 @@ endif()
 iree_lit_test_suite(
     name = "lit",
     srcs = [
-        #"reduction.mlir",
-        #"softmax.mlir",
-        #"softmax_v2.mlir",
+        "reduction.mlir",
+        "softmax.mlir",
+        "softmax_v2.mlir",
         # First few ops of softmax only, acts as a proxy example.
-        #"softmax_partial.mlir",
+        "softmax_partial.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -17,6 +17,11 @@ endif()
 iree_lit_test_suite(
   NAME
     lit
+  SRCS
+    "reduction.mlir"
+    "softmax.mlir"
+    "softmax_partial.mlir"
+    "softmax_v2.mlir"
   TOOLS
     FileCheck
     iree-compile


### PR DESCRIPTION
A recent integration regression prompted the disabling of those tests. Reenable them.