### PR TITLE
Use Device Mapping Interface for Transform Dialect Ops

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
@@ -24,8 +24,10 @@ td_library(
         include = ["*.td"],
     ),
     deps = [
+        "@llvm-project//mlir:GPUDeviceMapperEnumsGen",
         "@llvm-project//mlir:InferTypeOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:SCFTdFiles",
         "@llvm-project//mlir:TransformDialectTdFiles",
     ],
 )
@@ -44,7 +46,10 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "CommonExtensionsOps.td",
-    deps = [":td_files"],
+    deps = [
+        ":td_files",
+        "@llvm-project//mlir:SCFDeviceMappingInterfacesIncGen",
+    ],
 )
 
 iree_compiler_cc_library(
@@ -73,11 +78,13 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:LinalgTransformOps",
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefTransforms",
         "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformDialect",
         "@llvm-project//mlir:Transforms",

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
@@ -39,11 +39,13 @@ iree_cc_library(
     MLIRArithUtils
     MLIRBufferizationDialect
     MLIRBufferizationTransforms
+    MLIRGPUOps
     MLIRLinalgTransformOps
     MLIRLinalgTransforms
     MLIRMemRefDialect
     MLIRMemRefTransforms
     MLIRPass
+    MLIRSCFDialect
     MLIRTensorDialect
     MLIRTransformDialect
     MLIRTransforms

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -11,6 +11,7 @@ include "mlir/Dialect/PDL/IR/PDLTypes.td"
 include "mlir/Dialect/Transform/IR/TransformDialect.td"
 include "mlir/Dialect/Transform/IR/TransformInterfaces.td"
 include "mlir/Interfaces/SideEffectInterfaces.td"
+include "mlir/Dialect/SCF/IR/DeviceMappingInterface.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 
@@ -210,7 +211,7 @@ def TileToForeachThreadAndWorkgroupCountRegionOp :
                    Variadic<PDL_Operation>:$tile_sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$static_num_threads,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$static_tile_sizes,
-                   OptionalAttr<I64ArrayAttr>:$thread_dim_mapping,
+                   OptionalAttr<DeviceMappingArrayAttr>:$mapping,
                    UnitAttr:$packed_sizes);
   let results = (outs PDL_Operation:$foreach_thread_op,
                       PDL_Operation:$tiled_op);
@@ -222,7 +223,7 @@ def TileToForeachThreadAndWorkgroupCountRegionOp :
          `tile_sizes` custom<DynamicIndexList>($tile_sizes,
                                                $static_tile_sizes,
                                                "ShapedType::kDynamicSize"))
-    (`(` `mapped` `to` `dims` $thread_dim_mapping^ `)`)? attr-dict
+    (`(` `mapping` `=` $mapping^ `)`)? attr-dict
   }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
   let hasVerifier = 1;
@@ -232,27 +233,27 @@ def TileToForeachThreadAndWorkgroupCountRegionOp :
                    "ArrayRef<int64_t>":$staticTileSizes,
                    CArg<"::mlir::transform::TileSizesSpec",
                         "::mlir::transform::TileSizesSpec()">,
-                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+                   CArg<"ArrayAttr", "{}">:$mapping)>,
     OpBuilder<(ins "Value":$target,
                    "ArrayRef<OpFoldResult>":$mixedTileSizes,
                    CArg<"::mlir::transform::TileSizesSpec",
                         "::mlir::transform::TileSizesSpec()">,
-                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+                   CArg<"ArrayAttr", "{}">:$mapping)>,
     OpBuilder<(ins "Value":$target,
                    "Value":$tileSizeHandle,
                    CArg<"::mlir::transform::TileSizesSpec",
                         "::mlir::transform::TileSizesSpec()">,
-                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+                   CArg<"ArrayAttr", "{}">:$mapping)>,
     OpBuilder<(ins "Value":$target,
                    "ArrayRef<int64_t>":$staticNumThreads,
                    CArg<"::mlir::transform::NumThreadsSpec",
                         "::mlir::transform::NumThreadsSpec()">,
-                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+                   CArg<"ArrayAttr", "{}">:$mapping)>,
     OpBuilder<(ins "Value":$target,
                    "ArrayRef<OpFoldResult>":$mixedNumThreads,
                    CArg<"::mlir::transform::NumThreadsSpec",
                         "::mlir::transform::NumThreadsSpec()">,
-                   CArg<"ArrayRef<int64_t>", "{}">:$threadDimMapping)>,
+                   CArg<"ArrayAttr", "{}">:$mapping)>,
   ];
 
   let extraClassDeclaration = [{

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileTensor.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTileTensor.cpp
@@ -120,21 +120,28 @@ static LogicalResult tileParallelDims(func::FuncOp funcOp,
     // If there are no dimensions to tile skip the transformation.
     if (partitionedLoops.empty()) continue;
     SmallVector<OpFoldResult> numThreads(numLoops, rewriter.getIndexAttr(0));
-    int64_t id = 0;
-    int64_t threadId = 0;
-    SmallVector<int64_t> idDims;
+    int64_t id = 0, threadDim = 0;
+    SmallVector<Attribute> idDims;
+    auto getThreadMapping = [&](int64_t dim) {
+      return mlir::gpu::GPUThreadMappingAttr::get(
+          tilingOp->getContext(), dim == 0   ? mlir::gpu::Threads::DimX
+                                  : dim == 1 ? mlir::gpu::Threads::DimY
+                                             : mlir::gpu::Threads::DimZ);
+    };
     for (unsigned loop : llvm::reverse(partitionedLoops)) {
       int64_t num = elementPerWorkgroup[id++];
       if (num > 1) {
         numThreads[loop] = rewriter.getIndexAttr(num);
-        idDims.push_back(threadId++);
+        idDims.push_back(getThreadMapping(threadDim++));
       }
     }
     std::reverse(idDims.begin(), idDims.end());
-    for (int64_t i = threadId; i < 3; i++) idDims.push_back(i);
+    for (int64_t i = threadDim; i < 3; i++)
+      idDims.push_back(getThreadMapping(i));
 
+    ArrayAttr mapping = rewriter.getArrayAttr(idDims);
     auto tilingResult =
-        linalg::tileToForeachThreadOp(rewriter, tilingOp, numThreads, idDims);
+        linalg::tileToForeachThreadOp(rewriter, tilingOp, numThreads, mapping);
     rewriter.replaceOp(tilingOp, tilingResult->tileOp->getResults());
   }
   return success();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_foreach.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/distribute_foreach.mlir
@@ -35,7 +35,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
         %10 = vector.transfer_read %6[%c0, %7], %cst {in_bounds = [true]} : memref<1x256xf32, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>, vector<4xf32>
         %11 = arith.addf %9, %10 : vector<4xf32>
         vector.transfer_write %11, %8[%c0, %c0] {in_bounds = [true]} : vector<4xf32>, memref<1x4xf32, affine_map<(d0, d1)[s0] -> (d0 * 1024 + s0 + d1)>>
-      } {thread_dim_mapping = [0, 1, 2]}
+      } {mapping = [#gpu.thread<x>, #gpu.thread<y>, #gpu.thread<z>]}
       return
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/tile_on_tensor.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/tile_on_tensor.mlir
@@ -56,7 +56,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:     scf.foreach_thread.perform_concurrently {
 //         CHECK:       tensor.parallel_insert_slice %[[L]] into %[[O]][0, %[[OFF]]] [1, 4] [1, 1] : tensor<1x4xf32> into tensor<1x256xf32>
 //         CHECK:     }
-//         CHECK:   } {thread_dim_mapping = [0, 1, 2]}
+//         CHECK:   } {mapping = [#gpu.thread<x>, #gpu.thread<y>, #gpu.thread<z>]}
 //         CHECK:   flow.dispatch.tensor.store %[[T]], %{{.*}}, offsets = [%{{.*}}, %{{.*}}], sizes = [1, 256], strides = [1, 1] : tensor<1x256xf32> -> !flow.dispatch.tensor<writeonly:tensor<233x1024xf32>>
 
 // -----
@@ -117,7 +117,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:     scf.foreach_thread.perform_concurrently {
 //         CHECK:       tensor.parallel_insert_slice %[[R]] into %[[O]][%[[ARG]]] [1] [1] : tensor<1xf32> into tensor<64xf32>
 //         CHECK:     }
-//         CHECK:   } {thread_dim_mapping = [0, 1, 2]}
+//         CHECK:   } {mapping = [#gpu.thread<x>, #gpu.thread<y>, #gpu.thread<z>]}
 //         CHECK:   flow.dispatch.tensor.store %[[T]], %{{.}}, offsets = [%{{.*}}], sizes = [64], strides = [1] : tensor<64xf32> -> !flow.dispatch.tensor<writeonly:tensor<128xf32>>
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -1,10 +1,12 @@
 transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %0 = transform.structured.match ops{["linalg.fill"]} in %variant_op
-  %foreach_thread, %tiled_fill = transform.structured.tile_to_foreach_thread_op %0 num_threads [5, 1] (mapped to dims [1, 0, 2])
+  %foreach_thread, %tiled_fill = transform.structured.tile_to_foreach_thread_op %0 num_threads [5, 1] 
+  ( mapping = [#gpu.thread<y>, #gpu.thread<x>, #gpu.thread<z>] )
 
   %1 = transform.structured.match ops{["linalg.matmul"]} in %variant_op
   %foreach_thread_2, %tiled_matmul = transform.structured.tile_to_foreach_thread_op %1 num_threads [7, 9]
+  ( mapping = [#gpu.thread<x>, #gpu.thread<y>, #gpu.thread<z>] )
 
   %variant_op_2 = transform.iree.bufferize %variant_op
 

--- a/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_custom_dispatch_formation_spec.mlir
@@ -5,7 +5,8 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %0 = transform.structured.match ops{["linalg.matmul"]} in %variant_op
 
   %foreach_thread, %tiled_generic =
-    transform.structured.tile_to_foreach_thread_op %0 num_threads [2]
+    transform.structured.tile_to_foreach_thread_op %0 num_threads [2] 
+    ( mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>] )
 
   %1 = transform.iree.bufferize %variant_op
 

--- a/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
@@ -5,7 +5,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op
 
   %foreach_thread, %tiled_generic =
-    transform.iree.tile_to_foreach_thread_and_workgroup_count_region %matmul tile_sizes [2]
+    transform.iree.tile_to_foreach_thread_and_workgroup_count_region %matmul tile_sizes [2] ( mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>] )
 
   %variant_op_2 = transform.iree.bufferize %variant_op
   %func = transform.structured.match ops{["func.func"]} in %variant_op_2

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -14,7 +14,7 @@ transform.structured.canonicalized_sequence failures(suppress) {
   // Step 2. First level of tiling + fusion parallelizes to blocks.
   // ===========================================================================
   %foreach_thread_grid, %grid_combiner_op =
-    transform.iree.tile_to_foreach_thread_and_workgroup_count_region %combiner_op tile_sizes [1]
+    transform.iree.tile_to_foreach_thread_and_workgroup_count_region %combiner_op tile_sizes [1]  ( mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>] )
   %not_combiner = transform.merge_handles %fill, %more_parallel_fill_op, %more_parallel_op : !pdl.operation
   transform.structured.fuse_into_containing_op %not_combiner into %foreach_thread_grid
 
@@ -22,14 +22,16 @@ transform.structured.canonicalized_sequence failures(suppress) {
   // ===========================================================================
   %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
   %foreach_thread_block_combiner_op, %block_combiner_op =
-    transform.structured.tile_to_foreach_thread_op %grid_combiner_op tile_sizes [1, 0, 0] (mapped to dims [2, 1, 0])
+    transform.structured.tile_to_foreach_thread_op %grid_combiner_op tile_sizes [1, 0, 0] 
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
   transform.structured.fuse_into_containing_op %fill_1d into %foreach_thread_block_combiner_op
 
   %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
   %grid_more_parallel_op = transform.structured.match interface{LinalgOp}
     attributes{iterator_types = ["parallel", "parallel", "reduction"]} in %variant_op
   %foreach_thread_block_more_parallel_op, %block_more_parallel_op =
-    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1, 0] (mapped to dims [2, 1, 0])
+    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1, 0] 
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
   transform.structured.fuse_into_containing_op %fill_2d into %foreach_thread_block_more_parallel_op
 
   // Step 4. Rank-reduce and vectorize.

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -20,10 +20,10 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // does not fuse even with --iree-flow-enable-aggressive-fusion.
   // %foreach_thread, %_ =
   // transform.iree.tile_to_foreach_thread_and_workgroup_count_region %div tile_sizes [1, 4]
-  //   (mapped to dims [0, 1, 2])
+  //   ( mapping = [#gpu.thread<x>, #gpu.thread<y>, #gpu.thread<x>] )
   %foreach_thread, %_ =
     transform.structured.tile_to_foreach_thread_op %div tile_sizes [1, 4]
-      (mapped to dims [0, 1, 2])
+      ( mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>] )
   // TODO: Merging and fusing merged handles does not work properly atm.
   transform.structured.fuse_into_containing_op %exps_sum into %foreach_thread
   transform.structured.fuse_into_containing_op %exps into %foreach_thread
@@ -58,15 +58,14 @@ transform.structured.canonicalized_sequence failures(propagate) {
                                                   %tiled_exp_and_exps_sum_2
     : !pdl.operation
   transform.structured.tile_to_foreach_thread_op %reduction_linalg_ops tile_sizes [1, 1]
-    (mapped to dims [2, 1, 0])
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
   // Fully parallel ops are tiled and mapped.
   %parallel_linalg_ops = transform.merge_handles %tiled_input_max_fill,
                                                  %tiled_exps_sum_fill,
                                                  %tiled_div
     : !pdl.operation
   transform.structured.tile_to_foreach_thread_op %parallel_linalg_ops num_threads [1, 4, 32]
-      (mapped to dims [2, 1, 0])
-
+      ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
   // Step 3. Rank-reduce and vectorize.
   // ==================================
   %funcx_2 = transform.structured.match ops{["func.func"]} in %variant_op

--- a/tests/transform_dialect/cuda/softmax_partial_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_partial_codegen_spec.mlir
@@ -14,6 +14,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %not_root = merge_handles %fill, %red : !pdl.operation
   %foreach_thread, %tiled_generic =
     transform.iree.tile_to_foreach_thread_and_workgroup_count_region %root tile_sizes [1, 4]
+    ( mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>] )
   transform.structured.fuse_into_containing_op %not_root into %foreach_thread
 
   // Step 2. Second level of tiling + fusion parallelizes to threads.
@@ -25,14 +26,14 @@ transform.structured.canonicalized_sequence failures(propagate) {
     attributes{iterator_types = ["parallel", "parallel", "parallel"]} in %variant_op
   %foreach_thread_reduction, %tiled_reduction_generic =
     transform.structured.tile_to_foreach_thread_op %reduction_linalg tile_sizes [1, 1]
-      (mapped to dims [2, 1, 0])
+      ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
   // TODO: this fusion currently does not happen properly, this is related to the clone
   // behavior when fusing into scf.foreach_thread.
   // Once fixed we'll be able to fuse.
   // Fusion will save us one roundtrip to memory.
   // transform.structured.fuse_into_containing_op %fill_linalg into %foreach_thread_reduction
   transform.structured.tile_to_foreach_thread_op %parallel_linalg num_threads [1, 4, 32]
-      (mapped to dims [2, 1, 0])
+      ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
 
 
   // Inability to tile reductions to scf.foreach_thread has 2 implications:

--- a/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
@@ -16,8 +16,8 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // Step 1. First level of tiling + fusion parallelizes to blocks.
   // ==============================================================
   %foreach_thread, %_ =
-  transform.iree.tile_to_foreach_thread_and_workgroup_count_region %div tile_sizes [1, 4]
-    (mapped to dims [0, 1, 2])
+  transform.iree.tile_to_foreach_thread_and_workgroup_count_region %div tile_sizes [1, 4]  
+    ( mapping = [#gpu.block<x>, #gpu.block<y>, #gpu.block<z>] )
   // TODO: Merging and fusing merged handles does not work properly atm.
   transform.structured.fuse_into_containing_op %exp_and_exps_sum into %foreach_thread
   transform.structured.fuse_into_containing_op %exps_sum_fill into %foreach_thread
@@ -49,15 +49,14 @@ transform.structured.canonicalized_sequence failures(propagate) {
                                                   %tiled_exp_and_exps_sum
     : !pdl.operation
   transform.structured.tile_to_foreach_thread_op %reduction_linalg_ops tile_sizes [1, 1]
-    (mapped to dims [2, 1, 0])
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
   // Fully parallel ops are tiled and mapped.
   %parallel_linalg_ops = transform.merge_handles %tiled_input_max_fill,
                                                  %tiled_exps_sum_fill,
                                                  %tiled_div
     : !pdl.operation
   transform.structured.tile_to_foreach_thread_op %parallel_linalg_ops num_threads [1, 4, 32]
-      (mapped to dims [2, 1, 0])
-
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>, #gpu.thread<x>] )
   // Step 3. Rank-reduce and vectorize.
   // ==================================
   %funcx_2 = transform.structured.match ops{["func.func"]} in %variant_op


### PR DESCRIPTION
`scf.foreach_thread` previously expressed thread mapping via an integer array, that was very confusing. To make mapping descriptive, the upstream MLIR implemented device mapping interface in https://reviews.llvm.org/D137413 . It provides a device mapping interface and two attributes GPUBlockMappingAttr and GPUThreadMappingAttr.

IREE uses upstream MLIR's transform dialect. This PR integrates new attributes to IREE's transform dialect examples.

Cherry-picks the following LLVM 
@6663f3470417523141ee87923840d17b35d6b4c7
@b7162e136edfbe7157e9341d4322705e50601796
@07665e78cb6008537e1ce6f5606d9838612d32fe
@0d845660f4e2c3dc3c1afc3db4c723db4bd32f01