### PR TITLE
Cleanup unused variables from a few build system files.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -358,14 +358,6 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
 )
 
-# Add to LINKOPTS on a binary to configure it for X/Wayland/Windows/etc
-# depending on the target cross-compilation platform.
-if(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-  set(IREE_TARGET_GUI_LINKOPTS "-SUBSYSTEM:WINDOWS")
-else()
-  set(IREE_TARGET_GUI_LINKOPTS "")
-endif()
-
 #-------------------------------------------------------------------------------
 # Size-optimized build flags
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/iree_hal_cts_test_suite.cmake
+++ b/build_tools/cmake/iree_hal_cts_test_suite.cmake
@@ -102,8 +102,6 @@ function(iree_hal_cts_test_suite)
             "${IREE_ROOT_DIR}/runtime/src/iree/hal/cts/testdata/${_FILE_NAME}.mlir"
           FLAGS
             ${_TRANSLATE_FLAGS}
-          COMPILE_TOOL
-            "iree-compile"
           PUBLIC
           TESTONLY
         )

--- a/runtime/src/iree/vm/BUILD
+++ b/runtime/src/iree/vm/BUILD
@@ -262,7 +262,6 @@ iree_bytecode_module(
     testonly = True,
     src = "bytecode_module_benchmark.mlir",
     c_identifier = "iree_vm_bytecode_module_benchmark_module",
-    compile_tool = "//tools:iree-compile",
     flags = ["--compile-mode=vm"],
 )
 
@@ -282,7 +281,6 @@ iree_bytecode_module(
     testonly = True,
     src = "bytecode_module_size_benchmark.mlir",
     c_identifier = "iree_vm_bytecode_module_size_benchmark_module",
-    compile_tool = "//tools:iree-compile",
     flags = ["--compile-mode=vm"],
 )
 

--- a/runtime/src/iree/vm/CMakeLists.txt
+++ b/runtime/src/iree/vm/CMakeLists.txt
@@ -227,8 +227,6 @@ iree_bytecode_module(
     "bytecode_module_benchmark.mlir"
   C_IDENTIFIER
     "iree_vm_bytecode_module_benchmark_module"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   TESTONLY
@@ -255,8 +253,6 @@ iree_bytecode_module(
     "bytecode_module_size_benchmark.mlir"
   C_IDENTIFIER
     "iree_vm_bytecode_module_size_benchmark_module"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   TESTONLY

--- a/runtime/src/iree/vm/test/BUILD
+++ b/runtime/src/iree/vm/test/BUILD
@@ -59,7 +59,6 @@ c_embed_data(
 iree_bytecode_module(
     name = "arithmetic_ops",
     src = "arithmetic_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -68,7 +67,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "arithmetic_ops_f32",
     src = "arithmetic_ops_f32.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -77,7 +75,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "arithmetic_ops_i64",
     src = "arithmetic_ops_i64.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -86,7 +83,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "assignment_ops",
     src = "assignment_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -95,7 +91,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "assignment_ops_f32",
     src = "assignment_ops_f32.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -104,7 +99,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "assignment_ops_i64",
     src = "assignment_ops_i64.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -113,7 +107,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "buffer_ops",
     src = "buffer_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -122,7 +115,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "call_ops",
     src = "call_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -131,7 +123,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "comparison_ops",
     src = "comparison_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -140,7 +131,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "comparison_ops_f32",
     src = "comparison_ops_f32.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -149,7 +139,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "comparison_ops_i64",
     src = "comparison_ops_i64.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -158,7 +147,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "control_flow_ops",
     src = "control_flow_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -167,7 +155,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "conversion_ops",
     src = "conversion_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -176,7 +163,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "conversion_ops_f32",
     src = "conversion_ops_f32.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -185,7 +171,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "conversion_ops_i64",
     src = "conversion_ops_i64.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -194,7 +179,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "global_ops",
     src = "global_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -203,7 +187,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "global_ops_f32",
     src = "global_ops_f32.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -212,7 +195,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "global_ops_i64",
     src = "global_ops_i64.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -221,7 +203,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "list_ops",
     src = "list_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -230,7 +211,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "list_ops_i64",
     src = "list_ops_i64.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -239,7 +219,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "list_variant_ops",
     src = "list_variant_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -248,7 +227,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "ref_ops",
     src = "ref_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -257,7 +235,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "shift_ops",
     src = "shift_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -266,7 +243,6 @@ iree_bytecode_module(
 iree_bytecode_module(
     name = "shift_ops_i64",
     src = "shift_ops_i64.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],
@@ -285,7 +261,6 @@ c_embed_data(
 iree_bytecode_module(
     name = "async_ops",
     src = "async_ops.mlir",
-    compile_tool = "//tools:iree-compile",
     flags = [
         "--compile-mode=vm",
     ],

--- a/runtime/src/iree/vm/test/CMakeLists.txt
+++ b/runtime/src/iree/vm/test/CMakeLists.txt
@@ -55,8 +55,6 @@ iree_bytecode_module(
     arithmetic_ops
   SRC
     "arithmetic_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -67,8 +65,6 @@ iree_bytecode_module(
     arithmetic_ops_f32
   SRC
     "arithmetic_ops_f32.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -79,8 +75,6 @@ iree_bytecode_module(
     arithmetic_ops_i64
   SRC
     "arithmetic_ops_i64.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -91,8 +85,6 @@ iree_bytecode_module(
     assignment_ops
   SRC
     "assignment_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -103,8 +95,6 @@ iree_bytecode_module(
     assignment_ops_f32
   SRC
     "assignment_ops_f32.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -115,8 +105,6 @@ iree_bytecode_module(
     assignment_ops_i64
   SRC
     "assignment_ops_i64.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -127,8 +115,6 @@ iree_bytecode_module(
     buffer_ops
   SRC
     "buffer_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -139,8 +125,6 @@ iree_bytecode_module(
     call_ops
   SRC
     "call_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -151,8 +135,6 @@ iree_bytecode_module(
     comparison_ops
   SRC
     "comparison_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -163,8 +145,6 @@ iree_bytecode_module(
     comparison_ops_f32
   SRC
     "comparison_ops_f32.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -175,8 +155,6 @@ iree_bytecode_module(
     comparison_ops_i64
   SRC
     "comparison_ops_i64.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -187,8 +165,6 @@ iree_bytecode_module(
     control_flow_ops
   SRC
     "control_flow_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -199,8 +175,6 @@ iree_bytecode_module(
     conversion_ops
   SRC
     "conversion_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -211,8 +185,6 @@ iree_bytecode_module(
     conversion_ops_f32
   SRC
     "conversion_ops_f32.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -223,8 +195,6 @@ iree_bytecode_module(
     conversion_ops_i64
   SRC
     "conversion_ops_i64.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -235,8 +205,6 @@ iree_bytecode_module(
     global_ops
   SRC
     "global_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -247,8 +215,6 @@ iree_bytecode_module(
     global_ops_f32
   SRC
     "global_ops_f32.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -259,8 +225,6 @@ iree_bytecode_module(
     global_ops_i64
   SRC
     "global_ops_i64.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -271,8 +235,6 @@ iree_bytecode_module(
     list_ops
   SRC
     "list_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -283,8 +245,6 @@ iree_bytecode_module(
     list_ops_i64
   SRC
     "list_ops_i64.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -295,8 +255,6 @@ iree_bytecode_module(
     list_variant_ops
   SRC
     "list_variant_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -307,8 +265,6 @@ iree_bytecode_module(
     ref_ops
   SRC
     "ref_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -319,8 +275,6 @@ iree_bytecode_module(
     shift_ops
   SRC
     "shift_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -331,8 +285,6 @@ iree_bytecode_module(
     shift_ops_i64
   SRC
     "shift_ops_i64.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC
@@ -356,8 +308,6 @@ iree_bytecode_module(
     async_ops
   SRC
     "async_ops.mlir"
-  COMPILE_TOOL
-    iree-compile
   FLAGS
     "--compile-mode=vm"
   PUBLIC

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -225,7 +225,6 @@ if(IREE_BUILD_COMPILER)
     DEPS
       iree::compiler::API2::Headers
       iree::compiler::API2::Impl
-    PUBLIC
     SETUP_INSTALL_RPATH
   )
 


### PR DESCRIPTION
* Remove explicit compile_tool arg when set to the default
* Remove unsupported/spurious PUBLIC option
* Remove no longer used IREE_TARGET_GUI_LINKOPTS