### PR TITLE
Minor fixes to enable compilation of e2e matmul tests.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
@@ -306,7 +306,7 @@ void IREEMaterializeEncodingPass::runOnOperation() {
               subspanOp.getResult()
                   .getType()
                   .template dyn_cast<IREE::Flow::DispatchTensorType>();
-          // For types that are not `Flow::DispatchTensorType` amrk as legal.
+          // For types that are not `Flow::DispatchTensorType` mark as legal.
           if (!resultType) return true;
           return resultType == typeConverter.convertType(resultType);
         });

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
@@ -306,6 +306,8 @@ void IREEMaterializeEncodingPass::runOnOperation() {
               subspanOp.getResult()
                   .getType()
                   .template dyn_cast<IREE::Flow::DispatchTensorType>();
+          // For types that are not `Flow::DispatchTensorType` amrk as legal.
+          if (!resultType) return true;
           return resultType == typeConverter.convertType(resultType);
         });
 

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -34,6 +34,8 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
   passManager.nest<ModuleOp>().nest<func::FuncOp>().addPass(
       createTypePropagationPass());
   passManager.nest<ModuleOp>().addPass(createBufferizeCopyOnlyDispatchesPass());
+  passManager.nest<ModuleOp>().addNestedPass<func::FuncOp>(
+      createIREEMaterializeEncodingPass());
   passManager.addPass(createLLVMCPULowerExecutableTargetPass());
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -391,6 +391,7 @@ MaterializeEncodingTypeConverter::MaterializeEncodingTypeConverter(
   addConversion([](IntegerType intType) { return intType; });
   addConversion([](IndexType indexType) { return indexType; });
   addConversion([](FloatType floatType) { return floatType; });
+  addConversion([](MemRefType memrefType) { return memrefType; });
   addConversion(
       [materializeEncodingFn](RankedTensorType t) -> RankedTensorType {
         return getMaterializedType(t, materializeEncodingFn);


### PR DESCRIPTION
While making the `e2e/matmul` tests to use the data tiling path, some minor issues were discovered. Address those in this PR. THey will be exercised once the tests get flipped.