### PR TITLE
Enable concurrent scheduling of stream.async.copy/update ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamInterfaces.td
@@ -188,6 +188,20 @@ def Stream_StreamableOp : OpInterface<"StreamableOpInterface"> {
         return false;
       }]
     >,
+    InterfaceMethod<
+      /*desc=*/[{
+        Returns true if this op can be scheduled to run concurrently with the
+        given user op that consumes (directly or indirectly) the results of
+        this op.
+      }],
+      /*retTy=*/"bool",
+      /*methodName=*/"canScheduleConcurrentlyWithConsumer",
+      /*args=*/(ins "Operation *":$consumerOp),
+      /*methodBody=*/"",
+      /*defaultImplementation=*/[{
+        return false;
+      }]
+    >,
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -1596,7 +1596,7 @@ def Stream_AsyncUpdateOp : Stream_Op<"async.update", [
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
   DeclareOpInterfaceMethods<Stream_StreamableOp, [
-    "isMetadata",
+    "canScheduleConcurrentlyWithConsumer",
   ]>,
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
@@ -1651,7 +1651,9 @@ def Stream_AsyncCopyOp : Stream_Op<"async.copy", [
   AllTypesMatch<["target", "result"]>,
   Stream_AffinityOp,
   Stream_AsyncPhaseOp,
-  Stream_StreamableOp,
+  DeclareOpInterfaceMethods<Stream_StreamableOp, [
+    "canScheduleConcurrentlyWithConsumer",
+  ]>,
   Util_SizeAwareOp,
   DeclareOpInterfaceMethods<Util_TiedOpInterface, [
     "getTiedResult",


### PR DESCRIPTION
Though still performing copies we'll now at least do them together and in cases where the copies are required we want them to be concurrent.

Progress on #7729 (some copies will go away in #6972, but ESRGAN for example will require copies unless #11102 is implemented).