### PR TITLE
[spirv] Fix K tile size deduction for cooperative matrix

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -13,6 +13,7 @@
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
+#include "llvm/ADT/APInt.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/MathExtras.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -85,7 +86,12 @@ static Optional<CooperativeMatrixSize> getCooperativeMatrixSize(
           mCount = mGCD.getSExtValue();
         }
 
-        int64_t kCount = std::min<int64_t>(k / matmulK, numKTilesPerWorkgroup);
+        const uint64_t kTileCount = k / matmulK;
+        const APInt kTileCountAPInt(/*numBits=*/64, kTileCount);
+
+        APInt kGCD = GreatestCommonDivisor(kTileCountAPInt,
+                                           APInt(64, numKTilesPerWorkgroup));
+        int64_t kCount = kGCD.getSExtValue();
 
         return CooperativeMatrixSize{matmulM, matmulN, matmulK,
                                      mCount,  nCount,  kCount};


### PR DESCRIPTION
We cannot just take the minimal value there; need to make sure tile sizes properly divide.