### PR TITLE
[CPU] Vector masking integration in IREE

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUDistributeSharedMemoryCopy.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <numeric>
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Codegen/PassDetail.h"
@@ -252,11 +253,12 @@ static void populateTilingAndDistribute(RewritePatternSet &patterns,
 
 static void populateVectorizationPatterns(RewritePatternSet &patterns) {
   VectorizationPatterns<linalg::GenericOp>::insert(
-      patterns, IREE::LinalgExt::LinalgTransformationFilter(
-                    {StringAttr::get(patterns.getContext(),
-                                     getCopyToWorkgroupMemoryMarker()),
-                     StringAttr::get(patterns.getContext(), kCopyDistributed)},
-                    std::nullopt));
+      patterns, IREE::LinalgExt::LinalgVectorizationOptions(),
+      IREE::LinalgExt::LinalgTransformationFilter(
+          {StringAttr::get(patterns.getContext(),
+                           getCopyToWorkgroupMemoryMarker()),
+           StringAttr::get(patterns.getContext(), kCopyDistributed)},
+          std::nullopt));
 }
 
 /// Return a flattened Id Value by combining the 3D gpu thread IDs.

--- a/compiler/src/iree/compiler/Codegen/Common/GPUVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUVectorization.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
@@ -53,12 +54,17 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns,
     }
     return success(maxFlatVecSize <= maxVectorSize);
   });
+
+  IREE::LinalgExt::LinalgVectorizationOptions vectorizationOptions;
   VectorizationPatterns<linalg::FillOp, linalg::GenericOp,
                         linalg::Conv1DNwcWcfOp,
-                        linalg::Conv1DNcwFcwOp>::insert(patterns, f);
+                        linalg::Conv1DNcwFcwOp>::insert(patterns,
+                                                        vectorizationOptions,
+                                                        f);
   patterns.add<linalg::CopyVectorizationPattern>(ctx);
   patterns.add<LinalgVectorizationPattern>(
-      ctx, f.addOpFilter<linalg::ContractionOpInterface>());
+      ctx, vectorizationOptions,
+      f.addOpFilter<linalg::ContractionOpInterface>());
 }
 
 namespace {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1162,6 +1162,8 @@ void ConvertToLLVMPass::runOnOperation() {
     vector::populateVectorToVectorCanonicalizationPatterns(patterns);
     vector::populateVectorBroadcastLoweringPatterns(patterns);
     vector::populateVectorContractLoweringPatterns(patterns);
+    vector::populateVectorMaskMaterializationPatterns(
+        patterns, /*force32BitVectorIndices=*/false);
     vector::populateVectorMaskOpLoweringPatterns(patterns);
     vector::populateVectorShapeCastLoweringPatterns(patterns);
     vector::populateVectorTransposeLoweringPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -49,6 +49,7 @@ iree_lit_test_suite(
             "unfused_fma.mlir",
             "vector_contract_to_arm_asm.mlir",
             "vector_contract_to_arm_intrinsics.mlir",
+            "vector_masking.mlir",
             "verify_linalg_transform_legality.mlir",
         ],
         include = ["*.mlir"],

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_lit_test_suite(
     "unfused_fma.mlir"
     "vector_contract_to_arm_asm.mlir"
     "vector_contract_to_arm_intrinsics.mlir"
+    "vector_masking.mlir"
     "verify_linalg_transform_legality.mlir"
   TOOLS
     FileCheck

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/vector_masking.mlir
@@ -1,0 +1,71 @@
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))' -split-input-file %s | FileCheck %s
+
+
+#compilation = #iree_codegen.compilation_info<
+    lowering_config = <tile_sizes = [[127, 255], [8, 32], [0, 0]]>,
+    translation_info  = <CPUDoubleTilingExpert>,
+    workgroup_size = []>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable private @preset_config_generic_add  {
+  hal.executable.variant @system_elf_x86_64, target = <"llvm-cpu", "system-elf-x86_64"> {
+    hal.executable.export @mask_dynamic_generic_add layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @mask_dynamic_generic_add() {
+        %cst = arith.constant 0.000000e+00 : f32
+        %0 = hal.interface.constant.load[0] : i32
+        %1 = hal.interface.constant.load[1] : i32
+        %6 = arith.index_cast %0 : i32 to index
+        %7 = arith.index_cast %1 : i32 to index
+        %lhs_binding = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%6, %7}
+        %rhs_binding = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer)
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%6, %7}
+        %result_binding = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
+            : !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %7}
+        %lhs = flow.dispatch.tensor.load %lhs_binding, offsets = [0, 0], sizes = [%6, %7], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%6, %7} -> tensor<?x?xf32>
+        %rhs = flow.dispatch.tensor.load %rhs_binding, offsets = [0, 0], sizes = [%6, %7], strides = [1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%6, %7} -> tensor<?x?xf32>
+        %init = tensor.empty(%6, %7) : tensor<?x?xf32>
+        %fill = linalg.fill ins(%cst : f32) outs(%init : tensor<?x?xf32>) -> tensor<?x?xf32>
+        %generic = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                                                    affine_map<(d0, d1) -> (d0, d1)>,
+                                                    affine_map<(d0, d1) -> (d0, d1)>],
+                                   iterator_types = ["parallel", "parallel"]}
+          ins(%lhs, %rhs : tensor<?x?xf32>, tensor<?x?xf32>) outs(%fill : tensor<?x?xf32>) {
+            ^bb0(%in0: f32, %in1: f32, %out: f32):
+          %add = arith.addf %in0, %in1 : f32
+          linalg.yield %add: f32
+        } -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %generic, %result_binding, offsets = [0, 0], sizes = [%6, %7], strides = [1, 1]
+            : tensor<?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?xf32>>{%6, %7}
+        return
+      }
+    }
+  }
+}
+
+// Masking is not applied to the main vector loop when the peeling is used.
+
+// CHECK-LABEL: func.func @mask_dynamic_generic_add
+// Main loop
+// CHECK:       scf.for
+// CHECK:         vector.load
+// CHECK:         vector.load
+// CHECK:         vector.store
+// Peel loop
+// CHECK:       scf.for
+// CHECK:         vector.maskedload
+// CHECK:         vector.maskedload
+// CHECK:         vector.maskedstore
+

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Common/GPUPatterns.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
@@ -32,9 +33,12 @@ extern llvm::cl::opt<bool> llvmgpuUseMMASync;
 static void populateVectorizationPatterns(RewritePatternSet &patterns) {
   IREE::LinalgExt::LinalgTransformationFilter f(
       StringAttr::get(patterns.getContext(), getVectorizeMarker()));
-  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns, f);
+  IREE::LinalgExt::LinalgVectorizationOptions vectorizationOptions;
+  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(
+      patterns, vectorizationOptions, f);
   patterns.add<LinalgVectorizationPattern>(
-      patterns.getContext(), f.addOpFilter<linalg::ContractionOpInterface>());
+      patterns.getContext(), vectorizationOptions,
+      f.addOpFilter<linalg::ContractionOpInterface>());
   vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
   vector::populateVectorReductionToContractPatterns(patterns);
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/Common/GPUPatterns.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
@@ -138,9 +139,11 @@ void populateVectorizationPatterns(MLIRContext *context,
                                    RewritePatternSet &patterns) {
   IREE::LinalgExt::LinalgTransformationFilter f(
       StringAttr::get(context, getVectorizeMarker()));
-  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns, f);
+  IREE::LinalgExt::LinalgVectorizationOptions opts;
+  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns,
+                                                                   opts, f);
   patterns.add<LinalgVectorizationPattern>(
-      context, f.addOpFilter<linalg::ContractionOpInterface>());
+      context, opts, f.addOpFilter<linalg::ContractionOpInterface>());
   vector::populateVectorTransferPermutationMapLoweringPatterns(patterns);
   vector::populateVectorReductionToContractPatterns(patterns);
 }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
@@ -121,10 +122,13 @@ Optional<SmallVector<int64_t>> getNativeVectorShape(Operation *op) {
 /// Add patterns to vectorize any supported Linalg ops.
 void populateVectorizationPatterns(RewritePatternSet &patterns) {
   IREE::LinalgExt::LinalgTransformationFilter f;
-  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(patterns, f);
+  IREE::LinalgExt::LinalgVectorizationOptions vectorizationOptions;
+  VectorizationPatterns<linalg::FillOp, linalg::GenericOp>::insert(
+      patterns, vectorizationOptions, f);
   linalg::populateConvolutionVectorizationPatterns(patterns);
   patterns.add<LinalgVectorizationPattern>(
-      patterns.getContext(), f.addOpFilter<linalg::ContractionOpInterface>());
+      patterns.getContext(), vectorizationOptions,
+      f.addOpFilter<linalg::ContractionOpInterface>());
 }
 
 /// Adds patterns to unroll vector ops to SPIR-V native vector size.

--- a/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
+++ b/compiler/src/iree/compiler/Codegen/Sandbox/LinalgTensorCodegenDriver.cpp
@@ -34,6 +34,7 @@ using mlir::iree_compiler::IREE::LinalgExt::CodegenStrategy;
 using mlir::iree_compiler::IREE::LinalgExt::LinalgPeelOptions;
 using mlir::iree_compiler::IREE::LinalgExt::LinalgTransformationFilter;
 using mlir::iree_compiler::IREE::LinalgExt::LinalgTransforms;
+using mlir::iree_compiler::IREE::LinalgExt::LinalgVectorizationOptions;
 using mlir::iree_compiler::IREE::LinalgExt::LinalgVectorLoweringOptions;
 
 #define DEBUG_TYPE "iree-linalg-tensor-codegen-driver"
@@ -94,6 +95,79 @@ static bool getTilingOptionsFromConfig(func::FuncOp funcOp, int64_t tilingLevel,
     return true;
   }
   return false;
+}
+
+/// Computes the canonical shape used to vectorize this dispatch. Retrieves
+/// the vectorization tile sizes (parallel and reduction levels) out of the
+/// lowering config and adjusts them to the format expected by the Linalg
+/// vectorizer.
+static SmallVector<int64_t> getCanonicalVectorShape(func::FuncOp funcOp) {
+  FailureOr<Operation *> rootOp = getRootOp(funcOp);
+  if (failed(rootOp)) {
+    return {};
+  }
+
+  unsigned numTileLevels =
+      mlir::iree_compiler::getNumTileLevels(rootOp.value());
+  if (numTileLevels < 3) {
+    return {};
+  }
+
+  // Retrieve the tile sizes from the last two tiling levels (parallel and
+  // reduction) used for vectorization.
+  SmallVector<int64_t> canonicalVectorShape =
+      mlir::iree_compiler::getTileSizes(rootOp.value(), numTileLevels - 2);
+  SmallVector<int64_t> reductionTileSizes =
+      mlir::iree_compiler::getTileSizes(rootOp.value(), numTileLevels - 1);
+
+  if (!reductionTileSizes.empty()) {
+    assert(canonicalVectorShape.size() == reductionTileSizes.size() &&
+           "Unexpected tile sizes");
+
+    // Combine the reduction tile sizes with the parallel tile sizes already in
+    // the canonical vector shape.
+    for (int i = 0, end = canonicalVectorShape.size(); i < end; ++i) {
+      if (reductionTileSizes[i] > 0)
+        canonicalVectorShape[i] = reductionTileSizes[i];
+    }
+  }
+
+  // Replace zeros in canonical vector shape to turn it into a valid shape.
+  std::replace(canonicalVectorShape.begin(), canonicalVectorShape.end(), 0, 1);
+  return canonicalVectorShape;
+}
+
+// Give the canonical vector shape of a dispatch, returns the vector sizes for a
+// particular linalg op within that dispatch.
+static SmallVector<int64_t> getVectorSizes(
+    linalg::LinalgOp linalgOp, ArrayRef<int64_t> canonicalVectorShape) {
+  FailureOr<Operation *> rootOp =
+      getRootOp(linalgOp->getParentOfType<func::FuncOp>());
+  if (failed(rootOp)) {
+    return {};
+  }
+
+  // TODO: Not easy to infer the tiles sizes for an op that is not the root op.
+  if (*rootOp != linalgOp.getOperation()) {
+    return {};
+  }
+
+  // TODO: Masking is only supported for dynamic shapes.
+  if (!linalgOp.hasDynamicShape()) {
+    return {};
+  }
+
+  if (canonicalVectorShape.empty()) {
+    return {};
+  }
+
+  assert(canonicalVectorShape.size() >= linalgOp.getNumLoops() &&
+         "Unexpected canonical vector shape or number of loops");
+
+  // Return the canonical vector shape subset based on the number of loops of
+  // the linalg op.
+  return {canonicalVectorShape.begin(),
+          std::next(canonicalVectorShape.begin(), linalgOp.getNumLoops())};
 }
 
 /// Constructs padding attributes for given anchor op. Returns failure if there
@@ -447,11 +521,14 @@ void LinalgFusePass::runOnOperation() {
       SmallVector<int64_t>{hoistPaddings.begin(), hoistPaddings.end()});
   paddingOptions.setTransposePaddings(transposePaddingVectors);
 
+  LinalgVectorizationOptions vectorizationOptions;
+  vectorizationOptions.setVectorizePadding(vectorizePadding);
+
   CodegenStrategy strategy;
   strategy.tileAndFuseIf(doTileAndFuse, anchorOpName, tileAndFuseOptions)
       .tileIf(doTiling, anchorOpName, tilingOptions)
       .padIf(pad, anchorOpName, paddingOptions)
-      .vectorizeIf(vectorize, "", nullptr, vectorizePadding);
+      .vectorizeIf(vectorize, "", vectorizationOptions);
 
   // Created a nested OpPassManager and run.
   OpPassManager dynamicPM(func::FuncOp::getOperationName());
@@ -679,6 +756,11 @@ void LinalgSingleTilingExpertPass::runOnOperation() {
         std::reverse(loopsToPeel.begin(), loopsToPeel.end());
       };
 
+  LinalgVectorizationOptions vectorizationOptions;
+  vectorizationOptions.setVectorizePadding(vectorizePadding);
+  vectorizationOptions.setCanonicalVectorSizes(getCanonicalVectorShape(funcOp));
+  vectorizationOptions.setVectorSizeComputationFunction(getVectorSizes);
+
   CodegenStrategy strategy;
   StringRef genericOpName = linalg::GenericOp::getOperationName();
   strategy.tileIf(doTiling, anchorOpName, tilingOptions)
@@ -686,7 +768,7 @@ void LinalgSingleTilingExpertPass::runOnOperation() {
       .decomposeIf(decomposeToLowerDimOp)
       .peelIf(peel, generalize ? genericOpName : anchorOpName, peelingOptions)
       .vectorizeIf(vectorize, generalize ? genericOpName : anchorOpName,
-                   nullptr, vectorizePadding);
+                   vectorizationOptions);
 
   // Created a nested OpPassManager and run.
   OpPassManager dynamicPM(func::FuncOp::getOperationName());

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -246,11 +246,46 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyPeelPass(
         LinalgExt::LinalgTransformationFilter());
 
 /// Create a LinalgStrategyVectorizePass.
+using VectorSizeComputationFunction =
+    std::function<SmallVector<int64_t, 4>(linalg::LinalgOp, ArrayRef<int64_t>)>;
+
+struct LinalgVectorizationOptions {
+  /// Canonical vector sizes for the vector iteration space (i.e., vectorization
+  /// factors). They are optional for input code with full static shapes.
+  SmallVector<int64_t> canonicalVectorSizes;
+
+  LinalgVectorizationOptions &
+  setCanonicalVectorSizes(ArrayRef<int64_t> vecSizes) {
+    assert(canonicalVectorSizes.empty() &&
+           "Canonical vector sizes are already set");
+    canonicalVectorSizes.append(vecSizes.begin(), vecSizes.end());
+    return *this;
+  }
+
+  /// Computation function that returns the vector sizes to vectorize a given
+  /// Linalg operation and the canonical vector sizes of the iteration space.
+  VectorSizeComputationFunction vectorSizeComputationFunction = nullptr;
+
+  LinalgVectorizationOptions &
+  setVectorSizeComputationFunction(VectorSizeComputationFunction fun) {
+    vectorSizeComputationFunction = std::move(fun);
+    return *this;
+  }
+
+  /// Enable vectorization of padding operations.
+  bool vectorizePadding = false;
+
+  LinalgVectorizationOptions &setVectorizePadding(bool vecPad) {
+    vectorizePadding = vecPad;
+    return *this;
+  }
+};
+
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyVectorizePass(
     StringRef opName = "",
+    const LinalgVectorizationOptions &options = LinalgVectorizationOptions(),
     const LinalgExt::LinalgTransformationFilter &filter =
-        LinalgExt::LinalgTransformationFilter(),
-    bool padVectorize = false);
+        LinalgExt::LinalgTransformationFilter());
 
 /// Create a LinalgStrategyEnablePass.
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyEnablePass(

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h
@@ -262,12 +262,14 @@ struct LinalgVectorizationPattern
   /// Construct a generic pattern applied to all LinalgOp that verify `filter`.
   LinalgVectorizationPattern(
       MLIRContext *context,
+      LinalgVectorizationOptions opts = LinalgVectorizationOptions(),
       LinalgTransformationFilter f = LinalgTransformationFilter(),
       PatternBenefit benefit = 1);
 
   /// Construct a pattern specifically applied to `opName`.
   LinalgVectorizationPattern(
       StringRef opName, MLIRContext *context,
+      LinalgVectorizationOptions opts = LinalgVectorizationOptions(),
       LinalgTransformationFilter f = LinalgTransformationFilter(),
       PatternBenefit benefit = 1);
 
@@ -276,6 +278,7 @@ struct LinalgVectorizationPattern
 
 private:
   /// LinalgTransformMarker handles special attribute manipulations.
+  LinalgVectorizationOptions options;
   LinalgTransformationFilter filter;
 };
 
@@ -286,6 +289,7 @@ template <>
 class VectorizationPatterns<> {
 public:
   static void insert(RewritePatternSet &patterns,
+                     const LinalgVectorizationOptions &opts,
                      const LinalgTransformationFilter &f) {}
 };
 
@@ -293,10 +297,11 @@ template <typename OpTy, typename... OpTypes>
 class VectorizationPatterns<OpTy, OpTypes...> {
 public:
   static void insert(RewritePatternSet &patterns,
+                     const LinalgVectorizationOptions &opts,
                      const LinalgTransformationFilter &f) {
     patterns.add<LinalgVectorizationPattern>(OpTy::getOperationName(),
-                                             patterns.getContext(), f);
-    VectorizationPatterns<OpTypes...>::insert(patterns, f);
+                                             patterns.getContext(), opts, f);
+    VectorizationPatterns<OpTypes...>::insert(patterns, opts, f);
   }
 };
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Vector/Transforms/Passes.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Pass/PassManager.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -243,23 +244,27 @@ LinalgSCFTileAndFusePattern::matchAndRewrite(TilingInterface op,
 }
 
 LinalgVectorizationPattern::LinalgVectorizationPattern(
-    MLIRContext *context, LinalgExt::LinalgTransformationFilter f,
-    PatternBenefit benefit)
-    : OpInterfaceRewritePattern<linalg::LinalgOp>(context, benefit),
-      filter(std::move(f)) {}
-
-LinalgVectorizationPattern::LinalgVectorizationPattern(
-    StringRef opName, MLIRContext *context,
+    MLIRContext *context, LinalgVectorizationOptions opts,
     LinalgExt::LinalgTransformationFilter f, PatternBenefit benefit)
     : OpInterfaceRewritePattern<linalg::LinalgOp>(context, benefit),
-      filter(f.addOpNameFilter(opName)) {}
+      options(std::move(opts)), filter(std::move(f)) {}
+
+LinalgVectorizationPattern::LinalgVectorizationPattern(
+    StringRef opName, MLIRContext *context, LinalgVectorizationOptions opts,
+    LinalgExt::LinalgTransformationFilter f, PatternBenefit benefit)
+    : OpInterfaceRewritePattern<linalg::LinalgOp>(context, benefit),
+      options(std::move(opts)), filter(f.addOpNameFilter(opName)) {}
 
 LogicalResult
 LinalgVectorizationPattern::matchAndRewrite(linalg::LinalgOp linalgOp,
                                             PatternRewriter &rewriter) const {
   if (failed(filter.checkAndNotify(rewriter, linalgOp)))
     return failure();
-  return vectorize(rewriter, linalgOp);
+  SmallVector<int64_t> vectorSizes;
+  if (options.vectorSizeComputationFunction)
+    vectorSizes.append(options.vectorSizeComputationFunction(
+        linalgOp, options.canonicalVectorSizes));
+  return vectorize(rewriter, linalgOp, vectorSizes);
 }
 
 namespace {
@@ -502,13 +507,11 @@ struct LinalgStrategyVectorizePass
 
   LinalgStrategyVectorizePass() = default;
 
-  LinalgStrategyVectorizePass(StringRef opName,
-                              LinalgExt::LinalgTransformationFilter filt,
-                              bool padVectorize = false)
-      : filter(std::move(filt)) {
-    this->anchorOpName.setValue(opName.str());
-    this->vectorizePadding.setValue(padVectorize);
-  }
+  LinalgStrategyVectorizePass(StringRef opName, LinalgVectorizationOptions opts,
+                              LinalgExt::LinalgTransformationFilter filt)
+      : options(std::move(opts)), filter(std::move(filt)) {
+    this->vectorizePadding = opts.vectorizePadding;
+  };
 
   void runOnOperation() override {
     auto funcOp = getOperation();
@@ -518,11 +521,17 @@ struct LinalgStrategyVectorizePass
     RewritePatternSet vectorizationPatterns(funcOp.getContext());
     if (!anchorOpName.empty()) {
       vectorizationPatterns.add<LinalgVectorizationPattern>(
-          anchorOpName, funcOp.getContext(), filter);
+          anchorOpName, funcOp.getContext(), options, filter);
     } else {
       vectorizationPatterns.add<LinalgVectorizationPattern>(funcOp.getContext(),
-                                                            filter);
+                                                            options, filter);
     }
+
+    // TODO: Move this down the pipeline once we have the ODM-based masking
+    // representation.
+    vector::populateVectorMaskLoweringPatternsForSideEffectingOps(
+        vectorizationPatterns);
+
     vector::populateVectorTransferPermutationMapLoweringPatterns(
         vectorizationPatterns);
     vector::populateVectorReductionToContractPatterns(vectorizationPatterns);
@@ -547,6 +556,7 @@ struct LinalgStrategyVectorizePass
     }
   }
 
+  LinalgVectorizationOptions options;
   LinalgExt::LinalgTransformationFilter filter;
 };
 
@@ -727,10 +737,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyPeelPass(
 
 /// Create a LinalgStrategyVectorizePass.
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgStrategyVectorizePass(
-    StringRef opName, const LinalgExt::LinalgTransformationFilter &filter,
-    bool padVectorize) {
-  return std::make_unique<LinalgStrategyVectorizePass>(opName, filter,
-                                                       padVectorize);
+    StringRef opName, const LinalgVectorizationOptions &options,
+    const LinalgExt::LinalgTransformationFilter &filter) {
+  return std::make_unique<LinalgStrategyVectorizePass>(opName, options, filter);
 }
 
 /// Create a LinalgStrategyEnablePass.


### PR DESCRIPTION
Enable vector masking for elementwise ops with dynamic shapes and no
reductions. More cases will be added incrementally.