### PR TITLE
Shut down runner VM if startup fails

### DIFF
--- a/build_tools/github_actions/runner/config/register.sh
+++ b/build_tools/github_actions/runner/config/register.sh
@@ -130,4 +130,12 @@ declare -a args=(
 # functionality.
 (set -x; : Running configuration with additional args: "${args[@]}")
 
+# DO NOT SUBMIT
+if (( RANDOM % 2 == 0 )); then
+  echo "OH NOES. Registration failed!!!!"
+  exit 1
+else
+  echo "Few, we won the coin toss"
+fi
+
 /runner-root/actions-runner/config.sh --token "${REGISTER_TOKEN}" "${args[@]}"

--- a/build_tools/github_actions/runner/config/register.sh
+++ b/build_tools/github_actions/runner/config/register.sh
@@ -130,12 +130,4 @@ declare -a args=(
 # functionality.
 (set -x; : Running configuration with additional args: "${args[@]}")
 
-# DO NOT SUBMIT
-if (( RANDOM % 2 == 0 )); then
-  echo "OH NOES. Registration failed!!!!"
-  exit 1
-else
-  echo "Few, we won the coin toss"
-fi
-
 /runner-root/actions-runner/config.sh --token "${REGISTER_TOKEN}" "${args[@]}"

--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -9,7 +9,10 @@
 # Installs and sets up the GitHub actions runner, creating services to start and
 # tear down the runner.
 
-set -xeuo pipefail
+set -xeEuo pipefail
+
+# If the startup script fails, shut down the VM.
+trap '/usr/sbin/shutdown -P now' ERR
 
 SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
 source "${SCRIPT_DIR}/functions.sh"


### PR DESCRIPTION
I was planning to do this as health check, which integrates with the
actual MIG infrastructure, but that has ended up being a laborious
process due to Google security rules and I still haven't gotten it to
work. In the meantime, we've been having frequent issues with server
errors from the GitHub actions control plane, which mean that the
runners are never registered and the instances just sit around
counting as "running" according to the autoscaler.

This is a really simple method to just shut down the runners if setup
fails. We should also add retries and stuff, but this works for now and
should hopefully avoid us ending up with half our instance pool just
sitting idle.

Tested:
I added a non-deterministic failure in the setup script (see reverted
commit) and confirmed that some of the instances initially shut down,
but eventually all came online as runners.

skip-ci: Runner startup configuration not tested by CI.