### PR TITLE
[spirv] Lower `tosa.apply_scale` before i64 emulation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -34,7 +34,6 @@
 #include "mlir/Conversion/MemRefToSPIRV/MemRefToSPIRV.h"
 #include "mlir/Conversion/SCFToSPIRV/SCFToSPIRV.h"
 #include "mlir/Conversion/TensorToSPIRV/TensorToSPIRV.h"
-#include "mlir/Conversion/TosaToArith/TosaToArith.h"
 #include "mlir/Conversion/VectorToSPIRV/VectorToSPIRV.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/Utils/Utils.h"
@@ -358,15 +357,6 @@ void ConvertToSPIRVPass::runOnOperation() {
 
   // Pull in SCF patterns to convert control flow ops.
   populateSCFToSPIRVPatterns(typeConverter, scfToSPIRVContext, patterns);
-
-  // Use the default 64-bit lowering for TOSA's ApplyScale operator:
-  //   This lowering widens integer types to 64-bit an performs the non-fused
-  //   operations, specifically multiply, add, and shift. Bit-widening
-  //   is used to guarantee higher-order bits are not truncated during the
-  //   multiply or add.
-  //
-  // TODO(antiagainst): Use a lowering that uses specific SPIRV intrinsics.
-  tosa::populateTosaRescaleToArithConversionPatterns(&patterns);
 
   // Pull in MemRef patterns to convert load/store ops.
   populateMemRefToSPIRVPatterns(typeConverter, patterns);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Conversion/AffineToStandard/AffineToStandard.h"
 #include "mlir/Conversion/MemRefToSPIRV/MemRefToSPIRV.h"
 #include "mlir/Conversion/MemRefToSPIRV/MemRefToSPIRVPass.h"
+#include "mlir/Conversion/TosaToArith/TosaToArith.h"
 #include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Func/Transforms/Passes.h"
 #include "mlir/Dialect/GPU/Transforms/Passes.h"
@@ -197,6 +198,11 @@ static void addSPIRVLoweringPasses(OpPassManager &pm, bool enableFastMath) {
   pm.addPass(createCSEPass());
 
   pm.addPass(createLowerAffinePass());
+
+  // Lower ApplyScale before the i64 Emulation Pass so that new 64-bit ops are
+  // also emulated if not supported by the target.
+  pm.addPass(tosa::createTosaToArith(/*includeApplyRescale=*/true,
+                                     /*use32BitApplyRescale=*/true));
   pm.addPass(createCanonicalizerPass());
   pm.addPass(createCSEPass());
 


### PR DESCRIPTION
This is to allow i64 emulation to pick up new 64-bit ops produced during `tosa.apply_scale` lowering.

Issue: https://github.com/iree-org/iree/issues/10996