### PR TITLE
Introduce a transform.do_not_dce_operands

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
@@ -71,6 +71,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
   DEPS
     ::CommonExtensionsOpGen
     IREEDialectsTransforms
+    IREELinalgExtDialect
     IREELinalgTransformDialect
     LLVMSupport
     MLIRAffineDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -637,17 +637,21 @@ void addTransformDialectInterpreterPasses(OpPassManager &passManager) {
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
           clCPUCodegenTransformDialectFileName));
-
-  // Dropping the schedule is only needed if we want to embed the transform in
-  // the module: we should drop the schedule once applied.
-  // This pass does nothing in the case where we apply a separate policy
-  // through a file.
+  // Dropping the schedule is needed:
+  //   1. if we want to embed the transform in the module: we should drop the
+  //      schedule once applied.
+  //   2. if transform.do_not_dce_operands ops are introduced.
   passManager.addPass(createDropSchedulePass());
 }
 
 void addTransformDialectJitterPasses(OpPassManager &passManager) {
   // Give control to the transform dialect.
   passManager.addPass(mlir::iree_compiler::createTransformDialectJitterPass());
+  // Dropping the schedule is needed:
+  //   1. if we want to embed the transform in the module: we should drop the
+  //      schedule once applied.
+  //   2. if transform.do_not_dce_operands ops are introduced.
+  passManager.addPass(createDropSchedulePass());
 }
 
 static void addLowerToLLVMPasses(OpPassManager &passManager) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -414,16 +414,21 @@ void addGPUTransformDialectInterpreterPasses(OpPassManager &passManager) {
       mlir::iree_compiler::createTransformDialectInterpreterPass(
           clGPUCodegenTransformDialectFileName));
 
-  // Dropping the schedule is only needed if we want to embed the transform in
-  // the module: we should drop the schedule once applied.
-  // This pass does nothing in the case where we apply a separate policy
-  // through a file.
+  // Dropping the schedule is needed:
+  //   1. if we want to embed the transform in the module: we should drop the
+  //      schedule once applied.
+  //   2. if transform.do_not_dce_operands ops are introduced.
   passManager.addPass(createDropSchedulePass());
 }
 
 void addGPUTransformDialectJitterPasses(OpPassManager &passManager) {
   // Give control to the transform dialect.
   passManager.addPass(mlir::iree_compiler::createTransformDialectJitterPass());
+  // Dropping the schedule is needed:
+  //   1. if we want to embed the transform in the module: we should drop the
+  //      schedule once applied.
+  //   2. if transform.do_not_dce_operands ops are introduced.
+  passManager.addPass(createDropSchedulePass());
 }
 
 void buildLLVMGPUTransformPassPipeline(OpPassManager &pm, bool useROCM) {

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -17,6 +17,24 @@ include "mlir/Interfaces/TilingInterface.td"
 include "mlir/Interfaces/ViewLikeInterface.td"
 
 
+def IREELinalgExt_DoNotDCEOperandsOp : 
+  Op<IREELinalgExt_Dialect, "transform.do_not_dce_operands", []> {
+  let summary = "Unfoldable op that just keeps its operands live";
+  let description = [{
+    Unfoldable op that just keeps its operands live. This is to use with the 
+    transform dialect in case where transforms introduce IR that would be 
+    otherwise DCE'd by canonicalizations.
+
+    This op should be added to the transform dialect in the fullness of time but
+    it can't be registered dynamically on the IREE side as that triggers errors
+    since the op does not implement any transform interface.
+  }];
+
+  let arguments = (ins Variadic<AnyType>:$operands);
+  let results = (outs);
+  let assemblyFormat = "attr-dict $operands `:` type($operands)";
+}
+
 //===----------------------------------------------------------------------===//
 // Base class.
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
@@ -33,7 +33,7 @@ public:
 #endif // LLVM_ENABLE_ABI_BREAKING_CHECKS
   }
 
-  void notifyOperationReplaced(Operation *op, ValueRange newValues) override;
+  void notifyRootReplaced(Operation *op, ValueRange newValues) override;
 
   void notifyOperationRemoved(Operation *op) override;
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -442,8 +442,8 @@ static Operation *findSingleDefiningOp(Operation *replacedOp,
       });
 }
 
-void mlir::TrackingListener::notifyOperationReplaced(Operation *op,
-                                                     ValueRange newValues) {
+void mlir::TrackingListener::notifyRootReplaced(Operation *op,
+                                                ValueRange newValues) {
   // Bail out if in error state.
   if (hadErrors)
     return;

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/Passes.h"
 #include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h"
@@ -240,6 +241,8 @@ struct DropSchedulePass : public PassWrapper<DropSchedulePass, Pass> {
 
   void runOnOperation() override {
     getOperation()->walk<WalkOrder::PreOrder>([&](Operation *nestedOp) {
+      if (isa<iree_compiler::IREE::LinalgExt::DoNotDCEOperandsOp>(nestedOp))
+        nestedOp->erase();
       if (isa<::mlir::transform::TransformOpInterface>(nestedOp)) {
         nestedOp->erase();
         return WalkResult::skip();

--- a/llvm-external-projects/iree-dialects/lib/Transforms/Listener.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/Listener.cpp
@@ -28,10 +28,9 @@ void ListenerList::notifyBlockCreated(Block *block) {
     listener->notifyBlockCreated(block);
 }
 
-void ListenerList::notifyOperationReplaced(Operation *op,
-                                           ValueRange newValues) {
+void ListenerList::notifyRootReplaced(Operation *op, ValueRange newValues) {
   for (RewriteListener *listener : listeners)
-    listener->notifyOperationReplaced(op, newValues);
+    listener->notifyRootReplaced(op, newValues);
 }
 
 void ListenerList::notifyOperationRemoved(Operation *op) {
@@ -39,10 +38,12 @@ void ListenerList::notifyOperationRemoved(Operation *op) {
     listener->notifyOperationRemoved(op);
 }
 
-void ListenerList::notifyMatchFailure(
-    Operation *op, function_ref<void(Diagnostic &)> reasonCallback) {
+LogicalResult ListenerList::notifyMatchFailure(
+    Location loc, function_ref<void(Diagnostic &)> reasonCallback) {
+  bool failed = false;
   for (RewriteListener *listener : listeners)
-    listener->notifyMatchFailure(op, reasonCallback);
+    failed |= listener->notifyMatchFailure(loc, reasonCallback).failed();
+  return failure(failed);
 }
 
 } // namespace mlir

--- a/llvm-external-projects/iree-dialects/lib/Transforms/ListenerCSE.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/ListenerCSE.cpp
@@ -334,7 +334,7 @@ void CSE::replaceUsesAndDelete(ScopedMapTy &knownValues, Operation *op,
     // END copied from mlir/lib/Transforms/CSE.cpp
     //===----------------------------------------------------------------------===//
     if (listener)
-      listener->notifyOperationReplaced(op, existing->getResults());
+      listener->notifyRootReplaced(op, existing->getResults());
     //===----------------------------------------------------------------------===//
     // BEGIN copied from mlir/lib/Transforms/CSE.cpp
     //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/test/lib/Transforms/TestListenerPasses.cpp
+++ b/llvm-external-projects/iree-dialects/test/lib/Transforms/TestListenerPasses.cpp
@@ -17,7 +17,7 @@ namespace {
 /// The test listener prints stuff to `stdout` so that it can be checked by lit
 /// tests.
 struct TestListener : public RewriteListener {
-  void notifyOperationReplaced(Operation *op, ValueRange newValues) override {
+  void notifyRootReplaced(Operation *op, ValueRange newValues) override {
     llvm::outs() << "REPLACED " << op->getName() << "\n";
   }
   void notifyOperationRemoved(Operation *op) override {


### PR DESCRIPTION
The new op is introduced in LinalgExt for now as it cannot be dynamically registered into the transform dialect atm. With this op, canonicalized_sequence does not DCE the SSA values introduced by ConfigExtractPartOp.

This is necessary to allow the next part of the config to be extracted without either DCE or dropped attributes under transforms limiting us.

With the existing ListenerGreedyPatternRewriteDriver.cpp, the new op would still be DCE'ed (!!!). 
So we also adapt the code to its recent upstream evolution.