### PR TITLE
Consistently query `ExecutableTargetAttr`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -184,7 +184,7 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
         return signalPassFailure();
       }
 
-      bool lowerToAVX2 = hasAVX2Feature(variantOp);
+      bool lowerToAVX2 = hasAVX2Feature(variantOp.getTarget());
       if (!testLoweringConfiguration) {
         switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.cpp
@@ -26,8 +26,8 @@ namespace mlir {
 namespace iree_compiler {
 
 const TargetMLTransformInfo TargetMLTransformInfo::getTargetMLTransformInfo(
-    IREE::HAL::ExecutableVariantOp variantOp) {
-  if (isRISCV(variantOp)) {
+    IREE::HAL::ExecutableTargetAttr targetAttr) {
+  if (isRISCV(targetAttr)) {
     return RISCVTargetMLTransformInfo();
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/TargetMLTransformInfo.h
@@ -9,7 +9,7 @@
 
 #include <limits>
 
-#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -22,7 +22,7 @@ struct TargetMLTransformInfo {
       std::numeric_limits<unsigned>::max();
 
   static const TargetMLTransformInfo getTargetMLTransformInfo(
-      IREE::HAL::ExecutableVariantOp variantOp);
+      IREE::HAL::ExecutableTargetAttr targetAttr);
 };
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -43,28 +43,40 @@ FailureOr<IREE::HAL::ExecutableExportOp> getEntryPoint(func::FuncOp funcOp);
 /// failure.
 FailureOr<IREE::HAL::ExecutableVariantOp> getExecutableVariantOp(Operation *op);
 
+/// Returns the StringAttr with the name `stringAttr` in the `targetAttr`, if
+/// found.
+Optional<StringAttr> getConfigStringAttr(
+    IREE::HAL::ExecutableTargetAttr targetAttr, StringRef stringAttr);
+
+/// Returns the IntegerAttr with the name `integerAttr` in the `targetAttr`, if
+/// found.
+Optional<IntegerAttr> getConfigIntegerAttr(
+    IREE::HAL::ExecutableTargetAttr targetAttr, StringRef integerAttr);
+
+/// Returns the LLVM Target triple associated with the `targetAttr`, if set.
+Optional<llvm::Triple> getTargetTriple(
+    IREE::HAL::ExecutableTargetAttr targetAttr);
+
+/// Returns the CPU target features associated with the `targetAttr`, if set.
+Optional<StringRef> getCpuFeatures(IREE::HAL::ExecutableTargetAttr targetAttr);
+
 /// Methods to get target information.
-bool isX86(IREE::HAL::ExecutableVariantOp variantOp);
-
-bool isAArch64(IREE::HAL::ExecutableVariantOp variantOp);
-
-bool isRISCV(IREE::HAL::ExecutableVariantOp variantOp);
-
-inline bool isVMVXBackend(IREE::HAL::ExecutableVariantOp variantOp) {
-  return variantOp.getTarget().getBackend().getValue().startswith("vmvx");
-}
+bool isX86(IREE::HAL::ExecutableTargetAttr targetAttr);
+bool isAArch64(IREE::HAL::ExecutableTargetAttr targetAttr);
+bool isRISCV(IREE::HAL::ExecutableTargetAttr targetAttr);
+bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Returns true if the 'variantOp' contains '+avx2' in its cpu features.
-bool hasAVX2Feature(IREE::HAL::ExecutableVariantOp variantOp);
+bool hasAVX2Feature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Returns true if the 'variantOp' contains '+v' in its cpu features.
-bool hasVFeature(IREE::HAL::ExecutableVariantOp variantOp);
+bool hasVFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Returns true if the 'variantOp' contains '+zve32x' in its cpu features.
-bool hasZve32xFeature(IREE::HAL::ExecutableVariantOp variantOp);
+bool hasZve32xFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Returns true if the 'variantOp' contains '+zve64x' in its cpu features.
-bool hasZve64xFeature(IREE::HAL::ExecutableVariantOp variantOp);
+bool hasZve64xFeature(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Checks if a tensor value is generated from a read-only object, like
 /// and interface binding with read-only attribute or from an `arith.constant`


### PR DESCRIPTION
#11057 added a `IREE::HAL::ExecutableTargetAttr::lookup` function which should be the preferred way to get a `ExecutableTargetAttr`, since it honors the overrides made possible by that PR.

It's also neatly shrinking code at call sites, and better conveys intent: before, we were querying a `ExecutableVariantOp` only to get at the `ExecutableTargetAttr`, now we query directly the latter.

The Utils are updated to all take a `ExecutableTargetAttr`, and since they were already implementing logic to handle optionally present fields, this further simplifies logic at call sites.

Some Utils implementation functions, which were internal, are now exposed in `Utils.h`. Particularly `getConfigStringAttr`. There seemed to be no point having various place in the code reimplement that boilerplate themselves (with opportunities to mishandle optionals).  A new `getConfigIntegerAttr` is added.

This is preparation for determining tile sizes based on target info in `MaterializeEncoding`, which following #11290 we will be able to do based on the `ExecutableTargetAttr` which we query there. It would be inconvenient, at least for testing purposes, to have to deal only with `ExecutableVariantOp` there, so the new `MaterializeEncoding` code in #11290 is using `IREE::HAL::ExecutableTargetAttr::lookup` and needs to access helpers taking a `ExecutableTargetAttr`, which was the original motivation for the `Utils.*` changes here.