### PR TITLE
ukernel tweaks

### DIFF
--- a/runtime/src/iree/builtins/ukernel/common.c
+++ b/runtime/src/iree/builtins/ukernel/common.c
@@ -6,8 +6,11 @@
 
 #include "iree/builtins/ukernel/common.h"
 
+#ifdef IREE_UK_ENABLE_VALIDATION
 IREE_UK_EXPORT const char* iree_uk_status_message(iree_uk_status_t status) {
   switch (status) {
+    case iree_uk_status_ok:
+      return "OK";
     case iree_uk_status_bad_flags:
       return "bad mmt4d flags";
     case iree_uk_status_bad_type:
@@ -22,3 +25,4 @@ IREE_UK_EXPORT const char* iree_uk_status_message(iree_uk_status_t status) {
       return "unknown";
   }
 }
+#endif

--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -110,6 +110,19 @@ extern "C" {
 // Attributes and metadata
 //===----------------------------------------------------------------------===//
 
+// Queries for [[attribute]] identifiers in modern compilers.
+#ifdef __has_attribute
+#define IREE_UK_HAVE_ATTRIBUTE(x) __has_attribute(x)
+#else
+#define IREE_UK_HAVE_ATTRIBUTE(x) 0
+#endif  // __has_attribute
+
+#ifdef __has_builtin
+#define IREE_UK_HAVE_BUILTIN(x) __has_builtin(x)
+#else
+#define IREE_UK_HAVE_BUILTIN(x) 0
+#endif  // __has_builtin
+
 // Tagged on functions that are part of the public API.
 // TODO(benvanik): use this to change symbol visibility? We don't want a library
 // that embeds this one to transitively export functions but may want to have
@@ -129,6 +142,58 @@ extern "C" {
 #else
 #define IREE_UK_RESTRICT restrict
 #endif  // _MSC_VER
+
+// Same as LLVM_BUILTIN_UNREACHABLE. Extremely dangerous. Use only in locations
+// that are provably unreachable (+/- edge case of unreachable-past-assertions
+// discussed below).
+//
+// The potential benefit of UNREACHABLE statements is code size and/or speed
+// optimization. This is an arcane optimization. As such, each use must be
+// carefully justified.
+//
+// There is the edge case of locations that are provably unreachable when
+// optional validation code is enabled, but the validation code may also be
+// disabled, making the location technically reachable. Typically: assertions.
+// Use careful judgement for such cases.
+//
+// A typical use case in microkernels is as follows. A microkernel is
+// parametrized by type triples packed into uint32s, and needs to have a switch
+// statement on those:
+//
+// switch (params->type_triple) {
+//   case iree_uk_mykernel_f32f32f32:  // 0xf5f5f5
+//     return 123;
+//   case iree_uk_mykernel_i8i8i32:  // 0x232325
+//     return 321;
+//   default:
+//     return 0;
+// }
+//
+// As long as the microkernel has validation code (running at least as Debug
+// assertions) validating type_triple, and this code is already past that,
+// and this switch statement covers all valid cases, the `default:` case should
+// be unreachable. Adding an UNREACHABLE statement there can help with code
+// size. This would be negligible if the case constants were small enough to
+// fit in compare-with-immediate instructions, but the 24-bit type triple
+// constants here would typically not, so without UNREACHABLE, the compiler has
+// to fully implement each 24-bit literal separately.
+//
+// https://godbolt.org/z/hTv4qqbx9 shows a snipped similar as above where
+// the __builtin_unreachable shrinks the AArch64 code from 11 to 7 instructions.
+#if IREE_UK_HAVE_BUILTIN(__builtin_unreachable) || defined(__GNUC__)
+#define IREE_UK_ASSUME_UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define IREE_UK_ASSUME_UNREACHABLE __assume(false)
+#else
+#define IREE_UK_ASSUME_UNREACHABLE
+#endif
+
+#if IREE_UK_HAVE_ATTRIBUTE(noinline) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define IREE_UK_ATTRIBUTE_NOINLINE __attribute__((noinline))
+#else
+#define IREE_UK_ATTRIBUTE_NOINLINE
+#endif  // IREE_UK_HAVE_ATTRIBUTE(noinline)
 
 //===----------------------------------------------------------------------===//
 // Local replacements for stdint.h types and constants
@@ -216,17 +281,56 @@ static inline void iree_uk_ssize_swap(iree_uk_ssize_t* a, iree_uk_ssize_t* b) {
 // Status codes returned by microkernels.
 //===----------------------------------------------------------------------===//
 
+// When IREE_UK_ENABLE_VALIDATION is defined, ukernels validate their inputs and
+// may return statuses other than iree_uk_status_ok.
+//
+// When IREE_UK_ENABLE_VALIDATION is not defined, statuses other than
+// iree_uk_status_ok are not even defined.
+//
+// Currently IREE_UK_ENABLE_VALIDATION is defined if and only if NDEBUG is not,
+// that is, validation treated as assertions, disabling them in release.
+//
+// This actually enables more thorough validation as it removes optimization
+// concerns from the validation code. Microkernels take raw
+// pointers/sizes/strides anyway, so if params are incorrect, UB will happen no
+// matter how much we try to validate.
+#ifndef NDEBUG
+#define IREE_UK_ENABLE_VALIDATION
+#endif
+
+// Status codes that ukernels may return.
 typedef enum iree_uk_status_e {
   iree_uk_status_ok = 0,
+#ifdef IREE_UK_ENABLE_VALIDATION
   iree_uk_status_bad_type,
   iree_uk_status_bad_flags,
   iree_uk_status_unsupported_huge_or_negative_dimension,
   iree_uk_status_unsupported_generic_tile_size,
   iree_uk_status_shapes_mismatch,
+#endif
 } iree_uk_status_t;
 
+#ifdef IREE_UK_ENABLE_VALIDATION
 // Convert a status code to a human-readable string.
 IREE_UK_EXPORT const char* iree_uk_status_message(iree_uk_status_t status);
+#else
+static inline const char* iree_uk_status_message(iree_uk_status_t status) {
+  // Typical callers do:
+  //
+  //   iree_uk_status_t status = iree_uk_someukernel(&ukernel_params);
+  //   if (status != iree_uk_status_ok) {
+  //     return iree_make_status(IREE_STATUS_INTERNAL,
+  //                             iree_uk_status_message(status));
+  //   }
+  //
+  // The below UNREACHABLE actually helps Clang 16 elide the caller's
+  // `if (status != iree_uk_status_ok)` branch: https://godbolt.org/z/xoanddxrv
+  if (status != iree_uk_status_ok) {
+    IREE_UK_ASSUME_UNREACHABLE;
+  }
+  return "OK";
+}
+#endif
 
 #define IREE_UK_RETURN_IF_ERROR(X)     \
   do {                                 \
@@ -364,90 +468,33 @@ static inline int iree_uk_type_size(iree_uk_type_t t) {
 }
 
 //===----------------------------------------------------------------------===//
-// Tuples of types, packed into a word.
+// Tuples of types, packed ("tied") into a word.
 //===----------------------------------------------------------------------===//
+
+// Note: the choice of word "tie" echoes C++ std::tie and generally tuple
+// terminology. We used to call that "pack" but that was confusing as that word
+// is also the name of a ukernel, iree_uk_pack.
 
 typedef iree_uk_uint16_t iree_uk_type_pair_t;
 typedef iree_uk_uint32_t iree_uk_type_triple_t;
 
-#define IREE_UK_PACK_2_TYPES(B0, B1) ((B0) + ((B1) << 8))
-#define IREE_UK_PACK_3_TYPES(B0, B1, B2) ((B0) + ((B1) << 8) + ((B2) << 16))
-#define IREE_UK_PACK_2_TYPES_LITERAL(T0, T1) \
-  IREE_UK_PACK_2_TYPES(IREE_UK_TYPE_##T0, IREE_UK_TYPE_##T1)
-#define IREE_UK_PACK_3_TYPES_LITERAL(T0, T1, T2) \
-  IREE_UK_PACK_3_TYPES(IREE_UK_TYPE_##T0, IREE_UK_TYPE_##T1, IREE_UK_TYPE_##T2)
+#define IREE_UK_TIE_2_TYPES(B0, B1) ((B0) + ((B1) << 8))
+#define IREE_UK_TIE_3_TYPES(B0, B1, B2) ((B0) + ((B1) << 8) + ((B2) << 16))
+#define IREE_UK_TIE_2_TYPES_LITERAL(T0, T1) \
+  IREE_UK_TIE_2_TYPES(IREE_UK_TYPE_##T0, IREE_UK_TYPE_##T1)
+#define IREE_UK_TIE_3_TYPES_LITERAL(T0, T1, T2) \
+  IREE_UK_TIE_3_TYPES(IREE_UK_TYPE_##T0, IREE_UK_TYPE_##T1, IREE_UK_TYPE_##T2)
 
-#define IREE_UK_UNPACK_TYPE(POS, WORD) (((WORD) >> (8 * (POS))) & 0xFF)
+#define IREE_UK_UNTIE_TYPE(POS, WORD) (((WORD) >> (8 * (POS))) & 0xFF)
 
-static inline iree_uk_type_t iree_uk_unpack_type(int pos,
-                                                 iree_uk_uint32_t word) {
-  return IREE_UK_UNPACK_TYPE(pos, word);
+static inline iree_uk_type_t iree_uk_untie_type(int pos,
+                                                iree_uk_uint32_t word) {
+  return IREE_UK_UNTIE_TYPE(pos, word);
 }
 
-#ifdef __has_builtin
-#define IREE_UK_HAS_BUILTIN(x) __has_builtin(x)
-#else
-#define IREE_UK_HAS_BUILTIN(x) 0
-#endif
-
-// Same as LLVM_BUILTIN_UNREACHABLE. Extremely dangerous. Use only in locations
-// that are provably unreachable (+/- edge case of unreachable-past-assertions
-// discussed below).
-//
-// The potential benefit of UNREACHABLE statements is code size and/or speed
-// optimization. This is an arcane optimization. As such, each use must be
-// carefully justified.
-//
-// There is the edge case of locations that are provably unreachable when
-// optional validation code is enabled, but the validation code may also be
-// disabled, making the location technically reachable. Typically: assertions.
-// Use careful judgement for such cases.
-//
-// A typical use case in microkernels is as follows. A microkernel is
-// parametrized by type triples packed into uint32s, and needs to have a switch
-// statement on those:
-//
-// switch (params->type_triple) {
-//   case iree_uk_mykernel_f32f32f32:  // 0xf5f5f5
-//     return 123;
-//   case iree_uk_mykernel_i8i8i32:  // 0x232325
-//     return 321;
-//   default:
-//     return 0;
-// }
-//
-// As long as the microkernel has validation code (running at least as Debug
-// assertions) validating type_triple, and this code is already past that,
-// and this switch statement covers all valid cases, the `default:` case should
-// be unreachable. Adding an UNREACHABLE statement there can help with code
-// size. This would be negligible if the case constants were small enough to
-// fit in compare-with-immediate instructions, but the 24-bit type triple
-// constants here would typically not, so without UNREACHABLE, the compiler has
-// to fully implement each 24-bit literal separately.
-//
-// https://godbolt.org/z/hTv4qqbx9 shows a snipped similar as above where
-// the __builtin_unreachable shrinks the AArch64 code from 11 to 7 instructions.
-#if IREE_UK_HAS_BUILTIN(__builtin_unreachable) || defined(__GNUC__)
-#define IREE_UK_ASSUME_UNREACHABLE __builtin_unreachable()
-#elif defined(_MSC_VER)
-#define IREE_UK_ASSUME_UNREACHABLE __assume(false)
-#else
-#define IREE_UK_ASSUME_UNREACHABLE
-#endif
-
-// Queries for [[attribute]] identifiers in modern compilers.
-#ifdef __has_attribute
-#define IREE_UK_HAVE_ATTRIBUTE(x) __has_attribute(x)
-#else
-#define IREE_UK_HAVE_ATTRIBUTE(x) 0
-#endif  // __has_attribute
-
-#if IREE_UK_HAVE_ATTRIBUTE(noinline) || \
-    (defined(__GNUC__) && !defined(__clang__))
-#define IREE_UK_ATTRIBUTE_NOINLINE __attribute__((noinline))
-#else
-#define IREE_UK_ATTRIBUTE_NOINLINE
-#endif  // IREE_UK_HAVE_ATTRIBUTE(noinline)
+//===----------------------------------------------------------------------===//
+// Local replacement for <string.h>
+//===----------------------------------------------------------------------===//
 
 // The `restrict` here have the effect of enabling the compiler to rewrite this
 // as a memcpy call, shrinking code size of the (slow anyway) generic code paths
@@ -457,6 +504,15 @@ static inline void iree_uk_memcpy(void* IREE_UK_RESTRICT dst,
                                   iree_uk_ssize_t size) {
   for (iree_uk_ssize_t i = 0; i < size; ++i)
     ((char*)dst)[i] = ((const char*)src)[i];
+}
+
+static inline void iree_uk_memset(void* buf, int val, iree_uk_ssize_t n) {
+  // No need for memset builtins: this naive loop is already transformed into a
+  // memset by both clang and gcc on ARM64. As __builtin_memset_inline requires
+  // a compile-time-constant size, it would require writing more complex code,
+  // which could actually prevent the optimization matching it as a single
+  // memset!
+  for (iree_uk_ssize_t i = 0; i < n; ++i) ((char*)buf)[i] = val;
 }
 
 #ifdef __cplusplus

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -13,15 +13,7 @@
 
 static iree_uk_status_t iree_uk_mmt4d_validate(
     const iree_uk_mmt4d_params_t* params) {
-#ifdef NDEBUG
-  // Avoid validation code overhead (code size and latency) in release builds.
-  // This actually enables more thorough validation as it removes optimization
-  // concerns from the validation code.
-  // Microkernels take raw pointers/sizes/strides anyway, so if params are
-  // incorrect, UB will happen no matter how much we try to validate.
-  return iree_uk_status_ok;
-#endif
-
+#ifdef IREE_UK_ENABLE_VALIDATION
   if (params->flags & ~IREE_UK_FLAG_ACCUMULATE) {
     return iree_uk_status_bad_flags;
   }
@@ -52,7 +44,7 @@ static iree_uk_status_t iree_uk_mmt4d_validate(
   if (tile_bytes > iree_uk_mmt4d_tile_generic_max_bytes) {
     return iree_uk_status_unsupported_generic_tile_size;
   }
-
+#endif  // IREE_UK_ENABLE_VALIDATION
   return iree_uk_status_ok;
 }
 
@@ -105,17 +97,6 @@ static void iree_uk_mmt4d_using_tile_func(const iree_uk_mmt4d_params_t* params,
   }
 }
 
-// A memset implementation that we can use here, as we can't #include <string.h>
-// as that brings in <stdint.h>. Special-cased for byte value 0.
-void iree_uk_memset_zero(void* buf, iree_uk_ssize_t n) {
-  // No need for memset builtins: this naive loop is already transformed into a
-  // memset by both clang and gcc on ARM64. As __builtin_memset_inline requires
-  // a compile-time-constant size, it would require writing more complex code,
-  // which could actually prevent the optimization matching it as a single
-  // memset!
-  for (iree_uk_ssize_t i = 0; i < n; ++i) ((char*)buf)[i] = 0;
-}
-
 // Helper for early-return path when K==0 and we just need to clear the output.
 static void iree_uk_mmt4d_zero_out(const iree_uk_mmt4d_params_t* params) {
   iree_uk_type_t out_type = iree_uk_mmt4d_out_type(params->type);
@@ -125,7 +106,7 @@ static void iree_uk_mmt4d_zero_out(const iree_uk_mmt4d_params_t* params) {
   iree_uk_ssize_t stride = params->out_stride << out_type_size_log2;
   char* out_ptr = params->out_buffer;
   for (iree_uk_ssize_t i = 0; i < params->M; ++i) {
-    iree_uk_memset_zero(out_ptr, contiguous_size);
+    iree_uk_memset(out_ptr, 0, contiguous_size);
     out_ptr += stride;
   }
 }

--- a/runtime/src/iree/builtins/ukernel/mmt4d_types.h
+++ b/runtime/src/iree/builtins/ukernel/mmt4d_types.h
@@ -11,21 +11,21 @@
 
 typedef enum iree_uk_mmt4d_type_t {
   iree_uk_mmt4d_type_f32f32f32 =
-      IREE_UK_PACK_3_TYPES_LITERAL(FLOAT_32, FLOAT_32, FLOAT_32),
+      IREE_UK_TIE_3_TYPES_LITERAL(FLOAT_32, FLOAT_32, FLOAT_32),
   iree_uk_mmt4d_type_i8i8i32 =
-      IREE_UK_PACK_3_TYPES_LITERAL(INT_8, INT_8, INT_32),
+      IREE_UK_TIE_3_TYPES_LITERAL(INT_8, INT_8, INT_32),
 } iree_uk_mmt4d_type_t;
 
 static inline iree_uk_type_t iree_uk_mmt4d_lhs_type(iree_uk_mmt4d_type_t type) {
-  return IREE_UK_UNPACK_TYPE(0, type);
+  return iree_uk_untie_type(0, type);
 }
 
 static inline iree_uk_type_t iree_uk_mmt4d_rhs_type(iree_uk_mmt4d_type_t type) {
-  return IREE_UK_UNPACK_TYPE(1, type);
+  return iree_uk_untie_type(1, type);
 }
 
 static inline iree_uk_type_t iree_uk_mmt4d_out_type(iree_uk_mmt4d_type_t type) {
-  return IREE_UK_UNPACK_TYPE(2, type);
+  return iree_uk_untie_type(2, type);
 }
 
 // Parameters for a mmt4d operation.

--- a/runtime/src/iree/builtins/ukernel/pack.c
+++ b/runtime/src/iree/builtins/ukernel/pack.c
@@ -11,14 +11,7 @@
 
 static iree_uk_status_t iree_uk_pack_validate(
     const iree_uk_pack_params_t* params) {
-#ifdef NDEBUG
-  // Avoid validation code overhead (code size and latency) in release builds.
-  // This actually enables more thorough validation as it removes optimization
-  // concerns from the validation code.
-  // Microkernels take raw pointers/sizes/strides anyway, so if params are
-  // incorrect, UB will happen no matter how much we try to validate.
-  return iree_uk_status_ok;
-#endif
+#ifdef IREE_UK_ENABLE_VALIDATION
   const iree_uk_uint32_t allflags =
       IREE_UK_FLAG_PACK_TRANSPOSE_INNER | IREE_UK_FLAG_PACK_TRANSPOSE_OUTER;
   if (params->flags & ~allflags) {
@@ -55,6 +48,7 @@ static iree_uk_status_t iree_uk_pack_validate(
       (outer_size1 - 1) * tile_size1 >= params->in_size1) {
     return iree_uk_status_shapes_mismatch;
   }
+#endif  // IREE_UK_ENABLE_VALIDATION
   return iree_uk_status_ok;
 }
 

--- a/runtime/src/iree/builtins/ukernel/pack_types.h
+++ b/runtime/src/iree/builtins/ukernel/pack_types.h
@@ -12,17 +12,17 @@
 #include "iree/builtins/ukernel/common.h"
 
 typedef enum iree_uk_pack_type_t {
-  iree_uk_pack_type_f32f32 = IREE_UK_PACK_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
-  iree_uk_pack_type_i8i8 = IREE_UK_PACK_2_TYPES_LITERAL(INT_8, INT_8),
-  iree_uk_pack_type_i32i32 = IREE_UK_PACK_2_TYPES_LITERAL(INT_32, INT_32),
+  iree_uk_pack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
+  iree_uk_pack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),
+  iree_uk_pack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
 } iree_uk_pack_type_t;
 
 static inline iree_uk_type_t iree_uk_pack_in_type(iree_uk_pack_type_t type) {
-  return IREE_UK_UNPACK_TYPE(0, type);
+  return iree_uk_untie_type(0, type);
 }
 
 static inline iree_uk_type_t iree_uk_pack_out_type(iree_uk_pack_type_t type) {
-  return IREE_UK_UNPACK_TYPE(1, type);
+  return iree_uk_untie_type(1, type);
 }
 
 // Parameters for a pack operation.

--- a/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
@@ -117,9 +117,9 @@ int iree_uk_test_type_pair_str(char* buf, int buf_length,
   char type0_buf[8];
   char type1_buf[8];
   iree_uk_test_type_str(type0_buf, sizeof type0_buf,
-                        iree_uk_unpack_type(0, pair));
+                        iree_uk_untie_type(0, pair));
   iree_uk_test_type_str(type1_buf, sizeof type1_buf,
-                        iree_uk_unpack_type(1, pair));
+                        iree_uk_untie_type(1, pair));
   return snprintf(buf, buf_length, "(%s,%s)", type0_buf, type1_buf);
 }
 
@@ -129,11 +129,11 @@ int iree_uk_test_type_triple_str(char* buf, int buf_length,
   char type1_buf[8];
   char type2_buf[8];
   iree_uk_test_type_str(type0_buf, sizeof type0_buf,
-                        iree_uk_unpack_type(0, triple));
+                        iree_uk_untie_type(0, triple));
   iree_uk_test_type_str(type1_buf, sizeof type1_buf,
-                        iree_uk_unpack_type(1, triple));
+                        iree_uk_untie_type(1, triple));
   iree_uk_test_type_str(type2_buf, sizeof type2_buf,
-                        iree_uk_unpack_type(2, triple));
+                        iree_uk_untie_type(2, triple));
   return snprintf(buf, buf_length, "(%s,%s,%s)", type0_buf, type1_buf,
                   type2_buf);
 }

--- a/runtime/src/iree/builtins/ukernel/unpack.c
+++ b/runtime/src/iree/builtins/ukernel/unpack.c
@@ -8,14 +8,7 @@
 
 static iree_uk_status_t iree_uk_unpack_validate(
     const iree_uk_unpack_params_t* params) {
-#ifdef NDEBUG
-  // Avoid validation code overhead (code size and latency) in release builds.
-  // This actually enables more thorough validation as it removes optimization
-  // concerns from the validation code.
-  // Microkernels take raw pointers/sizes/strides anyway, so if params are
-  // incorrect, UB will happen no matter how much we try to validate.
-  return iree_uk_status_ok;
-#endif
+#ifdef IREE_UK_ENABLE_VALIDATION
   const iree_uk_uint32_t allflags =
       IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER | IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER;
   if (params->flags & ~allflags) {
@@ -52,6 +45,7 @@ static iree_uk_status_t iree_uk_unpack_validate(
       (outer_size1 - 1) * tile_size1 >= params->out_size1) {
     return iree_uk_status_shapes_mismatch;
   }
+#endif  // IREE_UK_ENABLE_VALIDATION
   return iree_uk_status_ok;
 }
 

--- a/runtime/src/iree/builtins/ukernel/unpack_types.h
+++ b/runtime/src/iree/builtins/ukernel/unpack_types.h
@@ -12,19 +12,19 @@
 #include "iree/builtins/ukernel/common.h"
 
 typedef enum iree_uk_unpack_type_t {
-  iree_uk_unpack_type_f32f32 = IREE_UK_PACK_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
-  iree_uk_unpack_type_i8i8 = IREE_UK_PACK_2_TYPES_LITERAL(INT_8, INT_8),
-  iree_uk_unpack_type_i32i32 = IREE_UK_PACK_2_TYPES_LITERAL(INT_32, INT_32),
+  iree_uk_unpack_type_f32f32 = IREE_UK_TIE_2_TYPES_LITERAL(FLOAT_32, FLOAT_32),
+  iree_uk_unpack_type_i8i8 = IREE_UK_TIE_2_TYPES_LITERAL(INT_8, INT_8),
+  iree_uk_unpack_type_i32i32 = IREE_UK_TIE_2_TYPES_LITERAL(INT_32, INT_32),
 } iree_uk_unpack_type_t;
 
 static inline iree_uk_type_t iree_uk_unpack_in_type(
     iree_uk_unpack_type_t type) {
-  return IREE_UK_UNPACK_TYPE(0, type);
+  return iree_uk_untie_type(0, type);
 }
 
 static inline iree_uk_type_t iree_uk_unpack_out_type(
     iree_uk_unpack_type_t type) {
-  return IREE_UK_UNPACK_TYPE(1, type);
+  return iree_uk_untie_type(1, type);
 }
 
 // Parameters for a unpack operation.


### PR DESCRIPTION
- Remove validation code from non-validation builds, including in callers (vmvx module entry points).
  - Consistently enclose validation code in `IREE_UK_ENABLE_VALIDATION`
  - Instead of going to `NDEBUG` everytime.
  - When validation is not enabled, do not even define the enum values besides `status_ok`).
  - This allows to assume unreachability of `if(status != status_ok)`  (since the other enum values don't even exist at compile time, the only way to return them would be some likely unintentional type punning, and since the only enum value is 0, it's probably UB anyway for any other value to be represented by that enum).
  - On AArch64, this saves 50--100 bytes per caller (e.g. `iree_vmvx_mmt4d`, `iree_vmvx_pack`, etc --- this is multiplied by the number of entry points that call ukernels, which could grow large) plus the constant savings of 200 bytes of rodata for the literal strings in `iree_uk_status_message`.
- Rename PACK to TIE, UNPACK to UNTIE for the helpers munging together 8bit type IDs into 16bit/32bit words. Was confusing with pack/unpack ukernels.
- Move attributes/builtins checks up in `common.h`.
- Move `iree_uk_memset` to `common.h`  (now a true memset, was `iree_uk_memset_zero`. Checked that that doesn't affect compilation).
