### PR TITLE
Add missing canonicalize pass on import

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/Passes.cpp
@@ -53,6 +53,7 @@ void registerMHLOConversionPassPipeline() {
 // Prepare HLO for use as an input to the Flow dialect.
 void buildMHLOInputConversionPassPipeline(OpPassManager &passManager) {
   passManager.addPass(mlir::mhlo::createStablehloLegalizeToHloPass());
+  passManager.addNestedPass<func::FuncOp>(mlir::createCanonicalizerPass());
   passManager.addNestedPass<func::FuncOp>(
       mhlo::createLegalizeControlFlowPass());
 


### PR DESCRIPTION
It is possible that the source of mhlo may not have canonicalized before exporting.
Add a canonicalization pass to cleanup the source model.