### PR TITLE
Excludes TF model directories from benchmark suite archive

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           # TODO(#10988): Excludes the experimental `models` and iree` dirs for
           # now.
-          tar --exclude '*.tflite' --exclude '*.mlir' \
+          tar --exclude '*.tflite' --exclude '*.mlir' --exclude '*-tf-model' \
             --exclude "${BENCHMARKS_DIR}/benchmark_suites/models" \
             --exclude "${BENCHMARKS_DIR}/benchmark_suites/iree" \
             -czf \


### PR DESCRIPTION
Excludes TF model directories from benchmark suite archive.

It's not ideal to keep growing the exclusion rules, but the way the current benchmark suite is structured makes it not easy to select the required files. We will soon replace this part with the new benchmark suite so I think it's fine to have a temporary solution for now.

Fixes #11158