### PR TITLE
Cherry-pick some SPIR-V related MLIR commits

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -334,8 +334,9 @@ void ConvertToSPIRVPass::runOnOperation() {
     }
     auto workgroupSize32 = llvm::to_vector<4>(llvm::map_range(
         workgroupSize, [](int64_t v) { return static_cast<int32_t>(v); }));
-    funcOp->setAttr(spirv::getEntryPointABIAttrName(),
-                    spirv::getEntryPointABIAttr(workgroupSize32, context));
+    funcOp->setAttr(
+        spirv::getEntryPointABIAttrName(),
+        spirv::getEntryPointABIAttr(context, workgroupSize32, llvm::None));
   }
 
   spirv::TargetEnvAttr targetAttr = getSPIRVTargetEnvAttr(moduleOp);

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.cpp
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.cpp
@@ -171,6 +171,7 @@ spirv::ResourceLimitsAttr convertResourceLimits(
       context, vkCapabilities.getMaxComputeSharedMemorySize(),
       vkCapabilities.getMaxComputeWorkGroupInvocations(),
       builder.getI64ArrayAttr(sizes), vkCapabilities.getSubgroupSize(),
+      /*min_subgroup_size=*/llvm::None, /*max_subgroup_size=*/llvm::None,
       ArrayAttr::get(context, spvAttrs));
 }
 }  // anonymous namespace


### PR DESCRIPTION
* [mlir][spirv] Check GlobalVariableOp result to be of pointer types
* [mlir][spirv] Improve vector extract/insert element conversion
* [mlir][spirv] Allow controlling subgroup size
* [mlir][spirv] Fix missing parameter usage