### PR TITLE
Set vectorSize back to 4 for non-divisible by 4 dimensions

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -399,6 +399,8 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
              shape.back() % (workgroupSize[0] * vectorSize) != 0) {
         vectorSize /= 2;
       }
+      if (vectorSize == 1)  // assume there is fastpath + slowpath
+        vectorSize = 4;
       int64_t problemSize = std::accumulate(
           shape.begin(), shape.end(), 1,
           [](const int64_t &a, const int64_t &b) { return a * b; });

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/workgroup_specialization_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/workgroup_specialization_pipeline_test.mlir
@@ -50,3 +50,56 @@ module attributes {hal.device.targets = [#hal.device.target<"cuda", {executable_
 //       CHECK:   vector.transfer_write
 //       CHECK: else
 //   CHECK-NOT:   vector.transfer
+
+
+// -----
+
+#map = affine_map<(d0) -> (d0)>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}>
+#device_target_cuda = #hal.device.target<"cuda", {executable_targets = [#executable_target_cuda_nvptx_fb], legacy_sync}>
+module attributes {hal.device.targets = [#device_target_cuda]} {
+  hal.executable private @vectorized_dispatch_0 {
+    hal.executable.variant public @cuda_nvptx_fb, target = #executable_target_cuda_nvptx_fb {
+      hal.executable.export public @vectorized_dispatch_0_generic_102401 ordinal(0) layout(#pipeline_layout) {
+      ^bb0(%arg0: !hal.device, %arg1: index):
+        %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1
+        hal.return %x, %y, %z : index, index, index
+      }
+      builtin.module {
+        func.func @vectorized_dispatch_0_generic_102401() {
+          %c0 = arith.constant 0 : index
+          %cst = arith.constant -3.000000e+00 : f32
+          %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<102401xf32>>
+          %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<102401xf32>>
+          %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<102401xf32>>
+          %3 = flow.dispatch.tensor.load %0, offsets = [0], sizes = [102401], strides = [1] : !flow.dispatch.tensor<readonly:tensor<102401xf32>> -> tensor<102401xf32>
+          %4 = flow.dispatch.tensor.load %1, offsets = [0], sizes = [102401], strides = [1] : !flow.dispatch.tensor<readonly:tensor<102401xf32>> -> tensor<102401xf32>
+          %5 = tensor.empty() : tensor<102401xf32>
+          %6 = linalg.generic {indexing_maps = [#map, #map, #map], iterator_types = ["parallel"]} ins(%3, %4 : tensor<102401xf32>, tensor<102401xf32>) outs(%5 : tensor<102401xf32>) {
+          ^bb0(%in: f32, %in_0: f32, %out: f32):
+            %7 = math.fma %cst, %in, %in_0 : f32
+            linalg.yield %7 : f32
+          } -> tensor<102401xf32>
+          flow.dispatch.tensor.store %6, %2, offsets = [0], sizes = [102401], strides = [1] : tensor<102401xf32> -> !flow.dispatch.tensor<writeonly:tensor<102401xf32>>
+          return
+        }
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @vectorized_dispatch_0_generic_102401
+//      CHECK:   %[[cst:.*]] = arith.constant 0.000000e+00 : f32
+//      CHECK:   %[[c256:.*]] = arith.constant 256 : index
+//      CHECK:   %[[c0:.*]] = arith.constant 0 : index
+//      CHECK:   %[[ARR:.*]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[c0]]) alignment(64) : memref<102401xf32>
+//      CHECK:   %[[ARR2:.*]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%[[c0]]) alignment(64) : memref<102401xf32>
+//      CHECK:   %[[BLKX:.*]] = hal.interface.workgroup.id[0] : index
+//      CHECK:   %[[BLKX2:.*]] = affine.min #map2()[%[[BLKX]]]
+//      CHECK:   %[[CMP:.*]] = arith.cmpi eq, %[[BLKX2]], %[[c256]] : index
+//      CHECK:   scf.if %[[CMP]]
+//      CHECK:   %[[TIDX:.*]] = gpu.thread_id  x
+//      CHECK:   %[[AFF:.*]] = affine.apply #map3(%[[TIDX]])[%[[BLKX]]]
+//      CHECK:   vector.transfer_read %[[ARR]][%[[AFF]]], %[[cst]] {in_bounds = [true]} : memref<102401xf32>, vector<4xf32>
+//      CHECK:   vector.transfer_read %[[ARR2]][%[[AFF]]], %[[cst]] {in_bounds = [true]} : memref<102401xf32>, vector<4xf32>


### PR DESCRIPTION
For issue #10003, the `WorkgroupSpecializationPass` nicely implements combination codegen of fastpath and the slowpath. But the tile size is still set incorrectly, this causes load stores on fastpath are still not vectorized.

The example given in the PR has a tensor of size 102401. `TileAndDistributeToWorkgroups` sets the tile size to `<tile_sizes = [[64]]>`. However, it should be 256, because the inner loop is unrolled with 4, and the 4 loads/stores are vectorized. See the generated ir below after this pass.

```
scf.for %arg0 = blockIdx.x to 102401 step blockDim.x  {
...
	linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%6, %7 : tensor<?xf32>, tensor<?xf32>) outs(%8 : tensor<?xf32>) 
	attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64]]>} ...
}
```
This leds load/store are fastpath do not get vectorized, see `vector<1xf32>`.

```
if(fastpath) {
    %7 = affine.apply #map3(%threadIdx.x)[%blockIdx]
    %8 = vector.transfer_read %0[%7], %cst {in_bounds = [true]} : memref<102401xf32>, vector<1xf32>
    ...
} else {
	//slowpath
}
```

This assumes that fastpath+slowpath is implemented. Even if loop trip count is not divisable by 4, it still sets vectorSize to 4. This helps generating correct tile size, see `tile_sizes = [[256]]` in code below.

```
scf.for %arg0 = blockIdx.x to 102401 step blockDim.x  {
        %9 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%6, %7 : tensor<?xf32>, tensor<?xf32>) outs(%8 : tensor<?xf32>) 
	attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[256]]>} ...
}
```
Setting tile size correctly helps to vectorize load/store, see `vector<4xf32>`.

```
 if(fastpath) {
    %7 = affine.apply #map3(%threadIdx.x)[%blockIdx]
    %8 = vector.transfer_read %0[%7], %cst {in_bounds = [true]} : memref<102401xf32>, vector<4xf32>
    ...
} else {
	//slowpath
}
```