### PR TITLE
Fix indexing out of range in tileConsumerAndFuseProducers

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -54,6 +54,12 @@ FailureOr<linalg::TileLoopNest> tileConsumerAndFuseProducers(
   // Search the number of outer parallel loops to separate them from possible
   // inner reduction dimensions.
   SmallVector<StringRef> iterTypes = consumerOp.getIteratorTypesArray();
+  // Make sure to only look at the leading loops for tiling---we will scan this
+  // array to find the first non-parallel loop later and use that for indexing
+  // into the tile sizes.
+  if (iterTypes.size() > tileSizes.size()) {
+    iterTypes.resize(tileSizes.size());
+  }
   applyPermutationToVector(iterTypes, tileInterchange);
   auto *it = find_if_not(iterTypes, linalg::isParallelIterator);
   int64_t split = std::distance(iterTypes.begin(), it);


### PR DESCRIPTION
`consumerOp` can have more iterators than `tileSizes`'s size. So only look at the loops we want to tile.

This is still fine for now because iterators are strings, so that when we use `applyPermutationToVector`, a new vector will be created with only `tileSizes.size()` iterators permuated and copied over; the rest will be empty strings. Later `find_if_not` will stop properly. But later the iterators will be integer values. Then suddenly all redundant (and not copied over) iterators will become 0 (parallel) so causing out of bound issue.