### PR TITLE
[spirv] Enable multi-buffering for simt matmuls

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -234,6 +234,7 @@ iree_compiler_cc_library(
         "DecomposeLinalgGeneric.cpp",
         "FoldAffineMinInDistributedLoops.cpp",
         "GPUDistributeSharedMemoryCopy.cpp",
+        "GPUMultiBuffering.cpp",
         "GPUPatterns.cpp",
         "GPUPipelining.cpp",
         "GPUReduceBankConflicts.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -203,6 +203,7 @@ iree_cc_library(
     "DecomposeLinalgGeneric.cpp"
     "FoldAffineMinInDistributedLoops.cpp"
     "GPUDistributeSharedMemoryCopy.cpp"
+    "GPUMultiBuffering.cpp"
     "GPUPatterns.cpp"
     "GPUPipelining.cpp"
     "GPUReduceBankConflicts.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/GPUMultiBuffering.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUMultiBuffering.cpp
@@ -15,9 +15,9 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
-struct LLVMGPUMultiBufferingPass
-    : public LLVMGPUMultiBufferingBase<LLVMGPUMultiBufferingPass> {
-  LLVMGPUMultiBufferingPass(unsigned numBuffers) : numBuffers(numBuffers) {}
+struct GPUMultiBufferingPass
+    : public GPUMultiBufferingBase<GPUMultiBufferingPass> {
+  GPUMultiBufferingPass(unsigned numBuffers) : numBuffers(numBuffers) {}
 
   void getDependentDialects(DialectRegistry& registry) const override {
     registry.insert<AffineDialect>();
@@ -50,9 +50,9 @@ struct LLVMGPUMultiBufferingPass
 };
 }  // namespace
 
-std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUMultiBuffering(
+std::unique_ptr<OperationPass<func::FuncOp>> createGPUMultiBuffering(
     unsigned numBuffers) {
-  return std::make_unique<LLVMGPUMultiBufferingPass>(numBuffers);
+  return std::make_unique<GPUMultiBufferingPass>(numBuffers);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -21,7 +21,6 @@ iree_compiler_cc_library(
         "KernelConfig.cpp",
         "LLVMGPUDistribute.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
-        "LLVMGPUMultiBuffering.cpp",
         "LLVMGPUTensorAlloc.cpp",
         "LLVMGPUTensorCoreVectorization.cpp",
         "LLVMGPUTensorPad.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -25,7 +25,6 @@ iree_cc_library(
     "KernelConfig.cpp"
     "LLVMGPUDistribute.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
-    "LLVMGPUMultiBuffering.cpp"
     "LLVMGPUTensorAlloc.cpp"
     "LLVMGPUTensorCoreVectorization.cpp"
     "LLVMGPUTensorPad.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -206,7 +206,7 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
       createRemoveSingleIterationLoopPass());
   if (pipelineDepth > 1)
     nestedModulePM.addNestedPass<func::FuncOp>(
-        createLLVMGPUMultiBuffering(pipelineDepth));
+        createGPUMultiBuffering(pipelineDepth));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -138,6 +138,10 @@ std::unique_ptr<OperationPass<func::FuncOp>> createMemrefCopyToLinalgPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGPUDistributeSharedMemoryCopy();
 
+/// Apply multi-buffering transformation.
+std::unique_ptr<OperationPass<func::FuncOp>> createGPUMultiBuffering(
+    unsigned numBuffers = 5);
+
 /// Apply software pipelining.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUPipeliningPass(
     bool epiloguePeeling = true, unsigned depth = 1);
@@ -428,10 +432,6 @@ createLLVMGPUTensorCoreVectorizationPass();
 /// Lower vector ops before convertion to LLVM.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorLoweringPass();
 
-/// Apply multi-buffering transformation.
-std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUMultiBuffering(
-    unsigned numBuffers = 5);
-
 /// Apply transformation to reduce the number of bank conflicts when accessing
 /// shared memory by padding fastest moving dimension with the specified size.
 std::unique_ptr<OperationPass<func::FuncOp>>
@@ -473,7 +473,8 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
     Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize);
-void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm);
+void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
+                                                unsigned pipelineDepth);
 
 /// Pass pipeline to lower IREE HAL executables by tiling and distributing
 /// reduction to workgroups and then subgroups.

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -164,6 +164,12 @@ def GPUReduceBankConflicts :
   let constructor = "mlir::iree_compiler::createGPUReduceSharedMemoryBankConflicts()";
 }
 
+def GPUMultiBuffering :
+    Pass<"iree-gpu-multi-buffering", "func::FuncOp"> {
+  let summary = "Pass to do multi buffering.";
+  let constructor = "mlir::iree_compiler::createGPUMultiBuffering()";
+}
+
 def GPUPipelining : Pass<"iree-gpu-pipelining", "func::FuncOp"> {
   let summary = "Pass to do software pipelining.";
   let constructor = "mlir::iree_compiler::createGPUPipeliningPass()";
@@ -407,12 +413,6 @@ def LLVMGPUVectorLowering :
     Pass<"iree-llvmgpu-vector-lowering", "func::FuncOp"> {
   let summary = "Pass to lower Vector ops before conversion to LLVM.";
   let constructor = "mlir::iree_compiler::createLLVMGPUVectorLoweringPass()";
-}
-
-def LLVMGPUMultiBuffering :
-    Pass<"iree-llvmgpu-multi-buffering", "func::FuncOp"> {
-  let summary = "Pass to do multi buffering.";
-  let constructor = "mlir::iree_compiler::createLLVMGPUMultiBuffering()";
 }
 
 def LLVMGPUVectorToGPU :

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -25,6 +25,8 @@ namespace mlir {
 namespace iree_compiler {
 namespace detail {
 
+constexpr unsigned AMDSoftwarePipelineDepth = 2;
+
 static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
                                         spirv::ResourceLimitsAttr limits) {
   const int subgroupSize = limits.getSubgroupSize();
@@ -37,7 +39,7 @@ static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
     threadMNK = {8, 4, 16};
   }
   return setMatmulOpConfig(limits, op, workgroupXY, threadMNK,
-                           /*enablePromotion=*/true);
+                           /*enablePromotion=*/true, AMDSoftwarePipelineDepth);
 }
 
 // RDNA architecture:

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -360,15 +360,17 @@ static bool tileMatmulK(const int64_t dimK, const int64_t residualTilingFactor,
   return false;
 }
 
-/// Computes the total number of bytes if promoting both matmul LHS and RHS with
-/// the tiven tile sizes.
-static int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize,
-                            int64_t kTileSize, int64_t elementBits) {
+int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize, int64_t kTileSize,
+                     int64_t elementBits) {
   const int64_t count =
       (mTileSize + nTileSize) *
       (kTileSize + detail::bankConflictReductionPaddingBits / elementBits);
   return (elementBits / 8) * count;
 }
+
+int64_t getMultiBufferMemoryUsage(int64_t singleBufferBytes, unsigned depth) {
+  return singleBufferBytes * (depth ? depth : 1);
+};
 
 /// Tries to adjust workgroup and tile sizes to enable vector load for both
 /// matmul LHS and RHS. Returns false only when it's not beneficial to promote.
@@ -430,19 +432,34 @@ static bool adjustToVectorLoad(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
 static bool adjustToPromote(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
                             int64_t &nTileSize, int64_t &kTileSize,
                             SmallVectorImpl<int64_t> &wgSize,
-                            const int subgroupSize, const int maxBytes,
-                            const int elementBits) {
+                            unsigned &pipelineDepth, const int subgroupSize,
+                            const int maxBytes, const int elementBits) {
   LLVM_DEBUG(llvm::dbgs() << "subgroup size = " << subgroupSize << "\n");
   const int vectorSize = kMaxVectorNumBits / elementBits;
   if (!adjustToVectorLoad(dimMNKSize, mTileSize, nTileSize, kTileSize, wgSize,
                           subgroupSize, vectorSize))
     return false;
 
-  auto usedBytes = getTileBytes(mTileSize, nTileSize, kTileSize, elementBits);
-  LLVM_DEBUG(llvm::dbgs() << "initial tile bytes = " << usedBytes << "\n");
-  if (usedBytes <= maxBytes) return true;
+  // Don't do multibuffering if the inner reduction loop is folded out.
+  if (dimMNKSize[2] == kTileSize) pipelineDepth = 1;
 
-  // Using too much workgorup memory. Try to reduce the tile size for X/Y once
+  auto usedBytes = getTileBytes(mTileSize, nTileSize, kTileSize, elementBits);
+
+  LLVM_DEBUG(llvm::dbgs() << "initial multibuffering bytes = "
+                          << getMultiBufferMemoryUsage(usedBytes, pipelineDepth)
+                          << "\n");
+
+  // First try to fit the given tile sizes with the largest pipelining depth
+  // possible.
+  do {
+    if (getMultiBufferMemoryUsage(usedBytes, pipelineDepth) <= maxBytes)
+      return true;
+  } while (pipelineDepth-- > 1);
+
+  // If we can't fit in workgroup memory, don't multibuffer.
+  pipelineDepth = 1;
+
+  // Using too much workgroup memory. Try to reduce the tile size for X/Y once
   // by a factor of two.
   int64_t &wgDimSize = wgSize[0] > wgSize[1] ? wgSize[0] : wgSize[1];
   int64_t &tileSize = wgSize[0] > wgSize[1] ? nTileSize : mTileSize;
@@ -463,7 +480,8 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
                                 linalg::LinalgOp op,
                                 std::array<int64_t, 2> bestWorkgroupSizeXY,
                                 std::array<int64_t, 3> bestThreadTileSizeMNK,
-                                bool enablePromotion) {
+                                bool enablePromotion,
+                                unsigned softwarePipelineDepth) {
   LLVM_DEBUG(llvm::dbgs() << "trying to deduce config as matmul...\n");
   OpOperand *lhs = op.getDpsInputOperand(0);
   OpOperand *rhs = op.getDpsInputOperand(1);
@@ -553,14 +571,18 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
   const int subgroupSize = limits.getSubgroupSize();
   const int maxBytes = limits.getMaxComputeSharedMemorySize();
 
-  auto pipeline =
+  // We want a 2-stage pipeline without multi-buffering if the depth is 0 to
+  // keep the default for compilation configs that don't specify a pipeline
+  // depth.
+  auto pipelineDepth = softwarePipelineDepth ? softwarePipelineDepth : 1;
+
+  // Try to adjust tiling sizes to fit in shared memory.
+  auto usePromotionPipeline =
       enablePromotion &&
-              adjustToPromote({dimM, dimN, dimK}, workgroupTileSizes[mIndex],
-                              workgroupTileSizes[nIndex],
-                              reductionTileSizes[kIndex], workgroupSize,
-                              subgroupSize, maxBytes, elementBits)
-          ? CodeGenPipeline::SPIRVMatmulPromoteVectorize
-          : CodeGenPipeline::SPIRVBaseVectorize;
+      adjustToPromote({dimM, dimN, dimK}, workgroupTileSizes[mIndex],
+                      workgroupTileSizes[nIndex], reductionTileSizes[kIndex],
+                      workgroupSize, pipelineDepth, subgroupSize, maxBytes,
+                      elementBits);
 
   SmallVector<int64_t> threadTileSizes(numLoops, 0);
   if (isBM) {
@@ -576,9 +598,17 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
   tileSizes.push_back(threadTileSizes);
   tileSizes.push_back(reductionTileSizes);
 
+  // Only the promotion pipeline has multibuffering + pipelining.
+  if (usePromotionPipeline) {
+    return setOpConfigAndEntryPointFnTranslation(
+        op->getParentOfType<func::FuncOp>(), op, tileSizes,
+        CodeGenPipeline::SPIRVMatmulPromoteVectorize, workgroupSize,
+        pipelineDepth);
+  }
+
   return setOpConfigAndEntryPointFnTranslation(
-      op->getParentOfType<func::FuncOp>(), op, tileSizes, pipeline,
-      workgroupSize);
+      op->getParentOfType<func::FuncOp>(), op, tileSizes,
+      CodeGenPipeline::SPIRVBaseVectorize, workgroupSize);
 }
 
 }  // namespace detail

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
@@ -24,6 +24,17 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// By default don't do any pipelining.
+constexpr unsigned defaultSoftwarePipelineDepth = 1;
+
+/// Computes the total number of bytes if promoting both matmul LHS and RHS with
+/// the tiven tile sizes.
+int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize, int64_t kTileSize,
+                     int64_t elementBits);
+
+/// Adjusts the shared memory usage based on the pipelining depth.
+int64_t getMultiBufferMemoryUsage(int64_t singleBufferBytes, unsigned depth);
+
 namespace detail {
 
 const int bankConflictReductionPaddingBits = 128;
@@ -37,11 +48,11 @@ LogicalResult setConvOpConfig(linalg::LinalgOp linalgOp,
 
 /// Sets CodeGen configurations via attributes to the given matmul `linalgOp`
 /// with the given best workgroup size and tile size hints.
-LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
-                                linalg::LinalgOp linalgOp,
-                                std::array<int64_t, 2> bestWorkgroupSizeXY,
-                                std::array<int64_t, 3> bestThreadTileSizeMNK,
-                                bool enablePromotion = false);
+LogicalResult setMatmulOpConfig(
+    spirv::ResourceLimitsAttr limits, linalg::LinalgOp linalgOp,
+    std::array<int64_t, 2> bestWorkgroupSizeXY,
+    std::array<int64_t, 3> bestThreadTileSizeMNK, bool enablePromotion = false,
+    unsigned softwarePipelineDepth = defaultSoftwarePipelineDepth);
 
 /// Sets CodeGen configuration for GPUs from a specific vendor.
 ///

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/BUILD
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "distribute_to_invocations.mlir",
             "emulate_i64.mlir",
             "illegal_configuration.mlir",
+            "lowering_matmul_promotion.mlir",
             "pipeline_matmul_cooperative_ops.mlir",
             "pipeline_matmul_promotion.mlir",
             "pipeline_matmul_vectorization.mlir",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     "distribute_to_invocations.mlir"
     "emulate_i64.mlir"
     "illegal_configuration.mlir"
+    "lowering_matmul_promotion.mlir"
     "pipeline_matmul_cooperative_ops.mlir"
     "pipeline_matmul_promotion.mlir"
     "pipeline_matmul_vectorization.mlir"

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
@@ -34,7 +34,7 @@ hal.executable @batch_matmul_f32_16x4096x40x4096 {
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 512, 8], [1, 8, 4], [0, 0, 0, 16]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @batch_matmul_f32_16x4096x40x4096
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [2 : index, 64 : index, 1 : index]
@@ -51,7 +51,7 @@ hal.executable @batch_matmul_f32_16x4096x40x4096 {
     #hal.descriptor_set.binding<2, storage_buffer>
   ]>
 ]>
-hal.executable @matmul_f16_64x1280x320 {
+hal.executable @matmul_f16_64x640x320 {
   hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb", {
       spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader, Float16], []>, AMD:DiscreteGPU, #spirv.resource_limits<
         max_compute_shared_memory_size = 65536,
@@ -59,32 +59,32 @@ hal.executable @matmul_f16_64x1280x320 {
         max_compute_workgroup_size = [1024, 1024, 1024],
         subgroup_size = 64>>
     }> {
-    hal.executable.export @matmul_f16_64x1280x320 layout(#pipeline_layout)
+    hal.executable.export @matmul_f16_64x640x320 layout(#pipeline_layout)
     builtin.module {
-      func.func @matmul_f16_64x1280x320() {
+      func.func @matmul_f16_64x640x320() {
         %c0 = arith.constant 0 : index
         %cst = arith.constant 0.000000e+00 : f16
         %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<64x320xf16>>
-        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<320x1280xf16>>
-        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<64x1280xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<320x640xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<64x640xf16>>
         %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 320], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x320xf16>> -> tensor<64x320xf16>
-        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [320, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<320x1280xf16>> -> tensor<320x1280xf16>
-        %5 = tensor.empty() : tensor<64x1280xf16>
-        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
-        %7 = linalg.matmul ins(%3, %4 : tensor<64x320xf16>, tensor<320x1280xf16>) outs(%6 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
-        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 1280], strides = [1, 1] : tensor<64x1280xf16> -> !flow.dispatch.tensor<writeonly:tensor<64x1280xf16>>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [320, 640], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<320x640xf16>> -> tensor<320x640xf16>
+        %5 = tensor.empty() : tensor<64x640xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x640xf16>) -> tensor<64x640xf16>
+        %7 = linalg.matmul ins(%3, %4 : tensor<64x320xf16>, tensor<320x640xf16>) outs(%6 : tensor<64x640xf16>) -> tensor<64x640xf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 640], strides = [1, 1] : tensor<64x640xf16> -> !flow.dispatch.tensor<writeonly:tensor<64x640xf16>>
         return
       }
     }
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 256], [8, 8], [0, 0, 32]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
-//      CHECK: hal.executable.export public @matmul_f16_64x1280x320
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128], [4, 8], [0, 0, 32]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2>
+//      CHECK: hal.executable.export public @matmul_f16_64x640x320
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
-// CHECK-SAME:   workgroup_size = [32 : index, 8 : index, 1 : index]
-//      CHECK: func.func @matmul_f16_64x1280x320()
+// CHECK-SAME:   workgroup_size = [16 : index, 16 : index, 1 : index]
+//      CHECK: func.func @matmul_f16_64x640x320()
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
 
@@ -126,7 +126,7 @@ hal.executable @batch_matmul_f32_16x4096x40x4096 {
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256, 16], [1, 8, 4], [0, 0, 0, 32]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @batch_matmul_f32_16x4096x40x4096
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [4 : index, 32 : index, 1 : index]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul.mlir
@@ -39,7 +39,7 @@ hal.executable @matmul_1x4096x9216 {
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 256], [1, 4], [0, 0, 32]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 //      CHECK: hal.executable.export public @matmul_1x4096x9216
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [64 : index, 1 : index, 1 : index]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -353,6 +353,6 @@ hal.executable public @matmul_256x1024x8 {
   }
 }
 
-//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
+//   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
 // CHECK-LABEL: hal.executable.export public @matmul_256x1024x8
 //  CHECK-SAME:   translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
@@ -114,6 +114,49 @@ hal.executable private @matmul_tensors {
 
 // -----
 
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 256], [8, 8], [0, 0, 32]]>
+#translation = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @matmul_tensors {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.4, [Shader, Float16], []>, Unknown:IntegratedGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 32768,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 1024],
+        subgroup_size = 64>>
+    }> {
+    hal.executable.export @illegal layout(#pipeline_layout) attributes {
+      translation_info = #translation,
+      workgroup_size = [32 : index, 8 : index, 1 : index]
+    }
+    builtin.module {
+      func.func @illegal() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<64x320xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<320x1280xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<64x1280xf16>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [64, 320], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x320xf16>> -> tensor<64x320xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [320, 1280], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<320x1280xf16>> -> tensor<320x1280xf16>
+        %5 = tensor.empty() : tensor<64x1280xf16>
+        %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
+        // expected-error @+1 {{expected shared memory usage <= 32768, got 51200}}
+        %7 = linalg.matmul {lowering_config = #config} ins(%3, %4 : tensor<64x320xf16>, tensor<320x1280xf16>) outs(%6 : tensor<64x1280xf16>) -> tensor<64x1280xf16>
+        flow.dispatch.tensor.store %7, %2, offsets = [0, 0], sizes = [64, 1280], strides = [1, 1] : tensor<64x1280xf16> -> !flow.dispatch.tensor<writeonly:tensor<64x1280xf16>>
+        return
+      }
+    }
+  }
+}
+
+// -----
+
 #config = #iree_codegen.lowering_config<tile_sizes = [[32, 64], [4, 2], [0, 0, 4]]>
 #translation = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -1,0 +1,84 @@
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-spirv-lower-executable-target-pass)))' %s | FileCheck %s
+
+// Verify multibuffering + pipelining
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+hal.executable @matmul_f32_128x256x64 {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<#spirv.vce<v1.5, [Shader], []>, AMD:DiscreteGPU, #spirv.resource_limits<
+      max_compute_shared_memory_size = 49152,
+      max_compute_workgroup_invocations = 1024,
+      max_compute_workgroup_size = [65535, 65535, 65535],
+      subgroup_size = 32>>}> {
+    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_f32_128x256x64() {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<128x512xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<512x256xf32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<128x256xf32>>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<128x256xf32>>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+        %7 = tensor.empty() : tensor<128x256xf32>
+        %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
+        %9 = linalg.matmul ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
+        %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+                ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
+        ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+          %11 = arith.divf %arg0, %arg1 : f32
+          linalg.yield %11 : f32
+        } -> tensor<128x256xf32>
+        flow.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x256xf32>>
+        return
+      }
+    }
+  }
+}
+
+//       CHECK-DAG: #[[MAP:.+]] = affine_map<(d0) -> ((d0 floordiv 16) mod 2)>
+//       CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2>
+//           CHECK: hal.executable.export public @matmul_f32_128x256x64
+//      CHECK-SAME:   translation_info = #[[TRANSLATION]]
+//      CHECK-SAME:   workgroup_size = [16 : index, 8 : index, 1 : index]
+//           CHECK: func.func @matmul_f32_128x256x64()
+//           CHECK:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
+//           CHECK:   memref.alloc() : memref<2x64x20xf32, 3>
+//           CHECK:   memref.alloc() : memref<2x16x68xf32, 3>
+//           CHECK:   scf.for
+//           CHECK:     affine.apply #[[MAP]]
+//           CHECK:     gpu.barrier
+//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[20, 1], offset: ?>, 3>
+//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[68, 1], offset: ?>, 3>
+//           CHECK:     gpu.barrier
+//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<8x16xf32, strided<[20, 1], offset: ?>, 3>, vector<4xf32>
+//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<16x4xf32, strided<[68, 1], offset: ?>, 3>, vector<4xf32>
+// CHECK-COUNT-128:     vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
+//   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_global_load__, in_bounds = [true]} : memref<1x4xf32, strided<[512, 1], offset: ?>>, vector<4xf32>
+//   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_global_load__, in_bounds = [true]} : memref<1x4xf32, strided<[256, 1], offset: ?>>, vector<4xf32>
+//           CHECK:     scf.yield
+//           CHECK:   gpu.barrier
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[20, 1], offset: ?>, 3>
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[68, 1], offset: ?>, 3>
+//           CHECK:   gpu.barrier
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<8x16xf32, strided<[20, 1], offset: ?>, 3>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<16x4xf32, strided<[68, 1], offset: ?>, 3>, vector<4xf32>
+// CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
+//   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<8x4xf32, strided<[256, 1], offset: ?>>, vector<4xf32>
+//   CHECK-COUNT-8:   arith.divf %{{.+}}, %{{.+}} : vector<4xf32>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<8x4xf32, strided<[256, 1], offset: ?>>


### PR DESCRIPTION
1. Moves LLVMGPUMultiBuffering to Common
2. Enables specifying a pipeline depth in the SPIRV promotion matmul lowering pipeline

Depends on #11058 to guarantee shared memory promotion in the pipeline. The current defaults will prioritize shared memory promotion over pipeline depth, so if we can fit in shared memory by reducing the pipelining depth it will choose to do that over reducing the tiling sizes. Next step is to enable different pipelining schedules. Currently only enabled for AMD, picking good pipelining depths other platforms can come one at a time after more control over the pipeline scheduling is added (e.g. store in stage 0).