### PR TITLE
Support loading run config to BenchmarkSuite

### DIFF
--- a/build_tools/benchmarks/CMakeLists.txt
+++ b/build_tools/benchmarks/CMakeLists.txt
@@ -25,7 +25,7 @@ function(benchmark_tool_py_test)
     ${ARGN}
   )
 
-  iree_local_py_test(
+  iree_build_tools_py_test(
     NAME
       "${_RULE_NAME}"
     SRC

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -162,8 +162,12 @@ def main(args: argparse.Namespace):
     benchmark_cases = benchmark_suite.filter_benchmarks_for_category(
         category=category)
     for benchmark_case in benchmark_cases:
-      flag_file_path = os.path.join(benchmark_case.benchmark_case_dir,
-                                    BENCHMARK_FLAGFILE)
+      benchmark_case_dir = benchmark_case.benchmark_case_dir
+      # TODO(#11076): Support run_config.
+      if benchmark_case_dir is None:
+        raise ValueError("benchmark_case_dir can't be None.")
+
+      flag_file_path = os.path.join(benchmark_case_dir, BENCHMARK_FLAGFILE)
       with open(flag_file_path, "r") as flag_file:
         module_path = get_module_path(flag_file)
 
@@ -171,7 +175,7 @@ def main(args: argparse.Namespace):
         raise RuntimeError(
             f"Can't find the module file in the flagfile: {flag_file_path}")
       module_path = os.path.abspath(
-          os.path.join(benchmark_case.benchmark_case_dir, module_path))
+          os.path.join(benchmark_case_dir, module_path))
 
       with open(module_path, "rb") as module_file:
         module_component_sizes = get_module_component_info(

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -14,7 +14,7 @@ import pathlib
 import sys
 
 # Add build_tools python dir to the search path.
-sys.path.insert(0, str(pathlib.Path(__file__).parent / ".." / "python"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
 import argparse
 import json
@@ -168,27 +168,26 @@ def main(args: argparse.Namespace):
     benchmark_cases = benchmark_suite.filter_benchmarks_for_category(
         category=category)
     for benchmark_case in benchmark_cases:
-      benchmark_case_dir = benchmark_case.benchmark_case_dir
       # TODO(#11076): Support run_config.
-      if benchmark_case_dir is None:
+      if benchmark_case.benchmark_case_dir is None:
         raise ValueError("benchmark_case_dir can't be None.")
+      benchmark_case_dir = pathlib.Path(benchmark_case.benchmark_case_dir)
 
-      flag_file_path = os.path.join(benchmark_case_dir, BENCHMARK_FLAGFILE)
-      with open(flag_file_path, "r") as flag_file:
+      flag_file_path = benchmark_case_dir / BENCHMARK_FLAGFILE
+      with flag_file_path.open("r") as flag_file:
         module_path = get_module_path(flag_file)
 
       if module_path is None:
         raise RuntimeError(
             f"Can't find the module file in the flagfile: {flag_file_path}")
-      module_path = os.path.abspath(
-          os.path.join(benchmark_case_dir, module_path))
+      module_path = (benchmark_case_dir / module_path).resolve()
 
-      with open(module_path, "rb") as module_file:
+      with module_path.open("rb") as module_file:
         module_component_sizes = get_module_component_info(
             module_file,
             os.stat(module_path).st_size)
 
-      cmake_target = match_module_cmake_target(module_path)
+      cmake_target = match_module_cmake_target(str(module_path))
       if cmake_target is None:
         raise RuntimeError(
             f"Module path isn't a module cmake target: {module_path}")

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -10,6 +10,12 @@ The benchmark suites need to be built with ninja and enable the CMake option
 IREE_ENABLE_COMPILATION_BENCHMARKS.
 """
 
+import pathlib
+import sys
+
+# Add build_tools python dir to the search path.
+sys.path.insert(0, str(pathlib.Path(__file__).parent / ".." / "python"))
+
 import argparse
 import json
 import os

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -58,7 +58,6 @@ class DriverInfo:
   driver_name: str
   loader_name: str
 
-
 # A map for IREE driver names. This allows us to normalize driver names like
 # mapping to more friendly ones and detach to keep driver names used in
 # benchmark presentation stable.

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -58,6 +58,7 @@ class DriverInfo:
   driver_name: str
   loader_name: str
 
+
 # A map for IREE driver names. This allows us to normalize driver names like
 # mapping to more friendly ones and detach to keep driver names used in
 # benchmark presentation stable.

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -75,7 +75,7 @@ class BenchmarkCase:
 def _find_driver_info_by_execution_config(
     module_execution_config: iree_definitions.ModuleExecutionConfig
 ) -> Optional[DriverInfo]:
-  """Finds the matched driver info by the module exeuction config.
+  """Finds the matched driver info by the module execution config.
 
   Args:
     module_execution_config: module execution config to match.

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -175,7 +175,7 @@ class BenchmarkSuite(object):
     return chosen_cases
 
   @staticmethod
-  def load_from_benchmark_framework(
+  def load_from_run_configs(
       run_configs: Sequence[iree_definitions.E2EModelRunConfig]):
 
     suite_map = collections.defaultdict(list)
@@ -197,19 +197,14 @@ class BenchmarkSuite(object):
             f"Can't map execution config to driver info: {module_exec_config}.")
 
       arch_info = target_device_spec.architecture.value
-      target_arch = f"{arch_info.type}-{arch_info.architecture}-{arch_info.microarchitecture}"
+      target_arch = f"{arch_info.type.value}-{arch_info.architecture}-{arch_info.microarchitecture}"
 
       model = module_gen_config.imported_model.model
-
-      bench_mode = list(module_gen_config.compile_config.tags)
-      for tag in module_exec_config.tags:
-        if tag not in bench_mode:
-          bench_mode.append(tag)
 
       benchmark_case = BenchmarkCase(
           model_name=model.name,
           model_tags=model.tags,
-          bench_mode=bench_mode,
+          bench_mode=module_exec_config.tags,
           target_arch=target_arch,
           driver_info=driver_info,
           benchmark_tool_name="iree-benchmark-module",

--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -198,6 +198,13 @@ class BenchmarkSuite(object):
   @staticmethod
   def load_from_run_configs(
       run_configs: Sequence[iree_definitions.E2EModelRunConfig]):
+    """Loads the benchmarks from the run configs.
+
+    Args:
+      run_configs: list of benchmark run configs.
+    Returns:
+      A benchmark suite.
+    """
 
     suite_map = collections.defaultdict(list)
     for run_config in run_configs:

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -9,8 +9,9 @@ import os
 import tempfile
 import unittest
 from typing import Sequence
-from common.benchmark_definition import IREE_DRIVERS_INFOS
+from common.benchmark_definition import IREE_DRIVERS_INFOS, DriverInfo
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
+from e2e_test_framework.definitions import common_definitions, iree_definitions
 
 
 class BenchmarkSuiteTest(unittest.TestCase):
@@ -125,6 +126,123 @@ class BenchmarkSuiteTest(unittest.TestCase):
               available_loaders=[],
               cpu_target_arch_filter="cpu-armv8",
               gpu_target_arch_filter="gpu-mali"), [case2])
+
+  def test_load_from_run_configs(self):
+    model_tflite = common_definitions.Model(
+        id="tflite",
+        name="model_tflite",
+        tags=[],
+        source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
+        source_url="",
+        entry_function="predict",
+        input_types=["1xf32"])
+    model_tf = common_definitions.Model(
+        id="tf",
+        name="model_tf",
+        tags=[],
+        source_type=common_definitions.ModelSourceType.EXPORTED_TF,
+        source_url="",
+        entry_function="predict",
+        input_types=["1xf32"])
+    exec_config_a = iree_definitions.ModuleExecutionConfig(
+        id="exec_a",
+        tags=["defaults"],
+        loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
+        driver=iree_definitions.RuntimeDriver.LOCAL_SYNC)
+    exec_config_b = iree_definitions.ModuleExecutionConfig(
+        id="exec_b",
+        tags=["experimental"],
+        loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
+        driver=iree_definitions.RuntimeDriver.LOCAL_TASK)
+    device_spec_a = common_definitions.DeviceSpec(
+        id="dev_a",
+        vendor_name="a",
+        architecture=common_definitions.DeviceArchitecture.RV32_GENERIC,
+        platform=common_definitions.DevicePlatform.GENERIC_LINUX,
+        device_parameters=[])
+    device_spec_b = common_definitions.DeviceSpec(
+        id="dev_b",
+        vendor_name="b",
+        architecture=common_definitions.DeviceArchitecture.RV64_GENERIC,
+        platform=common_definitions.DevicePlatform.GENERIC_LINUX,
+        device_parameters=[])
+    run_config_a = iree_definitions.E2EModelRunConfig(
+        module_generation_config=iree_definitions.ModuleGenerationConfig(
+            imported_model=iree_definitions.ImportedModel.from_model(
+                model_tflite),
+            compile_config=iree_definitions.CompileConfig(id="1",
+                                                          tags=[],
+                                                          compile_targets=[])),
+        module_execution_config=exec_config_a,
+        target_device_spec=device_spec_a,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    run_config_b = iree_definitions.E2EModelRunConfig(
+        module_generation_config=iree_definitions.ModuleGenerationConfig(
+            imported_model=iree_definitions.ImportedModel.from_model(
+                model_tflite),
+            compile_config=iree_definitions.CompileConfig(id="2",
+                                                          tags=[],
+                                                          compile_targets=[])),
+        module_execution_config=exec_config_b,
+        target_device_spec=device_spec_b,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    run_config_c = iree_definitions.E2EModelRunConfig(
+        module_generation_config=iree_definitions.ModuleGenerationConfig(
+            imported_model=iree_definitions.ImportedModel.from_model(model_tf),
+            compile_config=iree_definitions.CompileConfig(id="3",
+                                                          tags=[],
+                                                          compile_targets=[])),
+        module_execution_config=exec_config_a,
+        target_device_spec=device_spec_a,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    run_configs = [run_config_a, run_config_b, run_config_c]
+
+    suite = BenchmarkSuite.load_from_run_configs(run_configs=run_configs)
+
+    self.assertEqual(suite.list_categories(),
+                     [("exported_tf", "exported_tf"),
+                      ("exported_tflite", "exported_tflite")])
+    self.assertEqual(
+        suite.filter_benchmarks_for_category(category="exported_tflite"), [
+            BenchmarkCase(model_name=model_tflite.name,
+                          model_tags=model_tflite.tags,
+                          bench_mode=exec_config_a.tags,
+                          target_arch="cpu-rv32-generic",
+                          driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
+                          benchmark_tool_name="iree-benchmark-module",
+                          benchmark_case_dir=None,
+                          run_config=run_config_a),
+            BenchmarkCase(model_name=model_tflite.name,
+                          model_tags=model_tflite.tags,
+                          bench_mode=exec_config_b.tags,
+                          target_arch="cpu-rv64-generic",
+                          driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
+                          benchmark_tool_name="iree-benchmark-module",
+                          benchmark_case_dir=None,
+                          run_config=run_config_b)
+        ])
+    self.assertEqual(
+        suite.filter_benchmarks_for_category(
+            category="exported_tf",
+            cpu_target_arch_filter="cpu-rv32-generic",
+            model_name_filter="model_tf",
+            mode_filter="defaults"),
+        [
+            BenchmarkCase(model_name=model_tf.name,
+                          model_tags=model_tf.tags,
+                          bench_mode=exec_config_a.tags,
+                          target_arch="cpu-rv32-generic",
+                          driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
+                          benchmark_tool_name="iree-benchmark-module",
+                          benchmark_case_dir=None,
+                          run_config=run_config_c)
+        ])
+    self.assertEqual(
+        suite.filter_benchmarks_for_category(
+            category="exported_tf",
+            cpu_target_arch_filter="cpu-rv32-generic",
+            model_name_filter="model_tf",
+            mode_filter="experimental"), [])
 
   @staticmethod
   def __create_bench(dir_path: str, model_name: str, model_tags: Sequence[str],

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -9,7 +9,7 @@ import os
 import tempfile
 import unittest
 from typing import Sequence
-from common.benchmark_definition import IREE_DRIVERS_INFOS, DriverInfo
+from common.benchmark_definition import IREE_DRIVERS_INFOS
 from common.benchmark_suite import BenchmarkCase, BenchmarkSuite
 from e2e_test_framework.definitions import common_definitions, iree_definitions
 
@@ -139,7 +139,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
     model_tf = common_definitions.Model(
         id="tf",
         name="model_tf",
-        tags=[],
+        tags=["fp32"],
         source_type=common_definitions.ModelSourceType.EXPORTED_TF,
         source_url="",
         entry_function="predict",
@@ -225,7 +225,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
         suite.filter_benchmarks_for_category(
             category="exported_tf",
             cpu_target_arch_filter="cpu-rv32-generic",
-            model_name_filter="model_tf",
+            model_name_filter="model_tf.*fp32",
             mode_filter="defaults"),
         [
             BenchmarkCase(model_name=model_tf.name,
@@ -241,7 +241,6 @@ class BenchmarkSuiteTest(unittest.TestCase):
         suite.filter_benchmarks_for_category(
             category="exported_tf",
             cpu_target_arch_filter="cpu-rv32-generic",
-            model_name_filter="model_tf",
             mode_filter="experimental"), [])
 
   @staticmethod

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -33,7 +33,7 @@ import sys
 import pathlib
 
 # Add build_tools python dir to the search path.
-sys.path.insert(0, str(pathlib.Path(__file__).parent / ".." / "python"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
 import atexit
 import os

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -192,6 +192,10 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
                          benchmark_results_filename: Optional[str],
                          capture_filename: Optional[str]) -> None:
     benchmark_case_dir = benchmark_case.benchmark_case_dir
+    # TODO(#11076): Support run_config.
+    if benchmark_case_dir is None:
+      raise ValueError("benchmark_case_dir can't be None.")
+
     android_case_dir = os.path.relpath(benchmark_case_dir,
                                        self.config.root_benchmark_dir)
 

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -29,13 +29,17 @@ Example usages:
     /path/to/host/build/dir
 """
 
+import sys
+import pathlib
+
+# Add build_tools python dir to the search path.
+sys.path.insert(0, str(pathlib.Path(__file__).parent / ".." / "python"))
+
 import atexit
 import os
-import re
 import subprocess
 import tarfile
 import shutil
-import sys
 
 from typing import Optional, Sequence
 from common.benchmark_config import BenchmarkConfig

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -38,6 +38,10 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
     # TODO(pzread): Taskset should be derived from CPU topology.
     # Only use the low 8 cores.
     taskset = "0xFF"
+    
+    # TODO(#11076): Support run_config.
+    if benchmark_case.benchmark_case_dir is None:
+      raise ValueError("benchmark_case_dir can't be None.")
 
     run_flags = self.__parse_flagfile(benchmark_case.benchmark_case_dir)
     # Replace the CUDA device flag with the specified GPU.

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -6,12 +6,16 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Runs all matched benchmark suites on a Linux device."""
 
+import sys
+import pathlib
+
+# Add build_tools python dir to the search path.
+sys.path.insert(0, str(pathlib.Path(__file__).parent / ".." / "python"))
+
 import subprocess
 import atexit
 import os
-import re
 import shutil
-import sys
 import tarfile
 
 from typing import List, Optional

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -10,7 +10,7 @@ import sys
 import pathlib
 
 # Add build_tools python dir to the search path.
-sys.path.insert(0, str(pathlib.Path(__file__).parent / ".." / "python"))
+sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
 import subprocess
 import atexit

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -38,7 +38,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
     # TODO(pzread): Taskset should be derived from CPU topology.
     # Only use the low 8 cores.
     taskset = "0xFF"
-    
+
     # TODO(#11076): Support run_config.
     if benchmark_case.benchmark_case_dir is None:
       raise ValueError("benchmark_case_dir can't be None.")

--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -309,12 +309,13 @@ endfunction()
 # ARGS: Command line arguments to the Python source file.
 # LABELS: Additional labels to apply to the test. The package path is added
 #     automatically.
+# PACKAGE_DIRS: Additional python module paths.
 function(iree_build_tools_py_test)
   cmake_parse_arguments(
     _RULE
     ""
     "NAME;SRC"
-    "ARGS;LABELS"
+    "ARGS;LABELS;PACKAGE_DIRS"
     ${ARGN}
   )
 
@@ -328,6 +329,7 @@ function(iree_build_tools_py_test)
     LABELS
       ${_RULE_LABELS}
     PACKAGE_DIRS
+      ${_RULE_PACKAGE_DIRS}
       "${IREE_ROOT_DIR}/build_tools/python"
   )
 endfunction()

--- a/build_tools/python/e2e_test_artifacts/artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/artifacts.py
@@ -36,7 +36,7 @@ def _generate_artifacts_root(
       parent_path=MODEL_ARTIFACTS_ROOT, models=models)
 
   iree_artifacts_root = iree_artifacts.generate_artifacts_root(
-      parent_path=IREE_ARTIFACTS_ROOT,
+      root_path=pathlib.PurePath(),
       model_artifacts_root=model_artifacts_root,
       module_generation_configs=iree_module_generation_configs)
 

--- a/build_tools/python/e2e_test_artifacts/artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/artifacts.py
@@ -26,7 +26,7 @@ class ArtifactsRoot(object):
 
 
 def _generate_artifacts_root(
-    models: Sequence[common_definitions.Model],
+    root_dir_path: pathlib.PurePath, models: Sequence[common_definitions.Model],
     iree_module_generation_configs: Sequence[
         iree_definitions.ModuleGenerationConfig]
 ) -> ArtifactsRoot:
@@ -36,7 +36,7 @@ def _generate_artifacts_root(
       parent_path=MODEL_ARTIFACTS_ROOT, models=models)
 
   iree_artifacts_root = iree_artifacts.generate_artifacts_root(
-      root_path=pathlib.PurePath(),
+      root_dir_path=root_dir_path,
       model_artifacts_root=model_artifacts_root,
       module_generation_configs=iree_module_generation_configs)
 
@@ -52,5 +52,7 @@ def generate_default_artifacts_root() -> ArtifactsRoot:
    _) = benchmark_collections.generate_benchmarks()
 
   return _generate_artifacts_root(
+      # Set empty root path to generate the relative paths.
+      root_dir_path=pathlib.PurePath(),
       models=model_groups.ALL,
       iree_module_generation_configs=iree_module_generation_configs)

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -70,7 +70,15 @@ def get_module_path(
     module_generation_config: iree_definitions.ModuleGenerationConfig,
     root_dir_path: pathlib.PurePath = pathlib.PurePath()
 ) -> pathlib.PurePath:
-  """Returns the path of an IREE compiled module."""
+  """Returns the path of an IREE compiled module.
+  
+  Args:
+    module_generation_config: IREE module generation config.
+    root_dir_path: path of the root artifact directory, on which the returned
+      path will be based.
+  Returns:
+    Path of the module file.
+  """
   model_dir_path = _get_model_dir_path(
       root_dir_path=root_dir_path,
       imported_model=module_generation_config.imported_model)

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -48,7 +48,6 @@ def _get_imported_model_path(
     parent_path: pathlib.PurePath,
     imported_model: iree_definitions.ImportedModel,
     model_artifact: model_artifacts.ModelArtifact) -> pathlib.PurePath:
-  """Returns the path of an IREE imported MLIR file."""
   model = imported_model.model
   if model.source_type == common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR:
     # Uses the MLIR model directly.

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -48,6 +48,7 @@ def _get_imported_model_path(
     parent_path: pathlib.PurePath,
     imported_model: iree_definitions.ImportedModel,
     model_artifact: model_artifacts.ModelArtifact) -> pathlib.PurePath:
+  """Returns the path of an IREE imported MLIR file."""
   model = imported_model.model
   if model.source_type == common_definitions.ModelSourceType.EXPORTED_LINALG_MLIR:
     # Uses the MLIR model directly.
@@ -56,48 +57,41 @@ def _get_imported_model_path(
   return parent_path / f"{model.name}.mlir"
 
 
-def get_model_dir_path(
+def _get_model_dir_path(
     imported_model: iree_definitions.ImportedModel,
-    root_path: pathlib.PurePath = pathlib.PurePath()
+    root_dir_path: pathlib.PurePath = pathlib.PurePath()
 ) -> pathlib.PurePath:
+  """Returns the path of an IREE model dir."""
   model = imported_model.model
   # IREE model dir: <parent_path>/<model_id>_<model_name>
-  return root_path / IREE_ARTIFACTS_ROOT / f"{model.id}_{model.name}"
-
-
-def get_module_dir_path(
-    module_generation_config: iree_definitions.ModuleGenerationConfig,
-    root_path: pathlib.PurePath = pathlib.PurePath()
-) -> pathlib.PurePath:
-  dir_path = get_model_dir_path(
-      root_path=root_path,
-      imported_model=module_generation_config.imported_model)
-  # Module dir path: <model_dir_path>/<compile_config_id>
-  return dir_path / module_generation_config.compile_config.id
+  return root_dir_path / IREE_ARTIFACTS_ROOT / f"{model.id}_{model.name}"
 
 
 def get_module_path(
     module_generation_config: iree_definitions.ModuleGenerationConfig,
-    root_path: pathlib.PurePath = pathlib.PurePath()
+    root_dir_path: pathlib.PurePath = pathlib.PurePath()
 ) -> pathlib.PurePath:
-  dir_path = get_module_dir_path(
-      root_path=root_path, module_generation_config=module_generation_config)
-  # Module path: <module_dir_path>/<model_name>.vmfb
-  return dir_path / f"{module_generation_config.imported_model.model.name}.vmfb"
+  """Returns the path of an IREE compiled module."""
+  model_dir_path = _get_model_dir_path(
+      root_dir_path=root_dir_path,
+      imported_model=module_generation_config.imported_model)
+  # Module path: <model_dir_path>/<compile_config_id>/<model_name>.vmfb
+  return model_dir_path / module_generation_config.compile_config.id / f"{module_generation_config.imported_model.model.name}.vmfb"
 
 
 def _build_module_directory(
-    root_path: pathlib.PurePath,
+    root_dir_path: pathlib.PurePath,
     module_generation_config: iree_definitions.ModuleGenerationConfig
 ) -> ModuleDirectory:
   compile_config = module_generation_config.compile_config
   module_path = get_module_path(
-      root_path=root_path, module_generation_config=module_generation_config)
+      root_dir_path=root_dir_path,
+      module_generation_config=module_generation_config)
   return ModuleDirectory(module_path=module_path, compile_config=compile_config)
 
 
 def generate_artifacts_root(
-    root_path: pathlib.PurePath,
+    root_dir_path: pathlib.PurePath,
     model_artifacts_root: model_artifacts.ArtifactsRoot,
     module_generation_configs: Sequence[iree_definitions.ModuleGenerationConfig]
 ) -> ArtifactsRoot:
@@ -114,14 +108,14 @@ def generate_artifacts_root(
 
   model_dir_map = collections.OrderedDict()
   for imported_model in all_imported_models.values():
-    model_dir_path = get_model_dir_path(root_path=root_path,
-                                        imported_model=imported_model)
+    model_dir_path = _get_model_dir_path(root_dir_path=root_dir_path,
+                                         imported_model=imported_model)
     model = imported_model.model
 
     module_dir_map = collections.OrderedDict()
     for config in grouped_generation_configs[model.id]:
       module_dir_map[config.compile_config.id] = _build_module_directory(
-          root_path=root_path, module_generation_config=config)
+          root_dir_path=root_dir_path, module_generation_config=config)
 
     model_artifact = model_artifacts_root.model_artifact_map.get(model.id)
     if model_artifact is None:

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -13,6 +13,8 @@ import pathlib
 from e2e_test_artifacts import model_artifacts
 from e2e_test_framework.definitions import common_definitions, iree_definitions
 
+IREE_ARTIFACTS_ROOT = pathlib.PurePath("iree")
+
 
 @dataclass(frozen=True)
 class ModuleDirectory(object):
@@ -54,20 +56,48 @@ def _get_imported_model_path(
   return parent_path / f"{model.name}.mlir"
 
 
+def get_model_dir_path(
+    imported_model: iree_definitions.ImportedModel,
+    root_path: pathlib.PurePath = pathlib.PurePath()
+) -> pathlib.PurePath:
+  model = imported_model.model
+  # IREE model dir: <parent_path>/<model_id>_<model_name>
+  return root_path / IREE_ARTIFACTS_ROOT / f"{model.id}_{model.name}"
+
+
+def get_module_dir_path(
+    module_generation_config: iree_definitions.ModuleGenerationConfig,
+    root_path: pathlib.PurePath = pathlib.PurePath()
+) -> pathlib.PurePath:
+  dir_path = get_model_dir_path(
+      root_path=root_path,
+      imported_model=module_generation_config.imported_model)
+  # Module dir path: <model_dir_path>/<compile_config_id>
+  return dir_path / module_generation_config.compile_config.id
+
+
+def get_module_path(
+    module_generation_config: iree_definitions.ModuleGenerationConfig,
+    root_path: pathlib.PurePath = pathlib.PurePath()
+) -> pathlib.PurePath:
+  dir_path = get_module_dir_path(
+      root_path=root_path, module_generation_config=module_generation_config)
+  # Module path: <module_dir_path>/<model_name>.vmfb
+  return dir_path / f"{module_generation_config.imported_model.model.name}.vmfb"
+
+
 def _build_module_directory(
-    parent_path: pathlib.PurePath,
+    root_path: pathlib.PurePath,
     module_generation_config: iree_definitions.ModuleGenerationConfig
 ) -> ModuleDirectory:
   compile_config = module_generation_config.compile_config
-  # IREE module dir: <parent_path>/<compile_config_id>
-  dir_path = parent_path / compile_config.id
-  # Module path: <parent_path>/<compile_config_id>/<model_name>.vmfb
-  module_path = dir_path / f"{module_generation_config.imported_model.model.name}.vmfb"
+  module_path = get_module_path(
+      root_path=root_path, module_generation_config=module_generation_config)
   return ModuleDirectory(module_path=module_path, compile_config=compile_config)
 
 
 def generate_artifacts_root(
-    parent_path: pathlib.PurePath,
+    root_path: pathlib.PurePath,
     model_artifacts_root: model_artifacts.ArtifactsRoot,
     module_generation_configs: Sequence[iree_definitions.ModuleGenerationConfig]
 ) -> ArtifactsRoot:
@@ -84,14 +114,14 @@ def generate_artifacts_root(
 
   model_dir_map = collections.OrderedDict()
   for imported_model in all_imported_models.values():
+    model_dir_path = get_model_dir_path(root_path=root_path,
+                                        imported_model=imported_model)
     model = imported_model.model
-    # IREE model dir: <parent_path>/<model_id>_<model_name>
-    model_dir_path = parent_path / f"{model.id}_{model.name}"
 
     module_dir_map = collections.OrderedDict()
     for config in grouped_generation_configs[model.id]:
       module_dir_map[config.compile_config.id] = _build_module_directory(
-          parent_path=model_dir_path, module_generation_config=config)
+          root_path=root_path, module_generation_config=config)
 
     model_artifact = model_artifacts_root.model_artifact_map.get(model.id)
     if model_artifact is None:

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
@@ -14,6 +14,20 @@ from e2e_test_artifacts import model_artifacts, iree_artifacts, test_configs
 
 class IreeArtifactsTest(unittest.TestCase):
 
+  def test_get_module_path(self):
+    gen_config = iree_definitions.ModuleGenerationConfig(
+        imported_model=test_configs.TFLITE_IMPORTED_MODEL,
+        compile_config=test_configs.COMPILE_CONFIG_A)
+    root_dir_path = pathlib.PurePath("root")
+
+    path = iree_artifacts.get_module_path(module_generation_config=gen_config,
+                                          root_dir_path=root_dir_path)
+
+    model = gen_config.imported_model.model
+    self.assertEqual(
+        path, root_dir_path / "iree" / f"{model.id}_{model.name}" /
+        gen_config.compile_config.id / f"{model.name}.vmfb")
+
   def test_generate_artifacts_root(self):
     model_artifacts_root = model_artifacts.ArtifactsRoot(
         model_artifact_map=collections.OrderedDict({
@@ -24,10 +38,10 @@ class IreeArtifactsTest(unittest.TestCase):
                 model_artifacts.ModelArtifact(model=test_configs.TF_MODEL,
                                               file_path=pathlib.PurePath("y"))
         }))
-    parent_path = pathlib.PurePath("root", "iree")
+    root_dir_path = pathlib.PurePath("root")
 
     artifacts_root = iree_artifacts.generate_artifacts_root(
-        parent_path=parent_path,
+        root_dir_path=root_dir_path,
         model_artifacts_root=model_artifacts_root,
         module_generation_configs=[
             iree_definitions.ModuleGenerationConfig(
@@ -42,7 +56,7 @@ class IreeArtifactsTest(unittest.TestCase):
         ])
 
     expect_tflite_dir_path = (
-        parent_path /
+        root_dir_path / "iree" /
         f"{test_configs.TFLITE_MODEL.id}_{test_configs.TFLITE_MODEL.name}")
     expect_tflite_imported_model_artifact = iree_artifacts.ImportedModelArtifact(
         imported_model=test_configs.TFLITE_IMPORTED_MODEL,
@@ -63,7 +77,7 @@ class IreeArtifactsTest(unittest.TestCase):
                 compile_config=test_configs.COMPILE_CONFIG_B),
     })
     expect_tf_dir_path = (
-        parent_path /
+        root_dir_path / "iree" /
         f"{test_configs.TF_MODEL.id}_{test_configs.TF_MODEL.name}")
     expect_tf_imported_model_artifact = iree_artifacts.ImportedModelArtifact(
         imported_model=test_configs.TF_IMPORTED_MODEL,
@@ -97,11 +111,10 @@ class IreeArtifactsTest(unittest.TestCase):
                 model_artifacts.ModelArtifact(model=test_configs.TF_MODEL,
                                               file_path=pathlib.PurePath("y"))
         }))
-    parent_path = pathlib.PurePath("root", "iree")
 
     self.assertRaises(
         ValueError, lambda: iree_artifacts.generate_artifacts_root(
-            parent_path=parent_path,
+            root_dir_path=pathlib.PurePath("root"),
             model_artifacts_root=model_artifacts_root,
             module_generation_configs=[
                 iree_definitions.ModuleGenerationConfig(

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
@@ -24,8 +24,9 @@ class IreeArtifactsTest(unittest.TestCase):
                                           root_dir_path=root_dir_path)
 
     model = gen_config.imported_model.model
+    iree_artifact_root = root_dir_path / iree_artifacts.IREE_ARTIFACTS_ROOT
     self.assertEqual(
-        path, root_dir_path / "iree" / f"{model.id}_{model.name}" /
+        path, iree_artifact_root / f"{model.id}_{model.name}" /
         gen_config.compile_config.id / f"{model.name}.vmfb")
 
   def test_generate_artifacts_root(self):
@@ -55,8 +56,9 @@ class IreeArtifactsTest(unittest.TestCase):
                 compile_config=test_configs.COMPILE_CONFIG_B),
         ])
 
+    iree_artifact_root = root_dir_path / iree_artifacts.IREE_ARTIFACTS_ROOT
     expect_tflite_dir_path = (
-        root_dir_path / "iree" /
+        iree_artifact_root /
         f"{test_configs.TFLITE_MODEL.id}_{test_configs.TFLITE_MODEL.name}")
     expect_tflite_imported_model_artifact = iree_artifacts.ImportedModelArtifact(
         imported_model=test_configs.TFLITE_IMPORTED_MODEL,
@@ -77,7 +79,7 @@ class IreeArtifactsTest(unittest.TestCase):
                 compile_config=test_configs.COMPILE_CONFIG_B),
     })
     expect_tf_dir_path = (
-        root_dir_path / "iree" /
+        iree_artifact_root /
         f"{test_configs.TF_MODEL.id}_{test_configs.TF_MODEL.name}")
     expect_tf_imported_model_artifact = iree_artifacts.ImportedModelArtifact(
         imported_model=test_configs.TF_IMPORTED_MODEL,


### PR DESCRIPTION
Adds `load_from_run_configs` to `BenchmarkSuite` to load the exported benchmark run configs from e2e test framework.

This change also adds `get_module_path` to `iree_artifacts`, which is a simple way to get the compiled module path without building the whole structure of the artifact directory. I'm thinking the `iree_artifacts.ArtifactsRoot` (which is to help get all paths in the artifact directory) might be over-complicated and can be replaced by simple helper functions (like the `get_moule_path` in this change). Will clean up that part if eventually we find such design is unnecessary.