### PR TITLE
Add a C++ transform-based strategy for CUDA reduction.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectJitterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectJitterPass.cpp
@@ -8,6 +8,7 @@
 #include "iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
+#include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h"
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
 #include "iree/compiler/Codegen/LLVMCPU/TransformExtensions/LLVMCPUExtensions.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
@@ -15,9 +16,7 @@
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/ScopeExit.h"
-#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
@@ -37,20 +36,230 @@
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
-#include "mlir/Parser/Parser.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
+#include "mlir/IR/Location.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
-#include "mlir/Support/FileUtilities.h"
 
 #define DEBUG_TYPE "iree-transform-dialect-jitter"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 using namespace mlir;
 
-namespace {
+// TODO: significantly better namespacing.
+using ::mlir::iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
+using ::mlir::iree_compiler::IREE::transform_dialect::
+    ForeachThreadToWorkgroupOp;
+using ::mlir::iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
+using ::mlir::iree_compiler::IREE::transform_dialect::
+    MapNestedForeachThreadToGpuThreadsOp;
+using ::mlir::iree_compiler::IREE::transform_dialect::
+    TileToForeachThreadAndWorkgroupCountRegionOp;
+using ::mlir::iree_compiler::IREE::transform_dialect::
+    VectorToWarpExecuteOnLane0Op;
+using ::mlir::iree_compiler::IREE::transform_dialect::VectorWarpDistributionOp;
+using ::mlir::transform::FuseIntoContainingOp;
+using ::mlir::transform::MatchOp;
+using ::mlir::transform::MergeHandlesOp;
+using ::mlir::transform::PrintOp;
+using ::mlir::transform::SplitHandlesOp;
+using ::mlir::transform::SplitReductionOp;
+using ::mlir::transform::TileToForeachThreadOp;
+using ::mlir::transform::VectorizeOp;
 
+/// Matches `args` within `targetH` and unpacks a number of handles `N`.
+/// Assumes there are exactly `N` matched ops (but could be relaxed).
+/// Returns the tuple of handles.
+template <int N, typename... MatchingArgs>
+auto matchAndUnpack(ImplicitLocOpBuilder &b, Value targetH,
+                    MatchingArgs... args) {
+  Value matchedH = b.create<MatchOp>(targetH, args...);
+  auto matchOp = b.create<SplitHandlesOp>(matchedH,
+                                          /*numHandles=*/N);
+  assert(matchOp->getNumResults() == N && "Unexpected number of results");
+  std::array<Value, N> a;
+  for (int64_t i = 0; i < N; ++i) a[i] = matchOp->getResult(i);
+  return std::tuple_cat(a);
+}
+
+/// Prints `handles` in order. Prints the whole IR if `handles` is empty.
+static void print(ImplicitLocOpBuilder &b, ValueRange handles = {}) {
+  if (handles.empty()) b.create<PrintOp>();
+  for (auto h : handles) b.create<PrintOp>(h);
+}
+
+namespace {
+struct BatchFusionSpec {};
+struct IterativeFusionSpec {};
+}  // namespace
+
+/// Performs the following transformations:
+///   1. Tiles `rootH` to scf.foreach_thread to with `tileSizesOrNumThreads`
+///      according to whether spec is a TileSizesSpec or a NumThreadsSpec.
+///   2. Maps the resulting scf.foreach_thread to threads according to
+///      `threadDimMapping`.
+///   3. Iterates over `opsHToFuse` in order and fuses into the containing op.
+/// Returns a handle to the resulting scf.foreach_thread.
+///
+/// Fusion is controlled by the BatchOrIterativeFusion templatetype:
+///   1. In batch mode, a single fusion command is issued and a topological sort
+///      is automatically computed by the fusion. Since this applies a single
+///      fusion, no interleaved canonicalization/cse/enabling occur and the
+///      resulting fusion may not be as good.
+///   2. In iterative mode, the user is responsible for providing the fusion
+///      order but interleaved canonicalization/cse/enabling occur which may
+///      result in better fusion results.
+///      TODO: Transform dialect op to apply topological sort and avoid the
+///      manual intervention.
+/// If `resultingFusedOpsHandles` is a non-null pointer, the fused operation are
+/// appended in order.
+// TODO: apply forwarding pattern.
+template <typename TilingTransformOp, typename TileOrNumThreadSpec,
+          typename BatchOrIterativeFusion>
+static Value tileAndFuseAndDistributeImpl(
+    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
+    ArrayRef<int64_t> tileSizesOrNumThreads, ArrayRef<int64_t> threadDimMapping,
+    SmallVector<Value> *resultingFusedOpsHandles) {
+  auto tileToForeachOp = b.create<TilingTransformOp>(
+      rootH, tileSizesOrNumThreads, TileOrNumThreadSpec(), threadDimMapping);
+  Value foreachThreadH = tileToForeachOp.getForeachThreadOp();
+  if (std::is_same<BatchOrIterativeFusion, BatchFusionSpec>::value) {
+    Value mergedOpsH =
+        b.create<MergeHandlesOp>(opsHToFuse, /*deduplicate=*/true);
+    Value fusedH = b.create<FuseIntoContainingOp>(mergedOpsH, foreachThreadH);
+    (void)fusedH;
+    assert(!resultingFusedOpsHandles && "Handle needs unpacking");
+  } else {
+    for (Value h : opsHToFuse) {
+      Value fusedH = b.create<FuseIntoContainingOp>(h, foreachThreadH);
+      if (resultingFusedOpsHandles) resultingFusedOpsHandles->push_back(fusedH);
+    }
+  }
+  return foreachThreadH;
+}
+
+template <typename TilingTransformOp = TileToForeachThreadOp,
+          typename BatchOrIterativeFusion = BatchFusionSpec>
+static Value tfdWithTileSizes(
+    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
+    ArrayRef<int64_t> tileSizes, ArrayRef<int64_t> threadDimMapping = {},
+    SmallVector<Value> *resultingFusedOpsHandles = nullptr) {
+  return tileAndFuseAndDistributeImpl<
+      TilingTransformOp, transform::TileSizesSpec, BatchOrIterativeFusion>(
+      b, rootH, opsHToFuse, tileSizes, threadDimMapping,
+      resultingFusedOpsHandles);
+}
+
+template <typename TilingTransformOp = TileToForeachThreadOp,
+          typename BatchOrIterativeFusion = BatchFusionSpec>
+static Value tfdWithNumThreads(
+    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
+    ArrayRef<int64_t> numThreads, ArrayRef<int64_t> threadDimMapping = {},
+    SmallVector<Value> *resultingFusedOpsHandles = nullptr) {
+  return tileAndFuseAndDistributeImpl<
+      TilingTransformOp, transform::NumThreadsSpec, BatchOrIterativeFusion>(
+      b, rootH, opsHToFuse, numThreads, threadDimMapping,
+      resultingFusedOpsHandles);
+}
+
+/// Apply patterns and vectorize (for now always applies rank-reduction).
+/// Takes a handle to a func.func and returns an updated handle to a
+/// func.func.
+// TODO: configure patterns.
+static Value vectorize(ImplicitLocOpBuilder &b, Value funcH) {
+  funcH = b.create<ApplyPatternsOp>(funcH, /*rankReducing=*/true);
+  return b.create<VectorizeOp>(funcH);
+}
+
+/// Post-bufferization mapping to blocks and threads.
+/// Takes a handle to a func.func and returns an updated handle to a
+/// func.func.
+static Value mapToBlockAndThreads(ImplicitLocOpBuilder &b, Value funcH,
+                                  ArrayRef<int64_t> blockSize) {
+  funcH = b.create<ForeachThreadToWorkgroupOp>(funcH);
+  return b.create<MapNestedForeachThreadToGpuThreadsOp>(funcH, blockSize);
+}
+
+/// Post-bufferization vector distribution with rank-reduction.
+/// Takes a handle to a func.func and returns an updated handle to a
+/// func.func.
+static Value distributeVectors(ImplicitLocOpBuilder &b, Value funcH,
+                               int64_t warpSize = 32) {
+  funcH = b.create<ApplyPatternsOp>(funcH, /*rankReducing=*/true);
+  Value ifH = b.create<MatchOp>(funcH, scf::IfOp::getOperationName());
+  ifH = b.create<VectorToWarpExecuteOnLane0Op>(ifH, warpSize);
+  b.create<VectorWarpDistributionOp>(funcH);
+  return funcH;
+}
+
+// TODO: generialize and automate over and over.
+// TODO: significantly shrink this down.
+static void buildReductionCudaStrategy(ImplicitLocOpBuilder &b,
+                                       Value variantH) {
+  Value originalFillH =
+      b.create<MatchOp>(variantH, linalg::FillOp::getOperationName());
+  Value originalGenericH =
+      b.create<MatchOp>(variantH, linalg::GenericOp::getOperationName());
+
+  // Step 1. Split the reduction to get meatier parallelism.
+  // TODO: use a scf.foreach_thread for this.
+  auto splitReductionTransformOp =
+      b.create<SplitReductionOp>(originalGenericH,
+                                 /*splitFactor=*/2,
+                                 /*insertSplitDimension=*/1);
+  Value splitFillH = splitReductionTransformOp.getFillOp();
+  Value splitLinalgH = splitReductionTransformOp.getSplitLinalgOp();
+  Value combinerH = splitReductionTransformOp.getCombiningLinalgOp();
+
+  // Step 2. First level of tiling + fusion parallelizes to blocks.
+  // clang-format off
+  tfdWithTileSizes<TileToForeachThreadAndWorkgroupCountRegionOp>(
+    b,
+    /*rootH=*/combinerH,
+    /*opsHToFuse=*/{originalFillH, splitFillH, splitLinalgH},
+    /*tileSizes=*/ArrayRef<int64_t>{1});
+  // clang-format on
+
+  // Step 3. Second level of tiling + fusion parallelizes to threads.
+  // TODO: Relying on ordering is brittle, harden this.
+  auto [fill2dH, parParRedH, fill1dH, parRedH] = matchAndUnpack<4>(
+      b, variantH,
+      ArrayRef<StringRef>{linalg::GenericOp::getOperationName(),
+                          linalg::FillOp::getOperationName()});
+  // clang-format off
+  tfdWithTileSizes(b,
+                   /*rootH=*/parRedH,
+                   /*opsHToFuse=*/{fill1dH},
+                   /*tileSizes=*/ArrayRef<int64_t>{1, 0, 0},
+                   /*threadDimMapping=*/ArrayRef<int64_t>{2, 1, 0});
+  tfdWithTileSizes(b,
+                   /*rootH=*/parParRedH,
+                   /*opsHToFuse=*/{fill2dH},
+                   /*tileSizes=*/ArrayRef<int64_t>{1, 1, 0},
+                   /*threadDimMapping=*/ArrayRef<int64_t>{2, 1, 0});
+  // clang-format on
+
+  // Step 4. Rank-reduce and vectorize.
+  Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
+  funcH = vectorize(b, funcH);
+
+  // Step 5. Bufferize.
+  variantH = b.create<IREEBufferizeOp>(variantH, /*targetGpu=*/true);
+
+  // Step 6. Post-bufferization mapping to blocks and threads.
+  // Need to match again since bufferizae invalidated all handles.
+  funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
+  funcH = mapToBlockAndThreads(b, funcH, ArrayRef<int64_t>{32, 2, 1});
+
+  // Step 7. Post-bufferization vector distribution with rank-reduction.
+  distributeVectors(b, funcH);
+}
+
+namespace {
 /// Pass declaration.
 /// Jitter pass that applies transform dialect ops for codegen.
 /// This needs to be its own pass because the registration mechanism and ops
@@ -60,9 +269,9 @@ class TransformDialectJitterPass
           TransformDialectJitterPass> {
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
-    // TODO: this is only necessary to make registry subset happy when running
-    // the lowering to LLVM. The lowering should be changed to stop using the
-    // nested pass manager and this will go away.
+    // TODO: this is only necessary to make registry subset happy when
+    // running the lowering to LLVM. The lowering should be changed to stop
+    // using the nested pass manager and this will go away.
 
     // clang-format off
     registry.insert<mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect,
@@ -70,6 +279,7 @@ class TransformDialectJitterPass
                     arith::ArithDialect,
                     AffineDialect,
                     bufferization::BufferizationDialect,
+                    BuiltinDialect,
                     func::FuncDialect,
                     gpu::GPUDialect,
                     linalg::LinalgDialect,
@@ -84,8 +294,8 @@ class TransformDialectJitterPass
         // clang-format on
         >();
 
-    // TODO: these should be registered by the extension instead, but there is
-    // no support for it in core currently.
+    // TODO: these should be registered by the extension instead, but there
+    // is no support for it in core currently.
     arith::registerBufferizableOpInterfaceExternalModels(registry);
     linalg::registerBufferizableOpInterfaceExternalModels(registry);
     scf::registerBufferizableOpInterfaceExternalModels(registry);
@@ -106,7 +316,30 @@ class TransformDialectJitterPass
 
   TransformDialectJitterPass() = default;
 
-  void runOnOperation() override {}
+  void runOnOperation() override {
+    Operation *target = getOperation();
+    MLIRContext *ctx = target->getContext();
+    Location loc = target->getLoc();
+
+    OpBuilder b(ctx);
+    auto topLevelTransformModule = b.create<ModuleOp>(loc);
+    Region &topLevelTransformRegion = topLevelTransformModule.getBodyRegion();
+    b.setInsertionPointToStart(&topLevelTransformRegion.front());
+    b.create<::transform_ext::CanonicalizedSequenceOp>(
+        target->getLoc(), transform::FailurePropagationMode::Suppress,
+        [](OpBuilder &b, Location loc, Value variantH) {
+          ImplicitLocOpBuilder ib(loc, b);
+          buildReductionCudaStrategy(ib, variantH);
+          b.create<transform::YieldOp>(loc);
+        });
+
+    LLVM_DEBUG(DBGS() << "apply transform:\n" << topLevelTransformModule);
+    if (failed(transform::applyTransformsInRegion(topLevelTransformRegion,
+                                                  target))) {
+      target->emitOpError() << "transform dialect jitter failed";
+      return signalPassFailure();
+    }
+  }
 };
 }  // namespace
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -7,6 +7,7 @@
 #ifndef IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS_H_
 #define IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS_H_
 
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
@@ -21,6 +22,12 @@ class FuncOp;
 namespace scf {
 class ForeachThreadOp;
 }  // namespace scf
+
+namespace transform {
+// Types needed for builders.
+struct TileSizesSpec;
+struct NumThreadsSpec;
+}  // namespace transform
 }  // namespace mlir
 
 #define GET_OP_CLASSES

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -79,6 +79,11 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
+  let builders = [
+    // TODO: Some bitvector to scale better than n-bools.
+    OpBuilder<(ins "Value":$target, "bool":$rankReducing)>
+  ];
+
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::Operation *target,
@@ -119,6 +124,10 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
 
   let assemblyFormat = "attr-dict $target";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target, CArg<"bool", "false">:$targetGpu)>
+  ];
 }
 
 def ForeachThreadToWorkgroupOp : Op<Transform_Dialect, 
@@ -168,6 +177,11 @@ def ForeachThreadToWorkgroupOp : Op<Transform_Dialect,
 
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
+
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::func::FuncOp target,
@@ -176,7 +190,7 @@ def ForeachThreadToWorkgroupOp : Op<Transform_Dialect,
   }];
 }
 
-def TileToForeachThreadAndWorkgroupCountRegion :
+def TileToForeachThreadAndWorkgroupCountRegionOp :
     Op<Transform_Dialect, "iree.tile_to_foreach_thread_and_workgroup_count_region",
       [AttrSizedOperandSegments,
        DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
@@ -211,6 +225,29 @@ def TileToForeachThreadAndWorkgroupCountRegion :
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let hasVerifier = 1;
+
+  let builders = [
+    OpBuilder<(ins "Value":$target,
+                   "ArrayRef<int64_t>":$staticTileSizes,
+                   CArg<"::mlir::transform::TileSizesSpec", 
+                        "::mlir::transform::TileSizesSpec()">,
+                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+    OpBuilder<(ins "Value":$target,
+                   "ArrayRef<OpFoldResult>":$mixedTileSizes,
+                   CArg<"::mlir::transform::TileSizesSpec", 
+                        "::mlir::transform::TileSizesSpec()">,
+                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+    OpBuilder<(ins "Value":$target,
+                   "ArrayRef<int64_t>":$staticNumThreads,
+                   CArg<"::mlir::transform::NumThreadsSpec", 
+                        "::mlir::transform::NumThreadsSpec()">,
+                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+    OpBuilder<(ins "Value":$target,
+                   "ArrayRef<OpFoldResult>":$mixedNumThreads,
+                   CArg<"::mlir::transform::NumThreadsSpec", 
+                        "::mlir::transform::NumThreadsSpec()">,
+                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+  ];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure apply(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -13,7 +13,7 @@ include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
 include "mlir/IR/OpBase.td"
 
-def MapNestedForeachThreadToGpuThreads : 
+def MapNestedForeachThreadToGpuThreadsOp : 
   Op<Transform_Dialect, "iree.map_nested_foreach_thread_to_gpu_threads",
     [FunctionalStyleTransformOpTrait, 
      MemoryEffectsOpInterface,
@@ -90,6 +90,10 @@ def MapNestedForeachThreadToGpuThreads :
 
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target, "ArrayRef<int64_t>":$workgroupSize)>
+  ];
 
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
@@ -193,6 +197,9 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
+  let builders = [
+    OpBuilder<(ins "Value":$target, "int64_t":$warpSize)>
+  ];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::scf::IfOp target,
@@ -202,10 +209,9 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
 }
 
 def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribute",
-    [FunctionalStyleTransformOpTrait, 
-     MemoryEffectsOpInterface,
-     TransformEachOpTrait, 
-     TransformOpInterface]> {
+    [TransformEachOpTrait, 
+     TransformOpInterface,
+     DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let description = [{
     Given a vector.warp_execute_on_lane_0, apply the patterns to rewrite into
     distributed form with warp synchronization. This produces IR that runs 
@@ -298,6 +304,10 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
   let assemblyFormat = "$target attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
+  let skipDefaultBuilders = 1;
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::Operation *target,

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
@@ -41,7 +41,16 @@ def CanonicalizedSequenceOp
   let assemblyFormat =
     "($root^)? `failures` `(` $failure_propagation_mode `)` attr-dict-with-keyword regions (`:` type($results)^)?";
 
+  let builders = [
+    OpBuilder<(ins "::mlir::transform::FailurePropagationMode":$failure_propagation_mode,
+                   CArg<"::llvm::function_ref<void(::mlir::OpBuilder &, ::mlir::Location, ::mlir::Value)>",
+                        "nullptr">)>
+  ];
+
   let extraClassDeclaration = [{
+    using BodyBuilderFn =
+        ::llvm::function_ref<void(::mlir::OpBuilder &, ::mlir::Location, ::mlir::Value)>;
+
     /// Allow the dialect prefix to be omitted.
     static ::llvm::StringRef getDefaultDialect() { return "transform"; }
   }];

--- a/tests/transform_dialect/cuda/reduction.mlir
+++ b/tests/transform_dialect/cuda/reduction.mlir
@@ -30,8 +30,24 @@ func.func @reduce() -> (!out_tensor_t) {
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
 // RUN: FileCheck %s --check-prefix=CHECK
 
+/// Note: the current --iree-codegen-llvmgpu-enable-transform-dialect-jit only works for exactly this softmax atm.
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target-pass))' \
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
 // RUN: iree-compile %s --iree-hal-target-backends=cuda \
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+/// Note: the current --iree-codegen-llvmgpu-enable-transform-dialect-jit only works for exactly this softmax atm.
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
 // RUN: iree-run-module --entry_function=reduce --device=cuda |\
 // RUN: FileCheck %s --check-prefix=EXEC
 

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -4,49 +4,53 @@ transform.structured.canonicalized_sequence failures(suppress) {
 ^bb1(%variant_op: !pdl.operation):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
 
-  // Split the reduction by 2 to obtain a more meaty parallel op with
-  // parallelism across size(reduction) / 2 threads.
+  // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
+  // ===========================================================================
   %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op
   %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
     transform.structured.split_reduction %0
       { split_factor = 2, insert_split_dimension = 1 }
 
-  // First level of tiling + fusion parallelizes to blocks.
-  // The mapping to block ids can only happen after bufferization atm.
+  // Step 2. First level of tiling + fusion parallelizes to blocks.
+  // ===========================================================================
   %foreach_thread_grid, %grid_combiner_op =
     transform.iree.tile_to_foreach_thread_and_workgroup_count_region %combiner_op tile_sizes [1]
   %not_combiner = transform.merge_handles %fill, %more_parallel_fill_op, %more_parallel_op : !pdl.operation
   transform.structured.fuse_into_containing_op %not_combiner into %foreach_thread_grid
 
-  // Second level of tiling + fusion parallelizes to threads.
-  // The mapping to thread ids can only happen after bufferization atm.
-  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
+  // Step 3. Second level of tiling + fusion parallelizes to threads.
+  // ===========================================================================
+  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
+  %foreach_thread_block_combiner_op, %block_combiner_op =
+    transform.structured.tile_to_foreach_thread_op %grid_combiner_op tile_sizes [1, 0, 0] (mapped to dims [2, 1, 0])
+  transform.structured.fuse_into_containing_op %fill_1d into %foreach_thread_block_combiner_op
 
+  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
   %grid_more_parallel_op = transform.structured.match interface{LinalgOp}
     attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %variant_op
   %foreach_thread_block_more_parallel_op, %block_more_parallel_op =
     transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1, 0] (mapped to dims [2, 1, 0])
   transform.structured.fuse_into_containing_op %fill_2d into %foreach_thread_block_more_parallel_op
   
-  // Second level of tiling + fusion parallelizes to threads.
-  // The mapping to thread ids can only happen after bufferization atm.
-  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
-  %foreach_thread_block_combiner_op, %block_combiner_op =
-    transform.structured.tile_to_foreach_thread_op %grid_combiner_op tile_sizes [1, 0, 0] (mapped to dims [2, 1, 0])
-  transform.structured.fuse_into_containing_op %fill_1d into %foreach_thread_block_combiner_op
-
+  // Step 4. Rank-reduce and vectorize.
+  // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op
   %func_2 = transform.iree.apply_patterns %func { rank_reducing }
   %func_3 = transform.structured.vectorize %func_2
 
+  // Step 5. Bufferize.
+  // ===========================================================================
   %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
 
+  // Step 6. Post-bufferization mapping to blocks and threads.
+  // ===========================================================================
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
   %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
   %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
       { workgroup_size = [32, 2, 1] }
 
-  // Vector distribution needs to happen on buffers.
+  // Step 7. Post-bufferization vector distribution with rank-reduction.
+  // ===========================================================================
   %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }


### PR DESCRIPTION
This C++ strategy matches the transform dialect script verbatim.
It can also be used to generate the script automatically in the future.
    
The C++ API enables more variadic manipulation than the transform dialect allows.
    
This should be incrementally improved until we reach the desired flexibility and generality.
