### PR TITLE
[spirv] Use a placeholder pointer type when creating resources

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -127,7 +127,7 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
     // We are using a none type for creating the global variable. It's fine.
     // The correctness boundary is the pass. We will fix it up during
     // conversion so it won't leak.
-    auto dummyType = spirv::PointerType::get(
+    auto placeholderType = spirv::PointerType::get(
         NoneType::get(module.getContext()), spirv::StorageClass::StorageBuffer);
 
     for (int i = subspanOps.size() - 1; i >= 0; --i) {
@@ -143,7 +143,7 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
         // need to have alias decoration.
         bool alias = setBindingTypes[setBindings[i]].size() > 1;
 
-        var = createResourceVariable(subspanOp.getLoc(), dummyType,
+        var = createResourceVariable(subspanOp.getLoc(), placeholderType,
                                      setBinding.first, setBinding.second, alias,
                                      module, &symbolTable);
         resourceVars[key] = var;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -124,6 +124,12 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
                    spirv::GlobalVariableOp>
         resourceVars;
 
+    // We are using a none type for creating the global variable. It's fine.
+    // The correctness boundary is the pass. We will fix it up during
+    // conversion so it won't leak.
+    auto dummyType = spirv::PointerType::get(
+        NoneType::get(module.getContext()), spirv::StorageClass::StorageBuffer);
+
     for (int i = subspanOps.size() - 1; i >= 0; --i) {
       auto subspanOp = subspanOps[i];
       const auto &setBinding = setBindings[i];
@@ -137,10 +143,7 @@ InterfaceResourceMap createResourceVariables(mlir::ModuleOp module) {
         // need to have alias decoration.
         bool alias = setBindingTypes[setBindings[i]].size() > 1;
 
-        // We are using the interface op's type for creating the global
-        // variable. It's fine. The correctness boundary is the pass.
-        // We will fix it up during conversion so it won't leak.
-        var = createResourceVariable(subspanOp.getLoc(), subspanOp.getType(),
+        var = createResourceVariable(subspanOp.getLoc(), dummyType,
                                      setBinding.first, setBinding.second, alias,
                                      module, &symbolTable);
         resourceVars[key] = var;


### PR DESCRIPTION
This avoids triggering validation failures when printing in verbose debugging mode.