### PR TITLE
Flow changes for enabling data tiling.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -1238,8 +1238,18 @@ def FLOW_TensorTraceOp : FLOW_Op<"tensor.trace", []> {
 // Parameterization Ops
 //===---------------------------------------------------------------------===//
 
-def Flow_DispatchWorkgroupCountFromDagRootOp :
-    FLOW_PureOp<"dispatch.workgroup_count_from_dag_root"> {
+class FLOW_DispatchWorkgroupCountOp<string mnemonic, list<Trait> traits = []> :
+    FLOW_PureOp<mnemonic, traits> {
+  let arguments = (ins Variadic<Index>:$operands);
+  let results = (outs Index:$x, Index:$y, Index:$z);
+
+  let assemblyFormat = [{
+    attr-dict $operands
+  }];
+}
+
+def FLOW_DispatchWorkgroupCountFromDagRootOp :
+    FLOW_DispatchWorkgroupCountOp<"dispatch.workgroup_count_from_dag_root"> {
   let summary = [{
     workgroup count computed based on iteration range of the root of the DAG
     for ops within the dispatch.
@@ -1254,12 +1264,20 @@ def Flow_DispatchWorkgroupCountFromDagRootOp :
     (typically based on the tile sizes used to tile and distribute the root of
     the DAG).
   }];
+}
 
-  let arguments = (ins Variadic<Index>:$operands);
-  let results = (outs Index:$x, Index:$y, Index:$z);
-
-  let assemblyFormat = [{
-    attr-dict $operands
+def FLOW_DispatchWorkgroupCountFromSetEncodingOp :
+    FLOW_DispatchWorkgroupCountOp<"dispatch.workgroup_count_from_set_encoding_op"> {
+  let summary = [{
+    Workgroup count for dispatches that have a root as set_encoding op.
+  }];
+  let description = [{
+    For dispatches where the set_encoding operation is the root (producers
+    might be fused into these ops), the actual iteration space is materialized
+    only in the backend. This op is a placeholder to represent the workgroup
+    count calculation that accounts for the materialization.
+    The operands to the op represent the shape of the source of the pack
+    operation.
   }];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -148,7 +148,8 @@ static bool isRootOp(Operation *op) {
     }
     return !isa<linalg::FillOp>(op);
   }
-  return isa<TilingInterface>(op);
+  return isa<TilingInterface>(op) ||
+         isa<LinalgExt::SetEncodingOp, LinalgExt::UnsetEncodingOp>(op);
 }
 
 /// Operations that are cloned into dispatch regions formed with other
@@ -157,8 +158,9 @@ bool isClonableIntoDispatchOp(Operation *op) {
   // TODO(#8637): `tensor.collapse_shape` and `tensor.expand_shape` are
   // trivially clonable too, but they cause problems
   // with bufferization. Make them clonable when fixed.
-  if (isa<arith::IndexCastOp, tensor::EmptyOp, tensor::CastOp,
-          tensor::ExtractOp, tensor::ExtractSliceOp, tensor::PadOp>(op)) {
+  if (isa<AffineApplyOp, arith::IndexCastOp, linalg::FillOp, tensor::EmptyOp,
+          tensor::CastOp, tensor::ExtractOp, tensor::ExtractSliceOp,
+          tensor::PadOp>(op)) {
     return true;
   }
   if (auto constantOp = dyn_cast<arith::ConstantOp>(op)) {
@@ -262,12 +264,44 @@ static bool hasComputeUsesOutsideDispatch(
   });
 }
 
+/// Populate the workgroup count region of dispatch operations. This region
+/// mostly contains operations that are placeholders for the actual computation
+/// that will be materialized in the backends.
+static void materializeDispatchWorkgroupCountRegion(
+    OpBuilder &builder, IREE::Flow::DispatchWorkgroupsOp dispatchOp,
+    Operation *rootOp, ValueRange workload) {
+  Region &workgroupCountRegion = dispatchOp.getWorkgroupCount();
+  if (!workgroupCountRegion.empty()) return;
+
+  auto workloadArgTypes = llvm::to_vector(
+      llvm::map_range(workload, [](Value v) { return v.getType(); }));
+  Location loc = dispatchOp.getLoc();
+  SmallVector<Location> locs(workload.size(), loc);
+  OpBuilder::InsertionGuard g(builder);
+  Block *body =
+      builder.createBlock(&workgroupCountRegion, workgroupCountRegion.end(),
+                          workloadArgTypes, locs);
+  auto numWorkgroupsOp =
+      TypeSwitch<Operation *, Operation *>(rootOp)
+          .Case<IREE::LinalgExt::SetEncodingOp>([&](auto setEncodingOp) {
+            return builder
+                .create<IREE::Flow::DispatchWorkgroupCountFromSetEncodingOp>(
+                    loc, body->getArguments());
+          })
+          .Default([&](Operation *) {
+            return builder
+                .create<IREE::Flow::DispatchWorkgroupCountFromDagRootOp>(
+                    loc, body->getArguments());
+          });
+  builder.create<IREE::Flow::ReturnOp>(loc, numWorkgroupsOp->getResults());
+}
+
 /// Creates a flow.dispatch.workgroup op without arguments.
 /// All the necessary operands are transiently captured and rewritten late as
 /// operands. This greatly simplifies transformations into the resulting op.
 static FailureOr<SmallVector<Operation *>>
 buildOperandLessFlowDispatchWorkgroupOp(PatternRewriter &rewriter, Location loc,
-                                        ArrayRef<Value> workload,
+                                        ValueRange workload,
                                         ArrayRef<Operation *> dispatchOps) {
   SmallVector<Value> resultDynamicDims;
   SmallVector<Type> resultTypes;
@@ -344,23 +378,10 @@ buildOperandLessFlowDispatchWorkgroupOp(PatternRewriter &rewriter, Location loc,
                           << *dispatchOp << "\n");
 
   // 4. Add a region for workgroup_count computation.
-  Region &workgroupCountRegion = dispatchOp.getWorkgroupCount();
-  Block *body = rewriter.createBlock(&workgroupCountRegion);
-  // Assuming that there is an insertion guard in place already, change the
-  // insertion point to the body.
-  rewriter.setInsertionPointToStart(body);
-  SmallVector<Value> workloadArgs;
-  for (auto workload : llvm::enumerate(workload)) {
-    workloadArgs.push_back(body->addArgument(workload.value().getType(), loc));
-  }
-  auto numWorkgroupsOp =
-      rewriter.create<DispatchWorkgroupCountFromDagRootOp>(loc, workloadArgs);
-  rewriter.create<ReturnOp>(loc, numWorkgroupsOp.getResults());
+  materializeDispatchWorkgroupCountRegion(rewriter, dispatchOp,
+                                          dispatchOps.back(), workload);
 
   LLVM_DEBUG(llvm::dbgs() << "After workgroup_count creation \n"
-                          << *dispatchOp << "\n");
-
-  LLVM_DEBUG(llvm::dbgs() << "Created dispatchOp shell \n"
                           << *dispatchOp << "\n");
   return clonedOps;
 }
@@ -585,9 +606,8 @@ static LogicalResult legalizeDispatchWorkgroupOperands(
       // Create a new basic block argument for this value.
       Type bbArgType = value.getType();
       if (tensorType) {
-        bbArgType = IREE::Flow::DispatchTensorType::get(
-            TensorAccess::ReadOnly, tensorType.getShape(),
-            tensorType.getElementType());
+        bbArgType = IREE::Flow::DispatchTensorType::get(TensorAccess::ReadOnly,
+                                                        tensorType);
       }
       bbArg = block.insertArgument(numOperands, bbArgType, value.getLoc());
     }
@@ -897,6 +917,18 @@ static bool isFusableWithConsumer(OpOperand &fusedOperand,
   Operation *producer = fusedOperand.get().getDefiningOp();
   Operation *consumer = fusedOperand.getOwner();
 
+  // Fuse unset_encoding operations with `tensor.extract_slice`.
+  if (isa<LinalgExt::UnsetEncodingOp>(producer) &&
+      isa<tensor::ExtractSliceOp>(consumer)) {
+    auto sliceOp = cast<tensor::ExtractSliceOp>(consumer);
+    return llvm::all_of(
+               sliceOp.getMixedOffsets(),
+               [](OpFoldResult ofr) { return isConstantIntValue(ofr, 0); }) &&
+           llvm::all_of(sliceOp.getMixedStrides(), [](OpFoldResult ofr) {
+             return isConstantIntValue(ofr, 1);
+           });
+  }
+
   auto producerLinalgOp = dyn_cast<linalg::LinalgOp>(producer);
   auto consumerLinalgOp = dyn_cast<linalg::LinalgOp>(consumer);
   if (!producerLinalgOp || !consumerLinalgOp) return false;
@@ -969,6 +1001,12 @@ static void fuseRootsWithConsumers(MLIRContext *context,
 static bool isFusableWithProducer(OpOperand &operand, bool aggressiveFusion) {
   Operation *producer = operand.get().getDefiningOp();
   Operation *consumer = operand.getOwner();
+
+  // Fuse linalg ops with set encoding op if the operand is an `outs` value.
+  if (isa<linalg::LinalgOp>(consumer) &&
+      isa<IREE::LinalgExt::SetEncodingOp>(producer)) {
+    return cast<DestinationStyleOpInterface>(consumer).isDpsInit(&operand);
+  }
 
   if (!isa<linalg::LinalgOp>(consumer) || !isa<linalg::LinalgOp>(producer)) {
     return false;
@@ -1190,10 +1228,13 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
     RewritePatternSet computeOpDispatchPatterns(context);
     computeOpDispatchPatterns.insert<
         CreateDispatchRegionOp<TilingInterface, OpInterfaceRewritePattern>,
+        CreateDispatchRegionOp<LinalgExt::SetEncodingOp, OpRewritePattern>,
+        CreateDispatchRegionOp<LinalgExt::UnsetEncodingOp, OpRewritePattern>,
         CreateDispatchRegionOp<tensor::InsertSliceOp, OpRewritePattern>>(
         context, filterForComputeOps);
     if (failed(createDispatchRegionsFromRootOps(
             funcOp, std::move(computeOpDispatchPatterns)))) {
+      funcOp.emitOpError("failed to create dispatch region based on operation");
       return signalPassFailure();
     }
   }
@@ -1214,6 +1255,8 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
         convertToFlowPatterns, context);
     if (failed(applyPatternsAndFoldGreedily(
             funcOp, std::move(convertToFlowPatterns)))) {
+      funcOp.emitOpError(
+          "failed to convert operation outside dispatch region into flow ops");
       return signalPassFailure();
     }
   }
@@ -1230,6 +1273,9 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
         context, filterForInsertSliceOps);
     if (failed(createDispatchRegionsFromRootOps(
             funcOp, std::move(insertSliceOpDispatchPatterns)))) {
+      funcOp.emitOpError(
+          "failed to move non-contiguous insert_slice ops into dispatch "
+          "region");
       return signalPassFailure();
     }
   }
@@ -1244,6 +1290,9 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
         context, filterForCleanupOps);
     if (failed(createDispatchRegionsFromRootOps(
             funcOp, std::move(cleanUpDispatchPatterns)))) {
+      funcOp.emitOpError(
+          "failed to move non-contiguous extract_slice ops into dispatch "
+          "region");
       return signalPassFailure();
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -1002,12 +1002,6 @@ static bool isFusableWithProducer(OpOperand &operand, bool aggressiveFusion) {
   Operation *producer = operand.get().getDefiningOp();
   Operation *consumer = operand.getOwner();
 
-  // Fuse linalg ops with set encoding op if the operand is an `outs` value.
-  if (isa<linalg::LinalgOp>(consumer) &&
-      isa<IREE::LinalgExt::SetEncodingOp>(producer)) {
-    return cast<DestinationStyleOpInterface>(consumer).isDpsInit(&operand);
-  }
-
   if (!isa<linalg::LinalgOp>(consumer) || !isa<linalg::LinalgOp>(producer)) {
     return false;
   }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -91,6 +91,10 @@ static llvm::cl::opt<bool> clEnableAggressiveFusion(
         "with reduction loops"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clEnableDataTiling(
+    "iree-flow-enable-data-tiling", llvm::cl::desc("Enable data tiling path"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<std::string> clMmt4dTargetOptions(
     "iree-flow-mmt4d-target-options",
     llvm::cl::desc("Convert linalg.matmul ops to MMT4D ops targetting the "
@@ -265,6 +269,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       // transpose.
       .addPredicatedPass(clNormalizeInputIndexingMap,
                          createInterchangeTransposeGenericOpsPass)
+      // Enable data tiling after all linalg level transformations.
+      .addPredicatedPass(clEnableDataTiling, createSetEncodingPass)
       ////////////////////////////////////////////////////////////////////////
       // Dispatch region formation.
       .addPredicatedPass(!clDispatchTransformFileName.empty(),

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.cpp
@@ -6,9 +6,11 @@
 
 #include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
 
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/Dominance.h"
@@ -31,18 +33,15 @@ static SmallVector<Range> getLoopRangesImpl(TilingInterface tilableOp,
   return loopRanges;
 }
 
-static SmallVector<Range> getLoopRangesImpl(tensor::InsertSliceOp insertSliceOp,
-                                            Location loc, OpBuilder &builder) {
+static SmallVector<Range> getLoopRangesFromValue(Value source, Location loc,
+                                                 OpBuilder &builder) {
+  SmallVector<OpFoldResult> dimValues =
+      tensor::createDimValues(builder, loc, source);
   OpFoldResult zero = builder.getIndexAttr(0);
   OpFoldResult one = builder.getIndexAttr(1);
-  Value source = insertSliceOp.getSource();
-  SmallVector<Range> loopRanges(insertSliceOp.getSourceType().getRank(),
-                                Range{zero, one, one});
-  for (auto dim : llvm::seq<unsigned>(0, loopRanges.size())) {
-    loopRanges[dim].size =
-        builder.create<tensor::DimOp>(loc, source, dim).getResult();
-  }
-  return loopRanges;
+  return llvm::to_vector(llvm::map_range(dimValues, [&](OpFoldResult dimValue) {
+    return Range{zero, dimValue, one};
+  }));
 }
 
 static SmallVector<Range> getLoopRangesImpl(tensor::ExtractSliceOp sliceOp,
@@ -62,13 +61,14 @@ static SmallVector<Range> getLoopRangesImpl(tensor::ExtractSliceOp sliceOp,
 SmallVector<Range> Flow::getLoopRanges(Operation *op, Location loc,
                                        OpBuilder &builder) {
   return llvm::TypeSwitch<Operation *, SmallVector<Range>>(op)
-      .Case([&](TilingInterface op) {
-        return getLoopRangesImpl(op, loc, builder);
+      .Case<LinalgExt::SetEncodingOp, LinalgExt::UnsetEncodingOp,
+            tensor::InsertSliceOp>([&](auto op) {
+        return getLoopRangesFromValue(op.getSource(), loc, builder);
       })
-      .Case([&](tensor::InsertSliceOp op) {
-        return getLoopRangesImpl(op, loc, builder);
+      .Case<tensor::ExtractSliceOp>([&](auto sliceOp) {
+        return getLoopRangesImpl(sliceOp, loc, builder);
       })
-      .Case([&](tensor::ExtractSliceOp op) {
+      .Case<TilingInterface>([&](TilingInterface op) {
         return getLoopRangesImpl(op, loc, builder);
       })
       .Default([](Operation *op) -> SmallVector<Range> {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/SetEncoding.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/SetEncoding.cpp
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -192,6 +193,31 @@ struct SetMatmulEncoding : public OpRewritePattern<linalg::MatmulOp> {
   int64_t padding;
 };
 
+/// Pattern to fold a `linalg.fill` -> `iree_linalg_ext.set_encoding`
+/// operation into a `linalg.fill` of the encoded type.
+struct FoldFillWithSetEncoding
+    : public OpRewritePattern<IREE::LinalgExt::SetEncodingOp> {
+  using OpRewritePattern<IREE::LinalgExt::SetEncodingOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::LinalgExt::SetEncodingOp encodingOp,
+                                PatternRewriter &rewriter) const override {
+    auto fillOp = encodingOp.getSource().getDefiningOp<linalg::FillOp>();
+    if (!fillOp) return failure();
+
+    // Create a new fill op, with outs being defined by a new `tensor.empty` op.
+    RankedTensorType encodingType = encodingOp.getResultType();
+    Location loc = fillOp.getLoc();
+    SmallVector<OpFoldResult> dimValues =
+        tensor::createDimValues(rewriter, loc, fillOp.getOutputs()[0]);
+    auto newEmptyOp = rewriter.create<tensor::EmptyOp>(
+        loc, dimValues, encodingType.getElementType(),
+        encodingType.getEncoding());
+    rewriter.replaceOpWithNewOp<linalg::FillOp>(encodingOp, fillOp.getInputs(),
+                                                ValueRange{newEmptyOp});
+    return success();
+  }
+};
+
 struct SetEncodingPass : public SetEncodingBase<SetEncodingPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::LinalgExt::IREELinalgExtDialect>();
@@ -205,6 +231,7 @@ void SetEncodingPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   patterns.insert<SetMatmulEncoding>(context, defaultPadding);
+  patterns.insert<FoldFillWithSetEncoding>(context);
   if (failed(
           applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
     return signalPassFailure();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1801,3 +1801,224 @@ module {
 //   CHECK-DAG:     flow.dispatch.tensor.store %[[GENERIC1]]#2
 //       CHECK:     flow.return
 //       CHECK:   return %[[DISPATCH]]#0, %[[DISPATCH]]#1, %[[DISPATCH]]#2
+
+// -----
+
+func.func @set_encoding_op(%arg0 : tensor<?x?xf32>)
+    -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> {
+  %0 = iree_linalg_ext.set_encoding %arg0
+      : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  return %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+}
+//      CHECK: func @set_encoding_op
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D0]], %[[D1]]](%[[ARG0]], %[[D0]], %[[D1]])
+// CHECK-NEXT:     %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>
+// CHECK-SAME:     %[[INDEXARG0:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[INDEXARG1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>
+//      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
+// CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[INDEXARG0]], %[[INDEXARG1]]}
+//      CHECK:     %[[ENCODING:.+]] = iree_linalg_ext.set_encoding %[[LOAD]]
+//      CHECK:     flow.dispatch.tensor.store %[[ENCODING]], %[[OUTARG]]
+// CHECK-SAME:         sizes = [%[[INDEXARG0]], %[[INDEXARG1]]]
+// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%[[INDEXARG0]], %[[INDEXARG1]]}
+//      CHECK:     flow.return
+//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:.+]]: index)
+//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_set_encoding_op %[[WL0]], %[[WL1]]
+//      CHECK:     flow.return %[[X]], %[[Y]], %[[Z]]
+//      CHECK:   return %[[DISPATCH]]
+
+// -----
+
+func.func @unset_encoding_op(%arg0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>)
+    -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.unset_encoding %arg0
+      : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//      CHECK: func @unset_encoding_op
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[D0]], %[[D1]]](%[[ARG0]], %[[D0]], %[[D1]])
+// CHECK-NEXT:     %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>
+// CHECK-SAME:     %[[INDEXARG0:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[INDEXARG1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
+//      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
+// CHECK-SAME:         sizes = [%[[INDEXARG0]], %[[INDEXARG1]]]
+// CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%[[INDEXARG0]], %[[INDEXARG1]]}
+//      CHECK:     %[[ENCODING:.+]] = iree_linalg_ext.unset_encoding %[[LOAD]]
+//      CHECK:     flow.dispatch.tensor.store %[[ENCODING]], %[[OUTARG]]
+// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[INDEXARG0]], %[[INDEXARG1]]}
+//      CHECK:     flow.return
+//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:.+]]: index)
+//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_dag_root %[[WL0]], %[[WL1]]
+//      CHECK:     flow.return %[[X]], %[[Y]], %[[Z]]
+//      CHECK:   return %[[DISPATCH]]
+
+// -----
+
+#map = affine_map<()[s0] -> (-s0 + (s0 ceildiv 16) * 16)>
+func.func @pad_and_set_encoding_op(%arg0 : tensor<?x?xf32>)
+    -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg0, %c1 : tensor<?x?xf32>
+  %p0 = affine.apply #map()[%d0]
+  %p1 = affine.apply #map()[%d1]
+  %pad = tensor.pad %arg0 low[0, 0] high[%p0, %p1] {
+    ^bb0(%b0: index, %b1: index):
+      tensor.yield %cst : f32
+    } : tensor<?x?xf32> to tensor<?x?xf32>
+  %encoding = iree_linalg_ext.set_encoding %pad
+      : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  return %encoding : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> ((s0 ceildiv 16) * 16)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (-s0 + (s0 ceildiv 16) * 16)>
+//      CHECK: func.func @pad_and_set_encoding
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:   %[[WLIN0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
+//  CHECK-DAG:   %[[WLIN1:.+]] = affine.apply #[[MAP0]]()[%[[D1]]]
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[WLIN0]], %[[WLIN1]]](%[[ARG0]], %[[D0]], %[[D1]])
+// CHECK-NEXT:     %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32>>
+// CHECK-SAME:     %[[INDEXARG0:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[INDEXARG1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>
+//      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
+// CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%[[INDEXARG0]], %[[INDEXARG1]]}
+//      CHECK:     %[[PADDED_D1:.+]] = affine.apply #[[MAP0]]()[%[[INDEXARG1]]]
+//      CHECK:     %[[PADDED_D0:.+]] = affine.apply #[[MAP0]]()[%[[INDEXARG0]]]
+//      CHECK:     %[[HIGHPAD1:.+]] = affine.apply #[[MAP1]]()[%[[INDEXARG1]]]
+//      CHECK:     %[[HIGHPAD0:.+]] = affine.apply #[[MAP1]]()[%[[INDEXARG0]]]
+//      CHECK:     %[[PADDED:.+]] = tensor.pad %[[LOAD]] low[0, 0] high[%[[HIGHPAD0]], %[[HIGHPAD1]]]
+//      CHECK:     %[[SET_ENCODING:.+]] = iree_linalg_ext.set_encoding %[[PADDED]]
+//      CHECK:     flow.dispatch.tensor.store %[[SET_ENCODING]], %[[OUTARG]]
+// CHECK-SAME:         sizes = [%[[PADDED_D0]], %[[PADDED_D1]]]
+// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%[[PADDED_D0]], %[[PADDED_D1]]}
+//      CHECK:     flow.return
+//      CHECK:   count(%[[WL0:[a-zA-Z0-9]+]]: index, %[[WL1:.+]]: index)
+//      CHECK:     %[[X:[a-zA-Z0-9]+]], %[[Y:[a-zA-Z0-9]+]], %[[Z:.+]] = flow.dispatch.workgroup_count_from_set_encoding_op %[[WL0]], %[[WL1]]
+//      CHECK:     flow.return %[[X]], %[[Y]], %[[Z]]
+//      CHECK:   return %[[DISPATCH]]
+
+// -----
+
+func.func @unset_encoding_and_slice(
+    %arg0: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>,
+    %arg1 : index, %arg2 : index) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.unset_encoding %arg0
+      : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> -> tensor<?x?xf32>
+  %1 = tensor.extract_slice %0[0, 0] [%arg1, %arg2] [1, 1]
+      : tensor<?x?xf32> to tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//      CHECK: func @unset_encoding_and_slice
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups[%[[ARG1]], %[[ARG2]]](%[[ARG0]], %[[D0]], %[[D1]], %[[ARG1]], %[[ARG2]])
+// CHECK-NEXT:     %[[INARG:.+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>
+// CHECK-SAME:     %[[INDEXARG0:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[INDEXARG1:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[INDEXARG2:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[INDEXARG3:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[OUTARG:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>
+//      CHECK:     %[[LOAD:.+]] = flow.dispatch.tensor.load %[[INARG]]
+// CHECK-SAME:         sizes = [%[[INDEXARG0]], %[[INDEXARG1]]]
+// CHECK-SAME:         !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%[[INDEXARG0]], %[[INDEXARG1]]}
+//      CHECK:     %[[ENCODING:.+]] = iree_linalg_ext.unset_encoding %[[LOAD]]
+//      CHECK:     %[[SLICE:.+]] = tensor.extract_slice %[[ENCODING]][0, 0] [%[[INDEXARG2]], %[[INDEXARG3]]]
+//      CHECK:     flow.dispatch.tensor.store %[[SLICE]], %[[OUTARG]]
+// CHECK-SAME:         sizes = [%[[INDEXARG2]], %[[INDEXARG3]]]
+// CHECK-SAME:         !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%[[INDEXARG2]], %[[INDEXARG3]]}
+//      CHECK:     flow.return
+
+// -----
+
+func.func @gemm_encoded(
+    %arg0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>,
+    %arg1 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>,
+    %arg2 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>)
+    -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>> {
+  %0 = linalg.matmul
+      ins(%arg0, %arg1
+          : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>,
+            tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>)
+      outs(%arg2 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>)
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  return %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+}
+//      CHECK: func.func @gemm_encoded
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups
+// CHECK-NEXT:     %[[LHS_IN:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>
+// CHECK-SAME:     %[[RHS_IN:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>>
+// CHECK-SAME:     %[[INIT_IN:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readwrite:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>>
+//  CHECK-DAG:     %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_IN]]
+//  CHECK-DAG:     %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_IN]]
+//  CHECK-DAG:     %[[INIT:.+]] = flow.dispatch.tensor.load %[[INIT_IN]]
+//      CHECK:     %[[GEMM:.+]] = linalg.matmul
+// CHECK-SAME:         ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:         outs(%[[INIT]] :
+//      CHECK:     flow.dispatch.tensor.store %[[GEMM]], %[[INIT_IN]]
+
+// -----
+
+func.func @gemm_fill_encoded(
+    %arg0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>,
+    %arg1 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>)
+    -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>
+  %empty = tensor.empty(%d0, %d1): tensor<?x?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %encoding = iree_linalg_ext.set_encoding %fill : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  %0 = linalg.matmul
+      ins(%arg0, %arg1
+          : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>,
+            tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>)
+      outs(%encoding : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>)
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  return %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+}
+//      CHECK: func.func @gemm_fill_encoded
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>
+//      CHECK:   %[[DISPATCH:.+]] = flow.dispatch.workgroups
+// CHECK-NEXT:     %[[LHS_IN:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>
+// CHECK-SAME:     %[[RHS_IN:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>>
+// CHECK-SAME:     %[[RESULT:[a-zA-Z0-9]+]]: !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>>
+//  CHECK-DAG:     %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_IN]]
+//  CHECK-DAG:     %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_IN]]
+//  CHECK-DAG:     %[[INIT:.+]] = tensor.empty
+//      CHECK:     %[[FILL:.+]] = linalg.fill
+// CHECK-SAME:         outs(%[[INIT]] :
+//      CHECK:     %[[ENCODING:.+]] = iree_linalg_ext.set_encoding %[[FILL]]
+//      CHECK:     %[[GEMM:.+]] = linalg.matmul
+// CHECK-SAME:         ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:         outs(%[[ENCODING]] :
+//      CHECK:     flow.dispatch.tensor.store %[[GEMM]], %[[RESULT]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/set_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/set_encoding.mlir
@@ -130,8 +130,7 @@ func.func @fold_fill_with_set_encoding(%arg0 : index, %arg1 : index)
   return %2 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
 }
 //      CHECK: func @fold_fill_with_set_encoding(
-//      CHECK:   %[[EMPTY:.+]] = tensor.empty
-// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+//      CHECK:   %[[EMPTY:.+]] = tensor.empty(%{{.+}}, %{{.+}}) : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
 //      CHECK:   %[[FILL:.+]] = linalg.fill
 // CHECK-SAME:       outs(%[[EMPTY]] : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>)
 //      CHECK:   return %[[FILL]]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/set_encoding.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/set_encoding.mlir
@@ -117,3 +117,21 @@ func.func @matmul_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
 //      CHECK:   %[[RESULT_PADDED:.+]] = iree_linalg_ext.unset_encoding %[[MATMUL]]
 //      CHECK:   %[[RESULT:.+]] = tensor.extract_slice %[[RESULT_PADDED]][0, 0] [%[[OUTS_D0]], %[[OUTS_D1]]] [1, 1]
 //      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @fold_fill_with_set_encoding(%arg0 : index, %arg1 : index)
+  -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> {
+  %cst = arith.constant 0.0 : f32
+  %0 = tensor.empty(%arg0, %arg1) : tensor<?x?xf32>
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %2 = iree_linalg_ext.set_encoding %1 : tensor<?x?xf32>
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  return %2 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+}
+//      CHECK: func @fold_fill_with_set_encoding(
+//      CHECK:   %[[EMPTY:.+]] = tensor.empty
+// CHECK-SAME:       tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+//      CHECK:   %[[FILL:.+]] = linalg.fill
+// CHECK-SAME:       outs(%[[EMPTY]] : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>)
+//      CHECK:   return %[[FILL]]

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/BUILD
@@ -62,6 +62,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",
         "//compiler/src/iree/compiler/Utils",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:Analysis",

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/CMakeLists.txt
@@ -43,6 +43,7 @@ iree_cc_library(
     "VerifyLowerings.cpp"
   DEPS
     ::PassesIncGen
+    IREELinalgExtDialect
     LLVMSupport
     MLIRAffineDialect
     MLIRAnalysis

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EncodeTensors.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 // TODO(benvanik): have a stream/upstream equivalent of the flow.dispatch.* ops.
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
@@ -41,7 +42,8 @@ namespace {
 static LogicalResult checkEncoding(Operation *op, RankedTensorType encodingType,
                                    ValueRange encodingDims,
                                    PatternRewriter &rewriter) {
-  if (encodingType.getEncoding()) {
+  auto encoding = encodingType.getEncoding();
+  if (encoding && !encoding.isa<IREE::LinalgExt::EncodingAttr>()) {
     return rewriter.notifyMatchFailure(op, [=](Diagnostic &d) {
       d << "unsupported tensor encoding: " << encodingType;
     });

--- a/integrations/tensorflow/iree-dialects/test/Dialect/iree_linalg_ext/resolve-shaped-type-result-dims.mlir
+++ b/integrations/tensorflow/iree-dialects/test/Dialect/iree_linalg_ext/resolve-shaped-type-result-dims.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-dialects-opt -resolve-shaped-type-result-dims -split-input-file %s | FileCheck %s
 
-func.func @pack_static(%arg0 : tensor<100x250xf32>) -> (index, index) {
+func.func @set_encoding_static(%arg0 : tensor<100x250xf32>) -> (index, index) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %0 = iree_linalg_ext.set_encoding %arg0 : tensor<100x250xf32> -> tensor<100x250xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
@@ -8,14 +8,14 @@ func.func @pack_static(%arg0 : tensor<100x250xf32>) -> (index, index) {
   %2 = tensor.dim %0, %c1 : tensor<100x250xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
   return %1, %2 : index, index
 }
-// CHECK-LABEL: func @pack_static(
+// CHECK-LABEL: func @set_encoding_static(
 //   CHECK-DAG:   %[[C100:.+]] = arith.constant 100 : index
 //   CHECK-DAG:   %[[C250:.+]] = arith.constant 250 : index
 //       CHECK:   return %[[C100]], %[[C250]]
 
 // -----
 
-func.func @pack_dynamic(%arg0 : tensor<?x?xf32>) -> (index, index) {
+func.func @set_encoding_dynamic(%arg0 : tensor<?x?xf32>) -> (index, index) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
@@ -23,7 +23,24 @@ func.func @pack_dynamic(%arg0 : tensor<?x?xf32>) -> (index, index) {
   %2 = tensor.dim %0, %c1 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
   return %1, %2 : index, index
 }
-//       CHECK: func @pack_dynamic(%[[ARG0:.+]]: tensor<?x?xf32>)
+//       CHECK: func @set_encoding_dynamic(%[[ARG0:.+]]: tensor<?x?xf32>)
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//       CHECK:   return %[[D0]], %[[D1]]
+
+// -----
+
+func.func @unset_encoding(%arg0: tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>) -> (index, index) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %0 = iree_linalg_ext.unset_encoding %arg0 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> -> tensor<?x?xf32>
+  %1 = tensor.dim %0, %c0 : tensor<?x?xf32>
+  %2 = tensor.dim %0, %c1 : tensor<?x?xf32>
+  return %1, %2 : index, index
+}
+//       CHECK: func @unset_encoding(%[[ARG0:.+]]: tensor<?x?xf32>)
 //   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //   CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -801,7 +801,7 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
 }
 
 def IREELinalgExt_SetEncodingOp : IREELinalgExt_PureOp<"set_encoding",[
-   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>
+   DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>, Pure
   ]> {
   let summary = "perform pack and pad operation on source";
   let description = [{
@@ -837,7 +837,9 @@ let builders = [
   }];
 }
 
-def IREELinalgExt_UnsetEncodingOp : IREELinalgExt_PureOp<"unset_encoding"> {
+def IREELinalgExt_UnsetEncodingOp : IREELinalgExt_PureOp<"unset_encoding", [
+    DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>, Pure
+  ]> {
   let summary = "perfom unpack and extract operation on source";
   let description = [{
     Operation to convert an tensor with encoding that represents

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2414,6 +2414,16 @@ LogicalResult UnsetEncodingOp::verify() {
   return success();
 }
 
+LogicalResult UnsetEncodingOp::reifyResultShapes(
+    OpBuilder &builder, ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  OpBuilder::InsertionGuard g(builder);
+  builder.setInsertionPoint(getOperation());
+  reifiedReturnShapes.resize(1);
+  reifiedReturnShapes[0] = getValueOrCreateConstantIndexOp(
+      builder, getLoc(), getDims(builder, getLoc(), getSource()));
+  return success();
+}
+
 namespace {
 /// This is derived from mlir/lib/Dialect/Linalg/IR/LinalgOps.cpp without any
 /// changes.


### PR DESCRIPTION
This change adds a pass to set encoding for operations, and adapts dispatch region formation to put these operations into dispatches.

- `set_encoding` operations go into a separate dispatch. Any `pad` producers are fused with this operation.
- `unset_encoding` operations go into a separate dispatch. Any `extract_slice` consumer gets fused with this operation.
- `set_encoding` operations that are producers for the `outs` operands of `linalg` operations are pulled into the same dispatch as the `linalg` op.

Since the number of workgroups computation varies from the default used today, a new op
`flow.dispatch.workgroup_count_from_set_encoding_op` is added. This can be materialized once the `set_encoding` operation is converted to the `pack` operation in the backend based on machine parameters.

Also implement the `ReifyRankedShapedTypeOpInterface` for `unset_encoding` op.