### PR TITLE
Enable GPU pipeline schedule with shared memory stores in stage 0

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -75,10 +75,10 @@ namespace Codegen {
 
 TranslationInfoAttr TranslationInfoAttr::get(
     MLIRContext *context, DispatchLoweringPassPipeline passPipeline,
-    unsigned softwarePipelineDepth) {
+    unsigned softwarePipelineDepth, unsigned softwarePipelineStoreStage) {
   auto pipelineAttr =
       DispatchLoweringPassPipelineAttr::get(context, passPipeline);
-  return get(context, pipelineAttr, softwarePipelineDepth);
+  return get(context, pipelineAttr, softwarePipelineDepth, softwarePipelineStoreStage);
 }
 
 DispatchLoweringPassPipeline
@@ -89,7 +89,7 @@ TranslationInfoAttr::getDispatchLoweringPassPipeline() {
 LogicalResult TranslationInfoAttr::verify(
     function_ref<InFlightDiagnostic()> emitError,
     IREE::Codegen::DispatchLoweringPassPipelineAttr passPipeline,
-    unsigned softwarePipelineDepth) {
+    unsigned softwarePipelineDepth, unsigned softwarePipelineStoreStage) {
   if (!passPipeline) {
     return emitError() << "missing pass pipeline specification";
   }
@@ -212,7 +212,8 @@ LogicalResult CompilationInfoAttr::verify(
   }
   if (failed(TranslationInfoAttr::verify(
           emitError, translationInfo.getPassPipeline(),
-          translationInfo.getSoftwarePipelineDepth()))) {
+          translationInfo.getSoftwarePipelineDepth(),
+          translationInfo.getSoftwarePipelineStoreStage()))) {
     return failure();
   }
   if (workgroupSize) {

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -78,7 +78,8 @@ TranslationInfoAttr TranslationInfoAttr::get(
     unsigned softwarePipelineDepth, unsigned softwarePipelineStoreStage) {
   auto pipelineAttr =
       DispatchLoweringPassPipelineAttr::get(context, passPipeline);
-  return get(context, pipelineAttr, softwarePipelineDepth, softwarePipelineStoreStage);
+  return get(context, pipelineAttr, softwarePipelineDepth,
+             softwarePipelineStoreStage);
 }
 
 DispatchLoweringPassPipeline

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -145,7 +145,8 @@ inline LogicalResult setOpConfigAndEntryPointFnTranslation(
   auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   setLoweringConfig(op, config);
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-      entryPointFn->getContext(), passPipeline, softwarePipelineDepth, softwarePipelineStoreStage);
+      entryPointFn->getContext(), passPipeline, softwarePipelineDepth,
+      softwarePipelineStoreStage);
   setTranslationInfo(entryPointFn, translationInfo, workgroupSize);
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -84,7 +84,8 @@ inline void setTranslationInfo(
 inline void setTranslationInfo(
     func::FuncOp entryPointFn,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workgroupSize, unsigned softwarePipelineDepth = 0) {
+    ArrayRef<int64_t> workgroupSize, unsigned softwarePipelineDepth = 0,
+    unsigned softwarePipelineStoreStage = 1) {
   FailureOr<IREE::HAL::ExecutableExportOp> exportOp =
       getEntryPoint(entryPointFn);
   MLIRContext *context = entryPointFn.getContext();
@@ -138,12 +139,13 @@ void setLoweringConfig(Operation *op, IREE::Codegen::LoweringConfigAttr config);
 inline LogicalResult setOpConfigAndEntryPointFnTranslation(
     func::FuncOp entryPointFn, Operation *op, TileSizesListTypeRef tileSizes,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workgroupSize = {}, unsigned softwarePipelineDepth = 0) {
+    ArrayRef<int64_t> workgroupSize = {}, unsigned softwarePipelineDepth = 0,
+    unsigned softwarePipelineStoreStage = 1) {
   MLIRContext *context = entryPointFn.getContext();
   auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   setLoweringConfig(op, config);
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-      entryPointFn->getContext(), passPipeline, softwarePipelineDepth);
+      entryPointFn->getContext(), passPipeline, softwarePipelineDepth, softwarePipelineStoreStage);
   setTranslationInfo(entryPointFn, translationInfo, workgroupSize);
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -113,18 +113,22 @@ def IREECodegen_TranslationInfoAttr :
 
   let assemblyFormat = [{
     `<` `` $passPipeline
-    (`pipeline_depth` `=` $softwarePipelineDepth^)? `>`
+    (`pipeline_depth` `=` $softwarePipelineDepth^)?
+    (`store_stage` `=` $softwarePipelineStoreStage^) `>`
   }];
 
   let parameters = (ins
     AttrParameter<"IREE::Codegen::DispatchLoweringPassPipelineAttr",
         "Name of the pipeline to be invoked on the translation unit.">:$passPipeline,
     OptionalParameter<"unsigned",
-        "The software pipeline depth to be used">:$softwarePipelineDepth
+        "The software pipeline depth to be used">:$softwarePipelineDepth,
+    DefaultValuedParameter<"unsigned", "1",
+        "The software pipeline stage to place stores">:$softwarePipelineStoreStage
   );
   let builders = [
     AttrBuilder<(ins "DispatchLoweringPassPipeline":$passPipeline,
-        CArg<"unsigned", "0">:$softwarePipelineDepth)>
+        CArg<"unsigned", "0">:$softwarePipelineDepth,
+        CArg<"unsigned", "1">:$softwarePipelineStoreStage>
   ];
   let extraClassDeclaration = [{
     // Returns the lowering pass pipeline set.

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -114,7 +114,7 @@ def IREECodegen_TranslationInfoAttr :
   let assemblyFormat = [{
     `<` `` $passPipeline
     (`pipeline_depth` `=` $softwarePipelineDepth^)?
-    (`store_stage` `=` $softwarePipelineStoreStage^) `>`
+    (`store_stage` `=` $softwarePipelineStoreStage^)? `>`
   }];
 
   let parameters = (ins
@@ -128,7 +128,7 @@ def IREECodegen_TranslationInfoAttr :
   let builders = [
     AttrBuilder<(ins "DispatchLoweringPassPipeline":$passPipeline,
         CArg<"unsigned", "0">:$softwarePipelineDepth,
-        CArg<"unsigned", "1">:$softwarePipelineStoreStage>
+        CArg<"unsigned", "1">:$softwarePipelineStoreStage)>
   ];
   let extraClassDeclaration = [{
     // Returns the lowering pass pipeline set.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Verifiers.cpp
@@ -96,6 +96,11 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
     ArrayRef<int64_t> workgroupSize) {
   auto pipeline =
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulTensorCore;
+
+  assert(translationInfo.getSoftwarePipelineStoreStage() == 1 &&
+         "Store to workgroup memory currently expected to happen in stage 1 of "
+         "software pipeline.");
+
   unsigned softwarePipelinedepth = translationInfo.getSoftwarePipelineDepth();
   StringRef pipelineName = stringifyEnum(pipeline);
   if (workgroupSize.empty()) {

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -156,7 +156,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createGPUMultiBuffering(
 
 /// Apply software pipelining.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUPipeliningPass(
-    bool epiloguePeeling = true, unsigned depth = 1);
+    bool epiloguePeeling = true, unsigned depth = 1, unsigned storeStage = 1);
 
 /// Converts vector ops to gpu dialect.
 std::unique_ptr<OperationPass<func::FuncOp>> createWorkGroupSwizzle(
@@ -500,7 +500,8 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize);
 void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
-                                                unsigned pipelineDepth);
+                                                unsigned pipelineDepth,
+                                                unsigned storeStage);
 
 /// Pass pipeline to lower IREE HAL executables by tiling and distributing
 /// reduction to workgroups and then subgroups.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -26,6 +26,7 @@ namespace iree_compiler {
 namespace detail {
 
 constexpr unsigned AMDSoftwarePipelineDepth = 2;
+constexpr unsigned AMDSoftwarePipelineStoreStage = 0;
 
 constexpr unsigned AMDNumSubgroupsPerWorkgroup = 4;
 // The number of tiles along M and N dimensions per workgroup.
@@ -50,7 +51,8 @@ static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
     threadMNK = {8, 4, 16};
   }
   return setMatmulOpConfig(limits, op, workgroupXY, threadMNK,
-                           /*enablePromotion=*/true, AMDSoftwarePipelineDepth);
+                           /*enablePromotion=*/true, AMDSoftwarePipelineDepth,
+                           AMDSoftwarePipelineStoreStage);
 }
 
 // RDNA architecture:

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -55,6 +55,34 @@ bool isMatmulOrBatchMatmul(linalg::LinalgOp linalgOp) {
          llvm::is_contained({2u, 3u}, linalgOp.getNumParallelLoops());
 }
 
+// Check if the given linalg op is fused with another op that may block
+// multi-buffering
+static bool isFusedWithUnbufferableOp(linalg::LinalgOp matmul) {
+  func::FuncOp entryPoint = matmul->getParentOfType<func::FuncOp>();
+
+  auto getResultBits = [](linalg::LinalgOp linalgOp) {
+    auto shapedType = linalgOp->getResult(0).getType().dyn_cast<ShapedType>();
+    return shapedType.getElementType().getIntOrFloatBitWidth();
+  };
+
+  auto matmulResultBits = getResultBits(matmul);
+  bool fusedWithUnbufferableOps = false;
+  entryPoint.walk([&](linalg::LinalgOp linalgOp) {
+    if (linalgOp == matmul || isMatmulOrBatchMatmul(linalgOp) ||
+        isa<linalg::FillOp>(linalgOp)) {
+      return WalkResult::advance();
+    }
+
+    // This is a conservative approach in case bufferization produces an intermediate buffer that prevents multi-buffering from working.
+    if (linalgOp->getNumResults() != 1 || !OpTrait::hasElementwiseMappableTraits(linalgOp) || getResultBits(linalgOp) != matmulResultBits) {
+      fusedWithUnbufferableOps = true;
+      return WalkResult::interrupt();
+    }
+    return WalkResult::advance();
+  });
+  return fusedWithUnbufferableOps;
+}
+
 //===----------------------------------------------------------------------===//
 // Convolution Default Configuration
 //===----------------------------------------------------------------------===//
@@ -375,8 +403,10 @@ int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize, int64_t kTileSize,
   return (elementBits / 8) * count;
 }
 
-int64_t getMultiBufferMemoryUsage(int64_t singleBufferBytes, unsigned depth) {
-  return singleBufferBytes * (depth ? depth : 1);
+int64_t getMultiBufferMemoryUsage(int64_t singleBufferBytes, unsigned depth,
+                                  unsigned storeStage) {
+  if (depth == 0) return singleBufferBytes;
+  return singleBufferBytes * (storeStage == 1 ? depth : depth + 1);
 };
 
 /// Tries to adjust workgroup and tile sizes to enable vector load for both
@@ -439,8 +469,9 @@ static bool adjustToVectorLoad(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
 static bool adjustToPromote(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
                             int64_t &nTileSize, int64_t &kTileSize,
                             SmallVectorImpl<int64_t> &wgSize,
-                            unsigned &pipelineDepth, const int subgroupSize,
-                            const int maxBytes, const int elementBits) {
+                            unsigned &pipelineDepth, unsigned &storeStage,
+                            const int subgroupSize, const int maxBytes,
+                            const int elementBits) {
   LLVM_DEBUG(llvm::dbgs() << "subgroup size = " << subgroupSize << "\n");
   const int vectorSize = kMaxVectorNumBits / elementBits;
   if (!adjustToVectorLoad(dimMNKSize, mTileSize, nTileSize, kTileSize, wgSize,
@@ -448,23 +479,35 @@ static bool adjustToPromote(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
     return false;
 
   // Don't do multibuffering if the inner reduction loop is folded out.
-  if (dimMNKSize[2] == kTileSize) pipelineDepth = 1;
+  if (dimMNKSize[2] == kTileSize) {
+    pipelineDepth = 1;
+    storeStage = 1;
+  }
 
   auto usedBytes = getTileBytes(mTileSize, nTileSize, kTileSize, elementBits);
 
   LLVM_DEBUG(llvm::dbgs() << "initial multibuffering bytes = "
-                          << getMultiBufferMemoryUsage(usedBytes, pipelineDepth)
+                          << getMultiBufferMemoryUsage(usedBytes, pipelineDepth,
+                                                       storeStage)
                           << "\n");
 
   // First try to fit the given tile sizes with the largest pipelining depth
   // possible.
   do {
-    if (getMultiBufferMemoryUsage(usedBytes, pipelineDepth) <= maxBytes)
+    if (getMultiBufferMemoryUsage(usedBytes, pipelineDepth, storeStage) <=
+        maxBytes)
       return true;
   } while (pipelineDepth-- > 1);
 
   // If we can't fit in workgroup memory, don't multibuffer.
   pipelineDepth = 1;
+
+  if (storeStage == 0) {
+    storeStage = 1;
+    if (getMultiBufferMemoryUsage(usedBytes, pipelineDepth, storeStage) <=
+        maxBytes)
+      return true;
+  }
 
   // Using too much workgroup memory. Try to reduce the tile size for X/Y once
   // by a factor of two.
@@ -488,7 +531,8 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
                                 std::array<int64_t, 2> bestWorkgroupSizeXY,
                                 std::array<int64_t, 3> bestThreadTileSizeMNK,
                                 bool enablePromotion,
-                                unsigned softwarePipelineDepth) {
+                                unsigned softwarePipelineDepth,
+                                unsigned softwarePipelineStoreStage) {
   LLVM_DEBUG(llvm::dbgs() << "trying to deduce config as matmul...\n");
   OpOperand *lhs = op.getDpsInputOperand(0);
   OpOperand *rhs = op.getDpsInputOperand(1);
@@ -582,14 +626,21 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
   // keep the default for compilation configs that don't specify a pipeline
   // depth.
   auto pipelineDepth = softwarePipelineDepth ? softwarePipelineDepth : 1;
+  auto storeStage = softwarePipelineStoreStage;
+
+  // Check whether multi-buffering is possible.
+  if (isFusedWithUnbufferableOp(op)) {
+    pipelineDepth = 1;
+    storeStage = 1;
+  }
 
   // Try to adjust tiling sizes to fit in shared memory.
   auto usePromotionPipeline =
       enablePromotion &&
       adjustToPromote({dimM, dimN, dimK}, workgroupTileSizes[mIndex],
                       workgroupTileSizes[nIndex], reductionTileSizes[kIndex],
-                      workgroupSize, pipelineDepth, subgroupSize, maxBytes,
-                      elementBits);
+                      workgroupSize, pipelineDepth, storeStage, subgroupSize,
+                      maxBytes, elementBits);
 
   SmallVector<int64_t> threadTileSizes(numLoops, 0);
   if (isBM) {
@@ -610,7 +661,7 @@ LogicalResult setMatmulOpConfig(spirv::ResourceLimitsAttr limits,
     return setOpConfigAndEntryPointFnTranslation(
         op->getParentOfType<func::FuncOp>(), op, tileSizes,
         CodeGenPipeline::SPIRVMatmulPromoteVectorize, workgroupSize,
-        pipelineDepth);
+        pipelineDepth, storeStage);
   }
 
   return setOpConfigAndEntryPointFnTranslation(

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
@@ -26,6 +26,7 @@ namespace iree_compiler {
 
 /// By default don't do any pipelining.
 constexpr unsigned defaultSoftwarePipelineDepth = 1;
+constexpr unsigned defaultSoftwarePipelineStoreStage = 1;
 
 /// Computes the total number of bytes if promoting both matmul LHS and RHS with
 /// the tiven tile sizes.
@@ -33,7 +34,8 @@ int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize, int64_t kTileSize,
                      int64_t elementBits);
 
 /// Adjusts the shared memory usage based on the pipelining depth.
-int64_t getMultiBufferMemoryUsage(int64_t singleBufferBytes, unsigned depth);
+int64_t getMultiBufferMemoryUsage(int64_t usedBytes, unsigned depth,
+                                  unsigned storeStage);
 
 namespace detail {
 
@@ -52,7 +54,8 @@ LogicalResult setMatmulOpConfig(
     spirv::ResourceLimitsAttr limits, linalg::LinalgOp linalgOp,
     std::array<int64_t, 2> bestWorkgroupSizeXY,
     std::array<int64_t, 3> bestThreadTileSizeMNK, bool enablePromotion = false,
-    unsigned softwarePipelineDepth = defaultSoftwarePipelineDepth);
+    unsigned softwarePipelineDepth = defaultSoftwarePipelineDepth,
+    unsigned softwarePipelineStoreStage = defaultSoftwarePipelineStoreStage);
 
 /// Sets CodeGen configurations via attributes to the given matmul `linalgOp`
 /// with tile sizes for cooperative matrix, if possible for the given matmul

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -321,8 +321,12 @@ void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm) {
 }
 
 void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
-                                                unsigned pipelineDepth) {
-  LLVM_DEBUG(llvm::dbgs() << "Pipeline Depth: " << pipelineDepth << "\n");
+                                                unsigned pipelineDepth,
+                                                unsigned storeStage) {
+  // Guards against 0 for consistency with older user provided tuning configs.
+  pipelineDepth = pipelineDepth ? pipelineDepth : 1;
+  LLVM_DEBUG(llvm::dbgs() << "Non-zero Pipeline Depth: " << pipelineDepth
+                          << "\n";);
   addTileAndDistributeToWorkgroupsPasses(
       pm, /*useFuseTensorPadWithConsumerPass=*/false,
       /*useWARForCooperativeMatrixCodegen=*/true);
@@ -333,9 +337,9 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
   // Tile and distribute to GPU invocations.
   nestedModulePM.addNestedPass<func::FuncOp>(createSPIRVTileAndPromotePass());
 
-  if (pipelineDepth > 1)
-    nestedModulePM.addNestedPass<func::FuncOp>(
-        createGPUMultiBuffering(pipelineDepth));
+  if (pipelineDepth > 1 || storeStage == 0)
+    nestedModulePM.addNestedPass<func::FuncOp>(createGPUMultiBuffering(
+        storeStage == 0 ? pipelineDepth + 1 : pipelineDepth));
 
   nestedModulePM.addNestedPass<func::FuncOp>(createMemrefCopyToLinalgPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
@@ -354,10 +358,12 @@ void addSPIRVMatmulPromoteVectorizePassPipeline(OpPassManager &pm,
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
+      memref::createFoldMemRefAliasOpsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass());
 
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createGPUPipeliningPass(pipelineDepth ? pipelineDepth : 1));
+  nestedModulePM.addNestedPass<func::FuncOp>(createGPUPipeliningPass(
+      /*epiloguePeeling=*/true, pipelineDepth, storeStage));
 
   addLoopMaterializationPasses(nestedModulePM);
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -169,7 +169,8 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
       case IREE::Codegen::DispatchLoweringPassPipeline::
           SPIRVMatmulPromoteVectorize:
         addSPIRVMatmulPromoteVectorizePassPipeline(
-            pipeline, translationInfo.value().getSoftwarePipelineDepth());
+            pipeline, translationInfo.value().getSoftwarePipelineDepth(),
+            translationInfo.value().getSoftwarePipelineStoreStage());
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::SPIRVSubgroupReduce:
         addSPIRVSubgroupReducePassPipeline(pipeline);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -135,12 +135,16 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
         "sizes and workgroup sizes");
   }
 
+  auto pipelineDepth = translationInfo.getSoftwarePipelineDepth();
+  pipelineDepth = pipelineDepth ? pipelineDepth : 1;
+
   // Verify shared memory usage of operands after tiling <= maxSharedMemory.
   unsigned tilingSharedMemSizeBytes = getTileBytes(
       workgroupTileSizes[0], workgroupTileSizes[1], reductionTileSizes[2],
       inputType.cast<ShapedType>().getElementType().getIntOrFloatBitWidth());
   unsigned totalSharedMemSizeBytes = getMultiBufferMemoryUsage(
-      tilingSharedMemSizeBytes, translationInfo.getSoftwarePipelineDepth());
+      tilingSharedMemSizeBytes, pipelineDepth,
+      translationInfo.getSoftwarePipelineStoreStage());
 
   if (totalSharedMemSizeBytes > maxSharedMemory) {
     return op->emitOpError("expected shared memory usage <= ")

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -328,7 +328,8 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
       getTileBytes(workgroupTileSizes[0], workgroupTileSizes[1],
                    reductionTileSizes[2], lhsType.getIntOrFloatBitWidth());
   unsigned totalSharedMemSizeBytes = getMultiBufferMemoryUsage(
-      tilingSharedMemSizeBytes, translationInfo.getSoftwarePipelineDepth());
+      tilingSharedMemSizeBytes, translationInfo.getSoftwarePipelineDepth(),
+      translationInfo.getSoftwarePipelineStoreStage());
 
   if (totalSharedMemSizeBytes > maxSharedMemory) {
     return op->emitOpError("expected shared memory usage <= ")

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
@@ -80,7 +80,7 @@ hal.executable @matmul_f16_64x640x320 {
 }
 
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128], [4, 8], [0, 0, 32]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2 store_stage = 0>
 //      CHECK: hal.executable.export public @matmul_f16_64x640x320
 // CHECK-SAME:   translation_info = #[[TRANSLATION]]
 // CHECK-SAME:   workgroup_size = [16 : index, 16 : index, 1 : index]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul.mlir
@@ -133,3 +133,55 @@ hal.executable @batch_matmul_f32_16x4096x40x4096 {
 //      CHECK: func.func @batch_matmul_f32_16x4096x40x4096()
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @batch_matmul_f16_1x4096x4096x512 {
+  hal.executable.variant @vulkan_spirv_fb, target = <"vulkan", "vulkan-spirv-fb", {
+      spirv.target_env = #spirv.target_env<#spirv.vce<v1.6, [Shader], []>, AMD:DiscreteGPU, #spirv.resource_limits<
+        max_compute_shared_memory_size = 65536,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 1024],
+        subgroup_size = 64>>
+    }> {
+    hal.executable.export @batch_matmul_f16_1x4096x4096x512 layout(#pipeline_layout)
+    builtin.module {
+      func.func @batch_matmul_f16_1x4096x4096x512() {
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<1x4096x512xf16>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<1x512x4096xf16>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<1x4096x4096xf32>>
+        %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [1, 4096, 512], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x4096x512xf16>> -> tensor<1x4096x512xf16>
+        %4 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [1, 512, 4096], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<1x512x4096xf16>> -> tensor<1x512x4096xf16>
+        %5 = tensor.empty() : tensor<1x4096x4096xf32>
+        %6 = tensor.empty() : tensor<1x4096x4096xf16>
+        %7 = linalg.fill ins(%cst : f16) outs(%6 : tensor<1x4096x4096xf16>) -> tensor<1x4096x4096xf16>
+        %8 = linalg.batch_matmul ins(%3, %4 : tensor<1x4096x512xf16>, tensor<1x512x4096xf16>) outs(%7 : tensor<1x4096x4096xf16>) -> tensor<1x4096x4096xf16>
+        %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%8 : tensor<1x4096x4096xf16>) outs(%5 : tensor<1x4096x4096xf32>) {
+        ^bb0(%in: f16, %out: f32):
+          %10 = arith.extf %in : f16 to f32
+          linalg.yield %10 : f32
+        } -> tensor<1x4096x4096xf32>
+        flow.dispatch.tensor.store %9, %2, offsets = [0, 0, 0], sizes = [1, 4096, 4096], strides = [1, 1, 1] : tensor<1x4096x4096xf32> -> !flow.dispatch.tensor<writeonly:tensor<1x4096x4096xf32>>
+        return
+      }
+    }
+  }
+}
+
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 256], [1, 8, 8], [0, 0, 0, 32]{{\]}}>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 1>
+//      CHECK: hal.executable.export public @batch_matmul_f16_1x4096x4096x512
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+// CHECK-SAME:   workgroup_size = [32 : index, 8 : index, 1 : index]
+//      CHECK: func.func @batch_matmul_f16_1x4096x4096x512()
+//      CHECK:   linalg.batch_matmul
+// CHECK-SAME:     lowering_config = #[[CONFIG]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -158,6 +158,7 @@ hal.executable @matmul_f32_128x256x64 {
 //           CHECK:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
 //           CHECK:   memref.alloc() : memref<3x64x20xf32, 3>
 //           CHECK:   memref.alloc() : memref<3x16x68xf32, 3>
+// TODO: transfer_writes should be forwarded to the following transfer_reads
 //   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32, #hal.descriptor_type<storage_buffer>>
 //   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
@@ -168,7 +169,6 @@ hal.executable @matmul_f32_128x256x64 {
 //           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
-//           CHECK:   gpu.barrier {__pipelining_first_stage__}
 //           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
 //           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -51,34 +51,49 @@ hal.executable @matmul_f32_128x256x64 {
   }
 }
 
-//       CHECK-DAG: #[[MAP:.+]] = affine_map<(d0) -> ((d0 floordiv 16) mod 2)>
-//       CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2>
+//       CHECK-DAG: #[[MAP:.+]] = affine_map<(d0) -> ((d0 floordiv 16) mod 3)>
+//       CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2 store_stage = 0>
 //           CHECK: hal.executable.export public @matmul_f32_128x256x64
 //      CHECK-SAME:   translation_info = #[[TRANSLATION]]
 //      CHECK-SAME:   workgroup_size = [16 : index, 8 : index, 1 : index]
 //           CHECK: func.func @matmul_f32_128x256x64()
 //           CHECK:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
-//           CHECK:   memref.alloc() : memref<2x64x20xf32, 3>
-//           CHECK:   memref.alloc() : memref<2x16x68xf32, 3>
+//           CHECK:   memref.alloc() : memref<3x64x20xf32, 3>
+//           CHECK:   memref.alloc() : memref<3x16x68xf32, 3>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32>
+//   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
+//           CHECK:   gpu.barrier {__pipelining_first_stage__}
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
+//           CHECK:   gpu.barrier {__pipelining_first_stage__}
 //           CHECK:   scf.for
-//           CHECK:     affine.apply #[[MAP]]
-//           CHECK:     gpu.barrier
-//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[20, 1], offset: ?>, 3>
-//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[68, 1], offset: ?>, 3>
-//           CHECK:     gpu.barrier
-//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<8x16xf32, strided<[20, 1], offset: ?>, 3>, vector<4xf32>
-//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<16x4xf32, strided<[68, 1], offset: ?>, 3>, vector<4xf32>
+//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x64x20xf32, 3>, vector<4xf32>
+//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x16x68xf32, 3>, vector<4xf32>
 // CHECK-COUNT-128:     vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
-//   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_global_load__, in_bounds = [true]} : memref<1x4xf32, strided<[512, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
-//   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_global_load__, in_bounds = [true]} : memref<1x4xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//           CHECK:     affine.apply #[[MAP]]
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
+//           CHECK:     gpu.barrier {__pipelining_first_stage__}
 //           CHECK:     scf.yield
-//           CHECK:   gpu.barrier
-//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[20, 1], offset: ?>, 3>
-//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, strided<[68, 1], offset: ?>, 3>
-//           CHECK:   gpu.barrier
-//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<8x16xf32, strided<[20, 1], offset: ?>, 3>, vector<4xf32>
-//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<16x4xf32, strided<[68, 1], offset: ?>, 3>, vector<4xf32>
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x64x20xf32, 3>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x16x68xf32, 3>, vector<4xf32>
 // CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
-//   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<8x4xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x64x20xf32, 3>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x16x68xf32, 3>, vector<4xf32>
+// CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32>, vector<4xf32>
 //   CHECK-COUNT-8:   arith.divf %{{.+}}, %{{.+}} : vector<4xf32>
-//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<8x4xf32, strided<[256, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32>

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_matmul_promotion.mlir
@@ -1,6 +1,104 @@
 // RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-spirv-lower-executable-target-pass)))' %s | FileCheck %s
 
-// Verify multibuffering + pipelining
+// Verify pipelining + multi-buffering.
+
+#compilation = #iree_codegen.compilation_info<
+    lowering_config  = <tile_sizes = [[64, 64], [8, 4], [0, 0, 16]]>,
+    translation_info = <SPIRVMatmulPromoteVectorize pipeline_depth = 2>,
+    workgroup_size = [16, 8, 1]>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+#map = affine_map<(d0, d1) -> (d0, d1)>
+
+hal.executable @matmul_f32_128x256x64 {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<#spirv.vce<v1.5, [Shader], []>, AMD:DiscreteGPU, #spirv.resource_limits<
+      max_compute_shared_memory_size = 49152,
+      max_compute_workgroup_invocations = 1024,
+      max_compute_workgroup_size = [65535, 65535, 65535],
+      subgroup_size = 32>>}> {
+    hal.executable.export public @matmul_f32_128x256x64 ordinal(0) layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_f32_128x256x64() {
+        %cst = arith.constant 0.000000e+00 : f32
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<128x512xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<512x256xf32>>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<128x256xf32>>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<128x256xf32>>
+        %4 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x512xf32>> -> tensor<128x512xf32>
+        %5 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [512, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x256xf32>> -> tensor<512x256xf32>
+        %6 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+        %7 = tensor.empty() : tensor<128x256xf32>
+        %8 = linalg.fill ins(%cst : f32) outs(%7 : tensor<128x256xf32>) -> tensor<128x256xf32>
+        %9 = linalg.matmul {__internal_linalg_transform__ = "workgroup", compilation_info = #compilation}
+           ins(%4, %5 : tensor<128x512xf32>, tensor<512x256xf32>) outs(%8 : tensor<128x256xf32>) -> tensor<128x256xf32>
+        %10 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel"]}
+                ins(%9, %6 : tensor<128x256xf32>, tensor<128x256xf32>) outs(%7 : tensor<128x256xf32>) {
+        ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+          %11 = arith.divf %arg0, %arg1 : f32
+          linalg.yield %11 : f32
+        } -> tensor<128x256xf32>
+        flow.dispatch.tensor.store %10, %3, offsets = [0, 0], sizes = [128, 256], strides = [1, 1] : tensor<128x256xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x256xf32>>
+        return
+      }
+    }
+  }
+}
+
+//       CHECK-DAG: #[[MAP:.+]] = affine_map<(d0) -> ((d0 floordiv 16) mod 2)>
+//       CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize pipeline_depth = 2>
+//           CHECK: hal.executable.export public @matmul_f32_128x256x64
+//      CHECK-SAME:   translation_info = #[[TRANSLATION]]
+//      CHECK-SAME:   workgroup_size = [16 : index, 8 : index, 1 : index]
+//           CHECK: func.func @matmul_f32_128x256x64()
+//           CHECK:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
+//           CHECK:   memref.alloc() : memref<2x64x20xf32, 3>
+//           CHECK:   memref.alloc() : memref<2x16x68xf32, 3>
+//           CHECK:   scf.for
+//           CHECK:     gpu.barrier
+//           CHECK:     affine.apply #[[MAP]]
+//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x20xf32, 3>
+//   CHECK-COUNT-2:     vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x68xf32, 3>
+//           CHECK:     gpu.barrier
+//  CHECK-COUNT-32:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<2x64x20xf32, 3>, vector<4xf32>
+//  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<2x16x68xf32, 3>, vector<4xf32>
+// CHECK-COUNT-128:     vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
+//   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//   CHECK-COUNT-2:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//           CHECK:     scf.yield
+//           CHECK:   gpu.barrier
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x20xf32, 3>
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x68xf32, 3>
+//           CHECK:   gpu.barrier
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<2x64x20xf32, 3>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<2x16x68xf32, 3>, vector<4xf32>
+// CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
+//           CHECK:   gpu.barrier
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x64x20xf32, 3>
+//   CHECK-COUNT-2:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<2x16x68xf32, 3>
+//           CHECK:   gpu.barrier
+//  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<2x64x20xf32, 3>, vector<4xf32>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<2x16x68xf32, 3>, vector<4xf32>
+// CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32, #hal.descriptor_type<storage_buffer>>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//   CHECK-COUNT-8:   arith.divf %{{.+}}, %{{.+}} : vector<4xf32>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32, #hal.descriptor_type<storage_buffer>>
+
+// -----
+
+// Store in stage 0 of pipeline.
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -60,16 +158,24 @@ hal.executable @matmul_f32_128x256x64 {
 //           CHECK:   %[[CST0:.+]] = arith.constant 0.000000e+00 : f32
 //           CHECK:   memref.alloc() : memref<3x64x20xf32, 3>
 //           CHECK:   memref.alloc() : memref<3x16x68xf32, 3>
-//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32>
-//   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32>, vector<4xf32>
-//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32, #hal.descriptor_type<storage_buffer>>
+//   CHECK-COUNT-8:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
-//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
 //           CHECK:   gpu.barrier {__pipelining_first_stage__}
-//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
-//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
+//           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
+//           CHECK:   vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:   vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
 //           CHECK:   gpu.barrier {__pipelining_first_stage__}
 //           CHECK:   scf.for
@@ -77,13 +183,13 @@ hal.executable @matmul_f32_128x256x64 {
 //  CHECK-COUNT-16:     vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x16x68xf32, 3>, vector<4xf32>
 // CHECK-COUNT-128:     vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
 //           CHECK:     affine.apply #[[MAP]]
-//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
-//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<128x512xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x64x20xf32, 3>
-//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
-//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32>, vector<4xf32>
+//           CHECK:     vector.transfer_read %{{.+}}, %[[CST0]] {__pipelining_first_stage__, in_bounds = [true]} : memref<512x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //           CHECK:     vector.transfer_write %{{.+}}, %{{.+}} {__pipelining_first_stage__, in_bounds = [true]} : vector<4xf32>, memref<3x16x68xf32, 3>
 //           CHECK:     gpu.barrier {__pipelining_first_stage__}
 //           CHECK:     scf.yield
@@ -93,7 +199,7 @@ hal.executable @matmul_f32_128x256x64 {
 //  CHECK-COUNT-32:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x64x20xf32, 3>, vector<4xf32>
 //  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<3x16x68xf32, 3>, vector<4xf32>
 // CHECK-COUNT-128:   vector.fma %{{.+}}, %{{.+}}, %{{.+}} : vector<4xf32>
-//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32>
-//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32>, vector<4xf32>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32, #hal.descriptor_type<storage_buffer>>
+//  CHECK-COUNT-16:   vector.transfer_read %{{.+}}, %[[CST0]] {in_bounds = [true]} : memref<128x256xf32, #hal.descriptor_type<storage_buffer>>, vector<4xf32>
 //   CHECK-COUNT-8:   arith.divf %{{.+}}, %{{.+}} : vector<4xf32>
-//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32>
+//   CHECK-COUNT-8:   vector.transfer_write %{{.+}}, %{{.+}} {in_bounds = [true]} : vector<4xf32>, memref<128x256xf32, #hal.descriptor_type<storage_buffer>>


### PR DESCRIPTION
Depends on #11086. Enables putting vector.transfer_write ops in stage 0 of the pipeline along with reading from global memory.