### PR TITLE
Changing default bytecode dispatch away from computed goto.

### DIFF
--- a/runtime/src/iree/base/config.h
+++ b/runtime/src/iree/base/config.h
@@ -241,6 +241,13 @@ typedef IREE_DEVICE_SIZE_T iree_device_size_t;
 #define IREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE 0
 #endif  // !IREE_VM_EXECUTION_TRACING_SRC_LOC_ENABLE
 
+#if !defined(IREE_VM_BYTECODE_DISPATCH_COMPUTED_GOTO_ENABLE)
+// Enables the use of compute goto for bytecode dispatch. This can have a
+// moderate performance improvement (~10-20%) on very heavy VMVX workloads but
+// adds 20-30KB to the binary size.
+#define IREE_VM_BYTECODE_DISPATCH_COMPUTED_GOTO_ENABLE 0
+#endif  // IREE_VM_BYTECODE_DISPATCH_COMPUTED_GOTO_ENABLE
+
 #if !defined(IREE_VM_EXT_F32_ENABLE)
 // Enables the 32-bit floating-point instruction extension.
 // Targeted from the compiler with `-iree-vm-target-extension-f32`.

--- a/runtime/src/iree/vm/bytecode_dispatch_util.h
+++ b/runtime/src/iree/vm/bytecode_dispatch_util.h
@@ -140,11 +140,12 @@ static inline const iree_vm_type_def_t* iree_vm_map_type(
 #define IREE_DISPATCH_TRACE_INSTRUCTION(...)
 #endif  // IREE_VM_EXECUTION_TRACING_ENABLE
 
-#if defined(IREE_COMPILER_MSVC) && !defined(IREE_COMPILER_CLANG)
-#define IREE_DISPATCH_MODE_SWITCH 1
-#else
+#if defined(IREE_COMPILER_CLANG) && \
+    IREE_VM_BYTECODE_DISPATCH_COMPUTED_GOTO_ENABLE
 #define IREE_DISPATCH_MODE_COMPUTED_GOTO 1
-#endif  // MSVC
+#else
+#define IREE_DISPATCH_MODE_SWITCH 1
+#endif  // IREE_VM_BYTECODE_DISPATCH_COMPUTED_GOTO_ENABLE
 
 #ifndef NDEBUG
 #define VMCHECK(expr) assert(expr)


### PR DESCRIPTION
It's a fairly marginal benefit to very heavy scalar VMVX workloads (~10-20%) but adds 20-30KB to the binary size and most users care more about that. Leaving the code path around so we can turn it back on if needed as workloads change.

```
ben@noxa-pc:/mnt/d/Dev/iree$ ../iree-build-wsl/runtime/src/iree/vm/bytecode_module_benchmark_switch --benchmark_min_time=10
2022-11-08T15:25:08-08:00
Running ../iree-build-wsl/runtime/src/iree/vm/bytecode_module_benchmark_switch
Run on (64 X 3700 MHz CPU s)
Load Average: 0.52, 0.58, 0.59
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_ModuleCreate                              1665 ns         1664 ns      8452830
BM_ModuleCreateState                         67.7 ns         67.7 ns    206451613
BM_FullModuleInit                            1698 ns         1699 ns      8296296
BM_EmptyFuncReference                        1.19 ns         1.19 ns   1000000000
BM_EmptyFuncBytecode                         55.2 ns         55.2 ns    256000000
BM_CallInternalFuncReference                 1.53 ns         1.53 ns   1000000000
BM_CallInternalFuncBytecode                  43.0 ns         43.0 ns    324637700
BM_CallImportedFuncBytecode                  48.0 ns         48.0 ns    291856680
BM_LoopSumReference/100000                   2.18 ns         2.19 ns   1000000000
BM_LoopSumBytecode/100000                    5.27 ns         5.27 ns   1000000000
BM_BufferReduceReference/100000              2.09 ns         2.09 ns   1000000000
BM_BufferReduceBytecode/100000               14.2 ns         14.2 ns    984700000
BM_BufferReduceBytecodeUnrolled/100000       12.6 ns         12.6 ns   1000000000
```
```
ben@noxa-pc:/mnt/d/Dev/iree$ ../iree-build-wsl/runtime/src/iree/vm/bytecode_module_benchmark_goto --benchmark_min_time=10
2022-11-08T15:28:05-08:00
Running ../iree-build-wsl/runtime/src/iree/vm/bytecode_module_benchmark_goto
Run on (64 X 3700 MHz CPU s)
Load Average: 0.52, 0.58, 0.59
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_ModuleCreate                              1638 ns         1638 ns      8615385
BM_ModuleCreateState                         47.0 ns         47.0 ns    297674419
BM_FullModuleInit                            1677 ns         1677 ns      8373832
BM_EmptyFuncReference                        1.19 ns         1.19 ns   1000000000
BM_EmptyFuncBytecode                         54.0 ns         54.0 ns    258213256
BM_CallInternalFuncReference                 1.53 ns         1.53 ns   1000000000
BM_CallInternalFuncBytecode                  41.9 ns         41.9 ns    334328360
BM_CallImportedFuncBytecode                  48.0 ns         48.0 ns    294252880
BM_LoopSumReference/100000                   2.19 ns         2.19 ns   1000000000
BM_LoopSumBytecode/100000                    4.64 ns         4.64 ns   1000000000
BM_BufferReduceReference/100000              2.09 ns         2.09 ns   1000000000
BM_BufferReduceBytecode/100000               10.1 ns         10.1 ns   1000000000
BM_BufferReduceBytecodeUnrolled/100000       10.1 ns         10.1 ns   1000000000
```