### PR TITLE
Use C++ callbacks to match reductions inside the transform dialect

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -383,4 +383,31 @@ def MatchCallbackOp :
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 }
 
+def TakeFirstOp :
+    Op<Transform_Dialect, "iree.take_first",
+       [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+        DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{
+    Given an arbitrary list of handles associated with potentially empty lists
+    of payload operations, produces two new handles:
+
+      - a handle pointing to the same payload operations as the first operand
+        handle with a non-empty list of payload operations;
+      - a handle pointing to the concatenated list of payload operations
+        associated with any other handle.
+
+    Note that this does not perform any deduplication.
+
+    This operation is useful to select a single target after some potentially
+    unsuccessful matches.
+  }];
+
+  let arguments = (ins Variadic<TransformTypeInterface>:$inputs);
+  let results = (outs TransformTypeInterface:$first,
+                      TransformTypeInterface:$rest);
+  let assemblyFormat =
+      "$inputs attr-dict `:` functional-type($inputs, results)";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+}
+
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/TransformMatchers.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/TransformMatchers.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/TransformExtensions/TransformMatchers.h"
 
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 
 using namespace mlir;
 using namespace mlir::iree_compiler;
@@ -108,6 +109,81 @@ transform_dialect::StructuredOpMatcher::input(AllOperands tag, IsPermutation) {
   return *this;
 }
 
+/// Traverses the transitive sources of `val` until it reaches an operation that
+/// is not a known "subset-like" operation, i.e. `extract_slice` or
+/// `foreach_thread`.
+static Operation *traverseSubsetsBackwards(Value val) {
+  do {
+    Operation *op = val.getDefiningOp();
+    if (!op) {
+      // TODO: This should likely be done via RegionBranchOpInterface as a sort
+      // of data flow analysis.
+      auto bbArg = val.cast<BlockArgument>();
+      Operation *blockOp = bbArg.getOwner()->getParentOp();
+      assert(blockOp && "detached block");
+      if (auto loop = dyn_cast<scf::ForeachThreadOp>(blockOp)) {
+        val = loop.getTiedOpOperand(bbArg)->get();
+        continue;
+      }
+      return blockOp;
+    }
+
+    // TODO: We may eventually want a "subset-like" interface that we can use to
+    // traverse ops here and in post-canonicalization replacement
+    // identification.
+    if (auto extractSlice = dyn_cast<tensor::ExtractSliceOp>(op)) {
+      val = extractSlice.getSource();
+      continue;
+    }
+    return op;
+  } while (true);
+}
+
+/// Greedily traverses the transitive uses of `val` until it reaches an
+/// operation that is not a known "subset-like" operation, i.e. `extract_slice`
+/// or `foreach_thread`.
+static Operation *traverseSubsetsForwardAnyUse(Value val) {
+  do {
+    for (OpOperand &use : val.getUses()) {
+      Operation *user = use.getOwner();
+      if (auto loop = dyn_cast<scf::ForeachThreadOp>(user)) {
+        auto range = loop.getOutputBlockArguments();
+        auto it = llvm::find_if(range, [&](BlockArgument bbarg) {
+          return loop.getTiedOpOperand(bbarg) != &use;
+        });
+        if (it == range.end()) return user;
+        val = *it;
+        continue;
+      }
+      if (auto slice = dyn_cast<tensor::ExtractSliceOp>(user)) {
+        val = slice.getResult();
+        continue;
+      }
+      return user;
+    }
+  } while (true);
+}
+
+transform_dialect::StructuredOpMatcher &
+transform_dialect::StructuredOpMatcher::input(int64_t position,
+                                              SubsetOf subset) {
+  // Implementation note: SubsetOf must *not* be passed by-reference because
+  // it is typically a temporary constructed within the argument of a function
+  // call, but it will be used in the lambda that outlives the temporary. The
+  // lambda itself must capture by value for the same reason.
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    int64_t transformedPosition =
+        position >= 0 ? position : linalgOp.getNumDpsInputs() + position;
+    if (transformedPosition >= linalgOp.getNumDpsInputs()) return false;
+
+    Operation *producer = traverseSubsetsBackwards(
+        linalgOp.getDpsInputOperand(transformedPosition)->get());
+    return subset.matcher.match(producer);
+  });
+  recordNestedMatcher(subset.matcher);
+  return *this;
+}
+
 transform_dialect::StructuredOpMatcher &
 transform_dialect::StructuredOpMatcher::output(AllOperands tag, IsPermutation) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
@@ -152,6 +228,42 @@ transform_dialect::StructuredOpMatcher::output(int64_t position,
   return *this;
 }
 
+transform_dialect::StructuredOpMatcher &
+transform_dialect::StructuredOpMatcher::output(int64_t position,
+                                               SubsetOf subset) {
+  // Implementation note: SubsetOf must *not* be passed by-reference because
+  // it is typically a temporary constructed within the argument of a function
+  // call, but it will be used in the lambda that outlives the temporary. The
+  // lambda itself must capture by value for the same reason.
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    int64_t transformedPosition =
+        position >= 0 ? position : linalgOp.getNumDpsInputs() + position;
+    if (transformedPosition >= linalgOp.getNumDpsInputs()) return false;
+
+    Operation *producer = traverseSubsetsBackwards(
+        linalgOp.getDpsInitOperand(transformedPosition)->get());
+    return subset.matcher.match(producer);
+  });
+  recordNestedMatcher(subset.matcher);
+  return *this;
+}
+
+transform_dialect::StructuredOpMatcher &
+transform_dialect::StructuredOpMatcher::result(int64_t position, HasAnyUse tag,
+                                               SubsetOf subset,
+                                               OptionalMatch optional) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    int64_t transformedPosition =
+        position >= 0 ? position : linalgOp->getNumResults() + position;
+    if (transformedPosition >= linalgOp->getNumResults()) return false;
+
+    Operation *user =
+        traverseSubsetsForwardAnyUse(linalgOp->getResult(transformedPosition));
+    return subset.matcher.match(user) || optional.value;
+  });
+  return *this;
+}
+
 //===---------------------------------------------------------------------===//
 // MatchCallbackResult.
 //===---------------------------------------------------------------------===//
@@ -165,4 +277,80 @@ ArrayRef<Operation *> transform_dialect::MatchCallbackResult::getPayloadGroup(
   }
   return llvm::makeArrayRef(payloadOperations)
       .slice(start, payloadGroupLengths[position]);
+}
+
+//===---------------------------------------------------------------------===//
+// Case-specific matcher builders.
+//===---------------------------------------------------------------------===//
+
+static constexpr unsigned cudaWarpSize = 32;
+
+void transform_dialect::makeGPUReductionMatcher(
+    transform_dialect::StructuredOpMatcher &reduction,
+    transform_dialect::StructuredOpMatcher &fill,
+    transform_dialect::StructuredOpMatcher &leading,
+    transform_dialect::StructuredOpMatcher &trailing) {
+  fill = m_StructuredOp<linalg::FillOp>();
+  trailing = m_StructuredOp<linalg::GenericOp>()
+                 .input(AllOperands(), IsPermutation())
+                 .output(AllOperands(), IsPermutation())
+                 .input(NumEqualsTo(1))
+                 .output(NumEqualsTo(1));
+  leading = trailing;
+  reduction = m_StructuredOp()
+                  .dim(AllDims(), ShapeKind::Static)
+                  .dim(-1, utils::IteratorType::reduction)
+                  .dim(-1, DivisibleBy(cudaWarpSize))
+                  // Can be extended to projected permutation with broadcast.
+                  .input(AllOperands(), IsPermutation())
+                  // TODO: we want to accept any input position here.
+                  .input(0, leading, OptionalMatch())
+                  .output(NumEqualsTo(1))
+                  .output(0, fill)
+                  // Only single combiner over 32 bits for now due to
+                  // reduction distribution.
+                  .output(0, ElementTypeBitWidth(32))
+                  .output(0, SingleCombinerReduction())
+                  .result(0, HasAnyUse(), trailing, OptionalMatch());
+}
+
+void transform_dialect::makeGPUSplitReductionMatcher(
+    transform_dialect::StructuredOpMatcher &parallel_reduction,
+    transform_dialect::StructuredOpMatcher &combiner_reduction,
+    transform_dialect::StructuredOpMatcher &parallel_fill,
+    transform_dialect::StructuredOpMatcher &original_fill,
+    transform_dialect::StructuredOpMatcher &leading,
+    transform_dialect::StructuredOpMatcher &trailing) {
+  original_fill = m_StructuredOp<linalg::FillOp>();
+  parallel_fill = m_StructuredOp<linalg::FillOp>();
+  trailing = m_StructuredOp<linalg::GenericOp>()
+                 .input(AllOperands(), IsPermutation())
+                 .output(AllOperands(), IsPermutation())
+                 .input(NumEqualsTo(1))
+                 .output(NumEqualsTo(1));
+  leading = m_StructuredOp<linalg::GenericOp>()
+                .input(AllOperands(), IsPermutation())
+                .output(AllOperands(), IsPermutation())
+                .input(NumEqualsTo(1))
+                .output(NumEqualsTo(1));
+  parallel_reduction = m_StructuredOp()
+                           .dim(AllDims(), ShapeKind::Static)
+                           .dim(-1, utils::IteratorType::reduction)
+                           .input(AllOperands(), IsPermutation())
+                           // TODO: we want to accept any input position here.
+                           .input(0, leading, OptionalMatch())
+                           .output(NumEqualsTo(1))
+                           .output(0, parallel_fill);
+  combiner_reduction =
+      m_StructuredOp()
+          .dim(AllDims(), ShapeKind::Static)
+          .dim(-1, utils::IteratorType::reduction)
+          // Can be extended to projected permutation with broadcast.
+          .input(AllOperands(), IsPermutation())
+          .input(0, SubsetOf(parallel_reduction))
+          .output(NumEqualsTo(1))
+          .output(0, SubsetOf(original_fill))
+          .output(0, ElementTypeBitWidth(32))
+          .output(0, SingleCombinerReduction())
+          .result(0, HasAnyUse(), SubsetOf(trailing), OptionalMatch());
 }

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -36,6 +36,7 @@ iree_lit_test_suite(
             "pad_dynamic_alloc.mlir",
             "materialize_encoding.mlir",
             "reduce_bank_conflicts.mlir",
+            "reductions.mlir",
             "remove_dead_allocs.mlir",
             "remove_trivial_loops.mlir",
             "swizzle_workgroup.mlir",
@@ -51,8 +52,16 @@ iree_lit_test_suite(
             "workgroup_specialization.mlir",
         ],
         include = ["*.mlir"],
+        exclude = [
+            "reductions_codegen_spec.mlir",
+        ],
     ),
     cfg = "//compiler:lit.cfg.py",
+    # transform dialect spec files are MLIR files that specify a transformation,
+    # they need to be included as data.
+    data = [
+        "reductions_codegen_spec.mlir",
+    ],
     tools = [
         "//tools:iree-opt",
         "@llvm-project//llvm:FileCheck",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_lit_test_suite(
     "materialize_encoding.mlir"
     "pad_dynamic_alloc.mlir"
     "reduce_bank_conflicts.mlir"
+    "reductions.mlir"
     "remove_dead_allocs.mlir"
     "remove_trivial_loops.mlir"
     "swizzle_workgroup.mlir"
@@ -48,6 +49,8 @@ iree_lit_test_suite(
   TOOLS
     FileCheck
     iree-opt
+  DATA
+    reductions_codegen_spec.mlir
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions.mlir
@@ -1,0 +1,312 @@
+// RUN: iree-opt %s --iree-transform-dialect-interpreter='transform-file-name=%p/reductions_codegen_spec.mlir' --split-input-file | FileCheck %s
+
+// Check that the same transform script applies to reductions with optional
+// leading and trailing elementwise operations, potentially reordered
+// producers and interleaving operations. This only checks for the matching
+// and the right fusion structure without the surrounding IREE dispatch, which
+// may fuse earlier, to decrease fragility.
+
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->   !out_tensor_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_t
+  return %2 : !out_tensor_t
+}
+
+// CHECK-LABEL: @reduce
+// CHECK: scf.foreach_thread
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+
+// -----
+
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @eltwise_reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
+  %2 = tensor.empty() : !in_tensor_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : !in_tensor_t) outs(%2 : !in_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = arith.addf %arg3, %arg3 : f32
+      %5 = arith.addf %4, %4 : f32
+      linalg.yield %5 : f32
+    } -> !in_tensor_t
+
+  %6 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%3 : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  return %6 : !out_tensor_t
+}
+
+// CHECK-LABEL: @eltwise_reduce
+// CHECK: scf.foreach_thread
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.generic
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+
+// -----
+
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @reduce_eltwise(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) -> !out_tensor_t
+  %5 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  %6 = tensor.empty() : !out_tensor_t
+  %7 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%5 : !out_tensor_t) outs(%6 : !out_tensor_t) {  
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = math.sqrt %arg3 : f32
+      linalg.yield %4 : f32
+    } -> !out_tensor_t
+  return %7 : !out_tensor_t
+}
+
+
+// CHECK-LABEL: @reduce_eltwise
+// CHECK: scf.foreach_thread
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:     linalg.generic
+
+// -----
+
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @eltwise_reduce_eltwise(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
+  %2 = tensor.empty() : !in_tensor_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : !in_tensor_t) outs(%2 : !in_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = arith.addf %arg3, %arg3 : f32
+      %5 = arith.addf %4, %4 : f32
+      linalg.yield %5 : f32
+    } -> !in_tensor_t
+
+  %6 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%3 : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  %7 = tensor.empty() : !out_tensor_t
+  %8 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%6 : !out_tensor_t) outs(%7 : !out_tensor_t) {  
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = math.sqrt %arg3 : f32
+      linalg.yield %4 : f32
+    } -> !out_tensor_t
+
+
+  return %8 : !out_tensor_t
+}
+
+// CHECK-LABEL: @eltwise_reduce_eltwise
+// CHECK: scf.foreach_thread
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.generic
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:     linalg.generic
+
+// -----
+
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @eltwise_reduce_eltwise_swapped(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %2 = tensor.empty() : !in_tensor_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : !in_tensor_t) outs(%2 : !in_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = arith.addf %arg3, %arg3 : f32
+      %5 = arith.addf %4, %4 : f32
+      linalg.yield %5 : f32
+    } -> !in_tensor_t
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
+  %6 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%3 : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  %7 = tensor.empty() : !out_tensor_t
+  %8 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%6 : !out_tensor_t) outs(%7 : !out_tensor_t) {  
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = math.sqrt %arg3 : f32
+      linalg.yield %4 : f32
+    } -> !out_tensor_t
+
+
+  return %8 : !out_tensor_t
+}
+
+// CHECK-LABEL: @eltwise_reduce_eltwise_swapped
+// CHECK: scf.foreach_thread
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.generic
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:     linalg.generic
+
+
+// -----
+
+!in_tensor_t = tensor<8x64xf32>
+!out_tensor_t = tensor<8xf32>
+
+func.func @eltwise_reduce_eltwise_interleaving(
+    %arg : !in_tensor_t, %arg2 : !in_tensor_t) -> (!out_tensor_t, !in_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %2 = tensor.empty() : !in_tensor_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : !in_tensor_t) outs(%2 : !in_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = arith.addf %arg3, %arg3 : f32
+      %5 = arith.addf %4, %4 : f32
+      linalg.yield %5 : f32
+    } -> !in_tensor_t
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
+  %6 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%3 : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %4 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %4 : f32
+      } -> !out_tensor_t
+
+  %interleaving_out = tensor.empty() : !in_tensor_t
+  %interleaving = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg2 : !in_tensor_t) outs(%interleaving_out : !in_tensor_t) {
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = arith.addf %arg3, %arg3 : f32
+      linalg.yield %4 : f32
+    } -> !in_tensor_t
+
+  %7 = tensor.empty() : !out_tensor_t
+  %8 = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%6 : !out_tensor_t) outs(%7 : !out_tensor_t) {  
+    ^bb0(%arg3: f32, %arg4: f32):
+      %4 = math.sqrt %arg3 : f32
+      linalg.yield %4 : f32
+    } -> !out_tensor_t
+
+  return %8, %interleaving : !out_tensor_t, !in_tensor_t
+}
+
+// CHECK-LABEL: @eltwise_reduce_eltwise_interleaving
+// CHECK: linalg.generic
+// CHECK: scf.foreach_thread
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.generic
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:   scf.foreach_thread
+// CHECK:     linalg.fill
+// CHECK:     linalg.generic
+// CHECK:     linalg.generic

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
@@ -1,0 +1,68 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb0(%arg0: !pdl.operation):
+  transform.iree.register_match_callbacks
+
+  %_, %fill, %reduction, %maybe_trailing_0 =
+    transform.iree.match_callback failures(propagate) "reduction"(%arg0)
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+  
+  %0, %1, %2, %combiner_op =
+    transform.structured.split_reduction %reduction { split_factor = 2, insert_split_dimension = 1 }
+
+  %fusion_root_1, %fusion_group_1 = transform.iree.take_first %maybe_trailing_0, %combiner_op
+    : (!pdl.operation, !pdl.operation) -> (!pdl.operation, !pdl.operation)
+  transform.structured.tile_to_foreach_thread_op %fusion_root_1 tile_sizes [1]
+    ( mapping = [#gpu.block<x>] )
+  
+  // TODO: bubbling should be a proper transform op, at which point we will be
+  // able to preserve the handles and avoid rematching below.
+  %func = transform.structured.match ops{["func.func"]} in %arg0
+  %func_1 = transform.iree.apply_patterns %func { bubble_collapse_expand }
+
+  %maybe_leading, %original_fill, %more_parallel_fill, %parallel_reduction, %combiner_reduction, %maybe_trailing =
+    transform.iree.match_callback failures(propagate) "split_reduction"(%arg0)
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+
+  %fusion_root_1_updated, %fusion_group_1_updated =
+    transform.iree.take_first %maybe_trailing, %combiner_reduction
+    : (!pdl.operation, !pdl.operation) -> (!pdl.operation, !pdl.operation)
+  // TODO: we need an extra navigation op similar to get_parent_loop to avoid rematching.
+  // %grid_loop = transform.iree.get_parent_of_type("scf.foreach_thread") %fusion_root_1_updated 
+  %grid_loop = transform.structured.match ops{["scf.foreach_thread"]} in %arg0
+  %fusion_group_1_full = transform.merge_handles %fusion_group_1_updated,
+    %maybe_leading, %original_fill, %more_parallel_fill, %parallel_reduction
+    : !pdl.operation
+  transform.structured.fuse_into_containing_op %fusion_group_1_full into %grid_loop
+
+  // Step 3.
+  %maybe_leading_2, %original_fill_2, %more_parallel_fill_2, %parallel_reduction_2, %combiner_reduction_2, %maybe_trailing_2 =
+    transform.iree.match_callback failures(propagate) "split_reduction"(%arg0)
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+  %fusion_root_22, %fusion_group_22 =
+    transform.iree.take_first %maybe_trailing_2, %combiner_reduction_2
+    : (!pdl.operation, !pdl.operation) -> (!pdl.operation, !pdl.operation)
+  %fusion_group_22_full = transform.merge_handles %fusion_group_22, %original_fill_2
+    : !pdl.operation
+  %block_loop_22, %fusion_root_22_tiled =
+    transform.structured.tile_to_foreach_thread_op %fusion_root_22
+    tile_sizes [1] ( mapping = [#gpu.thread<z>] )
+  transform.structured.fuse_into_containing_op %fusion_group_22_full into %block_loop_22
+
+  %fusion_group_21 = transform.merge_handles %maybe_leading_2, %more_parallel_fill_2
+    : !pdl.operation
+  %block_loop_21, %fusion_root_21_tiled =
+    transform.structured.tile_to_foreach_thread_op %parallel_reduction_2
+    tile_sizes [1, 1] ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
+  transform.structured.fuse_into_containing_op %fusion_group_21 into %block_loop_21
+  
+  // Step 4. Rank-reduce.
+  // ===========================================================================
+  %func_2 = transform.iree.apply_patterns %func_1 { rank_reducing }
+
+  // We don't perform any following transformation (vectorization, bufferizaton,
+  // mapping) because this schedule is applied to Linalg-only code without the
+  // surrounding context and because it would make it difficult to detect, e.g.,
+  // lack of fusion.
+}


### PR DESCRIPTION
Instead of relying on the fragile matching of all payload operations of
the same kind and splitting them in the fixed number of singleton
buckets, use the C++ callback to match the reduction structure. Now, the
exact same callback is used to find the case where the transform
dialect-based pipeline applies and to identify the ops that are
transformed later on. This is still suboptimal as the matching is done
twice, but further integration is left to future work. So are
integration tests via C++ builder API for the transform dialect.