### PR TITLE
[spirv] Drop workaround for reduction after changing default

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -665,8 +665,6 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
   // requires special capability.
   if (!targetEnv.allows(spirv::Capability::GroupNonUniformShuffle))
     return failure();
-  // TODO: Remove the following once SwiftShader is detached from the default.
-  if (targetEnv.getVendorID() == spirv::Vendor::SwiftShader) return failure();
 
   SmallVector<unsigned> reductionDims;
   op.getReductionDims(reductionDims);


### PR DESCRIPTION
https://github.com/iree-org/iree/pull/10529 updated the default so now we can drop this temorary workaround.