### PR TITLE
Support reduction+elementwise in transform dialect strategies

### DIFF
--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -27,6 +27,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = [
         "reduction.mlir",
+        "reduction_eltwise.mlir",
         "reduction_v2.mlir",
         "softmax.mlir",
         "softmax_v2.mlir",
@@ -38,6 +39,7 @@ iree_lit_test_suite(
     # they need to be included as data.
     data = [
         "reduction_codegen_spec.mlir",
+        "reduction_eltwise_codegen_spec.mlir",
         "reduction_v2_codegen_spec.mlir",
         "softmax_codegen_spec.mlir",
         "softmax_v2_codegen_spec.mlir",

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "reduction.mlir"
+    "reduction_eltwise.mlir"
     "reduction_v2.mlir"
     "softmax.mlir"
     "softmax_partial.mlir"
@@ -30,6 +31,7 @@ iree_lit_test_suite(
     iree-run-module
   DATA
     reduction_codegen_spec.mlir
+    reduction_eltwise_codegen_spec.mlir
     reduction_v2_codegen_spec.mlir
     softmax_codegen_spec.mlir
     softmax_dispatch_spec.mlir

--- a/tests/transform_dialect/cuda/reduction_eltwise.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise.mlir
@@ -1,0 +1,100 @@
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) -> !out_tensor_t
+  %5 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  %6 = tensor.empty() : !out_tensor_t
+  %7 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%5 : !out_tensor_t) outs(%6 : !out_tensor_t) {  
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = math.sqrt %arg3 : f32
+      linalg.yield %4 : f32
+    } -> !out_tensor_t
+  return %7 : !out_tensor_t
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
+/// Note: the current --iree-codegen-llvmgpu-enable-transform-dialect-jit only works for exactly this reduction atm.
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="8x64xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+/// Note: the current --iree-codegen-llvmgpu-enable-transform-dialect-jit only works for exactly this reduction atm.
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="8x64xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+  //     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  //     CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  //     CHECK-DAG: %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
+  //     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+  //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 128 : i64} : memref<1x2xf32, 3>
+  //     CHECK-DAG: %[[TIDX:.]] = gpu.thread_id  x
+  //     CHECK-DAG: %[[TIDY:.]] = gpu.thread_id  y
+  //     CHECK-DAG: %[[TIDZ:.]] = gpu.thread_id  z
+
+  //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+
+  // Distributed reduction: everyone loads then 5 xor + addf expected
+  //         CHECK: vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+  // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+  //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}
+
+  //         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+  //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+  //         CHECK: scf.if %[[CONDXIS0]]
+  //         CHECK:   vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
+  //         CHECK: gpu.barrier
+
+  // Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
+  // It should contain the fused elementwise operation.
+  //         CHECK: %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
+  //          TODO: cond eq 0 and cond ult 1 do not CSE atm.
+  //         CHECK: %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
+  //         CHECK: scf.if %[[CONXANDYARE0]] {
+  //         CHECK:   vector.transfer_read
+  //         CHECK:   vector.reduction <add>
+  //         CHECK:   math.sqrt
+  //         CHECK:   vector.transfer_write
+  //         CHECK: gpu.barrier
+  //         CHECK: memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
+
+
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 8xf32=8 8 8 8 8 8 8 8

--- a/tests/transform_dialect/cuda/reduction_eltwise.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise.mlir
@@ -35,7 +35,7 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
 // RUN:     --iree-stream-transformation-pipeline \
 // RUN:     --iree-hal-configuration-pipeline | \
 // RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
-// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_eltwise_codegen_spec.mlir | \
 // RUN: FileCheck %s --check-prefix=CHECK
 
 /// Note: the current --iree-codegen-llvmgpu-enable-transform-dialect-jit only works for exactly this reduction atm.
@@ -49,7 +49,7 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
 // RUN: FileCheck %s --check-prefix=CHECK
 
 // RUN: iree-compile %s --iree-hal-target-backends=cuda \
-// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_codegen_spec.mlir | \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_eltwise_codegen_spec.mlir | \
 // RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="8x64xf32=1" |\
 // RUN: FileCheck %s --check-prefix=EXEC
 

--- a/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
@@ -1,0 +1,65 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(suppress) {
+^bb1(%variant_op: !pdl.operation):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+  
+  // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
+  // ===========================================================================
+  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op
+  %reduction, %eltwise = transform.split_handles %0 in [2] : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
+    transform.structured.split_reduction %reduction
+      { split_factor = 2, insert_split_dimension = 1 }
+
+  // Step 2. First level of tiling + fusion parallelizes to blocks. Tile the
+  // trailing elementwise the same way we want to tile the reduction.
+  // ===========================================================================
+  %grid_loop, %eltwise_grid_op = transform.iree.tile_to_foreach_thread_and_workgroup_count_region %eltwise 
+    tile_sizes [1] (mapping = [#gpu.block<x>])
+  %not_eltwise = transform.merge_handles %fill, %more_parallel_fill_op, %more_parallel_op, %combiner_op : !pdl.operation
+  transform.structured.fuse_into_containing_op %not_eltwise into %grid_loop
+
+  // Step 3. Second level of tiling + fusion parallelizes to threads.
+  // ===========================================================================
+  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
+  %eltwise_block_loop, %eltwise_block_op =
+    transform.structured.tile_to_foreach_thread_op %eltwise_grid_op tile_sizes [1]
+    ( mapping = [#gpu.thread<z>] )
+  %block_combiner_op = transform.structured.match ops{["linalg.generic"]}
+    attributes {iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
+  %combined_and_fill = transform.merge_handles %fill_1d, %block_combiner_op : !pdl.operation
+  transform.structured.fuse_into_containing_op %combined_and_fill into %eltwise_block_loop
+
+  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
+  %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
+  %foreach_thread_block_more_parallel_op, %block_more_parallel_op =
+    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1] 
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
+  transform.structured.fuse_into_containing_op %fill_2d into %foreach_thread_block_more_parallel_op
+
+  // Step 4. Rank-reduce and vectorize.
+  // ===========================================================================
+  %func = transform.structured.match ops{["func.func"]} in %variant_op
+  %func_2 = transform.iree.apply_patterns %func { rank_reducing }
+  %func_3 = transform.structured.vectorize %func_2
+
+  // Step 5. Bufferize.
+  // ===========================================================================
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+
+  // Step 6. Post-bufferization mapping to blocks and threads.
+  // ===========================================================================
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
+  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
+      { workgroup_size = [32, 2, 1] }
+
+  // Step 7. Post-bufferization vector distribution with rank-reduction.
+  // ===========================================================================
+  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  transform.iree.vector.warp_distribute %func_7
+}


### PR DESCRIPTION
Add a handwritten and a generated transform dialect schedule to support codegen for reduction+elementwise targeting CUDA. Unlike standalone reduction, this needs additional fusion into the trailing elementwise. The transform dialect generated on-the-fly differs when the elementwise is present. This should be eventually expressed in the dialect itself, but we are currently lacking the necessary ops.