### PR TITLE
Do not try to fuse with ops that are cloned into dispatch regions anyway.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -653,7 +653,8 @@ static void fuseRootsWithProducers(MLIRContext *context, Operation *root,
     for (OpOperand &operand : candidate->getOpOperands()) {
       Operation *producer = operand.get().getDefiningOp();
       if (!producer) continue;
-      if (hasFusionGroupsAttribute(producer) || hasRootOpAttribute(producer)) {
+      if (isClonableIntoDispatchOp(producer) ||
+          hasFusionGroupsAttribute(producer) || hasRootOpAttribute(producer)) {
         continue;
       }
 
@@ -798,6 +799,12 @@ static FailureOr<SmallVector<Flow::DispatchWorkgroupsOp>> createFusionGroups(
   SmallVector<Operation *> roots(numRoots, nullptr);
   DenseMap<unsigned, SmallVector<Operation *>> producers;
 
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n--- After deciding fusion groups ---\n";
+    funcOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+
   // TODO: Incrementally add ops to an empty DispatchGroupOp instead of
   // annotating fusion group IDs via attributes.
   funcOp.walk([&](Operation *op) {
@@ -854,6 +861,12 @@ static FailureOr<SmallVector<Flow::DispatchWorkgroupsOp>> createFusionGroups(
     regionOps.push_back(regionOp);
   }
 
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n--- After creating flow.dispatch.region ---\n";
+    funcOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
+
   // Clone additional producers and rewrite to DispatchWorkgroupsOp.
   SmallVector<Flow::DispatchWorkgroupsOp> result;
   for (auto regionOp : regionOps) {
@@ -865,6 +878,12 @@ static FailureOr<SmallVector<Flow::DispatchWorkgroupsOp>> createFusionGroups(
 
     result.push_back(*maybeWorkgroupOp);
   }
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n--- After creating flow.dispatch.workgroups ---\n";
+    funcOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
 
   return result;
 }
@@ -1031,12 +1050,6 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
   if (failed(maybeWorkgroupsOps)) return signalPassFailure();
   SmallVector<Flow::DispatchWorkgroupsOp> workgroupsOps = *maybeWorkgroupsOps;
 
-  LLVM_DEBUG({
-    llvm::dbgs() << "\n--- After first step of dispatch region formation ---\n";
-    funcOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-    llvm::dbgs() << "\n\n";
-  });
-
   // Step 2: Rewrite InsertSliceOps to FlowUpdateOps.
   if (failed(convertInsertSliceOps(rewriter, funcOp, workgroupsOps,
                                    generateWorkloadRegion)))
@@ -1053,6 +1066,12 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
           rewriter, funcOp, generateWorkloadRegion);
   if (failed(newWorkgroupsOps)) return signalPassFailure();
   workgroupsOps.append(newWorkgroupsOps->begin(), newWorkgroupsOps->end());
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "\n--- After other conversions ---\n";
+    funcOp->print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
+    llvm::dbgs() << "\n\n";
+  });
 
   // A few extra canonicalizations/lowerings.
   {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -2050,3 +2050,33 @@ func.func @extract_slice1(%arg0 : tensor<5x24x48xf32>) -> tensor<4xf32> {
 //       CHECK:   %[[SLICE:.+]] = flow.tensor.slice %[[ARG0]][%[[C2]], %[[C3]], %[[C4]] for %[[C1]], %[[C1]], %[[C4]]]
 //       CHECK:   %[[RESULT:.+]] = flow.tensor.reshape %[[SLICE]]
 //       CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @clone_fill_ops(%arg0 : tensor<128x256xf32>, %arg1 : tensor<256x512xf32>,
+    %arg2 : tensor<128x256xf32>, %arg3 : tensor<256x512xf32>)
+    -> (tensor<128x512xf32>, tensor<128x512xf32>) {
+  %0 = tensor.empty() : tensor<128x512xf32>
+  %cst = arith.constant 0.0 : f32
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %2 = linalg.matmul ins(%arg0, %arg1 : tensor<128x256xf32>, tensor<256x512xf32>)
+      outs(%1 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  %3 = linalg.matmul ins(%arg2, %arg3 : tensor<128x256xf32>, tensor<256x512xf32>)
+      outs(%1 : tensor<128x512xf32>) -> tensor<128x512xf32>
+  return %2, %3 : tensor<128x512xf32>, tensor<128x512xf32>
+}
+// CHECK-LABEL: func @clone_fill_ops(
+//  CHECK-SAME:   %[[ARG0:[a-zA-Z0-9]+]]: tensor<128x256xf32>
+//  CHECK-SAME:   %[[ARG1:[a-zA-Z0-9]+]]: tensor<256x512xf32>
+//  CHECK-SAME:   %[[ARG2:[a-zA-Z0-9].+]]: tensor<128x256xf32>
+//  CHECK-SAME:   %[[ARG3:[a-zA-Z0-9].+]]: tensor<256x512xf32>
+//       CHECK:   %[[DISPATCH1:.+]] = flow.dispatch.workgroups
+//  CHECK-SAME:       (%[[ARG0]], %[[ARG1]])
+//       CHECK:     tensor.empty()
+//       CHECK:     linalg.fill
+//       CHECK:     linalg.matmul
+//       CHECK:   %[[DISPATCH2:.+]] = flow.dispatch.workgroups
+//  CHECK-SAME:       (%[[ARG2]], %[[ARG3]])
+//       CHECK:     tensor.empty()
+//       CHECK:     linalg.fill
+//       CHECK:     linalg.matmul

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1745,9 +1745,9 @@ module {
 //  CHECK-NEXT:     %[[ARG1:.+]]: !flow.dispatch.tensor<readonly:tensor<12x128x128xf32>>
 //       CHECK:     %[[LOAD0:.+]] = flow.dispatch.tensor.load %[[ARG1]]
 //       CHECK:     %[[FILL0:.+]] = linalg.fill
+//       CHECK:     %[[FILL1:.+]] = linalg.fill
 //       CHECK:     %[[GENERIC0:.+]] = linalg.generic
 //  CHECK-SAME:         ins(%[[LOAD0]] : tensor<12x128x128xf32>) outs(%[[FILL0]] : tensor<12x128xf32>)
-//       CHECK:     %[[FILL1:.+]] = linalg.fill
 //       CHECK:     %[[GENERIC1:.+]]:2 = linalg.generic
 //  CHECK-SAME:         ins(%[[LOAD0]], %[[GENERIC0]] : tensor<12x128x128xf32>, tensor<12x128xf32>)
 //  CHECK-SAME:         outs(%{{.*}}, %[[FILL1]] : tensor<12x128x128xf32>, tensor<12x128xf32>)


### PR DESCRIPTION
With changes to CSE also CSE ops with a single block introduces false sharing of `linalg.fill` ops (since they get CSE-ed). It is better to clone these ops into all the dispatches that use them. This was already the case, but they were also treated as producers, which meant they would get pulled into a dispatch (and the dispatch returning their value). Fix the producer fusability consideration, to not include clonable ops, since they get fused anyway.