### PR TITLE
EncodingInfo may depend on the shape, not just on the element type

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -94,7 +94,7 @@ struct MaterializeEncodingInfo {
   SmallVector<int64_t> outerDimsPerm;
 };
 using MaterializeEncodingFn =
-    std::function<FailureOr<MaterializeEncodingInfo>(TensorEncoding, Type)>;
+    std::function<FailureOr<MaterializeEncodingInfo>(RankedTensorType)>;
 
 /// TypeConverter to use for materializing the encoding.
 struct MaterializeEncodingTypeConverter : public TypeConverter {

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -22,40 +22,6 @@ using namespace mlir::iree_compiler;
 using namespace mlir::iree_compiler::IREE::LinalgExt;
 
 //===---------------------------------------------------------------------===//
-// Methods to convert the encoding to parameters of the Pack operation
-//===---------------------------------------------------------------------===//
-
-/// Given the `encoding` return the `MaterializeEncodingInfo` to use for
-/// materializing the pack op.
-// TODO(ravishankarm): This is currently hard-coded here for convenience. When
-// used in IREE, this will be computed based on the architecture information in
-// `hal.executable.variant`.
-// A real implementation would return tile sizes that depend on at least the
-// `elementType`. Moreover, in a real implementation, the tile sizes would
-// typically also depend on target information. This is demonstrated in
-// iree/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
-static FailureOr<MaterializeEncodingInfo>
-chooseEncodingInfo(IREE::LinalgExt::TensorEncoding encoding,
-                   Type /*elementType*/) {
-  switch (encoding) {
-  case TensorEncoding::GEMM_LHS:
-    return MaterializeEncodingInfo{{0, 1}, {8, 4}, {}};
-    break;
-  case TensorEncoding::GEMM_RHS:
-    return MaterializeEncodingInfo{{0, 1}, {4, 8}, {}};
-    break;
-  case TensorEncoding::GEMM_RESULT:
-    return MaterializeEncodingInfo{{0, 1}, {8, 8}, {}};
-    break;
-  case TensorEncoding::GEMM_RHS_TRANSPOSE:
-    return MaterializeEncodingInfo{{1, 0}, {8, 4}, {1, 0}};
-    break;
-  default:
-    return failure();
-  }
-}
-
-//===---------------------------------------------------------------------===//
 // Utility methods
 //===---------------------------------------------------------------------===//
 
@@ -77,7 +43,7 @@ getMaterializedType(RankedTensorType tensorType,
   if (!encoding)
     return tensorType;
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
-      materializeEncodingFn(encoding.value(), tensorType.getElementType());
+      materializeEncodingFn(tensorType);
   if (failed(materializeEncodingInfo)) {
     return tensorType;
   }
@@ -96,6 +62,44 @@ static SmallVector<OpFoldResult> getAsOpFoldResult(OpBuilder &builder,
                                                    ArrayRef<int64_t> values) {
   return llvm::to_vector(llvm::map_range(
       values, [&](int64_t v) { return getAsOpFoldResult(builder, v); }));
+}
+
+//===---------------------------------------------------------------------===//
+// Methods to convert the encoding to parameters of the Pack operation
+//===---------------------------------------------------------------------===//
+
+/// Given the `encoding` return the `MaterializeEncodingInfo` to use for
+/// materializing the pack op.
+// TODO(ravishankarm): This is currently hard-coded here for convenience. When
+// used in IREE, this will be computed based on the architecture information in
+// `hal.executable.variant`.
+// A real implementation would return tile sizes that depend on at least the
+// `tensorType`'s element type (e.g. different tile sizes for i8 vs f32, because
+// the SIMD instructions may have different shapes).
+// Moreover, in a real implementation, the tile sizes would typically also
+// depend on target information. This is demonstrated in
+// iree/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
+static FailureOr<MaterializeEncodingInfo>
+chooseEncodingInfo(RankedTensorType tensorType) {
+  Optional<TensorEncoding> encoding = getEncoding(tensorType);
+  if (!encoding)
+    return failure();
+  switch (*encoding) {
+  case TensorEncoding::GEMM_LHS:
+    return MaterializeEncodingInfo{{0, 1}, {8, 4}, {}};
+    break;
+  case TensorEncoding::GEMM_RHS:
+    return MaterializeEncodingInfo{{0, 1}, {4, 8}, {}};
+    break;
+  case TensorEncoding::GEMM_RESULT:
+    return MaterializeEncodingInfo{{0, 1}, {8, 8}, {}};
+    break;
+  case TensorEncoding::GEMM_RHS_TRANSPOSE:
+    return MaterializeEncodingInfo{{1, 0}, {8, 4}, {1, 0}};
+    break;
+  default:
+    return failure();
+  }
 }
 
 //===---------------------------------------------------------------------===//
@@ -126,9 +130,9 @@ static FailureOr<PackOp>
 lowerSetEncodingOpToPackOp(RewriterBase &rewriter, SetEncodingOp encodingOp,
                            Value source,
                            MaterializeEncodingFn materializeEncodingFn) {
-  Type elementType = encodingOp.getSourceType().getElementType();
+  RankedTensorType resultType = encodingOp.getResultType();
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
-      materializeEncodingFn(encodingOp.getResultTensorEncoding(), elementType);
+      materializeEncodingFn(resultType);
   if (failed(materializeEncodingInfo)) {
     return rewriter.notifyMatchFailure(encodingOp, "unhandled result encoding");
   }
@@ -142,8 +146,8 @@ lowerSetEncodingOpToPackOp(RewriterBase &rewriter, SetEncodingOp encodingOp,
       PackOp::getResultShape(rewriter, loc, sourceDims, innerTileSizesOfr,
                              materializeEncodingInfo->innerDimsPos,
                              materializeEncodingInfo->outerDimsPerm);
-  auto initTensor =
-      rewriter.create<tensor::EmptyOp>(loc, resultDims, elementType);
+  auto initTensor = rewriter.create<tensor::EmptyOp>(
+      loc, resultDims, resultType.getElementType());
   Optional<Value> paddingValue = getPaddingValue(source);
   return rewriter.create<PackOp>(
       loc, source, initTensor, materializeEncodingInfo->innerDimsPos,
@@ -157,9 +161,9 @@ static FailureOr<UnPackOp>
 lowerUnsetEncodingToUnpackOp(RewriterBase &rewriter, UnsetEncodingOp encodingOp,
                              Value packedValue,
                              MaterializeEncodingFn materializeEncodingFn) {
-  Type elementType = encodingOp.getResultType().getElementType();
+  RankedTensorType sourceType = encodingOp.getSourceType();
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
-      materializeEncodingFn(encodingOp.getSourceTensorEncoding(), elementType);
+      materializeEncodingFn(sourceType);
   if (failed(materializeEncodingInfo)) {
     return rewriter.notifyMatchFailure(encodingOp, "unhandled source encoding");
   }
@@ -167,8 +171,8 @@ lowerUnsetEncodingToUnpackOp(RewriterBase &rewriter, UnsetEncodingOp encodingOp,
   Location loc = encodingOp.getLoc();
   SmallVector<OpFoldResult> resultDims =
       getDims(rewriter, loc, encodingOp.getSource());
-  auto initTensor =
-      rewriter.create<tensor::EmptyOp>(loc, resultDims, elementType);
+  auto initTensor = rewriter.create<tensor::EmptyOp>(
+      loc, resultDims, sourceType.getElementType());
 
   SmallVector<OpFoldResult> innerTileSizesOfr =
       getAsOpFoldResult(rewriter, materializeEncodingInfo->innerTileSizes);
@@ -232,14 +236,8 @@ lowerOpWithEncoding(RewriterBase &rewriter, tensor::EmptyOp emptyOp,
                     ValueRange convertedOperands,
                     MaterializeEncodingFn materializeEncodingFn) {
   auto resultType = emptyOp.getResult().getType().cast<RankedTensorType>();
-  Type elementType = resultType.getElementType();
-  Optional<TensorEncoding> encoding = getEncoding(resultType);
-  if (!encoding) {
-    return rewriter.notifyMatchFailure(emptyOp,
-                                       "result type does not have encoding");
-  }
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
-      materializeEncodingFn(encoding.value(), elementType);
+      materializeEncodingFn(resultType);
   if (failed(materializeEncodingInfo)) {
     return rewriter.notifyMatchFailure(
         emptyOp, "failed to find materialization info for result type");


### PR DESCRIPTION
In #11290 I assumed that the element type was the only part of the shaped type that the EncodingInfo would need to depend on, but I was forgetting that in certain narrow-shape cases, the narrow dimension values are actually relevant. The idea is that we can avoid padding a very narrow matrix to the kernel tile size, by adjusting the kernel tile size accordingly. The prime example is in matrix-times-vector products: we don't want to turn the vector into a matrix of width say 8 just because that's the width of our matrix-times-matrix kernel. The existing matmul-to-mmt4d pass has code for this, generating narrow kernel tile shapes, here, Compare `m0k0n0`, `m0k0n0ForMatVec`, `m0k0n0ForWhenRhsHas2Columns`: https://github.com/iree-org/iree/blob/7723971eb7ecabfe8cda394de1e474e23b89a38c/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgMatmulToMmt4D.cpp#L322-L391 . 