### PR TITLE
ASan tests: account for multi-driver Lit tests

### DIFF
--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -120,9 +120,6 @@ fi
 
 label_exclude_regex="($(IFS="|" ; echo "${label_exclude_args[*]?}"))"
 
-# For the purpose of determining whether to disable LSAN, we need to catch not
-# only the tests that are specifically labelled `driver=vulkan`, but also any
-# multi-driver test that may run Vulkan among other drivers.
 vulkan_label_regex='^driver=vulkan$'
 
 cd ${BUILD_DIR?}

--- a/tests/e2e/models/BUILD
+++ b/tests/e2e/models/BUILD
@@ -39,6 +39,7 @@ iree_lit_test_suite(
     ),
     cfg = "//tests:lit.cfg.py",
     tags = [
+        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
         "hostonly",
         "optonly",  # swiftshader is too slow in dbg
     ],

--- a/tests/e2e/models/BUILD
+++ b/tests/e2e/models/BUILD
@@ -39,7 +39,8 @@ iree_lit_test_suite(
     ),
     cfg = "//tests:lit.cfg.py",
     tags = [
-        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
+        "driver=local-task",
+        "driver=vulkan",
         "hostonly",
         "optonly",  # swiftshader is too slow in dbg
     ],

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     FileCheck
     iree-run-mlir
   LABELS
+    "driver=vulkan"
     "hostonly"
     "optonly"
   TIMEOUT

--- a/tests/e2e/models/CMakeLists.txt
+++ b/tests/e2e/models/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     FileCheck
     iree-run-mlir
   LABELS
+    "driver=local-task"
     "driver=vulkan"
     "hostonly"
     "optonly"

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -60,7 +60,8 @@ iree_lit_test_suite(
     ),
     cfg = "//tests:lit.cfg.py",
     tags = [
-        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
+        "driver=local-task",
+        "driver=vulkan",
         "hostonly",
     ],
     tools = [

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -59,7 +59,10 @@ iree_lit_test_suite(
         ] + BACKEND_TESTS,
     ),
     cfg = "//tests:lit.cfg.py",
-    tags = ["hostonly"],
+    tags = [
+        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
+        "hostonly",
+    ],
     tools = [
         "//tools:iree-opt",
         "//tools:iree-run-mlir",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     iree-opt
     iree-run-mlir
   LABELS
+    "driver=vulkan"
     "hostonly"
 )
 

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -26,6 +26,7 @@ iree_lit_test_suite(
     iree-opt
     iree-run-mlir
   LABELS
+    "driver=local-task"
     "driver=vulkan"
     "hostonly"
 )

--- a/tests/e2e/tensor_ops/BUILD
+++ b/tests/e2e/tensor_ops/BUILD
@@ -20,7 +20,8 @@ iree_lit_test_suite(
     ],
     cfg = "//tests:lit.cfg.py",
     tags = [
-        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
+        "driver=local-task",
+        "driver=vulkan",
         "hostonly",
     ],
     tools = [

--- a/tests/e2e/tensor_ops/BUILD
+++ b/tests/e2e/tensor_ops/BUILD
@@ -19,7 +19,10 @@ iree_lit_test_suite(
         "tensor_cast.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
-    tags = ["hostonly"],
+    tags = [
+        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
+        "hostonly",
+    ],
     tools = [
         "//tools:iree-benchmark-module",
         "//tools:iree-compile",

--- a/tests/e2e/tensor_ops/CMakeLists.txt
+++ b/tests/e2e/tensor_ops/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     iree-compile
     iree-run-mlir
   LABELS
+    "driver=local-task"
     "driver=vulkan"
     "hostonly"
 )

--- a/tests/e2e/tensor_ops/CMakeLists.txt
+++ b/tests/e2e/tensor_ops/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     iree-compile
     iree-run-mlir
   LABELS
+    "driver=vulkan"
     "hostonly"
 )
 

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -33,7 +33,8 @@ iree_lit_test_suite(
     ),
     cfg = "//tools:lit.cfg.py",
     tags = [
-        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
+        "driver=local-task",
+        "driver=vulkan",
         "hostonly",
     ],
     tools = [

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     ),
     cfg = "//tools:lit.cfg.py",
     tags = [
+        "driver=vulkan",  # Multiple driver= tags allowed. Used by sanitizer CI.
         "hostonly",
     ],
     tools = [

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     iree-run-module
     not
   LABELS
+    "driver=vulkan"
     "hostonly"
 )
 

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -33,6 +33,7 @@ iree_lit_test_suite(
     iree-run-module
     not
   LABELS
+    "driver=local-task"
     "driver=vulkan"
     "hostonly"
 )


### PR DESCRIPTION
This PR reenables all tests that were disabled under ASan!

The LSAN failures that motivated the current exclude list should all be fixed by #11206.

Yet, simply dropping the exclude-list doesn't work, because some of the entries in that list are Lit tests that exercise multiple drivers in a way that's encoded as `//RUN` comments within the test source, opaque to the build and test system --- there was no way to tell which of those tests involved Vulkan.

It would be nice to only disable LSAN for the Vulkan part of these tests, but this isn't feasible as things are currently structured, with the multiple driver runs conflated withing a single Lit test source.

At first I introduced a new tag/label, `multi-driver-including-vulkan`, to label those tests, so that `build_and_test_asan.sh` could disable LSAN accordingly.

Then I thought, how does this scale? Will there be a `multi-driver-XYZ` tag for all combinations of (possibly multiple?!) drivers?

Then I thought, let's just use the existing `driver=vulkan` tag for this, giving it "multiple choices possible" semantics. Actually, "tags" are meant to work that way; perhaps the only thing about that tag that makes it somewhat surprising that it would work that way is the `=` sign: it might seem strange to have `driver=X` and `driver=Y` tags together on the same rule. Then again maybe we'll get used to it, and maybe precisely having such tags side by side (as enforced by `buildifier`) will make it clear that it does have such semantics.