### PR TITLE
Replace string path with pathlib in benchmark tools

### DIFF
--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -5,11 +5,10 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 # All benchmarks' relative path against root build directory.
 
-import os
-
 from argparse import Namespace
 from dataclasses import dataclass
 from typing import Optional
+import pathlib
 
 BENCHMARK_SUITE_REL_PATH = "benchmark_suites"
 BENCHMARK_RESULTS_REL_PATH = "benchmark-results"
@@ -27,10 +26,10 @@ class TraceCaptureConfig:
     capture_tmp_dir: the temporary directory to store captured traces.
   """
 
-  traced_benchmark_tool_dir: str
-  trace_capture_tool: str
-  capture_tarball: str
-  capture_tmp_dir: str
+  traced_benchmark_tool_dir: pathlib.Path
+  trace_capture_tool: pathlib.Path
+  capture_tarball: pathlib.Path
+  capture_tmp_dir: pathlib.Path
 
 
 @dataclass
@@ -58,11 +57,11 @@ class BenchmarkConfig:
       times.
   """
 
-  root_benchmark_dir: str
-  benchmark_results_dir: str
+  root_benchmark_dir: pathlib.Path
+  benchmark_results_dir: pathlib.Path
   git_commit_hash: str
 
-  normal_benchmark_tool_dir: Optional[str] = None
+  normal_benchmark_tool_dir: Optional[pathlib.Path] = None
   trace_capture_config: Optional[TraceCaptureConfig] = None
 
   driver_filter: Optional[str] = None
@@ -81,8 +80,9 @@ class BenchmarkConfig:
       git_commit_hash: the git commit hash of IREE.
     """
 
-    def real_path_or_none(path: str) -> Optional[str]:
-      return os.path.realpath(path) if path else None
+    def real_path_or_none(
+        path: Optional[pathlib.Path]) -> Optional[pathlib.Path]:
+      return path.resolve() if path else None
 
     if not args.normal_benchmark_tool_dir and not args.traced_benchmark_tool_dir:
       raise ValueError(
@@ -95,24 +95,22 @@ class BenchmarkConfig:
           "The following 3 flags should be simultaneously all specified or all unspecified: --traced_benchmark_tool_dir, --trace_capture_tool, --capture_tarball"
       )
 
-    per_commit_tmp_dir = os.path.realpath(
-        os.path.join(args.tmp_dir, git_commit_hash))
+    per_commit_tmp_dir: pathlib.Path = (args.tmp_dir /
+                                        git_commit_hash).resolve()
 
     if args.traced_benchmark_tool_dir is None:
       trace_capture_config = None
     else:
       trace_capture_config = TraceCaptureConfig(
-          traced_benchmark_tool_dir=real_path_or_none(
-              args.traced_benchmark_tool_dir),
-          trace_capture_tool=real_path_or_none(args.trace_capture_tool),
-          capture_tarball=real_path_or_none(args.capture_tarball),
-          capture_tmp_dir=os.path.join(per_commit_tmp_dir, CAPTURES_REL_PATH))
+          traced_benchmark_tool_dir=args.traced_benchmark_tool_dir.resolve(),
+          trace_capture_tool=args.trace_capture_tool.resolve(),
+          capture_tarball=args.capture_tarball.resolve(),
+          capture_tmp_dir=per_commit_tmp_dir / CAPTURES_REL_PATH)
 
-    build_dir = os.path.realpath(args.build_dir)
+    build_dir = args.build_dir.resolve()
     return BenchmarkConfig(
-        root_benchmark_dir=os.path.join(build_dir, BENCHMARK_SUITE_REL_PATH),
-        benchmark_results_dir=os.path.join(per_commit_tmp_dir,
-                                           BENCHMARK_RESULTS_REL_PATH),
+        root_benchmark_dir=build_dir / BENCHMARK_SUITE_REL_PATH,
+        benchmark_results_dir=per_commit_tmp_dir / BENCHMARK_RESULTS_REL_PATH,
         git_commit_hash=git_commit_hash,
         normal_benchmark_tool_dir=real_path_or_none(
             args.normal_benchmark_tool_dir),

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -22,9 +22,9 @@ class BenchmarkConfigTest(unittest.TestCase):
     self.tmp_dir = tempfile.TemporaryDirectory()
     self.build_dir_path = pathlib.Path(self.build_dir.name).resolve()
     self.normal_tool_dir = self.build_dir_path / "normal_tool"
-    os.mkdir(self.normal_tool_dir)
+    self.normal_tool_dir.mkdir()
     self.traced_tool_dir = self.build_dir_path / "traced_tool"
-    os.mkdir(self.traced_tool_dir)
+    self.traced_tool_dir.mkdir()
     self.trace_capture_tool = tempfile.NamedTemporaryFile()
     os.chmod(self.trace_capture_tool.name, stat.S_IEXEC)
 

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -5,6 +5,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import pathlib
 import stat
 import unittest
 import tempfile
@@ -19,11 +20,10 @@ class BenchmarkConfigTest(unittest.TestCase):
   def setUp(self):
     self.build_dir = tempfile.TemporaryDirectory()
     self.tmp_dir = tempfile.TemporaryDirectory()
-    self.normal_tool_dir = os.path.realpath(
-        os.path.join(self.build_dir.name, "normal_tool"))
+    self.build_dir_path = pathlib.Path(self.build_dir.name).resolve()
+    self.normal_tool_dir = self.build_dir_path / "normal_tool"
     os.mkdir(self.normal_tool_dir)
-    self.traced_tool_dir = os.path.realpath(
-        os.path.join(self.build_dir.name, "traced_tool"))
+    self.traced_tool_dir = self.build_dir_path / "traced_tool"
     os.mkdir(self.traced_tool_dir)
     self.trace_capture_tool = tempfile.NamedTemporaryFile()
     os.chmod(self.trace_capture_tool.name, stat.S_IEXEC)
@@ -46,18 +46,15 @@ class BenchmarkConfigTest(unittest.TestCase):
 
     config = BenchmarkConfig.build_from_args(args=args, git_commit_hash="abcd")
 
-    per_commit_tmp_dir = os.path.realpath(
-        os.path.join(self.tmp_dir.name, "abcd"))
+    per_commit_tmp_dir = pathlib.Path(self.tmp_dir.name).resolve() / "abcd"
     expected_trace_capture_config = TraceCaptureConfig(
         traced_benchmark_tool_dir=self.traced_tool_dir,
-        trace_capture_tool=os.path.realpath(self.trace_capture_tool.name),
-        capture_tarball=os.path.realpath("capture.tar"),
-        capture_tmp_dir=os.path.join(per_commit_tmp_dir, "captures"))
+        trace_capture_tool=pathlib.Path(self.trace_capture_tool.name).resolve(),
+        capture_tarball=pathlib.Path("capture.tar").resolve(),
+        capture_tmp_dir=per_commit_tmp_dir / "captures")
     expected_config = BenchmarkConfig(
-        root_benchmark_dir=os.path.realpath(
-            os.path.join(self.build_dir.name, "benchmark_suites")),
-        benchmark_results_dir=os.path.realpath(
-            os.path.join(per_commit_tmp_dir, "benchmark-results")),
+        root_benchmark_dir=self.build_dir_path / "benchmark_suites",
+        benchmark_results_dir=per_commit_tmp_dir / "benchmark-results",
         git_commit_hash="abcd",
         normal_benchmark_tool_dir=self.normal_tool_dir,
         trace_capture_config=expected_trace_capture_config,

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -12,6 +12,7 @@ shared between different stages of the same benchmark pipeline.
 
 import json
 import os
+import pathlib
 import re
 import subprocess
 

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -83,7 +83,7 @@ IREE_PRETTY_NAME_TO_DRIVER_NAME = {
 }
 
 
-def execute_cmd(args: Sequence[str],
+def execute_cmd(args: Sequence[Any],
                 verbose: bool = False,
                 **kwargs) -> subprocess.CompletedProcess:
   """Executes a command and returns the completed process.
@@ -94,13 +94,12 @@ def execute_cmd(args: Sequence[str],
   Raises:
     CalledProcessError if the command fails.
   """
-  cmd = " ".join(args)
   if verbose:
-    print(f"cmd: {cmd}")
+    print(f"cmd: {args}")
   try:
     return subprocess.run(args, check=True, text=True, **kwargs)
   except subprocess.CalledProcessError as exc:
-    print((f"\n\nThe following command failed:\n\n{cmd}"
+    print((f"\n\nThe following command failed:\n\n{args}"
            f"\n\nReturn code: {exc.returncode}\n\n"))
     if exc.stdout:
       print(f"Stdout:\n\n{exc.stdout}\n\n")
@@ -109,7 +108,7 @@ def execute_cmd(args: Sequence[str],
     raise exc
 
 
-def execute_cmd_and_get_output(args: Sequence[str],
+def execute_cmd_and_get_output(args: Sequence[Any],
                                verbose: bool = False,
                                **kwargs) -> str:
   """Executes a command and returns its stdout.

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -121,8 +121,7 @@ def execute_cmd_and_get_output(args: Sequence[Any],
 
 def get_git_commit_hash(commit: str) -> str:
   return execute_cmd_and_get_output(['git', 'rev-parse', commit],
-                                    cwd=os.path.dirname(
-                                        os.path.realpath(__file__)))
+                                    cwd=pathlib.Path(__file__).resolve().parent)
 
 
 def get_iree_benchmark_module_arguments(

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import pathlib
 import tempfile
 import unittest
 
@@ -26,10 +27,10 @@ class FakeBenchmarkDriver(BenchmarkDriver):
     self.raise_exception_on_case = raise_exception_on_case
 
   def run_benchmark_case(self, benchmark_case: BenchmarkCase,
-                         benchmark_results_filename: Optional[str],
-                         capture_filename: Optional[str]) -> None:
+                         benchmark_results_filename: Optional[pathlib.Path],
+                         capture_filename: Optional[pathlib.Path]) -> None:
     if (self.raise_exception_on_case is not None and
-        self.raise_exception_on_case in benchmark_case.benchmark_case_dir):
+        self.raise_exception_on_case in str(benchmark_case.benchmark_case_dir)):
       raise Exception("fake exception")
 
     if benchmark_results_filename:
@@ -49,22 +50,22 @@ class BenchmarkDriverTest(unittest.TestCase):
     self.tmp_dir = tempfile.TemporaryDirectory()
     self.root_dir = tempfile.TemporaryDirectory()
 
-    with open(os.path.join(self.tmp_dir.name, "build_config.txt"), "w") as f:
+    self.tmp_dir_path = pathlib.Path(self.tmp_dir.name)
+    with (self.tmp_dir_path / "build_config.txt").open("w") as f:
       f.write("IREE_HAL_DRIVER_LOCAL_SYNC=ON\n")
       f.write("IREE_HAL_DRIVER_LOCAL_TASK=ON\n")
       f.write("IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF=ON\n")
 
     self.config = BenchmarkConfig(
-        root_benchmark_dir=self.root_dir.name,
-        benchmark_results_dir=os.path.join(self.tmp_dir.name,
-                                           BENCHMARK_RESULTS_REL_PATH),
+        root_benchmark_dir=pathlib.Path(self.root_dir.name),
+        benchmark_results_dir=self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH,
         git_commit_hash="abcd",
-        normal_benchmark_tool_dir=self.tmp_dir.name,
+        normal_benchmark_tool_dir=self.tmp_dir_path,
         trace_capture_config=TraceCaptureConfig(
-            traced_benchmark_tool_dir=self.tmp_dir.name,
-            trace_capture_tool=os.path.join(self.tmp_dir.name, "capture_tool"),
-            capture_tarball="captures.tar",
-            capture_tmp_dir=os.path.join(self.tmp_dir.name, CAPTURES_REL_PATH)))
+            traced_benchmark_tool_dir=self.tmp_dir_path,
+            trace_capture_tool=self.tmp_dir_path / "capture_tool",
+            capture_tarball=self.tmp_dir_path / "captures.tar",
+            capture_tmp_dir=self.tmp_dir_path / CAPTURES_REL_PATH))
 
     self.device_info = DeviceInfo(platform_type=PlatformType.LINUX,
                                   model="Unknown",
@@ -78,17 +79,17 @@ class BenchmarkDriverTest(unittest.TestCase):
                           bench_mode=["1-thread", "full-inference"],
                           target_arch="CPU-ARM64-v8A",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-                          benchmark_case_dir="case1",
+                          benchmark_case_dir=pathlib.Path("case1"),
                           benchmark_tool_name="tool")
     case2 = BenchmarkCase(model_name="DeepNetv2",
                           model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="CPU-ARM64-v8A",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
-                          benchmark_case_dir="case2",
+                          benchmark_case_dir=pathlib.Path("case2"),
                           benchmark_tool_name="tool")
     self.benchmark_suite = BenchmarkSuite({
-        "suite/TFLite": [case1, case2],
+        pathlib.Path("suite/TFLite"): [case1, case2],
     })
 
   def tearDown(self) -> None:
@@ -98,22 +99,20 @@ class BenchmarkDriverTest(unittest.TestCase):
   def test_add_previous_benchmarks_and_captures(self):
     driver = BenchmarkDriver(self.device_info, self.config,
                              self.benchmark_suite)
-    os.makedirs(os.path.join(self.tmp_dir.name, BENCHMARK_RESULTS_REL_PATH))
-    os.makedirs(os.path.join(self.tmp_dir.name, CAPTURES_REL_PATH))
-    benchmark_filename = os.path.join(
-        self.tmp_dir.name, BENCHMARK_RESULTS_REL_PATH,
+    os.makedirs(self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH)
+    os.makedirs(self.tmp_dir_path / CAPTURES_REL_PATH)
+    benchmark_filename = (
+        self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH /
         "MobileNetv2 [fp32,imagenet] (TFLite) big-core,full-inference with IREE-LLVM-CPU @ Pixel-4 (CPU-ARMv8.2-A).json"
     )
-    capture_filename = os.path.join(
-        self.tmp_dir.name, CAPTURES_REL_PATH,
+    benchmark_filename.write_text("")
+    capture_filename = (
+        self.tmp_dir_path / CAPTURES_REL_PATH /
         "MobileNetv2 [fp32,imagenet] (TFLite) big-core,full-inference with IREE-LLVM-CPU @ Pixel-4 (CPU-ARMv8.2-A).tracy"
     )
-    with open(os.path.join(benchmark_filename), "w") as f:
-      f.write("")
-    with open(os.path.join(capture_filename), "w") as f:
-      f.write("")
+    capture_filename.write_text("")
 
-    driver.add_previous_benchmarks_and_captures(self.tmp_dir.name)
+    driver.add_previous_benchmarks_and_captures(self.tmp_dir_path)
 
     self.assertEqual(driver.get_benchmark_result_filenames(),
                      [benchmark_filename])
@@ -130,24 +129,16 @@ class BenchmarkDriverTest(unittest.TestCase):
     self.assertEqual(driver.get_benchmark_results().benchmarks[0].context,
                      "fake_context")
     self.assertEqual(driver.get_benchmark_result_filenames(), [
-        os.path.join(
-            self.tmp_dir.name, BENCHMARK_RESULTS_REL_PATH,
-            "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).json"
-        ),
-        os.path.join(
-            self.tmp_dir.name, BENCHMARK_RESULTS_REL_PATH,
-            "DeepNetv2 [f32] (TFLite) full-inference with IREE-LLVM-CPU-Sync @ Unknown (CPU-ARMv8-A).json"
-        )
+        self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH /
+        "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).json",
+        self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH /
+        "DeepNetv2 [f32] (TFLite) full-inference with IREE-LLVM-CPU-Sync @ Unknown (CPU-ARMv8-A).json"
     ])
     self.assertEqual(driver.get_capture_filenames(), [
-        os.path.join(
-            self.tmp_dir.name, CAPTURES_REL_PATH,
-            "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).tracy"
-        ),
-        os.path.join(
-            self.tmp_dir.name, CAPTURES_REL_PATH,
-            "DeepNetv2 [f32] (TFLite) full-inference with IREE-LLVM-CPU-Sync @ Unknown (CPU-ARMv8-A).tracy"
-        )
+        self.tmp_dir_path / CAPTURES_REL_PATH /
+        "DeepNet (TFLite) 1-thread,full-inference with IREE-LLVM-CPU @ Unknown (CPU-ARMv8-A).tracy",
+        self.tmp_dir_path / CAPTURES_REL_PATH /
+        "DeepNetv2 [f32] (TFLite) full-inference with IREE-LLVM-CPU-Sync @ Unknown (CPU-ARMv8-A).tracy"
     ])
     self.assertEqual(driver.get_benchmark_errors(), [])
 

--- a/build_tools/benchmarks/common/benchmark_driver_test.py
+++ b/build_tools/benchmarks/common/benchmark_driver_test.py
@@ -5,7 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import json
-import os
 import pathlib
 import tempfile
 import unittest
@@ -34,14 +33,13 @@ class FakeBenchmarkDriver(BenchmarkDriver):
       raise Exception("fake exception")
 
     if benchmark_results_filename:
-      with open(benchmark_results_filename, "w") as f:
-        f.write(json.dumps({
-            "context": "fake_context",
-            "benchmarks": [],
-        }))
+      benchmark_results_filename.write_text(
+          json.dumps({
+              "context": "fake_context",
+              "benchmarks": [],
+          }))
     if capture_filename:
-      with open(capture_filename, "w") as f:
-        f.write("{}")
+      capture_filename.write_text("{}")
 
 
 class BenchmarkDriverTest(unittest.TestCase):
@@ -51,10 +49,10 @@ class BenchmarkDriverTest(unittest.TestCase):
     self.root_dir = tempfile.TemporaryDirectory()
 
     self.tmp_dir_path = pathlib.Path(self.tmp_dir.name)
-    with (self.tmp_dir_path / "build_config.txt").open("w") as f:
-      f.write("IREE_HAL_DRIVER_LOCAL_SYNC=ON\n")
-      f.write("IREE_HAL_DRIVER_LOCAL_TASK=ON\n")
-      f.write("IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF=ON\n")
+    (self.tmp_dir_path / "build_config.txt").write_text(
+        "IREE_HAL_DRIVER_LOCAL_SYNC=ON\n"
+        "IREE_HAL_DRIVER_LOCAL_TASK=ON\n"
+        "IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF=ON\n")
 
     self.config = BenchmarkConfig(
         root_benchmark_dir=pathlib.Path(self.root_dir.name),
@@ -99,18 +97,18 @@ class BenchmarkDriverTest(unittest.TestCase):
   def test_add_previous_benchmarks_and_captures(self):
     driver = BenchmarkDriver(self.device_info, self.config,
                              self.benchmark_suite)
-    os.makedirs(self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH)
-    os.makedirs(self.tmp_dir_path / CAPTURES_REL_PATH)
+    (self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH).mkdir(parents=True)
+    (self.tmp_dir_path / CAPTURES_REL_PATH).mkdir(parents=True)
     benchmark_filename = (
         self.tmp_dir_path / BENCHMARK_RESULTS_REL_PATH /
         "MobileNetv2 [fp32,imagenet] (TFLite) big-core,full-inference with IREE-LLVM-CPU @ Pixel-4 (CPU-ARMv8.2-A).json"
     )
-    benchmark_filename.write_text("")
+    benchmark_filename.touch()
     capture_filename = (
         self.tmp_dir_path / CAPTURES_REL_PATH /
         "MobileNetv2 [fp32,imagenet] (TFLite) big-core,full-inference with IREE-LLVM-CPU @ Pixel-4 (CPU-ARMv8.2-A).tracy"
     )
-    capture_filename.write_text("")
+    capture_filename.touch()
 
     driver.add_previous_benchmarks_and_captures(self.tmp_dir_path)
 

--- a/build_tools/benchmarks/common/benchmark_presentation.py
+++ b/build_tools/benchmarks/common/benchmark_presentation.py
@@ -7,6 +7,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, Generic, List, Optional, Sequence, Tuple, TypeVar, Union
+import pathlib
 import dataclasses
 import json
 import urllib.parse
@@ -167,7 +168,7 @@ COMPILATION_METRICS_TO_TABLE_MAPPERS: List[
 
 
 def aggregate_all_benchmarks(
-    benchmark_files: Sequence[str],
+    benchmark_files: Sequence[pathlib.Path],
     expected_pr_commit: Optional[str] = None,
     verbose: bool = False) -> Dict[str, AggregateBenchmarkLatency]:
   """Aggregates all benchmarks in the given files.
@@ -184,9 +185,7 @@ def aggregate_all_benchmarks(
   aggregate_results = {}
 
   for benchmark_file in benchmark_files:
-    with open(benchmark_file) as f:
-      content = f.read()
-    file_results = BenchmarkResults.from_json_str(content)
+    file_results = BenchmarkResults.from_json_str(benchmark_file.read_text())
 
     if ((expected_pr_commit is not None) and
         (file_results.commit != expected_pr_commit)):
@@ -212,7 +211,7 @@ def aggregate_all_benchmarks(
 
 
 def collect_all_compilation_metrics(
-    compile_stats_files: Sequence[str],
+    compile_stats_files: Sequence[pathlib.Path],
     expected_pr_commit: Optional[str] = None) -> Dict[str, CompilationMetrics]:
   """Collects all compilation statistics in the given files.
 
@@ -227,7 +226,7 @@ def collect_all_compilation_metrics(
   compile_metrics = {}
 
   for compile_stats_file in compile_stats_files:
-    with open(compile_stats_file) as f:
+    with compile_stats_file.open("r") as f:
       file_results = CompilationResults.from_json_object(json.load(f))
 
     if ((expected_pr_commit is not None) and

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -6,6 +6,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import os
+import pathlib
 import tempfile
 import unittest
 from typing import Sequence
@@ -18,12 +19,13 @@ class BenchmarkSuiteTest(unittest.TestCase):
 
   def test_list_categories(self):
     suite = BenchmarkSuite({
-        "suite/TFLite": [],
-        "suite/PyTorch": [],
+        pathlib.Path("suite/TFLite"): [],
+        pathlib.Path("suite/PyTorch"): [],
     })
 
-    self.assertEqual(suite.list_categories(), [("PyTorch", "suite/PyTorch"),
-                                               ("TFLite", "suite/TFLite")])
+    self.assertEqual(suite.list_categories(),
+                     [("PyTorch", pathlib.Path("suite/PyTorch")),
+                      ("TFLite", pathlib.Path("suite/TFLite"))])
 
   def test_filter_benchmarks_for_category(self):
     case1 = BenchmarkCase(model_name="deepnet",
@@ -31,24 +33,24 @@ class BenchmarkSuiteTest(unittest.TestCase):
                           bench_mode=["1-thread", "full-inference"],
                           target_arch="CPU-ARMv8",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
-                          benchmark_case_dir="case1",
+                          benchmark_case_dir=pathlib.Path("case1"),
                           benchmark_tool_name="tool")
     case2 = BenchmarkCase(model_name="deepnetv2",
                           model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="GPU-Mali",
                           driver_info=IREE_DRIVERS_INFOS["iree-vulkan"],
-                          benchmark_case_dir="case2",
+                          benchmark_case_dir=pathlib.Path("case2"),
                           benchmark_tool_name="tool")
     case3 = BenchmarkCase(model_name="deepnetv3",
                           model_tags=["f32"],
                           bench_mode=["full-inference"],
                           target_arch="CPU-x86_64",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
-                          benchmark_case_dir="case3",
+                          benchmark_case_dir=pathlib.Path("case3"),
                           benchmark_tool_name="tool")
     suite = BenchmarkSuite({
-        "suite/TFLite": [case1, case2, case3],
+        pathlib.Path("suite/TFLite"): [case1, case2, case3],
     })
 
     cpu_and_gpu_benchmarks = suite.filter_benchmarks_for_category(
@@ -84,7 +86,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
 
   def test_filter_benchmarks_for_nonexistent_category(self):
     suite = BenchmarkSuite({
-        "suite/TFLite": [],
+        pathlib.Path("suite/TFLite"): [],
     })
 
     benchmarks = suite.filter_benchmarks_for_category(
@@ -98,8 +100,9 @@ class BenchmarkSuiteTest(unittest.TestCase):
 
   def test_load_from_benchmark_suite_dir(self):
     with tempfile.TemporaryDirectory() as tmp_dir:
-      tflite_dir = os.path.join(tmp_dir, "TFLite")
-      pytorch_dir = os.path.join(tmp_dir, "PyTorch")
+      tmp_dir = pathlib.Path(tmp_dir)
+      tflite_dir = tmp_dir / "TFLite"
+      pytorch_dir = tmp_dir / "PyTorch"
       BenchmarkSuiteTest.__create_bench(tflite_dir,
                                         model_name="DeepNet",
                                         model_tags=["f32"],
@@ -200,8 +203,8 @@ class BenchmarkSuiteTest(unittest.TestCase):
     suite = BenchmarkSuite.load_from_run_configs(run_configs=run_configs)
 
     self.assertEqual(suite.list_categories(),
-                     [("exported_tf", "exported_tf"),
-                      ("exported_tflite", "exported_tflite")])
+                     [("exported_tf", pathlib.Path("exported_tf")),
+                      ("exported_tflite", pathlib.Path("exported_tflite"))])
     self.assertEqual(
         suite.filter_benchmarks_for_category(category="exported_tflite"), [
             BenchmarkCase(model_name=model_tflite.name,
@@ -244,17 +247,16 @@ class BenchmarkSuiteTest(unittest.TestCase):
             mode_filter="experimental"), [])
 
   @staticmethod
-  def __create_bench(dir_path: str, model_name: str, model_tags: Sequence[str],
-                     bench_mode: Sequence[str], target_arch: str, config: str,
-                     tool: str):
+  def __create_bench(dir_path: pathlib.Path, model_name: str,
+                     model_tags: Sequence[str], bench_mode: Sequence[str],
+                     target_arch: str, config: str, tool: str):
     case_name = f"{config}__{target_arch}__{','.join(bench_mode)}"
     model_name_with_tags = model_name
     if len(model_tags) > 0:
       model_name_with_tags += f"-{','.join(model_tags)}"
-    bench_path = os.path.join(dir_path, model_name_with_tags, case_name)
+    bench_path = dir_path / model_name_with_tags / case_name
     os.makedirs(bench_path)
-    with open(os.path.join(bench_path, "tool"), "w") as f:
-      f.write(tool)
+    (bench_path / "tool").write_text(tool)
 
     return BenchmarkCase(model_name=model_name,
                          model_tags=model_tags,

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -255,7 +255,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
     if len(model_tags) > 0:
       model_name_with_tags += f"-{','.join(model_tags)}"
     bench_path = dir_path / model_name_with_tags / case_name
-    os.makedirs(bench_path)
+    bench_path.mkdir(parents=True)
     (bench_path / "tool").write_text(tool)
 
     return BenchmarkCase(model_name=model_name,

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -8,6 +8,7 @@
 import glob
 import os
 import argparse
+import pathlib
 from typing import List, Sequence
 
 
@@ -15,12 +16,14 @@ def build_common_argument_parser():
   """Returns an argument parser with common options."""
 
   def check_dir_path(path):
-    if os.path.isdir(path):
+    path = pathlib.Path(path)
+    if path.is_dir():
       return path
     else:
       raise argparse.ArgumentTypeError(path)
 
   def check_exe_path(path):
+    path = pathlib.Path(path)
     if os.access(path, os.X_OK):
       return path
     else:
@@ -69,10 +72,12 @@ def build_common_argument_parser():
   parser.add_argument("--output",
                       "-o",
                       default=None,
+                      type=pathlib.Path,
                       help="Path to the output file")
   parser.add_argument("--capture_tarball",
                       "--capture-tarball",
                       default=None,
+                      type=pathlib.Path,
                       help="Path to the tarball for captures")
   parser.add_argument("--no-clean",
                       action="store_true",
@@ -101,13 +106,15 @@ def build_common_argument_parser():
       "--tmp_dir",
       "--tmp-dir",
       "--tmpdir",
-      default="/tmp/iree-benchmarks",
+      default=pathlib.Path("/tmp/iree-benchmarks"),
+      type=check_dir_path,
       help="Base directory in which to store temporary files. A subdirectory"
       " with a name matching the git commit hash will be created.")
   parser.add_argument(
       "--continue_from_directory",
       "--continue-from-directory",
       default=None,
+      type=check_dir_path,
       help="Path to directory with previous benchmark temporary files. This"
       " should be for the specific commit (not the general tmp-dir). Previous"
       " benchmark and capture results from here will not be rerun and will be"

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -133,7 +133,7 @@ def build_common_argument_parser():
   return parser
 
 
-def expand_and_check_file_paths(paths: Sequence[str]) -> List[str]:
+def expand_and_check_file_paths(paths: Sequence[str]) -> List[pathlib.Path]:
   """Expands the wildcards in the paths and check if they are files.
     Returns:
       List of expanded paths.
@@ -141,10 +141,10 @@ def expand_and_check_file_paths(paths: Sequence[str]) -> List[str]:
 
   expanded_paths = []
   for path in paths:
-    expanded_paths += glob.glob(path)
+    expanded_paths += [pathlib.Path(path) for path in glob.glob(path)]
 
   for path in expanded_paths:
-    if not os.path.isfile(path):
+    if not path.is_file():
       raise ValueError(f"{path} is not a file.")
 
   return expanded_paths

--- a/build_tools/benchmarks/diff_local_benchmarks.py
+++ b/build_tools/benchmarks/diff_local_benchmarks.py
@@ -12,20 +12,19 @@ Example usage:
 """
 
 import argparse
-import json
-import os
-import requests
+import pathlib
 
 from typing import Optional
 
 from common.benchmark_presentation import *
 
 
-def get_benchmark_result_markdown(base_benchmark_file: Optional[str],
-                                  target_benchmark_file: Optional[str],
-                                  base_compile_stats_file: Optional[str],
-                                  target_compile_stats_file: Optional[str],
-                                  verbose: bool = False) -> str:
+def get_benchmark_result_markdown(
+    base_benchmark_file: Optional[pathlib.Path],
+    target_benchmark_file: Optional[pathlib.Path],
+    base_compile_stats_file: Optional[pathlib.Path],
+    target_compile_stats_file: Optional[pathlib.Path],
+    verbose: bool = False) -> str:
   """Gets the full markdown summary of all benchmarks in files."""
   base_benchmarks = {}
   target_benchmarks = {}
@@ -68,7 +67,8 @@ def parse_arguments():
   """Parses command-line options."""
 
   def check_file_path(path):
-    if os.path.isfile(path):
+    path = pathlib.Path(path)
+    if path.is_file():
       return path
     else:
       raise ValueError(path)

--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -123,8 +123,8 @@ def query_base_benchmark_results(commit,
   return get_from_dashboard(f'{url}/apis/v2/getBuild', payload, verbose=verbose)
 
 
-def get_benchmark_result_markdown(benchmark_files: Sequence[str],
-                                  compile_stats_files: Sequence[str],
+def get_benchmark_result_markdown(benchmark_files: Sequence[pathlib.Path],
+                                  compile_stats_files: Sequence[pathlib.Path],
                                   query_base: bool,
                                   comment_title: str,
                                   verbose: bool = False) -> Tuple[str, str]:

--- a/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
+++ b/build_tools/benchmarks/post_benchmarks_as_pr_comment.py
@@ -54,7 +54,7 @@ IREE_PROJECT_ID = 'IREE'
 MAX_BASE_COMMIT_QUERY_COUNT = 10
 # The max number of rows to show per table.
 TABLE_SIZE_CUT = 3
-THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+THIS_DIRECTORY = pathlib.Path(__file__).resolve().parent
 
 
 def get_required_env_var(var: str) -> str:

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -57,15 +57,16 @@ from common.android_device_utils import (get_android_device_model,
 from common.common_arguments import build_common_argument_parser
 
 # Root directory to perform benchmarks in on the Android device.
-ANDROID_TMPDIR = "/data/local/tmp/iree-benchmarks"
+ANDROID_TMPDIR = pathlib.PurePosixPath("/data/local/tmp/iree-benchmarks")
 
-NORMAL_TOOL_REL_DIR = "normal-tools"
-TRACED_TOOL_REL_DIR = "traced-tools"
+NORMAL_TOOL_REL_DIR = pathlib.PurePosixPath("normal-tools")
+TRACED_TOOL_REL_DIR = pathlib.PurePosixPath("traced-tools")
 
 
-def adb_push_to_tmp_dir(content: str,
-                        relative_dir: str = "",
-                        verbose: bool = False) -> str:
+def adb_push_to_tmp_dir(
+    content: pathlib.Path,
+    relative_dir: pathlib.PurePosixPath = pathlib.PurePosixPath(),
+    verbose: bool = False) -> pathlib.PurePosixPath:
   """Pushes content onto the Android device.
 
   Args:
@@ -75,21 +76,23 @@ def adb_push_to_tmp_dir(content: str,
   Returns:
     The full path to the content on the Android device.
   """
-  filename = os.path.basename(content)
-  android_path = os.path.join(ANDROID_TMPDIR, relative_dir, filename)
+  filename = content.name
+  android_path = ANDROID_TMPDIR / relative_dir / filename
   # When the output is a TTY, keep the default progress info output.
   # In other cases, redirect progress info to null to avoid bloating log files.
   stdout_redirect = None if sys.stdout.isatty() else subprocess.DEVNULL
   execute_cmd(
-      ["adb", "push", os.path.abspath(content), android_path],
+      ["adb", "push", str(content.resolve()),
+       str(android_path)],
       verbose=verbose,
       stdout=stdout_redirect)
   return android_path
 
 
-def adb_execute_and_get_output(cmd_args: Sequence[str],
-                               relative_dir: str = "",
-                               verbose: bool = False) -> str:
+def adb_execute_and_get_output(
+    cmd_args: Sequence[str],
+    relative_dir: pathlib.PurePosixPath = pathlib.PurePosixPath(),
+    verbose: bool = False) -> str:
   """Executes command with adb shell.
 
   Switches to `relative_dir` relative to the android tmp directory before
@@ -104,7 +107,7 @@ def adb_execute_and_get_output(cmd_args: Sequence[str],
     A string for the command output.
   """
   cmd = ["adb", "shell"]
-  cmd.extend(["cd", os.path.join(ANDROID_TMPDIR, relative_dir)])
+  cmd.extend(["cd", str(ANDROID_TMPDIR / relative_dir)])
   cmd.append("&&")
   cmd.extend(cmd_args)
 
@@ -112,7 +115,7 @@ def adb_execute_and_get_output(cmd_args: Sequence[str],
 
 
 def adb_execute(cmd_args: Sequence[str],
-                relative_dir: str = "",
+                relative_dir: pathlib.PurePosixPath = pathlib.PurePosixPath(),
                 verbose: bool = False) -> subprocess.CompletedProcess:
   """Executes command with adb shell.
 
@@ -128,7 +131,7 @@ def adb_execute(cmd_args: Sequence[str],
     The completed process.
   """
   cmd = ["adb", "shell"]
-  cmd.extend(["cd", os.path.join(ANDROID_TMPDIR, relative_dir)])
+  cmd.extend(["cd", str(ANDROID_TMPDIR / relative_dir)])
   cmd.append("&&")
   cmd.extend(cmd_args)
 
@@ -148,7 +151,7 @@ def adb_execute_as_root(cmd_args: Sequence[str]) -> subprocess.CompletedProcess:
 
 
 def adb_start_cmd(cmd_args: Sequence[str],
-                  relative_dir: str,
+                  relative_dir: pathlib.PurePosixPath = pathlib.PurePosixPath(),
                   verbose: bool = False) -> subprocess.Popen:
   """Executes command with adb shell in a directory and returns the handle
   without waiting for completion.
@@ -162,7 +165,7 @@ def adb_start_cmd(cmd_args: Sequence[str],
     A Popen object for the started command.
   """
   cmd = ["adb", "shell"]
-  cmd.extend(["cd", f"{ANDROID_TMPDIR}/{relative_dir}"])
+  cmd.extend(["cd", str(ANDROID_TMPDIR / relative_dir)])
   cmd.append("&&")
   cmd.extend(cmd_args)
 
@@ -172,16 +175,17 @@ def adb_start_cmd(cmd_args: Sequence[str],
   return subprocess.Popen(cmd, stdout=subprocess.PIPE, text=True)
 
 
-def get_vmfb_full_path_for_benchmark_case(benchmark_case_dir: str) -> str:
-  flagfile_path = os.path.join(benchmark_case_dir, MODEL_FLAGFILE_NAME)
-  flagfile = open(flagfile_path, "r")
-  flagfile_lines = flagfile.readlines()
+def get_vmfb_full_path_for_benchmark_case(
+    benchmark_case_dir: pathlib.Path) -> pathlib.Path:
+  flagfile_path = benchmark_case_dir / MODEL_FLAGFILE_NAME
+  with flagfile_path.open("r") as flagfile:
+    flagfile_lines = flagfile.readlines()
   for line in flagfile_lines:
     flag_name, flag_value = line.strip().split("=")
     if flag_name == "--module_file":
       # Realpath canonicalization matters. The caller may rely on that to track
       # which files it already pushed.
-      return os.path.realpath(os.path.join(benchmark_case_dir, flag_value))
+      return (benchmark_case_dir / flag_value).resolve()
   raise ValueError(f"{flagfile_path} does not contain a --module_file flag")
 
 
@@ -193,19 +197,19 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     self.already_pushed_files = {}
 
   def run_benchmark_case(self, benchmark_case: BenchmarkCase,
-                         benchmark_results_filename: Optional[str],
-                         capture_filename: Optional[str]) -> None:
+                         benchmark_results_filename: Optional[pathlib.Path],
+                         capture_filename: Optional[pathlib.Path]) -> None:
     benchmark_case_dir = benchmark_case.benchmark_case_dir
     # TODO(#11076): Support run_config.
     if benchmark_case_dir is None:
       raise ValueError("benchmark_case_dir can't be None.")
 
-    android_case_dir = os.path.relpath(benchmark_case_dir,
-                                       self.config.root_benchmark_dir)
+    android_case_dir = pathlib.PurePosixPath(
+        benchmark_case_dir.relative_to(self.config.root_benchmark_dir))
 
     self.__push_vmfb_file(benchmark_case_dir)
-    self.__check_and_push_file(
-        os.path.join(benchmark_case_dir, MODEL_FLAGFILE_NAME), android_case_dir)
+    self.__check_and_push_file(benchmark_case_dir / MODEL_FLAGFILE_NAME,
+                               android_case_dir)
 
     taskset = self.__deduce_taskset(benchmark_case.bench_mode)
 
@@ -222,11 +226,13 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
                          capture_filename=capture_filename,
                          taskset=taskset)
 
-  def __run_benchmark(self, android_case_dir: str, tool_name: str,
-                      driver_info: DriverInfo, results_filename: str,
-                      taskset: str):
-    host_tool_path = os.path.join(self.config.normal_benchmark_tool_dir,
-                                  tool_name)
+  def __run_benchmark(self, android_case_dir: pathlib.PurePosixPath,
+                      tool_name: str, driver_info: DriverInfo,
+                      results_filename: pathlib.Path, taskset: str):
+    if self.config.normal_benchmark_tool_dir is None:
+      raise ValueError("normal_benchmark_tool_dir can't be None.")
+
+    host_tool_path = self.config.normal_benchmark_tool_dir / tool_name
     android_tool = self.__check_and_push_file(host_tool_path,
                                               NORMAL_TOOL_REL_DIR)
     cmd = [
@@ -235,7 +241,7 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     if tool_name == "iree-benchmark-module":
       cmd.extend(
           get_iree_benchmark_module_arguments(
-              results_filename=f"'{os.path.basename(results_filename)}'",
+              results_filename=results_filename.name,
               driver_info=driver_info,
               benchmark_min_time=self.config.benchmark_min_time))
 
@@ -247,23 +253,27 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     # return.
     pull_cmd = [
         "adb", "pull",
-        os.path.join(ANDROID_TMPDIR, android_case_dir,
-                     os.path.basename(results_filename)), results_filename
+        (ANDROID_TMPDIR / android_case_dir / results_filename.name).as_posix(),
+        str(results_filename)
     ]
     execute_cmd_and_get_output(pull_cmd, verbose=self.verbose)
 
     if self.verbose:
       print(result_json)
 
-  def __run_capture(self, android_case_dir: str, tool_name: str,
-                    capture_filename: str, taskset: str):
+  def __run_capture(self, android_case_dir: pathlib.PurePosixPath,
+                    tool_name: str, capture_filename: pathlib.Path,
+                    taskset: str):
     capture_config = self.config.trace_capture_config
-    host_tool_path = os.path.join(capture_config.traced_benchmark_tool_dir,
-                                  tool_name)
+    if capture_config is None:
+      raise ValueError("capture_config can't be None.")
+
+    host_tool_path = capture_config.traced_benchmark_tool_dir / tool_name
     android_tool = self.__check_and_push_file(host_tool_path,
                                               TRACED_TOOL_REL_DIR)
     run_cmd = [
-        "TRACY_NO_EXIT=1", f"IREE_PRESERVE_DYLIB_TEMP_FILES={ANDROID_TMPDIR}",
+        "TRACY_NO_EXIT=1",
+        f"IREE_PRESERVE_DYLIB_TEMP_FILES={ANDROID_TMPDIR.as_posix()}",
         "taskset", taskset, android_tool, f"--flagfile={MODEL_FLAGFILE_NAME}"
     ]
 
@@ -277,7 +287,8 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     # send the signal to let the previously waiting benchmark tool to
     # complete.
     capture_cmd = [
-        capture_config.trace_capture_tool, "-f", "-o", capture_filename
+        str(capture_config.trace_capture_tool), "-f", "-o",
+        str(capture_filename)
     ]
     # If verbose, just let the subprocess print its output. The subprocess
     # may need to detect if the output is a TTY to decide whether to log
@@ -296,13 +307,13 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     # Not specified: use the 7th core.
     return "80"
 
-  def __push_vmfb_file(self, benchmark_case_dir: str):
+  def __push_vmfb_file(self, benchmark_case_dir: pathlib.Path):
     vmfb_path = get_vmfb_full_path_for_benchmark_case(benchmark_case_dir)
-    vmfb_dir = os.path.dirname(vmfb_path)
-    vmfb_rel_dir = os.path.relpath(vmfb_dir, self.config.root_benchmark_dir)
-    self.__check_and_push_file(vmfb_path, vmfb_rel_dir)
+    vmfb_rel_dir = vmfb_path.parent.relative_to(self.config.root_benchmark_dir)
+    self.__check_and_push_file(vmfb_path, pathlib.PurePosixPath(vmfb_rel_dir))
 
-  def __check_and_push_file(self, host_path: str, relative_dir: str):
+  def __check_and_push_file(self, host_path: pathlib.Path,
+                            relative_dir: pathlib.PurePosixPath):
     """Checks if the file has been pushed and pushes it if not."""
     android_path = self.already_pushed_files.get(host_path)
     if android_path is not None:
@@ -317,27 +328,26 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
 
 def set_cpu_frequency_scaling_governor(governor: str):
   git_root = execute_cmd_and_get_output(["git", "rev-parse", "--show-toplevel"])
-  cpu_script = os.path.join(git_root, "build_tools", "benchmarks",
-                            "set_android_scaling_governor.sh")
+  cpu_script = (pathlib.Path(git_root) / "build_tools" / "benchmarks" /
+                "set_android_scaling_governor.sh")
   android_path = adb_push_to_tmp_dir(cpu_script)
-  adb_execute_as_root([android_path, governor])
+  adb_execute_as_root([str(android_path), governor])
 
 
 def set_gpu_frequency_scaling_policy(policy: str):
   git_root = execute_cmd_and_get_output(["git", "rev-parse", "--show-toplevel"])
   device_model = get_android_device_model()
   gpu_name = get_android_gpu_name()
+  benchmarks_tool_dir = pathlib.Path(git_root) / "build_tools" / "benchmarks"
   if device_model == "Pixel-6" or device_model == "Pixel-6-Pro":
-    gpu_script = os.path.join(git_root, "build_tools", "benchmarks",
-                              "set_pixel6_gpu_scaling_policy.sh")
+    gpu_script = benchmarks_tool_dir / "set_pixel6_gpu_scaling_policy.sh"
   elif gpu_name.lower().startswith("adreno"):
-    gpu_script = os.path.join(git_root, "build_tools", "benchmarks",
-                              "set_adreno_gpu_scaling_policy.sh")
+    gpu_script = benchmarks_tool_dir / "set_adreno_gpu_scaling_policy.sh"
   else:
     raise RuntimeError(
         f"Unsupported device '{device_model}' for setting GPU scaling policy")
   android_path = adb_push_to_tmp_dir(gpu_script)
-  adb_execute_as_root([android_path, policy])
+  adb_execute_as_root([str(android_path), policy])
 
 
 def main(args):
@@ -369,13 +379,16 @@ def main(args):
 
   # Clear the benchmark directory on the Android device first just in case
   # there are leftovers from manual or failed runs.
-  execute_cmd_and_get_output(["adb", "shell", "rm", "-rf", ANDROID_TMPDIR],
-                             verbose=args.verbose)
+  execute_cmd_and_get_output(
+      ["adb", "shell", "rm", "-rf",
+       ANDROID_TMPDIR.as_posix()],
+      verbose=args.verbose)
 
   if not args.no_clean:
     # Clear the benchmark directory on the Android device.
     atexit.register(execute_cmd_and_get_output,
-                    ["adb", "shell", "rm", "-rf", ANDROID_TMPDIR],
+                    ["adb", "shell", "rm", "-rf",
+                     ANDROID_TMPDIR.as_posix()],
                     verbose=args.verbose)
     # Also clear temporary directory on the host device.
     atexit.register(shutil.rmtree, args.tmp_dir)

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -178,9 +178,7 @@ def adb_start_cmd(cmd_args: Sequence[str],
 def get_vmfb_full_path_for_benchmark_case(
     benchmark_case_dir: pathlib.Path) -> pathlib.Path:
   flagfile_path = benchmark_case_dir / MODEL_FLAGFILE_NAME
-  with flagfile_path.open("r") as flagfile:
-    flagfile_lines = flagfile.readlines()
-  for line in flagfile_lines:
+  for line in flagfile_path.read_text().splitlines():
     flag_name, flag_value = line.strip().split("=")
     if flag_name == "--module_file":
       # Realpath canonicalization matters. The caller may rely on that to track

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -253,7 +253,7 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     # return.
     pull_cmd = [
         "adb", "pull",
-        (ANDROID_TMPDIR / android_case_dir / results_filename.name).as_posix(),
+        str(ANDROID_TMPDIR / android_case_dir / results_filename.name),
         str(results_filename)
     ]
     execute_cmd_and_get_output(pull_cmd, verbose=self.verbose)
@@ -272,8 +272,7 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     android_tool = self.__check_and_push_file(host_tool_path,
                                               TRACED_TOOL_REL_DIR)
     run_cmd = [
-        "TRACY_NO_EXIT=1",
-        f"IREE_PRESERVE_DYLIB_TEMP_FILES={ANDROID_TMPDIR.as_posix()}",
+        "TRACY_NO_EXIT=1", f"IREE_PRESERVE_DYLIB_TEMP_FILES={ANDROID_TMPDIR}",
         "taskset", taskset, android_tool, f"--flagfile={MODEL_FLAGFILE_NAME}"
     ]
 
@@ -379,16 +378,15 @@ def main(args):
 
   # Clear the benchmark directory on the Android device first just in case
   # there are leftovers from manual or failed runs.
-  execute_cmd_and_get_output(
-      ["adb", "shell", "rm", "-rf",
-       ANDROID_TMPDIR.as_posix()],
-      verbose=args.verbose)
+  execute_cmd_and_get_output(["adb", "shell", "rm", "-rf",
+                              str(ANDROID_TMPDIR)],
+                             verbose=args.verbose)
 
   if not args.no_clean:
     # Clear the benchmark directory on the Android device.
     atexit.register(execute_cmd_and_get_output,
                     ["adb", "shell", "rm", "-rf",
-                     ANDROID_TMPDIR.as_posix()],
+                     str(ANDROID_TMPDIR)],
                     verbose=args.verbose)
     # Also clear temporary directory on the host device.
     atexit.register(shutil.rmtree, args.tmp_dir)

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -177,14 +177,14 @@ def adb_start_cmd(cmd_args: Sequence[str],
 
 def get_vmfb_full_path_for_benchmark_case(
     benchmark_case_dir: pathlib.Path) -> pathlib.Path:
-  flagfile_path = benchmark_case_dir / MODEL_FLAGFILE_NAME
-  for line in flagfile_path.read_text().splitlines():
+  flagfile = benchmark_case_dir / MODEL_FLAGFILE_NAME
+  for line in flagfile.read_text().splitlines():
     flag_name, flag_value = line.strip().split("=")
     if flag_name == "--module_file":
       # Realpath canonicalization matters. The caller may rely on that to track
       # which files it already pushed.
       return (benchmark_case_dir / flag_value).resolve()
-  raise ValueError(f"{flagfile_path} does not contain a --module_file flag")
+  raise ValueError(f"{flagfile} does not contain a --module_file flag")
 
 
 class AndroidBenchmarkDriver(BenchmarkDriver):

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -227,7 +227,7 @@ class AndroidBenchmarkDriver(BenchmarkDriver):
     if tool_name == "iree-benchmark-module":
       cmd.extend(
           get_iree_benchmark_module_arguments(
-              results_filename=results_filename.name,
+              results_filename=f"'{results_filename.name}'",
               driver_info=driver_info,
               benchmark_min_time=self.config.benchmark_min_time))
 

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -14,7 +14,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
 import subprocess
 import atexit
-import os
 import shutil
 import tarfile
 
@@ -77,7 +76,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
       raise ValueError("normal_benchmark_tool_dir can't be None.")
 
     tool_name = benchmark_case.benchmark_tool_name
-    tool_path = str(self.config.normal_benchmark_tool_dir / tool_name)
+    tool_path = self.config.normal_benchmark_tool_dir / tool_name
     cmd = ["taskset", taskset, tool_path] + run_flags
     if tool_name == "iree-benchmark-module":
       cmd.extend(
@@ -98,8 +97,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
     if capture_config is None:
       raise ValueError("capture_config can't be None.")
 
-    tool_path = str(capture_config.traced_benchmark_tool_dir /
-                    benchmark_case.benchmark_tool_name)
+    tool_path = capture_config.traced_benchmark_tool_dir / benchmark_case.benchmark_tool_name
     cmd = ["taskset", taskset, tool_path] + run_flags
     process = subprocess.Popen(cmd,
                                env={"TRACY_NO_EXIT": "1"},
@@ -110,7 +108,7 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
     wait_for_iree_benchmark_module_start(process, self.verbose)
 
     capture_cmd = [
-        str(capture_config.trace_capture_tool), "-f", "-o", capture_filename
+        capture_config.trace_capture_tool, "-f", "-o", capture_filename
     ]
     stdout_redirect = None if self.verbose else subprocess.DEVNULL
     execute_cmd(capture_cmd, verbose=self.verbose, stdout=stdout_redirect)

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -66,8 +66,10 @@ class LinuxBenchmarkDriver(BenchmarkDriver):
                          run_flags=run_flags)
 
   def __parse_flagfile(self, case_dir: pathlib.Path) -> List[str]:
-    with (case_dir / MODEL_FLAGFILE_NAME).open("r") as flagfile:
-      return [line.strip() for line in flagfile.readlines()]
+    return [
+        line.strip()
+        for line in (case_dir / MODEL_FLAGFILE_NAME).read_text().splitlines()
+    ]
 
   def __run_benchmark(self, benchmark_case: BenchmarkCase,
                       results_filename: pathlib.Path, taskset: str,

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -19,6 +19,7 @@ Example usage:
 import argparse
 import json
 import os
+import pathlib
 import requests
 
 from typing import Any, Dict, Optional
@@ -32,7 +33,7 @@ from common.benchmark_thresholds import BENCHMARK_THRESHOLDS
 
 IREE_GITHUB_COMMIT_URL_PREFIX = 'https://github.com/iree-org/iree/commit'
 IREE_PROJECT_ID = 'IREE'
-THIS_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+THIS_DIRECTORY = pathlib.Path(__file__).resolve().parent
 
 COMMON_DESCRIIPTION = """
 <br>

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -305,7 +305,7 @@ def main(args):
   # Collect benchmark results from all files.
   all_results = []
   for benchmark_file in benchmark_files:
-    with open(benchmark_file) as f:
+    with benchmark_file.open("r") as f:
       content = f.read()
     all_results.append(BenchmarkResults.from_json_str(content))
   for other_results in all_results[1:]:

--- a/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
+++ b/build_tools/benchmarks/upload_benchmarks_to_dashboard.py
@@ -305,9 +305,8 @@ def main(args):
   # Collect benchmark results from all files.
   all_results = []
   for benchmark_file in benchmark_files:
-    with benchmark_file.open("r") as f:
-      content = f.read()
-    all_results.append(BenchmarkResults.from_json_str(content))
+    all_results.append(
+        BenchmarkResults.from_json_str(benchmark_file.read_text()))
   for other_results in all_results[1:]:
     all_results[0].merge(other_results)
   all_results = all_results[0]


### PR DESCRIPTION
Replace string paths with pathlib in benchmark tools. To help review, this change is bascially:

- Replace `str` with `pathlib.Path`
- Replace `os.path.join` with `/` operator
- Replace other `os.path` functions (https://docs.python.org/3/library/pathlib.html#correspondence-to-tools-in-the-os-module)
- Replace `open(file_path, x)` with `file_path.open(x)`
- In `run_benchmarks_on_android.py`, all paths on Android devices are marked as `pathlib.PurePosixPath`, to make sure the path format is correct in commands on Android devices. 

Fix #11055