### PR TITLE
Separate bench_mode into bench_mode and compile_tags

### DIFF
--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -193,11 +193,14 @@ def main(args: argparse.Namespace):
             f"Module path isn't a module cmake target: {module_path}")
       compilation_time_ms = target_build_time_map[cmake_target]
 
-      compilation_info = CompilationInfo(model_name=benchmark_case.model_name,
-                                         model_tags=benchmark_case.model_tags,
-                                         model_source=category,
-                                         target_arch=benchmark_case.target_arch,
-                                         bench_mode=benchmark_case.bench_mode)
+      compilation_info = CompilationInfo(
+          model_name=benchmark_case.model_name,
+          model_tags=benchmark_case.model_tags,
+          model_source=category,
+          target_arch=benchmark_case.target_arch,
+          # TODO(#11071): compile_tags should be retrived from benchmark_case.compile_tags
+          # during the migration.
+          compile_tags=benchmark_case.bench_mode)
       compilation_statistics = CompilationStatistics(
           compilation_info=compilation_info,
           module_component_sizes=module_component_sizes,

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -193,14 +193,16 @@ def main(args: argparse.Namespace):
             f"Module path isn't a module cmake target: {module_path}")
       compilation_time_ms = target_build_time_map[cmake_target]
 
-      compilation_info = CompilationInfo(
-          model_name=benchmark_case.model_name,
-          model_tags=benchmark_case.model_tags,
-          model_source=category,
-          target_arch=benchmark_case.target_arch,
-          # TODO(#11071): compile_tags should be retrived from benchmark_case.compile_tags
-          # during the migration.
-          compile_tags=benchmark_case.bench_mode)
+      if benchmark_case.run_config is not None:
+        compile_tags = benchmark_case.run_config.module_generation_config.compile_config.tags
+      else:
+        # TODO(#11071): Remove legacy path.
+        compile_tags = benchmark_case.bench_mode
+      compilation_info = CompilationInfo(model_name=benchmark_case.model_name,
+                                         model_tags=benchmark_case.model_tags,
+                                         model_source=category,
+                                         target_arch=benchmark_case.target_arch,
+                                         compile_tags=compile_tags)
       compilation_statistics = CompilationStatistics(
           compilation_info=compilation_info,
           module_component_sizes=module_component_sizes,

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -306,9 +306,9 @@ class BenchmarkInfo:
   model_tags: Sequence[str]
   model_source: str
   bench_mode: Sequence[str]
-  compile_tags: Optional[Sequence[str]]
   driver_info: DriverInfo
   device_info: DeviceInfo
+  compile_tags: Optional[Sequence[str]] = None
 
   def __str__(self):
     # Get the target architecture and better driver name depending on the runner.
@@ -328,6 +328,7 @@ class BenchmarkInfo:
     else:
       model_part = f"{self.model_name} ({self.model_source})"
     device_part = f"{self.device_info.model} ({target_arch})"
+
     if self.compile_tags is not None:
       mode_tags = f'[{",".join(self.compile_tags)}][{",".join(self.bench_mode)}]'
     else:
@@ -350,6 +351,7 @@ class BenchmarkInfo:
     ) = name.split()
     model_source = model_source.strip("()")
     model_tags = model_tags.strip("[]").split(",")
+
     if mode_tags.startswith("[") and mode_tags.endswith("]"):
       bench_mode, compile_tags = mode_tags.strip("[]").split("][")
       bench_mode = mode_tags.split(",")


### PR DESCRIPTION
This is a part of migrating benchmarks to the new e2e test framework.

In the e2e test framework, we have a clear separation between compile configs and run configs. Each of them has its own tags to describe the config. Previously we only have a single list `bench_mode` to represent the configs of each benchmark.

The `bench_mode` is part of the current primary key to identify each benchmark. Eventually we will deprecate this way and use artificial ids instead, but it won't happen soon. Right now we need to embed the tags in the primary key from both the compile configs and run configs, during the migration stage.

This change extends the `<bench_mode>` section in the benchmark key `MobileNetV2 ... <bench_mode> with IREE-LLVM-CPU ...` into `MobileNetV2 ... [<compile_tags>][<run_tags>] with IREE-LLVM-CPU ...`, so we can parse the old and new benchmark keys in the same way.

Before fully migrating to the new benchmark pipeline, we'll backfill all records in the dashboard with the new format of benchmark key.

Besides the benchmark key, the key of compilation statistics is also renamed `bench_mode` to `compile_tags`. This is only used between tools and doesn't require a backfill.