### PR TITLE
Relax shape checking of pack/unpack ops.

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/CMakeLists.txt
@@ -26,6 +26,7 @@ add_mlir_library(IREELinalgExtDialect
   MLIRSCFDialect
   MLIRFuncDialect
   MLIRTensorDialect
+  MLIRTensorUtils
   MLIRTilingInterface
   MLIRViewLikeInterface
 )

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -17,6 +17,7 @@
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/Builders.h"
@@ -114,6 +115,20 @@ static bool isInvalid(ArrayRef<int64_t> dimsPos, int64_t rank) {
     return true;
   return llvm::any_of(
       dimsPos, [rank](int64_t dimPos) { return dimPos < 0 || dimPos >= rank; });
+}
+
+/// Returns true if the dimension of `sourceShape` is smaller than the dimension
+/// of the `limitShape`.
+static bool isSmallerThan(ArrayRef<int64_t> sourceShape,
+                          ArrayRef<int64_t> limitShape) {
+  assert(sourceShape.size() == limitShape.size());
+  return llvm::all_of(
+      llvm::zip(sourceShape, limitShape), [](std::tuple<int64_t, int64_t> it) {
+        int64_t sourceExtent = std::get<0>(it);
+        int64_t limit = std::get<1>(it);
+        return sourceExtent == ShapedType::kDynamicSize ||
+               limit == ShapedType::kDynamicSize || sourceExtent <= limit;
+      });
 }
 
 //===----------------------------------------------------------------------===//
@@ -1510,15 +1525,16 @@ static bool hasZeros(ArrayRef<OpFoldResult> tiles) {
 
 /// Check if we have enough static information to catch undefined behavior when
 /// the tile size does not divide perfectly the dimension of the input tensor.
-static bool areNotFullTiles(ArrayRef<int64_t> inputShape,
-                            DenseMap<int64_t, OpFoldResult> dimAndTileMapping) {
+static bool
+areNotFullTiles(ArrayRef<int64_t> inputShape,
+                DenseMap<int64_t, OpFoldResult> const &dimAndTileMapping) {
   int64_t rank = inputShape.size();
   for (int64_t dim = 0; dim < rank; dim++) {
     if (inputShape[dim] == ShapedType::kDynamicSize)
       continue;
-    if (dimAndTileMapping.count(dim)) {
-      Optional<int64_t> constantTile =
-          getConstantIntValue(dimAndTileMapping[dim]);
+    auto it = dimAndTileMapping.find(dim);
+    if (it != dimAndTileMapping.end()) {
+      Optional<int64_t> constantTile = getConstantIntValue(it->second);
       if (!constantTile)
         continue;
       if (inputShape[dim] % (*constantTile) != 0)
@@ -1607,23 +1623,79 @@ static LogicalResult commonVerifierPackAndUnPackOp(OpTy packOrUnPack) {
   static_assert(llvm::is_one_of<OpTy, PackOp, UnPackOp>::value,
                 "applies to only pack or unpack operations");
   Operation *op = packOrUnPack.getOperation();
-  int64_t rank = (std::is_same<OpTy, PackOp>::value)
-                     ? packOrUnPack.getInputRank()
-                     : packOrUnPack.getOutputRank();
+  ShapedType unpackedType = (std::is_same<OpTy, PackOp>::value)
+                                ? packOrUnPack.getInputType()
+                                : packOrUnPack.getOutputType();
+  int64_t unpackedRank = unpackedType.getRank();
   SmallVector<int64_t> innerDimsPos =
       extractFromI64ArrayAttr(packOrUnPack.getInnerDimsPos());
   SmallVector<int64_t> outerDimPerm =
       extractFromI64ArrayAttr(packOrUnPack.getOuterDimsPerm());
   // Verify tiles. Make sure each provided tile is non-zero.
-  if (hasZeros(packOrUnPack.getMixedTiles()))
+  SmallVector<OpFoldResult> mixedTiles = packOrUnPack.getMixedTiles();
+  if (hasZeros(mixedTiles))
     return op->emitError("invalid tile factor");
-  if (isInvalid(innerDimsPos, rank))
+  if (isInvalid(innerDimsPos, unpackedRank))
     return op->emitError("invalid inner_dims_pos vector");
-  if (isInvalid(outerDimPerm, rank))
+  if (isInvalid(outerDimPerm, unpackedRank))
     return op->emitError("invalid outer_dims_perm vector");
-  if (packOrUnPack.getMixedTiles().size() != innerDimsPos.size()) {
+  if (mixedTiles.size() != innerDimsPos.size()) {
     return op->emitError(
         "blocking factors must equal the number of dimensions to block");
+  }
+
+  // Blocking factors must be less or equal than the input rank, and must
+  // match the number of `dims_pos`.
+  if (mixedTiles.size() > unpackedRank) {
+    return op->emitError(
+        "blocking factors must be less or equal than the input rank");
+  }
+
+  ShapedType packedType = (std::is_same<OpTy, PackOp>::value)
+                              ? packOrUnPack.getOutputType()
+                              : packOrUnPack.getInputType();
+  int64_t packedRank = packedType.getRank();
+  // Require output rank to match input rank + number of blocking factors.
+  if (unpackedRank + mixedTiles.size() != packedRank) {
+    return op->emitError(
+        "packed rank must equal unpacked rank + blocking factors");
+  }
+
+  // Verify result shape is greater than the minimum expected
+  // by the pack operation, and that the output shape
+  // represents full tiles.
+  // Verify result type against inferred type.
+  ShapedType expectedPackedType = PackOp::getPackedType(
+      unpackedType, packOrUnPack.getStaticTiles(), innerDimsPos, outerDimPerm);
+  if (!isSmallerThan(expectedPackedType.getShape(), packedType.getShape())) {
+    return op->emitError("the shape of output is not large enough to hold the "
+                         "packed data. Expected at least ")
+           << expectedPackedType << ", got " << packedType;
+  }
+  if (!llvm::all_of(
+          llvm::zip(packedType.getShape().take_back(mixedTiles.size()),
+                    mixedTiles),
+          [](std::tuple<int64_t, OpFoldResult> it) {
+            Optional<int64_t> constTileSize =
+                getConstantIntValue(std::get<1>(it));
+            int64_t shape = std::get<0>(it);
+            if (!constTileSize) {
+              // If specified tile size is dynamic, output shape should
+              // be dynamic too.
+              return shape == ShapedType::kDynamicSize;
+            } else {
+              if (shape == ShapedType::kDynamicSize) {
+                // For the shape being dynamic when tile size is
+                // specified, return true. In canonical form a constant
+                // tile size should lead to constant shape of the tiled
+                // dimension, but not needed for verification.
+                return true;
+              }
+              return shape == constTileSize.value();
+            }
+          })) {
+    return op->emitError("mismatch in inner tile sizes specified and shaped of "
+                         "tiled dimension in the packed type");
   }
   return success();
 }
@@ -1645,10 +1717,7 @@ void PackOp::build(OpBuilder &builder, OperationState &state, Value source,
   SmallVector<Value> dynamicTileSizes;
   dispatchIndexOpFoldResults(innerTiles, dynamicTileSizes, staticTileSizes,
                              ShapedType::kDynamicSize);
-  ShapedType resultType =
-      getPackedType(source.getType().cast<ShapedType>(), staticTileSizes,
-                    innerDimsPos, outerDimsPerm);
-  build(builder, state, resultType, source, output,
+  build(builder, state, output.getType(), source, output,
         outerDimsPerm.empty() ? nullptr
                               : builder.getI64ArrayAttr(outerDimsPerm),
         builder.getI64ArrayAttr(innerDimsPos), dynamicTileSizes,
@@ -1665,42 +1734,20 @@ LogicalResult PackOp::verify() {
     return failure();
   }
 
-  // Blocking factors must be less or equal than the input rank, and must
-  // match the number of `dims_pos`.
-  if (numberOfBlockingFactors > getInputRank()) {
-    return op->emitError(
-        "blocking factors must be less or equal than the input rank");
-  }
-
-  // Require output rank to match input rank + number of blocking factors.
-  if ((getInputRank() + numberOfBlockingFactors) != getOutputRank()) {
-    return op->emitError(
-        "output rank must equal input rank + blocking factors");
-  }
-
   // Bail out if the tile does not divide the dimension fully. In the case of
   // dynamic tile factors or dimensions, having a partial tile is undefined
   // behavior.
+  auto dimAndTileMapping = getDimAndTileMapping();
   if (!getPaddingValue() &&
-      areNotFullTiles(getInputShape(), getDimAndTileMapping())) {
+      areNotFullTiles(getInputShape(), dimAndTileMapping)) {
     return op->emitError("invalid tile factor provided. Only full tiles are "
                          "supported when padding_value is not set");
   }
-  // Verify result type against inferred type.
-  SmallVector<int64_t> outerDimPerm =
-      extractFromI64ArrayAttr(getOuterDimsPerm());
-  ShapedType expectedOutputType = getPackedType(
-      getInputType(), getStaticTiles(), innerDimsPos, outerDimPerm);
-  if (!areShapesCompatible(expectedOutputType.getShape(), getOutputShape())) {
-    return op->emitError(
-               "infered type do not match provided output type. Expected ")
-           << expectedOutputType << " but got: " << getOutputType();
-  }
 
   if (auto paddingValue = getPaddingValue()) {
-    if (paddingValue.getType() != expectedOutputType.getElementType()) {
+    if (paddingValue.getType() != getInputType().getElementType()) {
       return op->emitError("expected padding_value has ")
-             << expectedOutputType.getElementType()
+             << getInputType().getElementType()
              << " but got: " << paddingValue.getType();
     }
   }
@@ -1738,10 +1785,7 @@ SmallVector<OpFoldResult> PackOp::getResultShape(
 }
 
 SmallVector<OpFoldResult> PackOp::getResultShape(OpBuilder &builder) {
-  return getResultShape(builder, getLoc(),
-                        getDims(builder, getLoc(), getInput()), getMixedTiles(),
-                        extractFromI64ArrayAttr(getInnerDimsPos()),
-                        extractFromI64ArrayAttr(getOuterDimsPerm()));
+  return tensor::createDimValues(builder, getLoc(), getOutput());
 }
 
 ShapedType PackOp::getPackedType(ShapedType sourceType,
@@ -2057,12 +2101,8 @@ LogicalResult PackOp::getResultTilePosition(
 LogicalResult
 PackOp::reifyResultShapes(OpBuilder &builder,
                           ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
-  OpBuilder::InsertionGuard g(builder);
-  builder.setInsertionPoint(getOperation());
-  reifiedReturnShapes.resize(1);
-  reifiedReturnShapes[0] = getValueOrCreateConstantIndexOp(
-      builder, getLoc(), getResultShape(builder));
-  return success();
+  return cast<LinalgExtOp>(getOperation())
+      .reifyResultShapes(builder, reifiedReturnShapes);
 }
 
 //===----------------------------------------------------------------------===//
@@ -2288,31 +2328,6 @@ LogicalResult UnPackOp::verify() {
       extractFromI64ArrayAttr(getInnerDimsPos());
   if (failed(commonVerifierPackAndUnPackOp(*this))) {
     return failure();
-  }
-
-  // Blocking factors must be less or equal than the output rank, and must
-  // match the number of `dims_pos`.
-  if (numberOfBlockingFactors > getOutputRank()) {
-    return op->emitError(
-        "blocking factors must be less or equal than the output rank");
-  }
-
-  // Require input rank to match output rank + number of blocking factors.
-  if ((getOutputRank() + numberOfBlockingFactors) != getInputRank()) {
-    return op->emitError(
-        "input rank must equal output rank + blocking factors");
-  }
-
-  // Verify input type against inferred type. The check includes the cases for
-  // incomplete tiles. We allow to `undo` the padding done in the pack.
-  SmallVector<int64_t> outerDimPerm =
-      extractFromI64ArrayAttr(getOuterDimsPerm());
-  ShapedType expectedInputType = PackOp::getPackedType(
-      getOutputType(), getStaticTiles(), innerDimsPos, outerDimPerm);
-  if (!areShapesCompatible(expectedInputType.getShape(), getInputShape())) {
-    return op->emitError(
-               "infered type do not match provided input type. Expected ")
-           << expectedInputType << " but got: " << getInputType();
   }
   return success();
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -121,7 +121,9 @@ static bool isInvalid(ArrayRef<int64_t> dimsPos, int64_t rank) {
 /// of the `limitShape`.
 static bool isSmallerThan(ArrayRef<int64_t> sourceShape,
                           ArrayRef<int64_t> limitShape) {
-  assert(sourceShape.size() == limitShape.size());
+  assert(
+      sourceShape.size() == limitShape.size() &&
+      "expected source shape rank, and limit of the shape to have same rank");
   return llvm::all_of(
       llvm::zip(sourceShape, limitShape), [](std::tuple<int64_t, int64_t> it) {
         int64_t sourceExtent = std::get<0>(it);
@@ -1664,7 +1666,6 @@ static LogicalResult commonVerifierPackAndUnPackOp(OpTy packOrUnPack) {
   // Verify result shape is greater than the minimum expected
   // by the pack operation, and that the output shape
   // represents full tiles.
-  // Verify result type against inferred type.
   ShapedType expectedPackedType = PackOp::getPackedType(
       unpackedType, packOrUnPack.getStaticTiles(), innerDimsPos, outerDimPerm);
   if (!isSmallerThan(expectedPackedType.getShape(), packedType.getShape())) {

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1726,10 +1726,6 @@ void PackOp::build(OpBuilder &builder, OperationState &state, Value source,
 }
 
 LogicalResult PackOp::verify() {
-  Operation *op = getOperation();
-  size_t numberOfBlockingFactors = getMixedTiles().size();
-  SmallVector<int64_t> innerDimsPos =
-      extractFromI64ArrayAttr(getInnerDimsPos());
   if (failed(commonVerifierPackAndUnPackOp(*this))) {
     return failure();
   }
@@ -1740,13 +1736,13 @@ LogicalResult PackOp::verify() {
   auto dimAndTileMapping = getDimAndTileMapping();
   if (!getPaddingValue() &&
       areNotFullTiles(getInputShape(), dimAndTileMapping)) {
-    return op->emitError("invalid tile factor provided. Only full tiles are "
-                         "supported when padding_value is not set");
+    return emitOpError("invalid tile factor provided. Only full tiles are "
+                       "supported when padding_value is not set");
   }
 
   if (auto paddingValue = getPaddingValue()) {
     if (paddingValue.getType() != getInputType().getElementType()) {
-      return op->emitError("expected padding_value has ")
+      return emitOpError("expected padding_value has ")
              << getInputType().getElementType()
              << " but got: " << paddingValue.getType();
     }
@@ -2322,10 +2318,6 @@ LogicalResult UnPackOp::getResultTilePosition(
 }
 
 LogicalResult UnPackOp::verify() {
-  Operation *op = getOperation();
-  size_t numberOfBlockingFactors = getMixedTiles().size();
-  SmallVector<int64_t> innerDimsPos =
-      extractFromI64ArrayAttr(getInnerDimsPos());
   if (failed(commonVerifierPackAndUnPackOp(*this))) {
     return failure();
   }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/convert_to_loops.mlir
@@ -1002,31 +1002,27 @@ func.func @KCRS_to_KCRSsr(%arg0: memref<?x?x?x?xf32>, %arg1: memref<?x?x?x?x8x32
   return
 }
 
-// CHECK-DAG:   #[[MAP0:.*]] = affine_map<()[s0] -> (s0 ceildiv 32)>
-// CHECK-DAG:   #[[MAP1:.*]] = affine_map<()[s0] -> (s0 ceildiv 8)>
-// CHECK-DAG:   #[[MAP2:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
-// CHECK-DAG:   #[[MAP3:.*]] = affine_map<(d0, d1) -> (d0 * 8 + d1)>
-// CHECK-LABEL: func.func @KCRS_to_KCRSsr(
+// CHECK-DAG:   #[[MAP0:.*]] = affine_map<(d0, d1) -> (d0 * 32 + d1)>
+// CHECK-DAG:   #[[MAP1:.*]] = affine_map<(d0, d1) -> (d0 * 8 + d1)>
+// CHECK:       func.func @KCRS_to_KCRSsr(
 // CHECK-DAG:     %[[zero:.*]] = arith.constant 0 : index
 // CHECK-DAG:     %[[one:.*]] = arith.constant 1 : index
-// CHECK-DAG:     %[[eight:.*]] = arith.constant 8 : index
-// CHECK-DAG:     %[[thirtytwo:.*]] = arith.constant 32 : index
 // CHECK-DAG:     %[[two:.*]] = arith.constant 2 : index
 // CHECK-DAG:     %[[three:.*]] = arith.constant 3 : index
-// CHECK-DAG:     %[[dimZero:.*]] = memref.dim %arg0, %[[zero]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[dimOne:.*]] = memref.dim %arg0, %[[one]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[dimTwo:.*]] = memref.dim %arg0, %[[two]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[dimThree:.*]] = memref.dim %arg0, %[[three]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[mapOnDimTwo:.*]] = affine.apply #[[MAP0]]()[%[[dimTwo]]]
-// CHECK-DAG:     %[[mapOnDimThree:.*]] = affine.apply #[[MAP1]]()[%[[dimThree]]]
+// CHECK-DAG:     %[[eight:.*]] = arith.constant 8 : index
+// CHECK-DAG:     %[[thirtyTwo:.*]] = arith.constant 32 : index
+// CHECK-DAG:     %[[dimZero:.*]] = memref.dim %arg1, %[[zero]] : memref<?x?x?x?x8x32xf32>
+// CHECK-DAG:     %[[dimOne:.*]] = memref.dim %arg1, %[[one]] : memref<?x?x?x?x8x32xf32>
+// CHECK-DAG:     %[[dimTwo:.*]] = memref.dim %arg1, %[[two]] : memref<?x?x?x?x8x32xf32>
+// CHECK-DAG:     %[[dimThree:.*]] = memref.dim %arg1, %[[three]] : memref<?x?x?x?x8x32xf32>
 // CHECK:         scf.for %[[K:.*]] = %[[zero]] to %[[dimZero]] step %[[one]] {
 // CHECK:           scf.for %[[C:.*]] = %[[zero]] to %[[dimOne]] step %[[one]] {
-// CHECK:             scf.for %[[R:.*]] = %[[zero]] to %[[mapOnDimTwo]] step %[[one]] {
-// CHECK:               scf.for %[[S:.*]] = %[[zero]] to %[[mapOnDimThree]] step %[[one]] {
+// CHECK:             scf.for %[[R:.*]] = %[[zero]] to %[[dimTwo]] step %[[one]] {
+// CHECK:               scf.for %[[S:.*]] = %[[zero]] to %[[dimThree]] step %[[one]] {
 // CHECK:                 scf.for %[[s:.*]] = %[[zero]] to %[[eight]] step %[[step]] {
-// CHECK:                   scf.for %[[r:.*]] = %[[zero]] to %[[thirtytwo]] step %[[step]] {
-// CHECK-DAG:                 %[[affineMapR:.*]] = affine.apply #[[MAP2]](%[[R]], %[[r]])
-// CHECK-DAG:                 %[[affineMapS:.*]] = affine.apply #[[MAP3]](%[[S]], %[[s]])
+// CHECK:                   scf.for %[[r:.*]] = %[[zero]] to %[[thirtyTwo]] step %[[step]] {
+// CHECK-DAG:                 %[[affineMapR:.*]] = affine.apply #[[MAP0]](%[[R]], %[[r]])
+// CHECK-DAG:                 %[[affineMapS:.*]] = affine.apply #[[MAP1]](%[[S]], %[[s]])
 // CHECK:                     %[[scalar:.*]] = memref.load %arg0[%[[K]], %[[C]], %[[affineMapR]], %[[affineMapS]]] : memref<?x?x?x?xf32>
 // CHECK:                     memref.store %[[scalar]], %arg1[%[[K]], %[[C]], %[[R]], %[[S]], %[[s]], %[[r]]] : memref<?x?x?x?x8x32xf32>
 // CHECK:                   }
@@ -1043,33 +1039,31 @@ func.func @KCRS_to_KCRSsr(%arg0: memref<?x?x?x?xf32>, %arg1: memref<?x?x?x?x8x?x
   return
 }
 
-// CHECK-DAG:  #[[MAP0:.*]] = affine_map<()[s0, s1] -> (s0 ceildiv s1)>
-// CHECK-DAG:  #[[MAP1:.*]] = affine_map<()[s0] -> (s0 ceildiv 8)>
-// CHECK-DAG:  #[[MAP2:.*]] = affine_map<(d0, d1)[s0] -> (d0 * s0 + d1)>
-// CHECK-DAG:  #[[MAP3:.*]] = affine_map<(d0, d1) -> (d0 * 8 + d1)>
+// CHECK-DAG:  #[[MAP0:.*]] = affine_map<(d0, d1)[s0] -> (d0 * s0 + d1)>
+// CHECK-DAG:  #[[MAP1:.*]] = affine_map<(d0, d1) -> (d0 * 8 + d1)>
 // CHECK:      func.func @KCRS_to_KCRSsr
 // CHECK-SAME:    %[[ARG0:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[ARG1:[a-zA-Z0-9]+]]
 // CHECK-SAME:    %[[ARG2:[a-zA-Z0-9]+]]
 // CHECK-DAG:     %[[zero:.*]] = arith.constant 0 : index
 // CHECK-DAG:     %[[one:.*]] = arith.constant 1 : index
-// CHECK-DAG:     %[[eight:.*]] = arith.constant 8 : index
 // CHECK-DAG:     %[[two:.*]] = arith.constant 2 : index
 // CHECK-DAG:     %[[three:.*]] = arith.constant 3 : index
-// CHECK-DAG:     %[[dimZero:.*]] = memref.dim %[[ARG0]], %[[zero]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[dimOne:.*]] = memref.dim %[[ARG0]], %[[one]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[dimTwo:.*]] = memref.dim %[[ARG0]], %[[two]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[dimThree:.*]] = memref.dim %[[ARG0]], %[[three]] : memref<?x?x?x?xf32>
-// CHECK-DAG:     %[[mapOnDimTwo:.*]] = affine.apply #[[MAP0]]()[%[[dimTwo]], %[[ARG2]]]
-// CHECK-DAG:     %[[mapOnDimThree:.*]] = affine.apply #[[MAP1]]()[%[[dimThree]]]
+// CHECK-DAG:     %[[eight:.*]] = arith.constant 8 : index
+// CHECK-DAG:     %[[five:.*]] = arith.constant 5 : index
+// CHECK-DAG:     %[[dimZero:.*]] = memref.dim %[[ARG1]], %[[zero]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG:     %[[dimOne:.*]] = memref.dim %[[ARG1]], %[[one]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG:     %[[dimTwo:.*]] = memref.dim %[[ARG1]], %[[two]] : memref<?x?x?x?x8x?xf32>
+// CHECK-DAG:     %[[dimThree:.*]] = memref.dim %[[ARG1]], %[[three]] : memref<?x?x?x?x8x?xf32>
 // CHECK:         scf.for %[[K:.*]] = %[[zero]] to %[[dimZero]] step %[[one]] {
 // CHECK:           scf.for %[[C:.*]] = %[[zero]] to %[[dimOne]] step %[[one]] {
-// CHECK:             scf.for %[[R:.*]] = %[[zero]] to %[[mapOnDimTwo]] step %[[one]] {
-// CHECK:               scf.for %[[S:.*]] = %[[zero]] to %[[mapOnDimThree]] step %[[one]] {
+// CHECK:             scf.for %[[R:.*]] = %[[zero]] to %[[dimTwo]] step %[[one]] {
+// CHECK:               scf.for %[[S:.*]] = %[[zero]] to %[[dimThree]] step %[[one]] {
+// CHECK:                 %[[dimFive:.*]] = memref.dim %[[ARG1]], %[[five]] : memref<?x?x?x?x8x?xf32>
 // CHECK:                 scf.for %[[s:.*]] = %[[zero]] to %[[eight]] step %[[step]] {
-// CHECK:                   scf.for %[[r:.*]] = %[[zero]] to %[[ARG2]] step %[[step]] {
-// CHECK-DAG:                 %[[affineMapR:.*]] = affine.apply #[[MAP2]](%[[R]], %[[r]])
-// CHECK-DAG:                 %[[affineMapS:.*]] = affine.apply #[[MAP3]](%[[S]], %[[s]])
+// CHECK:                   scf.for %[[r:.*]] = %[[zero]] to %[[dimFive]] step %[[step]] {
+// CHECK-DAG:                 %[[affineMapR:.*]] = affine.apply #[[MAP0]](%[[R]], %[[r]])[%[[ARG2]]]
+// CHECK-DAG:                 %[[affineMapS:.*]] = affine.apply #[[MAP1]](%[[S]], %[[s]])
 // CHECK:                     %[[scalar:.*]] = memref.load %[[ARG0]][%[[K]], %[[C]], %[[affineMapR]], %[[affineMapS]]] : memref<?x?x?x?xf32>
 // CHECK:                     memref.store %[[scalar]], %[[ARG1]][%[[K]], %[[C]], %[[R]], %[[S]], %[[s]], %[[r]]] : memref<?x?x?x?x8x?xf32>
 // CHECK:                   }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -691,6 +691,24 @@ func.func @pack(%arg0: memref<3x3xf32>, %arg1: memref<3x3x1x1xf32>) {
 
 // -----
 
+func.func @extra_pad_and_pack(%input: tensor<13x15xf32>, %output: tensor<3x8x8x2xf32>, %pad: f32) -> tensor<3x8x8x2xf32> {
+  // expected-error@+1 {{infered type do not match provided output type. Expected 'tensor<2x8x8x2xf32>' but got: 'tensor<3x8x8x2xf32>}}
+  %0 = iree_linalg_ext.pack %input padding_value(%pad: f32) inner_dims_pos = [0, 1] inner_tiles = [8, 2] into %output : (tensor<13x15xf32> tensor<3x8x8x2xf32>) -> tensor<3x8x8x2xf32>
+  return %0 : tensor<3x8x8x2xf32>
+}
+// CHECK:      func @extra_pad_and_pack(
+// CHECK-SAME:   %[[INPUT:.+]]: tensor<13x15xf32>
+// CHECK-SAME:   %[[OUTPUT:.+]]: tensor<3x8x8x2xf32>
+// CHECK-SAME:   %[[PAD:.+]]: f32
+// CHECK:        %[[RES:.+]] = iree_linalg_ext.pack %[[INPUT]]
+// CHECK-SAME:     padding_value(%[[PAD]] : f32)
+// CHECK-SAME:     inner_dims_pos = [0, 1]
+// CHECK-SAME:     inner_tiles = [8, 2]
+// CHECK-SAME:     into %[[OUTPUT]]
+// CHECK:       return %[[RES]]
+
+// -----
+
 func.func @pad_and_pack_static(%input: tensor<13x15xf32>, %output: tensor<2x8x8x2xf32>, %pad: f32) -> tensor<2x8x8x2xf32> {
   %0 = iree_linalg_ext.pack %input padding_value(%pad : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 2] into %output : (tensor<13x15xf32> tensor<2x8x8x2xf32>) -> tensor<2x8x8x2xf32>
   return %0 : tensor<2x8x8x2xf32>

--- a/tests/e2e/linalg_ext_ops/pack.mlir
+++ b/tests/e2e/linalg_ext_ops/pack.mlir
@@ -412,7 +412,7 @@ func.func @dynamic_pack_pad_transpose_inner_and_outer_dims_large() {
   %c32 = arith.constant 32 : index
   %tiled_d0 = arith.ceildivui %d0, %c32 : index
   %tiled_d1 = arith.ceildivui %d1, %c16 : index
-  %init_pack = tensor.empty(%tiled_d0, %tiled_d1) : tensor<?x?x16x32xi32>
+  %init_pack = tensor.empty(%tiled_d1, %tiled_d0) : tensor<?x?x16x32xi32>
   %pack = iree_linalg_ext.pack %source padding_value(%padding_value : i32)
       outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [16, 32] into %init_pack
       : (tensor<?x?xi32> tensor<?x?x16x32xi32>) -> tensor<?x?x16x32xi32>


### PR DESCRIPTION
With padding current pack/unpack op verifier checks that the packed type is rounded up to the next multiple of the inner data tiles. Relax this to allow shape to be greater than the source, and divisible by the tile size.

Also common out more of the verification between pack and unpack ops.