### PR TITLE
Execute runtime build on bigger managed runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -286,7 +286,7 @@ jobs:
   build_test_runtime:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
     steps:


### PR DESCRIPTION
Wheeeee! Let's make things fast.

More seriously: these are now an option for us and I've set some up. We
also have more at the enterprise level. This removes the need for us to
managed our own self-hosted runners for CPU tasks. I'll work on moving
over the bigger jobs (more complicated because I need to change the
artifact passing).