### PR TITLE
Add lib/ directory to dist tarball.

### DIFF
--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -170,9 +170,19 @@ function(iree_cc_binary)
       if(APPLE)
         set(_origin_prefix "@loader_path")
       endif()
+      # See: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+      # Assume relative path as a sibling of the lib dir.
+      set(_install_rpath "${_origin_prefix}:${_origin_prefix}/../${CMAKE_INSTALL_LIBDIR}")
+      if(CMAKE_INSTALL_LIBDIR)
+        cmake_path(IS_ABSOLUTE CMAKE_INSTALL_LIBDIR _is_abs_libdir)
+        if(_is_abs_libdir)
+          # Use the libdir verbatim.
+          set(_install_rpath "${_origin_prefix}:${CMAKE_INSTALL_LIBDIR}")
+        endif()
+      endif()
       set_target_properties(${_NAME} PROPERTIES
         BUILD_WITH_INSTALL_RPATH OFF
-        INSTALL_RPATH "${_origin_prefix}:${_origin_prefix}/../lib"
+        INSTALL_RPATH "${_install_rpath}"
       )
     endif()
   endif()

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -172,12 +172,16 @@ function(iree_cc_binary)
       endif()
       # See: https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
       # Assume relative path as a sibling of the lib dir.
-      set(_install_rpath "${_origin_prefix}:${_origin_prefix}/../${CMAKE_INSTALL_LIBDIR}")
-      if(CMAKE_INSTALL_LIBDIR)
-        cmake_path(IS_ABSOLUTE CMAKE_INSTALL_LIBDIR _is_abs_libdir)
+      set(_lib_dir "${CMAKE_INSTALL_LIBDIR}")
+      if (NOT _lib_dir)
+        set(_lib_dir "lib")
+      endif()
+      set(_install_rpath "${_origin_prefix}:${_origin_prefix}/../${_lib_dir}")
+      if(_lib_dir)
+        cmake_path(IS_ABSOLUTE _lib_dir _is_abs_libdir)
         if(_is_abs_libdir)
           # Use the libdir verbatim.
-          set(_install_rpath "${_origin_prefix}:${CMAKE_INSTALL_LIBDIR}")
+          set(_install_rpath "${_origin_prefix}:${_lib_dir}")
         endif()
       endif()
       set_target_properties(${_NAME} PROPERTIES

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -164,6 +164,7 @@ def build_main_dist():
   print("*** Packaging ***")
   dist_entries = [
       "bin",
+      "lib",
       "tests",
   ]
   dist_archive = os.path.join(

--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -137,18 +137,22 @@ def build_main_dist():
 
   # CMake configure.
   print("*** Configuring ***")
-  subprocess.run([
-      sys.executable,
-      CMAKE_CI_SCRIPT,
-      f"-B{BUILD_DIR}",
-      "--log-level=VERBOSE",
-      f"-DCMAKE_INSTALL_PREFIX={INSTALL_DIR}",
-      f"-DCMAKE_BUILD_TYPE=Release",
-      f"-DIREE_BUILD_COMPILER=ON",
-      f"-DIREE_BUILD_PYTHON_BINDINGS=OFF",
-      f"-DIREE_BUILD_SAMPLES=OFF",
-  ] + extra_cmake_flags,
-                 check=True)
+  subprocess.run(
+      [
+          sys.executable,
+          CMAKE_CI_SCRIPT,
+          f"-B{BUILD_DIR}",
+          "--log-level=VERBOSE",
+          f"-DCMAKE_INSTALL_PREFIX={INSTALL_DIR}",
+          # On some distributions, this will install to lib64. We would like
+          # consistency in built packages, so hard-code it.
+          "-DCMAKE_INSTALL_LIBDIR=lib",
+          f"-DCMAKE_BUILD_TYPE=Release",
+          f"-DIREE_BUILD_COMPILER=ON",
+          f"-DIREE_BUILD_PYTHON_BINDINGS=OFF",
+          f"-DIREE_BUILD_SAMPLES=OFF",
+      ] + extra_cmake_flags,
+      check=True)
 
   print("*** Building ***")
   subprocess.run([


### PR DESCRIPTION
* Explicitly configures distribution to build lib/ directory (some OS's will default this to lib64 and we like consistency)
* Adapt install rpath logic to account for CMAKE_INSTALL_LIBDIR