### PR TITLE
NFC: Add better error message.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -1028,7 +1028,10 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
   auto maybeWorkgroupsOps =
       createFusionGroups(rewriter, funcOp, dominanceInfo,
                          generateWorkloadRegion, aggressiveFusion);
-  if (failed(maybeWorkgroupsOps)) return signalPassFailure();
+  if (failed(maybeWorkgroupsOps)) {
+    funcOp->emitOpError("failed to create fused dispatches");
+    return signalPassFailure();
+  }
   SmallVector<Flow::DispatchWorkgroupsOp> workgroupsOps = *maybeWorkgroupsOps;
 
   LLVM_DEBUG({
@@ -1039,20 +1042,19 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
 
   // Step 2: Rewrite InsertSliceOps to FlowUpdateOps.
   if (failed(convertInsertSliceOps(rewriter, funcOp, workgroupsOps,
-                                   generateWorkloadRegion)))
+                                   generateWorkloadRegion))) {
+    funcOp->emitOpError(
+        "failed to create dispatch region for `tensor.insert_slice`");
     return signalPassFailure();
+  }
 
   // Step 3: Rewrite ExtractSliceOps to FlowUpdateOps.
   if (failed(convertExtractSliceOps(rewriter, funcOp, workgroupsOps,
-                                    generateWorkloadRegion)))
+                                    generateWorkloadRegion))) {
+    funcOp->emitOpError(
+        "failed to create dispatch region for `tensor.extract_slice`");
     return signalPassFailure();
-
-  // Step 4: Create a DispatchWorkgroupsOp for certain other ops.
-  FailureOr<SmallVector<Flow::DispatchWorkgroupsOp>> newWorkgroupsOps =
-      wrapInWorkgroupsOp<LinalgExt::SetEncodingOp, LinalgExt::UnsetEncodingOp>(
-          rewriter, funcOp, generateWorkloadRegion);
-  if (failed(newWorkgroupsOps)) return signalPassFailure();
-  workgroupsOps.append(newWorkgroupsOps->begin(), newWorkgroupsOps->end());
+  }
 
   // A few extra canonicalizations/lowerings.
   {
@@ -1063,9 +1065,11 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
         convertToFlowPatterns);
     IREE::Flow::TensorReshapeOp::getCanonicalizationPatterns(
         convertToFlowPatterns, context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp,
-                                            std::move(convertToFlowPatterns))))
+    if (failed(applyPatternsAndFoldGreedily(
+            funcOp, std::move(convertToFlowPatterns)))) {
+      funcOp->emitOpError("failed conversion to flow.tensor ops");
       return signalPassFailure();
+    }
 
     // Finally fold `tensor.insert_slice/extract_slice` operations with
     // `flow.dispatch.tensor.load/store`.
@@ -1073,8 +1077,12 @@ void DispatchLinalgOnTensorsPass::runOnOperation() {
     Flow::populateTensorSliceOpWithDispatchTensorOpFoldingPatterns(
         foldExtractInsertSliceOps, context);
     if (failed(applyPatternsAndFoldGreedily(
-            funcOp, std::move(foldExtractInsertSliceOps))))
+            funcOp, std::move(foldExtractInsertSliceOps)))) {
+      funcOp->emitOpError(
+          "failed to insert/extract_slice with "
+          "flow.dispatch.tensor.load/store");
       return signalPassFailure();
+    }
   }
 }
 


### PR DESCRIPTION
Adding better error messages to DispatchLinalgOnTensors (probably got dropped with the big move to use `flow.dispatch.region`).  Also removing an unnecessary code path to create dispatches out `set/unset_encoding` ops. Those should be covered already as root ops.