### PR TITLE
Some strictness to bring Clang, GCC and MSVC more in line with each other

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -197,6 +197,10 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wthread-safety-beta"
     "-Wunused-comparison"
     "-Wvla"
+    "-Wpointer-arith"
+
+    # Clang is lax by default on SIMD vector typing. GCC is strict by default.
+    "-fno-lax-vector-conversions"
 
   # TODO(#6959): Enable -Werror once we have a presubmit CI.
   GCC

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -190,6 +190,7 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wliteral-conversion"
     "-Wnon-virtual-dtor"
     "-Woverloaded-virtual"
+    "-Wpointer-arith"
     "-Wself-assign"
     "-Wstring-conversion"
     "-Wtautological-overlap-compare"
@@ -197,7 +198,6 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     "-Wthread-safety-beta"
     "-Wunused-comparison"
     "-Wvla"
-    "-Wpointer-arith"
 
     # Clang is lax by default on SIMD vector typing. GCC is strict by default.
     "-fno-lax-vector-conversions"

--- a/runtime/src/iree/hal/local/elf/platform/generic.c
+++ b/runtime/src/iree/hal/local/elf/platform/generic.c
@@ -93,7 +93,7 @@ iree_status_t iree_memory_view_protect_ranges(void* base_address,
 
 void iree_memory_view_flush_icache(void* base_address,
                                    iree_host_size_t length) {
-  IREE_ELF_CLEAR_CACHE(base_address, base_address + length);
+  IREE_ELF_CLEAR_CACHE(base_address, ((char*)base_address) + length);
 }
 
 #endif  // IREE_PLATFORM_GENERIC

--- a/runtime/src/iree/hal/local/elf/platform/linux.c
+++ b/runtime/src/iree/hal/local/elf/platform/linux.c
@@ -158,7 +158,7 @@ iree_status_t iree_memory_view_protect_ranges(void* base_address,
 
 void iree_memory_view_flush_icache(void* base_address,
                                    iree_host_size_t length) {
-  IREE_ELF_CLEAR_CACHE(base_address, base_address + length);
+  IREE_ELF_CLEAR_CACHE(base_address, ((char*)base_address) + length);
 }
 
 #endif  // IREE_PLATFORM_*


### PR DESCRIPTION
`-Wpointer-arith` brings Clang and GCC in line with MSVC

`-fno-lax-vector-conversions` brings Clang in line with GCC.