### PR TITLE
Add a pass to materialize the encoding during executable translation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -163,6 +163,7 @@ iree_compiler_cc_library(
         "ForOpCanonicalizationPass.cpp",
         "FuseTensorPadWithConsumer.cpp",
         "IREEComprehensiveBufferizePass.cpp",
+        "MaterializeEncodingPass.cpp",
         "OptimizeVectorTransferPass.cpp",
         "PolynomialApproximationPass.cpp",
         "TestPartitionableLoopsInterface.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -133,6 +133,7 @@ iree_cc_library(
     "ForOpCanonicalizationPass.cpp"
     "FuseTensorPadWithConsumer.cpp"
     "IREEComprehensiveBufferizePass.cpp"
+    "MaterializeEncodingPass.cpp"
     "OptimizeVectorTransferPass.cpp"
     "PolynomialApproximationPass.cpp"
     "TestPartitionableLoopsInterface.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
@@ -1,0 +1,344 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+//===---------------------------------------------------------------------===//
+// Pass to materialize the encoding of tensor based on target information.
+//===---------------------------------------------------------------------===//
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+/// For `dispatchTensorType` that bind a `RankedTensorType` with encoding,
+/// returns the materialized shape of the `dispatchTensorType`. The
+/// dynamic dimensions of the `dispatchTensorType` are provided in
+/// `dynamicDims`.
+static FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensor(
+    OpBuilder &builder, Location loc,
+    IREE::LinalgExt::MaterializeEncodingTypeConverter &typeConverter,
+    IREE::Flow::DispatchTensorType dispatchTensorType, ValueRange dynamicDims) {
+  auto boundTensorType =
+      dispatchTensorType.getBoundType().dyn_cast<RankedTensorType>();
+  if (!boundTensorType) {
+    return failure();
+  }
+
+  auto encoding =
+      boundTensorType.getEncoding().dyn_cast<IREE::LinalgExt::EncodingAttr>();
+  if (!encoding) {
+    return failure();
+  }
+
+  IREE::LinalgExt::MaterializeEncodingFn materializeEncodingFn =
+      typeConverter.getMaterializeEncodingFn();
+  FailureOr<IREE::LinalgExt::MaterializeEncodingInfo> encodingInfo =
+      materializeEncodingFn(encoding.getEncoding().getValue());
+  if (failed(encodingInfo)) {
+    return failure();
+  }
+
+  SmallVector<OpFoldResult, 4> targetShape = getMixedSizes(
+      builder.getIndexArrayAttr(dispatchTensorType.getShape()), dynamicDims);
+  SmallVector<OpFoldResult> innerTileSizes = llvm::to_vector(llvm::map_range(
+      encodingInfo->innerTileSizes,
+      [&](int64_t v) -> OpFoldResult { return builder.getIndexAttr(v); }));
+  SmallVector<OpFoldResult> convertedTargetShape =
+      IREE::LinalgExt::PackOp::getResultShape(
+          builder, loc, targetShape, innerTileSizes, encodingInfo->innerDimsPos,
+          encodingInfo->outerDimsPerm);
+  return convertedTargetShape;
+}
+
+/// For `dispatchTensorType` that bind a `RankedTensorType` with encoding,
+/// returns the dynamic dimensions of the materialized shape of the
+/// `dispatchTensorType`. The dynamic dimensions of the `dispatchTensorType` are
+/// provided in `dynamicDims`.
+static FailureOr<SmallVector<Value>> getPackedDynamicDimsForDispatchTensor(
+    OpBuilder &builder, Location loc,
+    IREE::LinalgExt::MaterializeEncodingTypeConverter &typeConverter,
+    IREE::Flow::DispatchTensorType dispatchTensorType, ValueRange dynamicDims) {
+  FailureOr<SmallVector<OpFoldResult>> convertedTargetShape =
+      getPackedDimsForDispatchTensor(builder, loc, typeConverter,
+                                     dispatchTensorType, dynamicDims);
+  if (failed(convertedTargetShape)) {
+    return failure();
+  }
+  SmallVector<int64_t> convertedStaticTargetShape;
+  SmallVector<Value> convertedDynamicTargetShape;
+  dispatchIndexOpFoldResults(
+      convertedTargetShape.value(), convertedDynamicTargetShape,
+      convertedStaticTargetShape, ShapedType::kDynamicSize);
+  return convertedDynamicTargetShape;
+}
+
+namespace {
+/// Given the `encoding` return the `MaterializeEncodingInfo` to use for
+/// materializing the pack op.
+// TODO(ravishankarm): THis is currently hard-coded here for convenience. When
+// used in IREE, this will be computed based on the architecture information in
+// `hal.executable.variant`.
+static FailureOr<IREE::LinalgExt::MaterializeEncodingInfo>
+getPackOpInfoFromEncoding(IREE::LinalgExt::TensorEncoding encoding) {
+  switch (encoding) {
+    case IREE::LinalgExt::TensorEncoding::GEMM_LHS:
+      return IREE::LinalgExt::MaterializeEncodingInfo{{0, 1}, {8, 4}, {}};
+      break;
+    case IREE::LinalgExt::TensorEncoding::GEMM_RHS:
+      return IREE::LinalgExt::MaterializeEncodingInfo{{0, 1}, {4, 8}, {}};
+      break;
+    case IREE::LinalgExt::TensorEncoding::GEMM_RESULT:
+      return IREE::LinalgExt::MaterializeEncodingInfo{{0, 1}, {8, 8}, {}};
+      break;
+    case IREE::LinalgExt::TensorEncoding::GEMM_RHS_TRANSPOSE:
+      return IREE::LinalgExt::MaterializeEncodingInfo{{1, 0}, {8, 4}, {1, 0}};
+      break;
+    default:
+      return failure();
+  }
+}
+
+/// Pattern to materialize the encoding for `hal.interface.binding.subspan`
+/// operations.
+struct MaterializeInterfaceBindingEncoding
+    : public IREE::LinalgExt::OpMaterializeEncodingPattern<
+          IREE::HAL::InterfaceBindingSubspanOp> {
+  using IREE::LinalgExt::OpMaterializeEncodingPattern<
+      IREE::HAL::InterfaceBindingSubspanOp>::OpMaterializeEncodingPattern;
+
+  LogicalResult matchAndRewrite(
+      IREE::HAL::InterfaceBindingSubspanOp subspanOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    auto resultType = subspanOp.getResult()
+                          .getType()
+                          .dyn_cast<IREE::Flow::DispatchTensorType>();
+    if (!resultType) {
+      return rewriter.notifyMatchFailure(
+          subspanOp, "expected result type to be !flow.dispatch.tensor");
+    }
+    auto boundTensorType =
+        resultType.getBoundType().dyn_cast<RankedTensorType>();
+    if (!boundTensorType) {
+      return rewriter.notifyMatchFailure(
+          subspanOp, "bound type is not a RankedTensorType");
+    }
+
+    auto convertedBoundType = getTypeConverter()->convertType(boundTensorType);
+    if (convertedBoundType == boundTensorType) {
+      return rewriter.notifyMatchFailure(subspanOp, "bound type already valid");
+    }
+
+    auto *typeConverter =
+        static_cast<IREE::LinalgExt::MaterializeEncodingTypeConverter *>(
+            getTypeConverter());
+    // Get the dynamic dims of the target.
+    Location loc = subspanOp.getLoc();
+    FailureOr<SmallVector<Value>> convertedDynamicDims =
+        getPackedDynamicDimsForDispatchTensor(rewriter, loc, *typeConverter,
+                                              resultType,
+                                              subspanOp.getDynamicDims());
+    if (failed(convertedDynamicDims)) {
+      return rewriter.notifyMatchFailure(
+          subspanOp, "failed to get converted dynamic dims");
+    }
+
+    auto newResultType = IREE::Flow::DispatchTensorType::get(
+        resultType.getAccess(), convertedBoundType);
+    rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
+        subspanOp, newResultType, subspanOp.getSet(), subspanOp.getBinding(),
+        subspanOp.getDescriptorType(), subspanOp.getByteOffset(),
+        convertedDynamicDims.value(), subspanOp.getAlignmentAttr());
+    return success();
+  }
+};
+
+/// Pattern to convert `flow.dispatch.tensor.store` operation when
+/// materializing the encoding.
+struct MaterializeFlowDispatchTensorLoadOp
+    : public IREE::LinalgExt::OpMaterializeEncodingPattern<
+          IREE::Flow::DispatchTensorLoadOp> {
+  using IREE::LinalgExt::OpMaterializeEncodingPattern<
+      IREE::Flow::DispatchTensorLoadOp>::OpMaterializeEncodingPattern;
+
+  LogicalResult matchAndRewrite(
+      IREE::Flow::DispatchTensorLoadOp loadOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // Only handle operations where the load covers the entire
+    // `!flow.dispatch.tensor` type.
+    // TODO(ravishankarm): Relax this for partial loads.
+    if (!loadOp.isLoadOfWholeSource()) {
+      return rewriter.notifyMatchFailure(loadOp, "unhandled partial loads");
+    }
+
+    auto sourceType = loadOp.getSourceType();
+    auto boundTensorType = sourceType.getBoundType();
+    auto *typeConverter =
+        static_cast<IREE::LinalgExt::MaterializeEncodingTypeConverter *>(
+            getTypeConverter());
+    if (typeConverter->convertType(boundTensorType) == boundTensorType) {
+      return rewriter.notifyMatchFailure(loadOp, "bound type already valid");
+    }
+
+    Location loc = loadOp.getLoc();
+    FailureOr<SmallVector<OpFoldResult>> convertedMixedSizes =
+        getPackedDimsForDispatchTensor(rewriter, loc, *typeConverter,
+                                       sourceType, loadOp.getSourceDims());
+    if (failed(convertedMixedSizes)) {
+      return rewriter.notifyMatchFailure(
+          loadOp, "failed to get converted dynamic dims for result");
+    }
+    SmallVector<OpFoldResult> convertedOffsets(convertedMixedSizes->size(),
+                                               rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> convertedStrides(convertedMixedSizes->size(),
+                                               rewriter.getIndexAttr(1));
+    SmallVector<int64_t> convertedStaticDims;
+    SmallVector<Value> convertedDynamicDims;
+    dispatchIndexOpFoldResults(convertedMixedSizes.value(),
+                               convertedDynamicDims, convertedStaticDims,
+                               ShapedType::kDynamicSize);
+    rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorLoadOp>(
+        loadOp, adaptor.getSource(), convertedDynamicDims, convertedOffsets,
+        convertedMixedSizes.value(), convertedStrides);
+
+    return success();
+  }
+};
+
+/// Pattern to convert `flow.dispatch.tensor.store` operation when
+/// materializing the encoding.
+struct MaterializeFlowDispatchTensorStoreOp
+    : public IREE::LinalgExt::OpMaterializeEncodingPattern<
+          IREE::Flow::DispatchTensorStoreOp> {
+  using IREE::LinalgExt::OpMaterializeEncodingPattern<
+      IREE::Flow::DispatchTensorStoreOp>::OpMaterializeEncodingPattern;
+
+  LogicalResult matchAndRewrite(
+      IREE::Flow::DispatchTensorStoreOp storeOp, OpAdaptor adaptor,
+      ConversionPatternRewriter &rewriter) const override {
+    // Only handle operations where the store covers the entire
+    // `!flow.dispatch.tensor` type.
+    // TODO(ravishankarm): Relax this for partial stores.
+    if (!storeOp.isStoreToWholeTarget()) {
+      return rewriter.notifyMatchFailure(storeOp, "unhandled partial stores");
+    }
+
+    auto targetType = storeOp.getTargetType();
+    auto boundTensorType = targetType.getBoundType();
+    auto *typeConverter =
+        static_cast<IREE::LinalgExt::MaterializeEncodingTypeConverter *>(
+            getTypeConverter());
+    if (typeConverter->convertType(boundTensorType) == boundTensorType) {
+      return rewriter.notifyMatchFailure(storeOp, "bound type already valid");
+    }
+
+    Location loc = storeOp.getLoc();
+    FailureOr<SmallVector<OpFoldResult>> convertedMixedSizes =
+        getPackedDimsForDispatchTensor(rewriter, loc, *typeConverter,
+                                       targetType, storeOp.getTargetDims());
+    if (failed(convertedMixedSizes)) {
+      return rewriter.notifyMatchFailure(
+          storeOp, "failed to get converted dynamic dims for result");
+    }
+    SmallVector<OpFoldResult> convertedOffsets(convertedMixedSizes->size(),
+                                               rewriter.getIndexAttr(0));
+    SmallVector<OpFoldResult> convertedStrides(convertedMixedSizes->size(),
+                                               rewriter.getIndexAttr(1));
+    SmallVector<int64_t> convertedStaticDims;
+    SmallVector<Value> convertedDynamicDims;
+    dispatchIndexOpFoldResults(convertedMixedSizes.value(),
+                               convertedDynamicDims, convertedStaticDims,
+                               ShapedType::kDynamicSize);
+    rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorStoreOp>(
+        storeOp, adaptor.getValue(), adaptor.getTarget(), convertedDynamicDims,
+        convertedOffsets, convertedMixedSizes.value(), convertedStrides);
+
+    return success();
+  }
+};
+
+struct IREEMaterializeEncodingPass
+    : public IREEMaterializeEncodingBase<IREEMaterializeEncodingPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<arith::ArithDialect, AffineDialect, IREE::Flow::FlowDialect,
+                    IREE::LinalgExt::IREELinalgExtDialect>();
+  }
+  void runOnOperation() override;
+};
+
+}  // namespace
+
+void IREEMaterializeEncodingPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  auto operation = getOperation();
+
+  {
+    RewritePatternSet materializeEncodingPattern(context);
+
+    IREE::LinalgExt::MaterializeEncodingTypeConverter typeConverter(
+        getPackOpInfoFromEncoding);
+    // Add type conversion for `!flow.dispatch.tensor` type.
+    typeConverter.addConversion(
+        [&typeConverter](IREE::Flow::DispatchTensorType dispatchTensorType) {
+          Type boundType = dispatchTensorType.getBoundType();
+          Type convertedBoundType = typeConverter.convertType(boundType);
+          if (convertedBoundType == boundType) {
+            return dispatchTensorType;
+          }
+          return IREE::Flow::DispatchTensorType::get(
+              dispatchTensorType.getAccess(), convertedBoundType);
+        });
+
+    IREE::LinalgExt::MaterializeEncodingConversionTarget target(*context);
+    target.addDynamicallyLegalOp<IREE::HAL::InterfaceBindingSubspanOp>(
+        [&typeConverter](IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
+          auto resultType =
+              subspanOp.getResult()
+                  .getType()
+                  .template dyn_cast<IREE::Flow::DispatchTensorType>();
+          return resultType == typeConverter.convertType(resultType);
+        });
+
+    IREE::LinalgExt::populateMaterializeEncodingPatterns(
+        materializeEncodingPattern, target, typeConverter);
+    materializeEncodingPattern.insert<MaterializeFlowDispatchTensorLoadOp,
+                                      MaterializeFlowDispatchTensorStoreOp,
+                                      MaterializeInterfaceBindingEncoding>(
+        typeConverter, context);
+    if (failed(applyPartialConversion(operation, target,
+                                      std::move(materializeEncodingPattern)))) {
+      operation.emitOpError("materialization failed");
+      return signalPassFailure();
+    }
+  }
+
+  // Add patterns to fold pack/unpack ops with pad/extract_slice ops and resolve
+  // dims ops.
+  {
+    RewritePatternSet patterns(context);
+    IREE::LinalgExt::populateFoldIntoPackAndUnpackOpsPatterns(patterns);
+    memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(operation, std::move(patterns)))) {
+      operation.emitOpError("folding patterns failed");
+      return signalPassFailure();
+    }
+  }
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createIREEMaterializeEncodingPass() {
+  return std::make_unique<IREEMaterializeEncodingPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -128,6 +128,7 @@ static LogicalResult getTileAndDistributeConfig(
   return success();
 }
 
+/// Get the materialization information from a `iree_linalg_ext.pack` operation.
 static FailureOr<IREE::LinalgExt::MaterializeEncodingInfo>
 getMaterializationInfo(IREE::LinalgExt::PackOp packOp) {
   IREE::LinalgExt::MaterializeEncodingInfo encodingInfo;
@@ -245,6 +246,13 @@ struct LowerDispatchWorkgroupCountForDagRootOp
   SmallVector<unsigned> partitionedLoops;
 };
 
+/// Pattern to lower a `flow.dispatch.workgroup_count_from_set_encoding` op.
+/// At the Flow level this op uses the logical shape of the tensor
+/// as the workload. This gets materialized into an physical tensor
+/// Lower this operation accounting for the change of shape from
+/// the logical shape to the physical shape. It lowers to
+/// a `flow.dispatch.workgroup_count_from_root_dag` where the root
+/// is the `pack` op that materialized the encoding.
 struct LowerDispatchWorkgroupCountFromSetEncodingOp
     : public OpRewritePattern<
           IREE::Flow::DispatchWorkgroupCountFromSetEncodingOp> {

--- a/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TypePropagationPass.cpp
@@ -74,7 +74,8 @@ static Optional<Type> getLegalizedType(Type t) {
     Optional<Type> legalizedElementType = getLegalizedElementType(elementType);
     if (!legalizedElementType) return llvm::None;
     return RankedTensorType::get(shapedType.getShape(),
-                                 legalizedElementType.value());
+                                 legalizedElementType.value(),
+                                 shapedType.getEncoding());
   }
   return llvm::None;
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -33,6 +33,7 @@ iree_lit_test_suite(
             "gpu_vectorization.mlir",
             "iree_comprehensive_bufferize.mlir",
             "pad_dynamic_alloc.mlir",
+            "materialize_encoding.mlir",
             "reduce_bank_conflicts.mlir",
             "remove_dead_allocs.mlir",
             "remove_trivial_loops.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -28,6 +28,7 @@ iree_lit_test_suite(
     "gpu_pipeline.mlir"
     "gpu_vectorization.mlir"
     "iree_comprehensive_bufferize.mlir"
+    "materialize_encoding.mlir"
     "pad_dynamic_alloc.mlir"
     "reduce_bank_conflicts.mlir"
     "remove_dead_allocs.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding.mlir
@@ -1,0 +1,150 @@
+// RUN: iree-opt --iree-codegen-materialize-encoding --canonicalize --cse --split-input-file %s | FileCheck %s
+
+func.func @set_encoding_op() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %d0 = hal.interface.constant.load [0] : index
+  %d1 = hal.interface.constant.load [1] : index
+  %outd0 = hal.interface.constant.load [2] : index
+  %outd1 = hal.interface.constant.load [3] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%d0, %d1}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%outd0, %outd1}
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%d0, %d1} -> tensor<?x?xf32>
+  %p0 = affine.apply affine_map<()[s0, s1] -> (-s0 + s1)>()[%d0, %outd0]
+  %p1 = affine.apply affine_map<()[s0, s1] -> (-s0 + s1)>()[%d1, %outd1]
+  %padded = tensor.pad %2 low[0, 0] high[%p0, %p1] {
+  ^bb0(%arg0: index, %arg1: index):
+    tensor.yield %cst : f32
+  } : tensor<?x?xf32> to tensor<?x?xf32>
+  %3 = iree_linalg_ext.set_encoding %padded : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  flow.dispatch.tensor.store %3, %1, offsets = [0, 0], sizes = [%outd0, %outd1], strides = [1, 1]
+      : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+      -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%outd0, %outd1}
+  return
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//       CHECK: func @set_encoding_op()
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[CST:.+]] = arith.constant 0.0
+//   CHECK-DAG:   %[[D0:.+]] = hal.interface.constant.load[0]
+//   CHECK-DAG:   %[[D1:.+]] = hal.interface.constant.load[1]
+//   CHECK-DAG:   %[[OUTD0:.+]] = hal.interface.constant.load[2]
+//   CHECK-DAG:   %[[OUTD1:.+]] = hal.interface.constant.load[3]
+//       CHECK:   %[[INPUT_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[TILED_OUTD0:.+]] = affine.apply #[[MAP0]]()[%[[OUTD0]]]
+//   CHECK-DAG:   %[[TILED_OUTD1:.+]] = affine.apply #[[MAP1]]()[%[[OUTD1]]]
+//       CHECK:   %[[OUTPUT_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//  CHECK-SAME:       !flow.dispatch.tensor<writeonly:tensor<?x?x8x4xf32>>{%[[TILED_OUTD0]], %[[TILED_OUTD1]]}
+//       CHECK:   %[[INPUT:.+]] = flow.dispatch.tensor.load %[[INPUT_BINDING]]
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%[[TILED_OUTD0]], %[[TILED_OUTD1]])
+//       CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack %[[INPUT]] padding_value(%[[CST]] : f32)
+//  CHECK-SAME:       inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[EMPTY]]
+//       CHECK:   flow.dispatch.tensor.store %[[PACK]], %[[OUTPUT_BINDING]]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_OUTD0]], %[[TILED_OUTD1]], 8, 4], strides = [1, 1, 1, 1]
+
+// -----
+
+func.func @unset_encoding_op() {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant 0.000000e+00 : f32
+  %d0 = hal.interface.constant.load [0] : index
+  %d1 = hal.interface.constant.load [1] : index
+  %outd0 = hal.interface.constant.load [2] : index
+  %outd1 = hal.interface.constant.load [3] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%d0, %d1}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%outd0, %outd1}
+  %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%d0, %d1], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%d0, %d1}
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  %3 = iree_linalg_ext.unset_encoding %2
+      : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>> -> tensor<?x?xf32>
+  %4 = tensor.extract_slice %3[0, 0] [%outd0, %outd1] [1, 1] : tensor<?x?xf32> to tensor<?x?xf32>
+  flow.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [%outd0, %outd1], strides = [1, 1]
+      : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%outd0, %outd1}
+  return
+}
+//   CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//   CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//       CHECK: func @unset_encoding_op()
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[D0:.+]] = hal.interface.constant.load[0]
+//   CHECK-DAG:   %[[D1:.+]] = hal.interface.constant.load[1]
+//   CHECK-DAG:   %[[OUTD0:.+]] = hal.interface.constant.load[2]
+//   CHECK-DAG:   %[[OUTD1:.+]] = hal.interface.constant.load[3]
+//   CHECK-DAG:   %[[TILED_D0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
+//   CHECK-DAG:   %[[TILED_D1:.+]] = affine.apply #[[MAP1]]()[%[[D1]]]
+//   CHECK-DAG:   %[[INPUT_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//  CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x8x4xf32>>{%[[TILED_D0]], %[[TILED_D1]]}
+//   CHECK-DAG:   %[[OUTPUT_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//       CHECK:   %[[INPUT:.+]] = flow.dispatch.tensor.load %[[INPUT_BINDING]]
+//  CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_D0]], %[[TILED_D1]], 8, 4], strides = [1, 1, 1, 1]
+//       CHECK:   %[[EMPTY:.+]] = tensor.empty(%[[OUTD0]], %[[OUTD1]])
+//       CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[INPUT]]
+//  CHECK-SAME:       inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[EMPTY]]
+//   CHECK-DAG:   flow.dispatch.tensor.store %[[UNPACK]], %[[OUTPUT_BINDING]]
+
+// -----
+
+func.func @gemm_lowering() {
+  %c0 = arith.constant 0 : index
+  %M = hal.interface.constant.load[0] : index
+  %N = hal.interface.constant.load[1] : index
+  %K = hal.interface.constant.load[2] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%M, %K}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>>{%K, %N}
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readwrite:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>>{%M, %N}
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>>{%M, %K}
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>>{%K, %N}
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>
+  %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+      : !flow.dispatch.tensor<readwrite:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>>{%M, %N}
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  %6 = linalg.matmul
+      ins(%3, %4 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_LHS>>,
+                   tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RHS_TRANSPOSE>>)
+      outs(%5 : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>)
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+  flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+      : tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>
+      -> !flow.dispatch.tensor<readwrite:tensor<?x?xf32, #iree_linalg_ext.encoding<GEMM_RESULT>>>{%M, %N}
+  return
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//      CHECK: func @gemm_lowering()
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0]
+//  CHECK-DAG:   %[[N:.+]] = hal.interface.constant.load[1]
+//  CHECK-DAG:   %[[K:.+]] = hal.interface.constant.load[2]
+//  CHECK-DAG:   %[[TILED_M:.+]] = affine.apply #[[MAP0]]()[%[[M]]]
+//  CHECK-DAG:   %[[TILED_K:.+]] = affine.apply #[[MAP1]]()[%[[K]]]
+//      CHECK:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
+// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x8x4xf32>>{%[[TILED_M]], %[[TILED_K]]}
+//      CHECK:   %[[TILED_N:.+]] = affine.apply #[[MAP0]]()[%[[N]]]
+//      CHECK:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
+// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x8x4xf32>>{%[[TILED_N]], %[[TILED_K]]}
+//      CHECK:   %[[OUTS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(2)
+// CHECK-SAME:       !flow.dispatch.tensor<readwrite:tensor<?x?x8x8xf32>>{%[[TILED_M]], %[[TILED_N]]}
+//      CHECK:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_K]], 8, 4], strides = [1, 1, 1, 1]
+//      CHECK:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_N]], %[[TILED_K]], 8, 4], strides = [1, 1, 1, 1]
+//      CHECK:   %[[OUTS:.+]] = flow.dispatch.tensor.load %[[OUTS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 8, 8], strides = [1, 1, 1, 1]
+//      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   flow.dispatch.tensor.store %[[MMT4D]], %[[OUTS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_M]], %[[TILED_N]], 8, 8], strides = [1, 1, 1, 1]

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -368,17 +368,19 @@ hal.executable private @preset_config_matmul_tensors {
 //  CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //      CHECK:   hal.return %[[C32]], %[[C4]], %[[C1]]
 //      CHECK: func.func @preset_config()
+//  CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
+//  CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
-//  CHECK-DAG:       %[[LHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [%[[IV0]], 0], sizes = [32, 256]
-//  CHECK-DAG:       %[[RHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [0, %[[IV1]]], sizes = [256, 16]
+//  CHECK-DAG:       %[[LHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [%[[IV0]], 0], sizes = [%[[C32]], 256]
+//  CHECK-DAG:       %[[RHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [0, %[[IV1]]], sizes = [256, %[[C16]]]
 //  CHECK-DAG:       %[[INIT:.+]] = tensor.empty
 //  CHECK-DAG:       %[[FILL:.+]] = linalg.fill
 // CHECK-SAME:           outs(%[[INIT]] :
 //  CHECK-DAG:       %[[GEMM:.+]] = linalg.matmul
 // CHECK-SAME:           outs(%[[FILL]] :
 //      CHECK:       flow.dispatch.tensor.store %[[GEMM]]
-// CHECK-SAME:           offsets = [%[[IV0]], %[[IV1]]], sizes = [32, 16]
+// CHECK-SAME:           offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[C32]], %[[C16]]]
 
 // -----
 
@@ -1726,3 +1728,92 @@ hal.executable private @no_tile {
 // CHECK-LABEL: func @no_tile()
 //   CHECK-NOT: scf.for
 //       CHECK: iree_linalg_ext.topk
+
+// -----
+
+hal.executable private @pack_lowering {
+  hal.executable.variant public @embedded_elf_x86_64, target = <"llvm-cpu", "embedded-elf-x86_64", {}> {
+    hal.executable.export public @gemm_lhs_pack ordinal(0) 
+        layout(#hal.pipeline.layout<push_constants = 0,
+            sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>)
+        attributes {translation_info = #iree_codegen.translation_info<CPUDataTiling>} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_set_encoding_op %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @gemm_lhs_pack() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64)
+            : !flow.dispatch.tensor<readonly:tensor<100x250xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64)
+            : !flow.dispatch.tensor<writeonly:tensor<14x64x8x4xf32>>
+        %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [100, 250], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<100x250xf32>> -> tensor<100x250xf32>
+        %3 = tensor.empty() : tensor<14x64x8x4xf32>
+        %4 = iree_linalg_ext.pack {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>} %2
+            padding_value(%cst : f32) inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %3
+            : (tensor<100x250xf32> tensor<14x64x8x4xf32>) -> tensor<14x64x8x4xf32>
+        flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [14, 64, 8, 4], strides = [1, 1, 1, 1]
+            : tensor<14x64x8x4xf32> -> !flow.dispatch.tensor<writeonly:tensor<14x64x8x4xf32>>
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> ((s0 ceildiv 8) ceildiv 64)
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> ((s0 ceildiv 4) ceildiv 64)
+//      CHECK: hal.executable.export public @gemm_lhs_pack
+// CHECK-NEXT:   %[[ARG0:.+]]: !hal.device
+// CHECK-SAME:   %[[ARG1:.+]]: index,
+// CHECK-SAME:   %[[ARG2:.+]]: index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[W0:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[W1:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]]]
+//      CHECK:   hal.return %[[W1]], %[[W0]], %[[C1]]
+
+// -----
+
+hal.executable private @pack_lowering {
+  hal.executable.variant public @embedded_elf_x86_64, target = <"llvm-cpu", "embedded-elf-x86_64", {}> {
+    hal.executable.export public @gemm_rhs_transpose_pack ordinal(0) 
+        layout(#hal.pipeline.layout<push_constants = 0,
+            sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>)
+        attributes {translation_info = #iree_codegen.translation_info<CPUDataTiling>} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_set_encoding_op %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @gemm_rhs_transpose_pack() {
+        %c0 = arith.constant 0 : index
+        %c114688 = arith.constant 114688 : index
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64)
+            : !flow.dispatch.tensor<readonly:tensor<250x500xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c114688) alignment(64)
+            : !flow.dispatch.tensor<writeonly:tensor<64x64x8x4xf32>>
+        %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [250, 500], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<250x500xf32>> -> tensor<250x500xf32>
+        %3 = tensor.empty() : tensor<64x64x8x4xf32>
+        %4 = iree_linalg_ext.pack {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>} %2
+            padding_value(%cst : f32) outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4] into %3
+            : (tensor<250x500xf32> tensor<64x64x8x4xf32>) -> tensor<64x64x8x4xf32>
+        flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [64, 64, 8, 4], strides = [1, 1, 1, 1]
+            : tensor<64x64x8x4xf32> -> !flow.dispatch.tensor<writeonly:tensor<64x64x8x4xf32>>
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> ((s0 ceildiv 8) ceildiv 64)
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> ((s0 ceildiv 4) ceildiv 64)
+//      CHECK: hal.executable.export public @gemm_rhs_transpose_pack
+// CHECK-NEXT:   %[[ARG0:.+]]: !hal.device
+// CHECK-SAME:   %[[ARG1:.+]]: index,
+// CHECK-SAME:   %[[ARG2:.+]]: index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[W0:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
+//  CHECK-DAG:   %[[W1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
+//      CHECK:   hal.return %[[W1]], %[[W0]], %[[C1]]

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -368,19 +368,17 @@ hal.executable private @preset_config_matmul_tensors {
 //  CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
 //      CHECK:   hal.return %[[C32]], %[[C4]], %[[C1]]
 //      CHECK: func.func @preset_config()
-//  CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
-//  CHECK-DAG:   %[[C16:.+]] = arith.constant 16 : index
 //      CHECK:   scf.for %[[IV0:.+]] =
 //      CHECK:     scf.for %[[IV1:.+]] =
-//  CHECK-DAG:       %[[LHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [%[[IV0]], 0], sizes = [%[[C32]], 256]
-//  CHECK-DAG:       %[[RHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [0, %[[IV1]]], sizes = [256, %[[C16]]]
+//  CHECK-DAG:       %[[LHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [%[[IV0]], 0], sizes = [32, 256]
+//  CHECK-DAG:       %[[RHS:.+]] = flow.dispatch.tensor.load %{{.+}}, offsets = [0, %[[IV1]]], sizes = [256, 16]
 //  CHECK-DAG:       %[[INIT:.+]] = tensor.empty
 //  CHECK-DAG:       %[[FILL:.+]] = linalg.fill
 // CHECK-SAME:           outs(%[[INIT]] :
 //  CHECK-DAG:       %[[GEMM:.+]] = linalg.matmul
 // CHECK-SAME:           outs(%[[FILL]] :
 //      CHECK:       flow.dispatch.tensor.store %[[GEMM]]
-// CHECK-SAME:           offsets = [%[[IV0]], %[[IV1]]], sizes = [%[[C32]], %[[C16]]]
+// CHECK-SAME:           offsets = [%[[IV0]], %[[IV1]]], sizes = [32, 16]
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -703,6 +703,8 @@ void buildLLVMCPUCodegenPassPipeline(OpPassManager &passManager) {
       createVerifyLinalgTransformLegalityPass());
   passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
       createTypePropagationPass());
+  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
+      createIREEMaterializeEncodingPass());
   passManager.addNestedPass<ModuleOp>(createBufferizeCopyOnlyDispatchesPass());
 
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -183,6 +183,11 @@ createFuseTensorPadWithConsumerPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConcretizePadResultShapePass();
 
+/// Materialize the encoding of operations. The layout to use for the encoded
+/// operations are backend specific.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createIREEMaterializeEncodingPass();
+
 //----------------------------------------------------------------------------//
 // Common codegen patterns.
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -89,13 +89,20 @@ def IREEComprehensiveBufferize :
   ];
 }
 
+def IREEMaterializeEncoding :
+    Pass<"iree-codegen-materialize-encoding", "func::FuncOp"> {
+  let summary = "Materialize the encoding for tensor as specified by the backend";
+  let constructor = "mlir::iree_compiler::createIREEMaterializeEncodingPass()";
+}
+
 def OptimizeVectorTransfer :
     Pass<"iree-codegen-optimize-vector-transfer", "func::FuncOp"> {
   let summary =
       "Run optimization transformations on vector transfer operations";
   let constructor = "mlir::iree_compiler::createOptimizeVectorTransferPass()";
   let options = [
-    Option<"optionFlatten", "flatten", "bool", "false", "Flatten the vector type of vector transfers where possible (contiguous row-major data).">
+    Option<"optionFlatten", "flatten", "bool", "false",
+           "Flatten the vector type of vector transfers where possible (contiguous row-major data).">
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.td
@@ -468,8 +468,17 @@ def FLOW_DispatchTensorLoadOp : FLOW_PureOp<"dispatch.tensor.load", [
       return getResult().getType().cast<RankedTensorType>();
     }
 
+    /// Return the type of the source as `IREE::Flow::DispatchTensorType`.
+    IREE::Flow::DispatchTensorType getSourceType() {
+      return getSource().getType().cast<IREE::Flow::DispatchTensorType>();
+    }
+
     ValueRange getOperandDynamicDims(unsigned idx) { return getSourceDims(); }
     ValueRange getResultDynamicDims(unsigned idx) { return getSizes(); }
+
+    /// Returns true if the load is loading the whole source. This is
+    /// best effort since this can miss some dynamic cases.
+    bool isLoadOfWholeSource();
   }];
 
   let hasVerifier = 1;
@@ -547,6 +556,11 @@ def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [
     /// Return the type of the value type as a RankedTensorType.
     RankedTensorType getValueType() { return getValue().getType().cast<RankedTensorType>(); }
 
+    /// Return the type of the target.
+    IREE::Flow::DispatchTensorType getTargetType() {
+      return getTarget().getType().cast<IREE::Flow::DispatchTensorType>();
+    }
+
     /// Return the number of leading operands before the `offsets`, `sizes` and
     /// and `strides` operands.
     static unsigned getOffsetSizeAndStrideStartOperandIndex() { return 3; }
@@ -569,6 +583,9 @@ def FLOW_DispatchTensorStoreOp : FLOW_Op<"dispatch.tensor.store", [
     /// !flow.dispatch.tensor.load is rank-reducing.
     llvm::SmallBitVector getDroppedDims();
 
+    /// Checks if the store covers the entire target. Note that
+    /// this is best effort, especially in cases where the the shapes are dynamic.
+    bool isStoreToWholeTarget();
   }];
 
   let hasVerifier = 1;


### PR DESCRIPTION
Under the data tiling approach, at the `Flow` level an `iree_linalg_ext.encoding` attribute is added to tensors to capture the need for a data layout transformation. During executable translation this encoding + information about backend can be used to decide how the encoding is to be materialized (using `pack` and `unpack` operations). This PR adds a pass to materialize the encoding for the CPU backends. It uses patterns from a similar pass in `IREE::LinalgExt::LinalgExtDialect`, in addition to adding legalizations for `hal.interface.binding`,
`flow.dispatch.tensor.load/store` and type conversion for `!flow.dispatch.tensor` type. To facilitate this

- A new class called `MaterializeEncodingTypeConverter`, that derives from `TypeConverter`, is added that is meant to be used with patterns that implement the materialization.
- A new class called `MaterializeConversionTarget`, that derives from `ConversionTarget`, is added that is meant to be used with the Dialect Conversion framework to drive the materialization.
- Both the above classes rely on a callback being implemented by the users of these class that given the encoding return the `MaterializeEncodingInfo` object that has everything needed to materialize the `pack`/`unpack` operations.
- This patch also adds the lowering for the `flow.dispatch.workgroup_count_from_set_encoding_op` needed to compute the number of workgroups correctly, based on the workload that was captured at the `Flow` level.

With these changes a `linalg.matmul` can be compiled with IREE using the `--iree-flow-enable-data-tiling` flag.