### PR TITLE
Decouple `GPUThreadMappingAttr` from GPU transform dialect

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUDistribute.cpp
@@ -43,9 +43,16 @@ struct LLVMGPUDistributePass
 
     IRRewriter rewriter(funcOp->getContext());
     rewriter.setInsertionPoint(funcOp);
+    MLIRContext* ctx = funcOp->getContext();
+    SmallVector<DeviceMappingAttrInterface> threadMappingAttributes = {
+        gpu::GPUThreadMappingAttr::get(ctx, gpu::Threads::DimX),
+        gpu::GPUThreadMappingAttr::get(ctx, gpu::Threads::DimY),
+        gpu::GPUThreadMappingAttr::get(ctx, gpu::Threads::DimZ)};
+
     DiagnosedSilenceableFailure const result =
         mlir::transform::gpu::mapNestedForeachToThreadsImpl(
-            rewriter, funcOp, workgroupSize, false, llvm::None);
+            rewriter, funcOp, workgroupSize, false, llvm::None,
+            threadMappingAttributes);
 
     if (!result.succeeded()) return signalPassFailure();
   }


### PR DESCRIPTION
Now GPU transform dialect works with any attribute, but the attributes must be defined outside of the code generator. In this way, iree can define own mappers. This PR integrates this change into iree.

Cherry pick the following llvm. The PR and llvm should go together. @beaffb041c689deb30d9b06fb3a68a1a4bae48a4