### PR TITLE
Forward vcvarsall env vars through lit.cfg.py.

### DIFF
--- a/compiler/lit.cfg.py
+++ b/compiler/lit.cfg.py
@@ -18,8 +18,18 @@ import lit.formats
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
 config.test_format = lit.formats.ShTest(execute_external=True)
-# Forward all IREE environment variables
-passthrough_env_vars = ["VK_ICD_FILENAMES"]
+
+# Forward all IREE environment variables, as well as some passthroughs.
+# Note: env vars are case-insensitive on Windows, so check matches carefully.
+#     https://stackoverflow.com/q/7797269
+passthrough_env_vars = [
+    # The Vulkan loader uses this
+    "VK_ICD_FILENAMES",
+    # WindowsLinkerTool uses these from vcvarsall
+    "VCTOOLSINSTALLDIR",
+    "UNIVERSALCRTSDKDIR",
+    "UCRTVERSION"
+]
 config.environment.update({
     k: v
     for k, v in os.environ.items()

--- a/tests/lit.cfg.py
+++ b/tests/lit.cfg.py
@@ -18,8 +18,18 @@ import lit.formats
 config.name = "IREE"
 config.suffixes = [".mlir", ".txt"]
 config.test_format = lit.formats.ShTest(execute_external=True)
-# Forward all IREE environment variables
-passthrough_env_vars = ["VK_ICD_FILENAMES"]
+
+# Forward all IREE environment variables, as well as some passthroughs.
+# Note: env vars are case-insensitive on Windows, so check matches carefully.
+#     https://stackoverflow.com/q/7797269
+passthrough_env_vars = [
+    # The Vulkan loader uses this
+    "VK_ICD_FILENAMES",
+    # WindowsLinkerTool uses these from vcvarsall
+    "VCTOOLSINSTALLDIR",
+    "UNIVERSALCRTSDKDIR",
+    "UCRTVERSION"
+]
 config.environment.update({
     k: v
     for k, v in os.environ.items()


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/11009

This fixes these two tests on Windows:
* `iree/compiler/Dialect/HAL/Target/LLVM/test/smoketest_system.mlir.test`
* `iree/tests/e2e/regression/libm_linking.mlir.test`

Developers should run vcvarsall before ctest, or configure their IDE as needed. For VSCode, I have this set:
```json
    "cmakeExplorer.extraCtestEnvVars": {
      "VCTOOLSINSTALLDIR": "C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\Preview\\VC\\Tools\\MSVC\\14.31.31103\\",
      "UNIVERSALCRTSDKDIR": "C:\\Program Files (x86)\\Windows Kits\\10\\",
      "UCRTVersion": "10.0.19041.0",
    },
```