### PR TITLE
[NFC] Generalize reduction vector size calculation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -552,10 +552,12 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
                                .cast<ShapedType>()
                                .getElementType();
   if (!elementType.isIntOrFloat()) return failure();
+  unsigned bitWidth = elementType.getIntOrFloatBitWidth();
   // Reduction distribution only supports 32-bit types now.
-  if (elementType.getIntOrFloatBitWidth() != 32) return failure();
+  if (bitWidth != 32) return failure();
 
-  unsigned vectorSize = 4;
+  const unsigned largestLoadSizeInBits = 128;
+  unsigned vectorSize = largestLoadSizeInBits / bitWidth;
   while ((*dimSize / vectorSize) % cudaWarpSize != 0) vectorSize /= 2;
 
   // TODO: Add reduction tiling to handle larger reductions.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -906,11 +906,13 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
   const Type elementType =
       op.getOutputs()[0].getType().cast<ShapedType>().getElementType();
   if (!elementType.isIntOrFloat()) return failure();
+  unsigned bitWidth = elementType.getIntOrFloatBitWidth();
   // Reduction distribution only supports 32-bit types now.
-  if (elementType.getIntOrFloatBitWidth() != 32) return failure();
+  if (bitWidth != 32) return failure();
 
   // Let each thread handle `vectorSize` elements.
-  unsigned vectorSize = 4;
+  const unsigned largestLoadSizeInBits = 128;
+  unsigned vectorSize = largestLoadSizeInBits / bitWidth;
   while ((*dimSize / vectorSize) % subgroupSize != 0) vectorSize /= 2;
 
   // TODO: Add reduction tiling to handle larger reductions.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -911,8 +911,7 @@ static LogicalResult setReductionConfig(const spirv::TargetEnv &targetEnv,
   if (bitWidth != 32) return failure();
 
   // Let each thread handle `vectorSize` elements.
-  const unsigned largestLoadSizeInBits = 128;
-  unsigned vectorSize = largestLoadSizeInBits / bitWidth;
+  unsigned vectorSize = kMaxVectorNumBits / bitWidth;
   while ((*dimSize / vectorSize) % subgroupSize != 0) vectorSize /= 2;
 
   // TODO: Add reduction tiling to handle larger reductions.


### PR DESCRIPTION
Since we only support 32bits type this is NFC but this pave the way to support more types efficiently.