### PR TITLE
Hook up a transform dialect jitter pass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -96,6 +96,60 @@ iree_compiler_cc_library(
 )
 
 iree_compiler_cc_library(
+    name = "TransformDialectJitterPass",
+    srcs = [
+        "TransformDialectJitterPass.cpp",
+    ],
+    deps = [
+        # Dialects
+        "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtTransformOps",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:AffineUtils",
+        "@llvm-project//mlir:AsyncDialect",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ArithUtils",
+        "@llvm-project//mlir:BufferizationDialect",
+        "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:GPUDialect",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:LLVMDialect",
+        "@llvm-project//mlir:PDLDialect",
+        "@llvm-project//mlir:PDLInterpDialect",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:SCFUtils",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformDialect",
+        "@llvm-project//mlir:VectorDialect",
+        # IR
+        "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Rewrite",
+        # Interfaces
+        # Transforms (needed mostly for the BufferizableOpInterfaceImpl)
+        "@llvm-project//mlir:ArithTransforms",
+        "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:SCFTransforms",
+        "@llvm-project//mlir:TensorTransforms",
+        "@llvm-project//mlir:VectorTransforms",
+        # Other Stuff
+        "//compiler/src/iree/compiler/Codegen:PassHeaders",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:Support",
+        # TransformExtensions
+        "//compiler/src/iree/compiler/Codegen/Common/TransformExtensions:CommonExtensions",
+        "//compiler/src/iree/compiler/Dialect/Flow/TransformExtensions:FlowExtensions",
+        "//compiler/src/iree/compiler/Codegen/LLVMCPU/TransformExtensions:LLVMCPUExtensions",
+        "//compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions:LLVMGPUExtensions",
+        "@llvm-project//mlir:LinalgTransformOps",
+    ],
+)
+
+iree_compiler_cc_library(
     name = "CommonPasses",
     srcs = [
         "BufferizationAnalysis.cpp",
@@ -203,6 +257,7 @@ iree_compiler_cc_library(
     deps = [
         ":CommonPasses",
         ":TransformDialectInterpreterPass",
+        ":TransformDialectJitterPass",
         "//compiler/src/iree/compiler/Codegen:PassHeaders",
         "//compiler/src/iree/compiler/Codegen/Common:FoldTensorExtractOpIncGen",
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -69,6 +69,54 @@ iree_cc_library(
 
 iree_cc_library(
   NAME
+    TransformDialectJitterPass
+  SRCS
+    "TransformDialectJitterPass.cpp"
+  DEPS
+    IREELinalgExtDialect
+    IREELinalgExtTransformOps
+    IREELinalgTransformDialect
+    LLVMSupport
+    MLIRAffineDialect
+    MLIRAffineUtils
+    MLIRArithDialect
+    MLIRArithTransforms
+    MLIRArithUtils
+    MLIRAsyncDialect
+    MLIRBufferizationDialect
+    MLIRBufferizationTransforms
+    MLIRFuncDialect
+    MLIRGPUOps
+    MLIRIR
+    MLIRLLVMDialect
+    MLIRLinalgDialect
+    MLIRLinalgTransformOps
+    MLIRLinalgTransforms
+    MLIRPDLDialect
+    MLIRPDLInterpDialect
+    MLIRParser
+    MLIRPass
+    MLIRRewrite
+    MLIRSCFDialect
+    MLIRSCFTransforms
+    MLIRSCFUtils
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTensorTransforms
+    MLIRTransformDialect
+    MLIRVectorDialect
+    MLIRVectorTransforms
+    iree::compiler::Codegen::Common::TransformExtensions::CommonExtensions
+    iree::compiler::Codegen::LLVMCPU::TransformExtensions::LLVMCPUExtensions
+    iree::compiler::Codegen::LLVMGPU::TransformExtensions::LLVMGPUExtensions
+    iree::compiler::Codegen::PassHeaders
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::TransformExtensions::FlowExtensions
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     CommonPasses
   HDRS
     "BufferizationAnalysis.h"
@@ -172,6 +220,7 @@ iree_cc_library(
   DEPS
     ::CommonPasses
     ::TransformDialectInterpreterPass
+    ::TransformDialectJitterPass
     IREELinalgExtDialect
     IREELinalgExtPasses
     IREELinalgExtTransforms

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectJitterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectJitterPass.cpp
@@ -1,0 +1,120 @@
+// Copyright 2021 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.h"
+#include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
+#include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
+#include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
+#include "iree/compiler/Codegen/LLVMCPU/TransformExtensions/LLVMCPUExtensions.h"
+#include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h"
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/SourceMgr.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Bufferization/Transforms/FuncBufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
+#include "mlir/Dialect/Linalg/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/PDL/IR/PDL.h"
+#include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/SCF/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
+#include "mlir/Parser/Parser.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Pass/PassRegistry.h"
+#include "mlir/Support/FileUtilities.h"
+
+#define DEBUG_TYPE "iree-transform-dialect-jitter"
+#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
+
+using namespace mlir;
+
+namespace {
+
+/// Pass declaration.
+/// Jitter pass that applies transform dialect ops for codegen.
+/// This needs to be its own pass because the registration mechanism and ops
+/// available are different than for other jitters.
+class TransformDialectJitterPass
+    : public iree_compiler::TransformDialectJitterBase<
+          TransformDialectJitterPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    // TODO: this is only necessary to make registry subset happy when running
+    // the lowering to LLVM. The lowering should be changed to stop using the
+    // nested pass manager and this will go away.
+
+    // clang-format off
+    registry.insert<mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect,
+                    mlir::iree_compiler::IREE::Flow::FlowDialect,
+                    arith::ArithDialect,
+                    AffineDialect,
+                    bufferization::BufferizationDialect,
+                    func::FuncDialect,
+                    gpu::GPUDialect,
+                    linalg::LinalgDialect,
+                    linalg::transform::LinalgTransformDialect,
+                    LLVM::LLVMDialect,
+                    pdl::PDLDialect,
+                    pdl_interp::PDLInterpDialect,
+                    scf::SCFDialect,
+                    tensor::TensorDialect,
+                    transform::TransformDialect,
+                    vector::VectorDialect
+        // clang-format on
+        >();
+
+    // TODO: these should be registered by the extension instead, but there is
+    // no support for it in core currently.
+    arith::registerBufferizableOpInterfaceExternalModels(registry);
+    linalg::registerBufferizableOpInterfaceExternalModels(registry);
+    scf::registerBufferizableOpInterfaceExternalModels(registry);
+    bufferization::func_ext::registerBufferizableOpInterfaceExternalModels(
+        registry);
+    tensor::registerBufferizableOpInterfaceExternalModels(registry);
+    vector::registerBufferizableOpInterfaceExternalModels(registry);
+
+    registry.addExtensions<
+        mlir::iree_compiler::IREE::LinalgExt::LinalgExtTransformOpsExtension,
+        transform_ext::StructuredTransformOpsExtension>();
+    iree_compiler::registerTransformDialectCommonExtension(registry);
+    iree_compiler::registerTransformDialectFlowExtension(registry);
+    iree_compiler::registerTransformDialectLLVMCPUExtension(registry);
+    iree_compiler::registerTransformDialectLLVMGPUExtension(registry);
+    linalg::registerTransformDialectExtension(registry);
+  }
+
+  TransformDialectJitterPass() = default;
+
+  void runOnOperation() override {}
+};
+}  // namespace
+
+namespace mlir {
+namespace iree_compiler {
+/// Create a Transform dialect jitter pass.
+std::unique_ptr<Pass> createTransformDialectJitterPass() {
+  return std::make_unique<TransformDialectJitterPass>();
+}
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -30,28 +30,32 @@ def CPU_TripleTilingExpert : I32EnumAttrCase<"CPUTripleTilingExpert", 7>;
 def CPU_DataTiling
     : I32EnumAttrCase<"CPUDataTiling", 8>;
 
-def Linalg_TransformInterpCodegen
-    : I32EnumAttrCase<"TransformDialectInterpreterCodegen", 9>;
-
-def LLVMGPU_SimpleDistribute : I32EnumAttrCase<"LLVMGPUDistribute", 10>;
-def LLVMGPU_Vectorize : I32EnumAttrCase<"LLVMGPUVectorize", 11>;
-def LLVMGPU_MatmulSimt : I32EnumAttrCase<"LLVMGPUMatmulSimt", 12>;
-def LLVMGPU_MatmulTensorCore : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 13>;
-def LLVMGPU_TransposeSharedMem : I32EnumAttrCase<"LLVMGPUTransposeSharedMem", 14>;
-def LLVMGPU_WarpReduction : I32EnumAttrCase<"LLVMGPUWarpReduction", 15>;
+def LLVMGPU_SimpleDistribute : I32EnumAttrCase<"LLVMGPUDistribute", 9>;
+def LLVMGPU_Vectorize : I32EnumAttrCase<"LLVMGPUVectorize", 10>;
+def LLVMGPU_MatmulSimt : I32EnumAttrCase<"LLVMGPUMatmulSimt", 11>;
+def LLVMGPU_MatmulTensorCore : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 12>;
+def LLVMGPU_TransposeSharedMem : I32EnumAttrCase<"LLVMGPUTransposeSharedMem", 13>;
+def LLVMGPU_WarpReduction : I32EnumAttrCase<"LLVMGPUWarpReduction", 14>;
 
 def SPIRV_BaseDistribute
-    : I32EnumAttrCase<"SPIRVBaseDistribute", 16>;
+    : I32EnumAttrCase<"SPIRVBaseDistribute", 15>;
 def SPIRV_BaseVectorize
-    : I32EnumAttrCase<"SPIRVBaseVectorize", 17>;
+    : I32EnumAttrCase<"SPIRVBaseVectorize", 16>;
 def SPIRV_MatmulPromoteVectorize
-    : I32EnumAttrCase<"SPIRVMatmulPromoteVectorize", 18>;
+    : I32EnumAttrCase<"SPIRVMatmulPromoteVectorize", 17>;
 def SPIRV_CooperativeMatrixVectorize
-    : I32EnumAttrCase<"SPIRVCooperativeMatrixVectorize", 19>;
+    : I32EnumAttrCase<"SPIRVCooperativeMatrixVectorize", 18>;
 def SPIRV_SubgroupReduce
-    : I32EnumAttrCase<"SPIRVSubgroupReduce", 20>;
+    : I32EnumAttrCase<"SPIRVSubgroupReduce", 19>;
 
-def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 21>;
+def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 20>;
+
+
+def Linalg_TransformInterpCodegen
+    : I32EnumAttrCase<"TransformDialectInterpreterCodegen", 100>;
+def Linalg_TransformJitCodegen
+    : I32EnumAttrCase<"TransformDialectJitterCodegen", 101>;
+
 def None : I32EnumAttrCase<"None", 0xff>;
 
 // EnumAttrCase for all known lowerings for ops within dispatch region
@@ -63,14 +67,17 @@ def DispatchLoweringPassPipelineEnum
                     CPU_DoubleTilingPadExpert, CPU_DoubleTilingPeelingExpert,
                     CPU_ConvTileAndDecomposeExpert, CPU_CPUAArchDoubleTilingExpert,
                     CPU_BufferOpsTileAndVectorize, CPU_TripleTilingExpert,
-                    CPU_DataTiling,
-                    Linalg_TransformInterpCodegen, LLVMGPU_SimpleDistribute,
+                    CPU_DataTiling, LLVMGPU_SimpleDistribute,
                     LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
                     LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction,
                     SPIRV_BaseDistribute, SPIRV_BaseVectorize,
                     SPIRV_MatmulPromoteVectorize, SPIRV_CooperativeMatrixVectorize,
                     SPIRV_SubgroupReduce,
-                    VMVX_Default, None
+                    VMVX_Default, 
+                    // Transform dialect based codegen
+                    Linalg_TransformInterpCodegen, 
+                    Linalg_TransformJitCodegen, 
+                    None
                   ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
   // Don't generate a C++ class! We want to use the AttrDef

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -226,10 +226,6 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
                 executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::
-              TransformDialectInterpreterCodegen:
-            addTransformDialectInterpreterPasses(executableLoweringPipeline);
-            break;
-          case IREE::Codegen::DispatchLoweringPassPipeline::
               CPUAArchDoubleTilingExpert:
             addCPUAArchDoubleTilingExpertPassPipeline(
                 executableLoweringPipeline);
@@ -239,6 +235,15 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::VMVXDefault:
             addVMVXDefaultPassPipeline(executableLoweringPipeline);
+            break;
+          // Transform-dialect pipelines.
+          case IREE::Codegen::DispatchLoweringPassPipeline::
+              TransformDialectInterpreterCodegen:
+            addTransformDialectInterpreterPasses(executableLoweringPipeline);
+            break;
+          case IREE::Codegen::DispatchLoweringPassPipeline::
+              TransformDialectJitterCodegen:
+            addTransformDialectJitterPasses(executableLoweringPipeline);
             break;
           default:
             variantOp.emitOpError("Unsupported pipeline on CPU target.");

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -645,6 +645,11 @@ void addTransformDialectInterpreterPasses(OpPassManager &passManager) {
   passManager.addPass(createDropSchedulePass());
 }
 
+void addTransformDialectJitterPasses(OpPassManager &passManager) {
+  // Give control to the transform dialect.
+  passManager.addPass(mlir::iree_compiler::createTransformDialectJitterPass());
+}
+
 static void addLowerToLLVMPasses(OpPassManager &passManager) {
   // LinalgExt -> SCF
   passManager.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -179,9 +179,14 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
       case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUWarpReduction:
         addGPUWarpReductionPassPipeline(executableLoweringPipeline);
         break;
+      // Transform-dialect pipelines.
       case IREE::Codegen::DispatchLoweringPassPipeline::
           TransformDialectInterpreterCodegen:
         addGPUTransformDialectInterpreterPasses(executableLoweringPipeline);
+        break;
+      case IREE::Codegen::DispatchLoweringPassPipeline::
+          TransformDialectJitterCodegen:
+        addGPUTransformDialectJitterPasses(executableLoweringPipeline);
         break;
       default:
         variantOp.emitOpError("Unsupported pipeline on GPU target.");

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -421,6 +421,11 @@ void addGPUTransformDialectInterpreterPasses(OpPassManager &passManager) {
   passManager.addPass(createDropSchedulePass());
 }
 
+void addGPUTransformDialectJitterPasses(OpPassManager &passManager) {
+  // Give control to the transform dialect.
+  passManager.addPass(mlir::iree_compiler::createTransformDialectJitterPass());
+}
+
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {
   pm.nest<ModuleOp>().nest<func::FuncOp>().addPass(createTypePropagationPass());
   pm.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -153,6 +153,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPadDynamicAlloc();
 /// registrations necessary for IREE.
 std::unique_ptr<Pass> createTransformDialectInterpreterPass(
     llvm::StringRef transformFileName = llvm::StringRef());
+std::unique_ptr<Pass> createTransformDialectJitterPass();
 
 /// Convert Linalg ops to Vector.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUVectorizationPass(
@@ -315,6 +316,7 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager);
 /// sandbox. Unlike other pipelines this pass mangaer is nested at the
 /// `hal.executable.variant` op.
 void addTransformDialectInterpreterPasses(OpPassManager &passManager);
+void addTransformDialectJitterPasses(OpPassManager &passManager);
 
 /// Populates the passes needed to multi level tile, fuse and vectorize
 /// lowering of linalg ops on tensors to vectors operations.
@@ -384,6 +386,7 @@ void addGPUWarpReductionPassPipeline(OpPassManager &pm);
 
 /// Experimental path for transform dialect.
 void addGPUTransformDialectInterpreterPasses(OpPassManager &pm);
+void addGPUTransformDialectJitterPasses(OpPassManager &pm);
 
 /// Simple lowering only distributute linalg ops on blocks and threads. This
 /// will result in scalar operations. Expects pass manager to be a

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -204,6 +204,12 @@ def TransformDialectInterpreter :
             "dialect spec embedded next to the top-level op.">,
   ];
 }
+def TransformDialectJitter :
+    Pass<"iree-transform-dialect-jitter"> {
+  let summary = "Pass to create and apply transform dialect on the fly.";
+  let constructor =
+    "mlir::iree_compiler::createTransformDialectJitterPass()";
+}
 
 def GPUVectorization :
     Pass<"iree-codegen-gpu-vectorization", "func::FuncOp"> {


### PR DESCRIPTION
This revision threads a new pass that can create C++ transform-dialect strategies.

The implementation of such strategies will occur in subsequent PRs, this is just the plumbing.