### PR TITLE
[DONOTMERGETOMAIN] Add a flag to disable tensor fusion in flow

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -99,6 +99,11 @@ static llvm::cl::opt<bool> clEnableDataTiling(
     "iree-flow-enable-data-tiling", llvm::cl::desc("Enable data tiling path"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clDisableFusionOfTensorOps(
+    "iree-disable-fusion-of-tensor-ops",
+    llvm::cl::desc("Disable fusion of tensor operations pass"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<std::string> clMmt4dTargetOptions(
     "iree-flow-mmt4d-target-options",
     llvm::cl::desc("Convert linalg.matmul ops to MMT4D ops targetting the "
@@ -249,9 +254,11 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass)
       // Elementwise fusion.
-      .addPass([]() {
-        return createFusionOfTensorOpsPass(clEnableAggressiveFusion);
-      })
+      .addPredicatedPass(
+          !clDisableFusionOfTensorOps,
+          []() {
+            return createFusionOfTensorOpsPass(clEnableAggressiveFusion);
+          })
       .addPredicatedPass(clEnableLinalgDetensorize,
                          mlir::createLinalgDetensorizePass)
       .addPass(mlir::createCanonicalizerPass)


### PR DESCRIPTION
This fusion interferes with further work on detecting and implementing fusion of elementwise operations in the transform dialect-driven codegen.