### PR TITLE
Add support for extracting second-level tiling from config.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectJitterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectJitterPass.cpp
@@ -130,7 +130,7 @@ template <typename TilingTransformOp, typename TileOrNumThreadSpec,
 static Value tileAndFuseAndDistributeImpl(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     std::conditional_t<std::is_same_v<TileOrNumThreadKind, TileOrNumThreadList>,
-                       ArrayRef<int64_t>, Value>
+                       ArrayRef<int64_t>, ArrayRef<OpFoldResult>>
         tileSizesOrNumThreads,
     ArrayAttr threadDimMapping, SmallVector<Value> *resultingFusedOpsHandles) {
   auto tileToForeachOp = b.create<TilingTransformOp>(
@@ -171,20 +171,21 @@ static Value tfdWithTileSizeHandle(
     SmallVector<Value> *resultingFusedOpsHandles = nullptr) {
   return tileAndFuseAndDistributeImpl<
       TilingTransformOp, transform::TileSizesSpec, BatchOrIterativeFusion,
-      TileOrNumThreadHandle>(b, rootH, opsHToFuse, tileSizeHandle,
+      TileOrNumThreadHandle>(b, rootH, opsHToFuse,
+                             ArrayRef<OpFoldResult>{tileSizeHandle},
                              threadDimMapping, resultingFusedOpsHandles);
 }
 
 template <typename TilingTransformOp = TileToForeachThreadOp,
           typename BatchOrIterativeFusion = BatchFusionSpec>
-static Value tfdWithNumThreads(
+static Value tfdWithNumThreadsHandle(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<int64_t> numThreads, ArrayAttr threadDimMapping = {},
+    Value numThreads, ArrayAttr threadDimMapping = {},
     SmallVector<Value> *resultingFusedOpsHandles = nullptr) {
   return tileAndFuseAndDistributeImpl<
       TilingTransformOp, transform::NumThreadsSpec, BatchOrIterativeFusion>(
-      b, rootH, opsHToFuse, numThreads, threadDimMapping,
-      resultingFusedOpsHandles);
+      b, rootH, opsHToFuse, ArrayRef<OpFoldResult>{numThreads},
+      threadDimMapping, resultingFusedOpsHandles);
 }
 
 /// Apply patterns and vectorize (for now always applies rank-reduction).
@@ -224,16 +225,8 @@ static Value distributeVectors(ImplicitLocOpBuilder &b, Value funcH,
 /// allows the transform dialect to build payload IR and not risk seeing it
 /// being DCE'd away immediately.
 static Value buildReductionStrategyBlockDistributionPart(
-    ImplicitLocOpBuilder &b, Value variantH) {
-  // TODO: this still requires specific knowledge of ops present in the IR
-  // and is brittle.
-  Value originalFillH =
-      b.create<MatchOp>(variantH, linalg::FillOp::getOperationName());
-  Value originalGenericH =
-      b.create<MatchOp>(variantH, linalg::GenericOp::getOperationName());
-  Value tileSizes =
-      b.create<ConfigExtractPart>(originalGenericH, "tile_sizes", 0);
-
+    ImplicitLocOpBuilder &b, Value variantH, Value originalFillH,
+    Value originalGenericH, Value tileSizes0Generic) {
   // Step 1. Split the reduction to get meatier parallelism.
   // TODO: use a scf.foreach_thread for this.
   auto splitReductionTransformOp =
@@ -254,9 +247,47 @@ static Value buildReductionStrategyBlockDistributionPart(
   tfdWithTileSizeHandle<TileToForeachThreadAndWorkgroupCountRegionOp>(
       b,
       /*rootH=*/combinerH,
-      /*opsHToFuse=*/{originalFillH, splitFillH, splitLinalgH}, tileSizes,
-      b.getArrayAttr({x}));
+      /*opsHToFuse=*/{originalFillH, splitFillH, splitLinalgH},
+      tileSizes0Generic, b.getArrayAttr({x}));
 
+  return variantH;
+}
+
+static Value buildReductionStrategyThreadDistributionPart(
+    ImplicitLocOpBuilder &b, Value variantH, Value tileSizes1Fill,
+    Value tileSizes1Generic) {
+  // TODO: Relying on ordering is brittle, harden this.
+  auto [fill2dH, parParRedH, fill1dH, parRedH] = matchAndUnpack<4>(
+      b, variantH,
+      ArrayRef<StringRef>{linalg::GenericOp::getOperationName(),
+                          linalg::FillOp::getOperationName()});
+  auto z = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
+                                                ::mlir::gpu::Threads::DimZ);
+  auto y = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
+                                                ::mlir::gpu::Threads::DimY);
+  (void)z;
+  (void)y;
+
+  // clang-format off
+  tfdWithTileSizes<TileToForeachThreadOp>(b,
+                   /*rootH=*/parRedH,
+                   /*opsHToFuse=*/{fill1dH},
+                  // TODO: activate this, we have the information but it does
+                  // not generate the IR we want atm.
+                  //  /*tileSizes=*/tileSizes1Fill,
+                  //  /*threadDimMapping=*/b.getArrayAttr({y}));
+                   /*tileSizes=*/ArrayRef<int64_t>{1, 0, 0},
+                   /*threadDimMapping=*/b.getArrayAttr({z}));
+  tfdWithTileSizes<TileToForeachThreadOp>(b,
+                   /*rootH=*/parParRedH,
+                   /*opsHToFuse=*/{fill2dH},
+                  // TODO: activate this, we have the information but it does
+                  // not generate the IR we want atm.
+                  //  /*tileSizes=*/tileSizes1Generic,
+                  //  /*threadDimMapping=*/b.getArrayAttr({y}));
+                   /*tileSizes=*/ArrayRef<int64_t>{1, 1, 0},
+                   /*threadDimMapping=*/b.getArrayAttr({z,y}));
+  // clang-format on
   return variantH;
 }
 
@@ -264,34 +295,31 @@ static Value buildReductionStrategyBlockDistributionPart(
 // TODO: significantly shrink this down.
 static void buildReductionCudaStrategy(ImplicitLocOpBuilder &b,
                                        Value variantH) {
+  // Step 0. Fetch transform information from the config and materialize it in
+  // the payload IR.
+  // TODO: this still requires specific knowledge of ops present in the IR
+  // and is very brittle.
+  Value originalFillH =
+      b.create<MatchOp>(variantH, linalg::FillOp::getOperationName());
+  Value originalGenericH =
+      b.create<MatchOp>(variantH, linalg::GenericOp::getOperationName());
+  Value tileSizes0Generic =
+      b.create<ConfigExtractPart>(originalGenericH, "tile_sizes", 0);
+  Value tileSizes1Fill =
+      b.create<ConfigExtractPart>(originalFillH, "tile_sizes", 1);
+  Value tileSizes1Generic =
+      b.create<ConfigExtractPart>(originalGenericH, "tile_sizes", 1);
+
   // Step 1: Distribute to blocks using the current IREE lowering config.
-  variantH = buildReductionStrategyBlockDistributionPart(b, variantH);
+  variantH = buildReductionStrategyBlockDistributionPart(
+      b, variantH, originalFillH, originalGenericH, tileSizes0Generic);
 
   // Step 2. Second level of tiling + fusion parallelizes to threads.
-  // TODO: Relying on ordering is brittle, harden this.
-  auto [fill2dH, parParRedH, fill1dH, parRedH] = matchAndUnpack<4>(
-      b, variantH,
-      ArrayRef<StringRef>{linalg::GenericOp::getOperationName(),
-                          linalg::FillOp::getOperationName()});
-  auto y = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
-                                                ::mlir::gpu::Threads::DimY);
-  auto z = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
-                                                ::mlir::gpu::Threads::DimZ);
-  // clang-format off
-  tfdWithTileSizes(b,
-                   /*rootH=*/parRedH,
-                   /*opsHToFuse=*/{fill1dH},
-                   /*tileSizes=*/ArrayRef<int64_t>{1, 0, 0},
-                   /*threadDimMapping=*/b.getArrayAttr({z}));
-  tfdWithTileSizes(b,
-                   /*rootH=*/parParRedH,
-                   /*opsHToFuse=*/{fill2dH},
-                   /*tileSizes=*/ArrayRef<int64_t>{1, 1, 0},
-                   /*threadDimMapping=*/b.getArrayAttr({z,y}));
-  // clang-format on
+  variantH = buildReductionStrategyThreadDistributionPart(
+      b, variantH, tileSizes1Fill, tileSizes1Generic);
 
   // Step 3. Rank-reduce and vectorize.
-  // TODO: assumes a single func::FuncOp to transform, may ned hardening.
+  // TODO: assumes a single func::FuncOp to transform, may need hardening.
   Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
   funcH = vectorize(b, funcH);
 
@@ -302,6 +330,7 @@ static void buildReductionCudaStrategy(ImplicitLocOpBuilder &b,
   // Need to match again since bufferize invalidated all handles.
   // TODO: assumes a single func::FuncOp to transform, may ned hardening.
   funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
+  // TODO: extract workgroup_size from config.
   funcH = mapToBlockAndThreads(b, funcH, ArrayRef<int64_t>{32, 2, 1});
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
@@ -339,9 +368,8 @@ class TransformDialectJitterPass
                     scf::SCFDialect,
                     tensor::TensorDialect,
                     transform::TransformDialect,
-                    vector::VectorDialect
-        // clang-format on
-        >();
+                    vector::VectorDialect>();
+    // clang-format on
 
     // TODO: these should be registered by the extension instead, but there
     // is no support for it in core currently.

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
@@ -84,6 +84,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:LinalgTransforms",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefTransforms",
+        "@llvm-project//mlir:PDLDialect",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
         "@llvm-project//mlir:TensorDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CMakeLists.txt
@@ -45,6 +45,7 @@ iree_cc_library(
     MLIRLinalgTransforms
     MLIRMemRefDialect
     MLIRMemRefTransforms
+    MLIRPDLDialect
     MLIRPass
     MLIRSCFDialect
     MLIRTensorDialect

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -211,8 +211,7 @@ def TileToForeachThreadAndWorkgroupCountRegionOp :
                    Variadic<PDL_Operation>:$tile_sizes,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$static_num_threads,
                    DefaultValuedAttr<I64ArrayAttr, "{}">:$static_tile_sizes,
-                   OptionalAttr<DeviceMappingArrayAttr>:$mapping,
-                   UnitAttr:$packed_sizes);
+                   OptionalAttr<DeviceMappingArrayAttr>:$mapping);
   let results = (outs PDL_Operation:$foreach_thread_op,
                       PDL_Operation:$tiled_op);
   let assemblyFormat = [{
@@ -236,11 +235,6 @@ def TileToForeachThreadAndWorkgroupCountRegionOp :
                    CArg<"ArrayAttr", "{}">:$mapping)>,
     OpBuilder<(ins "Value":$target,
                    "ArrayRef<OpFoldResult>":$mixedTileSizes,
-                   CArg<"::mlir::transform::TileSizesSpec",
-                        "::mlir::transform::TileSizesSpec()">,
-                   CArg<"ArrayAttr", "{}">:$mapping)>,
-    OpBuilder<(ins "Value":$target,
-                   "Value":$tileSizeHandle,
                    CArg<"::mlir::transform::TileSizesSpec",
                         "::mlir::transform::TileSizesSpec()">,
                    CArg<"ArrayAttr", "{}">:$mapping)>,


### PR DESCRIPTION
This commit allows using the extracted config values for the second level tiling.
In the process, we add the ability to dynamically extract list of operations from pdl::OperationType values, both here and upstream.

This greatly simplifies manipulating pdl::Operation that capture lists of operations, interspersed with regular Values and Attr.