### PR TITLE
Set maximum number of threads in the thread block for CUDA

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -277,6 +277,21 @@ class CUDATargetBackend final : public TargetBackend {
           llvm::MDNode::get(llvmModule->getContext(), llvmMetadata);
       llvmModule->getOrInsertNamedMetadata("nvvm.annotations")
           ->addOperand(llvmMetadataNode);
+      /* Set maximum number of threads in the thread block (CTA). */
+      auto generateMetadata = [&](int dim, StringRef name) {
+        llvm::Metadata *llvmMetadata[] = {
+            llvm::ValueAsMetadata::get(llvmFunc),
+            llvm::MDString::get(llvmModule->getContext(), name),
+            llvm::ValueAsMetadata::get(llvm::ConstantInt::get(
+                llvm::Type::getInt32Ty(llvmModule->getContext()), dim))};
+        llvm::MDNode *llvmMetadataNode =
+            llvm::MDNode::get(llvmModule->getContext(), llvmMetadata);
+        llvmModule->getOrInsertNamedMetadata("nvvm.annotations")
+            ->addOperand(llvmMetadataNode);
+      };
+      generateMetadata(workgroupSize[0], "maxntidx");
+      generateMetadata(workgroupSize[1], "maxntidy");
+      generateMetadata(workgroupSize[2], "maxntidz");
     }
 
     std::unique_ptr<llvm::TargetMachine> targetMachine;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
@@ -41,6 +41,7 @@ stream.executable public @add_dispatch_0 {
 }
 
 // PTX: .entry add_dispatch_0
+// PTX: .maxntid 64, 1, 1
 // PTX:   add.rn.f32
 
 //      CHECK:   hal.executable.binary public @cuda_nvptx_fb attributes {


### PR DESCRIPTION
PTX programming models provides some performance tuning directives; see https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#performance-tuning-directives The downstream compiler namely ptxas leverages these information for better register allocation or to handle other resource management that improves the performance.

As far as I understand, iree always knows the number of threads. This PR sets `maxntid` to CUDA kernel. 