### PR TITLE
NUMA node pinning APIs/topology queries

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/registration/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/local_task/registration/CMakeLists.txt
@@ -19,6 +19,8 @@ iree_cc_library(
     "driver_module.c"
   DEPS
     iree::base
+    iree::base::internal
+    iree::base::internal::path
     iree::hal
     iree::hal::drivers::local_task::task_driver
     iree::hal::local::loaders::registration

--- a/runtime/src/iree/task/api.c
+++ b/runtime/src/iree/task/api.c
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <cpuinfo.h>
 #include "iree/task/api.h"
 
 #include <stdbool.h>
@@ -75,26 +76,36 @@ IREE_FLAG(
     "detected and used when --task_topology_group_count=0 and is ignored\n"
     "otherwise.\n");
 
+IREE_FLAG(
+    string, task_numa_nodes, "",
+    "Creates executors for specified CPU NUMA nodes.\n");
+
 // TODO(benvanik): add --task_topology_dump to dump out the current machine
 // configuration as seen by the topology utilities.
 
 iree_status_t iree_task_topology_initialize_from_flags(
     iree_task_topology_t* out_topology) {
   IREE_ASSERT_ARGUMENT(out_topology);
+  iree_host_size_t numa_node_id = out_topology->numa_node_id;
   iree_task_topology_initialize(out_topology);
 
-  if (FLAG_task_topology_group_count != 0) {
-    iree_task_topology_initialize_from_group_count(
-        FLAG_task_topology_group_count, out_topology);
-  } else if (strcmp(FLAG_task_topology_mode, "physical_cores") == 0) {
-    iree_task_topology_initialize_from_physical_cores(
-        FLAG_task_topology_max_group_count, out_topology);
+  if (strlen(FLAG_task_numa_nodes) != 0) {
+    iree_task_topology_initialize_with_cluster(
+        FLAG_task_topology_max_group_count, numa_node_id, out_topology);
   } else {
-    return iree_make_status(
-        IREE_STATUS_INVALID_ARGUMENT,
-        "one of --task_topology_group_count or --task_topology_mode must be "
-        "specified and be a valid value; have --task_topology_mode=%s.",
-        FLAG_task_topology_mode);
+    if (FLAG_task_topology_group_count != 0) {
+        iree_task_topology_initialize_from_group_count(
+            FLAG_task_topology_group_count, out_topology);
+    } else if (strcmp(FLAG_task_topology_mode, "physical_cores") == 0) {
+        iree_task_topology_initialize_from_physical_cores(
+            FLAG_task_topology_max_group_count, out_topology);
+    } else {
+        return iree_make_status(
+            IREE_STATUS_INVALID_ARGUMENT,
+            "one of --task_topology_group_count or --task_topology_mode must be "
+            "specified and be a valid value; have --task_topology_mode=%s.",
+            FLAG_task_topology_mode);
+    }
   }
 
   return iree_ok_status();
@@ -107,21 +118,52 @@ iree_status_t iree_task_topology_initialize_from_flags(
 iree_status_t iree_task_executor_create_from_flags(
     iree_allocator_t host_allocator, iree_task_executor_t** out_executor) {
   IREE_ASSERT_ARGUMENT(out_executor);
+  const char *task_numa_nodes = FLAG_task_numa_nodes;
+  iree_string_view_t numa_nodes = iree_string_view_trim(iree_make_string_view(
+      task_numa_nodes, strlen(task_numa_nodes)));
+  iree_host_size_t num_nodes = 0;
+  cpuinfo_initialize();
+  iree_host_size_t cpuinfo_node_count = cpuinfo_get_clusters_count();
+  iree_host_size_t *nodes = (iree_host_size_t*) malloc(cpuinfo_node_count * sizeof(iree_host_size_t));
+  while (!iree_string_view_is_empty(numa_nodes)) {
+    iree_string_view_t key_value;
+    iree_string_view_split(numa_nodes, ',', &key_value, &numa_nodes);
+    char node_str[3];
+    strncpy(node_str, key_value.data, key_value.size);
+    iree_host_size_t input_node = (iree_host_size_t) strtol(node_str, NULL, 10);
+    nodes[num_nodes] = input_node;
+    if (input_node > cpuinfo_node_count - 1) {
+      return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                              "input_node %lu out of range (0 - %zu)",
+                              input_node,
+                              cpuinfo_node_count - 1);
+    }
+    num_nodes++;
+  }
+  if (iree_string_view_is_empty(numa_nodes)) {
+    num_nodes = 1;
+  }
+
   *out_executor = NULL;
   IREE_TRACE_ZONE_BEGIN(z0);
 
-  iree_task_executor_options_t options;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_task_executor_options_initialize_from_flags(&options));
+  iree_status_t status;
+  for (int i = 0; i < num_nodes; i++) {
+    iree_task_topology_t topology;
 
-  iree_task_topology_t topology;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
+    topology.numa_node_id = nodes[i];
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
       z0, iree_task_topology_initialize_from_flags(&topology));
+    
+    iree_task_executor_options_t options;
+    IREE_RETURN_AND_END_ZONE_IF_ERROR(
+        z0, iree_task_executor_options_initialize_from_flags(&options));
 
-  iree_status_t status = iree_task_executor_create(
-      options, &topology, host_allocator, out_executor);
+    status = iree_task_executor_create(
+        options, &topology, host_allocator, &out_executor[i]);
 
-  iree_task_topology_deinitialize(&topology);
+    iree_task_topology_deinitialize(&topology);
+  }
 
   IREE_TRACE_ZONE_END(z0);
   return status;

--- a/runtime/src/iree/task/topology.c
+++ b/runtime/src/iree/task/topology.c
@@ -82,8 +82,10 @@ void iree_task_topology_initialize_from_group_count(
     iree_host_size_t group_count, iree_task_topology_t* out_topology) {
   IREE_TRACE_ZONE_BEGIN(z0);
   IREE_TRACE_ZONE_APPEND_VALUE(z0, group_count);
+  iree_host_size_t numa_node_id = out_topology->numa_node_id;
 
   iree_task_topology_initialize(out_topology);
+  out_topology->numa_node_id = numa_node_id;
   for (iree_host_size_t i = 0; i < group_count; ++i) {
     iree_task_topology_group_t* group = &out_topology->groups[i];
     iree_task_topology_group_initialize(i, group);

--- a/runtime/src/iree/task/topology.h
+++ b/runtime/src/iree/task/topology.h
@@ -76,6 +76,7 @@ void iree_task_topology_group_initialize(uint8_t group_index,
 // We can add the more common heuristics over time to the core and leave the
 // edge cases for applications to construct.
 typedef struct iree_task_topology_t {
+  iree_host_size_t numa_node_id;
   iree_host_size_t group_count;
   iree_task_topology_group_t groups[IREE_TASK_EXECUTOR_MAX_WORKER_COUNT];
 } iree_task_topology_t;
@@ -125,6 +126,9 @@ void iree_task_topology_initialize_from_group_count(
 // Initializes a topology with one group for each physical core in the machine.
 void iree_task_topology_initialize_from_physical_cores(
     iree_host_size_t max_core_count, iree_task_topology_t* out_topology);
+
+void iree_task_topology_initialize_with_cluster(
+  iree_host_size_t max_core_count, iree_host_size_t numa_node_id, iree_task_topology_t* out_topology);
 
 #ifdef __cplusplus
 }  // extern "C"


### PR DESCRIPTION
@benvanik Here is my draft PR for NUMA node pinning APIs from [this issue](https://github.com/iree-org/iree/issues/10765), would like your comments/suggestions.

Some potential things to fix:
1. How I should set -Wnoerror, -Wnopointer-arith, -Wnovla without changing `build_tools/cmake/iree_copts.cmake`
2. Rotating processors from base processor

You can test it with:

1. `apt-get install dh-autoreconf`
3. Build iree
4. Run with command (can specify --device and --task_numa_nodes flags with comma-separated list with no spaces
e.g. --device=local-task://?nodes=0,1 --task_numa_nodes=0,1):
`../iree-build/tools/iree-benchmark-module --module_file=matmul.vmfb --device=local-task://?nodes=0 --entry_function=predict --function_input="3136x64xf32=1.0" --function_input="64x256xf32=1.0" --task_numa_nodes=0 --task_topology_max_group_count=8`