### PR TITLE
Fixes how the mmperf repo is cloned in the mmperf workflow

### DIFF
--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -17,7 +17,6 @@ on:
   schedule:
     - cron: '0 13 * * *'
   workflow_dispatch:
-  pull_request:
 
 env:
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}

--- a/.github/workflows/run_mmperf.yml
+++ b/.github/workflows/run_mmperf.yml
@@ -17,6 +17,7 @@ on:
   schedule:
     - cron: '0 13 * * *'
   workflow_dispatch:
+  pull_request:
 
 env:
   GCS_DIR: gs://iree-github-actions-${{ github.event_name == 'pull_request' && 'presubmit' || 'postsubmit' }}-artifacts/${{ github.run_id }}/${{ github.run_attempt }}
@@ -78,13 +79,13 @@ jobs:
       - name: "Building mmperf for CPU"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+            gcr.io/iree-oss/mmperf@sha256:bc74f3bbb0e3e8373ab0b35362b6f2a92b1d770432b6711f61403e73a1af076a \
           ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cpu" "${IREE_SHA}"
       - name: "Running mmperf on CPU"
         run: |
           mkdir ${RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+            gcr.io/iree-oss/mmperf@sha256:bc74f3bbb0e3e8373ab0b35362b6f2a92b1d770432b6711f61403e73a1af076a \
           ./build_tools/benchmarks/mmperf/run_mmperf.sh "${BUILD_DIR}" "${RESULTS_DIR}"
       - name: "Uploading results"
         run: |
@@ -113,7 +114,7 @@ jobs:
       - name: "Building mmperf for CUDA"
         run: |
           ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+            gcr.io/iree-oss/mmperf@sha256:bc74f3bbb0e3e8373ab0b35362b6f2a92b1d770432b6711f61403e73a1af076a \
           ./build_tools/benchmarks/mmperf/build_mmperf.sh "${BUILD_DIR}" "cuda" "${IREE_SHA}"
       - name: "Removing unused files"
         run: |
@@ -165,7 +166,7 @@ jobs:
           mkdir ${RESULTS_DIR}
           ./build_tools/github_actions/docker_run.sh \
           --gpus all \
-            gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c \
+            gcr.io/iree-oss/mmperf@sha256:bc74f3bbb0e3e8373ab0b35362b6f2a92b1d770432b6711f61403e73a1af076a \
           ./build_tools/benchmarks/mmperf/run_mmperf.sh "${BUILD_DIR}" "${RESULTS_DIR}"
       - name: "Uploading results"
         run: |

--- a/build_tools/benchmarks/mmperf/build_mmperf.sh
+++ b/build_tools/benchmarks/mmperf/build_mmperf.sh
@@ -13,7 +13,7 @@
 # in the `mmperf` repo and built from source, and other backends are expected
 # to already be installed.
 #
-# Please refer to `build_tools/docker/mmperf/Dockerfile` for commands on
+# Please refer to `build_tools/docker/dockerfiles/mmperf.Dockerfile` for commands on
 # installing various backends.
 #
 # Currently x86 CPU and CUDA are supported.

--- a/build_tools/docker/context/setup_mmperf.sh
+++ b/build_tools/docker/context/setup_mmperf.sh
@@ -24,11 +24,13 @@ export REPO_DIR=$1
 export REPO_SHA=$2
 
 pushd ${REPO_DIR}
-git clone --jobs 8 --depth 1 --no-single-branch --recurse-submodules https://github.com/mmperf/mmperf.git
-pushd mmperf
 
-# Checkout a specific commit.
+mkdir mmperf
+pushd mmperf
+git init
+git fetch --depth 1 https://github.com/mmperf/mmperf.git "${REPO_SHA}"
 git checkout ${REPO_SHA}
+git submodule update --init --recursive --jobs 8 --depth 1
 
 # Create virtual environment.
 python3 -m venv mmperf.venv

--- a/build_tools/docker/dockerfiles/mmperf.Dockerfile
+++ b/build_tools/docker/dockerfiles/mmperf.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2021 The IREE Authors
+# Copyright 2022 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
@@ -105,7 +105,7 @@ ENV BLIS_DIR="/opt/blis"
 ######## MMPERF ########
 COPY build_tools/docker/context/setup_mmperf.sh /usr/local/bin
 
-ARG MMPERF_SHA="ae523a3"
+ARG MMPERF_SHA="ae523a31449a58ef39592c6b8cf9c042e0a55a1f"
 
 # Generate a version of mmperf for CPU.
 RUN mkdir -p "/usr/local/src/mmperf" \

--- a/build_tools/docker/prod_digests.txt
+++ b/build_tools/docker/prod_digests.txt
@@ -13,4 +13,4 @@ gcr.io/iree-oss/manylinux2014_x86_64-release@sha256:b3b096e4b96746c3ae4cc52e8800
 gcr.io/iree-oss/shark@sha256:c72ef54dcb6ec485e8a96b0dfc43307875f4c4c7619f7fdc60bf5220a5672259
 gcr.io/iree-oss/base-bleeding-edge@sha256:479eefb76447c865cf58c5be7ca9fe33f48584b474a1da3dfaa125aad2510463
 gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be
-gcr.io/iree-oss/mmperf@sha256:7a7f66eb4ff1f0c36b01fb2b5c99c9c01814fc18754537f4140e86081439cd8c
+gcr.io/iree-oss/mmperf@sha256:bc74f3bbb0e3e8373ab0b35362b6f2a92b1d770432b6711f61403e73a1af076a


### PR DESCRIPTION
Fixes how the github repo is cloned according to comments in https://github.com/iree-org/iree/pull/10956#discussion_r1029856233