### PR TITLE
[GPU] Reduce the number of warp shuffles needed for reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/warp_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/warp_reduction.mlir
@@ -118,6 +118,7 @@ hal.executable private @simple_reduce_multi_warp  {
 }
 
 // CHECK-LABEL: func.func @simple_reduce_multi_warp() {
+//   CHECK-DAG:   %[[C0I:.*]] = arith.constant 0 : i32
 //   CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //   CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : i32
 //   CHECK-DAG:   %[[C2:.*]] = arith.constant 2 : i32
@@ -125,7 +126,6 @@ hal.executable private @simple_reduce_multi_warp  {
 //   CHECK-DAG:   %[[C8:.*]] = arith.constant 8 : i32
 //   CHECK-DAG:   %[[C16:.*]] = arith.constant 16 : i32
 //   CHECK-DAG:   %[[C32:.*]] = arith.constant 32 : i32
-//   CHECK-DAG:   %[[C2I:.*]] = arith.constant 2 : index
 //   CHECK-DAG:   %[[C32I:.*]] = arith.constant 32 : index
 //   CHECK-DAG:   %[[IDENTITY:.*]] = arith.constant 0.000000e+00 : f32
 //   CHECK-DAG:   %[[TID:.*]] = gpu.thread_id  x
@@ -154,19 +154,10 @@ hal.executable private @simple_reduce_multi_warp  {
 //       CHECK:     }
 //       CHECK:     gpu.barrier
 //       CHECK:     %[[LOAD_VAL:.*]] = memref.load %[[A]][%[[LANE_ID]]] : memref<2xf32, 3>
-//       CHECK:     %[[USE_IDENTITY:.*]] = arith.cmpi sge, %[[LANE_ID]], %[[C2I]] : index
-//       CHECK:     %[[LANE_VAL:.*]] = arith.select %[[USE_IDENTITY]], %[[IDENTITY]], %[[LOAD_VAL]] : f32
-//       CHECK:     %[[S10:.*]], %{{.*}} = gpu.shuffle  xor %[[LANE_VAL]], %[[C1]], %[[C32]] : f32
-//       CHECK:     %[[S11:.*]] = arith.addf %[[LANE_VAL]], %[[S10]] : f32
-//       CHECK:     %[[S12:.*]], %{{.*}} = gpu.shuffle  xor %[[S11]], %[[C2]], %[[C32]] : f32
-//       CHECK:     %[[S13:.*]] = arith.addf %[[S11]], %[[S12]] : f32
-//       CHECK:     %[[S14:.*]], %{{.*}} = gpu.shuffle  xor %[[S13]], %[[C4]], %[[C32]] : f32
-//       CHECK:     %[[S15:.*]] = arith.addf %[[S13]], %[[S14]] : f32
-//       CHECK:     %[[S16:.*]], %{{.*}} = gpu.shuffle  xor %[[S15]], %[[C8]], %[[C32]] : f32
-//       CHECK:     %[[S17:.*]] = arith.addf %[[S15]], %[[S16]] : f32
-//       CHECK:     %[[S18:.*]], %{{.*}} = gpu.shuffle  xor %[[S17]], %[[C16]], %[[C32]] : f32
-//       CHECK:     %[[S19:.*]] = arith.addf %[[S17]], %[[S18]] : f32
-//       CHECK:     %[[S20:.*]] = arith.addf %[[S19]], %[[E]] : f32
+//       CHECK:     %[[S10:.*]], %{{.*}} = gpu.shuffle  xor %[[LOAD_VAL]], %[[C1]], %[[C32]] : f32
+//       CHECK:     %[[S11:.*]] = arith.addf %[[LOAD_VAL]], %[[S10]] : f32
+//       CHECK:     %[[S12:.*]], %{{.*}} = gpu.shuffle  idx %[[S11]], %[[C0I]], %[[C32]] : f32
+//       CHECK:     %[[S20:.*]] = arith.addf %[[S12]], %[[E]] : f32
 //       CHECK:     %[[B:.*]] = vector.broadcast %[[S20]] : f32 to vector<1xf32>
 //       CHECK:     scf.yield %[[B]] : vector<1xf32>
 //       CHECK:   }
@@ -229,3 +220,66 @@ hal.executable private @reduce_then_broadcast  {
 //       CHECK:   }
 //   CHECK-NOT:  scf.if
 //       CHECK:  return
+
+// -----
+
+#executable_target_cuda_nvptx_fb = #hal.executable.target<"cuda", "cuda-nvptx-fb">
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable private @reduce_odd_num_warp  {
+  hal.executable.variant @cuda, target = #executable_target_cuda_nvptx_fb {
+    hal.executable.export @reduce_odd_num_warp layout(#pipeline_layout) attributes {
+      workgroup_size = [96 : index, 1 : index, 1 : index]
+    }
+    builtin.module {
+    func.func @reduce_odd_num_warp() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant dense<0.000000e+00> : vector<1xf32>
+      %cst_0 = arith.constant 0.000000e+00 : f32
+      %c64 = arith.constant 64 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : memref<768xf32>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<1xf32>
+      %6 = vector.transfer_read %0[%c0], %cst_0 {in_bounds = [true]} : memref<768xf32>, vector<768xf32>
+      %7 = vector.broadcast %6 : vector<768xf32> to vector<1x768xf32>
+      %8 = vector.multi_reduction <maxf>, %7, %cst [1] : vector<1x768xf32> to vector<1xf32>
+      vector.transfer_write %8, %1[%c0] {in_bounds = [true]} : vector<1xf32>, memref<1xf32>
+      return
+    }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @reduce_odd_num_warp() {
+//   CHECK-DAG:   %[[C0I:.+]] = arith.constant 0 : i32
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : i32
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : i32
+//   CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
+//   CHECK-DAG:   %[[C32I:.+]] = arith.constant 32 : i32
+//   CHECK-DAG:   %[[C32:.+]] = arith.constant 32 : index
+//   CHECK-DAG:   %[[CF:.+]] = arith.constant 0xFF800000 : f32
+//       CHECK:   %[[ID:.+]] = gpu.thread_id  x
+//       CHECK:   %[[ALLOC:.+]] = memref.alloc() : memref<3xf32, 3>
+//       CHECK:   %[[WARP_ID:.+]] = arith.divui %[[ID]], %[[C32]] : index
+//       CHECK:   %[[LANE_ID:.+]] = arith.remui %[[ID]], %[[C32]] : index
+
+//       CHECK:   gpu.barrier
+//       CHECK:   %[[V:.+]] = memref.load %[[ALLOC]][%[[LANE_ID]]] : memref<3xf32, 3>
+//       CHECK:   %[[C:.+]] = arith.cmpi sge, %[[LANE_ID]], %[[C3]] : index
+//       CHECK:   %[[SEL:.+]] = arith.select %[[C]], %[[CF]], %[[V]] : f32
+//       CHECK:   %[[S0:.+]], %{{.*}} = gpu.shuffle  xor %[[SEL]], %[[C1]], %[[C32I]] : f32
+//       CHECK:   %[[S1:.+]] = arith.maxf %[[SEL]], %[[S0]] : f32
+//       CHECK:   %[[S2:.+]], %{{.*}} = gpu.shuffle  xor %[[S1]], %[[C2]], %[[C32I]] : f32
+//       CHECK:   %[[S3:.+]] = arith.maxf %[[S1]], %[[S2]] : f32
+//       CHECK:   %[[S4:.+]], %{{.*}} = gpu.shuffle  idx %[[S3]], %[[C0I]], %[[C32I]] : f32
+//       CHECK:   %[[S5:.+]] = arith.maxf %[[S4]], %cst_0 : f32
+//       CHECK:   %[[B:.+]] = vector.broadcast %[[S5]] : f32 to vector<1xf32>
+//       CHECK:   %[[LANE0:.+]] = arith.cmpi eq, %[[ID]], %[[C0]] : index
+//       CHECK:   scf.if %[[LANE0]] {
+//       CHECK:     vector.transfer_write %[[B]], %{{.*}}[%[[C0]]] {in_bounds = [true]} : vector<1xf32>, memref<1xf32>
+//       CHECK:   }
+//       CHECK:   return

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_pipeline_test.mlir
@@ -868,8 +868,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f32, 3>
 //         CHECK:     nvvm.barrier0
 //         CHECK:     llvm.load {{.*}} : !llvm.ptr<f32, 3>
-//         CHECK:     llvm.icmp "sge" {{.*}}, {{.*}} : i64
-// CHECK-COUNT-5:     nvvm.shfl.sync  bfly
+// CHECK-COUNT-3:     nvvm.shfl.sync  bfly
 
 // -----
 
@@ -931,8 +930,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} : !llvm.ptr<f32, 3>
 //         CHECK:     nvvm.barrier0
 //         CHECK:     llvm.load {{.*}} : !llvm.ptr<f32, 3>
-//         CHECK:     llvm.icmp "sge" {{.*}}, {{.*}} : i64
-// CHECK-COUNT-5:     nvvm.shfl.sync  bfly
+// CHECK-COUNT-3:     nvvm.shfl.sync  bfly
 //         CHECK:     llvm.fdiv %{{.*}}, %{{.*}}  : vector<4xf32>
 //         CHECK:     llvm.store %{{.*}}, %{{.*}} {alignment = 4 : i64} : !llvm.ptr<vector<4xf32>>
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
@@ -40,6 +40,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 }
 
 //   CHECK-LABEL:  func.func @warp_reduction_dispatch
+//     CHECK-DAG:    %[[C0I:.+]] = arith.constant 0 : i32
 //     CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
 //     CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : i32
 //     CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : i32
@@ -47,7 +48,6 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //     CHECK-DAG:    %[[C8:.+]] = arith.constant 8 : i32
 //     CHECK-DAG:    %[[C16:.+]] = arith.constant 16 : i32
 //     CHECK-DAG:    %[[C32:.+]] = arith.constant 32 : i32
-//     CHECK-DAG:    %[[C16I:.+]] = arith.constant 16 : index
 //     CHECK-DAG:    %[[C32I:.+]] = arith.constant 32 : index
 //     CHECK-DAG:    %[[C2048:.+]] = arith.constant 2048 : index
 //     CHECK-DAG:    %[[C10240:.+]] = arith.constant 10240 : index
@@ -80,19 +80,16 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:    }
 //         CHECK:    gpu.barrier
 //         CHECK:    %[[LOAD_VAL:.+]] = memref.load %[[ALLOC]][%[[LANE_ID]]] : memref<16xf32, 3>
-//         CHECK:    %[[USE_IDENTITY:.+]] = arith.cmpi sge, %[[LANE_ID]], %[[C16I]] : index
-//         CHECK:    %[[LANE_VAL:.+]] = arith.select %[[USE_IDENTITY]], %[[IDENTITY]], %[[LOAD_VAL]] : f32
-//         CHECK:    %[[S5:.+]], %{{.*}} = gpu.shuffle  xor %[[LANE_VAL]], %[[C1]], %[[C32]] : f32
-//         CHECK:    %[[R7:.+]] = arith.addf %[[LANE_VAL]], %[[S5]] : f32
+//         CHECK:    %[[S5:.+]], %{{.*}} = gpu.shuffle  xor %[[LOAD_VAL]], %[[C1]], %[[C32]] : f32
+//         CHECK:    %[[R7:.+]] = arith.addf %[[LOAD_VAL]], %[[S5]] : f32
 //         CHECK:    %[[S6:.+]], %{{.*}} = gpu.shuffle  xor %[[R7]], %[[C2]], %[[C32]] : f32
 //         CHECK:    %[[R8:.+]] = arith.addf %[[R7]], %[[S6]] : f32
 //         CHECK:    %[[S7:.+]], %{{.*}} = gpu.shuffle  xor %[[R8]], %[[C4]], %[[C32]] : f32
 //         CHECK:    %[[R9:.+]] = arith.addf %[[R8]], %[[S7]] : f32
 //         CHECK:    %[[S8:.+]], %{{.*}} = gpu.shuffle  xor %[[R9]], %[[C8]], %[[C32]] : f32
-//         CHECK:    %[[R10:.+]] = arith.addf %[[R9]], %[[S8]] : f32
-//         CHECK:    %[[S9:.+]], %{{.*}} = gpu.shuffle  xor %[[R10]], %[[C16]], %[[C32]] : f32
-//         CHECK:    %[[R11:.+]] = arith.addf %[[R10]], %[[S9]] : f32
-//         CHECK:    %[[R12:.+]] = arith.addf %[[R11]], %[[CF]] : f32
+//         CHECK:    %[[R11:.+]] = arith.addf %[[R9]], %[[S8]] : f32
+//         CHECK:    %[[S9:.+]], %{{.*}} = gpu.shuffle  idx %[[R11]], %[[C0I]], %[[C32]] : f32
+//         CHECK:    %[[R12:.+]] = arith.addf %[[S9]], %[[CF]] : f32
 //         CHECK:    %[[R13:.+]] = vector.broadcast %[[R12]] : f32 to vector<1xf32>
 //         CHECK:    %[[TID0:.+]] = arith.cmpi eq, %[[TID]], %[[C0]] : index
 //         CHECK:    scf.if %[[TID0]] {
@@ -173,10 +170,6 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:    }
 //         CHECK:    gpu.barrier
 //         CHECK:    memref.load
-//         CHECK:    arith.cmpi
-//         CHECK:    arith.select
-//         CHECK:    gpu.shuffle  xor
-//         CHECK:    arith.addf
 //         CHECK:    gpu.shuffle  xor
 //         CHECK:    arith.addf
 //         CHECK:    gpu.shuffle  xor

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -41,6 +41,7 @@ hal.executable @warp_reduction_dispatch {
 }
 
 //   CHECK-LABEL:  func.func @warp_reduction_dispatch
+//     CHECK-DAG:    %[[C0I:.+]] = arith.constant 0 : i32
 //     CHECK-DAG:    %[[C0:.+]] = arith.constant 0 : index
 //     CHECK-DAG:    %[[C1:.+]] = arith.constant 1 : i32
 //     CHECK-DAG:    %[[C2:.+]] = arith.constant 2 : i32
@@ -48,7 +49,6 @@ hal.executable @warp_reduction_dispatch {
 //     CHECK-DAG:    %[[C8:.+]] = arith.constant 8 : i32
 //     CHECK-DAG:    %[[C16:.+]] = arith.constant 16 : i32
 //     CHECK-DAG:    %[[C32:.+]] = arith.constant 32 : i32
-//     CHECK-DAG:    %[[C4I:.+]] = arith.constant 4 : index
 //     CHECK-DAG:    %[[C32I:.+]] = arith.constant 32 : index
 //     CHECK-DAG:    %[[C512:.+]] = arith.constant 512 : index
 //     CHECK-DAG:    %[[C10240:.+]] = arith.constant 10240 : index
@@ -81,19 +81,12 @@ hal.executable @warp_reduction_dispatch {
 //         CHECK:    }
 //         CHECK:    gpu.barrier
 //         CHECK:    %[[LOAD_VAL:.+]] = memref.load %[[ALLOC]][%[[LANE_ID]]] : memref<4xf32, 3>
-//         CHECK:    %[[USE_IDENTITY:.+]] = arith.cmpi sge, %[[LANE_ID]], %[[C4I]] : index
-//         CHECK:    %[[LANE_VAL:.+]] = arith.select %[[USE_IDENTITY]], %[[IDENTITY]], %[[LOAD_VAL]] : f32
-//         CHECK:    %[[S5:.+]], %{{.*}} = gpu.shuffle  xor %[[LANE_VAL]], %[[C1]], %[[C32]] : f32
-//         CHECK:    %[[R7:.+]] = arith.addf %[[LANE_VAL]], %[[S5]] : f32
+//         CHECK:    %[[S5:.+]], %{{.*}} = gpu.shuffle  xor %[[LOAD_VAL]], %[[C1]], %[[C32]] : f32
+//         CHECK:    %[[R7:.+]] = arith.addf %[[LOAD_VAL]], %[[S5]] : f32
 //         CHECK:    %[[S6:.+]], %{{.*}} = gpu.shuffle  xor %[[R7]], %[[C2]], %[[C32]] : f32
 //         CHECK:    %[[R8:.+]] = arith.addf %[[R7]], %[[S6]] : f32
-//         CHECK:    %[[S7:.+]], %{{.*}} = gpu.shuffle  xor %[[R8]], %[[C4]], %[[C32]] : f32
-//         CHECK:    %[[R9:.+]] = arith.addf %[[R8]], %[[S7]] : f32
-//         CHECK:    %[[S8:.+]], %{{.*}} = gpu.shuffle  xor %[[R9]], %[[C8]], %[[C32]] : f32
-//         CHECK:    %[[R10:.+]] = arith.addf %[[R9]], %[[S8]] : f32
-//         CHECK:    %[[S9:.+]], %{{.*}} = gpu.shuffle  xor %[[R10]], %[[C16]], %[[C32]] : f32
-//         CHECK:    %[[R11:.+]] = arith.addf %[[R10]], %[[S9]] : f32
-//         CHECK:    %[[R12:.+]] = arith.addf %[[R11]], %[[CF]] : f32
+//         CHECK:    %[[S7:.+]], %{{.*}} = gpu.shuffle  idx %[[R8]], %[[C0I]], %[[C32]] : f32
+//         CHECK:    %[[R12:.+]] = arith.addf %[[S7]], %[[CF]] : f32
 //         CHECK:    %[[R13:.+]] = vector.splat %[[R12]] : vector<1xf32>
 //         CHECK:    %[[TID0:.+]] = arith.cmpi eq, %[[TID]], %[[C0]] : index
 //         CHECK:    scf.if %[[TID0]] {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_reduction_subgroup.mlir
@@ -77,23 +77,20 @@ hal.executable private @subgroup_reduce {
 // CHECK:   spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
 // CHECK:   %[[LOAD_VAL:.+]] = spirv.Load "Workgroup" {{.+}} : f32
-// CHECK:   %[[USE_IDENTITY:.+]] = spirv.SGreaterThanEqual {{.+}}, %[[C8]] : i32
-// CHECK:   %[[LANE_VAL:.+]] = spirv.Select %[[USE_IDENTITY]], %[[F0]], %[[LOAD_VAL]] : i1, f32
-// CHECK:   %[[S4:.+]] = spirv.GroupNonUniformShuffleXor <Subgroup> %[[LANE_VAL]], %[[C1]] : f32, i32
-// CHECK:   %[[ADD7:.+]] = spirv.FAdd %[[LANE_VAL]], %[[S4]] : f32
+// CHECK:   %[[S4:.+]] = spirv.GroupNonUniformShuffleXor <Subgroup> %[[LOAD_VAL]], %[[C1]] : f32, i32
+// CHECK:   %[[ADD7:.+]] = spirv.FAdd %[[LOAD_VAL]], %[[S4]] : f32
 // CHECK:   %[[S5:.+]] = spirv.GroupNonUniformShuffleXor <Subgroup> %[[ADD7]], %[[C2]] : f32, i32
 // CHECK:   %[[ADD8:.+]] = spirv.FAdd %[[ADD7]], %[[S5]] : f32
 // CHECK:   %[[S6:.+]] = spirv.GroupNonUniformShuffleXor <Subgroup> %[[ADD8]], %[[C4]] : f32, i32
 // CHECK:   %[[ADD9:.+]] = spirv.FAdd %[[ADD8]], %[[S6]] : f32
-// CHECK:   %[[S7:.+]] = spirv.GroupNonUniformShuffleXor <Subgroup> %[[ADD9]], %[[C8]] : f32, i32
-// CHECK:   %[[ADD10:.+]] = spirv.FAdd %[[ADD9]], %[[S7]] : f32
-//         CHECK:   spirv.FAdd %[[ADD10]], %[[F0]] : f32
+// CHECK:   %[[S7:.+]] = spirv.GroupNonUniformShuffle <Subgroup> %[[ADD9]], %[[C0]] : f32, i32
+// CHECK:   %[[ADD10:.+]] = spirv.FAdd %[[S7]], %[[F0]] : f32
 
 // CHECK:   %[[EQ:.+]] = spirv.IEqual %{{.+}}, %[[C0]] : i32
 // CHECK:   spirv.mlir.selection {
 // CHECK:     spirv.BranchConditional %[[EQ]], ^bb1, ^bb2
 // CHECK:   ^bb1:
-// CHECK:     spirv.Store "StorageBuffer" %{{.+}}, %{{.+}} : f32
+// CHECK:     spirv.Store "StorageBuffer" %{{.+}}, %[[ADD10]] : f32
 // CHECK:     spirv.Branch ^bb2
 // CHECK:   ^bb2:
 // CHECK:     spirv.mlir.merge


### PR DESCRIPTION
The last merge potentially doesn't need to reduce across all the lanes.