### PR TITLE
Adding flag for setting VMA preferredLargeHeapBlockSize.

### DIFF
--- a/runtime/src/iree/hal/drivers/vulkan/api.h
+++ b/runtime/src/iree/hal/drivers/vulkan/api.h
@@ -166,6 +166,13 @@ typedef uint32_t iree_hal_vulkan_device_flags_t;
 typedef struct iree_hal_vulkan_device_options_t {
   // Flags controlling device behavior.
   iree_hal_vulkan_device_flags_t flags;
+
+  // Sets the VMA preferredLargeHeapBlockSize field to control the preferred
+  // size of a large heap block allocation. This effectively specifies the
+  // minimum amount of memory required and will always allocate at least this
+  // much.
+  // NOTE: this is temporary and likely to get removed in the future.
+  iree_device_size_t large_heap_block_size;
 } iree_hal_vulkan_device_options_t;
 
 IREE_API_EXPORT void iree_hal_vulkan_device_options_initialize(

--- a/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/registration/driver_module.cc
@@ -34,6 +34,10 @@ IREE_FLAG(bool, vulkan_tracing, true,
 IREE_FLAG(
     bool, vulkan_dedicated_compute_queue, false,
     "Use a dedicated queue with VK_QUEUE_COMPUTE_BIT for dispatch workloads.");
+IREE_FLAG(
+    int64_t, vulkan_large_heap_block_size, 0,
+    "Preferred allocator block size for large allocations in bytes. Sets the "
+    "minimum bound on memory consumption.");
 
 static iree_status_t iree_hal_vulkan_create_driver_with_flags(
     iree_string_view_t identifier, iree_allocator_t host_allocator,
@@ -71,6 +75,10 @@ static iree_status_t iree_hal_vulkan_create_driver_with_flags(
   if (FLAG_vulkan_dedicated_compute_queue) {
     driver_options.device_options.flags |=
         IREE_HAL_VULKAN_DEVICE_FLAG_DEDICATED_COMPUTE_QUEUE;
+  }
+  if (FLAG_vulkan_large_heap_block_size) {
+    driver_options.device_options.large_heap_block_size =
+        FLAG_vulkan_large_heap_block_size;
   }
 
   // Load the Vulkan library. This will fail if the library cannot be found or

--- a/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
@@ -82,9 +82,9 @@ static void VKAPI_PTR iree_hal_vulkan_vma_free_callback(
 #endif  // IREE_STATISTICS_ENABLE
 
 iree_status_t iree_hal_vulkan_vma_allocator_create(
-    VkInstance instance, VkPhysicalDevice physical_device,
-    VkDeviceHandle* logical_device, iree_hal_device_t* device,
-    iree_hal_allocator_t** out_allocator) {
+    const iree_hal_vulkan_device_options_t* options, VkInstance instance,
+    VkPhysicalDevice physical_device, VkDeviceHandle* logical_device,
+    iree_hal_device_t* device, iree_hal_allocator_t** out_allocator) {
   IREE_ASSERT_ARGUMENT(instance);
   IREE_ASSERT_ARGUMENT(physical_device);
   IREE_ASSERT_ARGUMENT(logical_device);
@@ -141,7 +141,7 @@ iree_status_t iree_hal_vulkan_vma_allocator_create(
   create_info.physicalDevice = physical_device;
   create_info.device = *logical_device;
   create_info.instance = instance;
-  create_info.preferredLargeHeapBlockSize = 64 * 1024 * 1024;
+  create_info.preferredLargeHeapBlockSize = options->large_heap_block_size;
   create_info.pAllocationCallbacks = logical_device->allocator();
   create_info.pDeviceMemoryCallbacks = &device_memory_callbacks;
   create_info.pHeapSizeLimit = NULL;

--- a/runtime/src/iree/hal/drivers/vulkan/vma_allocator.h
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_allocator.h
@@ -34,7 +34,8 @@ extern "C" {
 //   https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator
 //   https://gpuopen-librariesandsdks.github.io/VulkanMemoryAllocator/html/
 iree_status_t iree_hal_vulkan_vma_allocator_create(
-    VkInstance instance, VkPhysicalDevice physical_device,
+    const iree_hal_vulkan_device_options_t* options, VkInstance instance,
+    VkPhysicalDevice physical_device,
     iree::hal::vulkan::VkDeviceHandle* logical_device,
     iree_hal_device_t* device, iree_hal_allocator_t** out_allocator);
 

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -502,6 +502,7 @@ IREE_API_EXPORT void iree_hal_vulkan_device_options_initialize(
     iree_hal_vulkan_device_options_t* out_options) {
   memset(out_options, 0, sizeof(*out_options));
   out_options->flags = 0;
+  out_options->large_heap_block_size = 64 * 1024 * 1024;
 }
 
 // Creates a transient command pool for the given queue family.
@@ -699,8 +700,8 @@ static iree_status_t iree_hal_vulkan_device_create_internal(
   // Create the device memory allocator that will service all buffer
   // allocation requests.
   iree_status_t status = iree_hal_vulkan_vma_allocator_create(
-      instance, physical_device, logical_device, (iree_hal_device_t*)device,
-      &device->device_allocator);
+      options, instance, physical_device, logical_device,
+      (iree_hal_device_t*)device, &device->device_allocator);
 
   // Create command pools for each queue family. If we don't have a transfer
   // queue then we'll ignore that one and just use the dispatch pool.


### PR DESCRIPTION
`--vulkan_large_heap_block_size=0`: default today (64MB)
`--vulkan_large_heap_block_size=4294967295`: max for most desktops (4GB)

Valid values are based on device limits:
https://vulkan.gpuinfo.org/displaydevicelimit.php?name=maxStorageBufferRange&platform=all