### PR TITLE
[WebGPU] Add compilation tests for xla_ops/ and tosa_ops/ (again).

### DIFF
--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -239,8 +239,10 @@ function(iree_check_single_backend_test_suite)
     # compiler target backends are enabled. Just assume all are enabled and only
     # rely on the runtime HAL driver check above for filtering.
 
-    # HACK: Always skip WebGPU when cross compiling until it has a HAL driver.
-    if(${_NORMALIZED_TARGET_BACKEND} STREQUAL "webgpu")
+    # No driver, so this is a special configuration. The assumption above
+    # might not be true, so skip (these tests are _probably_ already being
+    # built on the host anyway, so no need to build when cross compiling).
+    if(NOT DEFINED _RULE_DRIVER)
       return()
     endif()
   else()

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -238,6 +238,11 @@ function(iree_check_single_backend_test_suite)
     # such as when cross compiling, then we can't easily check for which
     # compiler target backends are enabled. Just assume all are enabled and only
     # rely on the runtime HAL driver check above for filtering.
+
+    # HACK: Always skip WebGPU when cross compiling until it has a HAL driver.
+    if(${_NORMALIZED_TARGET_BACKEND} STREQUAL "webgpu")
+      return()
+    endif()
   else()
     # We are building the host tools, so check enabled compiler target backends.
     if(NOT IREE_TARGET_BACKEND_${_NORMALIZED_TARGET_BACKEND})

--- a/build_tools/cmake/iree_check_test.cmake
+++ b/build_tools/cmake/iree_check_test.cmake
@@ -242,6 +242,7 @@ function(iree_check_single_backend_test_suite)
     # No driver, so this is a special configuration. The assumption above
     # might not be true, so skip (these tests are _probably_ already being
     # built on the host anyway, so no need to build when cross compiling).
+    # TODO(#11354): Use a different test function / move compile to test-time
     if(NOT DEFINED _RULE_DRIVER)
       return()
     endif()

--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -265,4 +265,5 @@ iree_check_single_backend_test_suite(
   #   "webgpu"
   COMPILER_FLAGS
     "--iree-input-type=tosa"
+    "--iree-codegen-gpu-native-math-precision=true"  # TODO(#11321): Infer/flip default
 )

--- a/tests/e2e/tosa_ops/CMakeLists.txt
+++ b/tests/e2e/tosa_ops/CMakeLists.txt
@@ -214,3 +214,55 @@ iree_check_single_backend_test_suite(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_webgpu
+  SRCS
+    "abs.mlir"
+    "add.mlir"
+    "arithmetic_right_shift.mlir"
+    "bitwise_and.mlir"
+    "bitwise_or.mlir"
+    "bitwise_xor.mlir"
+    "ceil.mlir"
+    "clamp.mlir"
+    "clz.mlir"
+    "const.mlir"
+    # "equal.mlir"  # TODO(#10906): fix (i8/i16?)
+    "exp.mlir"
+    "floor.mlir"
+    "fully_connected.mlir"
+    "gather.mlir"
+    # "greater.mlir"  # TODO(#10906): fix (i8/i16?)
+    # "greater_equal.mlir"  # TODO(#10906): fix (i8/i16?)
+    "if.mlir"
+    "log.mlir"
+    "logical_left_shift.mlir"
+    "logical_right_shift.mlir"
+    "matmul.mlir"
+    # "max_pool.mlir"  # TODO(#10906): fix (i8/i16?)
+    "maximum.mlir"
+    "minimum.mlir"
+    "mul.mlir"
+    "negate.mlir"
+    "pad.mlir"
+    "reciprocal.mlir"
+    "reduce.mlir"
+    "reshape.mlir"
+    "rsqrt.mlir"
+    "select.mlir"
+    "sigmoid.mlir"
+    "sub.mlir"
+    # "table.mlir"  # TODO(#10906): fix (i8/i16?)
+    "tanh.mlir"
+    "transpose.mlir"
+    "while.mlir"
+  TARGET_BACKEND
+    "webgpu"
+  # Only test compilation for now, the WebGPU driver is not stable/tested yet.
+  # DRIVER
+  #   "webgpu"
+  COMPILER_FLAGS
+    "--iree-input-type=tosa"
+)

--- a/tests/e2e/xla_ops/CMakeLists.txt
+++ b/tests/e2e/xla_ops/CMakeLists.txt
@@ -501,3 +501,72 @@ iree_check_single_backend_test_suite(
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###
+
+iree_check_single_backend_test_suite(
+  NAME
+    check_webgpu
+  SRCS
+    "abs.mlir"
+    "add.mlir"
+    "batch_norm_inference.mlir"
+    "bitcast_convert.mlir"
+    "broadcast.mlir"
+    "broadcast_add.mlir"
+    "broadcast_in_dim.mlir"
+    # "clamp.mlir"  # TODO(#10906): fix (i8/i16?)
+    # "compare.mlir"  # TODO(#10906): fix (i8/i16?)
+    "concatenate.mlir"
+    "constant.mlir"
+    # "convert.mlir"  # TODO(#10906): fix (i8/i16?)
+    "convolution.mlir"
+    "cosine.mlir"
+    "divide.mlir"
+    "dot.mlir"
+    "dot_general.mlir"
+    "dynamic_slice.mlir"
+    "dynamic_update_slice.mlir"
+    "exponential.mlir"
+    "exponential_fp16.mlir"
+    "exponential_minus_one.mlir"
+    # "fft.mlir"  # TODO(#9583): fix (fft codegen via spirv)
+    # "finite.mlir"  # TODO(#10906): fix (i8/i16?)
+    "floor.mlir"
+    "gather.mlir"
+    "iota.mlir"
+    "log.mlir"
+    "log_plus_one.mlir"
+    # "maximum.mlir"  # TODO(#10906): fix (i8/i16?)
+    # "minimum.mlir"  # TODO(#10906): fix (i8/i16?)
+    "multiply.mlir"
+    "negate.mlir"
+    "pad.mlir"
+    "pow.mlir"
+    "reduce.mlir"
+    "reduce_window.mlir"
+    "remainder.mlir"
+    "reshape.mlir"
+    # "reverse.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "rng_normal.mlir"
+    "rng_uniform.mlir"
+    "round.mlir"
+    "rsqrt.mlir"
+    # "scatter.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "scatter_dynamic.mlir"
+    "select.mlir"
+    "sine.mlir"
+    "slice.mlir"
+    # "sort.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "sqrt.mlir"
+    "subtract.mlir"
+    "tanh.mlir"
+    "torch_index_select.mlir"
+    "transpose.mlir"
+    "while.mlir"
+  TARGET_BACKEND
+    "webgpu"
+  # Only test compilation for now, the WebGPU driver is not stable/tested yet.
+  # DRIVER
+  #   "webgpu"
+  COMPILER_FLAGS
+    "--iree-input-type=mhlo"
+)

--- a/tests/e2e/xla_ops/CMakeLists.txt
+++ b/tests/e2e/xla_ops/CMakeLists.txt
@@ -545,17 +545,17 @@ iree_check_single_backend_test_suite(
     "reduce_window.mlir"
     "remainder.mlir"
     "reshape.mlir"
-    # "reverse.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "reverse.mlir"
     "rng_normal.mlir"
     "rng_uniform.mlir"
     "round.mlir"
     "rsqrt.mlir"
-    # "scatter.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "scatter.mlir"
     "scatter_dynamic.mlir"
     "select.mlir"
     "sine.mlir"
     "slice.mlir"
-    # "sort.mlir"  # TODO(#10908): fix (NumWorkgroups)
+    "sort.mlir"
     "sqrt.mlir"
     "subtract.mlir"
     "tanh.mlir"
@@ -569,4 +569,5 @@ iree_check_single_backend_test_suite(
   #   "webgpu"
   COMPILER_FLAGS
     "--iree-input-type=mhlo"
+    "--iree-codegen-gpu-native-math-precision=true"  # TODO(#11321): Infer/flip default
 )


### PR DESCRIPTION
This reverts https://github.com/iree-org/iree/pull/10918 to roll forward https://github.com/iree-org/iree/pull/10909, adding a hack to skip WebGPU testdata compilation when cross compiling. The right way to add this test coverage is likely either
* Adding a new test macro that just tests compilation without even considering runtime/execution
* Adding the `IREE_HAL_DRIVER_WEBGPU` option and running tests with it (this won't really work until I have more tests working, and the tools are updated to somehow handle async readback... so I'm not hopeful about this approach for at least several months)