### PR TITLE
Decomposed linalg's quantized depthwise conv zero-point computations

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
@@ -25,7 +25,8 @@ namespace iree_compiler {
 
 namespace {
 
-Value makeLinalgInit(ImplicitLocOpBuilder &rewriter, Value value) {
+// Creates an empty copy matching the provided value.
+Value emptyCopy(ImplicitLocOpBuilder &rewriter, Value value) {
   RankedTensorType ty = value.getType().cast<RankedTensorType>();
   Type eTy = ty.getElementType();
 
@@ -39,26 +40,40 @@ Value makeLinalgInit(ImplicitLocOpBuilder &rewriter, Value value) {
   return rewriter.create<tensor::EmptyOp>(ty.getShape(), eTy, dynSizes);
 }
 
-Value applyZeroPoint(ImplicitLocOpBuilder &rewriter, Value conv, Value sum,
+// Creates an zero initialized tensor of given shape and type.
+Value emptyZero(ImplicitLocOpBuilder &builder, RankedTensorType ty,
+                llvm::SmallVector<Value> dyn) {
+  Value empty =
+      builder.create<tensor::EmptyOp>(ty.getShape(), ty.getElementType(), dyn);
+
+  Attribute attr = builder.getZeroAttr(ty.getElementType());
+  Value cnst = builder.create<arith::ConstantOp>(attr);
+  return builder.create<linalg::FillOp>(ValueRange{cnst}, ValueRange{empty})
+      .result();
+}
+
+// Apply the multiply subtract corresponding with a zero-point adjustment
+// broadcasting according to the afifne map.
+Value applyZeroPoint(ImplicitLocOpBuilder &builder, Value conv, Value sum,
                      Value zp, ArrayRef<int> affine_map) {
-  auto context = rewriter.getContext();
+  auto context = builder.getContext();
   auto convTy = conv.getType().cast<RankedTensorType>();
 
   llvm::SmallVector<AffineExpr> sumExprs;
   for (auto i : affine_map) {
-    sumExprs.push_back(rewriter.getAffineDimExpr(i));
+    sumExprs.push_back(builder.getAffineDimExpr(i));
   }
 
   SmallVector<utils::IteratorType> iterators(convTy.getRank(),
                                              utils::IteratorType::parallel);
 
-  auto convMap = rewriter.getMultiDimIdentityMap(convTy.getRank());
+  auto convMap = builder.getMultiDimIdentityMap(convTy.getRank());
   auto sumMap = AffineMap::get(convTy.getRank(), 0, sumExprs, context);
 
   SmallVector<AffineMap> affineMaps{convMap, sumMap, convMap};
 
-  Value init = makeLinalgInit(rewriter, conv);
-  return rewriter
+  Value init = emptyCopy(builder, conv);
+  return builder
       .create<linalg::GenericOp>(
           init.getType(), ValueRange{conv, sum}, ValueRange{init}, affineMaps,
           iterators,
@@ -68,6 +83,46 @@ Value applyZeroPoint(ImplicitLocOpBuilder &rewriter, Value conv, Value sum,
             b.create<linalg::YieldOp>(loc, sum);
           })
       .getResult(0);
+}
+
+// Add the scalar value to the tensor.
+Value addScalar(ImplicitLocOpBuilder &builder, Value value, Value scalar) {
+  auto ty = value.getType().cast<RankedTensorType>();
+  SmallVector<utils::IteratorType> iterators(ty.getRank(),
+                                             utils::IteratorType::parallel);
+  auto map = builder.getMultiDimIdentityMap(ty.getRank());
+  Value init = emptyCopy(builder, value);
+  return builder
+      .create<linalg::GenericOp>(
+          init.getType(), ValueRange{value}, ValueRange{init},
+          ArrayRef<AffineMap>{map, map}, iterators,
+          [=](OpBuilder &b, Location loc, ValueRange args) {
+            Value add = b.create<arith::AddIOp>(loc, args[0], scalar);
+            b.create<linalg::YieldOp>(loc, add);
+          })
+      .getResult(0);
+}
+
+void GetDynamicDym(ImplicitLocOpBuilder &builder,
+                   llvm::SmallVector<int64_t> &dims,
+                   llvm::SmallVector<Value> &dynDims, Value value,
+                   int64_t dim) {
+  ShapedType ty = value.getType().cast<ShapedType>();
+  dims.push_back(ty.getDimSize(dim));
+  if (ty && ty.isDynamicDim(dim))
+    dynDims.push_back(builder.create<tensor::DimOp>(value, dim));
+}
+
+Value multiplyDims(ImplicitLocOpBuilder &builder, Value value,
+                   llvm::ArrayRef<int64_t> dims) {
+  Value count = builder.create<tensor::DimOp>(value, dims.front());
+
+  for (auto d : dims.drop_front()) {
+    Value dim = builder.create<tensor::DimOp>(value, d);
+    count = builder.create<arith::MulIOp>(count, dim);
+  }
+
+  return count;
 }
 
 // Pattern lowering conv_2d_nhwc_hwcf_q to conv_2d_nhwc_hwcf.
@@ -86,15 +141,13 @@ struct QuantizedConvToConv
     auto iZp = op.getInputs()[2];
     auto fZp = op.getInputs()[3];
     auto inputTy = input.getType().cast<RankedTensorType>();
-    auto filterTy = filter.getType().cast<RankedTensorType>();
     auto resultTy = op.getType(0).cast<ShapedType>();
     auto accETy = resultTy.getElementType();
 
     auto strides = op.getStrides();
     auto dilations = op.getDilations();
 
-    IntegerAttr iZpConst;
-    IntegerAttr fZpConst;
+    IntegerAttr iZpConst, fZpConst;
     bool iZpIsZero = matchPattern(iZp, m_Constant(&iZpConst)) &&
                      iZpConst.getValue().isZero();
     bool fZpIsZero = matchPattern(fZp, m_Constant(&fZpConst)) &&
@@ -106,7 +159,6 @@ struct QuantizedConvToConv
                             resultTy, ValueRange{input, filter},
                             op.getOutputs(), strides, dilations)
                         .getResult(0);
-    RankedTensorType newConvTy = newConv.getType().cast<RankedTensorType>();
 
     // If the zero pointer value is zero we can just replace.
     if (iZpIsZero && fZpIsZero) {
@@ -144,48 +196,27 @@ struct QuantizedConvToConv
       inputSum = builder.create<tensor::ExpandShapeOp>(expandTy, inputSum,
                                                        reassociationMap);
 
-      // Perform a sum-pooling operation across the kernel width and height.
-      auto poolTy = RankedTensorType::get(
-          {expandTy.getDimSize(0), newConvTy.getDimSize(1),
-           newConvTy.getDimSize(2), expandTy.getDimSize(3)},
-          accETy);
-
+      llvm::SmallVector<int64_t> poolDims;
       llvm::SmallVector<Value> poolDynDims;
-      if (expandTy.isDynamicDim(0))
-        poolDynDims.push_back(builder.create<tensor::DimOp>(inputSum, 0));
+      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 0);
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 1);
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 2);
+      GetDynamicDym(builder, poolDims, poolDynDims, inputSum, 3);
 
-      if (newConvTy.isDynamicDim(1))
-        poolDynDims.push_back(builder.create<tensor::DimOp>(newConv, 1));
+      // Perform a sum-pooling operation across the kernel width and height.
+      auto poolTy = RankedTensorType::get(poolDims, accETy);
+      Value poolTensor = emptyZero(builder, poolTy, poolDynDims);
 
-      if (newConvTy.isDynamicDim(2))
-        poolDynDims.push_back(builder.create<tensor::DimOp>(newConv, 2));
+      // Create the empty kernel defining the shape for the pooling operation.
+      llvm::SmallVector<int64_t> kDims;
+      llvm::SmallVector<Value> kDyn;
+      GetDynamicDym(builder, kDims, kDyn, filter, 0);
+      GetDynamicDym(builder, kDims, kDyn, filter, 1);
+      Value poolInit = builder.create<tensor::EmptyOp>(kDims, accETy, kDyn);
 
-      if (expandTy.isDynamicDim(3))
-        poolDynDims.push_back(builder.create<tensor::DimOp>(inputSum, 3));
-
-      Value poolTensor = builder.create<tensor::EmptyOp>(poolTy.getShape(),
-                                                         accETy, poolDynDims);
-
-      Attribute initialAttr = builder.getZeroAttr(accETy);
-      Value initialValue = builder.create<arith::ConstantOp>(initialAttr);
-      poolTensor = builder
-                       .create<linalg::FillOp>(ValueRange{initialValue},
-                                               ValueRange{poolTensor})
-                       .result();
-
-      llvm::SmallVector<int64_t> kernel{filterTy.getDimSize(0),
-                                        filterTy.getDimSize(1)};
-      llvm::SmallVector<Value> kernelDynDims;
-      for (int i = 0; i < 2; i++) {
-        if (filterTy.isDynamicDim(i))
-          kernelDynDims.push_back(builder.create<tensor::DimOp>(filter, i));
-      }
-
-      Value poolDims =
-          builder.create<tensor::EmptyOp>(kernel, accETy, kernelDynDims);
       inputSum = builder
                      .create<linalg::PoolingNhwcSumOp>(
-                         ArrayRef<Type>{poolTy}, ValueRange{inputSum, poolDims},
+                         ArrayRef<Type>{poolTy}, ValueRange{inputSum, poolInit},
                          poolTensor, strides, dilations)
                      .getResult(0);
 
@@ -201,34 +232,108 @@ struct QuantizedConvToConv
 
     // Apply the final update that occurs when there are multiple zero-points.
     if (!iZpIsZero && !fZpIsZero) {
-      Value dim0 = builder.create<tensor::DimOp>(filter, 0);
-      Value dim1 = builder.create<tensor::DimOp>(filter, 1);
-      Value dim2 = builder.create<tensor::DimOp>(filter, 2);
-      Value mul_dim0_dim1 = builder.create<arith::MulIOp>(dim0, dim1);
-      Value mul_dim0_dim1_dim2 =
-          builder.create<arith::MulIOp>(mul_dim0_dim1, dim2);
-      Value cast =
-          builder.create<arith::IndexCastOp>(accETy, mul_dim0_dim1_dim2);
+      Value count = multiplyDims(builder, filter, {0, 1, 2});
+      Value cast = builder.create<arith::IndexCastOp>(accETy, count);
+      Value ifZp = builder.create<arith::MulIOp>(iZp, fZp);
+      Value zpUpdate = builder.create<arith::MulIOp>(ifZp, cast);
 
-      auto convTy = newConv.getType().cast<RankedTensorType>();
-      SmallVector<utils::IteratorType> iterators(convTy.getRank(),
-                                                 utils::IteratorType::parallel);
-      auto convMap = rewriter.getMultiDimIdentityMap(convTy.getRank());
-      SmallVector<AffineMap> affineMaps{convMap, convMap};
+      newConv = addScalar(builder, newConv, zpUpdate);
+    }
 
-      Value init = makeLinalgInit(builder, newConv);
-      newConv = builder
-                    .create<linalg::GenericOp>(
-                        init.getType(), ValueRange{newConv}, ValueRange{init},
-                        affineMaps, iterators,
-                        [=](OpBuilder &b, Location loc, ValueRange args) {
-                          Value mul1 = b.create<arith::MulIOp>(loc, iZp, fZp);
-                          Value mul2 = b.create<arith::MulIOp>(loc, mul1, cast);
-                          Value sum =
-                              b.create<arith::AddIOp>(loc, args[0], mul2);
-                          b.create<linalg::YieldOp>(loc, sum);
-                        })
-                    .getResult(0);
+    rewriter.replaceOp(op, newConv);
+    return success();
+  }
+};
+
+// Pattern lowering depthwise_conv_2d_nhwc_hwc_q to depthwise_conv_2d_nhwc_hwc.
+//
+// This is implementing the math explained in Section 2.3 of
+// https://arxiv.org/abs/1712.05877.
+struct QuantizedDepthwiseConvToDepthwiseConv
+    : public OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcQOp> {
+  using OpRewritePattern<linalg::DepthwiseConv2DNhwcHwcQOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::DepthwiseConv2DNhwcHwcQOp op,
+                                PatternRewriter &rewriter) const override {
+    ImplicitLocOpBuilder builder(op.getLoc(), rewriter);
+    auto input = op.getInputs()[0];
+    auto filter = op.getInputs()[1];
+    auto iZp = op.getInputs()[2];
+    auto fZp = op.getInputs()[3];
+    auto resultTy = op.getType(0).cast<ShapedType>();
+    auto accETy = resultTy.getElementType();
+
+    auto strides = op.getStrides();
+    auto dilations = op.getDilations();
+
+    IntegerAttr iZpConst, fZpConst;
+    bool iZpIsZero = matchPattern(iZp, m_Constant(&iZpConst)) &&
+                     iZpConst.getValue().isZero();
+    bool fZpIsZero = matchPattern(fZp, m_Constant(&fZpConst)) &&
+                     fZpConst.getValue().isZero();
+
+    // First implement the convolution without the zero point.
+    Value newConv = builder
+                        .create<linalg::DepthwiseConv2DNhwcHwcOp>(
+                            resultTy, ValueRange{input, filter},
+                            op.getOutputs(), strides, dilations)
+                        .getResult(0);
+
+    // If the zero pointer value is zero we can just replace.
+    if (iZpIsZero && fZpIsZero) {
+      rewriter.replaceOp(op, newConv);
+      return success();
+    }
+
+    // Compute the summation and correction for the filter zero point:
+    //  sum(c) = filter(a, b, c)
+    //  conv(a, b, c, d) -= iZp * sum(d)
+    if (!iZpIsZero) {
+      Value filterSum =
+          sumReduceDimensionSubset(builder, filter, accETy,
+                                   /*reduce_dim=*/{true, true, false});
+      newConv = applyZeroPoint(builder, newConv, filterSum, iZp, {3});
+    }
+
+    if (!fZpIsZero) {
+      llvm::SmallVector<int64_t> poolDims;
+      llvm::SmallVector<Value> poolDynDims;
+      GetDynamicDym(builder, poolDims, poolDynDims, input, 0);
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 1);
+      GetDynamicDym(builder, poolDims, poolDynDims, newConv, 2);
+      GetDynamicDym(builder, poolDims, poolDynDims, input, 3);
+
+      // Perform a sum-pooling operation across the kernel width and height.
+      auto poolTy = RankedTensorType::get(poolDims, accETy);
+      Value poolTensor = emptyZero(builder, poolTy, poolDynDims);
+
+      // Create the empty kernel defining the shape for the pooling operation.
+      llvm::SmallVector<int64_t> kDims;
+      llvm::SmallVector<Value> kDyn;
+      GetDynamicDym(builder, kDims, kDyn, filter, 0);
+      GetDynamicDym(builder, kDims, kDyn, filter, 1);
+      Value poolInit = builder.create<tensor::EmptyOp>(kDims, accETy, kDyn);
+
+      Value inputSum =
+          builder
+              .create<linalg::PoolingNhwcSumOp>(ArrayRef<Type>{poolTy},
+                                                ValueRange{input, poolInit},
+                                                poolTensor, strides, dilations)
+              .getResult(0);
+
+      // Apply the zero-point update based on the input sum.
+      newConv = applyZeroPoint(builder, newConv, inputSum, fZp, {0, 1, 2, 3});
+    }
+
+    // Apply the final update that occurs when there are multiple zero-points.
+    if (!iZpIsZero && !fZpIsZero) {
+      Value count = multiplyDims(builder, filter, {0, 1});
+      Value cast = builder.create<arith::IndexCastOp>(accETy, count);
+
+      Value ifZp = builder.create<arith::MulIOp>(iZp, fZp);
+      Value zpUpdate = builder.create<arith::MulIOp>(ifZp, cast);
+
+      newConv = addScalar(builder, newConv, zpUpdate);
     }
 
     rewriter.replaceOp(op, newConv);
@@ -243,7 +348,8 @@ struct LinalgQuantizedConvToConvPass
     Operation *op = getOperation();
     MLIRContext *context = op->getContext();
     RewritePatternSet patterns(context);
-    patterns.add<QuantizedConvToConv>(context);
+    patterns.add<QuantizedConvToConv, QuantizedDepthwiseConvToDepthwiseConv>(
+        context);
     memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
     if (failed(applyPatternsAndFoldGreedily(op, std::move(patterns)))) {
       signalPassFailure();

--- a/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
+++ b/compiler/src/iree/compiler/InputConversion/Common/test/linalg_quantized_conv_to_conv.mlir
@@ -321,15 +321,15 @@ func.func @conv2d_all_dyn(%arg0: tensor<?x?x?x?xi8>, %arg1: tensor<?x?x?x?xi8>, 
   // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
 
   // CHECK: %[[DIM0:.+]] = tensor.dim %arg1, %[[I0]]
-  // CHECK: %[[DIM1:.+]] = tensor.dim %arg1, %[[I1]]
-  // CHECK: %[[DIM2:.+]] = tensor.dim %arg1, %[[I2]]
-  // CHECK: %[[MUL_DIM0_DIM1:.+]] = arith.muli %[[DIM0]], %[[DIM1]]
-  // CHECK: %[[MUL_DIM0_DIM1_DIM2:.+]] = arith.muli %[[MUL_DIM0_DIM1]], %[[DIM2]]
-  // CHECK: %[[CAST:.+]] = arith.index_cast %[[MUL_DIM0_DIM1_DIM2]] : index to i32
-  // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
-  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
-  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
-  // CHECK: %[[DIM3:.+]] = tensor.dim %arg1, %[[I3]]
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg1, %[[I1]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg1, %[[I2]]
+  // CHECK-DAG: %[[MUL1:.+]] = arith.muli %[[DIM0]], %[[DIM1]]
+  // CHECK-DAG: %[[MUL2:.+]] = arith.muli %[[MUL1]], %[[DIM2]]
+  // CHECK-DAG: %[[CAST:.+]] = arith.index_cast %[[MUL2]] : index to i32
+  // CHECK-DAG: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK-DAG: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK-DAG: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK-DAG: %[[DIM3:.+]] = tensor.dim %arg1, %[[I3]]
   // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]) : tensor<?x?x?x?xi32>
   // CHECK: %[[RESULT:.+]] = linalg.generic
   // CHECK-SAME: indexing_maps = [#map2, #map2]
@@ -340,4 +340,240 @@ func.func @conv2d_all_dyn(%arg0: tensor<?x?x?x?xi8>, %arg1: tensor<?x?x?x?xi8>, 
 
   // CHECK: return %[[RESULT]]
   return %0 : tensor<?x?x?x?xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dconv2d
+func.func @dconv2d(%arg0 : tensor<1x64x64x16xi8>, %arg1 : tensor<4x4x16xi8>, %arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32> {
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 0 : i32
+
+  // CHECK: %[[RET:.+]] = linalg.depthwise_conv_2d_nhwc_hwc {
+  // CHECK-SAME:    dilations = dense<1> : tensor<2xi64>,
+  // CHECK-SAME:    strides = dense<1> : tensor<2xi64>}
+  // CHECK-SAME:    ins(%arg0, %arg1 : tensor<1x64x64x16xi8>, tensor<4x4x16xi8>)
+  // CHECK-SAME:    outs(%arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32>
+  %result = linalg.depthwise_conv_2d_nhwc_hwc_q {
+      dilations = dense<1> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    }
+    ins(%arg0, %arg1, %iZp, %fZp : tensor<1x64x64x16xi8>, tensor<4x4x16xi8>, i32, i32)
+    outs(%arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32>
+  // CHECK: %[[RET]]
+  return %result : tensor<1x61x61x16xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dconv2d_izp
+func.func @dconv2d_izp(%arg0 : tensor<1x64x64x16xi8>, %arg1 : tensor<4x4x16xi8>, %arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32> {
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i32
+  %iZp = arith.constant 2 : i32
+  %fZp = arith.constant 0 : i32
+
+  // CHECK: %[[CONV:.+]] = linalg.depthwise_conv_2d_nhwc_hwc
+
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<16xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<16xi32>)
+  // CHECK: %[[SUM:.+]] = linalg.generic
+  // CHECK-SAME:      indexing_maps = [#map, #map1]
+  // CHECK-SAME:      iterator_types = ["parallel", "reduction", "reduction"]
+  // CHECK-SAME:      ins(%arg1 : tensor<4x4x16xi8>)
+  // CHECK-SAME:      outs(%[[FILL]] : tensor<16xi32>) {
+  // CHECK:   ^bb0(%[[IN:.+]]: i8, %[[OUT:.+]]: i32):
+  // CHECK:    %[[EXT:.+]] = arith.extsi %[[IN]] : i8 to i32
+  // CHECK:    %[[ADD:.+]] = arith.addi %6, %[[OUT]]
+  // CHECK:    linalg.yield %[[ADD]]
+
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1x61x61x16xi32>
+  // CHECK: %[[UPDATE:.+]] = linalg.generic 
+  // CHECK-SAME: indexing_maps = [#map2, #map3, #map2]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME: ins(%[[CONV]], %[[SUM]] : tensor<1x61x61x16xi32>, tensor<16xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<1x61x61x16xi32>)
+  // CHECK: ^bb0(%[[IN0:.+]]: i32, %[[IN1:.+]]: i32, %[[OUT:.+]]: i32):
+  // CHECK:   %[[MUL:.+]] = arith.muli %[[IN1]], %[[C2]] : i32
+  // CHECK:   %[[SUB:.+]] = arith.subi %[[IN0]], %[[MUL]] : i32
+  // CHECK:   linalg.yield %[[SUB]] : i32
+
+  %result = linalg.depthwise_conv_2d_nhwc_hwc_q {
+      dilations = dense<1> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    }
+    ins(%arg0, %arg1, %iZp, %fZp : tensor<1x64x64x16xi8>, tensor<4x4x16xi8>, i32, i32)
+    outs(%arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32>
+  // CHECK: return %[[UPDATE]]
+  return %result : tensor<1x61x61x16xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @dconv2d_fzp
+func.func @dconv2d_fzp(%arg0 : tensor<1x64x64x16xi8>, %arg1 : tensor<4x4x16xi8>, %arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32> {
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C2:.+]] = arith.constant 2 : i32
+  %iZp = arith.constant 0 : i32
+  %fZp = arith.constant 2 : i32
+
+  // CHECK: %[[CONV:.+]] = linalg.depthwise_conv_2d_nhwc_hwc
+
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1x61x61x16xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<1x61x61x16xi32>)
+  // CHECK: %[[WINDOW:.+]] = tensor.empty() : tensor<4x4xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nhwc_sum 
+  // CHECK-SAME:      dilations = dense<1> : tensor<2xi64>
+  // CHECK-SAME:      strides = dense<1> : tensor<2xi64>
+  // CHECK-SAME:      ins(%arg0, %[[WINDOW]] : tensor<1x64x64x16xi8>, tensor<4x4xi32>)
+  // CHECK-SAME:      outs(%[[FILL]] : tensor<1x61x61x16xi32>)
+
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1x61x61x16xi32>
+  // CHECK:  %[[UPDATE:.+]] = linalg.generic 
+  // CHECK-SAME:      indexing_maps = [#map, #map, #map]
+  // CHECK-SAME:      iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME:      ins(%[[CONV]], %[[POOL]] : tensor<1x61x61x16xi32>, tensor<1x61x61x16xi32>)
+  // CHECK-SAME:      outs(%[[EMPTY]] : tensor<1x61x61x16xi32>)
+  // CHECK:  ^bb0(%[[IN0:.+]]: i32, %[[IN1:.+]]: i32, %[[OUT:.+]]: i32):
+  // CHECK:    %[[MUL:.+]] = arith.muli %[[IN1]], %[[C2]] : i32
+  // CHECK:    %[[SUB:.+]] = arith.subi %[[IN0]], %[[MUL]] : i32
+  // CHECK:    linalg.yield %[[SUB]]
+  %result = linalg.depthwise_conv_2d_nhwc_hwc_q {
+      dilations = dense<1> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    }
+    ins(%arg0, %arg1, %iZp, %fZp : tensor<1x64x64x16xi8>, tensor<4x4x16xi8>, i32, i32)
+    outs(%arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32>
+
+  // CHECK: return %[[UPDATE]]
+  return %result : tensor<1x61x61x16xi32>
+}
+
+// -----
+
+// CHECK-LABEL: func.func @dconv2d_ifzp
+func.func @dconv2d_ifzp(%arg0 : tensor<1x64x64x16xi8>, %arg1 : tensor<4x4x16xi8>, %arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32> {
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C1232:.+]] = arith.constant 1232 : i32
+  // CHECK-DAG: %[[C7:.+]] = arith.constant 7 : i32
+  // CHECK-DAG: %[[C11:.+]] = arith.constant 11 : i32
+  %iZp = arith.constant 7 : i32
+  %fZp = arith.constant 11 : i32
+
+  // CHECK: %[[DCONV:.+]] = linalg.depthwise_conv_2d_nhwc_hwc
+
+  // CHECK: %[[SUMF:.+]] = linalg.generic
+  // CHECK-SAME: ins(%arg1 : tensor<4x4x16xi8>)
+  // CHECK: %[[FIX_IZP:.+]] = linalg.generic 
+  // CHECK-SAME: ins(%[[DCONV]], %[[SUMF]] : tensor<1x61x61x16xi32>, tensor<16xi32>)
+
+  // CHECK: %[[WINDOW:.+]] = tensor.empty() : tensor<4x4xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nhwc_sum
+  // CHECK-SAME: ins(%arg0, %[[WINDOW]] : tensor<1x64x64x16xi8>, tensor<4x4xi32>)
+  // CHECK: %[[FIX_FZP:.+]] = linalg.generic
+  // CHECK:  ins(%[[FIX_IZP]], %[[POOL]] : tensor<1x61x61x16xi32>, tensor<1x61x61x16xi32>)
+
+  // CHECK: %[[EMPTY:.+]] = tensor.empty() : tensor<1x61x61x16xi32>
+  // CHECK: %[[RET:.+]] = linalg.generic 
+  // CHECK-SAME: indexing_maps = [#map2, #map2]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+  // CHECK-SAME: ins(%[[FIX_FZP]] : tensor<1x61x61x16xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<1x61x61x16xi32>)
+  // CHECK: ^bb0(%[[IN:.+]]: i32, %[[OUT:.+]]: i32):
+  // CHECK:   %[[ADD:.+]] = arith.addi %[[IN]], %[[C1232]] : i32
+  // CHECK:   linalg.yield %[[ADD]]
+  %result = linalg.depthwise_conv_2d_nhwc_hwc_q {
+      dilations = dense<1> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    }
+    ins(%arg0, %arg1, %iZp, %fZp : tensor<1x64x64x16xi8>, tensor<4x4x16xi8>, i32, i32)
+    outs(%arg2 : tensor<1x61x61x16xi32>) -> tensor<1x61x61x16xi32>
+
+  // CHECK: return %[[RET]]
+  return %result : tensor<1x61x61x16xi32>
+}
+
+// -----
+
+// CHECK-LABEL: @dconv2d_dyn
+func.func @dconv2d_dyn(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?xi8>, %arg2 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32> {
+  // CHECK-DAG: %[[I0:.+]] = arith.constant 0 : index
+  // CHECK-DAG: %[[I1:.+]] = arith.constant 1 : index
+  // CHECK-DAG: %[[I2:.+]] = arith.constant 2 : index
+  // CHECK-DAG: %[[I3:.+]] = arith.constant 3 : index
+  // CHECK-DAG: %[[C0:.+]] = arith.constant 0 : i32
+  // CHECK-DAG: %[[C7:.+]] = arith.constant 7 : i32
+  // CHECK-DAG: %[[C11:.+]] = arith.constant 11 : i32
+  // CHECK-DAG: %[[C77:.+]] = arith.constant 77 : i32
+
+  %iZp = arith.constant 7 : i32
+  %fZp = arith.constant 11 : i32
+
+  // CHECK: %[[DCONV:.+]] = linalg.depthwise_conv_2d_nhwc_hwc
+
+  // CHECK: %[[DIM:.+]] = tensor.dim %arg1, %[[I2]] : tensor<?x?x?xi8>
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM]]) : tensor<?xi32>
+  // CHECK: %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<?xi32>) -> tensor<?xi32>
+  // CHECK: %[[SUMF:.+]] = linalg.generic
+  // CHECK-SAME: ins(%arg1 : tensor<?x?x?xi8>)
+  // CHECK-SAME: outs(%[[FILL]] : tensor<?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK: %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK: %[[DIM3:.+]] = tensor.dim %arg0, %[[I3]]
+  // CHECK: %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]) : tensor<?x?x?x?xi32>
+  // CHECK: %[[FIX_IZP:.+]] = linalg.generic 
+  // CHECK-SAME: ins(%[[DCONV]], %[[SUMF]] : tensor<?x?x?x?xi32>, tensor<?xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+
+  // CHECK:  %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK:  %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK:  %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK:  %[[DIM3:.+]] = tensor.dim %arg0, %[[I3]]
+  // CHECK:  %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]) : tensor<?x?x?x?xi32>
+  // CHECK:  %[[FILL:.+]] = linalg.fill ins(%[[C0]] : i32) outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg1, %[[I0]] : tensor<?x?x?xi8>
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg1, %[[I1]] : tensor<?x?x?xi8>
+  // CHECK: %[[WINDOW:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]]) : tensor<?x?xi32>
+  // CHECK: %[[POOL:.+]] = linalg.pooling_nhwc_sum
+  // CHECK-SAME: ins(%arg0, %[[WINDOW]] : tensor<?x?x?x?xi8>, tensor<?x?xi32>)
+  // CHECK-SAME: outs(%[[FILL]] : tensor<?x?x?x?xi32>)
+
+  // CHECK:  %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK:  %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK:  %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK:  %[[DIM3:.+]] = tensor.dim %arg0, %[[I3]]
+  // CHECK:  %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]) : tensor<?x?x?x?xi32>
+  // CHECK: %[[FIX_FZP:.+]] = linalg.generic
+  // CHECK-SAME: ins(%[[FIX_IZP]], %[[POOL]] : tensor<?x?x?x?xi32>, tensor<?x?x?x?xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+
+  // CHECK: %[[DIM0:.+]] = tensor.dim %arg1, %[[I0]]
+  // CHECK: %[[DIM1:.+]] = tensor.dim %arg1, %[[I1]]
+  // CHECK: %[[MUL:.+]] = arith.muli %[[DIM0]], %[[DIM1]] : index
+  // CHECK: %[[CAST:.+]] = arith.index_cast %[[MUL]] : index to i32
+  // CHECK: %[[IFZP:.+]] = arith.muli %[[CAST]], %[[C77]]
+
+  // CHECK:  %[[DIM0:.+]] = tensor.dim %arg0, %[[I0]]
+  // CHECK:  %[[DIM1:.+]] = tensor.dim %arg2, %[[I1]]
+  // CHECK:  %[[DIM2:.+]] = tensor.dim %arg2, %[[I2]]
+  // CHECK:  %[[DIM3:.+]] = tensor.dim %arg0, %[[I3]]
+  // CHECK:  %[[EMPTY:.+]] = tensor.empty(%[[DIM0]], %[[DIM1]], %[[DIM2]], %[[DIM3]]) : tensor<?x?x?x?xi32>
+  // CHECK: %[[RET:.+]] = linalg.generic 
+  // CHECK-SAME: ins(%[[FIX_FZP]] : tensor<?x?x?x?xi32>)
+  // CHECK-SAME: outs(%[[EMPTY]] : tensor<?x?x?x?xi32>)
+  // CHECK:    ^bb0(%[[IN:.+]]: i32, %{{.+}}: i32):
+  // CHECK:    %[[ADD:.+]] = arith.addi %[[IN]], %[[IFZP]]
+  // CHECK:    linalg.yield %[[ADD]]
+  %result = linalg.depthwise_conv_2d_nhwc_hwc_q {
+      dilations = dense<1> : tensor<2xi64>,
+      strides = dense<1> : tensor<2xi64>
+    }
+    ins(%arg0, %arg1, %iZp, %fZp : tensor<?x?x?x?xi8>, tensor<?x?x?xi8>, i32, i32)
+    outs(%arg2 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+
+  // CHECK: return %[[RET]]
+  return %result : tensor<?x?x?x?xi32>
 }


### PR DESCRIPTION
Moving the zero-point adjustment outside of the depthwise convolution and into generics should reduce the overall computation time required by reducing the inner mul-add reduction.