### PR TITLE
Adding a makefile to the dynamic_shapes sample.

### DIFF
--- a/samples/dynamic_shapes/Makefile
+++ b/samples/dynamic_shapes/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# This is an example showing a basic makefile that links in the IREE runtime by
+# way of the unified static library. It's recommended that IREE is added as a
+# subproject and cmake is used to add the dependencies (as in the CMakeLists.txt
+# in this directory) but when using other build systems this is easier to adapt.
+#
+# Configure the runtime:
+#   cmake -GNinja -B ../iree-build-runtime/ .
+# Build the runtime:
+#   cmake --build ../iree-build-runtime/ --target iree_runtime_unified
+# Make this binary:
+#   make RUNTIME_BUILD_DIR=../iree-build-runtime/
+#
+# Note that if IREE_SIZE_OPTIMIZED is used to build the runtime then the
+# -DNDEBUG and -DIREE_STATUS_MODE=0 are required on any binaries using it. YMMV
+# if changing any compiler options and not keeping them in sync. Prefer using
+# cmake to ensure consistency between the builds.
+#
+# If cpuinfo is not supported on your platform then configure the runtime with
+# -DIREE_ENABLE_CPUINFO=OFF.
+
+RUNTIME_SRC_DIR ?= ../../runtime/src/
+RUNTIME_BUILD_DIR ?= ../../../iree-build-runtime/
+
+SRC_FILES := main.c
+INCLUDE_DIRS := ${RUNTIME_SRC_DIR}
+INCLUDE_FLAGS := $(addprefix -I,${INCLUDE_DIRS})
+LIBRARY_DIRS := \
+		${RUNTIME_BUILD_DIR}/build_tools/third_party/flatcc/ \
+		${RUNTIME_BUILD_DIR}/runtime/src/iree/runtime/ \
+		${RUNTIME_BUILD_DIR}/third_party/cpuinfo/ \
+		${RUNTIME_BUILD_DIR}/third_party/cpuinfo/deps/clog
+LINK_LIBRARIES := \
+		iree_runtime_unified \
+		flatcc_parsing \
+		cpuinfo \
+		clog \
+		dl \
+		pthread
+LIBRARY_FLAGS := $(addprefix -L,${LIBRARY_DIRS}) $(addprefix -l,${LINK_LIBRARIES})
+CXX_FLAGS := -flto -Os ${INCLUDE_FLAGS} ${LIBRARY_FLAGS}
+
+all: dynamic-shapes
+clean:
+	rm -f dynamic-shapes
+
+dynamic-shapes: ${SRC_FILES}
+	${CXX} ${SRC_FILES} ${CXX_FLAGS} -o $@

--- a/samples/dynamic_shapes/README.md
+++ b/samples/dynamic_shapes/README.md
@@ -93,6 +93,10 @@ them.
     cmake --build ../iree-build/ --target iree_samples_dynamic_shapes
     ```
 
+    Alternatively if using a non-CMake build system the `Makefile` provided can
+    be used as a reference of how to use the IREE runtime in an external
+    project.
+
 5. Run the sample binary:
 
    ```

--- a/samples/dynamic_shapes/main.c
+++ b/samples/dynamic_shapes/main.c
@@ -15,7 +15,7 @@ iree_status_t reduce_sum_1d(iree_runtime_session_t* session, const int* values,
       session, iree_make_cstring_view("module.reduce_sum_1d"), &call));
 
   iree_hal_buffer_view_t* arg0 = NULL;
-  const iree_hal_dim_t arg0_shape[1] = {values_length};
+  const iree_hal_dim_t arg0_shape[1] = {(iree_hal_dim_t)values_length};
 
   iree_status_t status = iree_ok_status();
   if (iree_status_is_ok(status)) {
@@ -24,8 +24,8 @@ iree_status_t reduce_sum_1d(iree_runtime_session_t* session, const int* values,
         IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
             .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
         },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);
@@ -73,8 +73,8 @@ iree_status_t reduce_sum_2d(iree_runtime_session_t* session, const int* values,
         IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
             .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
         },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);
@@ -113,8 +113,8 @@ iree_status_t add_one(iree_runtime_session_t* session, const int* values,
         IREE_ARRAYSIZE(arg0_shape), arg0_shape, IREE_HAL_ELEMENT_TYPE_SINT_32,
         IREE_HAL_ENCODING_TYPE_DENSE_ROW_MAJOR,
         (iree_hal_buffer_params_t){
-            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
             .usage = IREE_HAL_BUFFER_USAGE_DEFAULT,
+            .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
         },
         iree_make_const_byte_span((void*)values, sizeof(int) * values_length),
         &arg0);


### PR DESCRIPTION
This is just intended as an example of how to construct a makefile that can compile and link a binary against a build of the IREE runtime unified library. Users in other build systems or with their own cmake utilities can use it to see what linking looks like. There are a lot of caveats with this approach and not using IREE as a cmake subproject is still YMMV.