### PR TITLE
Move the api-test binary to the project wide binary directory.

### DIFF
--- a/compiler/src/iree/compiler/API2/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API2/CMakeLists.txt
@@ -96,6 +96,7 @@ set_target_properties(
     # TODO: We should really be dumping binaries into bin/ not
     # tools/. This must line up with binaries built this way because
     # DLLs must be in the same directory as the binary.
+    # See: https://github.com/iree-org/iree/issues/11297
     RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tools"
     ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib"
 )

--- a/compiler/src/iree/compiler/API2/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API2/test/CMakeLists.txt
@@ -22,3 +22,11 @@ iree_cc_test(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+# Move to bin/ directory and systematically name more appropriately.
+# See: https://github.com/iree-org/iree/issues/11297
+set_target_properties(iree_compiler_API2_test_api-test-binary
+  PROPERTIES
+  OUTPUT_NAME "test-iree-compiler-api-test-binary"
+  RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/tools"
+)


### PR DESCRIPTION
* Since it depends on a DLL, it must be placed properly.

Tested: Locally on Windows

See for a better solution: https://github.com/iree-org/iree/issues/11297