### PR TITLE
Add a `--iree-vmvx-tune-cpu` flag

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -308,12 +308,19 @@ void ExecutableTargetAttr::print(AsmPrinter &p) const {
 std::string ExecutableTargetAttr::getSymbolNameFragment() {
   std::string name = getFormat().getValue().lower();
   if (auto config = getConfiguration()) {
-    for (StringRef configField : {"target_triple", "cpu_features"}) {
-      if (auto attr = config.getAs<StringAttr>(configField)) {
-        if (!attr.getValue().empty()) {
-          name += '_';
-          name += attr.getValue().lower();
-        }
+    if (auto targetTripleAttr = config.getAs<StringAttr>("target_triple")) {
+      StringRef arch = targetTripleAttr.getValue().split('-').first;
+      if (!(arch.empty() || arch == "unknown" ||
+            StringRef(name).endswith(arch))) {
+        name += '_';
+        name += arch.lower();
+      }
+    }
+    if (auto cpuFeaturesAttr = config.getAs<StringAttr>("cpu_feature")) {
+      StringRef cpuFeatures = cpuFeaturesAttr.getValue();
+      if (!cpuFeatures.empty()) {
+        name += '_';
+        name += cpuFeatures.lower();
       }
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -306,7 +306,18 @@ void ExecutableTargetAttr::print(AsmPrinter &p) const {
 }
 
 std::string ExecutableTargetAttr::getSymbolNameFragment() {
-  return sanitizeSymbolName(getFormat().getValue().lower());
+  std::string name = getFormat().getValue().lower();
+  if (auto config = getConfiguration()) {
+    for (StringRef configField : {"target_triple", "cpu_features"}) {
+      if (auto attr = config.getAs<StringAttr>(configField)) {
+        if (!attr.getValue().empty()) {
+          name += '_';
+          name += attr.getValue().lower();
+        }
+      }
+    }
+  }
+  return sanitizeSymbolName(name, /*coalesce_delims=*/true);
 }
 
 Attribute ExecutableTargetAttr::getMatchExpression() {

--- a/compiler/src/iree/compiler/Utils/StringUtils.cpp
+++ b/compiler/src/iree/compiler/Utils/StringUtils.cpp
@@ -27,14 +27,16 @@ std::string replaceAllSubstrs(const std::string &str, const std::string &match,
   return copy;
 }
 
-std::string sanitizeSymbolName(StringRef name) {
+std::string sanitizeSymbolName(StringRef name, bool coalesce_delims) {
   std::string result;
   result.reserve(name.size());
+  const char delim = '_';
   for (size_t i = 0; i < name.size(); ++i) {
     char c = name[i];
     if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
           (c >= '0' && c <= '9') || c == '_')) {
-      c = '_';
+      c = delim;
+      if (coalesce_delims && !result.empty() && result.back() == c) continue;
     }
     result.push_back(c);
   }

--- a/compiler/src/iree/compiler/Utils/StringUtils.h
+++ b/compiler/src/iree/compiler/Utils/StringUtils.h
@@ -25,7 +25,10 @@ std::string replaceAllSubstrs(const std::string &str, const std::string &match,
                               const std::string &substitute);
 
 // Sanitizes a symbol name for compatibility with common targets (C, file
-// systems, debug databases, etc).
+// systems, debug databases, etc). Characters outside the allowed range are
+// replaced by `_`.
+//
+// If coalesce_delims is true then consecutive `_` are replaced by a single `_`.
 //
 // MLIR identifiers must match this regex:
 //   (letter|[_]) (letter|digit|[_$.])*
@@ -37,7 +40,10 @@ std::string replaceAllSubstrs(const std::string &str, const std::string &match,
 //  `abc` -> `abc`
 //  `a.b` -> `a_b`
 //  `a$-æb` -> `a___b`
-std::string sanitizeSymbolName(StringRef name);
+//
+// If coalesce_delims is true then:
+//  `a$-æb` -> `a_b`
+std::string sanitizeSymbolName(StringRef name, bool coalesce_delims = false);
 
 // Sanitizes a file name for compatibility with common file systems.
 //


### PR DESCRIPTION
While VMVX is portable, some IR is more conducive of high performance on some devices, than others.

With the migration from old mmt4d to new set-encoding, the target information allowing to select tile sizes is now part of regular LLVM-CPU target flags as far as LLVM-CPU is concerned, but for VMVX, for parity with the old mmt4d pass's ability to specify tile sizes in flow to enable picking up the right ukernels, we need to preserve the ability to specific a target CPU + features, even if that's just a tuning hint in the case of VMVX.

I came across the "this is where we would multiversion" comment so I beght (irregular past tense of bite) the bullet.

Example: `--iree-vmvx-tune-cpu=x86-64,aarch64,aarch64+dotprod+i8mm`

Results in

```
  hal.executable.variant public @vmvx_bytecode_fb_x86_64, target = <"vmvx", "vmvx-bytecode-fb", {cpu_features = "", target_triple = "x86-64"}> {
...
  hal.executable.variant public @vmvx_bytecode_fb_aarch64, target = <"vmvx", "vmvx-bytecode-fb", {cpu_features = "", target_triple = "aarch64"}> {
...
  hal.executable.variant public @vmvx_bytecode_fb_aarch64_dotprod_i8mm, target = <"vmvx", "vmvx-bytecode-fb", {cpu_features = "+dotprod,+i8mm", target_triple = "aarch64"}> {
...
```

with `hal.executable.variant`'s for each.

It's fine for a llvm target triple to only contain the first componentl, CPU architecture, and not the other components. The llvm::Triple constructor parsing a string is fine with that. So just that is enough to get the right mmt4d tile sizes selected.

