### PR TITLE
[spirv] Allow multiple tiles on M/N dimension for cooperative matrix

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -26,77 +26,114 @@ using llvm::APIntOps::GreatestCommonDivisor;
 
 // The default number of subgroups to use per workgroup.
 constexpr unsigned numSubgroupsPerWorkgroup = 4;
-// The default number of tiles along K dimension to use per workgroup.
-constexpr unsigned numKTilesPerWorkgroup = 2;
+// The default number of tiles along each dimension to use per workgroup.
+constexpr unsigned numTilesPerSubgroupDim = 2;
 
 namespace mlir {
 namespace iree_compiler {
 namespace detail {
 
 struct CooperativeMatrixSize {
-  int64_t m;       // Native cooperative matrix size along M dimension
-  int64_t n;       // Native cooperative matrix size along N dimension
-  int64_t k;       // Native cooperative matrix size along K dimension
-  int64_t mCount;  // # subgroups along M dimension
-  int64_t nCount;  // # subgroups along N dimension
-  int64_t kCount;  // # tiles along K dimension
+  int64_t mSize;       // Native cooperative matrix size along M dimension
+  int64_t nSize;       // Native cooperative matrix size along N dimension
+  int64_t kSize;       // Native cooperative matrix size along K dimension
+  int64_t mWarpCount;  // # subgroups along M dimension
+  int64_t nWarpCount;  // # subgroups along N dimension
+  int64_t mTileCount;  // # tiles per subgroup along M dimension
+  int64_t nTileCount;  // # tiles per subgroup along N dimension
+  int64_t kTileCount;  // # tiles along K dimension
 };
 
 /// Returns the cooperative matrix (M, N, K) sizes that are supported by the
 /// target environment and match the given parameters.
 static Optional<CooperativeMatrixSize> getCooperativeMatrixSize(
-    spirv::ResourceLimitsAttr resourceLimits, Type lhsType, Type rhsType,
-    Type resultType, int64_t m, int64_t n, int64_t k) {
+    spirv::ResourceLimitsAttr resourceLimits, Type aType, Type bType,
+    Type cType, int64_t m, int64_t n, int64_t k) {
   auto properties = resourceLimits.getCooperativeMatrixPropertiesNv()
                         .getAsRange<spirv::CooperativeMatrixPropertiesNVAttr>();
   for (auto property : properties) {
-    if (property.getAType() == lhsType && property.getBType() == rhsType &&
-        property.getCType() == resultType &&
-        property.getResultType() == resultType &&
-        property.getScope().getValue() == spirv::Scope::Subgroup) {
-      const unsigned matmulM = property.getMSize();
-      const unsigned matmulN = property.getNSize();
-      const unsigned matmulK = property.getKSize();
-      if (m % matmulM == 0 && n % matmulN == 0 && k % matmulK == 0) {
-        const uint64_t nTileCount = n / matmulN;
-        const uint64_t mTileCount = m / matmulM;
-        const APInt nTileCountAPInt(/*numBits=*/64, nTileCount);
-        const APInt mTileCountAPInt(/*numBits=*/64, mTileCount);
-
-        int64_t nCount = 0, mCount = 0;
-        uint64_t subgroupCount = numSubgroupsPerWorkgroup;
-        uint64_t squareRoot = 1ull << (llvm::Log2_64(subgroupCount) / 2);
-
-        // See if the square root of subgroupCount can divide mTileCount. If so
-        // it means we can distribute to both dimensions evenly. Otherwise, try
-        // to distribute to N and then M.
-        if (mTileCount > squareRoot && mTileCount % squareRoot == 0) {
-          mCount = squareRoot;
-          APInt nGCD = GreatestCommonDivisor(
-              nTileCountAPInt, APInt(64, subgroupCount / squareRoot));
-          nCount = nGCD.getSExtValue();
-        } else {
-          APInt nGCD =
-              GreatestCommonDivisor(nTileCountAPInt, APInt(64, subgroupCount));
-          nCount = nGCD.getSExtValue();
-
-          subgroupCount /= nCount;
-          APInt mGCD =
-              GreatestCommonDivisor(mTileCountAPInt, APInt(64, subgroupCount));
-          mCount = mGCD.getSExtValue();
-        }
-
-        const uint64_t kTileCount = k / matmulK;
-        const APInt kTileCountAPInt(/*numBits=*/64, kTileCount);
-
-        APInt kGCD = GreatestCommonDivisor(kTileCountAPInt,
-                                           APInt(64, numKTilesPerWorkgroup));
-        int64_t kCount = kGCD.getSExtValue();
-
-        return CooperativeMatrixSize{matmulM, matmulN, matmulK,
-                                     mCount,  nCount,  kCount};
-      }
+    if (property.getAType() != aType || property.getBType() != bType ||
+        property.getCType() != cType || property.getResultType() != cType ||
+        property.getScope().getValue() != spirv::Scope::Subgroup) {
+      continue;  // Cannot use this cooperative matrix configuration
     }
+
+    const unsigned matmulM = property.getMSize();
+    const unsigned matmulN = property.getNSize();
+    const unsigned matmulK = property.getKSize();
+    if (m % matmulM != 0 || n % matmulN != 0 || k % matmulK != 0) continue;
+
+    uint64_t nTotalTileCount = n / matmulN;
+    uint64_t mTotalTileCount = m / matmulM;
+
+    uint64_t remainingWarps = numSubgroupsPerWorkgroup;
+    uint64_t remainingTiles = numTilesPerSubgroupDim * numTilesPerSubgroupDim;
+    uint64_t warpSqrt = 1ull << (llvm::Log2_64(remainingWarps) / 2);
+    uint64_t tileSqrt = 1ull << (llvm::Log2_64(remainingTiles) / 2);
+
+    int64_t mWarpCount = 0, nWarpCount = 0;
+    int64_t mTileCount = 0, nTileCount = 0;
+
+    // See if the square root can divide mTotalTileCount. If so it means we can
+    // distribute to both dimensions evenly. Otherwise, try to distribute to N
+    // and then M.
+    if (mTotalTileCount > (warpSqrt * tileSqrt) &&
+        mTotalTileCount % (warpSqrt * tileSqrt) == 0) {
+      mWarpCount = warpSqrt;
+      mTileCount = tileSqrt;
+
+      remainingWarps /= warpSqrt;
+      remainingTiles /= tileSqrt;
+
+      APInt nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                         APInt(64, remainingWarps));
+      nWarpCount = nGCD.getSExtValue();
+      nTotalTileCount /= nWarpCount;
+      remainingWarps /= nWarpCount;
+
+      nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                   APInt(64, remainingTiles));
+      nTileCount = nGCD.getSExtValue();
+    } else {
+      APInt nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                         APInt(64, remainingWarps));
+      nWarpCount = nGCD.getSExtValue();
+      nTotalTileCount /= nWarpCount;
+      remainingWarps /= nWarpCount;
+
+      nGCD = GreatestCommonDivisor(APInt(64, nTotalTileCount),
+                                   APInt(64, remainingTiles));
+      nTileCount = nGCD.getSExtValue();
+      remainingTiles /= nTileCount;
+
+      APInt mGCD = GreatestCommonDivisor(APInt(64, mTotalTileCount),
+                                         APInt(64, remainingWarps));
+      mWarpCount = mGCD.getSExtValue();
+      mTotalTileCount /= mWarpCount;
+      remainingWarps /= mWarpCount;
+
+      mGCD = GreatestCommonDivisor(APInt(64, mTotalTileCount),
+                                   APInt(64, remainingTiles));
+      mTileCount = mGCD.getSExtValue();
+    }
+
+    const uint64_t kTotalTileCount = k / matmulK;
+    APInt kGCD = GreatestCommonDivisor(APInt(64, kTotalTileCount),
+                                       APInt(64, numTilesPerSubgroupDim));
+    int64_t kTileCount = kGCD.getSExtValue();
+
+    LLVM_DEBUG({
+      llvm::dbgs() << "chosen cooperative matrix configuration:\n";
+      llvm::dbgs() << "  (M, N, K) size = (" << matmulM << ", " << matmulN
+                   << ", " << matmulK << ")\n";
+      llvm::dbgs() << "  (M, N) subgroup count = (" << mWarpCount << ", "
+                   << nWarpCount << ")\n";
+      llvm::dbgs() << "  (M, N, K) tile count per subgroup = (" << mTileCount
+                   << ", " << nTileCount << ", " << kTileCount << ")\n";
+    });
+    return CooperativeMatrixSize{matmulM,    matmulN,    matmulK,
+                                 mWarpCount, nWarpCount, mTileCount,
+                                 nTileCount, kTileCount};
   }
   return llvm::None;
 }
@@ -152,33 +189,42 @@ static LogicalResult setCooperativeMatrixConfig(
       SPIRVCooperativeMatrixVectorize;
 
   std::array<int64_t, 3> workgroupSize{
-      coopMatSize->nCount * resourceLimits.getSubgroupSize(),
-      coopMatSize->mCount, 1};
+      coopMatSize->nWarpCount * resourceLimits.getSubgroupSize(),
+      coopMatSize->mWarpCount, 1};
 
-  SmallVector<int64_t> workgroupTileSizes(kIndex + 1, 0);
-  if (isBM) workgroupTileSizes[bIndex] = 1;
-  workgroupTileSizes[mIndex] = coopMatSize->mCount * coopMatSize->m;
-  workgroupTileSizes[nIndex] = coopMatSize->nCount * coopMatSize->n;
-  workgroupTileSizes[kIndex] = coopMatSize->kCount * coopMatSize->k;
+  SmallVector<int64_t> vectorSizes(kIndex + 1, 0);
+  if (isBM) vectorSizes[bIndex] = 1;
+  vectorSizes[mIndex] = coopMatSize->mSize;
+  vectorSizes[nIndex] = coopMatSize->nSize;
+  vectorSizes[kIndex] = coopMatSize->kSize;
 
   SmallVector<int64_t> subgroupTileSizes(kIndex + 1, 0);
   if (isBM) subgroupTileSizes[bIndex] = 1;
-  subgroupTileSizes[mIndex] = coopMatSize->m;
-  subgroupTileSizes[nIndex] = coopMatSize->n;
-  subgroupTileSizes[kIndex] = coopMatSize->k;
+  subgroupTileSizes[mIndex] = coopMatSize->mTileCount * vectorSizes[mIndex];
+  subgroupTileSizes[nIndex] = coopMatSize->nTileCount * vectorSizes[nIndex];
+  subgroupTileSizes[kIndex] = coopMatSize->kTileCount * vectorSizes[kIndex];
+
+  SmallVector<int64_t> workgroupTileSizes(kIndex + 1, 0);
+  if (isBM) workgroupTileSizes[bIndex] = 1;
+  workgroupTileSizes[mIndex] =
+      coopMatSize->mWarpCount * subgroupTileSizes[mIndex];
+  workgroupTileSizes[nIndex] =
+      coopMatSize->nWarpCount * subgroupTileSizes[nIndex];
+  workgroupTileSizes[kIndex] = subgroupTileSizes[kIndex];
 
   // Also create one level for reduction. This is needed because of
   // SPIRVTileAndPromotePass requires it.
   // TODO(#10499): Consolidate tiling configuration across different pipelines.
   SmallVector<int64_t> reductionTileSizes;
   reductionTileSizes.append(lastParallelDim + 1, 0);
-  reductionTileSizes.push_back(coopMatSize->kCount * coopMatSize->k);
+  reductionTileSizes.push_back(workgroupTileSizes[kIndex]);
 
   TileSizesListType tileSizes;
   tileSizes.reserve(3);
   tileSizes.push_back(workgroupTileSizes);
   tileSizes.push_back(subgroupTileSizes);
   tileSizes.push_back(reductionTileSizes);
+  tileSizes.push_back(vectorSizes);
 
   return setOpConfigAndEntryPointFnTranslation(
       op->getParentOfType<func::FuncOp>(), op, tileSizes, pipeline,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -74,14 +74,14 @@ hal.executable public @matmul_256x1024x128_div_add {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[32, 32, 32], [16, 16, 16], [0, 0, 32]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
-//      CHECK: hal.executable.export public @matmul_256x1024x128_div_add
-// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+//  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [32, 32], [0, 0, 32], [16, 16, 16]{{\]}}>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//CHECK-LABEL: hal.executable.export public @matmul_256x1024x128_div_add
+// CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_256x1024x128_div_add()
 //      CHECK:   linalg.matmul
-// CHECK-SAME:     lowering_config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[$CONFIG]]
 
 // -----
 
@@ -148,14 +148,14 @@ hal.executable public @batch_matmul_16x128x256x512_div {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32, 32, 32], [1, 16, 16, 16], [0, 0, 0, 32]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
-//      CHECK: hal.executable.export public @batch_matmul_16x128x256x512_div
-// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+//  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//CHECK-LABEL: hal.executable.export public @batch_matmul_16x128x256x512_div
+// CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_16x128x256x512_div()
 //      CHECK:   linalg.batch_matmul
-// CHECK-SAME:     lowering_config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[$CONFIG]]
 
 // -----
 
@@ -220,14 +220,14 @@ hal.executable @generic_batch_matmul_32x8x512x64 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32, 32, 32], [1, 16, 16, 16], [0, 0, 0, 32]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
-//      CHECK: hal.executable.export public @generic_batch_matmul_32x8x512x64
-// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+//  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//CHECK-LABEL: hal.executable.export public @generic_batch_matmul_32x8x512x64
+// CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @generic_batch_matmul_32x8x512x64()
 //      CHECK:   linalg.generic
-// CHECK-SAME:     lowering_config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[$CONFIG]]
 
 // -----
 
@@ -286,14 +286,14 @@ hal.executable public @batch_matmul_16x1024x1024x80 {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 32, 32, 16], [1, 16, 16, 16], [0, 0, 0, 16]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
-//      CHECK: hal.executable.export public @batch_matmul_16x1024x1024x80
-// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+//  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//CHECK-LABEL: hal.executable.export public @batch_matmul_16x1024x1024x80
+// CHECK-SAME:   translation_info = #[[$TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_16x1024x1024x80()
 //      CHECK:   linalg.batch_matmul
-// CHECK-SAME:     lowering_config = #[[CONFIG]]
+// CHECK-SAME:     lowering_config = #[[$CONFIG]]
 
 // -----
 
@@ -353,6 +353,6 @@ hal.executable public @matmul_256x1024x8 {
   }
 }
 
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
-//       CHECK: hal.executable.export public @matmul_256x1024x8
-//  CHECK-SAME:   translation_info = #[[TRANSLATION]]
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
+// CHECK-LABEL: hal.executable.export public @matmul_256x1024x8
+//  CHECK-SAME:   translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -76,21 +76,29 @@ hal.executable public @matmul_256x1024x128_div_add {
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
+// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<256 x vector<4xf32>>)>, Workgroup>
+//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<512 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @matmul_256x1024x128_div_add
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
 //     CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
+//     CHECK-DAG:     %[[C8:.+]] = spirv.Constant 8 : i32
 //     CHECK-DAG:     %[[C32:.+]] = spirv.Constant 32 : i32
 //     CHECK-DAG:     %[[C128:.+]] = spirv.Constant 128 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:     %[[LOCAL_VAR:.+]] = spirv.Variable : !spirv.ptr<!spirv.coopmatrix<16x16xf16, Subgroup>, Function>
+//         CHECK:     %[[LOCAL_VAR0:.+]] = spirv.Variable : !spirv.ptr<!spirv.coopmatrix<16x16xf16, Subgroup>, Function>
+//         CHECK:     %[[LOCAL_VAR1:.+]] = spirv.Variable : !spirv.ptr<!spirv.coopmatrix<16x16xf16, Subgroup>, Function>
+//         CHECK:     %[[LOCAL_VAR2:.+]] = spirv.Variable : !spirv.ptr<!spirv.coopmatrix<16x16xf16, Subgroup>, Function>
+//         CHECK:     %[[LOCAL_VAR3:.+]] = spirv.Variable : !spirv.ptr<!spirv.coopmatrix<16x16xf16, Subgroup>, Function>
 //         CHECK:     spirv.mlir.loop
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+//         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
+//         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
@@ -102,18 +110,53 @@ hal.executable public @matmul_256x1024x128_div_add {
 
 //         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD4:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C8]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD5:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C8]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:       %[[MA0:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD2]], %{{.+}}
-//         CHECK:       %[[MA1:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD3]], %[[MA0]]
+//         CHECK:       %[[LD6:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C8]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:       %[[LD7:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C8]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:       spirv.Store "Function" %[[LOCAL_VAR]], %[[MA1]]
+//         CHECK:       %[[MA0:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD4]], %{{.+}}
+//         CHECK:       %[[MA1:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD6]], %[[MA0]]
+//         CHECK:       %[[MA2:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD5]], %{{.+}}
+//         CHECK:       %[[MA3:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD7]], %[[MA2]]
+//         CHECK:       %[[MA4:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD2]], %[[LD4]], %{{.+}}
+//         CHECK:       %[[MA5:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD3]], %[[LD6]], %[[MA4]]
+//         CHECK:       %[[MA6:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD2]], %[[LD5]], %{{.+}}
+//         CHECK:       %[[MA7:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD3]], %[[LD7]], %[[MA6]]
+
+//         CHECK:       spirv.Store "Function" %[[LOCAL_VAR0]], %[[MA1]]
+//         CHECK:       spirv.Store "Function" %[[LOCAL_VAR1]], %[[MA3]]
+//         CHECK:       spirv.Store "Function" %[[LOCAL_VAR2]], %[[MA5]]
+//         CHECK:       spirv.Store "Function" %[[LOCAL_VAR3]], %[[MA7]]
 //         CHECK:       spirv.mlir.merge
 
-//         CHECK:     %[[LD_FN:.+]] = spirv.Load "Function" %[[LOCAL_VAR]] : !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[LD_FN0:.+]] = spirv.Load "Function" %[[LOCAL_VAR3]] : !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[LD_FN1:.+]] = spirv.Load "Function" %[[LOCAL_VAR2]] : !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[LD_FN2:.+]] = spirv.Load "Function" %[[LOCAL_VAR1]] : !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[LD_FN3:.+]] = spirv.Load "Function" %[[LOCAL_VAR0]] : !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %[[LD_FN]], %[[C4]], %[[COL_MAJOR]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %[[LD_FN0]], %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %[[LD_FN1]], %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %[[LD_FN2]], %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %[[LD_FN3]], %[[C8]], %[[COL_MAJOR]]
 
 //         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
 //         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
@@ -190,43 +233,59 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
+// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<256 x vector<4xf32>>)>, Workgroup>
+//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<512 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @batch_matmul_16x128x256x512_div
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
 //     CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
+//     CHECK-DAG:     %[[C8:.+]] = spirv.Constant 8 : i32
 //     CHECK-DAG:     %[[C32:.+]] = spirv.Constant 32 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
 //         CHECK:     %{{.+}} = spirv.CompositeConstruct %[[F0]] : (f16) -> !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:     %[[LOCAL_VAR:.+]] = spirv.Variable : !spirv.ptr<!spirv.coopmatrix<16x16xf16, Subgroup>, Function>
+// CHECK-COUNT-4:     %{{.+}} = spirv.Variable : !spirv.ptr<!spirv.coopmatrix<16x16xf16, Subgroup>, Function>
 //         CHECK:     spirv.mlir.loop
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
+//         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
+//         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
-//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:       %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:       %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C8]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-8:       %{{.+}} = spirv.NV.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
 
-//         CHECK:       %[[MA0:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD2]], %{{.+}}
-//         CHECK:       %[[MA1:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD3]], %[[MA0]]
-
-//         CHECK:       spirv.Store "Function" %[[LOCAL_VAR]], %[[MA1]]
+// CHECK-COUNT-4:       spirv.Store "Function" %{{.+}}, %{{.+}}
 //         CHECK:       spirv.mlir.merge
 
-//         CHECK:     %[[LD_FN:.+]] = spirv.Load "Function" %[[LOCAL_VAR]] : !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:     %{{.+}} = spirv.Load "Function" %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %[[LD_FN]], %[[C4]], %[[COL_MAJOR]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]
 
 //         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
+//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
+// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
 //         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
@@ -376,13 +435,14 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 
 //   CHECK-LABEL: spirv.module Logical GLSL450
 
-// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<128 x vector<4xf32>>)>, Workgroup>
+// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<256 x vector<4xf32>>)>, Workgroup>
+//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<512 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @generic_batch_matmul_32x128x512x64
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
 //     CHECK-DAG:     %[[C4:.+]] = spirv.Constant 4 : i32
+//     CHECK-DAG:     %[[C8:.+]] = spirv.Constant 8 : i32
 //     CHECK-DAG:     %[[C64:.+]] = spirv.Constant 64 : i32
 //     CHECK-DAG:     %[[C256:.+]] = spirv.Constant 256 : i32
 //     CHECK-DAG:     %[[F0:.+]] = spirv.Constant 0.000000e+00 : f16
@@ -395,20 +455,26 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 //         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
+//         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
+//         CHECK:       %{{.+}} = spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
+//         CHECK:       spirv.Store "Workgroup" %{{.+}}, %{{.+}} : vector<4xf32>
 //         CHECK:       spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
-//         CHECK:       %[[LD0:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD1:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:       %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:       %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C8]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-//         CHECK:       %[[LD2:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
-//         CHECK:       %[[LD3:.+]] = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C4]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-8:       %{{.+}} = spirv.NV.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
 
-//         CHECK:       %[[MA0:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD0]], %[[LD2]], %{{.+}}
-//         CHECK:       %[[MA1:.+]] = spirv.NV.CooperativeMatrixMulAdd %[[LD1]], %[[LD3]], %[[MA0]]
-
-//         CHECK:       spirv.Store "Function" %[[LOCAL_VAR]], %[[MA1]]
+// CHECK-COUNT-4:       spirv.Store "Function" %{{.+}}, %{{.+}}
 //         CHECK:       spirv.mlir.merge
 
-//         CHECK:     %[[LD_FN:.+]] = spirv.Load "Function" %[[LOCAL_VAR]] : !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:     %{{.+}} = spirv.Load "Function" %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.NV.CooperativeMatrixStore %{{.+}}, %[[LD_FN]], %[[C4]], %[[COL_MAJOR]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]
+//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
+//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C8]], %[[COL_MAJOR]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='hal.executable(hal.executable.variant(builtin.module(func.func(iree-spirv-tile-and-vectorize-to-cooperative-ops))))' -canonicalize -cse %s | FileCheck %s
 
-#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32, 32], [16, 16, 16], [0, 0, 32]]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[32, 32], [16, 16], [0, 0, 32], [16, 16, 16]]>
 #translation = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -169,7 +169,7 @@ hal.executable public @matmul_256x1024x128_div_add {
 
 // -----
 
-#config = #iree_codegen.lowering_config<tile_sizes = [[1, 32, 32, 32], [1, 16, 16, 16], [0, 0, 0, 32]]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 32, 32], [1, 16, 16], [0, 0, 0, 32], [1, 16, 16, 16]]>
 #translation = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [


### PR DESCRIPTION
This commits enables us to have multiple tiles along M and N dimension
per warp when going through the cooperative matrix pipeline. 