### PR TITLE
Disable LSAN in the ASAN tests on Vulkan

### DIFF
--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -120,12 +120,7 @@ fi
 
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
-label_exclude_args_exclude_vulkan=(
-  "${label_exclude_args[@]}"
-  "^driver=vulkan$"
-)
-
-label_exclude_regex_exclude_vulkan="($(IFS="|" ; echo "${label_exclude_args_exclude_vulkan[*]?}"))"
+vulkan_label_regex='^driver=vulkan$'
 
 # These tests currently have asan failures
 declare -a excluded_tests=(
@@ -160,7 +155,7 @@ ctest \
   --timeout 900 \
   --output-on-failure \
   --no-tests=error \
-  --label-exclude "${label_exclude_regex_exclude_vulkan}" \
+  --label-exclude "${label_exclude_regex}|${vulkan_label_regex}" \
   --exclude-regex "${excluded_tests_regex?}"
 
 echo "******************** llvm-external-projects tests ***********************"
@@ -174,6 +169,6 @@ ASAN_OPTIONS=detect_leaks=0 \
     --timeout 900 \
     --output-on-failure \
     --no-tests=error \
-    --label-regex "^driver=vulkan$" \
+    --label-regex "${vulkan_label_regex}" \
     --label-exclude "${label_exclude_regex}" \
     --exclude-regex "${excluded_tests_regex?}"

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -120,6 +120,13 @@ fi
 
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
+label_exclude_args_exclude_vulkan=(
+  "${label_exclude_args[@]}"
+  "^driver=vulkan$"
+)
+
+label_exclude_regex_exclude_vulkan="($(IFS="|" ; echo "${label_exclude_args_exclude_vulkan[*]?}"))"
+
 # These tests currently have asan failures
 declare -a excluded_tests=(
   # TODO(#5716): Fix flaky ASan crash in these tests
@@ -148,13 +155,25 @@ excluded_tests_regex="($(IFS="|" ; echo "${excluded_tests[*]?}"))"
 
 cd ${BUILD_DIR?}
 
-echo "******************** Running main project ctests ************************"
+echo "********** Running main project ctests on non-Vulkan backends ***********"
 ctest \
   --timeout 900 \
   --output-on-failure \
   --no-tests=error \
-  --label-exclude "${label_exclude_regex}" \
+  --label-exclude "${label_exclude_regex_exclude_vulkan}" \
   --exclude-regex "${excluded_tests_regex?}"
 
 echo "******************** llvm-external-projects tests ***********************"
 cmake --build . --target check-iree-dialects -- -k 0
+
+echo "**************** Running main project ctests on Vulkan ******************"
+# Disable LeakSanitizer (LSAN) because of a history of issues with Swiftshader
+# (#5716, #8489, #11203).
+ASAN_OPTIONS=detect_leaks=0 \
+  ctest \
+    --timeout 900 \
+    --output-on-failure \
+    --no-tests=error \
+    --label-regex "^driver=vulkan$" \
+    --label-exclude "${label_exclude_regex}" \
+    --exclude-regex "${excluded_tests_regex?}"


### PR DESCRIPTION
Fixes #11203.

This PR started out as a tentative massaging of LSAN to avert some issue on CI bots, but that didn't work and it later appeared that there was a rich history of LSAN issues with Swiftshader and the correct course of action was to disable the LSAN part of ASAN when running ASAN tests on Vulkan.

Reusing this PR so we keep the motivating history in one place. See the below https://github.com/iree-org/iree/pull/11206#issuecomment-1320578288
