### PR TITLE
Add strategy+test for reduction(elementwise)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -496,6 +496,13 @@ struct ElementTypeBitWidth : public SingleValuePredicateParam<size_t> {
 /// Predicate tag indicating that the affine map is a permutation.
 struct IsPermutation {};
 
+/// Indicates that the match is optional. The matcher is still expected to run
+/// and capture if successful. The parameter can be set to false
+struct OptionalMatch : public SingleValuePredicateParam<bool> {
+  OptionalMatch() : Base(true) {}
+  explicit OptionalMatch(bool set) : Base(set) {}
+};
+
 /// Predicate tag indicating that the reduction is produced by a single combiner
 /// operation.
 struct SingleCombinerReduction {};
@@ -550,9 +557,9 @@ class StructuredOpMatcher {
 
   /// Adds a predicate checking that the given iteration space dimension is
   /// static/dynamic. The dimension index may be negative, in which case
-  /// dimensions are counted from the last one Python-style, or be an AllDims
-  /// tag, in which case all dimensions are checked. This may be eventually
-  /// extended to slices and/or lists of dimensions.
+  /// dimensions are counted from the last one (i.e. Python-style), or be an
+  /// AllDims tag, in which case all dimensions are checked. This may be
+  /// eventually extended to slices and/or lists of dimensions.
   StructuredOpMatcher &dim(int64_t dimension, ShapeKind kind) {
     predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
       SmallVector<int64_t> shape = linalgOp.getStaticLoopRanges();
@@ -577,8 +584,8 @@ class StructuredOpMatcher {
   /// Adds a predicate checking that the given iteration space dimension has the
   /// given iterator type, e.g., parallel or reduction. The dimension index may
   /// be negative, in which case dimensions are counted from the last one
-  /// Python-style, or be an AllDims tag, in which case all dimensions are
-  /// checked. This may be eventually extended to slices and/or lists of
+  /// (i.e. Python-style), or be an AllDims tag, in which case all dimensions
+  /// are checked. This may be eventually extended to slices and/or lists of
   /// dimensions.
   StructuredOpMatcher &dim(int64_t dimension, utils::IteratorType kind) {
     predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
@@ -606,7 +613,7 @@ class StructuredOpMatcher {
   /// Adds a predicate checking that the given iteration space dimension is
   /// statically known to be divisible by the given value. The dimension index
   /// may be negative, in which case dimensions are counted from the last one
-  /// Python-style.
+  /// (i.e. Python-style).
   StructuredOpMatcher &dim(int64_t dimension, DivisibleBy divisibleBy) {
     predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
       unsigned rank = linalgOp.getNumLoops();
@@ -632,15 +639,18 @@ class StructuredOpMatcher {
   /// Adds a predicate that recursively applies other predicates to the
   /// operation defining the `position`-th operand. The position may be
   /// negative, in which case positions are counted from the last one
-  /// Python-style.
+  /// (i.e. Python-style). When the match is optional, the predicate check
+  /// succeeds as long as the `position` is in bounds. The matcher is executed
+  /// if there is a defining operation for the input operand.
   template <typename T>
   std::enable_if_t<
       llvm::is_detected<::mlir::detail::has_operation_or_value_matcher_t, T,
                         Operation *>::value,
       StructuredOpMatcher &>
-  input(int64_t position, T &operandMatcher) {
-    predicates.push_back([position,
-                          &operandMatcher](linalg::LinalgOp linalgOp) -> bool {
+  input(int64_t position, T &operandMatcher,
+        OptionalMatch optional = OptionalMatch(false)) {
+    predicates.push_back([position, &operandMatcher,
+                          optional](linalg::LinalgOp linalgOp) -> bool {
       int64_t transformedPosition =
           position >= 0 ? position : linalgOp.getNumDpsInputs() + position;
       if (transformedPosition >= linalgOp.getNumDpsInputs()) return false;
@@ -648,8 +658,11 @@ class StructuredOpMatcher {
       Operation *definingOp = linalgOp.getDpsInputOperand(transformedPosition)
                                   ->get()
                                   .getDefiningOp();
-      if (!definingOp) return false;
-      return operandMatcher.match(definingOp);
+      if (!definingOp) return optional.value;
+      // We MUST run the matcher at this point, even if the match is optional,
+      // to allow for capture.
+      if (operandMatcher.match(definingOp)) return true;
+      return optional.value;
     });
     return *this;
   }
@@ -726,14 +739,17 @@ class StructuredOpMatcher {
   /// Adds a predicate that recursively applies other predicates to the
   /// operation defining the init/out operand corresponding to `position`-th
   /// output. The position may be negative, in which case positions are counted
-  /// from the last one Python-style.
+  /// from the last one (i.e. Python-style). When the match is optional, the
+  /// predicate check succeeds as long as the `position` is in bounds. The
+  /// matcher executed if there is a defining operation for the output operand.
   template <typename T>
   std::enable_if_t<
       llvm::is_detected<::mlir::detail::has_operation_or_value_matcher_t, T,
                         Operation *>::value,
       StructuredOpMatcher &>
-  output(int64_t position, T &operandMatcher) {
-    predicates.push_back([position,
+  output(int64_t position, T &operandMatcher,
+         OptionalMatch optional = OptionalMatch(false)) {
+    predicates.push_back([position, optional,
                           &operandMatcher](linalg::LinalgOp linalgOp) -> bool {
       int64_t transformedPosition =
           position >= 0 ? position : linalgOp.getNumDpsInits() + position;
@@ -742,30 +758,41 @@ class StructuredOpMatcher {
       Operation *definingOp = linalgOp.getDpsInitOperand(transformedPosition)
                                   ->get()
                                   .getDefiningOp();
-      if (!definingOp) return false;
-      return operandMatcher.match(definingOp);
+      if (!definingOp) return optional.value;
+      // We MUST run the matcher at this point, even if the match is optional,
+      // to allow for capture.
+      if (operandMatcher.match(definingOp)) return true;
+      return optional.value;
     });
     return *this;
   }
 
   /// Adds a predicate that recursively applies to users of the `position`-th
   /// result of the structured op. Succeeds if any user matches the predicate.
+  /// When the match is optional, the predicate check succeeds as long as the
+  /// `position` is in bounds, after running the given matcher.
   template <typename T>
   std::enable_if_t<
       llvm::is_detected<::mlir::detail::has_operation_or_value_matcher_t, T,
                         Operation *>::value,
       StructuredOpMatcher &>
-  result(int64_t position, HasAnyUse tag, T &resultUserMatcher) {
-    predicates.push_back([&resultUserMatcher,
+  result(int64_t position, HasAnyUse tag, T &resultUserMatcher,
+         OptionalMatch optional = OptionalMatch(false)) {
+    predicates.push_back([&resultUserMatcher, optional,
                           position](linalg::LinalgOp linalgOp) -> bool {
       int64_t transformedPosition =
           position >= 0 ? position : linalgOp->getNumResults() + position;
       if (transformedPosition >= linalgOp->getNumResults()) return false;
 
-      return llvm::any_of(linalgOp->getResult(transformedPosition).getUsers(),
-                          [&resultUserMatcher](Operation *op) {
-                            return resultUserMatcher.match(op);
-                          });
+      // We MUST run the matcher at this point, even if the match is optional,
+      // to allow for capture.
+      if (llvm::any_of(linalgOp->getResult(transformedPosition).getUsers(),
+                       [&resultUserMatcher](Operation *op) {
+                         return resultUserMatcher.match(op);
+                       })) {
+        return true;
+      }
+      return optional.value;
     });
     return *this;
   }
@@ -788,49 +815,6 @@ StructuredOpMatcher m_StructuredOp() {
   return StructuredOpMatcher::create<OpType...>();
 }
 
-class OptionalStructuredOpMatcher;
-OptionalStructuredOpMatcher m_OptionalStructuredOp(
-    StructuredOpMatcher &&nested);
-
-/// A wrapper around a structured op matcher that injects optionality. The
-/// wrapped predicates will get applied for capturing purposes, but the `match`
-/// of this class will always succeed to allow the matching to continue. One can
-/// check if the wrapped match actually succeeded by checking if the operation
-/// was captured.
-class OptionalStructuredOpMatcher {
-  friend OptionalStructuredOpMatcher m_OptionalStructuredOp(
-      StructuredOpMatcher &&nested);
-  explicit OptionalStructuredOpMatcher(StructuredOpMatcher &&nested)
-      : nested(nested) {}
-
- public:
-  /// Returns true if the wrapped matcher succeeded as indicated by the capture.
-  bool succeeded() const { return nested.getCaptured(); }
-
-  /// Runs the wrapped matcher and returns true regardless of its result.
-  bool match(Operation *op) {
-    (void)nested.match(op);
-    return true;
-  }
-
- private:
-  /// Actual structured matcher.
-  StructuredOpMatcher nested;
-};
-
-/// Makes the given structured op matcher optional.
-OptionalStructuredOpMatcher m_OptionalStructuredOp(
-    StructuredOpMatcher &&nested) {
-  return OptionalStructuredOpMatcher(std::move(nested));
-}
-
-/// Creates an optional matcher for ops with the kinds provided as template
-/// arguments.
-template <typename... OpType>
-OptionalStructuredOpMatcher m_OptionalStructuredOp() {
-  return m_OptionalStructuredOp(m_StructuredOp<OpType...>());
-}
-
 }  // namespace
 
 static constexpr unsigned cudaWarpSize = 32;
@@ -846,9 +830,6 @@ static bool matchGPUReduction(linalg::LinalgOp op,
                              .input(NumEqualsTo(1))
                              .output(NumEqualsTo(1));
   auto leadingEltwise = trailingEltwise;
-  auto maybeTrailingEltwise =
-      m_OptionalStructuredOp(std::move(trailingEltwise));
-  auto maybeLeadingEltwise = m_OptionalStructuredOp(std::move(leadingEltwise));
   auto pattern = m_StructuredOp()
                      .dim(AllDims(), ShapeKind::Static)
                      .dim(-1, utils::IteratorType::reduction)
@@ -856,18 +837,18 @@ static bool matchGPUReduction(linalg::LinalgOp op,
                      // Can be extended to projected permutation with broadcast.
                      .input(AllOperands(), IsPermutation())
                      // TODO: we want to accept any input position here.
-                     .input(0, maybeLeadingEltwise)
+                     .input(0, leadingEltwise, OptionalMatch())
                      .output(NumEqualsTo(1))
                      .output(0, fill)
                      // Only single combiner over 32 bits for now due to
                      // reduction distribution.
                      .output(0, ElementTypeBitWidth(32))
                      .output(0, SingleCombinerReduction())
-                     .result(0, HasAnyUse(), maybeTrailingEltwise);
+                     .result(0, HasAnyUse(), trailingEltwise, OptionalMatch());
   if (!matchPattern(op, pattern)) return false;
 
-  info.hasLeadingEltwise = maybeLeadingEltwise.succeeded();
-  info.hasTrailingEltwise = maybeTrailingEltwise.succeeded();
+  info.hasLeadingEltwise = leadingEltwise.getCaptured() != nullptr;
+  info.hasTrailingEltwise = trailingEltwise.getCaptured() != nullptr;
 
   // Hardcoded workagroup size, this could be deduced from the reduction dim.
   info.workgroupSize = {32, 2, 1};

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -204,6 +204,10 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
   if (getSwappingPatterns())
     addSwappingPatterns(patterns, getSwapPaddingElideConditional());
   if (getAdditionalIreePatterns()) addAdditionalIreePatterns(patterns);
+  if (getBubbleCollapseExpand()) {
+    linalg::populateFoldReshapeOpsByExpansionPatterns(
+        patterns, [](OpOperand *) { return true; });
+  }
 
   TrackingListener listener(state);
   GreedyRewriteConfig config;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -33,6 +33,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
     unspecified order:
       - additional_iree_patterns: fancy patterns we shortcut into the system,
       will need to be sliced out better in the future.
+      - bubble_collapse_expand: bubble `expand_shape` up and `collapse_shape`
+      down across Linalg ops.
       - canonicalization: adds all the canonicalization patterns of all
       registered dialects and ops.
       - promote_foreach_thread_capture_to_shared: adds patterns that rewrite
@@ -74,7 +76,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
                        UnitAttr:$rank_reducing,
                        UnitAttr:$simplify_memref_metadata,
                        UnitAttr:$swap_padding_elide_conditional,
-                       UnitAttr:$swapping_patterns);
+                       UnitAttr:$swapping_patterns,
+                       UnitAttr:$bubble_collapse_expand);
   let results = (outs PDL_Operation:$result);
 
   let assemblyFormat = "$target attr-dict";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -99,6 +99,11 @@ static llvm::cl::opt<bool> clEnableDataTiling(
     "iree-flow-enable-data-tiling", llvm::cl::desc("Enable data tiling path"),
     llvm::cl::init(false));
 
+static llvm::cl::opt<bool> clDisableFusionOfTensorOps(
+    "iree-disable-fusion-of-tensor-ops",
+    llvm::cl::desc("Disable fusion of tensor operations pass"),
+    llvm::cl::init(false));
+
 static llvm::cl::opt<std::string> clMmt4dTargetOptions(
     "iree-flow-mmt4d-target-options",
     llvm::cl::desc("Convert linalg.matmul ops to MMT4D ops targetting the "
@@ -249,9 +254,11 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass)
       // Elementwise fusion.
-      .addPass([]() {
-        return createFusionOfTensorOpsPass(clEnableAggressiveFusion);
-      })
+      .addPredicatedPass(
+          !clDisableFusionOfTensorOps,
+          []() {
+            return createFusionOfTensorOpsPass(clEnableAggressiveFusion);
+          })
       .addPredicatedPass(clEnableLinalgDetensorize,
                          mlir::createLinalgDetensorizePass)
       .addPass(mlir::createCanonicalizerPass)

--- a/tests/transform_dialect/cuda/eltwise_reduction.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction.mlir
@@ -1,0 +1,124 @@
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
+  %2 = tensor.empty() : !in_tensor_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : !in_tensor_t) outs(%2 : !in_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = arith.addf %arg3, %arg3 : f32
+      %5 = arith.addf %4, %4 : f32
+      linalg.yield %5 : f32
+    } -> !in_tensor_t
+
+  %6 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%3 : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  return %6 : !out_tensor_t
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline \
+// RUN:       --iree-disable-fusion-of-tensor-ops=true \
+// RUN:       --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: FileCheck %s --check-prefix=DISPATCH
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline \
+// RUN:       --iree-disable-fusion-of-tensor-ops=true \
+// RUN:       --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' 
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/%S_codegen_spec.mlir | \
+// RUN: FileCheck %s
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline \
+// RUN:       --iree-disable-fusion-of-tensor-ops=true \
+// RUN:       --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' 
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: FileCheck %s
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-disable-fusion-of-tensor-ops=true \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/%S_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="8x64xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-disable-fusion-of-tensor-ops=true \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="8x64xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+// Check that both generics ended up in the same region.
+// DISPATCH:     hal.executable.variant
+// DISPATCH:     linalg.fill
+// DISPATCH-NOT: hal.executable.variant
+// DISPATCH:     linalg.generic
+// DISPATCH-NOT: hal.executable.variant
+// DISPATCH:     linalg.generic
+
+//     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+//     CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+//     CHECK-DAG: %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
+//     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+//     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 128 : i64} : memref<1x2xf32, 3>
+//     CHECK-DAG: %[[TIDX:.]] = gpu.thread_id  x
+//     CHECK-DAG: %[[TIDY:.]] = gpu.thread_id  y
+//     CHECK-DAG: %[[TIDZ:.]] = gpu.thread_id  z
+
+//         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+
+// Distributed reduction: everyone loads, does the elementwise then 5 xor + addf expected
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+//         CHECK: arith.addf
+//         CHECK: arith.addf
+// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+//         CHECK: %[[RES:.*]] = arith.addf %{{.*}}
+
+//         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+//         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+//         CHECK: scf.if %[[CONDXIS0]]
+//         CHECK:   vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
+//         CHECK: gpu.barrier
+
+// Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
+//         CHECK: %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
+//          TODO: cond eq 0 and cond ult 1 do not CSE atm.
+//         CHECK: %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
+//         CHECK: scf.if %[[CONXANDYARE0]] {
+//         CHECK:   vector.transfer_read
+//         CHECK:   vector.reduction <add>
+//         CHECK:   vector.transfer_write
+//         CHECK: gpu.barrier
+//         CHECK: memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
+
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 8xf32=256 256 256 256 256 256 256 256

--- a/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
@@ -1,0 +1,82 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(suppress) {
+^bb1(%variant_op: !pdl.operation):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+
+  // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
+  // ===========================================================================
+  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op
+  %eltwise, %reduction = transform.split_handles %0 in [2] : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
+    transform.structured.split_reduction %reduction
+      { split_factor = 2, insert_split_dimension = 1 }
+
+  // Step 2. First level of tiling + fusion parallelizes to blocks.
+  // ===========================================================================
+  %foreach_thread_grid, %grid_combiner_op =
+    transform.structured.tile_to_foreach_thread_op %combiner_op tile_sizes [1]
+      ( mapping = [#gpu.block<x>] )
+
+  // Step 2.1: Cannot fuse across the "expand_shape" produced by reduction
+  // splitting above, so we need to bubble that up via patterns and rematch
+  // the entire structure.
+  // TODO: bubbling should be a proper transform op, at which point we will be
+  // able to preserve the handles.
+  // ===========================================================================
+  %func = transform.structured.match ops{["func.func"]} in %variant_op
+  transform.iree.apply_patterns %func { bubble_collapse_expand }
+  %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op
+  %fill_2, %more_parallel_fill_2 = transform.split_handles %fills in [2]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op
+  %expanded_eltwise, %more_parallel_2, %combiner_2 =
+    transform.split_handles %generics in [3] : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+  %foreach_thread_grid_2 = transform.structured.match ops{["scf.foreach_thread"]} in %variant_op
+  %not_combiner = transform.merge_handles %fill_2, %more_parallel_fill_2, %more_parallel_2, %expanded_eltwise : !pdl.operation
+  transform.structured.fuse_into_containing_op %not_combiner into %foreach_thread_grid_2
+
+  // Step 3. Second level of tiling + fusion parallelizes to threads. Also
+  // fuse in the leading elementwise.
+  // ===========================================================================
+  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
+  %foreach_thread_block_combiner_op, %block_combiner_op =
+    transform.structured.tile_to_foreach_thread_op %combiner_2 tile_sizes [1] 
+    ( mapping = [#gpu.thread<z>] )
+  transform.structured.fuse_into_containing_op %fill_1d into %foreach_thread_block_combiner_op
+
+  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
+  %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
+  %grid_eltwise_op = transform.structured.match ops{["linalg.generic"]}
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]} in %variant_op
+  %foreach_thread_block_more_parallel_op, %block_more_parallel_op =
+    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1] 
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
+  transform.structured.fuse_into_containing_op %fill_2d into %foreach_thread_block_more_parallel_op
+  transform.structured.fuse_into_containing_op %grid_eltwise_op into %foreach_thread_block_more_parallel_op
+
+  // Step 4. Rank-reduce and vectorize.
+  // ===========================================================================
+  %func_1 = transform.structured.match ops{["func.func"]} in %variant_op
+  %func_2 = transform.iree.apply_patterns %func_1 { rank_reducing }
+  %func_3 = transform.structured.vectorize %func_2
+
+  // Step 5. Bufferize.
+  // ===========================================================================
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+
+  // Step 6. Post-bufferization mapping to blocks and threads.
+  // ===========================================================================
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
+  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
+      { workgroup_size = [32, 2, 1] }
+
+  // Step 7. Post-bufferization vector distribution with rank-reduction.
+  // ===========================================================================
+  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  transform.iree.vector.warp_distribute %func_7
+}

--- a/tests/transform_dialect/cuda/eltwise_reduction_dispatch_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_dispatch_spec.mlir
@@ -1,0 +1,13 @@
+// RUN: iree-opt %s
+
+// Dispatch elementwise followed by fusion into the same region.
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb1(%variant_op: !pdl.operation):
+  %ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]} in %variant_op
+  %fill, %eltwise, %reduction = transform.split_handles %ops in [3]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+  %region_op1 = transform.iree.wrap_in_dispatch_region %reduction
+  %others = transform.merge_handles %fill, %eltwise : !pdl.operation
+  %region_op2 = transform.iree.move_preceding_op_into_dispatch_region %others into %region_op1
+  transform.iree.region_to_workgroups %region_op2
+}

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise.mlir
@@ -1,0 +1,139 @@
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
+  %2 = tensor.empty() : !in_tensor_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : !in_tensor_t) outs(%2 : !in_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = arith.addf %arg3, %arg3 : f32
+      %5 = arith.addf %4, %4 : f32
+      linalg.yield %5 : f32
+    } -> !in_tensor_t
+
+  %6 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%3 : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  %7 = tensor.empty() : !out_tensor_t
+  %8 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%6 : !out_tensor_t) outs(%7 : !out_tensor_t) {  
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = math.sqrt %arg3 : f32
+      linalg.yield %4 : f32
+    } -> !out_tensor_t
+
+
+  return %8 : !out_tensor_t
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline \
+// RUN:       --iree-disable-fusion-of-tensor-ops=true \
+// RUN:       --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: FileCheck %s --check-prefix=DISPATCH
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline \
+// RUN:       --iree-disable-fusion-of-tensor-ops=true \
+// RUN:       --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' 
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/%S_codegen_spec.mlir | \
+// RUN: FileCheck %s
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline \
+// RUN:       --iree-disable-fusion-of-tensor-ops=true \
+// RUN:       --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' 
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: FileCheck %s
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-disable-fusion-of-tensor-ops=true \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/%S_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="8x64xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-disable-fusion-of-tensor-ops=true \
+// RUN:     --iree-flow-dispatch-use-transform-dialect=%p/%S_dispatch_spec.mlir \
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="8x64xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+// Check that all generics ended up in the same region.
+// DISPATCH:     hal.executable.variant
+// DISPATCH:     linalg.fill
+// DISPATCH-NOT: hal.executable.variant
+// DISPATCH:     linalg.generic
+// DISPATCH-NOT: hal.executable.variant
+// DISPATCH:     linalg.generic
+// DISPATCH-NOT: hal.executable.variant
+// DISPATCH:     linalg.generic
+
+//     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+//     CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+//     CHECK-DAG: %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
+//     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+//     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 128 : i64} : memref<1x2xf32, 3>
+//     CHECK-DAG: %[[TIDX:.]] = gpu.thread_id  x
+//     CHECK-DAG: %[[TIDY:.]] = gpu.thread_id  y
+//     CHECK-DAG: %[[TIDZ:.]] = gpu.thread_id  z
+
+//         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+
+// Distributed reduction: everyone loads, does the elementwise then 5 xor + addf expected
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+//         CHECK: arith.addf
+//         CHECK: arith.addf
+// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+//         CHECK: %[[RES:.*]] = arith.addf %{{.*}}
+
+//         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+//         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+//         CHECK: scf.if %[[CONDXIS0]]
+//         CHECK:   vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
+//         CHECK: gpu.barrier
+
+// Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
+//         CHECK: %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
+//          TODO: cond eq 0 and cond ult 1 do not CSE atm.
+//         CHECK: %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
+//         CHECK: scf.if %[[CONXANDYARE0]] {
+//         CHECK:   vector.transfer_read
+//         CHECK:   vector.reduction <add>
+//         CHECK:   math.sqrt
+//         CHECK:   vector.transfer_write
+//         CHECK: gpu.barrier
+//         CHECK: memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
+
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 8xf32=16 16 16 16 16 16 16 16

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
@@ -1,0 +1,89 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(suppress) {
+^bb1(%variant_op: !pdl.operation):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+
+  // Step 1. Split the reduction to get meatier (size(red) / 2)-way parallelism.
+  // ===========================================================================
+  %0 = transform.structured.match ops{["linalg.generic"]} in %variant_op
+  %leading_eltwise, %reduction, %trailing_eltwise = transform.split_handles %0 in [3]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation)
+  %init_or_alloc_op, %more_parallel_fill_op, %more_parallel_op, %combiner_op =
+    transform.structured.split_reduction %reduction
+      { split_factor = 2, insert_split_dimension = 1 }
+
+  // Step 2. First level of tiling + fusion parallelizes to blocks. Tile the
+  // trailing elementwise the same way we want to tile the reduction.
+  // ===========================================================================
+  %grid_loop, %trailing_eltwise_grid_op =
+    transform.structured.tile_to_foreach_thread_op %trailing_eltwise tile_sizes [1]
+      ( mapping = [#gpu.block<x>] )
+
+  // Step 2.1: Cannot fuse across the "expand_shape" produced by reduction
+  // splitting above, so we need to bubble that up via patterns and rematch
+  // the entire structure.
+  // TODO: bubbling should be a proper transform op, at which point we will be
+  // able to preserve the handles.
+  // ===========================================================================
+  %func = transform.structured.match ops{["func.func"]} in %variant_op
+  transform.iree.apply_patterns %func { bubble_collapse_expand }
+  %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op
+  %fill_2, %more_parallel_fill_2 = transform.split_handles %fills in [2]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %generics = transform.structured.match ops{["linalg.generic"]} in %variant_op
+  %expanded_eltwise, %more_parallel_2, %combiner_2, %trailing_eltwise_2 =
+    transform.split_handles %generics in [4]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+  %foreach_thread_grid_2 = transform.structured.match ops{["scf.foreach_thread"]} in %variant_op
+  %not_trailing = transform.merge_handles %fill_2, %more_parallel_fill_2,
+    %more_parallel_2, %expanded_eltwise, %combiner_2 : !pdl.operation
+  transform.structured.fuse_into_containing_op %not_trailing into %foreach_thread_grid_2
+
+  // Step 3. Second level of tiling + fusion parallelizes to threads. Also
+  // fuse in the leading and trailing elementwise.
+  // ===========================================================================
+  %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
+  %foreach_thread_trailing_eltwise_op, %block_trailing_eltwise_op =
+    transform.structured.tile_to_foreach_thread_op %trailing_eltwise_2 tile_sizes [1] 
+    ( mapping = [#gpu.thread<z>] )
+  %block_combiner_op = transform.structured.match ops{["linalg.generic"]}
+    attributes {iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
+  %fill_and_reduction = transform.merge_handles %fill_1d, %block_combiner_op : !pdl.operation
+  transform.structured.fuse_into_containing_op %fill_and_reduction into %foreach_thread_trailing_eltwise_op
+
+  %fill_2d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1x2xf32> in %variant_op
+  %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
+  %grid_eltwise_op = transform.structured.match ops{["linalg.generic"]}
+    attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>]} in %variant_op
+  %foreach_thread_block_more_parallel_op, %block_more_parallel_op =
+    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1] 
+    ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
+  transform.structured.fuse_into_containing_op %fill_2d into %foreach_thread_block_more_parallel_op
+  transform.structured.fuse_into_containing_op %grid_eltwise_op into %foreach_thread_block_more_parallel_op
+
+  // Step 4. Rank-reduce and vectorize.
+  // ===========================================================================
+  %func_1 = transform.structured.match ops{["func.func"]} in %variant_op
+  %func_2 = transform.iree.apply_patterns %func_1 { rank_reducing }
+  %func_3 = transform.structured.vectorize %func_2
+
+  // Step 5. Bufferize.
+  // ===========================================================================
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+
+  // Step 6. Post-bufferization mapping to blocks and threads.
+  // ===========================================================================
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
+  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
+      { workgroup_size = [32, 2, 1] }
+
+  // Step 7. Post-bufferization vector distribution with rank-reduction.
+  // ===========================================================================
+  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  transform.iree.vector.warp_distribute %func_7
+}

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise_dispatch_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise_dispatch_spec.mlir
@@ -1,0 +1,15 @@
+// RUN: iree-opt %s
+
+// Dispatch elementwise(fusion(elementwise)) into the same region. The elementwise
+// feeding the reduction is automatically fused by IREE, so we disable that fusion
+// and form the dispatch region manually here to avoid that.
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb1(%variant_op: !pdl.operation):
+  %ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]} in %variant_op
+  %fill, %leading_eltwise, %reduction, %trailing_eltwise = transform.split_handles %ops in [4]
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+  %region_op1 = transform.iree.wrap_in_dispatch_region %trailing_eltwise
+  %others = transform.merge_handles %fill, %leading_eltwise, %reduction : !pdl.operation
+  %region_op2 = transform.iree.move_preceding_op_into_dispatch_region %others into %region_op1
+  transform.iree.region_to_workgroups %region_op2
+}


### PR DESCRIPTION
Depends on #11314

IREE will automatically fuse the leading elementwise into a reduction,
so we need to instruct it otherwise via the CLI option and to form the
dispatch region manually using another transform dialect snippet.