### PR TITLE
Add expansion bubble-up to apply_patterns transform op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -204,6 +204,10 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
   if (getSwappingPatterns())
     addSwappingPatterns(patterns, getSwapPaddingElideConditional());
   if (getAdditionalIreePatterns()) addAdditionalIreePatterns(patterns);
+  if (getBubbleCollapseExpand()) {
+    linalg::populateFoldReshapeOpsByExpansionPatterns(
+        patterns, [](OpOperand *) { return true; });
+  }
 
   TrackingListener listener(state);
   GreedyRewriteConfig config;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -33,6 +33,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
     unspecified order:
       - additional_iree_patterns: fancy patterns we shortcut into the system,
       will need to be sliced out better in the future.
+      - bubble_collapse_expand: bubble `expand_shape` up and `collapse_shape`
+      down across Linalg ops.
       - canonicalization: adds all the canonicalization patterns of all
       registered dialects and ops.
       - promote_foreach_thread_capture_to_shared: adds patterns that rewrite
@@ -70,6 +72,7 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
 
   let arguments = (ins PDL_Operation:$target,
                        UnitAttr:$additional_iree_patterns,
+                       UnitAttr:$bubble_collapse_expand,
                        UnitAttr:$canonicalization,
                        UnitAttr:$promote_foreach_thread_capture_to_shared,
                        UnitAttr:$rank_reducing,

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
@@ -57,3 +57,34 @@ transform.sequence failures(propagate) {
   %0 = transform.structured.match ops{["func.func"]} in %arg1
   transform.iree.apply_patterns %0 { promote_foreach_thread_capture_to_shared }
 }
+
+// -----
+
+#map2 = affine_map<(d0, d1) -> (d0, d1)>
+
+func.func private @mutate(f32) -> f32
+
+// CHECK-LABEL: @bubble_up
+func.func @bubble_up(%arg0: tensor<32x64xf32>) -> tensor<32x2x32xf32> {
+  // Check that shape expansion precedes linalg.generic after the patterns were applied.
+  // CHECK: tensor.expand_shape
+  // CHECK: tensor.expand_shape
+  // CHECK: linalg.generic
+  %init = tensor.empty() : tensor<32x64xf32>
+  %result = linalg.generic {
+    indexing_maps = [#map2, #map2],
+    iterator_types = ["parallel", "parallel"]}
+  ins(%arg0: tensor<32x64xf32>) outs(%init: tensor<32x64xf32>) {
+  ^bb0(%arg1: f32, %arg2: f32):
+    %0 = func.call @mutate(%arg1) : (f32) -> f32
+    linalg.yield %0 : f32
+  } -> tensor<32x64xf32>
+  %out = tensor.expand_shape %result[[0], [1, 2]] : tensor<32x64xf32> into tensor<32x2x32xf32>
+  return %out : tensor<32x2x32xf32>
+}
+
+transform.sequence failures(propagate) {
+^bb1(%arg1: !pdl.operation):
+  %0 = transform.structured.match ops{["func.func"]} in %arg1
+  transform.iree.apply_patterns %0 { bubble_collapse_expand }
+}


### PR DESCRIPTION
This transformation is useful when fusing leading operations into a reduction after splitting said reduction.