### PR TITLE
NFC: Separate setting translation info and dispatch configuration

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/UserConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/UserConfig.cpp
@@ -19,9 +19,11 @@ LogicalResult setUserConfig(
         "info");
   }
 
+  auto info = compilationInfo.getTranslationInfo();
+  if (failed(setTranslationInfo(entryPointFn, info))) return failure();
+
   SmallVector<int64_t> workgroupSize = compilationInfo.getWorkgroupSizeVals();
-  setTranslationInfo(entryPointFn, compilationInfo.getTranslationInfo(),
-                     workgroupSize);
+  if (failed(setWorkgroupSize(entryPointFn, workgroupSize))) return failure();
 
   setLoweringConfig(computeOp, compilationInfo.getLoweringConfig());
   eraseCompilationInfo(computeOp);

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.cpp
@@ -263,16 +263,23 @@ SmallVector<int64_t> getWorkgroupSize(IREE::HAL::ExecutableExportOp exportOp) {
   return {};
 }
 
-void setTranslationInfo(IREE::HAL::ExecutableExportOp exportOp,
-                        IREE::Codegen::TranslationInfoAttr translationInfo,
-                        ArrayRef<int64_t> workgroupSize) {
-  exportOp->setAttr(kTranslationInfoAttrName, translationInfo);
-  // The workgroup size is set on the entry point op directly.
-  if (!workgroupSize.empty()) {
-    MLIRContext *context = exportOp->getContext();
-    auto attrs = getIndexIntegerArrayAttr(context, workgroupSize);
-    exportOp.setWorkgroupSizeAttr(attrs);
-  }
+LogicalResult setWorkgroupSize(func::FuncOp entryPoint,
+                               ArrayRef<int64_t> workgroupSize) {
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(entryPoint);
+  if (failed(exportOp)) return failure();
+  if (workgroupSize.empty()) return success();
+  auto attr = getIndexIntegerArrayAttr(exportOp->getContext(), workgroupSize);
+  exportOp->setWorkgroupSizeAttr(attr);
+  return success();
+}
+
+LogicalResult setTranslationInfo(
+    func::FuncOp entryPoint,
+    IREE::Codegen::TranslationInfoAttr translationInfo) {
+  FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(entryPoint);
+  if (failed(exportOp)) return failure();
+  exportOp.value()->setAttr(kTranslationInfoAttrName, translationInfo);
+  return success();
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.h
@@ -57,41 +57,35 @@ inline IREE::Codegen::TranslationInfoAttr getTranslationInfo(
   return getTranslationInfo(*exportOp);
 }
 
-/// Returns the workgroup size specified on the `exportOp`.
-SmallVector<int64_t> getWorkgroupSize(IREE::HAL::ExecutableExportOp exportOp);
-
-/// Set the translate executable info with the entry point op. Overwrites the
-/// existing attributes.
 // TODO(ravishankarm, benvanik): Eventually all the information needed for the
 // lowering will be consolidated into a single attribute with richer
 // information.
-void setTranslationInfo(IREE::HAL::ExecutableExportOp exportOp,
-                        IREE::Codegen::TranslationInfoAttr translationInfo,
-                        ArrayRef<int64_t> workgroupSize = {});
-inline void setTranslationInfo(
-    func::FuncOp entryPointFn,
-    IREE::Codegen::TranslationInfoAttr translationInfo,
-    ArrayRef<int64_t> workgroupSize = {}) {
-  FailureOr<IREE::HAL::ExecutableExportOp> exportOp =
-      getEntryPoint(entryPointFn);
-  return setTranslationInfo(*exportOp, translationInfo, workgroupSize);
-}
 
-/// Sets the translation info on the `hal.executable.export` op
-/// corresponding to the `entryPointFn`. Returns failure if a translation info
-/// is already set on the entry point op and is incompatible with what is being
-/// set.
-inline void setTranslationInfo(
-    func::FuncOp entryPointFn,
+/// Returns the workgroup size specified on the `exportOp`.
+SmallVector<int64_t> getWorkgroupSize(IREE::HAL::ExecutableExportOp exportOp);
+
+/// Sets and overwrites the dispatch workgroup size for the given entry point
+/// function. Returns failure if the given entry point is not exported via
+/// hal.executable.export.
+LogicalResult setWorkgroupSize(func::FuncOp entryPoint,
+                               ArrayRef<int64_t> workgroupSize);
+
+/// Sets and overwites the translate executable info for the given entry point.
+/// Returns failure if the given entry point is not exported via
+/// hal.executable.export.
+LogicalResult setTranslationInfo(
+    func::FuncOp entryPoint,
+    IREE::Codegen::TranslationInfoAttr translationInfo);
+
+inline LogicalResult setTranslationInfo(
+    func::FuncOp entryPoint,
     IREE::Codegen::DispatchLoweringPassPipeline passPipeline,
-    ArrayRef<int64_t> workgroupSize, unsigned softwarePipelineDepth = 0,
+    unsigned softwarePipelineDepth = 0,
     unsigned softwarePipelineStoreStage = 1) {
-  FailureOr<IREE::HAL::ExecutableExportOp> exportOp =
-      getEntryPoint(entryPointFn);
-  MLIRContext *context = entryPointFn.getContext();
-  auto translationInfo =
-      IREE::Codegen::TranslationInfoAttr::get(context, passPipeline);
-  setTranslationInfo(*exportOp, translationInfo, workgroupSize);
+  auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
+      entryPoint.getContext(), passPipeline, softwarePipelineDepth,
+      softwarePipelineStoreStage);
+  return setTranslationInfo(entryPoint, translationInfo);
 }
 
 //===----------------------------------------------------------------------===//
@@ -144,11 +138,9 @@ inline LogicalResult setOpConfigAndEntryPointFnTranslation(
   MLIRContext *context = entryPointFn.getContext();
   auto config = IREE::Codegen::LoweringConfigAttr::get(context, tileSizes);
   setLoweringConfig(op, config);
-  auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
-      entryPointFn->getContext(), passPipeline, softwarePipelineDepth,
-      softwarePipelineStoreStage);
-  setTranslationInfo(entryPointFn, translationInfo, workgroupSize);
-  return success();
+  if (failed(setWorkgroupSize(entryPointFn, workgroupSize))) return failure();
+  return setTranslationInfo(entryPointFn, passPipeline, softwarePipelineDepth,
+                            softwarePipelineStoreStage);
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1573,7 +1573,8 @@ static LogicalResult setRootConfig(
     }
   }
 
-  setTranslationInfo(entryPointFn, translationInfo);
+  if (failed(setTranslationInfo(entryPointFn, translationInfo)))
+    return failure();
   return setDefaultRootConfig(entryPointFn, partitionableLoopOp, lbs, ubs);
 }
 
@@ -1604,7 +1605,8 @@ static LogicalResult setRootConfig(
       iterationDomain, [&](Range r) { return getStaticValue(r.size); }));
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
       entryPointFn->getContext(), pipeline);
-  setTranslationInfo(entryPointFn, translationInfo);
+  if (failed(setTranslationInfo(entryPointFn, translationInfo)))
+    return failure();
   return setDefaultRootConfig(entryPointFn, partitionableLoopOp, lbs, ubs);
 }
 
@@ -1725,8 +1727,9 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
 
   if (!getTranslationInfo(entryPointFn)) {
     // Fall back, just set the translation to CPUDefault.
-    setTranslationInfo(entryPointFn, DispatchLoweringPassPipeline::CPUDefault,
-                       /*workgroupSize=*/ArrayRef<int64_t>{});
+    if (failed(setTranslationInfo(entryPointFn,
+                                  DispatchLoweringPassPipeline::CPUDefault)))
+      return failure();
   }
 
   return success();
@@ -1764,14 +1767,14 @@ LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
       auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
           moduleOp.getContext(), IREE::Codegen::DispatchLoweringPassPipeline::
                                      TransformDialectInterpreterCodegen);
-      setTranslationInfo(funcOp, translationInfo);
+      if (failed(setTranslationInfo(funcOp, translationInfo))) return failure();
       continue;
     }
     if (clCPUEnableTransformDialectJit) {
       auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
           moduleOp.getContext(), IREE::Codegen::DispatchLoweringPassPipeline::
                                      TransformDialectJitterCodegen);
-      setTranslationInfo(funcOp, translationInfo);
+      if (failed(setTranslationInfo(funcOp, translationInfo))) return failure();
       continue;
     }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1573,8 +1573,9 @@ static LogicalResult setRootConfig(
     }
   }
 
-  if (failed(setTranslationInfo(entryPointFn, translationInfo)))
+  if (failed(setTranslationInfo(entryPointFn, translationInfo))) {
     return failure();
+  }
   return setDefaultRootConfig(entryPointFn, partitionableLoopOp, lbs, ubs);
 }
 
@@ -1605,8 +1606,9 @@ static LogicalResult setRootConfig(
       iterationDomain, [&](Range r) { return getStaticValue(r.size); }));
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
       entryPointFn->getContext(), pipeline);
-  if (failed(setTranslationInfo(entryPointFn, translationInfo)))
+  if (failed(setTranslationInfo(entryPointFn, translationInfo))) {
     return failure();
+  }
   return setDefaultRootConfig(entryPointFn, partitionableLoopOp, lbs, ubs);
 }
 
@@ -1728,8 +1730,9 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
   if (!getTranslationInfo(entryPointFn)) {
     // Fall back, just set the translation to CPUDefault.
     if (failed(setTranslationInfo(entryPointFn,
-                                  DispatchLoweringPassPipeline::CPUDefault)))
+                                  DispatchLoweringPassPipeline::CPUDefault))) {
       return failure();
+    }
   }
 
   return success();

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -879,7 +879,7 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
       auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
           moduleOp.getContext(), IREE::Codegen::DispatchLoweringPassPipeline::
                                      TransformDialectInterpreterCodegen);
-      setTranslationInfo(funcOp, translationInfo);
+      if (failed(setTranslationInfo(funcOp, translationInfo))) return failure();
       if (clGPUCodegenTransformDialectTileSizes.empty()) continue;
     }
 


### PR DESCRIPTION
This makes various helper functions more targeted and cleaned up some duplicated logic.