### PR TITLE
Update pybind11 to latest.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
     runs-on: managed-windows-cpu
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    if: needs.setup.outputs.should-run == 'true'
     runs-on: managed-windows-cpu
     defaults:
       run:

--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -9,7 +9,7 @@ requires = [
     # MLIR build depends.
     "numpy",
     "packaging",
-    "pybind11>=2.8.0",
+    "pybind11>=2.10.1",
     "PyYAML",
 ]
 build-backend = "setuptools.build_meta"

--- a/runtime/bindings/python/iree/runtime/build_requirements.txt
+++ b/runtime/bindings/python/iree/runtime/build_requirements.txt
@@ -4,7 +4,7 @@
 #   python -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
 
 numpy>=1.19.4
-pybind11>=2.8.0
+pybind11>=2.10.1
 requests
 wheel>=0.36.2
 PyYAML>=5.4.1

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "cmake==3.22.2",
     "ninja==1.10.2",
     "packaging",
-    "pybind11>=2.8.0",
+    "pybind11>=2.10.1",
     "PyYAML",
     "requests",
 ]


### PR DESCRIPTION
This fixes a build failure of the Python bindings on Windows. We were testing Python 3.10.8, but now we are testing Python 3.11.0.
* Old 3.10.8 success: https://github.com/iree-org/iree/actions/runs/3452338984/jobs/5762178428
* Old 3.11.0 failure: https://github.com/iree-org/iree/actions/runs/3461697554/jobs/5779634638

New successful run on Python 3.11.0: https://github.com/iree-org/iree/actions/runs/3463493036/jobs/5783809576