### PR TITLE
Prevent inlining of ukernel elementwise ops into shims.

### DIFF
--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -428,6 +428,20 @@ static inline iree_uk_type_t iree_uk_unpack_type(int pos,
 #define IREE_UK_ASSUME_UNREACHABLE
 #endif
 
+// Queries for [[attribute]] identifiers in modern compilers.
+#ifdef __has_attribute
+#define IREE_UK_HAVE_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define IREE_UK_HAVE_ATTRIBUTE(x) 0
+#endif  // __has_attribute
+
+#if IREE_UK_HAVE_ATTRIBUTE(noinline) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define IREE_UK_ATTRIBUTE_NOINLINE __attribute__((noinline))
+#else
+#define IREE_UK_ATTRIBUTE_NOINLINE
+#endif  // IREE_UK_HAVE_ATTRIBUTE(noinline)
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/runtime/src/iree/builtins/ukernel/elementwise_impl.c.inc
+++ b/runtime/src/iree/builtins/ukernel/elementwise_impl.c.inc
@@ -110,15 +110,15 @@ static inline int iree_uk_count_leading_zeros_u32(const iree_uk_uint32_t n) {
 // the function iree_uk_generic_{category}_2d.
 // Corresponds to the header macro DECLARE_UKERNEL_BINARY_2D.
 #define DISPATCH_UKERNEL_BINARY_2D(opcode, opcode_t, dtype, category)         \
-  IREE_UK_EXPORT int iree_uk_##category##_##opcode##_2d(            \
-      const dtype* lhs, iree_uk_ssize_t lhs_offset,                       \
-      iree_uk_ssize_t lhs_stride0, iree_uk_ssize_t lhs_stride1,       \
-      const dtype* rhs, iree_uk_ssize_t rhs_offset,                       \
-      iree_uk_ssize_t rhs_stride0, iree_uk_ssize_t rhs_stride1,       \
-      dtype* IREE_UK_RESTRICT out, iree_uk_ssize_t out_offset,               \
-      iree_uk_ssize_t out_stride0, iree_uk_ssize_t out_stride1,       \
-      iree_uk_ssize_t size0, iree_uk_ssize_t size1) {                 \
-    return iree_uk_generic_##category##_2d(                              \
+  IREE_UK_EXPORT int iree_uk_##category##_##opcode##_2d(                      \
+      const dtype* lhs, iree_uk_ssize_t lhs_offset,                           \
+      iree_uk_ssize_t lhs_stride0, iree_uk_ssize_t lhs_stride1,               \
+      const dtype* rhs, iree_uk_ssize_t rhs_offset,                           \
+      iree_uk_ssize_t rhs_stride0, iree_uk_ssize_t rhs_stride1,               \
+      dtype* IREE_UK_RESTRICT out, iree_uk_ssize_t out_offset,                \
+      iree_uk_ssize_t out_stride0, iree_uk_ssize_t out_stride1,               \
+      iree_uk_ssize_t size0, iree_uk_ssize_t size1) {                         \
+    return iree_uk_generic_##category##_2d(                                   \
         opcode_t, lhs, lhs_offset, lhs_stride0, lhs_stride1, rhs, rhs_offset, \
         rhs_stride0, rhs_stride1, out, out_offset, out_stride0, out_stride1,  \
         size0, size1);                                                        \
@@ -127,16 +127,16 @@ static inline int iree_uk_count_leading_zeros_u32(const iree_uk_uint32_t n) {
 // Defines a generic "dispatched" implementation via opcode_t by invoking
 // the function iree_uk_generic_{category}_2d.
 // Corresponds to the header macro DECLARE_UKERNEL_BINARY_2D.
-#define DISPATCH_UKERNEL_UNARY_2D(opcode, opcode_t, dtype, category)      \
-  IREE_UK_EXPORT int iree_uk_##category##_##opcode##_2d(        \
-      const dtype* in, iree_uk_ssize_t in_offset,                     \
-      iree_uk_ssize_t in_stride0, iree_uk_ssize_t in_stride1,     \
-      dtype* IREE_UK_RESTRICT out, iree_uk_ssize_t out_offset,           \
-      iree_uk_ssize_t out_stride0, iree_uk_ssize_t out_stride1,   \
-      iree_uk_ssize_t size0, iree_uk_ssize_t size1) {             \
-    return iree_uk_generic_##category##_2d(                          \
-        opcode_t, in, in_offset, in_stride0, in_stride1, out, out_offset, \
-        out_stride0, out_stride1, size0, size1);                          \
+#define DISPATCH_UKERNEL_UNARY_2D(opcode, opcode_t, dtype, category)          \
+  IREE_UK_EXPORT int iree_uk_##category##_##opcode##_2d(                      \
+      const dtype* in, iree_uk_ssize_t in_offset, iree_uk_ssize_t in_stride0, \
+      iree_uk_ssize_t in_stride1, dtype* IREE_UK_RESTRICT out,                \
+      iree_uk_ssize_t out_offset, iree_uk_ssize_t out_stride0,                \
+      iree_uk_ssize_t out_stride1, iree_uk_ssize_t size0,                     \
+      iree_uk_ssize_t size1) {                                                \
+    return iree_uk_generic_##category##_2d(                                   \
+        opcode_t, in, in_offset, in_stride0, in_stride1, out, out_offset,     \
+        out_stride0, out_stride1, size0, size1);                              \
   }
 
 //===----------------------------------------------------------------------===//
@@ -146,8 +146,10 @@ static inline int iree_uk_count_leading_zeros_u32(const iree_uk_uint32_t n) {
 // Computes a single element of an x32b opcode. On error, should set
 // |*result_code| to a non-zero value (but should not touch it otherwise).
 static void iree_uk_generic_x32b_op(iree_uk_x32b_opcode_t opcode,
-                                         int* result_code, const iree_uk_uint32_t* lhs,
-                                         const iree_uk_uint32_t* rhs, iree_uk_uint32_t* out) {
+                                    int* result_code,
+                                    const iree_uk_uint32_t* lhs,
+                                    const iree_uk_uint32_t* rhs,
+                                    iree_uk_uint32_t* out) {
   switch (opcode) {
     case IREE_UK_X32B_ADDF:
       ASF32(out) = ASF32(lhs) + ASF32(rhs);
@@ -202,8 +204,9 @@ static void iree_uk_generic_x32b_op(iree_uk_x32b_opcode_t opcode,
 // Computes a single element of an x32u opcode. On error, should set
 // |*result_code| to a non-zero value (but should not touch it otherwise).
 static void iree_uk_generic_x32u_op(iree_uk_x32u_opcode_t opcode,
-                                         int* result_code, const iree_uk_uint32_t* in,
-                                         iree_uk_uint32_t* out) {
+                                    int* result_code,
+                                    const iree_uk_uint32_t* in,
+                                    iree_uk_uint32_t* out) {
   switch (opcode) {
     case IREE_UK_X32U_ABSF:
       ASF32(out) = fabsf(ASF32(in));
@@ -239,7 +242,7 @@ static void iree_uk_generic_x32u_op(iree_uk_x32u_opcode_t opcode,
 //===----------------------------------------------------------------------===//
 
 // Generic 32bit binary kernels.
-static int iree_uk_generic_x32b_2d(
+IREE_UK_ATTRIBUTE_NOINLINE static int iree_uk_generic_x32b_2d(
     iree_uk_x32b_opcode_t opcode,
     // LHS.
     const iree_uk_uint32_t* lhs, iree_uk_ssize_t lhs_offset,
@@ -257,16 +260,16 @@ static int iree_uk_generic_x32b_2d(
   for (iree_uk_ssize_t i = 0; i < size0; ++i) {
     for (iree_uk_ssize_t j = 0; j < size1; ++j) {
       iree_uk_generic_x32b_op(opcode, &result_code,
-                                   &lhs[i * lhs_stride0 + j * lhs_stride1],
-                                   &rhs[i * rhs_stride0 + j * rhs_stride1],
-                                   &out[i * out_stride0 + j * out_stride1]);
+                              &lhs[i * lhs_stride0 + j * lhs_stride1],
+                              &rhs[i * rhs_stride0 + j * rhs_stride1],
+                              &out[i * out_stride0 + j * out_stride1]);
     }
   }
   return result_code;
 }
 
 // Generic 32bit unary kernels.
-static int iree_uk_generic_x32u_2d(
+IREE_UK_ATTRIBUTE_NOINLINE static int iree_uk_generic_x32u_2d(
     iree_uk_x32u_opcode_t opcode,
     // IN.
     const iree_uk_uint32_t* in, iree_uk_ssize_t in_offset,
@@ -281,8 +284,8 @@ static int iree_uk_generic_x32u_2d(
   for (iree_uk_ssize_t i = 0; i < size0; ++i) {
     for (iree_uk_ssize_t j = 0; j < size1; ++j) {
       iree_uk_generic_x32u_op(opcode, &result_code,
-                                   &in[i * in_stride0 + j * in_stride1],
-                                   &out[i * out_stride0 + j * out_stride1]);
+                              &in[i * in_stride0 + j * in_stride1],
+                              &out[i * out_stride0 + j * out_stride1]);
     }
   }
   return result_code;


### PR DESCRIPTION
Before:
```
3.4%  22.7Ki    /mnt/d/Dev/iree/runtime/src/iree/builtins/ukernel/elementwise_generic.c

   0.0%  2.23Ki   0.3%  2.20Ki    iree_uk_pack
   0.0%  1.53Ki   0.2%  1.49Ki    iree_uk_x32b_shrsi_2d
   0.0%  1.53Ki   0.2%  1.49Ki    iree_uk_x32b_shrui_2d
   0.0%  1.49Ki   0.2%  1.44Ki    iree_uk_x32u_ctlz_2d
   0.0%  1.24Ki   0.2%  1.19Ki    iree_uk_x32b_shli_2d
   0.0%  1.20Ki   0.2%  1.16Ki    iree_uk_x32b_muli_2d
   0.0%  1.16Ki   0.2%  1.11Ki    iree_vm_shim_ukernel_x32b_2d_v
   0.0%  1.13Ki   0.2%  1.08Ki    iree_uk_x32b_addi_2d
   0.0%  1.13Ki   0.2%  1.08Ki    iree_uk_x32b_andi_2d
   0.0%  1.12Ki   0.2%  1.08Ki    iree_uk_x32b_ori_2d
   0.0%  1.13Ki   0.2%  1.08Ki    iree_uk_x32b_subi_2d
   0.0%  1.13Ki   0.2%  1.08Ki    iree_uk_x32b_xori_2d
   0.0%     852   0.1%     797    iree_vm_shim_ukernel_x32u_2d_v
   0.0%     695   0.1%     648    iree_uk_x32u_rsqrtf_2d
   0.0%     638   0.1%     600    iree_uk_mmt4d
   0.0%     643   0.1%     584    iree_uk_mmt4d_tile_i8i8i32_generic
   0.0%     625   0.1%     564    iree_uk_mmt4d_tile_f32f32f32_generic
   0.0%     578   0.1%     532    iree_uk_x32u_ceilf_2d
   0.0%     579   0.1%     532    iree_uk_x32u_floorf_2d
   0.0%     569   0.1%     524    iree_uk_x32b_addf_2d
   0.0%     569   0.1%     524    iree_uk_x32b_mulf_2d
   0.0%     569   0.1%     524    iree_uk_x32b_subf_2d
   0.0%     489   0.1%     444    iree_uk_x32u_absf_2d
   0.0%     489   0.1%     444    iree_uk_x32u_negf_2d
   0.0%     317   0.0%     272    iree_uk_x32u_expf_2d
   0.0%     317   0.0%     272    iree_uk_x32u_logf_2d
   0.0%     313   0.0%     268    iree_uk_x32b_divf_2d
   0.0%     314   0.0%     268    iree_uk_x32b_divsi_2d
   0.0%     314   0.0%     268    iree_uk_x32b_divui_2d
   0.0%     256   0.0%     209    iree_uk_status_message
   0.0%     108   0.0%      64    iree_uk_memset_zero
   0.0%     123   0.0%      60    iree_uk_mmt4d_select_tile_func_generic
   0.0%     108   0.0%      48    iree_uk_mmt4d_select_tile_func_arch
```

After:
```
0.5%  3.13Ki    /mnt/d/Dev/iree/runtime/src/iree/builtins/ukernel/elementwise_generic.c

   0.0%  2.23Ki   0.4%  2.20Ki    iree_uk_pack
   0.0%  1.16Ki   0.2%  1.11Ki    iree_vm_shim_ukernel_x32b_2d_v
   0.0%     852   0.1%     797    iree_vm_shim_ukernel_x32u_2d_v
   0.0%     638   0.1%     600    iree_uk_mmt4d
   0.0%     643   0.1%     584    iree_uk_mmt4d_tile_i8i8i32_generic
   0.0%     616   0.1%     568    iree_uk_generic_x32b_2d
   0.0%     625   0.1%     564    iree_uk_mmt4d_tile_f32f32f32_generic
   0.0%     608   0.1%     560    iree_uk_generic_x32u_2d
   0.0%     248   0.0%     201    iree_uk_status_message
   0.0%     141   0.0%      96    iree_uk_x32b_addf_2d
   0.0%     141   0.0%      96    iree_uk_x32b_addi_2d
   0.0%     141   0.0%      96    iree_uk_x32b_andi_2d
   0.0%     141   0.0%      96    iree_uk_x32b_divf_2d
   0.0%     142   0.0%      96    iree_uk_x32b_divsi_2d
   0.0%     142   0.0%      96    iree_uk_x32b_divui_2d
   0.0%     141   0.0%      96    iree_uk_x32b_mulf_2d
   0.0%     141   0.0%      96    iree_uk_x32b_muli_2d
   0.0%     140   0.0%      96    iree_uk_x32b_ori_2d
   0.0%     141   0.0%      96    iree_uk_x32b_shli_2d
   0.0%     142   0.0%      96    iree_uk_x32b_shrsi_2d
   0.0%     142   0.0%      96    iree_uk_x32b_shrui_2d
   0.0%     141   0.0%      96    iree_uk_x32b_subf_2d
   0.0%     141   0.0%      96    iree_uk_x32b_subi_2d
   0.0%     141   0.0%      96    iree_uk_x32b_xori_2d
   0.0%     125   0.0%      80    iree_uk_x32u_absf_2d
   0.0%     126   0.0%      80    iree_uk_x32u_ceilf_2d
   0.0%     125   0.0%      80    iree_uk_x32u_ctlz_2d
   0.0%     125   0.0%      80    iree_uk_x32u_expf_2d
   0.0%     127   0.0%      80    iree_uk_x32u_floorf_2d
   0.0%     125   0.0%      80    iree_uk_x32u_logf_2d
   0.0%     125   0.0%      80    iree_uk_x32u_negf_2d
   0.0%     127   0.0%      80    iree_uk_x32u_rsqrtf_2d
   0.0%     108   0.0%      64    iree_uk_memset_zero
   0.0%     123   0.0%      60    iree_uk_mmt4d_select_tile_func_generic
   0.0%     108   0.0%      48    iree_uk_mmt4d_select_tile_func_arch
```