### PR TITLE
Adding `--verify` and `--compile-to=` flags to iree-compile.

### DIFF
--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -28,15 +28,29 @@ struct IREEVMPipelineHooks {
   std::function<void(OpPassManager &)> buildConstEvalPassPipelineCallback;
 };
 
+enum class IREEVMPipelinePhase {
+  Input,
+  ABI,
+  Flow,
+  Stream,
+  HAL,
+  VM,
+  End,
+};
+
 // Builds a pass pipeline to perform end-to-end compilation from a
 // supported MLIR-based input to the IREE vm dialect.
+//
+// If a |runTo| phase is specified the pipeline will stop and output the full
+// IR after the phase completes.
 void buildIREEVMTransformPassPipeline(
     BindingOptions bindingOptions, InputDialectOptions inputOptions,
     HighLevelOptimizationOptions highLevelOptimizationOptions,
     SchedulingOptions schedulingOptions,
     IREE::HAL::TargetOptions executableOptions,
     IREE::VM::TargetOptions targetOptions, IREEVMPipelineHooks &hooks,
-    OpPassManager &passManager);
+    OpPassManager &passManager,
+    IREEVMPipelinePhase compileTo = IREEVMPipelinePhase::End);
 
 // Builds the above with options initialized from flags.
 void buildDefaultIREEVMTransformPassPipeline(OpPassManager &passManager);


### PR DESCRIPTION
`--verify=false` disables verification similar to setting `-verify-each=0` in iree-opt. This can be useful when compiling models in debug builds as verification can often take 2-5x longer than actual compilation.

`--compile-to=` allows for early-exit of the compilation pipeline based on well-known stages: `input`, `abi`, `flow`, `stream`, `hal`, `vm`. Defaults to `end` which runs the entire pipeline to completion. Now if someone wants to see what their program looks like in the stream dialect they can just add `--compile-to=stream` and get the IR vs needing to slice/mangling print-ir-after commands.