### PR TITLE
[WebGPU] Use staging_buffer->bind_group_layout during pipeline creation.

### DIFF
--- a/runtime/src/iree/hal/drivers/webgpu/pipeline_layout.h
+++ b/runtime/src/iree/hal/drivers/webgpu/pipeline_layout.h
@@ -10,6 +10,7 @@
 #include "iree/base/api.h"
 #include "iree/hal/api.h"
 #include "iree/hal/drivers/webgpu/platform/webgpu.h"
+#include "iree/hal/drivers/webgpu/staging_buffer.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -60,7 +61,9 @@ typedef struct iree_hal_webgpu_set_binding_info_t {
 iree_status_t iree_hal_webgpu_pipeline_layout_create(
     WGPUDevice device, iree_host_size_t set_layout_count,
     iree_hal_descriptor_set_layout_t* const* set_layouts,
-    iree_host_size_t push_constant_count, iree_allocator_t host_allocator,
+    iree_host_size_t push_constant_count,
+    iree_hal_webgpu_staging_buffer_t* staging_buffer,
+    iree_allocator_t host_allocator,
     iree_hal_pipeline_layout_t** out_pipeline_layout);
 
 WGPUPipelineLayout iree_hal_webgpu_pipeline_layout_handle(

--- a/runtime/src/iree/hal/drivers/webgpu/staging_buffer.c
+++ b/runtime/src/iree/hal/drivers/webgpu/staging_buffer.c
@@ -97,12 +97,22 @@ iree_status_t iree_hal_webgpu_staging_buffer_initialize(
   out_staging_buffer->bind_group =
       wgpuDeviceCreateBindGroup(device, &descriptor);
 
+  const WGPUBindGroupLayoutDescriptor empty_group_layout_descriptor = {
+      .nextInChain = NULL,
+      .label = WGPU_DEBUG_LABEL("_empty_binding"),
+      .entryCount = 0,
+      .entries = NULL,
+  };
+  out_staging_buffer->empty_bind_group_layout =
+      wgpuDeviceCreateBindGroupLayout(device, &empty_group_layout_descriptor);
+
   IREE_TRACE_ZONE_END(z0);
   return iree_ok_status();
 }
 
 void iree_hal_webgpu_staging_buffer_deinitialize(
     iree_hal_webgpu_staging_buffer_t* staging_buffer) {
+  iree_wgpuBindGroupLayoutDrop(staging_buffer->empty_bind_group_layout);
   iree_wgpuBindGroupDrop(staging_buffer->bind_group);
   iree_wgpuBindGroupLayoutDrop(staging_buffer->bind_group_layout);
   iree_hal_buffer_release(staging_buffer->device_buffer);

--- a/runtime/src/iree/hal/drivers/webgpu/staging_buffer.h
+++ b/runtime/src/iree/hal/drivers/webgpu/staging_buffer.h
@@ -56,6 +56,9 @@ typedef struct iree_hal_webgpu_staging_buffer_t {
   // Bind group containing the buffer as dynamic at base offset 0.
   WGPUBindGroup bind_group;
 
+  // Layout of an empty bind group, useful for padding within pipeline layouts.
+  WGPUBindGroupLayout empty_bind_group_layout;
+
   // Current write offset in the device buffer.
   uint32_t offset;
 } iree_hal_webgpu_staging_buffer_t;

--- a/runtime/src/iree/hal/drivers/webgpu/webgpu_device.c
+++ b/runtime/src/iree/hal/drivers/webgpu/webgpu_device.c
@@ -279,7 +279,7 @@ static iree_status_t iree_hal_webgpu_device_create_pipeline_layout(
   iree_hal_webgpu_device_t* device = iree_hal_webgpu_device_cast(base_device);
   return iree_hal_webgpu_pipeline_layout_create(
       device->handle, set_layout_count, set_layouts, push_constants,
-      device->host_allocator, out_pipeline_layout);
+      &device->staging_buffer, device->host_allocator, out_pipeline_layout);
 }
 
 static iree_status_t iree_hal_webgpu_device_create_semaphore(


### PR DESCRIPTION
This fixes an error I was seeing when trying to initialize a posenet program:
```
The entry-point uses bindings in group 3 but [PipelineLayout] doesn't have a BindGroupLayout for this index
 - While calling [Device "IREE WebGPU device"].CreateComputePipeline([ComputePipelineDescriptor]).
```

---

The next error message is this:
```
The buffer type in the shader (BufferBindingType::Storage) is not compatible with the type in the layout (BufferBindingType::Uniform).
 - While validating that the entry-point's declaration for @group(3) @binding(0) matches [BindGroupLayout]
 - While validating the entry-point's compatibility for group 3 with [BindGroupLayout]
 - While calling [Device "IREE WebGPU device"].CreateComputePipeline([ComputePipelineDescriptor]).
```
That should be fixed with https://github.com/iree-org/iree/issues/11183 and a change to `WGSLReplacePushConstants.cpp` (descriptor type from `StorageBuffer` to `UniformBuffer`).