### PR TITLE
Use upstream SCF tiling in CPU codegen

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -254,7 +254,6 @@ struct LinalgSingleTilingExpertPass
     this->anchorOpName = options.anchorOpName;
     this->tileSizes = options.tileSizes;
     this->tileInterchange = options.tileInterchange;
-    this->peeledLoops = options.peeledLoops;
     this->pad = options.pad;
     this->paddingValues = options.paddingValues;
     this->packPaddings = options.packPaddings;

--- a/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -69,10 +69,8 @@ static SmallVector<Value> buildTileSizesForOp(OpBuilder &b, Operation *op,
   newTileSizes.resize(tilingOp.getLoopIteratorTypes().size(), /*default=*/0);
 
   OpBuilder::InsertionGuard guard(b);
-  b.setInsertionPointToStart(
-      &op->getParentOfType<func::FuncOp>().getBody().front());
   return llvm::to_vector(map_range(newTileSizes, [&](int64_t size) {
-    Value v = b.create<arith::ConstantIndexOp>(op->getLoc(), size);
+    Value v = b.create<arith::ConstantIndexOp>(tilingOp->getLoc(), size);
     return v;
   }));
 }

--- a/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -63,11 +63,10 @@ static FailureOr<Operation *> getRootOp(func::FuncOp funcOp) {
 /// method returns a proper tile sizes vector for each op during tiling.
 static SmallVector<Value> buildTileSizesForOp(OpBuilder &b, Operation *op,
                                               SmallVector<int64_t> tileSizes) {
-  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-  assert(linalgOp && "can only compute tile size on linalg ops");
+  auto tilingOp = cast<TilingInterface>(op);
 
   SmallVector<int64_t> newTileSizes = tileSizes;
-  newTileSizes.resize(linalgOp.getNumLoops(), /*default=*/0);
+  newTileSizes.resize(tilingOp.getLoopIteratorTypes().size(), /*default=*/0);
 
   OpBuilder::InsertionGuard guard(b);
   b.setInsertionPointToStart(

--- a/compiler/src/iree/compiler/Codegen/Sandbox/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Sandbox/Passes.h
@@ -48,7 +48,6 @@ struct LinalgSingleTilingExpertPassOptions {
   std::string anchorOpName = "";
   SmallVector<int64_t> tileSizes = {};
   SmallVector<int64_t> tileInterchange = {};
-  SmallVector<int64_t> peeledLoops = {};
   bool pad = false;
   SmallVector<std::string> paddingValues = {};
   SmallVector<int64_t> packPaddings = {};

--- a/compiler/src/iree/compiler/Codegen/Sandbox/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Sandbox/Passes.td
@@ -101,8 +101,6 @@ def LinalgSingleTilingExpert
     ListOption<"tileInterchange", "tile-interchange", "int64_t",
                 "Tile loop interchange",
                 "llvm::cl::ZeroOrMore">,
-    ListOption<"peeledLoops", "peeled-loops", "int64_t", "Peeled loops",
-               "llvm::cl::ZeroOrMore">,
     Option<"pad", "pad", "bool", /*default=*/"false",
       "Pad the anchor op operands.">,
     ListOption<"paddingValues", "padding-values", "std::string",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -10,6 +10,7 @@
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Pass/Pass.h"
 
 namespace mlir {
@@ -202,7 +203,7 @@ createLinalgStrategyTileAndFusePass(
 /// Create a LinalgStrategyTilePass.
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyTilePass(
     StringRef opName = "",
-    const linalg::LinalgTilingOptions &opt = linalg::LinalgTilingOptions(),
+    const scf::SCFTilingOptions &options = scf::SCFTilingOptions(),
     const LinalgExt::LinalgTransformationFilter &filter =
         LinalgExt::LinalgTransformationFilter());
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/CodegenStrategy.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/CodegenStrategy.h
@@ -56,7 +56,7 @@ private:
 
 /// Represent one application of LinalgStrategyTilePass.
 struct Tile : public Transformation {
-  Tile(StringRef name, linalg::LinalgTilingOptions options,
+  Tile(StringRef name, scf::SCFTilingOptions options,
        LinalgExt::LinalgTransformationFilter::FilterFunction f = nullptr)
       : Transformation(std::move(f)), opName(name),
         options(std::move(options)) {}
@@ -69,7 +69,7 @@ struct Tile : public Transformation {
 
 private:
   std::string opName;
-  linalg::LinalgTilingOptions options;
+  scf::SCFTilingOptions options;
 };
 
 /// Represent one application of LinalgStrategyPadPass.
@@ -189,7 +189,7 @@ struct CodegenStrategy {
   /// Append a pattern to add a level of tiling for Op `opName` with tiling
   /// `options`.
   CodegenStrategy &
-  tile(StringRef opName, const linalg::LinalgTilingOptions &options,
+  tile(StringRef opName, const scf::SCFTilingOptions &options,
        const LinalgExt::LinalgTransformationFilter::FilterFunction &f =
            nullptr) {
     transformationSequence.emplace_back(
@@ -199,7 +199,7 @@ struct CodegenStrategy {
   /// Conditionally append a pattern to add a level of tiling for
   /// `LinalgOpType` with tiling `options`.
   CodegenStrategy &
-  tileIf(bool b, StringRef opName, linalg::LinalgTilingOptions options,
+  tileIf(bool b, StringRef opName, scf::SCFTilingOptions options,
          LinalgExt::LinalgTransformationFilter::FilterFunction f = nullptr) {
     return b ? tile(opName, std::move(options), std::move(f)) : *this;
   }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
@@ -10,6 +10,7 @@
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
 #include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/IR/PatternMatch.h"
 
 namespace mlir {
@@ -159,6 +160,43 @@ private:
   LinalgTransformationFilter filter;
   /// Options to control tiling;
   linalg::LinalgTilingOptions options;
+};
+
+///
+/// Linalg SCF tiling pattern.
+///
+/// Apply the `tiling` transformation as a pattern.
+/// `filter` controls LinalgTransformMarker matching and update when specified.
+/// See `tiling` for more details.
+struct LinalgSCFTilingPattern
+    : public OpInterfaceRewritePattern<TilingInterface> {
+  /// Construct a generic pattern applied to all LinalgOp that verify `filter`.
+  LinalgSCFTilingPattern(
+      MLIRContext *context, scf::SCFTilingOptions options,
+      LinalgTransformationFilter f = LinalgTransformationFilter(),
+      PatternBenefit benefit = 1);
+
+  /// Construct a pattern specifically applied to `opName`.
+  LinalgSCFTilingPattern(
+      StringRef opName, MLIRContext *context, scf::SCFTilingOptions options,
+      LinalgTransformationFilter f = LinalgTransformationFilter(),
+      PatternBenefit benefit = 1);
+
+  /// `matchAndRewrite` implementation that returns the significant transformed
+  /// pieces of IR.
+  LogicalResult returningMatchAndRewrite(TilingInterface op,
+                                         PatternRewriter &rewriter) const;
+
+  LogicalResult matchAndRewrite(TilingInterface op,
+                                PatternRewriter &rewriter) const override {
+    return returningMatchAndRewrite(op, rewriter);
+  }
+
+private:
+  /// LinalgTransformMarker handles special attribute manipulations.
+  LinalgTransformationFilter filter;
+  /// Options to control tiling;
+  scf::SCFTilingOptions options;
 };
 
 template <typename... OpTypes>

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -495,12 +495,7 @@ struct LinalgStrategyTilePass
                                                 filter);
     else
       tilingPattern.add<LinalgSCFTilingPattern>(ctx, options, filter);
-    if (anchorOpName == tensor::PadOp::getOperationName()) {
-      linalg::LinalgTilingOptions legacyTilingOptions;
-      legacyTilingOptions.setTileSizeComputationFunction(
-          options.tileSizeComputationFunction);
-      populatePadTensorTilingPatterns(tilingPattern, legacyTilingOptions);
-    }
+
     (void)applyPatternsAndFoldGreedily(funcOp, std::move(tilingPattern));
   }
 


### PR DESCRIPTION
Use the upstream SCF tiling to replace `LinalgTilingPattern`.

This change also removes the `peeled-loops` option from `LinalgSingleTilingExpert`, which is unused and unsupported in the upstream (and we have a separate pass for peeling).