### PR TITLE
Support distribution to more than 3 dimension at the workgroup level

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -82,17 +82,7 @@ static LogicalResult getTileAndDistributeConfig(
   }
 
   partitionableLoops =
-      partitionableLoopInterface.getPartitionableLoops(kNumMaxParallelDims);
-  // For now assert that number of partitionable loops are less than the
-  // supported max.
-  // TODO(ravishankarm): Relax this restriction.
-  if (partitionableLoops.size() > kNumMaxParallelDims) {
-    return rootOp.value()->emitOpError(
-               "expected number of partitionable loops to be less than or "
-               "equal to ")
-           << kNumMaxParallelDims;
-  }
-
+      partitionableLoopInterface.getPartitionableLoops(llvm::None);
   IREE::Codegen::LoweringConfigAttr rootOpConfig = getLoweringConfig(*rootOp);
   if (!rootOpConfig) {
     return rootOp.value()->emitOpError(
@@ -208,8 +198,18 @@ struct LowerDispatchWorkgroupCountForDagRootOp
     // slowest varying.
     SmallVector<Value> numWorkgroups;
     for (auto partitionedLoop : llvm::reverse(partitionedLoops)) {
-      numWorkgroups.push_back(getValueOrCreateConstantIndexOp(
-          rewriter, loc, numTiles[partitionedLoop]));
+      Value numTileAlongDim = getValueOrCreateConstantIndexOp(
+          rewriter, loc, numTiles[partitionedLoop]);
+      if (numWorkgroups.size() == kNumMaxParallelDims) {
+        // IREE runtime only has 3 ID dimensions. After all the num of tiles are
+        // combined into one.
+        AffineExpr s0 = rewriter.getAffineSymbolExpr(0);
+        AffineExpr s1 = rewriter.getAffineSymbolExpr(1);
+        numWorkgroups.back() = makeComposedAffineApply(
+            rewriter, loc, s0 * s1, {numWorkgroups.back(), numTileAlongDim});
+        continue;
+      }
+      numWorkgroups.push_back(numTileAlongDim);
     }
     Value one = rewriter.create<arith::ConstantIndexOp>(loc, 1);
     numWorkgroups.resize(kNumMaxParallelDims, one);
@@ -374,7 +374,8 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
 
     auto linalgTilingOptions =
         linalg::LinalgTilingOptions()
-            .setDistributionOptions(getIREELinalgLoopDistributionOptions())
+            .setDistributionOptions(
+                getIREELinalgLoopDistributionOptions(tileSizes))
             .setInterchange(llvm::to_vector<4>(
                 llvm::map_range(interchange,
                                 [](int64_t v) -> unsigned {

--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -244,6 +244,99 @@ hal.executable private @add4D {
 
 // -----
 
+#config = #iree_codegen.lowering_config<tile_sizes = [[2, 64, 64, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+#executable_target_embedded_elf_x86_64_ = #hal.executable.target<"llvm-cpu", "embedded-elf-x86_64", {
+  data_layout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  native_vector_size = 16 : index,
+  target_triple = "x86_64-unknown-linux-gnu"}>
+#map = affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>
+#translation = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+hal.executable private @add_distribute4D {
+  hal.executable.variant public @llvm, target = #executable_target_embedded_elf_x86_64_ {
+    hal.executable.export public @add_distribute4D layout(#pipeline_layout) attributes {translation_info = #translation} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index, %arg3 : index, %arg4 :index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @add_distribute4D() {
+        %0 = hal.interface.constant.load[0] : index
+        %1 = hal.interface.constant.load[1] : index
+        %2 = hal.interface.constant.load[2] : index
+        %3 = hal.interface.constant.load[3] : index
+        %4 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32)
+            : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
+        %5 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(32)
+            : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
+        %6 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(32)
+            : !flow.dispatch.tensor<writeonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
+        %7 = flow.dispatch.tensor.load %4, offsets = [0, 0, 0, 0], sizes = [%0, %1, %2, %3], strides = [1, 1, 1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3} -> tensor<?x?x?x?xf32>
+        %8 = flow.dispatch.tensor.load %5, offsets = [0, 0, 0, 0], sizes = [%0, %1, %2, %3], strides = [1, 1, 1, 1]
+            : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3} -> tensor<?x?x?x?xf32>
+        %9 = tensor.empty(%0, %1, %2, %3) : tensor<?x?x?x?xf32>
+        %10 = linalg.generic {
+            indexing_maps = [#map, #map, #map], iterator_types = ["parallel", "parallel", "parallel", "parallel"]}
+            ins(%7, %8 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>) outs(%9 : tensor<?x?x?x?xf32>) attrs =  {lowering_config = #config} {
+        ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+          %11 = arith.addf %arg0, %arg1 : f32
+          linalg.yield %11 : f32
+        } -> tensor<?x?x?x?xf32>
+        flow.dispatch.tensor.store %10, %6, offsets = [0, 0, 0, 0], sizes = [%0, %1, %2, %3], strides = [1, 1, 1, 1]
+            : tensor<?x?x?x?xf32> -> !flow.dispatch.tensor<writeonly:tensor<?x?x?x?xf32>>{%0, %1, %2, %3}
+        return
+      }
+    }
+  }
+}
+//  CHECK-DAG: #[[MAP:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0, s1] -> ((s0 ceildiv 64) * (s1 ceildiv 2))>
+//  CHECK-DAG: #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 2)>
+//  CHECK-DAG: #[[MAP3:.+]] = affine_map<()[s0] -> (s0 * 64)>
+
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingExpert>
+//      CHECK: hal.executable.export public @add_distribute4D
+// CHECK-SAME:   translation_info = #[[TRANSLATION]]
+// CHECK-NEXT:   (%[[DEVICE:.+]]: !hal.device,
+// CHECK-SAME:    %[[WORKLOAD_0:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_1:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_2:[a-zA-Z0-9_]+]]: index
+// CHECK-SAME:    %[[WORKLOAD_3:[a-zA-Z0-9_]+]]: index)
+//  CHECK-DAG:    %[[D0:.+]] = affine.apply #[[MAP1]]()[%[[WORKLOAD_1]], %[[WORKLOAD_0]]
+//  CHECK-DAG:    %[[D1:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_2]]]
+//  CHECK-DAG:    %[[D2:.+]] = affine.apply #[[MAP]]()[%[[WORKLOAD_3]]]
+//      CHECK:    hal.return %[[D2]], %[[D1]], %[[D0]] : index, index, index
+//      CHECK: func.func @add_distribute4D()
+//  CHECK-DAG:   %[[D0:.+]] = hal.interface.constant.load[0] : index
+//  CHECK-DAG:   %[[D1:.+]] = hal.interface.constant.load[1] : index
+//  CHECK-DAG:   %[[D2:.+]] = hal.interface.constant.load[2] : index
+//  CHECK-DAG:   %[[D3:.+]] = hal.interface.constant.load[3] : index
+//  CHECK-DAG:   %[[IDX:.+]] = hal.interface.workgroup.id[0] : index
+//  CHECK-DAG:   %[[IDY:.+]] = hal.interface.workgroup.id[1] : index
+//  CHECK-DAG:   %[[IDZ:.+]] = hal.interface.workgroup.id[2] : index
+//  CHECK-DAG:   %[[NUMT:.+]] = affine.apply #[[MAP]]()[%[[D1]]]
+//  CHECK-DAG:   %[[ID3:.+]] = arith.remui %[[IDZ]], %[[NUMT]] : index
+//  CHECK-DAG:   %[[ID4:.+]] = arith.divui %[[IDZ]], %[[NUMT]] : index
+//  CHECK-DAG:   %[[L4:.+]] = affine.apply #[[MAP2]]()[%[[ID4]]]
+//      CHECK:   scf.for %[[IV0:.+]] = %[[L4]]
+//      CHECK:     %[[L3:.+]] = affine.apply #[[MAP3]]()[%[[ID3]]]
+//      CHECK:     scf.for %[[IV1:.+]] = %[[L3]]
+//      CHECK:       scf.for %[[IV2:.+]] =
+//      CHECK:         scf.for %[[IV3:.+]] =
+//  CHECK-NOT:         scf.for
+//      CHECK:         %[[GENERIC:.+]] = linalg.generic
+//      CHECK:         flow.dispatch.tensor.store %[[GENERIC]], %{{.+}}, offsets = [%[[IV0]], %[[IV1]], %[[IV2]], %[[IV3]]]
+
+// -----
+
 #config = #iree_codegen.lowering_config<tile_sizes = [[1, 64, 64, 0], [1, 16, 4, 0], [0, 0, 0, 64]]>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -45,7 +45,7 @@ llvm::SmallVector<unsigned> getPartitionableLoopsImpl(
   if (maxNumPartitionedLoops.has_value() &&
       parallelLoops.size() > maxNumPartitionedLoops.value()) {
     parallelLoops =
-        llvm::to_vector(llvm::ArrayRef<unsigned>(parallelLoops)
+        llvm::to_vector(llvm::makeArrayRef(parallelLoops)
                             .take_back(maxNumPartitionedLoops.value()));
   }
   return parallelLoops;
@@ -102,13 +102,14 @@ struct OuterParallelAsPartitionableLoops
       }
       partitionableLoops.push_back(iteratorType.index());
     }
-    if (maxNumPartitionedLoops.has_value() &&
-        partitionableLoops.size() > maxNumPartitionedLoops.value()) {
-      partitionableLoops.erase(partitionableLoops.begin(),
-                               std::next(partitionableLoops.begin(),
-                                         partitionableLoops.size() -
-                                             maxNumPartitionedLoops.value()));
+    if (!maxNumPartitionedLoops.has_value() ||
+        partitionableLoops.size() <= maxNumPartitionedLoops.value()) {
+      return partitionableLoops;
     }
+    partitionableLoops.erase(
+        partitionableLoops.begin(),
+        std::next(partitionableLoops.begin(),
+                  partitionableLoops.size() - maxNumPartitionedLoops.value()));
     return partitionableLoops;
   }
 };
@@ -137,13 +138,14 @@ struct FftOpPartitionableLoops
     if (!fftOp.hasCoeff()) {
       partitionableLoops.pop_back();
     }
-    if (maxNumPartitionedLoops.has_value() &&
-        partitionableLoops.size() > maxNumPartitionedLoops.value()) {
-      partitionableLoops.erase(partitionableLoops.begin(),
-                               std::next(partitionableLoops.begin(),
-                                         partitionableLoops.size() -
-                                             maxNumPartitionedLoops.value()));
+    if (!maxNumPartitionedLoops.has_value() ||
+        partitionableLoops.size() <= maxNumPartitionedLoops.value()) {
+      return partitionableLoops;
     }
+    partitionableLoops.erase(
+        partitionableLoops.begin(),
+        std::next(partitionableLoops.begin(),
+                  partitionableLoops.size() - maxNumPartitionedLoops.value()));
     return partitionableLoops;
   }
 };
@@ -165,13 +167,14 @@ struct AllParallelAsPartitionableLoops
       }
       partitionableLoops.push_back(iteratorType.index());
     }
-    if (maxNumPartitionedLoops.has_value() &&
-        partitionableLoops.size() > maxNumPartitionedLoops.value()) {
-      partitionableLoops.erase(partitionableLoops.begin(),
-                               std::next(partitionableLoops.begin(),
-                                         partitionableLoops.size() -
-                                             maxNumPartitionedLoops.value()));
+    if (!maxNumPartitionedLoops.has_value() ||
+        partitionableLoops.size() <= maxNumPartitionedLoops.value()) {
+      return partitionableLoops;
     }
+    partitionableLoops.erase(
+        partitionableLoops.begin(),
+        std::next(partitionableLoops.begin(),
+                  partitionableLoops.size() - maxNumPartitionedLoops.value()));
     return partitionableLoops;
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -32,7 +32,8 @@ static llvm::SmallVector<unsigned> pruneUnitTripParallelLoops(
 
 /// Returns the partitionable loops for all Linalg ops.
 llvm::SmallVector<unsigned> getPartitionableLoopsImpl(
-    linalg::LinalgOp linalgOp, unsigned maxNumPartitionedLoops) {
+    linalg::LinalgOp linalgOp,
+    llvm::Optional<unsigned> maxNumPartitionedLoops) {
   llvm::SmallVector<unsigned> parallelLoops;
   linalgOp.getParallelDims(parallelLoops);
   // Get the static loop ranges.
@@ -41,9 +42,11 @@ llvm::SmallVector<unsigned> getPartitionableLoopsImpl(
   parallelLoops = pruneUnitTripParallelLoops(parallelLoops, staticLoopRanges);
   // TODO(ravishankarm): For now the outer parallel loops are dropped. This is
   // a pragmatic choice for now but might need to be revisited.
-  if (parallelLoops.size() > maxNumPartitionedLoops) {
-    parallelLoops = llvm::to_vector(llvm::ArrayRef<unsigned>(parallelLoops)
-                                        .take_back(maxNumPartitionedLoops));
+  if (maxNumPartitionedLoops.has_value() &&
+      parallelLoops.size() > maxNumPartitionedLoops.value()) {
+    parallelLoops =
+        llvm::to_vector(llvm::ArrayRef<unsigned>(parallelLoops)
+                            .take_back(maxNumPartitionedLoops.value()));
   }
   return parallelLoops;
 }
@@ -62,7 +65,7 @@ struct LinalgOpPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           LinalgOpPartitionableLoops<OpTy>, OpTy> {
   llvm::SmallVector<unsigned> getPartitionableLoops(
-      Operation *op, unsigned maxNumPartitionedLoops) const {
+      Operation *op, llvm::Optional<unsigned> maxNumPartitionedLoops) const {
     auto linalgOp = cast<linalg::LinalgOp>(op);
     return getPartitionableLoopsImpl(linalgOp, maxNumPartitionedLoops);
   }
@@ -73,7 +76,7 @@ struct Mmt4DOpPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           Mmt4DOpPartitionableLoops, linalg::Mmt4DOp> {
   llvm::SmallVector<unsigned> getPartitionableLoops(
-      Operation *op, unsigned maxNumPartitionedLoops) const {
+      Operation *op, llvm::Optional<unsigned> maxNumPartitionedLoops) const {
     return {0, 1};
   }
 };
@@ -85,7 +88,7 @@ struct OuterParallelAsPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           OuterParallelAsPartitionableLoops<OpTy>, OpTy> {
   llvm::SmallVector<unsigned> getPartitionableLoops(
-      Operation *op, unsigned maxNumPartitionedLoops) const {
+      Operation *op, llvm::Optional<unsigned> maxNumPartitionedLoops) const {
     // For now just return the loops that are returned by the
     // `TiledOpInterface`. This needs to be further pruned to remove unit-dim
     // loops, but that needs the interface to return the static sizes of the
@@ -99,11 +102,12 @@ struct OuterParallelAsPartitionableLoops
       }
       partitionableLoops.push_back(iteratorType.index());
     }
-    if (partitionableLoops.size() > maxNumPartitionedLoops) {
-      partitionableLoops.erase(
-          partitionableLoops.begin(),
-          std::next(partitionableLoops.begin(),
-                    partitionableLoops.size() - maxNumPartitionedLoops));
+    if (maxNumPartitionedLoops.has_value() &&
+        partitionableLoops.size() > maxNumPartitionedLoops.value()) {
+      partitionableLoops.erase(partitionableLoops.begin(),
+                               std::next(partitionableLoops.begin(),
+                                         partitionableLoops.size() -
+                                             maxNumPartitionedLoops.value()));
     }
     return partitionableLoops;
   }
@@ -115,7 +119,7 @@ template <typename OpTy>
 struct NoPartitionableLoops : public PartitionableLoopsInterface::ExternalModel<
                                   NoPartitionableLoops<OpTy>, OpTy> {
   llvm::SmallVector<unsigned> getPartitionableLoops(
-      Operation *op, unsigned maxNumPartitionedLoops) const {
+      Operation *op, llvm::Optional<unsigned> maxNumPartitionedLoops) const {
     return {};
   }
 };
@@ -125,7 +129,7 @@ struct FftOpPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           FftOpPartitionableLoops, IREE::LinalgExt::FftOp> {
   llvm::SmallVector<unsigned> getPartitionableLoops(
-      Operation *op, unsigned maxNumPartitionedLoops) const {
+      Operation *op, llvm::Optional<unsigned> maxNumPartitionedLoops) const {
     auto fftOp = cast<IREE::LinalgExt::FftOp>(op);
     auto range = llvm::seq<unsigned>(0, fftOp.getOperandRank());
     SmallVector<unsigned> partitionableLoops(range.begin(), range.end());
@@ -133,11 +137,12 @@ struct FftOpPartitionableLoops
     if (!fftOp.hasCoeff()) {
       partitionableLoops.pop_back();
     }
-    if (partitionableLoops.size() > maxNumPartitionedLoops) {
-      partitionableLoops.erase(
-          partitionableLoops.begin(),
-          std::next(partitionableLoops.begin(),
-                    partitionableLoops.size() - maxNumPartitionedLoops));
+    if (maxNumPartitionedLoops.has_value() &&
+        partitionableLoops.size() > maxNumPartitionedLoops.value()) {
+      partitionableLoops.erase(partitionableLoops.begin(),
+                               std::next(partitionableLoops.begin(),
+                                         partitionableLoops.size() -
+                                             maxNumPartitionedLoops.value()));
     }
     return partitionableLoops;
   }
@@ -150,7 +155,7 @@ struct AllParallelAsPartitionableLoops
     : public PartitionableLoopsInterface::ExternalModel<
           AllParallelAsPartitionableLoops<OpTy>, OpTy> {
   llvm::SmallVector<unsigned> getPartitionableLoops(
-      Operation *op, unsigned maxNumPartitionedLoops) const {
+      Operation *op, llvm::Optional<unsigned> maxNumPartitionedLoops) const {
     SmallVector<unsigned> partitionableLoops;
     auto interfaceOp = cast<OpTy>(op);
     for (auto iteratorType :
@@ -160,11 +165,12 @@ struct AllParallelAsPartitionableLoops
       }
       partitionableLoops.push_back(iteratorType.index());
     }
-    if (partitionableLoops.size() > maxNumPartitionedLoops) {
-      partitionableLoops.erase(
-          partitionableLoops.begin(),
-          std::next(partitionableLoops.begin(),
-                    partitionableLoops.size() - maxNumPartitionedLoops));
+    if (maxNumPartitionedLoops.has_value() &&
+        partitionableLoops.size() > maxNumPartitionedLoops.value()) {
+      partitionableLoops.erase(partitionableLoops.begin(),
+                               std::next(partitionableLoops.begin(),
+                                         partitionableLoops.size() -
+                                             maxNumPartitionedLoops.value()));
     }
     return partitionableLoops;
   }

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.td
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.td
@@ -24,12 +24,12 @@ def PartitionableLoopsInterface : OpInterface<"PartitionableLoopsInterface"> {
       /*desc=*/[{
         Returns the loop IDs (0 being outermost) that are partitionable.
 
-        The size of the vector returned is always lesser than
-        `maxNumPartitionedLoops`.
+        If `maxNumPartitionedLoops` is passed the size of the vector returned
+        is always lesser than the value.
       }],
       /*retTy=*/"::llvm::SmallVector<unsigned>",
       /*methodName=*/"getPartitionableLoops",
-      /*args=*/(ins "unsigned":$maxNumPartitionedLoops),
+      /*args=*/(ins "llvm::Optional<unsigned>":$maxNumPartitionedLoops),
       /*methodBody=*/"",
       /*defaultImplementation*/"return {};"
     >,

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -353,8 +353,7 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
       IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUDistribute;
   TileSizesListType tileSizes;
   auto interfaceOp = cast<PartitionableLoopsInterface>(*op);
-  auto partitionedLoops =
-      interfaceOp.getPartitionableLoops(kNumMaxParallelDims);
+  auto partitionedLoops = interfaceOp.getPartitionableLoops(llvm::None);
   if (partitionedLoops.empty()) {
     tileSizes.push_back({});
     return setOpConfigAndEntryPointFnTranslation(entryPoint, op, tileSizes,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1111,7 +1111,15 @@ static LogicalResult setDefaultOpConfig(spirv::ResourceLimitsAttr limits,
                                  Optional<int64_t> lossFactor = llvm::None) {
     LLVM_DEBUG(llvm::dbgs() << "\nLoss factor: " << lossFactor << "\n");
     initConfiguration();
-
+    // If there are more than 3 parallel dim try to tile the extra higher level
+    // dimensions to 1 for extra dimensions.
+    if (isa<linalg::GenericOp>(linalgOp.getOperation())) {
+      SmallVector<int64_t> ranges = linalgOp.getStaticLoopRanges();
+      for (int64_t i = 0, e = workgroupTileSizes.size(); i < e; i++) {
+        if (workgroupTileSizes[i] != 0) break;
+        if (ranges[i] != 1) workgroupTileSizes[i] = 1;
+      }
+    }
     // Scan from the innermost shape dimension and try to deduce the
     // configuration for the corresponding GPU workgroup dimension.
     int64_t wgDim = 0;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_default_linalg_ops.mlir
@@ -515,7 +515,7 @@ hal.executable @four_dim_elementwise {
   }
 }
 
-//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 2, 4, 8], [0, 1, 1, 4], [4, 0, 0, 0]{{\]}}>
+//   CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 2, 4, 8], [0, 1, 1, 4]{{\]}}>
 //   CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVBaseVectorize>
 // CHECK-LABEL: hal.executable.export public @four_dim_elementwise
 //  CHECK-SAME:   translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/Utils/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Utils/BUILD
@@ -38,6 +38,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",

--- a/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Utils/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_cc_library(
     LLVMSupport
     MLIRAffineDialect
     MLIRArithDialect
+    MLIRArithUtils
     MLIRFuncDialect
     MLIRGPUOps
     MLIRIR

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -17,6 +17,7 @@
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -633,13 +634,53 @@ static Value buildHALWorkgroupInfoOp(OpBuilder &b, unsigned dim) {
   return b.template create<OpTy>(b.getInsertionPoint()->getLoc(), dim);
 }
 
-linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions() {
+linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
+    const SmallVector<int64_t> &tileSizes) {
   return {
-      [](OpBuilder &builder, Location loc, ArrayRef<Range> parallelLoopRanges) {
+      [&tileSizes](OpBuilder &builder, Location loc,
+                   ArrayRef<Range> parallelLoopRanges) {
+        SmallVector<int64_t> nonZeroTileSizes;
+        for (int64_t size : tileSizes) {
+          if (size != 0) nonZeroTileSizes.push_back(size);
+        }
         auto numParallelDims = parallelLoopRanges.size();
 
         SmallVector<linalg::ProcInfo, 3> procInfo(numParallelDims);
+        Value splitDim;
         for (size_t dim = 0; dim < numParallelDims; ++dim) {
+          if (numParallelDims > 3 && dim >= 2) {
+            if (!splitDim) {
+              splitDim =
+                  buildHALWorkgroupInfoOp<IREE::HAL::InterfaceWorkgroupIDOp>(
+                      builder, 2);
+            }
+            Value size = getValueOrCreateConstantIndexOp(
+                builder, loc,
+                parallelLoopRanges[numParallelDims - dim - 1].size);
+            Value offset = getValueOrCreateConstantIndexOp(
+                builder, loc,
+                parallelLoopRanges[numParallelDims - dim - 1].offset);
+            AffineExpr d0, d1;
+            int64_t tileSize = nonZeroTileSizes[numParallelDims - dim - 1];
+            bindSymbols(builder.getContext(), d0, d1);
+            Value numTiles = makeComposedAffineApply(
+                builder, loc, (d0 - d1).ceilDiv(tileSize), {size, offset});
+            Value dimValue;
+            if (dim == numParallelDims - 1)
+              dimValue = splitDim;
+            else {
+              dimValue =
+                  builder.create<arith::RemUIOp>(loc, splitDim, numTiles);
+              splitDim =
+                  builder.create<arith::DivUIOp>(loc, splitDim, numTiles);
+            }
+            procInfo[numParallelDims - dim - 1] = {
+                dimValue,
+                numTiles,
+                linalg::DistributionMethod::Cyclic,
+            };
+            continue;
+          }
           procInfo[numParallelDims - dim - 1] = {
               buildHALWorkgroupInfoOp<IREE::HAL::InterfaceWorkgroupIDOp>(
                   builder, dim),

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -648,7 +648,8 @@ linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
         SmallVector<linalg::ProcInfo, 3> procInfo(numParallelDims);
         Value splitDim;
         for (size_t dim = 0; dim < numParallelDims; ++dim) {
-          if (numParallelDims > 3 && dim >= 2) {
+          if (numParallelDims > kNumMaxParallelDims &&
+              dim >= kNumMaxParallelDims - 1) {
             if (!splitDim) {
               splitDim =
                   buildHALWorkgroupInfoOp<IREE::HAL::InterfaceWorkgroupIDOp>(

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -178,7 +178,8 @@ Operation *createLinalgCopyOp(OpBuilder &b, Location loc, Value from, Value to,
 
 /// Returns the option that distributes the ops using the flow workgroup
 /// ID/Count operations.
-linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions();
+linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
+    const SmallVector<int64_t> &tileSizes);
 
 /// Replace the uses of memref `oldOp` with the given `val` and for subview uses
 /// propagate the type change. Changing the memref type may require propagating

--- a/integrations/tensorflow/test/iree_tf_tests/layers/vulkan__dynamic_dims_Softmax.run
+++ b/integrations/tensorflow/test/iree_tf_tests/layers/vulkan__dynamic_dims_Softmax.run
@@ -1,4 +1,2 @@
-# XFAIL: *
-# Failing due to Issue #9802
 # REQUIRES: vulkan
 # RUN: %PYTHON -m iree_tf_tests.layers.layers_test --target_backends=iree_vulkan --dynamic_dims=true --training=false --test_default_kwargs_only=true --layer=Softmax --artifacts_dir=%t

--- a/integrations/tensorflow/test/iree_tf_tests/math/vulkan__dynamic_dim_log_softmax.run
+++ b/integrations/tensorflow/test/iree_tf_tests/math/vulkan__dynamic_dim_log_softmax.run
@@ -1,4 +1,2 @@
-# XFAIL: *
-# Failing due to Issue #9802
 # REQUIRES: vulkan
 # RUN: %PYTHON -m iree_tf_tests.math.math_test --target_backends=iree_vulkan --dynamic_dims=true --functions=log_softmax --artifacts_dir=%t

--- a/integrations/tensorflow/test/iree_tf_tests/math/vulkan__dynamic_dim_softmax.run
+++ b/integrations/tensorflow/test/iree_tf_tests/math/vulkan__dynamic_dim_softmax.run
@@ -1,4 +1,2 @@
-# XFAIL: *
-# Failing due to Issue #9802
 # REQUIRES: vulkan
 # RUN: %PYTHON -m iree_tf_tests.math.math_test --target_backends=iree_vulkan --dynamic_dims=true --functions=softmax --artifacts_dir=%t


### PR DESCRIPTION
So far we were not distributing higher level dimensions for operations with more than 3 parallel dimensions. This delinearize the z dimension for case with more than 3 dimension and allow better distribution if the kernel config asks for it.
Also change the default config of llvmgpu and spirv backend to take advantage of that.