### PR TITLE
Adding IREE_LINK_COMPILER_SHARED_LIBRARY cmake flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,7 @@ option(IREE_BYTECODE_MODULE_ENABLE_TSAN "Enable thread sanitizer in IREE modules
 option(IREE_ENABLE_UBSAN "Enable undefined behavior sanitizer" OFF)
 option(IREE_ENABLE_SPLIT_DWARF "Enable gsplit-dwarf for debug information if the platform supports it" OFF)
 option(IREE_ENABLE_THIN_ARCHIVES "Enables thin ar archives (elf systems only). Disable for released static archives" OFF)
+option(IREE_LINK_COMPILER_SHARED_LIBRARY "Links IREE tools using the compiler compiled into a shared library" ON)
 
 # STREQUAL feels wrong here - we don't care about the exact true-value used,
 # ON or TRUE or something else. But we haven't been able to think of a less bad

--- a/compiler/src/iree/compiler/API2/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API2/CMakeLists.txt
@@ -112,9 +112,18 @@ install(
 # The bazel side uses a "Impl" library alias to generically represent
 # static or shared. Provide a corresponding one here.
 
+if(IREE_LINK_COMPILER_SHARED_LIBRARY)
 iree_cc_library(
   NAME
     Impl
   DEPS
     ::SharedImpl
 )
+else()
+iree_cc_library(
+  NAME
+    Impl
+  DEPS
+    ::StaticImpl
+)
+endif()  # IREE_LINK_COMPILER_SHARED_LIBRARY


### PR DESCRIPTION
This is enabled by default and tools link in the fancy shared library. When disabled the tools link in the static library version. This can be useful when wanting to build standalone binaries. It's also useful to work around MSVC's link.exe issues with ilk files >4GB that we run into with the shared library enabled.