### PR TITLE
Add support for generalizing unpack op when outer dim sizes are all 1s. 

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -126,7 +126,7 @@ void populateTopkSplitReductionPattern(
 std::unique_ptr<OperationPass<func::FuncOp>> createTopkSplitReductionPass();
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLinalgExtPackOpVectorizationPass();
+createLinalgExtVectorizationPass();
 
 // Marker used as attribute the depth of the split reduction transformations.
 const StringLiteral kSplitReductionDepthMarker = "__split_reduction_depth__";

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -125,8 +125,7 @@ void populateTopkSplitReductionPattern(
 
 std::unique_ptr<OperationPass<func::FuncOp>> createTopkSplitReductionPass();
 
-std::unique_ptr<OperationPass<func::FuncOp>>
-createLinalgExtVectorizationPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createLinalgExtVectorizationPass();
 
 // Marker used as attribute the depth of the split reduction transformations.
 const StringLiteral kSplitReductionDepthMarker = "__split_reduction_depth__";

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -71,15 +71,15 @@ def TopkSplitReduction:
   ];
 }
 
-def LinalgExtPackOpVectorization:
-    Pass<"iree-linalg-ext-pack-op-vectorization", "func::FuncOp"> {
+def LinalgExtVectorization:
+    Pass<"iree-linalg-ext-vectorization", "func::FuncOp"> {
   let summary = "Vectorization pass for LinalgExt pack ops.";
   let description = [{
     Vectorizes LinalgExt ops when they meet the conditions, e.g., having static
     shapes, etc.
   }];
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::"
-                    "createLinalgExtPackOpVectorizationPass()";
+                    "createLinalgExtVectorizationPass()";
 }
 
 //===---------------------------------------------------------------------====//

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -49,6 +49,10 @@ SmallVector<T> undoInterchange(ArrayRef<T> elements,
   return vec;
 }
 
+/// Returns the `interchangeVector` based on `dimsPos`.
+SmallVector<int64_t> computeInterchangeFromDimPos(ArrayRef<int64_t> dimsPos,
+                                                  int64_t rank);
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1516,32 +1516,6 @@ static bool areNotFullTiles(ArrayRef<int64_t> inputShape,
   return false;
 }
 
-/// Return the `interchangeVector` based on `dims_pos`.
-static SmallVector<int64_t>
-computeInterchangeFromDimPos(ArrayRef<int64_t> innerDimsPos,
-                             int64_t inputRank) {
-  SmallVector<int64_t> interchangeVector;
-  interchangeVector.reserve(innerDimsPos.size());
-  // First map dims and their position. For example, dims_pos = [2, 0] will map
-  // to:
-  // [
-  //  [ key: 2, value: 0]
-  //  [ key: 0, value: 1]
-  // ]
-  // where key is the idx in dims_pos while value its position in dims_pos.
-  DenseMap<int64_t, int64_t> dimsAndPosMapping;
-  for (int64_t dimsIdx = 0, end = innerDimsPos.size(); dimsIdx < end; dimsIdx++)
-    dimsAndPosMapping[innerDimsPos[dimsIdx]] = dimsIdx;
-
-  // Scan the position in order and insert the value in the map
-  // to compute the interchange vector.
-  for (int64_t dimsIdx = 0; dimsIdx < inputRank; dimsIdx++) {
-    if (dimsAndPosMapping.count(dimsIdx))
-      interchangeVector.push_back(dimsAndPosMapping[dimsIdx]);
-  }
-  return interchangeVector;
-}
-
 /// Utility function shared between Pack and UnPack to get the tile sizes as
 /// OpFoldResults.
 // TODO: interface or base class in .td

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -1008,9 +1008,8 @@ struct GeneralizeUnPackOpPattern : OpRewritePattern<UnPackOp> {
   }
 };
 
-struct LinalgExtPackOpVectorizationPass
-    : public LinalgExtPackOpVectorizationBase<
-          LinalgExtPackOpVectorizationPass> {
+struct LinalgExtVectorizationPass
+    : public LinalgExtVectorizationBase<LinalgExtVectorizationPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<linalg::LinalgDialect, func::FuncDialect,
                     arith::ArithDialect, scf::SCFDialect, tensor::TensorDialect,
@@ -1071,8 +1070,8 @@ struct LinalgExtPackOpVectorizationPass
 } // namespace
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLinalgExtPackOpVectorizationPass() {
-  return std::make_unique<LinalgExtPackOpVectorizationPass>();
+createLinalgExtVectorizationPass() {
+  return std::make_unique<LinalgExtVectorizationPass>();
 }
 
 } // namespace LinalgExt

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -27,7 +27,6 @@
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/LoopInvariantCodeMotionUtils.h"
 #include "mlir/Transforms/Passes.h"
-#include "llvm/ADT/SetVector.h"
 
 using namespace mlir;
 
@@ -851,8 +850,7 @@ Value getInputOrPaddedInput(OpBuilder &builder, PackOp packOp) {
       continue;
     }
 
-    // The size is less than or equal to tileSize because outer dims to be all
-    // 1s.
+    // The size is less than or equal to tileSize because outer dims are all 1s.
     Optional<int64_t> tileSize =
         getConstantIntValue(tileAndPosMapping.lookup(dim));
     assert(tileSize.hasValue() && "dynamic inner tile size is not supported");

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -967,7 +967,6 @@ struct GeneralizeUnPackOpPattern : OpRewritePattern<UnPackOp> {
         computeInterchangeFromDimPos(innerDimsPos, outputRank);
     SmallVector<int64_t> transpShape =
         interchange<int64_t>(readShape, interchangeVector);
-    auto transpType = RankedTensorType::get(transpShape, elemType);
 
     Value empty = rewriter.create<tensor::EmptyOp>(loc, transpShape, elemType);
     auto transposedOp = rewriter.create<linalg::TransposeOp>(

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/vectorization.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/vectorization.mlir
@@ -171,3 +171,53 @@ func.func @KC_to_CKck(%arg0: tensor<128x256xf32>, %arg1: tensor<32x4x32x8xf32>) 
 // CHECK:           scf.yield %[[RES1]]
 // CHECK:         }
 // CHECK:         return %[[RES0]]
+
+// -----
+
+func.func @simple_KCRSsr_to_KCRS(%arg0: tensor<1x1x1x1x8x32xf32>, %arg1: tensor<1x1x32x8xf32>) -> tensor<1x1x32x8xf32> {
+  %0 = iree_linalg_ext.unpack %arg0 inner_dims_pos = [3, 2] inner_tiles = [8, 32] into %arg1 : (tensor<1x1x1x1x8x32xf32> tensor<1x1x32x8xf32>) -> tensor<1x1x32x8xf32>
+  return %0 : tensor<1x1x32x8xf32>
+}
+// CHECK-LABEL: func.func @simple_KCRSsr_to_KCRS
+// CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
+// CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
+// CHECK-DAG:     %[[C0:.+]] = arith.constant 0 : index
+// CHECK-DAG:     %[[ZERO:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:         %[[READ:.+]] = vector.transfer_read %[[IN]]
+// CHECK-SAME       [[%[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]], %[[C0]]], %[[CST]]
+// CHECK-SAME:      {in_bounds = [true, true]} : tensor<1x1x1x1x8x32xf32>, vector<8x32xf32>
+// CHECK:         %[[TRANSP:.+]] = vector.transpose %[[READ]], [1, 0]
+// CHECK:         %[[WRITE:.+]] = vector.transfer_write %[[TRANSP]]
+// CHECK-SAME:      %[[OUT]][%[[C0]], %[[C0]], %[[C0]], %[[C0]]]
+// CHECK-SAME:      {in_bounds = [true, true]} : vector<32x8xf32>, tensor<1x1x32x8xf32>
+// CHECK:         return %[[WRITE]]
+
+// -----
+
+func.func @simple_unpack_and_extract_slice(%input: tensor<1x1x8x2xf32>, %output: tensor<5x1xf32>) -> tensor<5x1xf32> {
+  %0 = iree_linalg_ext.unpack %input inner_dims_pos = [0, 1] inner_tiles = [8, 2] into %output : (tensor<1x1x8x2xf32> tensor<5x1xf32>) -> tensor<5x1xf32>
+  return %0 : tensor<5x1xf32>
+}
+// CHECK-LABEL: func.func @simple_unpack_and_extract_slice
+// CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
+// CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
+// CHECK:         %[[SLICE_IN:.+]] = tensor.extract_slice %[[IN]]
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 8, 2] [1, 1, 1, 1]
+// CHECK-SAME:      : tensor<1x1x8x2xf32> to tensor<8x2xf32>
+// CHECK:         %[[RES:.+]] = tensor.extract_slice %[[SLICE_IN]]
+// CHECK-SAME:      [0, 0] [5, 1] [1, 1] : tensor<8x2xf32> to tensor<5x1xf32>
+// CHECK:         return %[[RES:.+]]
+
+// -----
+
+func.func @simple_CNnc_to_NC(%arg0: tensor<1x1x32x8xf32>, %arg1: tensor<32x8xf32>) -> tensor<32x8xf32>{
+  %0 = iree_linalg_ext.unpack %arg0 outer_dims_perm = [1, 0] inner_dims_pos = [0, 1] inner_tiles = [32, 8] into %arg1 : (tensor<1x1x32x8xf32> tensor<32x8xf32>) -> tensor<32x8xf32>
+  return %0 : tensor<32x8xf32>
+}
+// CHECK-LABEL: func.func @simple_CNnc_to_NC
+// CHECK-SAME:    %[[IN:[A-Za-z0-9]+]]:
+// CHECK-SAME:    %[[OUT:[A-Za-z0-9]+]]:
+// CHECK:         %[[SLICE_IN:.+]] = tensor.extract_slice %[[IN]]
+// CHECK-SAME:      [0, 0, 0, 0] [1, 1, 32, 8] [1, 1, 1, 1]
+// CHECK-SAME:      : tensor<1x1x32x8xf32> to tensor<32x8xf32>
+// CHECK:         return %[[SLICE_IN]]

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/vectorization.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/vectorization.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-dialects-opt --iree-linalg-ext-pack-op-vectorization --split-input-file %s | FileCheck %s
+// RUN: iree-dialects-opt --iree-linalg-ext-vectorization --split-input-file %s | FileCheck %s
 
 func.func @simple_KCRS_to_KCRSsr(%arg0: tensor<1x1x32x8xf32>, %arg1: tensor<1x1x1x1x8x32xf32>) -> tensor<1x1x1x1x8x32xf32> {
   %0 = iree_linalg_ext.pack %arg0 inner_dims_pos = [3, 2] inner_tiles = [8, 32] into %arg1 : (tensor<1x1x32x8xf32> tensor<1x1x1x1x8x32xf32>) -> tensor<1x1x1x1x8x32xf32>


### PR DESCRIPTION
It generalizes the unpack op into extract_slice + copy + insert_slice
ops. Because the outer dim sizes are all 1s, we're able to extract the
inner tiles from input, apply the transposition, and insert it back to a
tensor. It enables the vectorization for unpack op.

The vector ops are not generated if there is no transposition. Because
it is on tensor semantics, the linalg.generic op (i.e., copy op) is
folded away in this case.

For outer dim sizes that are not all 1s, we have to update the upstream
`scf::tileUsingSCFForOp` method to accept multi operations created
during tiling. That would be the next step after landing this commit.

The commit also moves `computeInterchangeFromDimPos` to utils.