### PR TITLE
Reenable all disabled tests on ASan, except `fragment_000.mlir`

### DIFF
--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -120,12 +120,7 @@ fi
 
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
-label_exclude_args_exclude_vulkan=(
-  "${label_exclude_args[@]}"
-  "^driver=vulkan$"
-)
-
-label_exclude_regex_exclude_vulkan="($(IFS="|" ; echo "${label_exclude_args_exclude_vulkan[*]?}"))"
+vulkan_label_regex='^driver=vulkan$'
 
 # These tests currently have asan failures
 declare -a excluded_tests=(
@@ -160,7 +155,7 @@ ctest \
   --timeout 900 \
   --output-on-failure \
   --no-tests=error \
-  --label-exclude "${label_exclude_regex_exclude_vulkan}" \
+  --label-exclude "${label_exclude_regex}|${vulkan_label_regex}" \
   --exclude-regex "${excluded_tests_regex?}"
 
 echo "******************** llvm-external-projects tests ***********************"
@@ -174,6 +169,6 @@ ASAN_OPTIONS=detect_leaks=0 \
     --timeout 900 \
     --output-on-failure \
     --no-tests=error \
-    --label-regex "^driver=vulkan$" \
+    --label-regex "${vulkan_label_regex}" \
     --label-exclude "${label_exclude_regex}" \
     --exclude-regex "${excluded_tests_regex?}"

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -125,19 +125,7 @@ vulkan_label_regex='^driver=vulkan$'
 # These tests currently have asan failures
 declare -a excluded_tests=(
   # TODO(#5716): Fix flaky ASan crash in these tests
-  "iree/tests/e2e/models/collatz.mlir.test"
-  "iree/tests/e2e/models/edge_detection.mlir.test"
   "iree/tests/e2e/models/fragment_000.mlir.test"
-  "iree/tests/e2e/models/fullyconnected.mlir.test"
-  "iree/tests/e2e/models/mnist_fake_weights.mlir.test"
-  "iree/tests/e2e/models/resnet50_fake_weights.mlir.test"
-  "iree/tests/e2e/models/unidirectional_lstm.mlir.test"
-  "iree/tests/e2e/regression/globals.mlir.test"
-  # TODO(#5715): Fix these
-  "iree/samples/simple_embedding/simple_embedding_vulkan_test"
-  "iree/tools/test/iree-benchmark-module.mlir.test"
-  "iree/tools/test/iree-run-module.mlir.test"
-  "iree/tools/test/multiple_exported_functions.mlir.test"
 )
 
 # Prefix with `^` anchor

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -120,6 +120,13 @@ fi
 
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
+label_exclude_args_exclude_vulkan=(
+  "${label_exclude_args[@]}"
+  "^driver=vulkan$"
+)
+
+label_exclude_regex_exclude_vulkan="($(IFS="|" ; echo "${label_exclude_args_exclude_vulkan[*]?}"))"
+
 # These tests currently have asan failures
 declare -a excluded_tests=(
   # TODO(#5716): Fix flaky ASan crash in these tests
@@ -148,13 +155,25 @@ excluded_tests_regex="($(IFS="|" ; echo "${excluded_tests[*]?}"))"
 
 cd ${BUILD_DIR?}
 
-echo "******************** Running main project ctests ************************"
+echo "********** Running main project ctests on non-Vulkan backends ***********"
 ctest \
   --timeout 900 \
   --output-on-failure \
   --no-tests=error \
-  --label-exclude "${label_exclude_regex}" \
+  --label-exclude "${label_exclude_regex_exclude_vulkan}" \
   --exclude-regex "${excluded_tests_regex?}"
 
 echo "******************** llvm-external-projects tests ***********************"
 cmake --build . --target check-iree-dialects -- -k 0
+
+echo "**************** Running main project ctests on Vulkan ******************"
+# Disable LeakSanitizer (LSAN) because of a history of issues with Swiftshader
+# (#5716, #8489, #11203).
+ASAN_OPTIONS=detect_leaks=0 \
+  ctest \
+    --timeout 900 \
+    --output-on-failure \
+    --no-tests=error \
+    --label-regex "^driver=vulkan$" \
+    --label-exclude "${label_exclude_regex}" \
+    --exclude-regex "${excluded_tests_regex?}"


### PR DESCRIPTION
Following #11206, the tests exclude-list can be trimmed down to just one entry.

(Until #11206 is merged, treat it as diffbase/look only at the top commit in this PR).