### PR TITLE
Adding `IREE::HAL::ExecutableTargetAttr::lookup` helper.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -622,6 +622,12 @@ def HAL_ExecutableTargetAttr :
     // Returns a hal.match.* expression tree that specifically matches a
     // device that can load an executable of this target.
     Attribute getMatchExpression();
+
+    // Returns the executable target configuration for the given operation.
+    // This will recursively walk parent operations until one with the
+    // `hal.executable.target` attribute is found or a `hal.executable.variant`
+    // specifies a value. Returns nullptr if no target specification can be found.
+    static ExecutableTargetAttr lookup(Operation *op);
   }];
 
   let hasCustomAssemblyFormat = 1;


### PR DESCRIPTION
This allows unit tests to specify an executable target on a local function scope without requiring a full variant in order to get config.

Example:
```mlir
#some_target = #hal.executable.target<
  "llvm-cpu", "embedded-elf-x86_64", {
    data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
    native_vector_size = 16 : index,
    target_triple = "x86_64-unknown-unknown-eabi-elf"
  }
>
func.func @set_encoding_op() attributes {
  hal.executable.target = #some_target
} {
  // IR that during transformation may want to lookup the target
  return
}
```