### PR TITLE
Fixing current deprecation warnings and re-enabling them.

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -97,7 +97,6 @@ build:generic_clang --copt=-Wall
 # ratio.
 build:generic_clang --copt=-Wno-ambiguous-member-template
 build:generic_clang --copt=-Wno-char-subscripts
-build:generic_clang --copt=-Wno-deprecated-declarations
 build:generic_clang --copt=-Wno-extern-c-compat # Matches upstream. Cannot impact due to extern C inclusion method.
 build:generic_clang --copt=-Wno-gnu-alignof-expression
 build:generic_clang --copt=-Wno-gnu-variable-sized-type-not-at-end

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -151,7 +151,6 @@ iree_select_compiler_opts(IREE_DEFAULT_COPTS
     # signal/noise ratio.
     "-Wno-ambiguous-member-template"
     "-Wno-char-subscripts"
-    "-Wno-deprecated-declarations"
     "-Wno-extern-c-compat" # Matches upstream. Cannot impact due to extern C inclusion method.
     "-Wno-gnu-alignof-expression"
     "-Wno-gnu-variable-sized-type-not-at-end"

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -87,7 +87,7 @@ static LogicalResult getTileAndDistributeConfig(
   // supported max.
   // TODO(ravishankarm): Relax this restriction.
   if (partitionableLoops.size() > kNumMaxParallelDims) {
-    return rootOp.getValue()->emitOpError(
+    return rootOp.value()->emitOpError(
                "expected number of partitionable loops to be less than or "
                "equal to ")
            << kNumMaxParallelDims;
@@ -95,7 +95,7 @@ static LogicalResult getTileAndDistributeConfig(
 
   IREE::Codegen::LoweringConfigAttr rootOpConfig = getLoweringConfig(*rootOp);
   if (!rootOpConfig) {
-    return rootOp.getValue()->emitOpError(
+    return rootOp.value()->emitOpError(
         "unable to find configuration of root op to define workgroup count "
         "region");
   }

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -52,7 +52,7 @@ static llvm::SmallVector<utils::IteratorType> getIteratorTypesFromAttr(
     ArrayAttr iteratorTypesAttr) {
   return llvm::to_vector(llvm::map_range(iteratorTypesAttr, [](Attribute attr) {
     return utils::symbolizeIteratorType(attr.cast<StringAttr>().getValue())
-        .getValue();
+        .value();
   }));
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -147,7 +147,7 @@ class ROCMTargetBackend final : public TargetBackend {
       std::array<int32_t, 3> workgroupSize;
       auto exportOp = exportOps[func.getName()];
       if (Optional<ArrayAttr> workgroupSizeAttr = exportOp.getWorkgroupSize()) {
-        for (auto it : llvm::enumerate(workgroupSizeAttr.getValue())) {
+        for (auto it : llvm::enumerate(workgroupSizeAttr.value())) {
           workgroupSize[it.index()] = it.value().cast<IntegerAttr>().getInt();
           flatWgSize *= it.value().cast<IntegerAttr>().getInt();
         }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2566,7 +2566,7 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
             if (failed(updatedOperand)) {
               return failure();
             }
-            updatedOperands.push_back(updatedOperand.getValue());
+            updatedOperands.push_back(updatedOperand.value());
             operandIndex++;
           }
         }
@@ -2576,7 +2576,7 @@ class CallOpConversion : public OpConversionPattern<CallOpTy> {
         if (failed(updatedOperand)) {
           return failure();
         }
-        updatedOperands.push_back(updatedOperand.getValue());
+        updatedOperands.push_back(updatedOperand.value());
         operandIndex++;
       }
     }

--- a/integrations/tensorflow/build_tools/bazel/iree-tf.bazelrc
+++ b/integrations/tensorflow/build_tools/bazel/iree-tf.bazelrc
@@ -16,6 +16,7 @@ build:generic_gcc --cxxopt=-std=c++17 --host_cxxopt=-std=c++17
 build --nocheck_visibility
 
 # Clang Flags for working around tensorflow warnings.
+build:generic_clang --copt=-Wno-deprecated-declarations --host_copt=-Wno-deprecated-declarations
 build:generic_clang --copt=-Wno-inconsistent-missing-override --host_copt=-Wno-inconsistent-missing-override
 build:generic_clang --copt=-Wno-c++11-narrowing --host_copt=-Wno-c++11-narrowing
 

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -105,8 +105,8 @@ void GlobalOp::build(OpBuilder &builder, OperationState &result, StringRef name,
   if (isMutable) {
     result.addAttribute("is_mutable", builder.getUnitAttr());
   }
-  if (initialValue.hasValue()) {
-    result.addAttribute("initial_value", initialValue.getValue());
+  if (initialValue.has_value()) {
+    result.addAttribute("initial_value", initialValue.value());
   }
   result.addAttribute("type", TypeAttr::get(type));
   result.attributes.append(attrs.begin(), attrs.end());

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
@@ -123,8 +123,7 @@ computeParallelTopk(Location loc, PatternRewriter &rewriter,
     Type indicesExpandedType =
         RankedTensorType::get(expandedShape, indicesElementType);
     indicesExpanded = rewriter.create<tensor::ExpandShapeOp>(
-        loc, indicesExpandedType, inputIndices.getValue(),
-        reassociationIndices);
+        loc, indicesExpandedType, inputIndices.value(), reassociationIndices);
   }
 
   // Define the expanded output types
@@ -175,7 +174,7 @@ computeParallelTopk(Location loc, PatternRewriter &rewriter,
                                                outputIndicesExpandedType};
   SmallVector<Value> parallelTopkIns = {valuesExpanded};
   if (indicesExpanded) {
-    parallelTopkIns.push_back(indicesExpanded.getValue());
+    parallelTopkIns.push_back(indicesExpanded.value());
   }
   SmallVector<Value> parallelTopkOuts = {negInfTensor, posInfTensor};
 

--- a/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/integrations/tensorflow/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -742,7 +742,7 @@ void transform_ext::CanonicalizedSequenceOp::getEffects(
 
 OperandRange transform_ext::CanonicalizedSequenceOp::getSuccessorEntryOperands(
     Optional<unsigned> index) {
-  assert(index && index.getValue() == 0 && "unexpected region index");
+  assert(index && index.value() == 0 && "unexpected region index");
   if (getOperation()->getNumOperands() == 1)
     return getOperation()->getOperands();
   return OperandRange(getOperation()->operand_end(),
@@ -752,7 +752,7 @@ OperandRange transform_ext::CanonicalizedSequenceOp::getSuccessorEntryOperands(
 void transform_ext::CanonicalizedSequenceOp::getSuccessorRegions(
     Optional<unsigned> index, ArrayRef<Attribute> operands,
     SmallVectorImpl<RegionSuccessor> &regions) {
-  if (!index.hasValue()) {
+  if (!index.has_value()) {
     Region *bodyRegion = &getBody();
     regions.emplace_back(bodyRegion, !operands.empty()
                                          ? bodyRegion->getArguments()

--- a/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/Input/InputOps.cpp
@@ -105,8 +105,8 @@ void GlobalOp::build(OpBuilder &builder, OperationState &result, StringRef name,
   if (isMutable) {
     result.addAttribute("is_mutable", builder.getUnitAttr());
   }
-  if (initialValue.hasValue()) {
-    result.addAttribute("initial_value", initialValue.getValue());
+  if (initialValue.has_value()) {
+    result.addAttribute("initial_value", initialValue.value());
   }
   result.addAttribute("type", TypeAttr::get(type));
   result.attributes.append(attrs.begin(), attrs.end());

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/SplitReduction.cpp
@@ -123,8 +123,7 @@ computeParallelTopk(Location loc, PatternRewriter &rewriter,
     Type indicesExpandedType =
         RankedTensorType::get(expandedShape, indicesElementType);
     indicesExpanded = rewriter.create<tensor::ExpandShapeOp>(
-        loc, indicesExpandedType, inputIndices.getValue(),
-        reassociationIndices);
+        loc, indicesExpandedType, inputIndices.value(), reassociationIndices);
   }
 
   // Define the expanded output types
@@ -175,7 +174,7 @@ computeParallelTopk(Location loc, PatternRewriter &rewriter,
                                                outputIndicesExpandedType};
   SmallVector<Value> parallelTopkIns = {valuesExpanded};
   if (indicesExpanded) {
-    parallelTopkIns.push_back(indicesExpanded.getValue());
+    parallelTopkIns.push_back(indicesExpanded.value());
   }
   SmallVector<Value> parallelTopkOuts = {negInfTensor, posInfTensor};
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -882,7 +882,7 @@ void transform_ext::CanonicalizedSequenceOp::getEffects(
 
 OperandRange transform_ext::CanonicalizedSequenceOp::getSuccessorEntryOperands(
     Optional<unsigned> index) {
-  assert(index && index.getValue() == 0 && "unexpected region index");
+  assert(index && index.value() == 0 && "unexpected region index");
   if (getOperation()->getNumOperands() == 1)
     return getOperation()->getOperands();
   return OperandRange(getOperation()->operand_end(),
@@ -892,7 +892,7 @@ OperandRange transform_ext::CanonicalizedSequenceOp::getSuccessorEntryOperands(
 void transform_ext::CanonicalizedSequenceOp::getSuccessorRegions(
     Optional<unsigned> index, ArrayRef<Attribute> operands,
     SmallVectorImpl<RegionSuccessor> &regions) {
-  if (!index.hasValue()) {
+  if (!index.has_value()) {
     Region *bodyRegion = &getBody();
     regions.emplace_back(bodyRegion, !operands.empty()
                                          ? bodyRegion->getArguments()


### PR DESCRIPTION
We can turn them back off if there's big integrates blocked by them but in the steady state having them off just leads to lazy inconsistency. TF is not warning-free and so the flag is moved so that we only ignore the deprecation warnings when building TF-related tooling. For IREE-owned code we are now clean.