### PR TITLE
Bump actions/add-to-project version to use new API.

### DIFF
--- a/.github/workflows/process_opened_issues.yml
+++ b/.github/workflows/process_opened_issues.yml
@@ -11,7 +11,7 @@ jobs:
     name: Adding issue to the IREE GitHub project
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/add-to-project@7a0820f97673dfefc999713a9a6d6b7ee128bba5 # v0.0.3
+      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
         with:
           project-url: https://github.com/orgs/iree-org/projects/1
           github-token: ${{ secrets.ADD_TO_PROJECT_TOKEN }}


### PR DESCRIPTION
(Untested)

Hoping this fixes errors like those on https://github.com/iree-org/iree/actions/runs/3380006187:

> [Adding issue to the IREE GitHub project](https://github.com/iree-org/iree/actions/runs/3380006187/jobs/5612284349#step:2:6)
Request failed due to following response errors: - The `ProjectNext` API is deprecated in favour of the more capable `ProjectV2` API. Follow the ProjectV2 guide at https://github.blog/changelog/2022-06-23-the-new-github-issues-june-23rd-update/, to find a suitable replacement.

skip-ci: this workflow isn't covered by CI