### PR TITLE
Fixing duplicate unused pass-through arguments of used bases in IPO.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -321,17 +321,6 @@ static FuncAnalysis analyzeFuncOp(func::FuncOp funcOp, Explorer &explorer) {
     }
   }
 
-  // Any argument that is the base of a duplicate needs to inherit the usage
-  // of all pointing at it.
-  // For example, %arg0 unused + %arg1 used dupe(%arg0) needs to ensure that
-  // %arg0 is preserved.
-  for (unsigned i = 0; i < argCount; ++i) {
-    int dupeIndex = analysis.callerUniformArgDupeMap[i];
-    if (dupeIndex != i && analysis.calleeUsedArgs.test(i)) {
-      analysis.calleeUsedArgs.set(dupeIndex);
-    }
-  }
-
   // We can drop any pass-through args that are exclusively used by returns as
   // we know all callers will stop passing them.
   for (unsigned i = 0; i < resultCount; ++i) {
@@ -346,7 +335,18 @@ static FuncAnalysis analyzeFuncOp(func::FuncOp funcOp, Explorer &explorer) {
       }
     }
     if (onlyReturnUsers) {
-      analysis.calleeUsedArgs.reset(i);
+      analysis.calleeUsedArgs.reset(argIndex);
+    }
+  }
+
+  // Any argument that is the base of a duplicate needs to inherit the usage
+  // of all pointing at it.
+  // For example, %arg0 unused + %arg1 used dupe(%arg0) needs to ensure that
+  // %arg0 is preserved.
+  for (unsigned i = 0; i < argCount; ++i) {
+    int dupeIndex = analysis.callerUniformArgDupeMap[i];
+    if (dupeIndex != i && analysis.calleeUsedArgs.test(i)) {
+      analysis.calleeUsedArgs.set(dupeIndex);
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/ipo.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/ipo.mlir
@@ -105,19 +105,19 @@ func.func @dupe_arg_caller_b(%arg0: index) -> index {
 
 // CHECK-LABEL: func.func private @dupe_unused_arg_callee
 // CHECK-SAME: (%[[CALLEE_ARG0:.+]]: index) -> index
-func.func private @dupe_unused_arg_callee(%arg0: index, %arg0_dupe: index) -> index {
+func.func private @dupe_unused_arg_callee(%arg0: index, %arg0_dupe: index) -> (index, index) {
   // CHECK: %[[CALLEE_RET0:.+]] = arith.addi %[[CALLEE_ARG0]], %[[CALLEE_ARG0]]
   %ret0 = arith.addi %arg0_dupe, %arg0_dupe : index
   // CHECK: return %[[CALLEE_RET0]]
-  return %ret0 : index
+  return %ret0, %arg0 : index, index
 }
 
 // CHECK: func.func @dupe_unused_arg_caller(%[[CALLER_ARG0:.+]]: index)
-func.func @dupe_unused_arg_caller(%arg0: index) -> index {
+func.func @dupe_unused_arg_caller(%arg0: index) -> (index, index) {
   // CHECK: %[[CALLER_RET0:.+]] = call @dupe_unused_arg_callee(%[[CALLER_ARG0]]) : (index) -> index
-  %ret0 = call @dupe_unused_arg_callee(%arg0, %arg0) : (index, index) -> index
-  // CHECK: return %[[CALLER_RET0]]
-  return %ret0 : index
+  %ret:2 = call @dupe_unused_arg_callee(%arg0, %arg0) : (index, index) -> (index, index)
+  // CHECK: return %[[CALLER_RET0]], %[[CALLER_ARG0]]
+  return %ret#0, %ret#1 : index, index
 }
 
 // -----


### PR DESCRIPTION
Fixes #11096.