### PR TITLE
Adding plumbing and samples of custom CUDA/SPIR-V/CPU dispatch code.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -782,6 +782,13 @@ add_custom_target(iree-run-module-test-deps
     "Building IREE run module test targets"
 )
 
+# Samples may require additional files to be built/configured and will add
+# dependencies to this target. It is a subset of `iree-test-deps`.
+add_custom_target(iree-sample-deps
+  COMMENT
+    "Building IREE sample data targets"
+)
+
 #-------------------------------------------------------------------------------
 # IREE top-level libraries
 #-------------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,7 +783,7 @@ add_custom_target(iree-run-module-test-deps
 )
 
 # Samples may require additional files to be built/configured and will add
-# dependencies to this target. It is a subset of `iree-test-deps`.
+# dependencies to this target.
 add_custom_target(iree-sample-deps
   COMMENT
     "Building IREE sample data targets"

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -69,6 +69,10 @@ echo "Building test deps"
 echo "------------------"
 "$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
 
+echo "Building sample deps"
+echo "------------------"
+"$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-sample-deps -- -k 0
+
 if (( IREE_READ_REMOTE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -54,6 +54,10 @@ echo "Building test deps"
 echo "------------------"
 "${CMAKE_BIN?}" --build "${BUILD_DIR?}" --target iree-test-deps -- -k 0
 
+echo "Building sample deps"
+echo "------------------"
+"${CMAKE_BIN?}" --build "${BUILD_DIR?}" --target iree-sample-deps -- -k 0
+
 echo "Building microbenchmark suites"
 echo "------------------"
 "${CMAKE_BIN?}" --build "${BUILD_DIR?}" --target iree-microbenchmark-suites -- -k 0

--- a/build_tools/cmake/build_and_test_tsan.sh
+++ b/build_tools/cmake/build_and_test_tsan.sh
@@ -66,6 +66,10 @@ echo "Building test deps"
 echo "------------------"
 "$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
 
+echo "Building sample deps"
+echo "------------------"
+"$CMAKE_BIN" --build "${BUILD_DIR?}" --target iree-sample-deps -- -k 0
+
 if (( IREE_READ_REMOTE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -87,6 +87,10 @@ echo "Building test deps for device"
 echo "------------------"
 "${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
 
+echo "Building sample deps for device"
+echo "------------------"
+"${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-sample-deps -- -k 0
+
 if (( IREE_READ_REMOTE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/build_host_and_android.sh
+++ b/build_tools/cmake/build_host_and_android.sh
@@ -86,3 +86,7 @@ echo "------------"
 echo "Building test deps for device"
 echo "------------------"
 "$CMAKE_BIN" --build . --target iree-test-deps -- -k 0
+
+echo "Building sample deps for device"
+echo "------------------"
+"$CMAKE_BIN" --build . --target iree-sample-deps -- -k 0

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -109,5 +109,8 @@ else
     echo "Building test deps for RISC-V"
     echo "-----------------------------"
     "${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
+    echo "Building sample deps for RISC-V"
+    echo "------------------"
+    "${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-sample-deps -- -k 0
   fi
 fi

--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -48,6 +48,10 @@ echo "Building test deps"
 echo "------------------"
 "${CMAKE_BIN?}" --build . --target iree-test-deps -- -k 0
 
+echo "Building sample deps"
+echo "------------------"
+"${CMAKE_BIN?}" --build . --target iree-sample-deps -- -k 0
+
 if (( IREE_READ_REMOTE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -78,6 +78,10 @@ function(iree_bytecode_module)
   list(APPEND _ARGS "-o")
   list(APPEND _ARGS "${_MODULE_FILE_NAME}")
 
+  # Add the build directory to the compiler object file search path by default.
+  # Users can add their own additional directories as needed.
+  list(APPEND _ARGS "--iree-hal-executable-object-search-path=\"${IREE_BINARY_DIR}\"")
+
   # If an LLVM CPU backend is enabled, supply the linker tool.
   if(IREE_LLD_TARGET)
     iree_get_executable_path(_LINKER_TOOL_EXECUTABLE "lld")

--- a/build_tools/cmake/iree_configure_testing.cmake
+++ b/build_tools/cmake/iree_configure_testing.cmake
@@ -24,6 +24,7 @@ function(iree_configure_test TEST_NAME)
   set(_TEST_TMPDIR "${IREE_TEST_TMPDIR_ROOT}/${TEST_NAME}_test_tmpdir")
   set_property(GLOBAL APPEND PROPERTY IREE_TEST_TMPDIRS ${_TEST_TMPDIR})
   set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "TEST_TMPDIR=${_TEST_TMPDIR}")
+  set_property(TEST ${TEST_NAME} APPEND PROPERTY ENVIRONMENT "IREE_BINARY_DIR=${IREE_BINARY_DIR}")
 
   # IREE_*_DISABLE environment variables may used to skip test cases which
   # require both a compiler target backend and compatible runtime HAL driver.

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -63,3 +63,7 @@ echo "------------"
 echo "Building test deps"
 echo "------------------"
 "$CMAKE_BIN" --build . --target iree-test-deps -- -k 0
+
+echo "Building sample deps"
+echo "------------------"
+"$CMAKE_BIN" --build . --target iree-sample-deps -- -k 0

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -1077,6 +1077,16 @@ class RewriteExternCallOpToDynamicImportCallOp
         llvmFuncOp, symbol);
     if (calleeOp && !calleeOp.isExternal()) return failure();
 
+    // If the function is marked as statically linked we don't touch it. That'll
+    // let it fall through to the linker stage where it can be picked up either
+    // from the runtime build (in the case of us producing static libraries) or
+    // the user-specified object files (when producing dynamic libraries).
+    if (calleeOp->hasAttr("hal.import.static")) {
+      return rewriter.notifyMatchFailure(callOp,
+                                         "external function is marked static "
+                                         "and does not need an import wrapper");
+    }
+
     // TODO(benvanik): way to determine if weak (maybe via linkage?).
     bool weak = false;
 

--- a/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/LinkingUtils.cpp
@@ -196,6 +196,9 @@ LogicalResult linkExecutablesInto(
       OpBuilder::atBlockBegin(&linkedTargetOp.getBlock());
   auto linkedModuleOp = getInnerModuleFn(linkedTargetOp.getInnerModule());
 
+  // Aggregation of all external objects specified on variants used.
+  SetVector<Attribute> objectAttrs;
+
   // Iterate over all source executable ops, linking as many as we can.
   for (auto sourceExecutableOp : sourceExecutableOps) {
     // Remap root executable refs.
@@ -210,6 +213,11 @@ LogicalResult linkExecutablesInto(
       // We could, for example, link all aarch64 variants together and then
       // use function multi-versioning to let LLVM insert runtime switches.
       if (variantOp.getTarget() != linkedTargetOp.getTarget()) continue;
+
+      // Add any required object files to the set we will link in the target.
+      if (auto objectsAttr = variantOp.getObjectsAttr()) {
+        objectAttrs.insert(objectsAttr.begin(), objectsAttr.end());
+      }
 
       // Remap variant refs.
       auto oldVariantRefAttr =
@@ -265,6 +273,12 @@ LogicalResult linkExecutablesInto(
     if (sourceExecutableOp.getOps<IREE::HAL::ExecutableVariantOp>().empty()) {
       sourceExecutableOp.erase();
     }
+  }
+
+  // Attach object files from source variants.
+  if (!objectAttrs.empty()) {
+    linkedTargetOp.setObjectsAttr(
+        builder.getArrayAttr(objectAttrs.takeVector()));
   }
 
   // Update references to @executable::@target::@entry symbols.

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.h
@@ -36,6 +36,8 @@ struct DescriptorSetLayout {
   SmallVector<DescriptorSetLayoutBinding> bindings;
 };
 
+using PipelineResourceMap = SmallVector<std::pair<unsigned, unsigned>>;
+
 struct PipelineLayout {
   // Total number of 32-bit push constants allocated. Not all dispatchable
   // functions using this layout will use all constants.
@@ -44,7 +46,7 @@ struct PipelineLayout {
   SmallVector<DescriptorSetLayout> setLayouts;
   // Mapping of flattened source resource bindings into the descriptor sets.
   // Matches 1:1 with the IREE::Stream::CmdDispatchOp::resources.
-  SmallVector<std::pair<unsigned, unsigned>> resourceMap;
+  PipelineResourceMap resourceMap;
 
   void print(llvm::raw_ostream &os) const;
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -635,6 +635,10 @@ def HAL_ExecutableTargetAttr :
     // device that can load an executable of this target.
     Attribute getMatchExpression();
 
+    // Returns true if this attribute is a generic version of |specificAttr|.
+    // A more generic version will match with many specific versions.
+    bool isGenericOf(IREE::HAL::ExecutableTargetAttr specificAttr);
+
     // Returns the executable target configuration for the given operation.
     // This will recursively walk parent operations until one with the
     // `hal.executable.target` attribute is found or a `hal.executable.variant`
@@ -643,6 +647,100 @@ def HAL_ExecutableTargetAttr :
   }];
 
   let hasCustomAssemblyFormat = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// #hal.executable.object<*>
+//===----------------------------------------------------------------------===//
+
+def HAL_ExecutableObjectAttr : AttrDef<HAL_Dialect, "ExecutableObject"> {
+  let mnemonic = "executable.object";
+  let summary = [{object file reference}];
+  let description = [{
+    WIP; defines an object file that can be linked into executables.
+    Today this is only supported for external file references with paths the
+    compiler can successfully resolve from its current working directory.
+
+    Future revisions may change this to an interface that allows both internal
+    and external resources to define the object contents. Linking needs to be
+    updated to support various object compositions and certain backends may
+    require additional infrastructure support.
+
+    In the long term the goal is to allow combinations of declared objects and
+    generated code in order to give control of linking behavior to frontends.
+    Instead of needing global command line flags to link in additional blobs
+    the frontend can emit executables with the dependencies already defined per
+    variant without needing to reach into the IREE compiler code.
+
+    Example:
+    ```mlir
+    #hal.executable.object<{path = "some/file.obj"}>
+    #hal.executable.object<{data = dense<[...]> : vector<2048xi8>}>
+    ```
+  }];
+
+  let parameters = (ins
+    OptionalParameter<"StringAttr", "">:$path,
+    OptionalParameter<"DenseIntElementsAttr", "">:$data
+  );
+
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    // Returns the absolute path of the referenced object file if it exists.
+    FailureOr<std::string> getAbsolutePath();
+
+    // Returns the contents of the object file or None if loading failed.
+    // TODO(benvanik): better return type to support mapping/etc? eh
+    Optional<std::string> loadData();
+  }];
+}
+
+def HAL_ExecutableObjectArrayAttr :
+    TypedArrayAttrBase<HAL_ExecutableObjectAttr,
+                       "HAL executable object references">;
+
+def HAL_ExecutableObjectsAttr : AttrDef<HAL_Dialect, "ExecutableObjects"> {
+  let mnemonic = "executable.objects";
+  let summary = [{target-specific object file references}];
+  let description = [{
+    A dictionary mapping executable target specifications to a list of objects.
+    This is used to allow layers of the stack that support multi-targeting to
+    specify information used during lowering into each particular target.
+
+    The key attributes are matched against each target variant based on the
+    backend and format as well as any configuration data provided. When
+    comparing the configuration only fields present in both the key and
+    target variant will be checked and must match. This allows specification of
+    generic sets ("all x86_64 targets get these objects") as well as specific
+    ones ("only x86_64 targets with vector_size = 64 get these objects").
+
+    Example:
+    ```mlir
+    #hal.executable.objects<{
+      #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64"> = [
+        #hal.executable.object<{path = "some/file_arm_64.obj"}>
+      ],
+      #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64"> = [
+        #hal.executable.object<{path = "some/file_x86_64.obj"}>
+      ]
+    }>
+    ```
+  }];
+
+  let parameters = (ins
+    AttrParameter<"ArrayAttr", "">:$targets,
+    AttrParameter<"ArrayAttr", "">:$targetObjects
+  );
+
+  let genVerifyDecl = 1;
+  let hasCustomAssemblyFormat = 1;
+
+  let extraClassDeclaration = [{
+    // Returns the objects specified for the given generic target.
+    Optional<ArrayAttr> getApplicableObjects(
+        IREE::HAL::ExecutableTargetAttr specificTargetAttr);
+  }];
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -1484,7 +1484,8 @@ def HAL_ExecutableSourceOp : HAL_Op<"executable.source", [
 
   let arguments = (ins
     OptionalAttr<StrAttr>:$sym_visibility,
-    SymbolNameAttr:$sym_name
+    SymbolNameAttr:$sym_name,
+    OptionalAttr<HAL_ExecutableObjectsAttr>:$objects
   );
 
   let regions = (region SizedRegion<1>:$body);
@@ -1499,6 +1500,10 @@ def HAL_ExecutableSourceOp : HAL_Op<"executable.source", [
 
   let extraClassDeclaration = [{
     Block& getBlock() { return getBody().front(); }
+
+    bool isExternal() {
+      return getBlock().getOps<::mlir::ModuleOp>().empty();
+    }
 
     ::mlir::ModuleOp getInnerModule() {
       auto moduleOps = getBlock().getOps<::mlir::ModuleOp>();
@@ -1648,7 +1653,8 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
   let arguments = (ins
     OptionalAttr<StrAttr>:$sym_visibility,
     SymbolNameAttr:$sym_name,
-    HAL_ExecutableTargetAttr:$target
+    HAL_ExecutableTargetAttr:$target,
+    OptionalAttr<HAL_ExecutableObjectArrayAttr>:$objects
   );
 
   let regions = (region SizedRegion<1>:$body);
@@ -1657,6 +1663,7 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
     custom<SymbolVisibility>($sym_visibility)
     $sym_name
     `,` `target` `=` $target
+    (`,` `objects` `=` $objects^ )?
     attr-dict-with-keyword
     regions
   }];
@@ -1668,6 +1675,10 @@ def HAL_ExecutableVariantOp : HAL_Op<"executable.variant", [
 
   let extraClassDeclaration = [{
     Block& getBlock() { return getBody().front(); }
+
+    bool isExternal() {
+      return getBlock().getOps<::mlir::ModuleOp>().empty();
+    }
 
     ::mlir::ModuleOp getInnerModule() {
       auto moduleOps = getBlock().getOps<::mlir::ModuleOp>();

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -11,6 +11,10 @@
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Utils/StringUtils.h"
 #include "llvm/ADT/StringExtras.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Path.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/Builders.h"
@@ -313,6 +317,49 @@ Attribute ExecutableTargetAttr::getMatchExpression() {
   return DeviceMatchExecutableFormatAttr::get(getContext(), getFormat());
 }
 
+// For now this is very simple: if there are any specified fields that are
+// present in this attribute they must match. We could allow target backends
+// to customize this via attribute interfaces in the future if we needed.
+bool ExecutableTargetAttr::isGenericOf(
+    IREE::HAL::ExecutableTargetAttr specificAttr) {
+  if (getBackend() != specificAttr.getBackend() ||
+      getFormat() != specificAttr.getFormat()) {
+    // Totally different backends and binary formats.
+    // There may be cases where we want to share things - such as when targeting
+    // both DLLs and dylibs or something - but today almost all of these are
+    // unique situations.
+    return false;
+  }
+
+  // If the config is empty on either we can quickly match.
+  // This is the most common case for users manually specifying targets.
+  auto genericConfigAttr = getConfiguration();
+  auto specificConfigAttr = specificAttr.getConfiguration();
+  if (!genericConfigAttr || !specificConfigAttr) return true;
+
+  // Ensure all fields in specificConfigAttr either don't exist or match.
+  for (auto expectedAttr : specificConfigAttr.getValue()) {
+    auto actualValue = genericConfigAttr.getNamed(expectedAttr.getName());
+    if (!actualValue) {
+      continue;  // ignore, not present in generic
+    }
+    if (actualValue->getValue() != expectedAttr.getValue()) {
+      return false;  // mismatch, both have values but they differ
+    }
+  }
+
+  // Ensure all fields in genericConfigAttr exist in the specific one.
+  // If missing then the generic is _more_ specific and can't match.
+  for (auto actualAttr : genericConfigAttr.getValue()) {
+    if (!specificConfigAttr.getNamed(actualAttr.getName())) {
+      return false;  // mismatch, present in generic but not specific
+    }
+  }
+
+  // All fields match or are omitted in the generic version.
+  return true;
+}
+
 // static
 ExecutableTargetAttr ExecutableTargetAttr::lookup(Operation *op) {
   auto *context = op->getContext();
@@ -331,6 +378,181 @@ ExecutableTargetAttr ExecutableTargetAttr::lookup(Operation *op) {
   // No target found during walk. No default to provide so fail and let the
   // caller decide what to do (assert/fallback/etc).
   return nullptr;
+}
+
+//===----------------------------------------------------------------------===//
+// #hal.executable.object
+//===----------------------------------------------------------------------===//
+
+// static
+Attribute ExecutableObjectAttr::parse(AsmParser &p, Type type) {
+  NamedAttrList dict;
+  // `<{` dict `}>`
+  if (failed(p.parseLess()) || failed(p.parseOptionalAttrDict(dict)) ||
+      failed(p.parseGreater())) {
+    return {};
+  }
+  auto pathAttr = dict.get("path").dyn_cast_or_null<StringAttr>();
+  auto dataAttr = dict.get("data").dyn_cast_or_null<DenseIntElementsAttr>();
+  return get(p.getContext(), pathAttr, dataAttr);
+}
+
+void ExecutableObjectAttr::print(AsmPrinter &p) const {
+  auto &os = p.getStream();
+  os << "<{";
+  if (auto pathAttr = getPath()) {
+    os << "path = ";
+    p.printAttribute(getPath());
+  } else if (auto dataAttr = getData()) {
+    os << "data = ";
+    p.printAttribute(getData());
+  }
+  os << "}>";
+}
+
+// Tries to find |filePath| on disk either at its absolute path or joined with
+// any of the specified |searchPaths| in order.
+// Returns the absolute file path when found or a failure if there are no hits.
+static FailureOr<std::string> findFileInPaths(
+    StringRef filePath, ArrayRef<std::string> searchPaths) {
+  // First try to see if it's an absolute path - we don't want to perform any
+  // additional processing on top of that.
+  if (llvm::sys::path::is_absolute(filePath)) {
+    if (llvm::sys::fs::exists(filePath)) return filePath.str();
+    return failure();
+  }
+
+  // Try a relative lookup from the current working directory.
+  if (llvm::sys::fs::exists(filePath)) return filePath.str();
+
+  // Search each path in turn for a file that exists.
+  // It doesn't mean we can open it but we'll get a better error out of the
+  // actual open attempt than what we could produce here.
+  for (auto searchPath : searchPaths) {
+    SmallVector<char> tryPath{searchPath.begin(), searchPath.end()};
+    llvm::sys::path::append(tryPath, filePath);
+    if (llvm::sys::fs::exists(Twine(tryPath))) return Twine(tryPath).str();
+  }
+
+  // Not found in either the user-specified absolute path, cwd, or the search
+  // paths.
+  return failure();
+}
+
+static llvm::cl::list<std::string> clExecutableObjectSearchPath(
+    "iree-hal-executable-object-search-path",
+    llvm::cl::desc("Additional search paths for resolving "
+                   "#hal.executable.object file references."),
+    llvm::cl::ZeroOrMore);
+
+FailureOr<std::string> ExecutableObjectAttr::getAbsolutePath() {
+  auto pathAttr = getPath();
+  if (!pathAttr) return failure();  // not a file reference
+  return findFileInPaths(pathAttr.getValue(), clExecutableObjectSearchPath);
+}
+
+Optional<std::string> ExecutableObjectAttr::loadData() {
+  if (auto dataAttr = getData()) {
+    // This is shady but so is using this feature.
+    // TODO(benvanik): figure out a way to limit the attribute to signless int8.
+    // We could share the attribute -> byte array code with the VM constant
+    // serialization if we wanted.
+    auto rawData = dataAttr.getRawData();
+    return std::string(rawData.data(), rawData.size());
+  } else if (auto pathAttr = getPath()) {
+    // Search for file and try to load it if found.
+    auto filePath =
+        findFileInPaths(pathAttr.getValue(), clExecutableObjectSearchPath);
+    if (failed(filePath)) {
+      llvm::errs()
+          << "ERROR: referenced object file not found on any path; use "
+             "--iree-hal-executable-object-search-path= to add search paths: "
+          << *this << "\n";
+      return None;
+    }
+    auto file = llvm::MemoryBuffer::getFile(*filePath);
+    if (!file) return None;
+    return std::string((*file)->getBuffer());
+  }
+  return None;
+}
+
+//===----------------------------------------------------------------------===//
+// #hal.executable.objects
+//===----------------------------------------------------------------------===//
+
+// static
+LogicalResult ExecutableObjectsAttr::verify(
+    function_ref<mlir::InFlightDiagnostic()> emitError, ArrayAttr targetsAttr,
+    ArrayAttr targetObjectsAttr) {
+  if (targetsAttr.size() != targetObjectsAttr.size()) {
+    return emitError() << "targets and objects must be 1:1";
+  }
+  for (auto targetAttr : targetsAttr) {
+    if (!targetAttr.isa<IREE::HAL::ExecutableTargetAttr>()) {
+      return emitError()
+             << "target keys must be #hal.executable.target attributes";
+    }
+  }
+  for (auto objectsAttr : targetObjectsAttr) {
+    auto objectsArrayAttr = objectsAttr.dyn_cast<ArrayAttr>();
+    if (!objectsArrayAttr) {
+      return emitError() << "target objects must be an array of "
+                            "#hal.executable.object attributes";
+    }
+  }
+  return success();
+}
+
+// static
+Attribute ExecutableObjectsAttr::parse(AsmParser &p, Type type) {
+  // `<{` target = [objects, ...], ... `}>`
+  SmallVector<Attribute> targetAttrs;
+  SmallVector<Attribute> objectsAttrs;
+  if (failed(p.parseLess())) return {};
+  if (succeeded(p.parseLBrace()) && !succeeded(p.parseOptionalRBrace())) {
+    do {
+      Attribute targetAttr;
+      ArrayAttr objectsAttr;
+      if (failed(p.parseAttribute(targetAttr)) || failed(p.parseEqual()) ||
+          failed(p.parseAttribute(objectsAttr))) {
+        return {};
+      }
+      targetAttrs.push_back(targetAttr);
+      objectsAttrs.push_back(objectsAttr);
+    } while (succeeded(p.parseOptionalComma()));
+    if (failed(p.parseRBrace())) return {};
+  }
+  if (failed(p.parseGreater())) return {};
+  return get(p.getContext(), ArrayAttr::get(p.getContext(), targetAttrs),
+             ArrayAttr::get(p.getContext(), objectsAttrs));
+}
+
+void ExecutableObjectsAttr::print(AsmPrinter &p) const {
+  auto &os = p.getStream();
+  os << "<{";
+  llvm::interleaveComma(llvm::zip(getTargets(), getTargetObjects()), os,
+                        [&](std::tuple<Attribute, Attribute> keyValue) {
+                          p.printAttribute(std::get<0>(keyValue));
+                          os << " = ";
+                          p.printAttributeWithoutType(std::get<1>(keyValue));
+                        });
+  os << "}>";
+}
+
+Optional<ArrayAttr> ExecutableObjectsAttr::getApplicableObjects(
+    IREE::HAL::ExecutableTargetAttr specificTargetAttr) {
+  SmallVector<Attribute> allObjectAttrs;
+  for (auto [targetAttr, objectsAttr] :
+       llvm::zip(getTargets(), getTargetObjects())) {
+    auto genericTargetAttr = targetAttr.cast<IREE::HAL::ExecutableTargetAttr>();
+    if (genericTargetAttr.isGenericOf(specificTargetAttr)) {
+      auto objectsArrayAttr = objectsAttr.cast<ArrayAttr>();
+      allObjectAttrs.append(objectsArrayAttr.begin(), objectsArrayAttr.end());
+    }
+  }
+  if (allObjectAttrs.empty()) return None;
+  return ArrayAttr::get(specificTargetAttr.getContext(), allObjectAttrs);
 }
 
 //===----------------------------------------------------------------------===//
@@ -632,6 +854,9 @@ Value DeviceMatchExecutableFormatAttr::buildConditionExpression(
 #include "iree/compiler/Dialect/HAL/IR/HALTypeInterfaces.cpp.inc"
 
 void HALDialect::registerAttributes() {
+  // Register command line flags:
+  (void)clExecutableObjectSearchPath;
+
   addAttributes<
 #define GET_ATTRDEF_LIST
 #include "iree/compiler/Dialect/HAL/IR/HALAttrs.cpp.inc"  // IWYU pragma: keep

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/test/attributes.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/test/attributes.mlir
@@ -31,6 +31,35 @@
 
 // -----
 
+"executable.objects"() {
+  // CHECK: data = #hal.executable.object<{data = dense<[4, 5, 6, 7]> : vector<4xi8>}>
+  data = #hal.executable.object<{data = dense<[4, 5, 6, 7]> : vector<4xi8>}>,
+  // CHECK: path = #hal.executable.object<{path = "foo"}>
+  path = #hal.executable.object<{path = "foo"}>
+} : () -> ()
+
+// -----
+
+#target_a = #hal.executable.target<"llvm-cpu", "a">
+#target_b = #hal.executable.target<"llvm-cpu", "b">
+#target_c = #hal.executable.target<"llvm-cpu", "c">
+// CHECK-LABEL: "executable.target_objects"
+"executable.target_objects"() {
+  // CHECK-SAME: empty = #hal.executable.objects<{}>
+  empty = #hal.executable.objects<{}>,
+  // CHECK-SAME: targets_a = #hal.executable.objects<{#hal.executable.target<"llvm-cpu", "a"> = [#hal.executable.object<{path = "a.o"}>]}>
+  targets_a = #hal.executable.objects<{
+    #target_a = [#hal.executable.object<{path = "a.o"}>]
+  }>,
+  // CHECK-SAME: targets_bc = #hal.executable.objects<{#hal.executable.target<"llvm-cpu", "b"> = [#hal.executable.object<{path = "b.o"}>], #hal.executable.target<"llvm-cpu", "c"> = [#hal.executable.object<{path = "c.o"}>]}>
+  targets_bc = #hal.executable.objects<{
+    #target_b = [#hal.executable.object<{path = "b.o"}>],
+    #target_c = [#hal.executable.object<{path = "c.o"}>]
+  }>
+} : () -> ()
+
+// -----
+
 "affinity.queue"() {
   // CHECK: any = #hal.affinity.queue<*>
   any = #hal.affinity.queue<*>,

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -202,7 +202,13 @@ class CUDATargetBackend final : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
+    // For now we disable translation if the variant has external object files.
+    // We could instead perform linking with those objects (if they're bitcode
+    // ala libdevice.bc, etc).
+    if (variantOp.isExternal()) return;
+
     buildLLVMGPUTransformPassPipeline(passManager, false);
   }
 
@@ -220,44 +226,14 @@ class CUDATargetBackend final : public TargetBackend {
     auto libraryName =
         variantOp->getParentOfType<IREE::HAL::ExecutableOp>().getName().str();
 
-    ModuleOp innerModuleOp = variantOp.getInnerModule();
+    // TODO(thomasraoux): property handle export ordinals; this code is assuming
+    // that ordinals are dense starting at 0 but that is not required.
 
-    // Remove all the functions that are not part of the CUDA kernel.
-    // TODO: Find a better solution to handle this.
-    auto illegalFuncOps =
-        llvm::to_vector<4>(innerModuleOp.getOps<func::FuncOp>());
-    for (auto funcOp : illegalFuncOps) {
-      funcOp.erase();
-    }
-
-    auto llvmModule =
-        mlir::translateModuleToLLVMIR(innerModuleOp, context, libraryName);
-    if (!llvmModule) {
-      return variantOp.emitError() << "failed to translate the MLIR LLVM "
-                                      "dialect to the native llvm::Module";
-    }
-
-    // Collect all the entry point names.
-    llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps;
-    for (auto op : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
-      exportOps[op.getSymName()] = op;
-    }
-    std::vector<std::array<int32_t, 3>> workgroupSizes;
-    std::vector<std::string> entryPointNames;
-    std::vector<uint32_t> workgroupLocalMemories;
-
-    for (auto func : innerModuleOp.getOps<LLVM::LLVMFuncOp>()) {
-      auto *llvmFunc = llvmModule->getFunction(func.getName());
-      if (llvmFunc->isDeclaration()) continue;
-      // setName will make sure the function name is unique.
-      llvmFunc->setName(sanitizeSymbolName(func.getName()));
-      entryPointNames.emplace_back(llvmFunc->getName());
+    // Collect all the entry point parameters.
+    SmallVector<std::array<int32_t, 3>> workgroupSizes;
+    SmallVector<uint32_t> workgroupLocalMemories;
+    for (auto exportOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
       std::array<int32_t, 3> workgroupSize;
-      uint32_t workgroupLocalMemory = 0;
-      auto exportOp = exportOps[func.getName()];
-      if (auto workgroupLocalMemoryAttr = exportOp.getWorkgroupLocalMemory()) {
-        workgroupLocalMemory = workgroupLocalMemoryAttr->getSExtValue();
-      }
       if (Optional<ArrayAttr> workgroupSizeAttr = exportOp.getWorkgroupSize()) {
         for (auto it : llvm::enumerate(workgroupSizeAttr.value())) {
           workgroupSize[it.index()] = it.value().cast<IntegerAttr>().getInt();
@@ -265,91 +241,149 @@ class CUDATargetBackend final : public TargetBackend {
       } else {
         workgroupSize = {1, 1, 1};
       }
-      workgroupLocalMemories.push_back(workgroupLocalMemory);
       workgroupSizes.push_back(workgroupSize);
-      llvm::Metadata *llvmMetadata[] = {
-          llvm::ValueAsMetadata::get(llvmFunc),
-          llvm::MDString::get(llvmModule->getContext(), "kernel"),
-          llvm::ValueAsMetadata::get(llvm::ConstantInt::get(
-              llvm::Type::getInt32Ty(llvmModule->getContext()), 1))};
-      llvm::MDNode *llvmMetadataNode =
-          llvm::MDNode::get(llvmModule->getContext(), llvmMetadata);
-      llvmModule->getOrInsertNamedMetadata("nvvm.annotations")
-          ->addOperand(llvmMetadataNode);
-      /* Set maximum number of threads in the thread block (CTA). */
-      auto generateMetadata = [&](int dim, StringRef name) {
-        llvm::Metadata *llvmMetadata[] = {
-            llvm::ValueAsMetadata::get(llvmFunc),
-            llvm::MDString::get(llvmModule->getContext(), name),
-            llvm::ValueAsMetadata::get(llvm::ConstantInt::get(
-                llvm::Type::getInt32Ty(llvmModule->getContext()), dim))};
-        llvm::MDNode *llvmMetadataNode =
-            llvm::MDNode::get(llvmModule->getContext(), llvmMetadata);
-        llvmModule->getOrInsertNamedMetadata("nvvm.annotations")
-            ->addOperand(llvmMetadataNode);
-      };
-      generateMetadata(workgroupSize[0], "maxntidx");
-      generateMetadata(workgroupSize[1], "maxntidy");
-      generateMetadata(workgroupSize[2], "maxntidz");
+      uint32_t workgroupLocalMemory = 0;
+      if (auto workgroupLocalMemoryAttr = exportOp.getWorkgroupLocalMemory()) {
+        workgroupLocalMemory = workgroupLocalMemoryAttr->getSExtValue();
+      }
+      workgroupLocalMemories.push_back(workgroupLocalMemory);
     }
 
-    std::unique_ptr<llvm::TargetMachine> targetMachine;
-    {
-      llvm::Triple triple("nvptx64-nvidia-cuda");
-      std::string targetChip = clTargetChip;
-      std::string features = "+ptx60";
-      std::string error;
-      const llvm::Target *target =
-          llvm::TargetRegistry::lookupTarget("", triple, error);
-      if (target == nullptr) {
-        return variantOp.emitError() << "cannot initialize target triple";
+    SmallVector<std::string> entryPointNames;
+    std::string ptxImage;
+    if (variantOp.isExternal()) {
+      if (!variantOp.getObjects().has_value()) {
+        return variantOp.emitOpError()
+               << "no objects defined for external variant";
+      } else if (variantOp.getObjects()->getValue().size() != 1) {
+        // For now we assume there will be exactly one object file.
+        // In the future we will want to perform a linking step here and ideally
+        // support _also_ linking in the codegen results.
+        return variantOp.emitOpError() << "only one object reference is "
+                                          "supported for external variants";
       }
-      targetMachine.reset(target->createTargetMachine(triple.str(), targetChip,
-                                                      features, {}, {}));
-      if (targetMachine == nullptr) {
-        return variantOp.emitError() << "cannot initialize target machine";
+
+      // Take exported names verbatim. The user must have already sanitized
+      // these to match the names in their kernels. We don't support any kind of
+      // mangling and if the user was silly enough to rely on nvcc C++ mangling
+      // they'll have to figure that out.
+      for (auto exportOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+        entryPointNames.emplace_back(exportOp.getSymName());
       }
+
+      auto objectAttr = variantOp.getObjects()
+                            ->getValue()
+                            .front()
+                            .cast<IREE::HAL::ExecutableObjectAttr>();
+      if (auto data = objectAttr.loadData()) {
+        ptxImage = data.value();
+      } else {
+        return variantOp.emitOpError()
+               << "object file could not be loaded: " << objectAttr;
+      }
+    } else {
+      ModuleOp innerModuleOp = variantOp.getInnerModule();
+
+      // Remove all the functions that are not part of the CUDA kernel.
+      // TODO(thomasraoux): remove this? this should not be required.
+      auto illegalFuncOps =
+          llvm::to_vector<4>(innerModuleOp.getOps<func::FuncOp>());
+      for (auto funcOp : illegalFuncOps) {
+        funcOp.erase();
+      }
+
+      auto llvmModule =
+          mlir::translateModuleToLLVMIR(innerModuleOp, context, libraryName);
+      if (!llvmModule) {
+        return variantOp.emitError() << "failed to translate the MLIR LLVM "
+                                        "dialect to the native llvm::Module";
+      }
+
+      for (auto [exportOp, workgroupSize] :
+           llvm::zip(variantOp.getOps<IREE::HAL::ExecutableExportOp>(),
+                     workgroupSizes)) {
+        auto *llvmFunc = llvmModule->getFunction(exportOp.getName());
+        if (llvmFunc->isDeclaration()) continue;
+
+        // setName will make sure the function name is unique.
+        llvmFunc->setName(sanitizeSymbolName(exportOp.getName()));
+        entryPointNames.emplace_back(llvmFunc->getName());
+
+        auto *annotations =
+            llvmModule->getOrInsertNamedMetadata("nvvm.annotations");
+        auto setMetadataValueI32 = [&](StringRef name, int value) {
+          llvm::Metadata *llvmMetadata[] = {
+              llvm::ValueAsMetadata::get(llvmFunc),
+              llvm::MDString::get(llvmModule->getContext(), name),
+              llvm::ValueAsMetadata::get(llvm::ConstantInt::get(
+                  llvm::Type::getInt32Ty(llvmModule->getContext()), value))};
+          annotations->addOperand(
+              llvm::MDNode::get(llvmModule->getContext(), llvmMetadata));
+        };
+        // Mark the entry point as a kernel.
+        setMetadataValueI32("kernel", 1);
+        // Set the maximum number of threads in the thread block (CTA).
+        setMetadataValueI32("maxntidx", workgroupSize[0]);
+        setMetadataValueI32("maxntidy", workgroupSize[1]);
+        setMetadataValueI32("maxntidz", workgroupSize[2]);
+      }
+
+      std::unique_ptr<llvm::TargetMachine> targetMachine;
+      {
+        llvm::Triple triple("nvptx64-nvidia-cuda");
+        std::string targetChip = clTargetChip;
+        std::string features = "+ptx60";
+        std::string error;
+        const llvm::Target *target =
+            llvm::TargetRegistry::lookupTarget("", triple, error);
+        if (target == nullptr) {
+          return variantOp.emitError() << "cannot initialize target triple";
+        }
+        targetMachine.reset(target->createTargetMachine(
+            triple.str(), targetChip, features, {}, {}));
+        if (targetMachine == nullptr) {
+          return variantOp.emitError() << "cannot initialize target machine";
+        }
+      }
+
+      llvmModule->setDataLayout(targetMachine->createDataLayout());
+
+      linkAndOptimize(*llvmModule, *targetMachine);
+
+      // Serialize CUDA kernel into the binary that we will embed in the
+      // final FlatBuffer.
+      ptxImage = translateModuleToISA(*llvmModule, *targetMachine);
     }
 
-    llvmModule->setDataLayout(targetMachine->createDataLayout());
-
-    linkAndOptimize(*llvmModule, *targetMachine);
+    if (dumpPtx) {
+      llvm::dbgs() << ptxImage;
+    }
+    if (!options.dumpBinariesPath.empty()) {
+      dumpDataToPath(options.dumpBinariesPath, options.dumpBaseName,
+                     variantOp.getName(), ".ptx", ptxImage);
+    }
 
     FlatbufferBuilder builder;
     iree_CUDAExecutableDef_start_as_root(builder);
 
-    // Serialize cuda kernel into the binary that we will embed in the
-    // final FlatBuffer.
-    std::string targetISA = translateModuleToISA(*llvmModule, *targetMachine);
-    if (dumpPtx) {
-      llvm::dbgs() << targetISA;
-    }
-    if (!options.dumpBinariesPath.empty()) {
-      dumpDataToPath(options.dumpBinariesPath, options.dumpBaseName,
-                     variantOp.getName(), ".ptx", targetISA);
-    }
-    auto ptxCudeRef = flatbuffers_uint8_vec_create(
-        builder, reinterpret_cast<const uint8_t *>(targetISA.c_str()),
-        targetISA.size());
-
-    auto entryPointsRef = builder.createStringVec(entryPointNames);
-    auto workgroupLocalMemoriesRef =
-        builder.createInt32Vec(workgroupLocalMemories);
-
+    auto ptxImageRef = flatbuffers_uint8_vec_create(
+        builder, reinterpret_cast<const uint8_t *>(ptxImage.c_str()),
+        ptxImage.size());
     iree_CUDABlockSizeDef_vec_start(builder);
-    auto blockSizes = workgroupSizes.begin();
-    for (auto shader : entryPointNames) {
-      iree_CUDABlockSizeDef_vec_push_create(builder, (*blockSizes)[0],
-                                            (*blockSizes)[1], (*blockSizes)[2]);
-      ++blockSizes;
+    for (const auto &workgroupSize : workgroupSizes) {
+      iree_CUDABlockSizeDef_vec_push_create(builder, workgroupSize[0],
+                                            workgroupSize[1], workgroupSize[2]);
     }
     auto blockSizesRef = iree_CUDABlockSizeDef_vec_end(builder);
+    auto workgroupLocalMemoriesRef =
+        builder.createInt32Vec(workgroupLocalMemories);
+    auto entryPointsRef = builder.createStringVec(entryPointNames);
 
     iree_CUDAExecutableDef_entry_points_add(builder, entryPointsRef);
+    iree_CUDAExecutableDef_block_sizes_add(builder, blockSizesRef);
     iree_CUDAExecutableDef_shared_memory_size_add(builder,
                                                   workgroupLocalMemoriesRef);
-    iree_CUDAExecutableDef_block_sizes_add(builder, blockSizesRef);
-    iree_CUDAExecutableDef_ptx_image_add(builder, ptxCudeRef);
+    iree_CUDAExecutableDef_ptx_image_add(builder, ptxImageRef);
     iree_CUDAExecutableDef_end_as_root(builder);
 
     // Add the binary data to the target executable.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -117,7 +117,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
  public:
   explicit LLVMCPUTargetBackend(LLVMTargetOptions options)
       : options_(std::move(options)) {
-    initConfiguration();
+    initializeConfiguration(options_);
   }
 
   std::string name() const override { return "llvm-cpu"; }
@@ -157,6 +157,25 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     buildLLVMCPULinkingPassPipeline(passManager);
   }
 
+  // Gets the LLVM target from |variantOp|.
+  // This will differ from the default options specified by command line flags
+  // whenever multi-targeting.
+  LLVMTarget getVariantTarget(IREE::HAL::ExecutableVariantOp variantOp) {
+    auto configAttr = variantOp.getTarget().getConfiguration();
+    auto tryAttrLookup = [&](StringRef name, StringRef fallback) {
+      if (!configAttr) return fallback.str();
+      auto value = configAttr.get(name).dyn_cast_or_null<StringAttr>();
+      if (!value) return fallback.str();
+      return value.str();
+    };
+    LLVMTarget target;
+    target.triple = tryAttrLookup("target_triple", options_.target.triple);
+    target.cpu = tryAttrLookup("cpu", options_.target.cpu);
+    target.cpuFeatures =
+        tryAttrLookup("cpu_features", options_.target.cpuFeatures);
+    return target;
+  }
+
   LogicalResult serializeExecutable(const SerializationOptions &options,
                                     IREE::HAL::ExecutableVariantOp variantOp,
                                     OpBuilder &executableBuilder) override {
@@ -177,10 +196,19 @@ class LLVMCPUTargetBackend final : public TargetBackend {
              << "cannot embed ELF and produce static library simultaneously";
     }
 
+    // Try to create the LLVM target machine interface for the variant target.
+    auto target = getVariantTarget(variantOp);
+    auto targetMachine = createTargetMachine(target, options_);
+    if (!targetMachine) {
+      return mlir::emitError(variantOp.getLoc())
+             << "failed to create target machine for target triple '"
+             << target.triple << "'";
+    }
+
     // Specialize the module to the target triple.
     // The executable will have been cloned into other ExecutableVariantOps for
     // other triples so it's fine to mutate in-place.
-    llvm::Triple targetTriple(options_.targetTriple);
+    const llvm::Triple &targetTriple = targetMachine->getTargetTriple();
     variantOp.getInnerModule()->setAttr(
         LLVM::LLVMDialect::getTargetTripleAttrName(),
         executableBuilder.getStringAttr(targetTriple.str()));
@@ -313,7 +341,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
       if (!linkerTool) {
         return mlir::emitError(variantOp.getLoc())
                << "failed to find a target linker for the given target triple '"
-               << options_.targetTriple << "'";
+               << targetTriple.str() << "'";
       }
 
       // Configure the module with any code generation options required later by
@@ -326,12 +354,6 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     }
 
     // Specialize the module to our target machine.
-    auto targetMachine = createTargetMachine(options_);
-    if (!targetMachine) {
-      return mlir::emitError(variantOp.getLoc())
-             << "failed to create target machine for target triple '"
-             << options_.targetTriple << "'";
-    }
     llvmModule->setDataLayout(targetMachine->createDataLayout());
     llvmModule->setTargetTriple(targetMachine->getTargetTriple().str());
 
@@ -348,14 +370,14 @@ class LLVMCPUTargetBackend final : public TargetBackend {
             "libdevice", loadDeviceBitcode(targetMachine.get(), context)))) {
       return mlir::emitError(variantOp.getLoc())
              << "failed linking in builtin library for target triple '"
-             << options_.targetTriple << "'";
+             << targetTriple.str() << "'";
     }
     if (failed(linkBuiltinLibrary(
             variantOp.getLoc(), moduleLinker, linkerFlag, targetMachine.get(),
             "libmusl", loadMuslBitcode(targetMachine.get(), context)))) {
       return mlir::emitError(variantOp.getLoc())
              << "failed linking in builtin library for target triple '"
-             << options_.targetTriple << "'";
+             << targetTriple.str() << "'";
     }
 
     // Strip any compiler identifiers that may have snuck in. We let the linker
@@ -370,7 +392,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
       return variantOp.emitError()
              << "failed to run LLVM-IR opt passes for IREE::HAL::ExecutableOp "
                 "targeting '"
-             << options_.targetTriple << "'";
+             << targetTriple.str() << "'";
     }
 
     // Fixup visibility from any symbols we may link in - we want to hide all
@@ -450,9 +472,9 @@ class LLVMCPUTargetBackend final : public TargetBackend {
                                               executableBuilder, libraryName,
                                               queryFunctionName, objectFiles);
     } else {
-      return serializeDynamicLibraryExecutable(options, variantOp,
-                                               executableBuilder, libraryName,
-                                               objectFiles, linkerTool.get());
+      return serializeDynamicLibraryExecutable(
+          options, variantOp, executableBuilder, libraryName, targetTriple,
+          objectFiles, linkerTool.get());
     }
   }
 
@@ -489,8 +511,8 @@ class LLVMCPUTargetBackend final : public TargetBackend {
   LogicalResult serializeDynamicLibraryExecutable(
       const SerializationOptions &options,
       IREE::HAL::ExecutableVariantOp variantOp, OpBuilder &executableBuilder,
-      const std::string &libraryName, const SmallVector<Artifact> &objectFiles,
-      LinkerTool *linkerTool) {
+      const std::string &libraryName, const llvm::Triple &targetTriple,
+      const SmallVector<Artifact> &objectFiles, LinkerTool *linkerTool) {
     // Link the generated object files into a dylib.
     auto linkArtifactsOr =
         linkerTool->linkDynamicLibrary(libraryName, objectFiles);
@@ -536,7 +558,6 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     } else {
       const char *mimeType = nullptr;
       const char *extension = "";
-      llvm::Triple targetTriple(options_.targetTriple);
       switch (targetTriple.getObjectFormat()) {
         case llvm::Triple::ObjectFormatType::COFF:
           mimeType = "application/x-msdownload";
@@ -612,7 +633,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
       format += "static";
     } else {
       // Construct the [loader]-[format]-[arch] triple.
-      llvm::Triple targetTriple(options_.targetTriple);
+      llvm::Triple targetTriple(options_.target.triple);
       if (options_.linkEmbedded) {
         // Using the IREE embedded ELF format/loader.
         format += "embedded-elf-";
@@ -674,8 +695,12 @@ class LLVMCPUTargetBackend final : public TargetBackend {
       config.emplace_back(StringAttr::get(context, name), value);
     };
 
-    // Set target triple.
-    addConfig("target_triple", StringAttr::get(context, options_.targetTriple));
+    // Set target attributes.
+    addConfig("target_triple",
+              StringAttr::get(context, options_.target.triple));
+    addConfig("cpu", StringAttr::get(context, options_.target.cpu));
+    addConfig("cpu_features",
+              StringAttr::get(context, options_.target.cpuFeatures));
 
     // Set data layout
     addConfig("data_layout", StringAttr::get(context, config_.dataLayoutStr));
@@ -685,17 +710,13 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     addConfig("native_vector_size",
               IntegerAttr::get(IndexType::get(context), config_.vectorSize));
 
-    // Set target CPU features.
-    addConfig("cpu_features",
-              StringAttr::get(context, options_.targetCPUFeatures));
-
     return IREE::HAL::ExecutableTargetAttr::get(
         context, StringAttr::get(context, "llvm-cpu"),
         StringAttr::get(context, format), DictionaryAttr::get(context, config));
   }
 
-  void initConfiguration() {
-    auto targetMachine = createTargetMachine(options_);
+  void initializeConfiguration(const LLVMTargetOptions &options) {
+    auto targetMachine = createTargetMachine(options.target, options);
 
     // Data layout
     llvm::DataLayout DL = targetMachine->createDataLayout();

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -149,7 +149,8 @@ class LLVMCPUTargetBackend final : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
     buildLLVMCPUCodegenPassPipeline(passManager);
   }
 
@@ -467,6 +468,32 @@ class LLVMCPUTargetBackend final : public TargetBackend {
         bitcodeFile.outputFile->keep();
       }
     }
+
+    // If custom object files were specified then add those to our artifact set.
+    // These will either be combined into the resulting static library or linked
+    // statically into the resulting dynamic library.
+    if (auto objectAttrs = variantOp.getObjects()) {
+      for (auto [index, attr] : llvm::enumerate(objectAttrs.value())) {
+        auto objectAttr = attr.cast<IREE::HAL::ExecutableObjectAttr>();
+        if (objectAttr.getPath()) {
+          auto absolutePath = objectAttr.getAbsolutePath();
+          if (failed(absolutePath)) {
+            llvm::errs()
+                << "ERROR: referenced object file not found on any path; use "
+                   "--iree-hal-executable-object-search-path= to add search "
+                   "paths: "
+                << objectAttr << "\n";
+            return failure();
+          }
+          objectFiles.push_back(Artifact::fromFile(*absolutePath));
+        } else if (auto dataAttr = objectAttr.getData()) {
+          objectFiles.push_back(Artifact::createTemporary(
+              objectFiles.front().path + "_object_" + std::to_string(index),
+              ".o"));
+        }
+      }
+    }
+
     if (options_.linkStatic) {
       return serializeStaticLibraryExecutable(options, variantOp,
                                               executableBuilder, libraryName,
@@ -528,7 +555,7 @@ class LLVMCPUTargetBackend final : public TargetBackend {
           << "    " << linkArtifacts.libraryFile.path;
       linkArtifacts.keepAllFiles();
       for (auto &objectFile : objectFiles) {
-        objectFile.outputFile->keep();
+        objectFile.keep();
       }
     }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp
@@ -28,16 +28,15 @@ namespace IREE {
 namespace HAL {
 
 std::unique_ptr<llvm::TargetMachine> createTargetMachine(
-    const LLVMTargetOptions &targetOptions) {
+    const LLVMTarget &target, const LLVMTargetOptions &targetOptions) {
   std::string errorMessage;
-  auto target = llvm::TargetRegistry::lookupTarget(targetOptions.targetTriple,
-                                                   errorMessage);
-  if (!target) return nullptr;
-  std::unique_ptr<llvm::TargetMachine> machine(target->createTargetMachine(
-      targetOptions.targetTriple, targetOptions.targetCPU /* cpu e.g k8*/,
-      targetOptions.targetCPUFeatures /* cpu features e.g avx512fma*/,
-      targetOptions.options, llvm::Reloc::Model::PIC_, {},
-      targetOptions.codeGenOptLevel,
+  auto llvmTarget =
+      llvm::TargetRegistry::lookupTarget(target.triple, errorMessage);
+  if (!llvmTarget) return nullptr;
+  std::unique_ptr<llvm::TargetMachine> machine(llvmTarget->createTargetMachine(
+      target.triple, target.cpu /* cpu e.g k8*/,
+      target.cpuFeatures /* cpu features e.g avx512fma*/, targetOptions.options,
+      llvm::Reloc::Model::PIC_, {}, targetOptions.codeGenOptLevel,
       /*JIT=*/false));
   return machine;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.h
@@ -21,7 +21,7 @@ namespace HAL {
 
 // Creates target machine form target options.
 std::unique_ptr<llvm::TargetMachine> createTargetMachine(
-    const LLVMTargetOptions &options);
+    const LLVMTarget &target, const LLVMTargetOptions &options);
 
 // Creates and runs LLVMIR optimization passes defined in LLVMTargetOptions.
 LogicalResult runLLVMIRPasses(const LLVMTargetOptions &options,

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -26,8 +26,8 @@ LLVMTargetOptions getDefaultLLVMTargetOptions() {
   static std::once_flag onceFlag;
   std::call_once(onceFlag, [&]() {
     // Host target triple.
-    targetOptions.targetTriple = llvm::sys::getDefaultTargetTriple();
-    targetOptions.targetCPU = llvm::sys::getHostCPUName().str();
+    targetOptions.target.triple = llvm::sys::getDefaultTargetTriple();
+    targetOptions.target.cpu = llvm::sys::getHostCPUName().str();
     {
       llvm::SubtargetFeatures features;
       llvm::StringMap<bool> hostFeatures;
@@ -36,7 +36,7 @@ LLVMTargetOptions getDefaultLLVMTargetOptions() {
           features.AddFeature(feature.first(), feature.second);
         }
       }
-      targetOptions.targetCPUFeatures = features.getString();
+      targetOptions.target.cpuFeatures = features.getString();
     }
 
     // LLVM loop optimization options.
@@ -66,7 +66,7 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
 
   static llvm::cl::opt<std::string> clTargetTriple(
       "iree-llvm-target-triple", llvm::cl::desc("LLVM target machine triple"),
-      llvm::cl::init(targetOptions.targetTriple));
+      llvm::cl::init(targetOptions.target.triple));
   static llvm::cl::opt<std::string> clTargetCPU(
       "iree-llvm-target-cpu",
       llvm::cl::desc(
@@ -91,13 +91,13 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       "iree-llvm-slp-vectorization", llvm::cl::init(false),
       llvm::cl::desc("Enable LLVM SLP Vectorization opt"));
 
-  targetOptions.targetTriple = clTargetTriple;
-  llvm::Triple targetTriple(targetOptions.targetTriple);
+  targetOptions.target.triple = clTargetTriple;
+  llvm::Triple targetTriple(targetOptions.target.triple);
   if (clTargetCPU != "host") {
-    targetOptions.targetCPU = clTargetCPU;
+    targetOptions.target.cpu = clTargetCPU;
   }
   if (clTargetCPUFeatures != "host") {
-    targetOptions.targetCPUFeatures = clTargetCPUFeatures;
+    targetOptions.target.cpuFeatures = clTargetCPUFeatures;
   }
 
   // LLVM opt options.
@@ -177,7 +177,7 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
     targetTriple.setEnvironment(llvm::Triple::EnvironmentType::EABI);
     targetTriple.setOS(llvm::Triple::OSType::UnknownOS);
     targetTriple.setObjectFormat(llvm::Triple::ObjectFormatType::ELF);
-    targetOptions.targetTriple = targetTriple.str();
+    targetOptions.target.triple = targetTriple.str();
   }
 
   static llvm::cl::opt<bool> clLinkStatic(

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
@@ -23,11 +23,15 @@ enum class SanitizerKind {
   kThread,
 };
 
+struct LLVMTarget {
+  std::string triple;
+  std::string cpu;
+  std::string cpuFeatures;
+};
+
 struct LLVMTargetOptions {
-  // Target machine configuration.
-  std::string targetTriple;
-  std::string targetCPU;
-  std::string targetCPUFeatures;
+  // Default target machine configuration.
+  LLVMTarget target;
 
   llvm::PipelineTuningOptions pipelineTuningOptions;
   // Optimization level to be used by the LLVM optimizer (middle-end).

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.cpp
@@ -18,6 +18,9 @@ namespace IREE {
 namespace HAL {
 
 // static
+Artifact Artifact::fromFile(StringRef path) { return {path.str(), nullptr}; }
+
+// static
 Artifact Artifact::createTemporary(StringRef prefix, StringRef suffix) {
   auto sanitizedPrefix = sanitizeFileName(prefix);
   auto sanitizedSuffix = sanitizeFileName(suffix);
@@ -54,6 +57,10 @@ Artifact Artifact::createVariant(StringRef basePath, StringRef suffix) {
   return {filePath.str().str(), std::move(file)};
 }
 
+void Artifact::keep() const {
+  if (outputFile) outputFile->keep();
+}
+
 Optional<std::vector<int8_t>> Artifact::read() const {
   auto fileData = llvm::MemoryBuffer::getFile(path);
   if (!fileData) {
@@ -85,10 +92,10 @@ bool Artifact::readInto(raw_ostream &targetStream) const {
 void Artifact::close() { outputFile->os().close(); }
 
 void Artifacts::keepAllFiles() {
-  if (libraryFile.outputFile) libraryFile.outputFile->keep();
-  if (debugFile.outputFile) debugFile.outputFile->keep();
+  libraryFile.keep();
+  debugFile.keep();
   for (auto &file : otherFiles) {
-    file.outputFile->keep();
+    file.keep();
   }
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
@@ -24,6 +24,10 @@ namespace IREE {
 namespace HAL {
 
 struct Artifact {
+  // Wraps an existing file on the file system.
+  // The file will not be deleted when the artifact is destroyed.
+  static Artifact fromFile(StringRef path);
+
   // Creates an output file path/container pair.
   // By default the file will be deleted when the link completes; callers must
   // use llvm::ToolOutputFile::keep() to prevent deletion upon success (or if
@@ -40,6 +44,9 @@ struct Artifact {
 
   std::string path;
   std::unique_ptr<llvm::ToolOutputFile> outputFile;
+
+  // Preserves the file contents on disk after the artifact has been destroyed.
+  void keep() const;
 
   // Reads the artifact file contents as bytes.
   Optional<std::vector<int8_t>> read() const;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LinkerTool.h
@@ -45,7 +45,7 @@ struct Artifact {
   Optional<std::vector<int8_t>> read() const;
 
   // Reads the artifact file and writes it into the given |stream|.
-  bool readInto(raw_ostream& targetStream) const;
+  bool readInto(raw_ostream &targetStream) const;
 
   // Closes the ostream of the file while preserving the temporary entry on
   // disk. Use this if files need to be modified by external tools that may
@@ -75,7 +75,7 @@ class LinkerTool {
   // Gets an instance of a linker tool for the given target options. This may
   // be a completely different toolchain than that of the host.
   static std::unique_ptr<LinkerTool> getForTarget(
-      llvm::Triple& targetTriple, LLVMTargetOptions& targetOptions);
+      const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 
   explicit LinkerTool(llvm::Triple targetTriple,
                       LLVMTargetOptions targetOptions)
@@ -91,7 +91,7 @@ class LinkerTool {
   // Configures a module prior to compilation with any additional
   // functions/exports it may need, such as shared object initializer functions.
   virtual LogicalResult configureModule(
-      llvm::Module* llvmModule, ArrayRef<llvm::Function*> exportedFuncs) {
+      llvm::Module *llvmModule, ArrayRef<llvm::Function *> exportedFuncs) {
     return success();
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/AndroidLinkerTool.cpp
@@ -222,7 +222,7 @@ class AndroidLinkerTool : public LinkerTool {
 };
 
 std::unique_ptr<LinkerTool> createAndroidLinkerTool(
-    Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
   assert(targetTriple.isAndroid() &&
          "only use the AndroidLinkerTool for Android targets");
   return std::make_unique<AndroidLinkerTool>(targetTriple, targetOptions);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
@@ -193,7 +193,7 @@ class EmbeddedLinkerTool : public LinkerTool {
 };
 
 std::unique_ptr<LinkerTool> createEmbeddedLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
   return std::make_unique<EmbeddedLinkerTool>(targetTriple, targetOptions);
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/EmbeddedLinkerTool.cpp
@@ -181,9 +181,11 @@ class EmbeddedLinkerTool : public LinkerTool {
       // command themselves.
       if (targetOptions.keepLinkerArtifacts) {
         for (auto &objectFile : objectFiles) {
-          llvm::errs() << "linker input preserved: "
-                       << objectFile.outputFile->getFilename();
-          objectFile.outputFile->keep();
+          if (objectFile.outputFile) {
+            llvm::errs() << "linker input preserved: "
+                         << objectFile.outputFile->getFilename();
+            objectFile.keep();
+          }
         }
       }
       return llvm::None;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/LinkerTools.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/LinkerTools.cpp
@@ -15,19 +15,19 @@ namespace HAL {
 // createMacLinkerTool using ld64.lld
 
 std::unique_ptr<LinkerTool> createAndroidLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createEmbeddedLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createUnixLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createWasmLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 std::unique_ptr<LinkerTool> createWindowsLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions);
 
 // static
 std::unique_ptr<LinkerTool> LinkerTool::getForTarget(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
   if (targetOptions.linkEmbedded) {
     return createEmbeddedLinkerTool(targetTriple, targetOptions);
   } else if (targetTriple.isAndroid()) {

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/UnixLinkerTool.cpp
@@ -138,7 +138,7 @@ class UnixLinkerTool : public LinkerTool {
 };
 
 std::unique_ptr<LinkerTool> createUnixLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
   return std::make_unique<UnixLinkerTool>(targetTriple, targetOptions);
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/WasmLinkerTool.cpp
@@ -135,7 +135,7 @@ class WasmLinkerTool : public LinkerTool {
 };
 
 std::unique_ptr<LinkerTool> createWasmLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
   return std::make_unique<WasmLinkerTool>(targetTriple, targetOptions);
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/internal/WindowsLinkerTool.cpp
@@ -280,7 +280,7 @@ class WindowsLinkerTool : public LinkerTool {
 };
 
 std::unique_ptr<LinkerTool> createWindowsLinkerTool(
-    llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
+    const llvm::Triple &targetTriple, LLVMTargetOptions &targetOptions) {
   return std::make_unique<WindowsLinkerTool>(targetTriple, targetOptions);
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/MetalSPIRV/MetalSPIRVTarget.cpp
@@ -66,7 +66,13 @@ class MetalSPIRVTargetBackend : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
+    // For now we disable translation if the variant has external object files.
+    // We could instead perform linking with those objects (if they're Metal
+    // archives, etc).
+    if (variantOp.isExternal()) return;
+
     buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/false);
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -98,7 +98,13 @@ class ROCMTargetBackend final : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
+    // For now we disable translation if the variant has external object files.
+    // We could instead perform linking with those objects (if they're bitcode
+    // ala libdevice.bc, etc).
+    if (variantOp.isExternal()) return;
+
     buildLLVMGPUTransformPassPipeline(passManager, true);
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.h
@@ -166,7 +166,8 @@ class TargetBackend {
   //       module { spirv.module { ... } }
   //     }
   //   }
-  virtual void buildTranslationPassPipeline(OpPassManager &passManager) = 0;
+  virtual void buildTranslationPassPipeline(
+      IREE::HAL::ExecutableVariantOp variantOp, OpPassManager &passManager) = 0;
 
   // Inserts passes used to link `hal.executable.variant` ops together.
   // The pass manager will be nested on the parent module of `hal.executable`

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
@@ -53,7 +53,8 @@ class VMVXTargetBackend final : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
     IREE::VMVX::buildVMVXTransformPassPipeline(passManager);
 
     OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
@@ -158,7 +159,8 @@ class VMVXInlineTargetBackend final : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
     IREE::VMVX::buildVMVXTransformPassPipeline(passManager);
   }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -113,13 +113,26 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
+    // For now we disable translation if the variant has external object files.
+    // We could instead perform linking with those objects (if they're .spv
+    // files we could use spirv-link or import them into MLIR and merge here).
+    if (variantOp.isExternal()) return;
+
     buildSPIRVCodegenPassPipeline(passManager, /*enableFastMath=*/false);
   }
 
   LogicalResult serializeExecutable(const SerializationOptions &options,
                                     IREE::HAL::ExecutableVariantOp variantOp,
                                     OpBuilder &executableBuilder) override {
+    // Today we special-case external variants but in the future we could allow
+    // for a linking approach allowing both code generation and external .spv
+    // files to be combined together.
+    if (variantOp.isExternal()) {
+      return serializeExternalExecutable(options, variantOp, executableBuilder);
+    }
+
     ModuleOp innerModuleOp = variantOp.getInnerModule();
     auto spirvModuleOps = innerModuleOp.getOps<spirv::ModuleOp>();
     if (!llvm::hasSingleElement(spirvModuleOps)) {
@@ -166,6 +179,67 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
 
     iree_SpirVExecutableDef_entry_points_add(builder, entryPointsRef);
     iree_SpirVExecutableDef_subgroup_sizes_add(builder, subgroupSizesRef);
+    iree_SpirVExecutableDef_code_add(builder, spvCodeRef);
+    iree_SpirVExecutableDef_end_as_root(builder);
+
+    // Add the binary data to the target executable.
+    auto binaryOp = executableBuilder.create<IREE::HAL::ExecutableBinaryOp>(
+        variantOp.getLoc(), variantOp.getSymName(),
+        variantOp.getTarget().getFormat(),
+        builder.getBufferAttr(executableBuilder.getContext()));
+    binaryOp.setMimeTypeAttr(
+        executableBuilder.getStringAttr("application/x-flatbuffers"));
+
+    return success();
+  }
+
+  LogicalResult serializeExternalExecutable(
+      const SerializationOptions &options,
+      IREE::HAL::ExecutableVariantOp variantOp, OpBuilder &executableBuilder) {
+    if (!variantOp.getObjects().has_value()) {
+      return variantOp.emitOpError()
+             << "no objects defined for external variant";
+    } else if (variantOp.getObjects()->getValue().size() != 1) {
+      // For now we assume there will be exactly one object file.
+      // TODO(#7824): support multiple .spv files in a single flatbuffer archive
+      // so that we can combine executables.
+      return variantOp.emitOpError() << "only one object reference is "
+                                        "supported for external variants";
+    }
+
+    // Take exported names verbatim for passing into VkShaderModuleCreateInfo.
+    SmallVector<StringRef, 8> entryPointNames;
+    for (auto exportOp : variantOp.getOps<IREE::HAL::ExecutableExportOp>()) {
+      entryPointNames.emplace_back(exportOp.getSymName());
+    }
+
+    // Load .spv object file.
+    auto objectAttr = variantOp.getObjects()
+                          ->getValue()
+                          .front()
+                          .cast<IREE::HAL::ExecutableObjectAttr>();
+    std::string spvBinary;
+    if (auto data = objectAttr.loadData()) {
+      spvBinary = data.value();
+    } else {
+      return variantOp.emitOpError()
+             << "object file could not be loaded: " << objectAttr;
+    }
+    if (spvBinary.size() % 4 != 0) {
+      return variantOp.emitOpError()
+             << "object file is not 4-byte aligned as expected for SPIR-V";
+    }
+
+    FlatbufferBuilder builder;
+    iree_SpirVExecutableDef_start_as_root(builder);
+
+    auto spvCodeRef = flatbuffers_uint32_vec_create(
+        builder, reinterpret_cast<const uint32_t *>(spvBinary.data()),
+        spvBinary.size() / sizeof(uint32_t));
+
+    auto entryPointsRef = builder.createStringVec(entryPointNames);
+
+    iree_SpirVExecutableDef_entry_points_add(builder, entryPointsRef);
     iree_SpirVExecutableDef_code_add(builder, spvCodeRef);
     iree_SpirVExecutableDef_end_as_root(builder);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -163,6 +163,7 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     // VkShaderModuleCreateInfo.
     SmallVector<StringRef, 8> entryPointNames;
     SmallVector<uint32_t, 8> subgroupSizes;
+    bool hasAnySubgroupSizes = false;
     spvModuleOp.walk([&](spirv::EntryPointOp exportOp) {
       entryPointNames.push_back(exportOp.getFn());
       auto fn = spvModuleOp.lookupSymbol<spirv::FuncOp>(exportOp.getFn());
@@ -170,15 +171,19 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
           spirv::getEntryPointABIAttrName());
       if (abi && abi.getSubgroupSize()) {
         subgroupSizes.push_back(*abi.getSubgroupSize());
+        hasAnySubgroupSizes = true;
       } else {
         subgroupSizes.push_back(0);
       }
     });
     auto entryPointsRef = builder.createStringVec(entryPointNames);
-    auto subgroupSizesRef = builder.createInt32Vec(subgroupSizes);
+    flatbuffers_int32_vec_ref_t subgroupSizesRef =
+        hasAnySubgroupSizes ? builder.createInt32Vec(subgroupSizes) : 0;
 
     iree_SpirVExecutableDef_entry_points_add(builder, entryPointsRef);
-    iree_SpirVExecutableDef_subgroup_sizes_add(builder, subgroupSizesRef);
+    if (subgroupSizesRef) {
+      iree_SpirVExecutableDef_subgroup_sizes_add(builder, subgroupSizesRef);
+    }
     iree_SpirVExecutableDef_code_add(builder, spvCodeRef);
     iree_SpirVExecutableDef_end_as_root(builder);
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/WebGPU/WebGPUTarget.cpp
@@ -84,7 +84,11 @@ class WebGPUTargetBackend : public TargetBackend {
         context, b.getStringAttr(deviceID()), configAttr);
   }
 
-  void buildTranslationPassPipeline(OpPassManager &passManager) override {
+  void buildTranslationPassPipeline(IREE::HAL::ExecutableVariantOp variantOp,
+                                    OpPassManager &passManager) override {
+    // For now we disable translation if the variant has external object files.
+    if (variantOp.isExternal()) return;
+
     // WebGPU does not support push constants (yet?), so replace loads from
     // push constants with loads from uniform buffers.
     // The corresponding runtime code must perform similar emulation, based

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -34,6 +34,20 @@ namespace HAL {
 namespace {
 
 //===----------------------------------------------------------------------===//
+// Linkage utilities
+//===----------------------------------------------------------------------===//
+
+static void setApplicableObjects(Operation *sourceOp,
+                                 IREE::HAL::ExecutableVariantOp targetOp) {
+  auto objectsAttr = sourceOp->getAttrOfType<IREE::HAL::ExecutableObjectsAttr>(
+      "hal.executable.objects");
+  if (!objectsAttr) return;
+  auto objects = objectsAttr.getApplicableObjects(targetOp.getTarget());
+  if (!objects) return;
+  targetOp.setObjectsAttr(*objects);
+}
+
+//===----------------------------------------------------------------------===//
 // hal.executable.source materialization
 //===----------------------------------------------------------------------===//
 
@@ -50,13 +64,13 @@ static LogicalResult materializeExecutableFromSourceOp(
   // With this hand-authored path all variants have the same layout and entry
   // points and we can just clone them.
   auto sourceEntryPointOps = sourceOp.getOps<IREE::HAL::ExecutableExportOp>();
-  auto sourceModuleOp = sourceOp.getInnerModule();
 
   // Materialize all of the hal.executable.variant ops for all backends we are
   // targeting.
   SymbolTable targetSymbolTable(executableOp);
   OpBuilder targetBuilder(&executableOp.getBlock().back());
   for (auto targetAttr : targetAttrs) {
+    // Create new variant and clone the exports.
     auto targetVariantOp = targetBuilder.create<IREE::HAL::ExecutableVariantOp>(
         sourceOp->getLoc(), targetAttr.getSymbolNameFragment(), targetAttr);
     targetSymbolTable.insert(targetVariantOp);
@@ -64,8 +78,20 @@ static LogicalResult materializeExecutableFromSourceOp(
     for (auto sourceEntryPointOp : sourceEntryPointOps) {
       variantBuilder.clone(*sourceEntryPointOp);
     }
-    variantBuilder.clone(*sourceModuleOp);
+
+    // Clone any target-specific object files specified.
+    if (auto objectsAttr = sourceOp.getObjectsAttr()) {
+      auto objects = objectsAttr.getApplicableObjects(targetAttr);
+      if (objects) targetVariantOp.setObjectsAttr(*objects);
+    }
+
+    // Clone inner module contents.
+    if (!sourceOp.isExternal()) {
+      auto sourceModuleOp = sourceOp.getInnerModule();
+      variantBuilder.clone(*sourceModuleOp);
+    }
   }
+
   // Remove the original.
   sourceOp.erase();
 
@@ -210,9 +236,9 @@ static mlir::func::FuncOp cloneFuncWithInterface(
 // Annotates |dispatchOp| with resource binding to interface binding mappings.
 // TODO(benvanik): have a HAL op with structured information instead.
 static void annotateDispatchSite(IREE::Stream::CmdDispatchOp dispatchOp,
-                                 const PipelineLayout &pipelineLayout) {
+                                 const PipelineResourceMap &resourceMap) {
   SmallVector<Attribute> bindingAttrs;
-  for (auto setBinding : pipelineLayout.resourceMap) {
+  for (auto setBinding : resourceMap) {
     bindingAttrs.push_back(IREE::HAL::InterfaceBindingAttr::get(
         dispatchOp.getContext(), setBinding.first, setBinding.second));
   }
@@ -227,34 +253,39 @@ static LogicalResult declareEntryPointOps(
     IREE::Stream::ExecutableOp sourceExecutableOp,
     IREE::HAL::ExecutableOp targetExecutableOp,
     const BindingLayoutAnalysis &layoutAnalysis) {
+  auto sourceModuleOp = sourceExecutableOp.getInnerModule();
   auto variantOps =
       targetExecutableOp.getBlock().getOps<IREE::HAL::ExecutableVariantOp>();
   OpBuilder executableBuilder(&targetExecutableOp.getBlock().front());
 
-  // For each exported function create a HAL export decl and dispatch thunk.
+  // Build a map of source function definitions to their version with the
+  // updated interface.
+  DenseMap<Operation *, Operation *> targetFuncOps;
   int nextOrdinal = 0;
   for (auto exportOp : sourceExecutableOp.getBody()
                            .getOps<IREE::Stream::ExecutableExportOp>()) {
-    int ordinal = nextOrdinal++;
-    auto sourceFuncOp =
-        sourceExecutableOp.getInnerModule().lookupSymbol<mlir::func::FuncOp>(
-            exportOp.getFunctionRef());
+    auto sourceFuncOp = sourceModuleOp.lookupSymbol<mlir::func::FuncOp>(
+        exportOp.getFunctionRef());
     if (failed(verifyEntryPointTypes(sourceFuncOp))) return failure();
-
-    const auto &pipelineLayout = layoutAnalysis.getPipelineLayout(exportOp);
 
     // Create the interface for this entry point based on the analysis of its
     // usage within the program.
+    const auto &pipelineLayout = layoutAnalysis.getPipelineLayout(exportOp);
     auto layoutAttr = makePipelineLayoutAttr(pipelineLayout, executableBuilder);
 
-    // Clone the source function and update it to use the new interface.
-    auto baseFuncOp =
-        cloneFuncWithInterface(sourceFuncOp, pipelineLayout, layoutAttr);
+    // Update all dispatch sites with the binding information required for
+    // conversion into the HAL dialect. By doing this here we ensure that the
+    // dialect conversion needs only local information on the ops and that it's
+    // not possible for the dispatches and their targets to get out of sync.
+    for (auto dispatchOp : layoutAnalysis.getExportDispatches(exportOp)) {
+      annotateDispatchSite(dispatchOp, pipelineLayout.resourceMap);
+    }
 
-    // Clone the updated function into each variant.
+    // Clone the updated function declaration into each variant.
+    int ordinal = nextOrdinal++;
     for (auto variantOp : variantOps) {
       // Declare the entry point on the target.
-      OpBuilder targetBuilder(&variantOp.getBlock().front());
+      OpBuilder targetBuilder(variantOp.getInnerModule());
       auto newExportOp = targetBuilder.create<IREE::HAL::ExecutableExportOp>(
           exportOp.getLoc(),
           targetBuilder.getStringAttr(exportOp.getFunctionRef()),
@@ -272,19 +303,37 @@ static LogicalResult declareEntryPointOps(
         newExportOp.getWorkgroupCount().insertArgument(0u, deviceType,
                                                        newExportOp.getLoc());
       }
-
-      // Clone the updated interface-based function into the target.
-      auto targetFuncOp = baseFuncOp.clone();
-      variantOp.getInnerModule().push_back(targetFuncOp);
     }
 
-    // Update all dispatch sites with the binding information.
-    for (auto dispatchOp : layoutAnalysis.getExportDispatches(exportOp)) {
-      annotateDispatchSite(dispatchOp, pipelineLayout);
-    }
-
-    baseFuncOp.erase();
+    // Clone the source function and update it to use the new interface.
+    auto targetFuncOp =
+        cloneFuncWithInterface(sourceFuncOp, pipelineLayout, layoutAttr);
+    targetFuncOps[sourceFuncOp] = targetFuncOp;
   }
+
+  // Clone all of the ops in the source module to each variant.
+  // We'll use the exported functions with the updated interfaces in place of
+  // the original versions and copy everything else verbatim.
+  for (auto variantOp : variantOps) {
+    auto targetBuilder = OpBuilder::atBlockBegin(
+        &variantOp.getInnerModule().getBodyRegion().front());
+    for (auto &op : sourceModuleOp.getOps()) {
+      auto targetFuncOp = targetFuncOps.find(&op);
+      if (targetFuncOp != targetFuncOps.end()) {
+        // Clone the updated function instead of the original.
+        targetBuilder.clone(*targetFuncOp->second);
+      } else {
+        // Regular op (globals, external function declarations, etc).
+        targetBuilder.clone(op);
+      }
+    }
+  }
+
+  // Drop the temporary target functions. We could avoid an additional clone if
+  // we only had one variant but this is relatively small in cost (once per
+  // variant).
+  for (auto it : targetFuncOps) it.second->erase();
+  targetFuncOps.clear();
 
   return success();
 }
@@ -425,6 +474,7 @@ class MaterializeInterfacesPass
             targetBuilder.create<IREE::HAL::ExecutableVariantOp>(
                 sourceOp->getLoc(), targetAttr.getSymbolNameFragment(),
                 targetAttr);
+        setApplicableObjects(sourceOp, targetContainerOp);
         targetSymbolTable.insert(targetContainerOp);
         OpBuilder containerBuilder(&targetContainerOp.getBlock().back());
         containerBuilder.create<mlir::ModuleOp>(sourceOp->getLoc());
@@ -443,6 +493,49 @@ class MaterializeInterfacesPass
       }
 
       sourceOp.erase();
+    }
+
+    // Do a cleanup pass for any dispatches that don't yet have interfaces
+    // assigned. If we had dispatches to externally-defined HAL executables we
+    // won't have materialized them from the stream ops above. We do expect to
+    // be able to find the dispatch targets such that we can pull out the
+    // pipeline layout, though, and any that fall through are errors.
+    auto annotateDispatchOp = [&](IREE::Stream::CmdDispatchOp dispatchOp) {
+      if (dispatchOp->hasAttr("hal.interface.bindings")) {
+        // Already have bindings defined.
+        return WalkResult::advance();
+      }
+      PipelineResourceMap resourceMap;
+      auto exportOp =
+          symbolTable.lookupNearestSymbolFrom<IREE::HAL::ExecutableExportOp>(
+              dispatchOp, dispatchOp.getEntryPointAttr());
+      if (exportOp) {
+        // Export found - we can use the pipeline layout defined there to infer
+        // the bindings. This allows for bindings to be sparse or have
+        // additional information declared.
+        for (auto setLayout : exportOp.getLayoutAttr().getSetLayouts()) {
+          for (auto binding : setLayout.getBindings()) {
+            resourceMap.emplace_back(setLayout.getOrdinal(),
+                                     binding.getOrdinal());
+          }
+        }
+      } else {
+        // No export found - this is likely an external executable and we can
+        // infer a dense pipeline layout. This is kind of shady as we may want
+        // to error in these cases where users have something special explicitly
+        // defined but then typo things but the ergonomic improvements in the
+        // normal case are worth that risk.
+        size_t resourceCount = dispatchOp.getResources().size();
+        for (int i = 0; i < resourceCount; ++i) {
+          // set=0, binding=resource ordinal
+          resourceMap.emplace_back(0, i);
+        }
+      }
+      annotateDispatchSite(dispatchOp, resourceMap);
+      return WalkResult::advance();
+    };
+    if (getOperation()->walk(annotateDispatchOp).wasInterrupted()) {
+      return signalPassFailure();
     }
   }
 };

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/TranslateExecutables.cpp
@@ -63,7 +63,7 @@ class TranslateTargetExecutableVariantsPass
     }
 
     OpPassManager passManager(variantOp.getOperationName());
-    targetBackend->buildTranslationPassPipeline(passManager);
+    targetBackend->buildTranslationPassPipeline(variantOp, passManager);
     if (failed(runPipeline(passManager, variantOp))) {
       variantOp.emitError() << "failed to run translation of source "
                                "executable to target executable for backend "

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -26,6 +26,7 @@ module attributes {hal.device.targets = [
   // CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
   // CHECK-NEXT: }
   // CHECK:     builtin.module
+  // CHECK-NEXT:  func.func private @extern_func()
   // CHECK-NEXT:  func.func @entry
   // CHECK:   hal.executable.variant public @embedded_elf_x86_64, target = #executable_target_embedded_elf_x86_64
   // CHECK:     hal.executable.export public @entry ordinal(0) layout(#pipeline_layout) {
@@ -33,6 +34,7 @@ module attributes {hal.device.targets = [
   // CHECK-NEXT:   hal.return %[[ARG0]], %[[ARG1]], %[[ARG0]] : index, index, index
   // CHECK-NEXT: }
   // CHECK:     builtin.module
+  // CHECK-NEXT:  func.func private @extern_func()
   // CHECK-NEXT:  func.func @entry
 
   stream.executable private @ex_workgroups {
@@ -40,6 +42,7 @@ module attributes {hal.device.targets = [
       stream.return %arg0, %arg1, %arg0 : index, index, index
     }
     builtin.module {
+      func.func private @extern_func()
       func.func @entry(%operand: i32, %arg0: !stream.binding {stream.alignment = 64 : index}, %arg1: !stream.binding {stream.alignment = 64 : index}, %arg2: !stream.binding {stream.alignment = 64 : index}) {
         return
       }

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -316,11 +316,12 @@ struct ConvertDispatchOp : public OpConversionPattern<IREE::Flow::DispatchOp> {
       }
     }
 
-    rewriter.replaceOpWithNewOp<IREE::Stream::AsyncDispatchOp>(
+    auto newOp = rewriter.replaceOpWithNewOp<IREE::Stream::AsyncDispatchOp>(
         op, resultTypes, adaptor.getWorkload(), adaptor.getEntryPoint(),
         dispatchOperands, dispatchOperandSizes, dispatchOperandOffsets,
         dispatchOperandEnds, dispatchOperandLengths, resultSizes,
         adaptor.getTiedOperandsAttr(), getAffinityFor(op));
+    newOp->setDialectAttrs(op->getDialectAttrs());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -644,10 +644,11 @@ static LogicalResult applyAsyncDispatchOp(IREE::Stream::AsyncDispatchOp asyncOp,
     newResourceAccesses.push_back(resourceAccess);
   }
 
-  builder.create<IREE::Stream::CmdDispatchOp>(
+  auto newOp = builder.create<IREE::Stream::CmdDispatchOp>(
       asyncOp.getLoc(), asyncOp.getWorkload(), asyncOp.getEntryPoint(),
       newOperands, newResources, newResourceSizes, newResourceOffsets,
       newResourceLengths, builder.getArrayAttr(newResourceAccesses));
+  newOp->setDialectAttrs(asyncOp->getDialectAttrs());
   asyncOp.erase();
   return success();
 }

--- a/experimental/web/testing/build_tests.sh
+++ b/experimental/web/testing/build_tests.sh
@@ -67,6 +67,9 @@ echo "=== Building default targets ==="
 echo "=== Building test deps ==="
 "${CMAKE_BIN?}" --build . --target iree-test-deps -- -k 0
 
+echo "=== Building sample deps ==="
+"${CMAKE_BIN?}" --build . --target iree-sample-deps -- -k 0
+
 echo "=== Generating list of tests ==="
 
 # TODO(scotttodd): Move this parsing and substitution into CMake?

--- a/gpudag.txt
+++ b/gpudag.txt
@@ -1,0 +1,56 @@
+gpu dag
+https://levelup.gitconnected.com/organizing-gpu-work-with-directed-acyclic-graphs-f3fd5f2c2af3
+
+constant-time LFU cache
+https://arpitbhayani.me/blogs/lfu
+
+memory aliasing
+https://levelup.gitconnected.com/gpu-memory-aliasing-45933681a15e
+
+
+debug channel
+https://github.com/Themaister/Granite/blob/master/assets/shaders/inc/debug_channel.h
+https://github.com/Themaister/Granite/blob/master/vulkan/device.cpp#L4789-L4835
+https://github.com/Themaister/Granite/blob/master/vulkan/command_buffer.cpp#L2436-L2479
+
+
+debug regions:
+  https://github.com/Themaister/Granite/blob/master/vulkan/command_buffer.cpp#L2376-L2424
+
+device:
+  timestamps/calibrated timestamps
+  profiling/perf counters
+  staging buffers https://github.com/Themaister/Granite/blob/master/vulkan/device.cpp#L1720-L1761
+    submit: https://github.com/Themaister/Granite/blob/master/vulkan/device.cpp#L1317-L1399
+    cmd buf invalidation: https://github.com/Themaister/Granite/blob/master/vulkan/command_buffer.cpp#L2370-L2371
+
+subgroup specialization
+  https://github.com/Themaister/Granite/blob/master/vulkan/command_buffer.cpp#L707-L736
+
+allocator
+  https://github.com/Themaister/Granite/blob/master/vulkan/memory_allocator.hpp
+  https://github.com/Themaister/Granite/blob/master/vulkan/memory_allocator.cpp
+
+buffer block pool:
+  https://github.com/Themaister/Granite/blob/master/vulkan/buffer_pool.hpp
+  https://github.com/Themaister/Granite/blob/master/vulkan/buffer_pool.cpp
+
+weak map:
+  https://github.com/Themaister/Granite/blob/master/util/generational_handle.hpp
+
+thread groups:
+  https://github.com/Themaister/Granite/blob/master/threading/thread_group.hpp
+  https://github.com/Themaister/Granite/blob/master/threading/thread_group.cpp
+
+pipeline events
+  https://github.com/Themaister/Granite/blob/master/renderer/render_graph.hpp#L843-L855
+
+dependency traversal/merging:
+  https://github.com/Themaister/Granite/blob/master/renderer/render_graph.cpp#L2369-L2466
+
+pass selection (based on deps):
+  https://github.com/Themaister/Granite/blob/master/renderer/render_graph.cpp#L2468-L2573
+  semaphores as way of determining dependencies
+
+barrier insertion:
+  https://github.com/Themaister/Granite/blob/master/renderer/render_graph.cpp#L2941-L3259

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -93,22 +93,28 @@ iree_status_t iree_hal_cuda_native_executable_create(
         "cuModuleLoadDataEx");
   }
 
-  executable->entry_count = entry_count;
-  for (iree_host_size_t i = 0; i < entry_count; i++) {
-    if (iree_status_is_ok(status)) {
+  if (iree_status_is_ok(status)) {
+    executable->entry_count = entry_count;
+    for (iree_host_size_t i = 0; i < entry_count; i++) {
       CUfunction function = NULL;
       const char* entry_name = flatbuffers_string_vec_at(entry_points_vec, i);
       status = CU_RESULT_TO_STATUS(
           context->syms, cuModuleGetFunction(&function, module, entry_name),
           "cuModuleGetFunction");
-      if (iree_status_is_ok(status)) {
-        status = CU_RESULT_TO_STATUS(
-            context->syms,
-            cuFuncSetAttribute(function,
-                               CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-                               shared_memory_sizes[i]),
-            "cuFuncSetAttribute");
+      if (!iree_status_is_ok(status)) break;
+      if (!function) {
+        status = iree_make_status(IREE_STATUS_NOT_FOUND,
+                                  "exported module function %s not found",
+                                  entry_name);
+        break;
       }
+      status = CU_RESULT_TO_STATUS(
+          context->syms,
+          cuFuncSetAttribute(function,
+                             CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+                             shared_memory_sizes[i]),
+          "cuFuncSetAttribute");
+      if (!iree_status_is_ok(status)) break;
       executable->entry_functions[i].cu_function = function;
       executable->entry_functions[i].block_size_x = block_sizes_vec[i].x;
       executable->entry_functions[i].block_size_y = block_sizes_vec[i].y;

--- a/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/stream_command_buffer.c
@@ -353,6 +353,7 @@ static iree_status_t iree_hal_cuda_stream_command_buffer_dispatch(
       iree_hal_cuda_pipeline_layout_num_constants(layout);
   iree_host_size_t constant_base_index =
       iree_hal_cuda_push_constant_index(layout);
+
   // Patch the push constants in the kernel arguments.
   for (iree_host_size_t i = 0; i < num_constants; i++) {
     *((uint32_t*)command_buffer->current_descriptor[i + constant_base_index]) =

--- a/samples/custom_dispatch/CMakeLists.txt
+++ b/samples/custom_dispatch/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_add_all_subdirs()

--- a/samples/custom_dispatch/README.md
+++ b/samples/custom_dispatch/README.md
@@ -1,0 +1,214 @@
+# Custom Dispatches
+
+"Dispatches" in IREE are parallelized device function calls where "device" may
+be a CPU task system, a GPU, or a dedicated accelerator. Parallelism is a
+first-class concept in this model and plugging custom dispatches into IREE
+requires reasoning about these function calls as if they were parallelized and
+dispatched across a 3D grid (as on GPUs or CPU task systems). Note that a
+degenerate case of grid dispatch is a grid size of 1x1x1 which turns the
+dispatches into simple (if inefficient) device-side function calls.
+
+In normal workflows the IREE compiler forms the dispatch functions by way of
+fusion and then uses code generation ("codegen") to translate the dispatch
+functions into backend-specific forms like PTX, SPIR-V, or LLVM IR. It's
+possible to augment this translation by either bypassing these steps entirely
+and providing the already translated representation of the dispatch function or
+extending the code generation portion by calling out to external functions from
+within the generated dispatch ("microkernels").
+
+There's ongoing work across the core IREE compiler and specific backends to
+enable more extension points and ways to connect to them from frontends or
+compiler transforms. This current set of samples demonstrates a very early
+version of this extensibility that can be used to tunnel through dispatch
+workloads by bypassing code generation. In its current form it is intended for
+things that would traditionally be custom ops in ML frameworks and produces much
+smaller, hermetic, retargetable, and optimizable programs than custom ops can.
+
+## Approaches
+
+In the fullness of time all backends will support all approaches but currently
+there are limitations:
+
+|                    | CPU                | CUDA               | Metal | SPIR-V             | WGSL            |
+|--------------------|:------------------:|:------------------:|:-----:|:------------------:|:---------------:|
+| Static Functions   | :white_check_mark: | TBD                | TBD   | TBD                | TBD             |
+| Dynamic Functions  | :white_check_mark: | TBD                | TBD   | :grey_question:    | :grey_question: |
+| Static Dispatches  | TBD                | :white_check_mark: | TBD   | :white_check_mark: | TBD             |
+| Dynamic Dispatches | TBD                | TBD                | TBD   | TBD                | TBD             |
+| Commands           | TBD                | TBD                | TBD   | TBD                | TBD             |
+
+### Statically-linked Function Calls
+
+**Overview**: user defines functions in .c files, compiles them with specific
+settings to .o files, emits calls to the functions in IR interleaved with other
+IR, and lets the IREE compiler link the objects into the final binary.
+
+**Workflow**:
+
+```
++-------------+               +---------------------+       +--------------+
+| functions.c | -> clang -+-> | functions_aarch64.o | -+    | example.mlir |
++-------------+           |   +---------------------+  |    +--------------+
+                          |   +---------------------+  |           v
+                          +-> | functions_x86_64.o  | -+----> iree-compile
+                              +---------------------+              v
+                                                            +--------------+
+                                                   hermetic | example.vmfb |
+                                                            +--------------+
+```
+
+**Samples**:
+
+* CPU: [custom_dispatch/cpu/embedded/](./cpu/embedded/) (.c -> .o)
+
+This approach is usable both from frontends as well as something that can be
+synthesized by compiler transforms ("replace op X with call to extern fX and
+link in object f.o") and the object files referenced can be generated on the
+fly and embedded into the IR to allow for compile-time specialization.
+
+This is the preferred method of extension as it preserves IREE's ability to
+specialize executables, optimize aggressively across call boundaries,
+hermetically deploy the custom code without runtime changes, and portably target
+multiple platforms and architectures.
+
+### Dynamically-linked Function Calls
+
+**Overview**: user defines functions in any source language with a compatible C
+ABI, wires them up and links them in their runtime binary, declares the
+externally available functions in IR, and emits calls to the functions in IR
+interleaved with other IR.
+
+**Workflow**:
+
+```
+                     +--------------+   +--------------+
+                     | example.mlir |   | runtime srcs | -+
+                     +--------------+   +--------------+  |
++--------------+            v           +--------------+  |
+| declarations | ----> iree-compile     | imports.c    | -+-> custom runtime
++--------------+            v           +--------------+
+                     +--------------+
+                     | example.vmfb |
+                     +--------------+
+```
+
+**Samples**:
+
+* TBD CPU dynamic imports
+
+Unlike the other approaches this requires runtime device support for dynamic
+linking and introduces complexity to the user as they must be careful to version
+their input programs and their runtime libraries themselves. IREE does provide
+basic support for optional imports such that users can emit their calls and add
+fallbacks but otherwise such behavior falls on the user to implement.
+
+### Statically-linked Dispatch Functions
+
+**Overview**: user produces the final dispatch executable binary themselves,
+declares it in IR, and dispatches it.
+
+**Workflow**:
+
+```
++------------+              +-------------------+       +--------------+
+| kernels.cu | -> nvcc -+-> | kernels_sm_52.ptx | -+    | example.mlir |
++------------+          |   +-------------------+  |    +--------------+
+                        |   +-------------------+  |           v
+                        +-> | kernels_sm_80.ptx | -+----> iree-compile
+                            +-------------------+              v
+                                                        +--------------+
+                                               hermetic | example.vmfb |
+                                                        +--------------+
+```
+
+**Samples**:
+
+* CUDA/PTX: [custom_dispatch/cuda/kernels/](./cuda/kernels/) (.cu -> .ptx)
+* Vulkan/SPIR-V: [custom_dispatch/vulkan/shaders/](./vulkan/shaders/) (.glsl -> .spv)
+
+Here IREE is used for scheduling the work and ensuring that buffers and
+parameters are passed to the dispatch function but otherwise treats them as
+opaque. This disables some IREE optimizations but the functions are still able
+to be scheduled concurrently and with parallelization. Many custom kernels can
+often be implemented like this instead of needing much heavier-weight runtime
+custom calls that prevent the asynchronous scheduling that IREE uses.
+
+The dispatch functions are embedded into the IREE compiler outputs such that no
+runtime changes are required and compiled programs are hermetic. Multi-targeting
+is enabled by allowing the user to provide binaries for the target devices and
+architectures they are compiling for.
+
+### Dynamically-linked Dispatch Functions
+
+**Overview**: user defines functions in a target-specific source language,
+compiles them into target-specific libraries, wires them up and links them in
+their runtime binary, declares the externally available dispatch executable in
+IR, and emits calls to the functions in IR interleaved with other IR.
+
+**Workflow**:
+
+```
+                     +--------------+   +--------------+
+                     | example.mlir |   | runtime srcs | -+
+                     +--------------+   +--------------+  |
++--------------+            v           +--------------+  |
+| declarations | ----> iree-compile     | dispatches.c | -+-> custom runtime
++--------------+            v           +--------------+
+                     +--------------+
+                     | example.vmfb |
+                     +--------------+
+```
+
+**Samples**: plumbing required.
+
+Similar to statically-linked dispatch functions IREE is doing the scheduling and
+managing resources but deferring the entire dispatch logic to externally-sourced
+executables. In contrast to the static linking approach this has the compiler
+emit references to runtime-provided target-specific executables that must be
+built into the runtime. This means that deployment gets more complicated as
+compiler-produced outputs are no longer hermetic and users must handle
+versioning and platform constraints themselves.
+
+### Custom Commands
+
+**Overview**: user writes custom command buffer operations in VM modules,
+declares them in IR, dispatches them, and then links their custom modules into
+the runtime.
+
+**Workflow**:
+
+```
+                     +--------------+   +--------------+
+                     | example.mlir |   | runtime srcs | -+
+                     +--------------+   +--------------+  |
++--------------+            v           +--------------+  |
+| declarations | ----> iree-compile     | module.c     | -+-> custom runtime
++--------------+            v           +--------------+
+                     +--------------+
+                     | example.vmfb |
+                     +--------------+
+```
+
+**Samples**: plumbing required.
+
+Though more work than the other approaches this allows for a host-side call that
+can produce new transfer or execution commands. The compiler effectively treats
+these calls as if they were custom versions of `hal.command_buffer.dispatch`/
+`iree_hal_command_buffer_dispatch` and the runtime custom module receives the
+device, command buffer, and push constants/bindings. Portable modules can
+use the HAL APIs to schedule more commands (multiple dispatches, transfers,
+collectives, etc) while backend-specific ones can crack open the HAL objects and
+get the internals with all the normal API stability caveats.
+
+An example use case would be calling a CUDA library that takes a `CUstream` as
+an argument. The user would define their custom module with a call that uses the
+`iree/hal/drivers/cuda/api.h` to cast the command buffer to a stream (using
+graph capture when the command buffer is constructing a graph), make the call,
+and then return. This only works if the library is designed for asynchronous and
+deferred execution - if the library makes large allocations, schedules blocking
+operations, or has side-effecting behavior then full custom modules must be
+used (see the [custom_module/async/](/samples/custom_module/async/) sample).
+
+When at all possible the dispatch function call or dispatch function
+substitution approaches should be used instead and in many cases that is
+sufficient for most workloads not involving other libraries.

--- a/samples/custom_dispatch/cpu/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_add_all_subdirs()

--- a/samples/custom_dispatch/cpu/embedded/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/embedded/CMakeLists.txt
@@ -1,0 +1,81 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if(NOT IREE_TARGET_BACKEND_LLVM_CPU OR
+   NOT IREE_HAL_DRIVER_LOCAL_SYNC OR
+   NOT IREE_HAL_EXECUTABLE_LOADER_EMBEDDED_ELF)
+  return()
+endif()
+
+# NOTE: this example uses clang to target only aarch64 and x86_64 as that's what
+# the example.mlir file is hardcoded to accept. It's possible to use arbitrary
+# compilers when using either the system linker or static library output options
+# of the CPU backend but embedded dynamic libraries have strict requirements and
+# it's easiest to always use clang (plus it is good at cross-compiling) and the
+# settings below.
+#
+# This example just shows how users can link in custom objects and is not
+# intended to demonstrate the infrastructure to produce the object files: when
+# using this custom kernel approach it is up to the user to handle that work.
+find_program(CLANG clang)
+if(NOT CLANG)
+  message(STATUS "IREE custom_dispatch/cpu/embedded ignored -- clang not found")
+  return()
+endif()
+
+# This only builds for x86-64 because this is just a sample and we don't feature
+# detect what backends are compiled into clang. We could extend this to build
+# for the current cmake target architecture but would also need to modify the
+# MLIR file to have the new target configuration.
+if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "(x86_64)|(AMD64|amd64)")
+  message(STATUS "IREE custom_dispatch/cpu/embedded ignored -- only builds for x86_64 (today)")
+  return()
+endif()
+
+function(embedded_function_object _ARCH)
+  set(_NAME iree_samples_custom_dispatch_cpu_embedded_object_${_ARCH})
+  add_custom_command(
+    OUTPUT functions_${_ARCH}.o
+    DEPENDS functions.c
+    COMMAND ${CLANG}
+        -target ${_ARCH}-unknown-unknown-eabi-elf
+        -std=c17
+        -fvisibility=hidden
+        -fno-plt
+        -fno-rtti
+        -fno-exceptions
+        -fdata-sections
+        -ffunction-sections
+        -funique-section-names
+        -c ${CMAKE_CURRENT_SOURCE_DIR}/functions.c
+        -o ${CMAKE_CURRENT_BINARY_DIR}/functions_${_ARCH}.o
+    VERBATIM
+  )
+  add_custom_target(${_NAME} DEPENDS
+    ${CMAKE_CURRENT_BINARY_DIR}/functions_${_ARCH}.o
+  )
+  add_dependencies(iree-test-deps "${_NAME}")
+  add_dependencies(iree-sample-deps "${_NAME}")
+endfunction()
+
+# Build the functions_*.o files for each architecture we target.
+embedded_function_object(aarch64)
+embedded_function_object(x86_64)
+
+iree_lit_test_suite(
+  NAME
+    examples
+  SRCS
+    "example_hal.mlir"
+    "example_stream.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+    iree-run-module
+  LABELS
+    "driver=local-sync"
+    "hostonly"
+)

--- a/samples/custom_dispatch/cpu/embedded/CMakeLists.txt
+++ b/samples/custom_dispatch/cpu/embedded/CMakeLists.txt
@@ -57,7 +57,6 @@ function(embedded_function_object _ARCH)
   add_custom_target(${_NAME} DEPENDS
     ${CMAKE_CURRENT_BINARY_DIR}/functions_${_ARCH}.o
   )
-  add_dependencies(iree-test-deps "${_NAME}")
   add_dependencies(iree-sample-deps "${_NAME}")
 endfunction()
 

--- a/samples/custom_dispatch/cpu/embedded/README.md
+++ b/samples/custom_dispatch/cpu/embedded/README.md
@@ -1,0 +1,145 @@
+# Custom CPU Dispatch Functions for Statically-linked Embedded ELFs
+
+See the [custom_dispatch README](/samples/custom_dispatch/README.md) for an
+overview of this approach.
+
+This sample demonstrates how to define external device functions that can be
+dispatched from within IREE programs via simple function calls. Here the
+functions are declared in the MLIR executables, called as normal calls, and
+then defined in a .c file that is cross-compiled for various architectures.
+The compiler uses the attribute specifying which object files to link against
+when performing its final linking and runs LTO to optimize across both the
+generated portions and hand-authored portions.
+
+### Work in Progress
+
+The calling convention used for passing pointers is currently a mess as the MLIR
+`memref` type is used to model buffer references and that expands to many
+arguments. Future revisions will just pass the pointers instead.
+
+Currently weak linkage is not available and external functions must always be
+provided when referenced. In future versions fallback IR will allow for object
+files to be specified only for certain platforms while allowing others to be
+generated via normal codegen paths.
+
+## Workflow
+
+```
++-------------+               +---------------------+       +--------------+
+| functions.c | -> clang -+-> | functions_aarch64.o | -+    | example.mlir |
++-------------+           |   +---------------------+  |    +--------------+
+                          |   +---------------------+  |           v
+                          +-> | functions_x86_64.o  | -+----> iree-compile
+                              +---------------------+              v
+                                                            +--------------+
+                                                            | example.vmfb |
+                                                            +--------------+
+```
+
+1. The user authors their functions in bare-metal C (no TLS, no threads, no
+   malloc, etc). These functions can cover entire workgroups (and a dispatch can
+   be a single workgroup so effectively just function calls) or be utilities
+   used by the function for localized work (microkernels, data type conversion,
+   etc). It's important to remember that parallelism scheduling is done
+   _outside_ of the function via the workgroup count and multiple threads may be
+   executing the function at any time.
+
+```c
+// NOTE: this will be simplified in the future:
+//  void simple_mul_workgroup(
+//    const float* restrict binding0, const float* restrict binding1,
+//    float* restrict binding2, size_t dim, size_t tid);
+void simple_mul_workgroup(
+    const float* restrict binding0, const float* restrict binding0_aligned,
+    size_t binding0_offset, size_t binding0_size, size_t binding0_stride,
+    const float* restrict binding1, const float* restrict binding1_aligned,
+    size_t binding1_offset, size_t binding1_size, size_t binding1_stride,
+    float* restrict binding2, float* restrict binding2_aligned,
+    size_t binding2_offset, size_t binding2_size, size_t binding2_stride,
+    size_t dim, size_t tid) {
+  size_t end = tid + 64;
+  if (end > dim) end = dim;
+  for (size_t i = tid; i < end; ++i) {
+    binding2[i] = binding0[i] * binding1[i];
+  }
+}
+```
+
+2. Source files are compiled to object files with bare-metal settings. Each
+   architecture the user is targeting will need its own object file(s).
+
+```cmake
+clang -target aarch64 ...[see CMakeLists.txt]... functions.c -o functions_aarch64.o
+```
+
+3. The user (or compiler transforms) adds calls to their functions by declaring
+   them and marking them as statically-linked.
+
+```mlir
+func.func private @simple_mul_workgroup(
+    %binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>,
+    %dim: index, %tid: index) attributes {hal.import.static}
+...
+func.call @simple_mul_workgroup(%memref0, %memref1, %memref2, %dim, %tid) : (memref<?xf32>, memref<?xf32>, memref<?xf32>, index, index) -> ()
+```
+
+4. The user (or compiler transforms) annotates the executables with the objects
+   to link against providing the function definitions.
+
+```mlir
+  stream.executable private @executable attributes {
+    hal.executable.objects = #hal.executable.objects<{
+      #aarch64_target = [
+        #hal.executable.object<{path = "functions_aarch64.o"}>
+      ]
+    }>
+```
+
+5. The IREE compiler selects the appropriate object files for the target
+   configuration and links them into the binaries it produces.
+
+## Instructions
+
+This presumes that `iree-compile` and `iree-run-module` have been installed or
+built. [See here](https://iree-org.github.io/iree/building-from-source/getting-started/)
+for instructions for CMake setup and building from source.
+
+0. Ensure that `clang` is on your PATH:
+
+    ```
+    clang --version
+    ```
+
+1. Build the `iree-sample-deps` CMake target to compile
+   [functions.c](./functions.c) to object files for aarch64 and x86_64:
+
+    ```
+    cmake --build ../iree-build/ --target iree-sample-deps
+    ```
+
+    In a user application this would be replaced with whatever build
+    infrastructure the user has for compiling code to object files. No IREE
+    compiler or runtime changes are required and the normal compiler install can
+    be used. Note that specific flags are required when producing the object
+    files.
+
+2. Compile the [example module](./example.mlir) to a .vmfb file and pass the
+   path to the build directory so the .spv files can be found:
+
+    ```
+    iree-compile \
+        --iree-hal-executable-object-search-path=../iree-build/ \
+        samples/custom_dispatch/cpu/embedded/example.mlir \
+        -o=/tmp/example.vmfb
+    ```
+
+3. Run the example program using the custom functions:
+
+    ```
+    iree-run-module \
+        --device=llvm-sync \
+        --entry_function=mixed_invocation \
+        --function_input=8xf32=2 \
+        --function_input=8xf32=4 \
+        /tmp/example.vmfb
+    ```

--- a/samples/custom_dispatch/cpu/embedded/example_hal.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_hal.mlir
@@ -1,0 +1,286 @@
+// RUN: iree-compile %s \
+// RUN:     --iree-hal-executable-object-search-path=$IREE_BINARY_DIR | \
+// RUN: iree-run-module \
+// RUN:     --device=local-sync \
+// RUN:     --entry_function=mixed_invocation \
+// RUN:     --function_input=8xf32=2 \
+// RUN:     --function_input=8xf32=4 | \
+// RUN: FileCheck %s
+
+// This example demonstrates authoring and dispatching retargetable executables
+// from the IREE `hal` dialect layer. This allows for target-specific code to
+// be written - including unique calls for each target - as the executable
+// variants are manually specified. The example_stream.mlir example shows how
+// where possible the executable variant generation can be left to the compiler.
+//
+// Enabling this at the HAL layer allows for codegen backends translating
+// executable variants to make local decisions about which external calls to
+// make and where the objects come from to provide those functions. Since
+// objects can be embedded in the IR it's possible for the backends to even
+// generate them on-demand for embedding (such as precompiling/JITing).
+
+// The configuration used for executable compilation.
+// This lets the compiler and runtime know the format and requirements of the
+// executable binaries produced and multiple variants with differing formats
+// and compilation options (architectures, etc) can be embedded for runtime
+// selection. By fully specifying the targets here we can target multiple
+// architectures and it's always possible to embed these instead of using the
+// coarse command line compiler flags that only set single targets.
+//
+// To avoid too much boilerplate this example only shows a single target. See
+// example_stream.mlir for an example with multi-targeting as there's less
+// boilerplate required at that level.
+#x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 32 : index,
+  target_triple = "x86_64-unknown-unknown-eabi-elf"
+}>
+
+// The target devices that the program will run on.
+// These can come from compiler flags and multiple targets can be supported
+// It's possible, for example, to support targeting multiple devices in the same
+// compiled binary (CPU + Vulkan, etc).
+#cpu_target = #hal.device.target<"llvm-cpu", {
+  executable_targets = [
+    #x86_64_target
+  ]
+}>
+
+module @example attributes {hal.device.targets = [#cpu_target]} {
+
+  // Executable containing exported shims and calls to external functions.
+  // Each executable can contain multiple exported functions and variants for
+  // different architectures or even devices. It's also possible to mix hand-
+  // authored functions with code generated ones even for the same functions
+  // such that code generation is used as a fallback when the hand-authored
+  // kernels aren't supported at runtime.
+  hal.executable private @executable {
+
+    // Variant linking in an x86-64 object file containing external functions.
+    hal.executable.variant public @x86_64, target = #x86_64_target, objects = [
+      // Object files linked into the executable.
+      // These object files are linked into the dynamic library and must meet
+      // the requirements for embedded ELF linkage (no TLS, no globals, no
+      // syscalls, no libc, etc).
+      #hal.executable.object<{
+        // Referencing a file path on disk but could also have the data
+        // embedded in order to make the MLIR file hermetic/portable across
+        // compilation pipelines. In the future we'll likely use MLIR's
+        // external resource functionality for this. By allowing for the
+        // objects to be embedded we can support JIT scenarios where some
+        // layer higher or lower may be emitting the objects to link in as
+        // part of the overall compilation.
+        path = "samples/custom_dispatch/cpu/embedded/functions_x86_64.o"
+      }>
+    ] {
+
+      // TODO(benvanik): demonstrate hal.executable.constant.block for
+      // specialization via host logic and hal.executable.constant.load for
+      // referencing them in the shims.
+
+      // Exported shim function calling the C `simple_mul_workgroup` function.
+      // The ordinal must be assigned by the user and unique for the executable.
+      // The layout defines the required bindings and push constants and can be
+      // thought of as the function signature.
+      hal.executable.export public @simple_mul ordinal(0)
+          layout(#hal.pipeline.layout<push_constants = 1, sets = [
+            <0, bindings = [
+                <0, storage_buffer, ReadOnly>,
+                <1, storage_buffer, ReadOnly>,
+                <2, storage_buffer>
+            ]>
+          ]>) {
+      ^bb0(%device: !hal.device, %workload: index):
+        // This host function is used to compute the XYZ workgroup count
+        // dispatched at runtime. It can query the %device for capabilities
+        // and limits (last-level cache sizes, etc). The other arguments are the
+        // values passed in the dispatch operation (usually things like root
+        // output op tensor dimensions and other abstract values).
+        %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+        %c1 = arith.constant 1 : index
+        hal.return %x, %c1, %c1 : index, index, index
+      }
+
+      // Similar to the above but in-place by using a read/write binding.
+      hal.executable.export public @simple_mul_inplace ordinal(1)
+          layout(#hal.pipeline.layout<push_constants = 1, sets = [
+            <0, bindings = [
+                <0, storage_buffer, ReadOnly>,
+                <1, storage_buffer>
+            ]>
+          ]>) {
+      ^bb0(%device: !hal.device, %workload: index):
+        %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+        %c1 = arith.constant 1 : index
+        hal.return %x, %c1, %c1 : index, index, index
+      }
+
+      // On the CPU side we use shims here to marshal across the ABI. This
+      // allows us to hide the implementation details of how the runtime calls
+      // into functions and call out to C functions that don't need to link
+      // against the runtime. We could probably come up with ways of automating
+      // this but that's mostly left as an exercise to the frontends that may be
+      // producing this IR for input to the IREE compiler as each may have its
+      // own quirks.
+      builtin.module {
+        // External function declaration using a user-chosen calling convention.
+        // NOTE: MLIR->LLVM conversion expands each memref to a tuple and
+        // there's currently no way to change that behavior.
+        // Each memref becomes:
+        // (%base_ptr: !llvm.ptr<f32>, %aligned_ptr: !llvm.ptr<f32>,
+        //  %offset: i64, %size: i64, %stride: i64)
+        // That results in the following llvm.func:
+        // (!llvm.ptr<f32>, !llvm.ptr<f32>, i64, i64, i64,  // binding0
+        //  !llvm.ptr<f32>, !llvm.ptr<f32>, i64, i64, i64,  // binding1
+        //  !llvm.ptr<f32>, !llvm.ptr<f32>, i64, i64, i64,  // binding2
+        //  i64,                                            // dim
+        //  i64)                                            // tid
+        // And required external C function:
+        // (float*, float*, size_t, size_t, size_t,
+        //  float*, float*, size_t, size_t, size_t,
+        //  float*, float*, size_t, size_t, size_t,
+        //  size_t,
+        //  size_t)
+        // This is not a good state to be in as we can't then map to external
+        // functions that have signatures we don't want to change. Please file
+        // upstream MLIR bugs about this behavior and the ability to just pass
+        // bare pointers if you care!
+        //
+        // NOTE: index will convert to i32 when targeting an ABI with 32-bit
+        // pointers and i64 otherwise. Use size_t on the C side to allow the
+        // same source code to work when compiled in either mode.
+        func.func private @simple_mul_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>, %dim: index, %tid: index) attributes {
+          // Ensures that we try to statically link this external function and
+          // pull it in from the object file.
+          hal.import.static
+        }
+
+        // IREE exported function using a HAL interface.
+        // At this layer of the stack all operands have been converted into
+        // constants and bindings have been specified.
+        func.func @simple_mul() {
+          %c0 = arith.constant 0 : index
+
+          // Push constants representing primitive operands can be loaded here.
+          %dim_i32 = hal.interface.constant.load[0] : i32
+          %dim = arith.index_castui %dim_i32 : i32 to index
+
+          // This function is invoked once per workgroup so determine where this
+          // particular workgroup is in the grid. In this example we use a
+          // workgroup size of 64x1x1 (which is exceedingly small for CPUs but
+          // useful for demonstration).
+          %workgroup_id_x = hal.interface.workgroup.id[0] : index
+          %tid = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+
+          // Bindings are accessed by reference.
+          %binding0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : memref<?xf32>{%dim}
+          %binding1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<?xf32>{%dim}
+          %binding2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : memref<?xf32>{%dim}
+
+          // Call the externally defined C function with an (almost) plain C
+          // calling convention (see above for details about the mess memrefs
+          // turn into).
+          //
+          // TODO: there are ways of accessing CPU information here such as
+          // active architecture and feature bits but it is not yet exposed to
+          // the HAL level.
+          func.call @simple_mul_workgroup(%binding0, %binding1, %binding2, %dim, %tid) : (memref<?xf32>, memref<?xf32>, memref<?xf32>, index, index) -> ()
+
+          // NOTE: this is code generated as normal - other MLIR ops can be used
+          // here for looping/control flow, vector operations, linalg, etc.
+          // This simple sample is just calling out to the external function but
+          // microkernels fused with other code are possible.
+
+          return
+        }
+
+        func.func private @simple_mul_inplace_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %dim: index, %tid: index) attributes {
+          hal.import.static
+        }
+        func.func @simple_mul_inplace() {
+          %c0 = arith.constant 0 : index
+
+          %dim_i32 = hal.interface.constant.load[0] : i32
+          %dim = arith.index_castui %dim_i32 : i32 to index
+
+          %workgroup_id_x = hal.interface.workgroup.id[0] : index
+          %tid = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+
+          // Same as above but note that we're treating %binding1 as read/write.
+          %binding0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : memref<?xf32>{%dim}
+          %binding1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<?xf32>{%dim}
+
+          func.call @simple_mul_inplace_workgroup(%binding0, %binding1, %dim, %tid) : (memref<?xf32>, memref<?xf32>, index, index) -> ()
+
+          return
+        }
+      }
+
+    }  // hal.executable.variant
+
+  }  // hal.executable
+
+  // Function demonstrating a few hand-authored dispatches mixed with codegen.
+  // Invoke with:
+  //  --device=local-sync
+  //  --entry_function=mixed_invocation
+  //  --function_input=8xf32=2
+  //  --function_input=8xf32=4
+  // CHECK-LABEL: EXEC @mixed_invocation
+  func.func @mixed_invocation(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+    // The only externally available metadata in the dispatch are the values
+    // passed in as operands. Here we pass in the dynamic dimension.
+    //
+    // HACK: for hand-authored kernels all primitive values passed in need to
+    // be i32 or a bit-castable type. This is because ABI packing of other types
+    // happens inside of the PackDispatchOperandsPass that is currently not
+    // usable with external functions as it changes the ABI. In the future we
+    // can better define the ABI such that it's possible to match the compiler
+    // expectations around padding/alignment. For now users must do the packing
+    // themselves (splitting i64 into i32+i32, etc).
+    %c0 = arith.constant 0 : index
+    %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+    %dim_i32 = arith.index_cast %dim : index to i32
+
+    // Dispatch a basic `ret = lhs * rhs` using an external function.
+    // This form (@executable::@export) allows for automatic variant selection
+    // when multi-targeting (@x86_64 will be chosen if available).
+    %0 = flow.dispatch @executable::@simple_mul[%dim](%dim_i32, %arg0, %arg1) {
+      // Bindings are automatically inferred when possible as part of the ABI
+      // but can be overridden if the user wants to use features such as sparse
+      // bindings or multiple descriptor sets. To do so the
+      // `hal.interface.bindings` attribute can be added to a dispatch op as
+      // follows mapping tensor operands/results to the pipeline layout
+      // sets/bindings:
+      hal.interface.bindings = [
+        #hal.interface.binding<0, 0>,
+        #hal.interface.binding<0, 1>,
+        #hal.interface.binding<0, 2>
+      ],
+      // HACK: keep the executable live through DCE. Only required when
+      // using the automatic variant selection.
+      // TODO(benvanik): automatically add this when required.
+      hal.executable.ref = [@executable]
+    } : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+
+    // Code gen some other ops - these will interleave with the hand-authored
+    // ones but naturally won't be able to fuse with them.
+    %1 = arith.addf %0, %arg1 : tensor<?xf32>
+
+    // Dispatch an in-place `rhs *= lhs` using an external function.
+    // This form (@executable::@variant::@export) specifically chooses a variant
+    // instead of relying on automatic selection. This can be used by frontends
+    // to allow user-controlled overrides of the dispatches, custom selection
+    // logic based on runtime parameters, etc. In general, though, the above
+    // automatic selection should be used.
+    //
+    // Note that we don't declare the hal.interface.bindings and let them be
+    // inferred - this only works when either specifying the variant that has
+    // a pipeline layout defined or all variants have the same pipeline layouts.
+    %2 = flow.dispatch @executable::@x86_64::@simple_mul_inplace[%dim](%dim_i32, %0, %1) : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> %1{%dim}
+
+    // CHECK: 8xf32=96 96 96 96 96 96 96 96
+    return %2 : tensor<?xf32>
+  }
+
+}  // module

--- a/samples/custom_dispatch/cpu/embedded/example_stream.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_stream.mlir
@@ -1,0 +1,210 @@
+// RUN: iree-compile %s \
+// RUN:     --iree-hal-executable-object-search-path=$IREE_BINARY_DIR | \
+// RUN: iree-run-module \
+// RUN:     --device=local-sync \
+// RUN:     --entry_function=mixed_invocation \
+// RUN:     --function_input=8xf32=2 \
+// RUN:     --function_input=8xf32=4 | \
+// RUN: FileCheck %s
+
+// This example demonstrates authoring and dispatching retargetable executables
+// from the IREE `stream` dialect layer. This allows for much more optimization
+// opportunity as bindings and operands can be mutated by the compiler unlike
+// approaches targeting the `hal` layer.
+//
+// In the future with improvements to lowerings into LLVM we should be able to
+// do this from the `flow` layer as well and thus connect all the way to
+// frontends. Currently memrefs are blocking the ability to define useful
+// external functions at the higher layers.
+//
+// By enabling this from higher levels of the stack it's possible for users to
+// hand-author what they need and have that get whole-program optimized,
+// multi-device scheduled, and portably deployed with (nearly) all the features
+// of IREE-generated workloads.
+
+// The configurations used for executable compilation.
+// This lets the compiler and runtime know the format and requirements of the
+// executable binaries produced and multiple variants with differing formats
+// and compilation options (architectures, etc) can be embedded for runtime
+// selection. By fully specifying the targets here we can target multiple
+// architectures and it's always possible to embed these instead of using the
+// coarse command line compiler flags that only set single targets.
+#aarch64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-arm_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 16 : index,
+  target_triple = "aarch64-unknown-unknown-eabi-elf"
+}>
+#x86_64_target = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 32 : index,
+  target_triple = "x86_64-unknown-unknown-eabi-elf"
+}>
+
+// The target devices that the program will run on.
+// These can come from compiler flags and multiple targets can be supported
+// It's possible, for example, to support targeting multiple devices in the same
+// compiled binary (CPU + Vulkan, etc).
+#cpu_target = #hal.device.target<"llvm-cpu", {
+  executable_targets = [
+    #aarch64_target,
+    #x86_64_target
+  ]
+}>
+
+module @example attributes {hal.device.targets = [#cpu_target]} {
+
+  // Executable containing exported shims and calls to external functions.
+  // Each executable can contain multiple exported functions and variants for
+  // different architectures or even devices. It's also possible to mix hand-
+  // authored functions with code generated ones even for the same functions
+  // such that code generation is used as a fallback when the hand-authored
+  // kernels aren't supported at runtime.
+  stream.executable private @executable attributes {
+    // Object files linked into the executable.
+    // These object files are linked into the dynamic library and must meet
+    // the requirements for embedded ELF linkage (no TLS, no globals, no
+    // syscalls, no libc, etc). Each compilation target can have its own unique
+    // set of objects to link in and the target keys can be generic. This allows
+    // for an object file to be linked in based only on the target triple while
+    // allowing for more specialized ones requiring certain CPU features to be
+    // only included when building those. For this example we just use the
+    // fully-specified targets.
+    hal.executable.objects = #hal.executable.objects<{
+      #aarch64_target = [
+        #hal.executable.object<{
+          // Referencing a file path on disk but could also have the data
+          // embedded in order to make the MLIR file hermetic/portable across
+          // compilation pipelines. In the future we'll likely use MLIR's
+          // external resource functionality for this. By allowing for the
+          // objects to be embedded we can support JIT scenarios where some
+          // layer higher or lower may be emitting the objects to link in as
+          // part of the overall compilation.
+          path = "samples/custom_dispatch/cpu/embedded/functions_aarch64.o"
+        }>
+      ],
+      #x86_64_target = [
+        #hal.executable.object<{
+          path = "samples/custom_dispatch/cpu/embedded/functions_x86_64.o"
+        }>
+      ]
+    }>
+  } {
+    stream.executable.export public @simple_mul workgroups(%workload: index) -> (index, index, index) {
+      // This host function is used to compute the XYZ workgroup count
+      // dispatched at runtime. It can query the %device for capabilities
+      // and limits (last-level cache sizes, etc). The other arguments are the
+      // values passed in the dispatch operation (usually things like root
+      // output op tensor dimensions and other abstract values).
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      stream.return %x, %c1, %c1 : index, index, index
+    }
+
+    // Similar to the above but in-place by using a read/write binding.
+    stream.executable.export public @simple_mul_inplace workgroups(%workload: index) -> (index, index, index) {
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      hal.return %x, %c1, %c1 : index, index, index
+    }
+
+    builtin.module {
+      // External function declaration using a user-chosen calling convention.
+      func.func private @simple_mul_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %binding2: memref<?xf32>, %dim: index, %tid: index) attributes {
+        // Ensures that we try to statically link this external function and
+        // pull it in from the object file.
+        hal.import.static
+      }
+
+      // IREE exported function using stream bindings and operands.
+      // Compiler passes will be able to optimize across this interface and
+      // deduplicate bindings/operands, convert/pack operands, and inline
+      // constants operands.
+      func.func @simple_mul(
+          %binding0: !stream.binding,
+          %binding1: !stream.binding,
+          %binding2: !stream.binding,
+          %dim: index) {
+        %c0 = arith.constant 0 : index
+
+        // This function is invoked once per workgroup so determine where this
+        // particular workgroup is in the grid. In this example we use a
+        // workgroup size of 64x1x1 (which is exceedingly small for CPUs but
+        // useful for demonstration).
+        %workgroup_id_x = flow.dispatch.workgroup.id[0] : index
+        %tid = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+
+        // Bindings are accessed by reference.
+        %memref0 = stream.binding.subspan %binding0[%c0] : !stream.binding -> memref<?xf32>{%dim}
+        %memref1 = stream.binding.subspan %binding1[%c0] : !stream.binding -> memref<?xf32>{%dim}
+        %memref2 = stream.binding.subspan %binding2[%c0] : !stream.binding -> memref<?xf32>{%dim}
+
+        // Call the externally defined C function with an (almost) plain C
+        // calling convention (see above for details about the mess memrefs
+        // turn into).
+        //
+        // TODO: there are ways of accessing CPU information here such as
+        // active architecture and feature bits but it is not yet exposed to
+        // the stream level.
+        func.call @simple_mul_workgroup(%memref0, %memref1, %memref2, %dim, %tid) : (memref<?xf32>, memref<?xf32>, memref<?xf32>, index, index) -> ()
+
+        // NOTE: this is code generated as normal - other MLIR ops can be used
+        // here for looping/control flow, vector operations, linalg, etc.
+        // This simple sample is just calling out to the external function but
+        // microkernels fused with other code are possible.
+
+        return
+      }
+
+      func.func private @simple_mul_inplace_workgroup(%binding0: memref<?xf32>, %binding1: memref<?xf32>, %dim: index, %tid: index) attributes {
+        hal.import.static
+      }
+      func.func @simple_mul_inplace(
+          %binding0: !stream.binding,
+          %binding1: !stream.binding,
+          %dim: index) {
+        %c0 = arith.constant 0 : index
+
+        %workgroup_id_x = flow.dispatch.workgroup.id[0] : index
+        %tid = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
+
+        // Same as above but note that we're treating %binding1 as read/write.
+        %memref0 = stream.binding.subspan %binding0[%c0] : !stream.binding -> memref<?xf32>{%dim}
+        %memref1 = stream.binding.subspan %binding1[%c0] : !stream.binding -> memref<?xf32>{%dim}
+
+        func.call @simple_mul_inplace_workgroup(%memref0, %memref1, %dim, %tid) : (memref<?xf32>, memref<?xf32>, index, index) -> ()
+
+        return
+      }
+    }
+  }
+
+  // Function demonstrating a few hand-authored dispatches mixed with codegen.
+  // Invoke with:
+  //  --device=local-sync
+  //  --entry_function=mixed_invocation
+  //  --function_input=8xf32=2
+  //  --function_input=8xf32=4
+  // CHECK-LABEL: EXEC @mixed_invocation
+  func.func @mixed_invocation(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+    // The only externally available metadata in the dispatch are the values
+    // passed in as operands. Here we pass in the dynamic dimension.
+    %c0 = arith.constant 0 : index
+    %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+
+    // Dispatch a basic `ret = lhs * rhs` using an external function.
+    // This form (@executable::@export) allows for automatic variant selection
+    // when multi-targeting.
+    %0 = flow.dispatch @executable::@simple_mul[%dim](%arg0, %arg1, %dim) : (tensor<?xf32>{%dim}, tensor<?xf32>{%dim}, index) -> tensor<?xf32>{%dim}
+
+    // Code gen some other ops - these will interleave with the hand-authored
+    // ones but naturally won't be able to fuse with them.
+    %1 = arith.addf %0, %arg1 : tensor<?xf32>
+
+    // Dispatch an in-place `rhs *= lhs` using an external function.
+    %2 = flow.dispatch @executable::@simple_mul_inplace[%dim](%0, %1, %dim) : (tensor<?xf32>{%dim}, tensor<?xf32>{%dim}, index) -> %1{%dim}
+
+    // CHECK: 8xf32=96 96 96 96 96 96 96 96
+    return %2 : tensor<?xf32>
+  }
+
+}  // module

--- a/samples/custom_dispatch/cpu/embedded/functions.c
+++ b/samples/custom_dispatch/cpu/embedded/functions.c
@@ -1,0 +1,83 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// NOTE: it is not safe to use the standard library functions in here.
+// Attempting to allocate memory (outside of small stack allocations), make
+// syscalls, use thread-local state, or pull in externally defined standard
+// library functions will result in a bad time.
+//
+// It is safe to include definitions/macros/etc but be veeery careful!
+// Embedded ELF shared libraries are intended to be portable across operating
+// systems and environments (including to bare-metal systems) and though the
+// IREE compiler can ensure it does not pull in things that may run afoul of
+// that it's the user's responsibility when injecting code like this.
+#include <stddef.h>
+#include <stdint.h>
+
+// NOTE: kernels must be exported with C naming (no C++ mangling) in order to
+// match the names used in the IR declarations.
+
+// NOTE: IREE ensures all bindings don't alias their active subranges and
+// it is safe to mark them as restrict. This is critical as the C compiler can't
+// analyze the codegen when compiling and has to play it safe by assuming any
+// write to any binding could be visible through other bindings.
+
+// NOTE: memref lowering in MLIR -> LLVM currently expands to two pointers and
+// three ints - do not rely on this behavior and only use the first pointer.
+// At some point someone will fix upstream to allow for passing raw base
+// pointers and the function signatures here will become much less verbose.
+
+// NOTE: MLIR's index type will map to either i32 or i64 based on the target
+// pointer width. size_t (or ssize_t) can be used in source to match that type.
+
+// `ret = lhs * rhs`
+//
+// Conforms to ABI:
+// #hal.pipeline.layout<push_constants = 1, sets = [
+//   <0, bindings = [
+//       <0, storage_buffer, ReadOnly>,
+//       <1, storage_buffer, ReadOnly>,
+//       <2, storage_buffer>
+//   ]>
+// ]>
+// With a workgroup size of 64x1x1.
+void simple_mul_workgroup(
+    const float* restrict binding0, const float* restrict binding0_aligned,
+    size_t binding0_offset, size_t binding0_size, size_t binding0_stride,
+    const float* restrict binding1, const float* restrict binding1_aligned,
+    size_t binding1_offset, size_t binding1_size, size_t binding1_stride,
+    float* restrict binding2, float* restrict binding2_aligned,
+    size_t binding2_offset, size_t binding2_size, size_t binding2_stride,
+    size_t dim, size_t tid) {
+  size_t end = tid + 64;
+  if (end > dim) end = dim;
+  for (size_t i = tid; i < end; ++i) {
+    binding2[i] = binding0[i] * binding1[i];
+  }
+}
+
+// `rhs *= lhs`
+//
+// Conforms to ABI:
+// #hal.pipeline.layout<push_constants = 1, sets = [
+//   <0, bindings = [
+//       <0, storage_buffer, ReadOnly>,
+//       <1, storage_buffer>
+//   ]>
+// ]>
+// With a workgroup size of 64x1x1.
+void simple_mul_inplace_workgroup(
+    const float* restrict binding0, const float* restrict binding0_aligned,
+    size_t binding0_offset, size_t binding0_size, size_t binding0_stride,
+    float* restrict binding1, float* restrict binding1_aligned,
+    size_t binding1_offset, size_t binding1_size, size_t binding1_stride,
+    size_t dim, size_t tid) {
+  size_t end = tid + 64;
+  if (end > dim) end = dim;
+  for (size_t i = tid; i < end; ++i) {
+    binding1[i] *= binding0[i];
+  }
+}

--- a/samples/custom_dispatch/cuda/CMakeLists.txt
+++ b/samples/custom_dispatch/cuda/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_add_all_subdirs()

--- a/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
+++ b/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
@@ -64,7 +64,6 @@ function(cuda_kernel_ptx _ARCH)
   add_custom_target(${_NAME} DEPENDS
     ${CMAKE_CURRENT_BINARY_DIR}/${_PTX_OBJ_NAME}.ptx
   )
-  add_dependencies(iree-test-deps "${_NAME}")
   add_dependencies(iree-sample-deps "${_NAME}")
 endfunction()
 

--- a/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
+++ b/samples/custom_dispatch/cuda/kernels/CMakeLists.txt
@@ -1,0 +1,87 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if(NOT IREE_TARGET_BACKEND_CUDA OR NOT IREE_HAL_DRIVER_CUDA)
+  return()
+endif()
+
+# NOTE: this is not how one should actually build their PTX files. Do not use
+# this as an authoritative source for compilation settings or CMake goo. If you
+# choose to go the route of custom CUDA kernels you must bring your own build
+# infrastructure. This sample only demonstrates how to use compiled PTX blobs
+# inside of the IREE compiler and this is the minimum amount of hacking that
+# could be done to do that.
+
+include(CheckLanguage)
+check_language(CUDA)
+if(NOT CMAKE_CUDA_COMPILER)
+  message(STATUS "IREE custom_dispatch/cuda/kernels ignored -- nvcc not found")
+  return()
+endif()
+enable_language(CUDA)
+
+function(cuda_kernel_ptx _ARCH)
+  set(_NAME iree_samples_custom_dispatch_cuda_kernels_ptx_${_ARCH})
+  set(_PTX_SRC_NAME "kernels.cu")
+  get_filename_component(_PTX_SRC_BASENAME ${_PTX_SRC_NAME} NAME_WE CACHE)
+  set(_PTX_OBJ_NAME "${_PTX_SRC_BASENAME}_sm_${_ARCH}")
+
+  add_library(${_NAME}_obj OBJECT)
+  target_sources(${_NAME}_obj PRIVATE ${_PTX_SRC_NAME})
+  set_source_files_properties(${_PTX_SRC_NAME} PROPERTIES LANGUAGE CUDA)
+  set_target_properties(${_NAME}_obj PROPERTIES
+    LANGUAGE CUDA
+    LINKER_LANGUAGE CUDA
+    CUDA_PTX_COMPILATION ON
+    CUDA_SEPARABLE_COMPILATION ON
+    CUDA_RESOLVE_DEVICE_SYMBOLS ON
+    CUDA_ARCHITECTURES "${_ARCH}"
+  )
+
+  # This makes my eyes bleed. There is probably a much better way of doing this
+  # and I wish the best of luck to those who try. From:
+  # https://sourcegraph.com/github.com/NVIDIA/MDL-SDK/-/blob/cmake/utilities.cmake?L1266
+  # This sample should probably just invoke nvcc directly.
+  get_property(_GENERATOR_IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(_GENERATOR_IS_MULTI_CONFIG)
+    set(_PTX_CONFIG_FOLDER /$<CONFIG>)
+    set(_CMAKEFILES_FOLDER "")
+  else()
+    set(_PTX_CONFIG_FOLDER "")
+    set(_CMAKEFILES_FOLDER /CMakeFiles)
+  endif()
+  add_custom_command(
+    OUTPUT ${_PTX_OBJ_NAME}.ptx
+    DEPENDS $<TARGET_OBJECTS:${_NAME}_obj>
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_CURRENT_BINARY_DIR}${_CMAKEFILES_FOLDER}/${_NAME}_obj.dir${_PTX_CONFIG_FOLDER}/${_PTX_SRC_BASENAME}.ptx
+        ${CMAKE_CURRENT_BINARY_DIR}/${_PTX_OBJ_NAME}.ptx
+  )
+  add_custom_target(${_NAME} DEPENDS
+    ${CMAKE_CURRENT_BINARY_DIR}/${_PTX_OBJ_NAME}.ptx
+  )
+  add_dependencies(iree-test-deps "${_NAME}")
+  add_dependencies(iree-sample-deps "${_NAME}")
+endfunction()
+
+# Build the kernels_*.ptx files for each architecture we target.
+cuda_kernel_ptx(52)
+cuda_kernel_ptx(80)
+
+iree_lit_test_suite(
+  NAME
+    example
+  SRCS
+    "example.mlir"
+  TOOLS
+    FileCheck
+    iree-compile
+    iree-run-module
+  LABELS
+    "driver=cuda"
+    "hostonly"
+)

--- a/samples/custom_dispatch/cuda/kernels/README.md
+++ b/samples/custom_dispatch/cuda/kernels/README.md
@@ -1,0 +1,143 @@
+# Custom CUDA Dispatch Kernels
+
+See the [custom_dispatch README](/samples/custom_dispatch/README.md) for an
+overview of this approach.
+
+This sample demonstrates how to define external device functions that can be
+dispatched from within IREE programs when following the IREE CUDA ABI. The user
+authoring the kernels compiles their CUDA code to PTX blobs and can dispatch
+functions within those blobs by declaring them in their IR.
+
+### Work in Progress
+
+Note that currently only entire kernel launches can be modeled and this prevents
+IREE from performing optimizations it otherwise can. In the future PTX linking
+will be implemented such that the external functions are referenced and linked
+with the compiler-produced portions such that more information about the usage
+of the dispatch can be used to specialize/prune the hand-authored kernel. Since
+the IREE CUDA ABI is not version-stable this entire kernel approach may require
+updating when taking new IREE versions while function-level linking would not.
+
+Since today only entire kernels can be provided the user must specify an empty
+executable (no `builtin.module` contents) and thus must provide objects for
+all targets they are compiling for. When partial function linking is available
+it'll be possible to provide fallback code as IR for when objects are not
+available.
+
+## Workflow
+
+```
++------------+              +-------------------+       +--------------+
+| kernels.cu | -> nvcc -+-> | kernels_sm_52.ptx | -+    | example.mlir |
++------------+          |   +-------------------+  |    +--------------+
+                        |   +-------------------+  |           v
+                        +-> | kernels_sm_80.ptx | -+----> iree-compile
+                            +-------------------+              v
+                                                        +--------------+
+                                                        | example.vmfb |
+                                                        +--------------+
+```
+
+1. The user authors their kernels in a .cu file.
+
+```c
+extern "C" __global__ void simple_mul(const float* __restrict__ binding0,
+                                      const float* __restrict__ binding1,
+                                      float* __restrict__ binding2, int dim) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < dim) binding2[tid] = binding0[tid] * binding1[tid];
+}
+```
+
+2. Source files are compiled to PTX files via nvcc. Each architecture the user
+   is targeting will need its own object file(s).
+
+```cmake
+nvcc ... (TODO, see CMakeLists.txt) -o kernels_sm_80.ptx
+```
+
+3. The user (or compiler transforms) declare the externally defined kernels and
+   the target-to-objects map for each architecture. The layout specifies how
+   the dispatch arguments are mapped to buffers and the workgroup size is the
+   CUDA block size. The region on the export is used to compute the workgroup
+   count (CUDA grid size) and can query the `%device` if runtime device
+   information is needed.
+
+```mlir
+  hal.executable.source private @executable attributes {
+    objects = #hal.executable.objects<{
+      #nvptx_sm_52_target = [
+        #hal.executable.object<{path = "kernels_sm_80.ptx"}>
+      ]
+    }>
+    hal.executable.export public @simple_mul ordinal(0)
+        layout(#hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+              <0, storage_buffer, ReadOnly>,
+              <1, storage_buffer, ReadOnly>,
+              <2, storage_buffer>
+          ]>
+        ]>) attributes {workgroup_size = [64 : index, 1 : index, 1 : index]} {
+    ^bb0(%device: !hal.device, %workload: index):
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      hal.return %x, %c1, %c1 : index, index, index
+    }
+  }
+```
+
+4. The user (or compiler transforms) dispatches the kernel.
+
+```mlir
+  %0 = flow.dispatch @executable::@simple_mul[%dim](%dim_i32, %arg0, %arg1) :
+      (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+```
+
+5. The IREE compiler selects the appropriate object files for the target
+   configuration and links them into the binaries it produces. Dispatches are
+   automatically routed to the appropriate variant of those available at
+   runtime.
+
+## Instructions
+
+This presumes that `iree-compile` and `iree-run-module` have been installed or
+built. [See here](https://iree-org.github.io/iree/building-from-source/getting-started/)
+for instructions for CMake setup and building from source.
+
+0. Ensure that the [CUDA SDK](https://developer.nvidia.com/cuda-downloads) and `nvcc` is on your PATH:
+
+    ```
+    nvcc --version
+    ```
+
+1. Build the `iree-sample-deps` CMake target to compile the .cu to .ptx:
+
+    ```
+    cmake --build ../iree-build/ --target iree-sample-deps
+    ```
+
+    In a user application this would be replaced with whatever build
+    infrastructure the user has for compiling kernels to PTX. No IREE
+    compiler or runtime changes are required and the normal compiler install can
+    be used.
+
+2. Compile the [example module](./example.mlir) to a .vmfb file and pass the
+   path to the build directory so the .spv files can be found:
+
+    ```
+    iree-compile \
+        --iree-hal-executable-object-search-path=../iree-build/ \
+        samples/custom_dispatch/cuda/kernels/example.mlir \
+        -o=/tmp/example.vmfb
+    ```
+
+3. Run the example program using the custom kernels:
+
+    ```
+    iree-run-module \
+        --device=cuda \
+        --entry_function=mixed_invocation \
+        --function_input=8xf32=2 \
+        --function_input=8xf32=4 \
+        /tmp/example.vmfb
+    ```

--- a/samples/custom_dispatch/cuda/kernels/example.mlir
+++ b/samples/custom_dispatch/cuda/kernels/example.mlir
@@ -1,0 +1,170 @@
+// RUN: iree-compile %s \
+// RUN:     --iree-hal-executable-object-search-path=$IREE_BINARY_DIR | \
+// RUN: iree-run-module \
+// RUN:     --device=cuda \
+// RUN:     --entry_function=mixed_invocation \
+// RUN:     --function_input=8xf32=2 \
+// RUN:     --function_input=8xf32=4 | \
+// RUN: FileCheck %s
+
+// The configurations used for executable compilation.
+// This lets the compiler and runtime know the format and requirements of the
+// executable binaries produced and multiple variants with differing formats
+// and compilation options (architectures, etc) can be embedded for runtime
+// selection.
+#nvptx_sm_52_target = #hal.executable.target<"cuda", "cuda-nvptx-fb", {
+  target_arch = "sm_52"
+}>
+#nvptx_sm_80_target = #hal.executable.target<"cuda", "cuda-nvptx-fb", {
+  target_arch = "sm_80"
+}>
+
+// The target devices that the program will run on.
+// These can come from compiler flags and multiple targets can be supported
+// It's possible, for example, to support targeting multiple devices in the same
+// compiled binary.
+#cuda_target = #hal.device.target<"cuda", {
+  executable_targets = [
+    #nvptx_sm_52_target,
+    #nvptx_sm_80_target
+  ],
+  // HACK: CUDA target currently uses the legacy synchronous execution model.
+  legacy_sync
+}>
+
+module @example attributes {hal.device.targets = [#cuda_target]} {
+
+  // Executable containing hand-authored kernels.
+  // Each executable can contain multiple exported functions and variants for
+  // different architectures or even devices. It's also possible to mix hand-
+  // authored functions with code generated ones even for the same functions
+  // such that code generation is used as a fallback when the hand-authored
+  // kernels aren't supported at runtime.
+  hal.executable.source private @executable attributes {
+    // Object files linked into the executable per-target.
+    // Certain backends (today) support either wholesale definition or linking
+    // of partial objects for imports used by generated code. Each compilation
+    // target can have its own unique set of objects to link in and the target
+    // keys can be generic. This allows for an object file to be linked in based
+    // only on the target triple while allowing for more specialized ones
+    // requiring certain CPU features to be only included when building those.
+    objects = #hal.executable.objects<{
+      #nvptx_sm_52_target = [
+        #hal.executable.object<{
+          // Referencing a file path on disk but could also have the data
+          // embedded in order to make the MLIR file hermetic/portable across
+          // compilation pipelines. In the future we'll likely use MLIR's
+          // external resource functionality for this. By allowing for the
+          // objects to be embedded we can support JIT scenarios where some
+          // layer higher or lower may be emitting the objects to link in as
+          // part of the overall compilation.
+          path = "samples/custom_dispatch/cuda/kernels/kernels_sm_52.ptx"
+        }>
+      ],
+      #nvptx_sm_80_target = [
+        #hal.executable.object<{
+          path = "samples/custom_dispatch/cuda/kernels/kernels_sm_80.ptx"
+        }>
+      ]
+    }>
+  } {
+
+    // TODO(benvanik): demonstrate hal.executable.constant.block for
+    // specialization via host logic. Maps to a read-only buffer passed into
+    // kernels. CUDA doesn't yet have these wired up.
+
+    // Exported function with the C name `simple_mul`.
+    // The ordinal must be assigned by the user and unique for the executable.
+    // The layout defines the required bindings and push constants and can be
+    // thought of as the function signature.
+    hal.executable.export public @simple_mul ordinal(0)
+        layout(#hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+              <0, storage_buffer, ReadOnly>,
+              <1, storage_buffer, ReadOnly>,
+              <2, storage_buffer>
+          ]>
+        ]>) attributes {
+      // Certain backends (like CUDA) require a workgroup size (aka block
+      // size) to be defined ahead of time.
+      workgroup_size = [64 : index, 1 : index, 1 : index]
+    } {
+    ^bb0(%device: !hal.device, %workload: index):
+      // This host function is used to compute the XYZ workgroup count
+      // dispatched at runtime. It can query the %device for capabilities
+      // and limits (shared memory size, etc). The other arguments are the
+      // values passed in the dispatch operation (usually things like root
+      // output op tensor dimensions and other abstract values).
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      hal.return %x, %c1, %c1 : index, index, index
+    }
+
+    // Similar to the above but in-place by using a read/write binding.
+    hal.executable.export public @simple_mul_inplace ordinal(1)
+        layout(#hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+              <0, storage_buffer, ReadOnly>,
+              <1, storage_buffer>
+          ]>
+        ]>) attributes {
+      workgroup_size = [64 : index, 1 : index, 1 : index]
+    } {
+    ^bb0(%device: !hal.device, %workload: index):
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      hal.return %x, %c1, %c1 : index, index, index
+    }
+
+  }  // hal.executable.source
+
+  // Function demonstrating a few hand-authored dispatches mixed with codegen.
+  // Invoke with:
+  //  --device=cuda
+  //  --entry_function=mixed_invocation
+  //  --function_input=8xf32=2
+  //  --function_input=8xf32=4
+  // CHECK-LABEL: EXEC @mixed_invocation
+  func.func @mixed_invocation(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+    // HACK: for hand-authored kernels all primitive values passed in need to
+    // be i32 or a bit-castable type. This is because ABI packing of other types
+    // happens inside of the PackDispatchOperandsPass that is currently not
+    // usable with external functions as it changes the ABI. In the future we
+    // can better define the ABI such that it's possible to match the compiler
+    // expectations around padding/alignment. For now users must do the packing
+    // themselves (splitting i64 into i32+i32, etc).
+    %c0 = arith.constant 0 : index
+    %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+    %dim_i32 = arith.index_cast %dim : index to i32
+
+    // Dispatch a basic `ret = lhs * rhs` kernel.
+    %0 = flow.dispatch @executable::@simple_mul[%dim](%dim_i32, %arg0, %arg1) {
+      // Bindings are automatically inferred when possible as part of the ABI
+      // but can be overridden if the user wants to use features such as sparse
+      // bindings or multiple descriptor sets. To do so the
+      // `hal.interface.bindings` attribute can be added to a dispatch op as
+      // follows mapping tensor operands/results to the pipeline layout
+      // sets/bindings:
+      hal.interface.bindings = [
+        #hal.interface.binding<0, 0>,
+        #hal.interface.binding<0, 1>,
+        #hal.interface.binding<0, 2>
+      ]
+    } : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+
+    // Code gen some other ops - these will interleave with the hand-authored
+    // ones but naturally won't be able to fuse with them.
+    %1 = arith.addf %0, %arg1 : tensor<?xf32>
+
+    // Dispatch an in-place `rhs *= lhs` kernel.
+    //
+    // Note that we don't declare the hal.interface.bindings and let them be
+    // inferred - this only works when either specifying the variant that has
+    // a pipeline layout defined or all variants have the same pipeline layouts.
+    %2 = flow.dispatch @executable::@simple_mul_inplace[%dim](%dim_i32, %0, %1) : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> %1{%dim}
+
+    // CHECK: 8xf32=96 96 96 96 96 96 96 96
+    return %2 : tensor<?xf32>
+  }
+
+}  // module

--- a/samples/custom_dispatch/cuda/kernels/kernels.cu
+++ b/samples/custom_dispatch/cuda/kernels/kernels.cu
@@ -1,0 +1,72 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// This minimal example just has some publicly exported (__global__) kernels.
+// It's possible with more build goo to include .cuh files and pull in any
+// CUDA functions that do not involve host behavior (kernel launches/etc).
+//
+// NOTE: kernels must be exported with C naming (no C++ mangling) in order to
+// match the names used in the IR declarations.
+//
+// NOTE: arguments are packed as a dense list of
+// ([ordered bindings...], [push constants...]). If a binding is declared as
+// read-only the kernel must not write to it as it may be shared by other
+// invocations.
+//
+// NOTE: today all constants must be i32. If larger types are required there are
+// packing rules that must line up with compiler expectations - passed i64
+// values must be padded to natural 8-byte alignment, for example.
+//
+// NOTE: IREE ensures that all I/O buffers are legal to have the __restrict__
+// keyword defined (no aliasing is induced that is potentially unsafe). It's
+// still possible for users to do bad things but such is the case with native
+// CUDA programming.
+//
+// NOTE: I/O buffer base pointers are likely to be nicely aligned (64B minimum
+// but usually larger) but the pointers passed in may be offset by any value
+// as they represent subranges of the underlying buffers. For example if the
+// user slices out elements 3 and 4 out of a 4xf32 tensor then the base buffer
+// pointer will be at +8B. In general if the input wasn't trying to be tricky
+// (bitcasting/etc) then natural alignment is guaranteed (an f32 tensor will
+// always have buffer pointers aligned to 4B).
+
+// `ret = lhs * rhs`
+//
+// Conforms to ABI:
+// #hal.pipeline.layout<push_constants = 1, sets = [
+//   <0, bindings = [
+//       <0, storage_buffer, ReadOnly>,
+//       <1, storage_buffer, ReadOnly>,
+//       <2, storage_buffer>
+//   ]>
+// ]>
+// workgroup_size = [64 : index, 1 : index, 1 : index]
+extern "C" __global__ void simple_mul(const float* __restrict__ binding0,
+                                      const float* __restrict__ binding1,
+                                      float* __restrict__ binding2, int dim) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < dim) {
+    binding2[tid] = binding0[tid] * binding1[tid];
+  }
+}
+
+// `rhs *= lhs`
+//
+// Conforms to ABI:
+// #hal.pipeline.layout<push_constants = 1, sets = [
+//   <0, bindings = [
+//       <0, storage_buffer, ReadOnly>,
+//       <1, storage_buffer>
+//   ]>
+// ]>
+// workgroup_size = [64 : index, 1 : index, 1 : index]
+extern "C" __global__ void simple_mul_inplace(
+    const float* __restrict__ binding0, float* __restrict__ binding1, int dim) {
+  int tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < dim) {
+    binding1[tid] *= binding0[tid];
+  }
+}

--- a/samples/custom_dispatch/vulkan/CMakeLists.txt
+++ b/samples/custom_dispatch/vulkan/CMakeLists.txt
@@ -1,0 +1,7 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_add_all_subdirs()

--- a/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
+++ b/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
@@ -42,7 +42,6 @@ add_custom_target(iree_samples_custom_dispatch_vulkan_shaders_spv DEPENDS
   ${CMAKE_CURRENT_BINARY_DIR}/simple_mul.spv
   ${CMAKE_CURRENT_BINARY_DIR}/simple_mul_inplace.spv
 )
-add_dependencies(iree-test-deps "${_SPV_TARGET}")
 add_dependencies(iree-sample-deps "${_SPV_TARGET}")
 
 iree_lit_test_suite(

--- a/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
+++ b/samples/custom_dispatch/vulkan/shaders/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+if(NOT IREE_TARGET_BACKEND_VULKAN_SPIRV OR NOT IREE_HAL_DRIVER_VULKAN)
+  return()
+endif()
+
+# NOTE: we use glslc (either provided by user or in the Vulkan SDK) to do our
+# .glsl -> .spv compilation. This example is just demonstrating how to use
+# custom shaders in .spv format and not supporting infrastructure for compiling
+# shaders from various textual input languages (HLSL/etc). Users are expected to
+# bring their own infrastructure if they want to bring their own source code.
+find_program(GLSLC glslc)
+if(NOT GLSLC)
+  message(STATUS "IREE custom_dispatch/vulkan/shaders ignored -- glslc not found")
+  return()
+endif()
+
+set(_SPV_TARGET iree_samples_custom_dispatch_vulkan_shaders_spv)
+add_custom_command(
+  OUTPUT simple_mul.spv
+  DEPENDS simple_mul.glsl
+  COMMAND ${GLSLC}
+      -fshader-stage=compute
+      -o simple_mul.spv
+      ${CMAKE_CURRENT_SOURCE_DIR}/simple_mul.glsl
+  VERBATIM
+)
+add_custom_command(
+  OUTPUT simple_mul_inplace.spv
+  DEPENDS simple_mul_inplace.glsl
+  COMMAND ${GLSLC}
+      -fshader-stage=compute
+      -o simple_mul_inplace.spv
+      ${CMAKE_CURRENT_SOURCE_DIR}/simple_mul_inplace.glsl
+  VERBATIM
+)
+add_custom_target(iree_samples_custom_dispatch_vulkan_shaders_spv DEPENDS
+  ${CMAKE_CURRENT_BINARY_DIR}/simple_mul.spv
+  ${CMAKE_CURRENT_BINARY_DIR}/simple_mul_inplace.spv
+)
+add_dependencies(iree-test-deps "${_SPV_TARGET}")
+add_dependencies(iree-sample-deps "${_SPV_TARGET}")
+
+iree_lit_test_suite(
+  NAME
+    example
+  SRCS
+    "example.mlir"
+  DATA
+    ${_SPV_TARGET}
+  TOOLS
+    FileCheck
+    iree-compile
+    iree-run-module
+  LABELS
+    "driver=vulkan"
+    "hostonly"
+)

--- a/samples/custom_dispatch/vulkan/shaders/README.md
+++ b/samples/custom_dispatch/vulkan/shaders/README.md
@@ -1,0 +1,147 @@
+# Custom Vulkan/SPIR-V Dispatch Shaders
+
+See the [custom_dispatch README](/samples/custom_dispatch/README.md) for an
+overview of this approach.
+
+This sample demonstrates how to define external device functions that can be
+dispatched from within IREE programs when following the IREE Vulkan/SPIR-V ABI.
+The user authoring the shaders compiles their GLSL/HLSL/etc code to SPIR-V blobs
+and can dispatch functions within those blobs by declaring them in their IR.
+
+### Work in Progress
+
+Note that currently only entire dispatches can be modeled and this prevents
+IREE from performing optimizations it otherwise can. In the future SPIR-V
+linking will be implemented such that the external functions are referenced and
+linked with the compiler-produced portions such that more information about the
+usage of the dispatch can be used to specialize/prune the hand-authored
+portions. Since the IREE Vulkan/SPIR-V ABI is not version-stable this entire
+shader approach may require updating when taking new IREE versions while
+function-level linking would not.
+
+Since today only entire shaders can be provided the user must specify an empty
+executable (no `builtin.module` contents) and thus must provide objects for
+all targets they are compiling for. When partial function linking is available
+it'll be possible to provide fallback code as IR for when objects are not
+available.
+
+## Workflow
+
+```
+                                                         +--------------+
+                                                         | example.mlir |
+                                                         +--------------+
++-----------------+             +----------------+              v
+| simple_mul.glsl | -> glslc -> | simple_mul.spv | ------> iree-compile
++-----------------+             +----------------+              v
+                                                         +--------------+
+                                                         | example.vmfb |
+                                                         +--------------+
+```
+
+1. The user authors their shaders in a .glsl (.hlsl/etc) file.
+
+```c
+#version 450
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+layout(set = 0, binding = 0) readonly buffer Binding0 { float binding0[]; };
+layout(set = 0, binding = 1) readonly buffer Binding1 { float binding1[]; };
+layout(set = 0, binding = 2) buffer Binding2 { float binding2[]; };
+layout(push_constant) uniform PushConstants { uint dim; };
+void main() {
+  uint tid = gl_GlobalInvocationID.x;
+  if (tid < dim) binding2[tid] = binding0[tid] * binding1[tid];
+}
+```
+
+2. Source files are compiled to SPIR-V files via glslc. Each architecture or
+   set of extensions the user is targeting will need its own object file(s).
+
+```cmake
+glslc -fshader-stage=compute simple_mul.glsl -o simple_mul.spv
+```
+
+3. The user (or compiler transforms) declare the externally defined shaders and
+   the target-to-objects map for each configuration. The layout specifies how
+   the dispatch arguments are mapped to buffers. The region on the export is
+   used to compute the workgroup count and can query the `%device` if runtime
+   device information is needed.
+
+```mlir
+  hal.executable.source private @executable attributes {
+    objects = #hal.executable.objects<{
+      #spirv_target = [
+        #hal.executable.object<{path = "simple_mul.spv"}>
+      ]
+    }>
+    hal.executable.export public @simple_mul ordinal(0)
+        layout(#hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+              <0, storage_buffer, ReadOnly>,
+              <1, storage_buffer, ReadOnly>,
+              <2, storage_buffer>
+          ]>
+        ]>) {
+    ^bb0(%device: !hal.device, %workload: index):
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      hal.return %x, %c1, %c1 : index, index, index
+    }
+  }
+```
+
+4. The user (or compiler transforms) dispatches the shader.
+
+```mlir
+  %0 = flow.dispatch @executable::@simple_mul[%dim](%dim_i32, %arg0, %arg1) :
+      (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+```
+
+5. The IREE compiler selects the appropriate object files for the target
+   configuration and links them into the binaries it produces. Dispatches are
+   automatically routed to the appropriate variant of those available at
+   runtime.
+
+## Instructions
+
+This presumes that `iree-compile` and `iree-run-module` have been installed or
+built. [See here](https://iree-org.github.io/iree/building-from-source/getting-started/)
+for instructions for CMake setup and building from source.
+
+0. Ensure that `glslc` is on your PATH (comes with the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home)):
+
+    ```
+    glslc --version
+    ```
+
+1. Build the `iree-sample-deps` CMake target to compile the GLSL to SPIR-V:
+
+    ```
+    cmake --build ../iree-build/ --target iree-sample-deps
+    ```
+
+    In a user application this would be replaced with whatever build
+    infrastructure the user has for compiling shaders to SPIR-V. No IREE
+    compiler or runtime changes are required and the normal compiler install can
+    be used.
+
+2. Compile the [example module](./example.mlir) to a .vmfb file and pass the
+   path to the build directory so the .spv files can be found:
+
+    ```
+    iree-compile \
+        --iree-hal-executable-object-search-path=../iree-build/ \
+        samples/custom_dispatch/vulkan/shaders/example.mlir \
+        -o=/tmp/example.vmfb
+    ```
+
+3. Run the example program using the custom shaders:
+
+    ```
+    iree-run-module \
+        --device=vulkan \
+        --entry_function=mixed_invocation \
+        --function_input=8xf32=2 \
+        --function_input=8xf32=4 \
+        /tmp/example.vmfb
+    ```

--- a/samples/custom_dispatch/vulkan/shaders/example.mlir
+++ b/samples/custom_dispatch/vulkan/shaders/example.mlir
@@ -1,0 +1,169 @@
+// RUN: iree-compile %s \
+// RUN:     --iree-hal-executable-object-search-path=$IREE_BINARY_DIR | \
+// RUN: iree-run-module \
+// RUN:     --device=vulkan \
+// RUN:     --entry_function=mixed_invocation \
+// RUN:     --function_input=8xf32=2 \
+// RUN:     --function_input=8xf32=4 | \
+// RUN: FileCheck %s
+
+// The configuration used for executable compilation.
+// This lets the compiler and runtime know the format and requirements of the
+// executable binaries produced and multiple variants with differing formats
+// and compilation options (architectures, etc) can be embedded for runtime
+// selection.
+#spirv_target = #hal.executable.target<"vulkan", "vulkan-spirv-fb", {
+  spirv.target_env = #spirv.target_env<
+    #spirv.vce<v1.3, [Shader, GroupNonUniform], [SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
+    #spirv.resource_limits<max_compute_workgroup_size = [128, 128, 64], subgroup_size = 64>
+  >
+}>
+
+// The target devices that the program will run on.
+// These can come from compiler flags and multiple targets can be supported
+// It's possible, for example, to support targeting multiple devices in the same
+// compiled binary.
+#vulkan_target = #hal.device.target<"vulkan", {
+  executable_targets = [#spirv_target],
+  // HACK: Vulkan target currently uses the legacy synchronous execution model.
+  legacy_sync
+}>
+
+module @example attributes {hal.device.targets = [#vulkan_target]} {
+
+  // Executable containing hand-authored shaders.
+  // Though each executable can contain multiple exported functions SPIR-V lacks
+  // decent linking support and we model them separately here. In future
+  // iterations of this functionality we will allow multiple .spv object files
+  // to be linked into a single executable so that we can eliminate some binary
+  // size overheads and improve runtime shader compilation performance.
+  //
+  // TODO(#7824): make export ordinals map to objects so that we can perform
+  // our own linking (until some future Vulkan extension is added for pipeline
+  // libraries).
+  hal.executable.source private @simple_mul attributes {
+    // Object files linked into the executable.
+    // Certain backends (today) support either wholesale definition or linking
+    // of partial objects for imports used by generated code. Each compilation
+    // target can have its own unique set of objects to link in and the target
+    // keys can be generic. This allows for an object file to be linked in based
+    // only on the target triple while allowing for more specialized ones
+    // requiring certain CPU features to be only included when building those.
+    objects = #hal.executable.objects<{
+      #spirv_target = [
+        #hal.executable.object<{
+          // Referencing a file path on disk but could also have the data
+          // embedded in order to make the MLIR file hermetic/portable across
+          // compilation pipelines. In the future we'll likely use MLIR's
+          // external resource functionality for this. By allowing for the
+          // objects to be embedded we can support JIT scenarios where some
+          // layer higher or lower may be emitting the objects to link in as
+          // part of the overall compilation.
+          path = "samples/custom_dispatch/vulkan/shaders/simple_mul.spv"
+        }>
+      ]
+    }>
+  } {
+
+    // TODO(benvanik): demonstrate hal.executable.constant.block for
+    // specialization via host logic. These map to specialization constants.
+
+    // Exported function with the C name `simple_mul`.
+    // The ordinal must be assigned by the user and unique for the executable.
+    // The layout defines the required bindings and push constants and can be
+    // thought of as the function signature.
+    hal.executable.export public @main ordinal(0)
+        layout(#hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+              <0, storage_buffer, ReadOnly>,
+              <1, storage_buffer, ReadOnly>,
+              <2, storage_buffer>
+          ]>
+        ]>) {
+    ^bb0(%device: !hal.device, %workload: index):
+      // This host function is used to compute the XYZ workgroup count
+      // dispatched at runtime. It can query the %device for capabilities
+      // and limits (shared memory size, etc). The other arguments are the
+      // values passed in the dispatch operation (usually things like root
+      // output op tensor dimensions and other abstract values).
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      hal.return %x, %c1, %c1 : index, index, index
+    }
+
+  }  // hal.executable
+
+  hal.executable.source private @simple_mul_inplace attributes {
+    objects = #hal.executable.objects<{
+      #spirv_target = [
+        #hal.executable.object<{
+          path = "samples/custom_dispatch/vulkan/shaders/simple_mul_inplace.spv"
+        }>
+      ]
+    }>
+  } {
+    // Similar to the above but in-place by using a read/write binding.
+    hal.executable.export public @main ordinal(0)
+        layout(#hal.pipeline.layout<push_constants = 1, sets = [
+          <0, bindings = [
+              <0, storage_buffer, ReadOnly>,
+              <1, storage_buffer>
+          ]>
+        ]>) {
+    ^bb0(%device: !hal.device, %workload: index):
+      %x = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%workload]
+      %c1 = arith.constant 1 : index
+      hal.return %x, %c1, %c1 : index, index, index
+    }
+  }  // hal.executable
+
+  // Function demonstrating a few hand-authored dispatches mixed with codegen.
+  // Invoke with:
+  //  --device=vulkan
+  //  --entry_function=mixed_invocation
+  //  --function_input=8xf32=2
+  //  --function_input=8xf32=4
+  // CHECK-LABEL: EXEC @mixed_invocation
+  func.func @mixed_invocation(%arg0: tensor<?xf32>, %arg1: tensor<?xf32>) -> tensor<?xf32> {
+    // HACK: for hand-authored shaders all primitive values passed in need to
+    // be i32 or a bit-castable type. This is because ABI packing of other types
+    // happens inside of the PackDispatchOperandsPass that is currently not
+    // usable with external functions as it changes the ABI. In the future we
+    // can better define the ABI such that it's possible to match the compiler
+    // expectations around padding/alignment. For now users must do the packing
+    // themselves (splitting i64 into i32+i32, etc).
+    %c0 = arith.constant 0 : index
+    %dim = tensor.dim %arg0, %c0 : tensor<?xf32>
+    %dim_i32 = arith.index_cast %dim : index to i32
+
+    // Dispatch a basic `ret = lhs * rhs` shader.
+    %0 = flow.dispatch @simple_mul::@main[%dim](%dim_i32, %arg0, %arg1) {
+      // Bindings are automatically inferred when possible as part of the ABI
+      // but can be overridden if the user wants to use features such as sparse
+      // bindings or multiple descriptor sets. To do so the
+      // `hal.interface.bindings` attribute can be added to a dispatch op as
+      // follows mapping tensor operands/results to the pipeline layout
+      // sets/bindings:
+      hal.interface.bindings = [
+        #hal.interface.binding<0, 0>,
+        #hal.interface.binding<0, 1>,
+        #hal.interface.binding<0, 2>
+      ]
+    } : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> tensor<?xf32>{%dim}
+
+    // Code gen some other ops - these will interleave with the hand-authored
+    // ones but naturally won't be able to fuse with them.
+    %1 = arith.addf %0, %arg1 : tensor<?xf32>
+
+    // Dispatch an in-place `rhs *= lhs` shader.
+    //
+    // Note that we don't declare the hal.interface.bindings and let them be
+    // inferred - this only works when either specifying the variant that has
+    // a pipeline layout defined or all variants have the same pipeline layouts.
+    %2 = flow.dispatch @simple_mul_inplace::@main[%dim](%dim_i32, %0, %1) : (i32, tensor<?xf32>{%dim}, tensor<?xf32>{%dim}) -> %1{%dim}
+
+    // CHECK: 8xf32=96 96 96 96 96 96 96 96
+    return %2 : tensor<?xf32>
+  }
+
+}  // module

--- a/samples/custom_dispatch/vulkan/shaders/simple_mul.glsl
+++ b/samples/custom_dispatch/vulkan/shaders/simple_mul.glsl
@@ -1,0 +1,36 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// `ret = lhs * rhs`
+//
+// Conforms to ABI:
+// #hal.pipeline.layout<push_constants = 1, sets = [
+//   <0, bindings = [
+//       <0, storage_buffer, ReadOnly>,
+//       <1, storage_buffer, ReadOnly>,
+//       <2, storage_buffer>
+//   ]>
+// ]>
+
+#version 450
+
+// Workgroup local size that factors into the host-side workgroup count math.
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) readonly buffer Binding0 { float binding0[]; };
+layout(set = 0, binding = 1) readonly buffer Binding1 { float binding1[]; };
+layout(set = 0, binding = 2) buffer Binding2 { float binding2[]; };
+
+layout(push_constant) uniform PushConstants {
+  uint dim;
+};
+
+void main() {
+  uint tid = gl_GlobalInvocationID.x;
+  if (tid < dim) {
+    binding2[tid] = binding0[tid] * binding1[tid];
+  }
+}

--- a/samples/custom_dispatch/vulkan/shaders/simple_mul_inplace.glsl
+++ b/samples/custom_dispatch/vulkan/shaders/simple_mul_inplace.glsl
@@ -1,0 +1,34 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// `rhs *= lhs`
+//
+// Conforms to ABI:
+// #hal.pipeline.layout<push_constants = 1, sets = [
+//   <0, bindings = [
+//       <0, storage_buffer, ReadOnly>,
+//       <1, storage_buffer>
+//   ]>
+// ]>
+
+#version 450
+
+// Workgroup local size that factors into the host-side workgroup count math.
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(set = 0, binding = 0) readonly buffer Binding0 { float binding0[]; };
+layout(set = 0, binding = 1) buffer Binding1 { float binding1[]; };
+
+layout(push_constant) uniform PushConstants {
+  uint dim;
+};
+
+void main() {
+  uint tid = gl_GlobalInvocationID.x;
+  if (tid < dim) {
+    binding1[tid] *= binding0[tid];
+  }
+}


### PR DESCRIPTION
This adds a skeleton workflow for declaring external objects that are able to be referenced by the compiler all the way from the high-level dialects (flow, at least) and a sample demonstrating how device functions in .cu, .glsl, and .o files can be connected end-to-end with execution. The end goal is to allow codegen backends - including extensions - to either select from precompiled object files or generate/JIT their own as part of translation.

The core feature added is the `#hal.executable.object` attribute that allows executable variants to have extra object files specified:
```mlir
hal.executable private @executable {
  // Variant linking in an x86-64 object file containing external functions.
  hal.executable.variant public @x86_64, target = #x86_64_target, objects = [
    // Object files linked into the executable.
    #hal.executable.object<{
      // Referencing a file path on disk but could also have the data embedded.
      path = "samples/custom_dispatch/cpu/embedded/functions.o"
    }>
```
The attribute also allows for data to be directly embedded and (in the future) specified via MLIR external resources. When using file paths either the absolute path, a path relative to the current working directory, or a relative path joined with search paths will be tried. `--iree-hal-executable-object-search-path=` can be specified multiple times to add to the search paths.

This can be extended as required for new backends (.metallibs and archives) as well as various formats for the existing ones (linking .spv files together, .bc instead of .o for LLVM IR, etc). There's some work to be done around interactions with linking phases that may limit the usefulness of these stages for cross-compilation but at least for now we can rely on a bleeding-edge user wanting to hand-author these dispatch functions not caring about it yet. Since objects are specified per-variant it's possible for a user to still cross-compile and multi-target just with a bit more IR (today). It's also possible to specify the objects at the stream level and (if we have a good story for tensor -> pointers) we could allow it at the flow/input-level too.

Some future ergonomics improvements are tracked in #11289.
In particular there will be a way to avoid the boilerplate the CPU side requires by having us generate that automatically for some very basic interfaces (limited access to workgroup params and the environment).