### PR TITLE
Optimize code size of the mmt4d ukernel.

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_select_tile_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_select_tile_arm_64.c
@@ -85,6 +85,7 @@ iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_arm_64(
     case iree_uk_mmt4d_type_i8i8i32:
       return iree_uk_mmt4d_select_tile_func_arm_64_i8i8i32(params);
     default:
+      IREE_UK_ASSUME_UNREACHABLE;
       return 0;
   }
 }

--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -377,6 +377,57 @@ static inline iree_uk_type_t iree_uk_unpack_type(int pos,
   return IREE_UK_UNPACK_TYPE(pos, word);
 }
 
+#ifdef __has_builtin
+#define IREE_UK_HAS_BUILTIN(x) __has_builtin(x)
+#else
+#define IREE_UK_HAS_BUILTIN(x) 0
+#endif
+
+// Same as LLVM_BUILTIN_UNREACHABLE. Extremely dangerous. Use only in locations
+// that are provably unreachable (+/- edge case of unreachable-past-assertions
+// discussed below).
+//
+// The potential benefit of UNREACHABLE statements is code size and/or speed
+// optimization. This is an arcane optimization. As such, each use must be
+// carefully justified.
+//
+// There is the edge case of locations that are provably unreachable when
+// optional validation code is enabled, but the validation code may also be
+// disabled, making the location technically reachable. Typically: assertions.
+// Use careful judgement for such cases.
+//
+// A typical use case in microkernels is as follows. A microkernel is
+// parametrized by type triples packed into uint32s, and needs to have a switch
+// statement on those:
+//
+// switch (params->type_triple) {
+//   case iree_uk_mykernel_f32f32f32:  // 0xf5f5f5
+//     return 123;
+//   case iree_uk_mykernel_i8i8i32:  // 0x232325
+//     return 321;
+//   default:
+//     return 0;
+// }
+//
+// As long as the microkernel has validation code (running at least as Debug
+// assertions) validating type_triple, and this code is already past that,
+// and this switch statement covers all valid cases, the `default:` case should
+// be unreachable. Adding an UNREACHABLE statement there can help with code
+// size. This would be negligible if the case constants were small enough to
+// fit in compare-with-immediate instructions, but the 24-bit type triple
+// constants here would typically not, so without UNREACHABLE, the compiler has
+// to fully implement each 24-bit literal separately.
+//
+// https://godbolt.org/z/hTv4qqbx9 shows a snipped similar as above where
+// the __builtin_unreachable shrinks the AArch64 code from 11 to 7 instructions.
+#if IREE_UK_HAS_BUILTIN(__builtin_unreachable) || defined(__GNUC__)
+#define IREE_UK_ASSUME_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define IREE_UK_ASSUME_UNREACHABLE __assume(false)
+#else
+#define IREE_UK_ASSUME_UNREACHABLE
+#endif
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/builtins/ukernel/mmt4d_select_tile_generic.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_select_tile_generic.h
@@ -9,11 +9,10 @@
 
 #include "iree/builtins/ukernel/mmt4d_types.h"
 
-// On success, *out_tile_func is the generic tile function to use to perform the
-// mmt4d with the given *params. The caller may want to first try to get an
-// optimized architecture-specific tile function before falling back on this.
-iree_uk_status_t iree_uk_mmt4d_select_tile_func_generic(
-    const iree_uk_mmt4d_params_t* params,
-    iree_uk_mmt4d_tile_func_t* out_tile_func);
+// Returns the generic tile function to use to perform the mmt4d with the given
+// *params. The caller may want to first try to get an optimized
+// architecture-specific tile function before falling back on this.
+iree_uk_mmt4d_tile_func_t iree_uk_mmt4d_select_tile_func_generic(
+    const iree_uk_mmt4d_params_t* params);
 
 #endif  // IREE_BUILTINS_UKERNEL_MMT4D_GENERIC_H_

--- a/runtime/src/iree/builtins/ukernel/mmt4d_types.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_types.h
@@ -70,4 +70,22 @@ typedef void (*iree_uk_mmt4d_tile_func_t)(
             iree_uk_int32_t K, iree_uk_uint32_t flags,                    \
             const iree_uk_mmt4d_params_t* params);
 
+// In order to be helpful as a reference for future architecture-specific
+// kernels, the generic kernels are structured like an actual optimized kernel,
+// using an "accumulator tile" that in this case is a stack array (which would
+// become a group of SIMD registers in an actual optimized kernel). The downside
+// of this approach is that we have to set a fixed max size for the accumulator
+// tile, but for now all known cases are comfortably far below where trouble
+// would happen. For reference:
+// - On ARM NEON, the entire register space is 512 bytes, so the accumulator
+//   tile is less than that, typically 256 to 384 bytes.
+// - On ARM SME, we will be working with an accumulator tile as large as 4096
+//   bytes (IIUC).
+// - The smallest stack frame size limit that we know we may have to deal with
+//   on certain targets is 16 kilobytes.
+// The size or architecture-specific tiles is relevant here because this
+// generic code is what will be run as a fallback if the device is found not to
+// support the CPU feature that the tile sizes were picked to target.
+enum { iree_uk_mmt4d_tile_generic_max_bytes = 4096 };
+
 #endif  // IREE_BUILTINS_UKERNEL_MMT4D_TYPES_H_


### PR DESCRIPTION
Total code size (AArch64, Release) for iree_uk_mmt4d* symbols excluding tile funcs (`iree_uk_mmt4d_tile*`; the size of these is unaffected by this PR).

```
Before: 996 bytes
After:  704 bytes
```
So that's a -30% shrink! Now in practice, this code would be used together with one of the tile funcs, ~300 bytes in average. So the effective code size shrink (from e.g. a CPU L1 instruction cache perspective) would be from ~1,300 bytes to ~1,000. Still pretty good.

The over all size of *all* tile funcs is bigger (~2,700 bytes) but only one of them tends to be used on a given machine, in a given workload.

Part of this is carefully using `__builtin_unreachable`. Another part is ensuring that all validation is localized in `iree_uk_mmt4d_validate`, and disabling all that if `NDEBUG`. So there's a little bit of danger here. There is the possibility of actually reaching a `__builtin_unreachable` in a Release build (where `NDEBUG` is defined) if a microkernel is called with bad params.