### PR TITLE
Assorted fixes for tests on Windows.

### DIFF
--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -234,19 +234,25 @@ function(iree_local_py_test)
       ${_RULE_ARGS}
   )
 
+  set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
+  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_ARGS})
+
+  # Extend the PYTHONPATH environment variable with _RULE_PACKAGE_DIRS.
   list(APPEND _RULE_PACKAGE_DIRS "$ENV{PYTHONPATH}")
-  string(JOIN ":" _PYTHONPATH ${_RULE_PACKAGE_DIRS})
+  if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
+    # Windows uses semi-colon delimiters, but so does CMake, so escape them.
+    list(JOIN _RULE_PACKAGE_DIRS "\\;" _PYTHONPATH)
+  else()
+    list(JOIN _RULE_PACKAGE_DIRS ":" _PYTHONPATH)
+  endif()
+  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT
+      "PYTHONPATH=${_PYTHONPATH}"
+  )
 
   if (NOT DEFINED _RULE_TIMEOUT)
     set(_RULE_TIMEOUT 60)
   endif()
 
-  set_property(TEST ${_NAME_PATH} PROPERTY LABELS "${_RULE_LABELS}")
-  set_property(TEST ${_NAME_PATH} PROPERTY TIMEOUT ${_RULE_ARGS})
-
-  set_property(TEST ${_NAME_PATH} PROPERTY ENVIRONMENT
-      "PYTHONPATH=${_PYTHONPATH}"
-  )
   iree_configure_test(${_NAME_PATH})
 
   # TODO(marbre): Find out how to add deps to tests.

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
@@ -173,7 +173,7 @@ static void pack_test(const iree_uk_pack_type_t& type) {
   for (const auto& shape : untransposed_out_shapes) {
     for (bool transpose_inner : {false, true}) {
       for (bool transpose_outer : {false, true}) {
-        iree_uk_pack_params_t params;
+        iree_uk_pack_params_t params = {};
         params.type = type;
         params.in_size0 = shape.size0 * shape.size2;
         params.in_size1 = shape.size1 * shape.size3;

--- a/samples/simple_embedding/BUILD
+++ b/samples/simple_embedding/BUILD
@@ -252,6 +252,9 @@ iree_bytecode_module(
 native_test(
     name = "simple_embedding_vulkan_test",
     src = ":simple_embedding_vulkan",
+    tags = [
+        "driver=vulkan",
+    ],
 )
 
 iree_cmake_extra_content(

--- a/samples/simple_embedding/CMakeLists.txt
+++ b/samples/simple_embedding/CMakeLists.txt
@@ -243,6 +243,8 @@ iree_native_test(
     "simple_embedding_vulkan_test"
   SRC
     ::simple_embedding_vulkan
+  LABELS
+    "driver=vulkan"
 )
 
 endif()


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/11009 (see some test runs of a `build_test_all_windows` CI job on https://github.com/iree-org/iree/pull/11050)

* Tag `simple_embedding_vulkan_test` as using Vulkan, so it can be filtered
* Initialize a struct in pack_test.cc
* Fix PYTHONPATH separator for iree_local_py_test on Windows (while keeping CMake happy)