### PR TITLE
Fix dependency link between API2 and generated files on Windows.

### DIFF
--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -63,9 +63,6 @@ function(iree_bytecode_module)
   endif()
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
-  # Explicit dep on the shared library used by compiler tools. This is only
-  # needed on Windows. See https://github.com/iree-org/iree/issues/11331.
-  iree_get_shared_library_path(_COMPILER_SHARED_LIBRARY "iree::compiler::API2::SharedImpl" "IREECompiler")
 
   if(DEFINED _RULE_MODULE_FILE_NAME)
     set(_MODULE_FILE_NAME "${_RULE_MODULE_FILE_NAME}")
@@ -133,8 +130,8 @@ function(iree_bytecode_module)
       ${_ARGS}
     # Changes to either the compiler tool or the input sources should rebuild.
     DEPENDS
+      iree::compiler::API2::RuntimeImpl
       ${_COMPILE_TOOL_EXECUTABLE}
-      ${_COMPILER_SHARED_LIBRARY}
       ${_LINKER_TOOL_EXECUTABLE}
       ${_RULE_SRC}
       ${_RULE_DEPENDS}

--- a/build_tools/cmake/iree_bytecode_module.cmake
+++ b/build_tools/cmake/iree_bytecode_module.cmake
@@ -130,7 +130,7 @@ function(iree_bytecode_module)
       ${_ARGS}
     # Changes to either the compiler tool or the input sources should rebuild.
     DEPENDS
-      iree::compiler::API2::RuntimeImpl
+      iree_compiler_API2_RuntimeImpl
       ${_COMPILE_TOOL_EXECUTABLE}
       ${_LINKER_TOOL_EXECUTABLE}
       ${_RULE_SRC}

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -61,6 +61,10 @@ function(iree_c_module)
   endif()
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
+  # Explicit dep on the shared library used by compiler tools. This is only
+  # needed on Windows. See https://github.com/iree-org/iree/issues/11331.
+  iree_get_shared_library_path(_COMPILER_SHARED_LIBRARY "iree::compiler::API2::SharedImpl" "IREECompiler")
+
   get_filename_component(_SRC_PATH "${_RULE_SRC}" REALPATH)
 
   set(_ARGS "--output-format=vm-c")
@@ -90,7 +94,7 @@ function(iree_c_module)
     OUTPUT ${_OUTPUT_FILES}
     COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}
     # Changes to either the compiler tool or the input source should rebuild.
-    DEPENDS ${_COMPILE_TOOL_EXECUTABLE} ${_SRC_PATH}
+    DEPENDS ${_COMPILE_TOOL_EXECUTABLE} ${_COMPILER_SHARED_LIBRARY} ${_SRC_PATH}
   )
 
   iree_cc_library(

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -61,9 +61,6 @@ function(iree_c_module)
   endif()
 
   iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE ${_COMPILE_TOOL})
-  # Explicit dep on the shared library used by compiler tools. This is only
-  # needed on Windows. See https://github.com/iree-org/iree/issues/11331.
-  iree_get_shared_library_path(_COMPILER_SHARED_LIBRARY "iree::compiler::API2::SharedImpl" "IREECompiler")
 
   get_filename_component(_SRC_PATH "${_RULE_SRC}" REALPATH)
 
@@ -91,10 +88,15 @@ function(iree_c_module)
   endif()
 
   add_custom_command(
-    OUTPUT ${_OUTPUT_FILES}
-    COMMAND ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}
+    OUTPUT
+      ${_OUTPUT_FILES}
+    COMMAND
+      ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}
     # Changes to either the compiler tool or the input source should rebuild.
-    DEPENDS ${_COMPILE_TOOL_EXECUTABLE} ${_COMPILER_SHARED_LIBRARY} ${_SRC_PATH}
+    DEPENDS
+      iree::compiler::API2::RuntimeImpl
+      ${_COMPILE_TOOL_EXECUTABLE}
+      ${_SRC_PATH}
   )
 
   iree_cc_library(

--- a/build_tools/cmake/iree_c_module.cmake
+++ b/build_tools/cmake/iree_c_module.cmake
@@ -94,7 +94,7 @@ function(iree_c_module)
       ${_COMPILE_TOOL_EXECUTABLE} ${_ARGS}
     # Changes to either the compiler tool or the input source should rebuild.
     DEPENDS
-      iree::compiler::API2::RuntimeImpl
+      iree_compiler_API2_RuntimeImpl
       ${_COMPILE_TOOL_EXECUTABLE}
       ${_SRC_PATH}
   )

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -182,16 +182,21 @@ function(iree_get_shared_library_path OUTPUT_PATH_VAR LIBRARY_TARGET LIBRARY_NAM
     set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
   else()
     # The target won't be directly defined by this CMake invocation so check
-    # for an already built library at IREE_HOST_BINARY_ROOT. If we find it,
+    # for an already built library under IREE_HOST_BINARY_ROOT. If we find it,
     # add it as an imported target so it gets picked up on later invocations.
-    set(_LIBRARY_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_LIBRARY_NAME}")
-    if(EXISTS ${_LIBRARY_PATH})
+    set(_LIBRARY_BIN_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_LIBRARY_NAME}")
+    set(_LIBRARY_LIB_PATH "${IREE_HOST_BINARY_ROOT}/lib/${_FULL_LIBRARY_NAME}")
+    if(EXISTS ${_LIBRARY_BIN_PATH})
       add_library("${LIBRARY_TARGET}" SHARED IMPORTED GLOBAL)
-      set_property(TARGET "${LIBRARY_TARGET}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_PATH}")
+      set_property(TARGET "${LIBRARY_TARGET}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_BIN_PATH}")
+      set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
+    elseif(EXISTS ${_LIBRARY_LIB_PATH})
+      add_library("${LIBRARY_TARGET}" SHARED IMPORTED GLOBAL)
+      set_property(TARGET "${LIBRARY_TARGET}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_LIB_PATH}")
       set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
     else()
-      message(FATAL_ERROR "Could not find '${LIBRARY_NAME}' at '${_LIBRARY_PATH}'. "
-              "Ensure that IREE_HOST_BINARY_ROOT points to installed binaries.")
+      message(FATAL_ERROR "Could not find '${LIBRARY_NAME}' under '${IREE_HOST_BINARY_ROOT}'. "
+              "Ensure that IREE_HOST_BINARY_ROOT points to install directory.")
     endif()
   endif()
 endfunction()

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -162,45 +162,6 @@ function(iree_get_executable_path OUTPUT_PATH_VAR EXECUTABLE)
   endif()
 endfunction()
 
-# iree_get_shared_library_path
-#
-# Gets the path to a shared library in a cross-compilation-aware way. Similar
-# to iree_get_executable_path.
-#
-# Paramters:
-# - OUTPUT_PATH_VAR: variable name for receiving the path to the built target.
-# - LIBRARY_TARGET: the target name that builds the library. Used when
-#     IREE_HOST_BINARY_ROOT is not set
-# - LIBRARY_NAME: the library name (without the 'lib' prefix or the executable
-#     suffix). Used when IREE_HOST_BINARY_ROOT is set.
-function(iree_get_shared_library_path OUTPUT_PATH_VAR LIBRARY_TARGET LIBRARY_NAME)
-  set(_FULL_LIBRARY_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
-
-  if(NOT DEFINED IREE_HOST_BINARY_ROOT OR TARGET "${LIBRARY_TARGET}")
-    # We can either expect the target to be defined as part of this CMake
-    # invocation (if not cross compiling) or the target is defined already.
-    set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
-  else()
-    # The target won't be directly defined by this CMake invocation so check
-    # for an already built library under IREE_HOST_BINARY_ROOT. If we find it,
-    # add it as an imported target so it gets picked up on later invocations.
-    set(_LIBRARY_BIN_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_LIBRARY_NAME}")
-    set(_LIBRARY_LIB_PATH "${IREE_HOST_BINARY_ROOT}/lib/${_FULL_LIBRARY_NAME}")
-    if(EXISTS ${_LIBRARY_BIN_PATH})
-      add_library("${LIBRARY_TARGET}" SHARED IMPORTED GLOBAL)
-      set_property(TARGET "${LIBRARY_TARGET}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_BIN_PATH}")
-      set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
-    elseif(EXISTS ${_LIBRARY_LIB_PATH})
-      add_library("${LIBRARY_TARGET}" SHARED IMPORTED GLOBAL)
-      set_property(TARGET "${LIBRARY_TARGET}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_LIB_PATH}")
-      set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
-    else()
-      message(FATAL_ERROR "Could not find '${LIBRARY_NAME}' under '${IREE_HOST_BINARY_ROOT}'. "
-              "Ensure that IREE_HOST_BINARY_ROOT points to install directory.")
-    endif()
-  endif()
-endfunction()
-
 #-------------------------------------------------------------------------------
 # select()-like Evaluation
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/iree_macros.cmake
+++ b/build_tools/cmake/iree_macros.cmake
@@ -162,6 +162,40 @@ function(iree_get_executable_path OUTPUT_PATH_VAR EXECUTABLE)
   endif()
 endfunction()
 
+# iree_get_shared_library_path
+#
+# Gets the path to a shared library in a cross-compilation-aware way. Similar
+# to iree_get_executable_path.
+#
+# Paramters:
+# - OUTPUT_PATH_VAR: variable name for receiving the path to the built target.
+# - LIBRARY_TARGET: the target name that builds the library. Used when
+#     IREE_HOST_BINARY_ROOT is not set
+# - LIBRARY_NAME: the library name (without the 'lib' prefix or the executable
+#     suffix). Used when IREE_HOST_BINARY_ROOT is set.
+function(iree_get_shared_library_path OUTPUT_PATH_VAR LIBRARY_TARGET LIBRARY_NAME)
+  set(_FULL_LIBRARY_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}${LIBRARY_NAME}${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+  if(NOT DEFINED IREE_HOST_BINARY_ROOT OR TARGET "${LIBRARY_TARGET}")
+    # We can either expect the target to be defined as part of this CMake
+    # invocation (if not cross compiling) or the target is defined already.
+    set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
+  else()
+    # The target won't be directly defined by this CMake invocation so check
+    # for an already built library at IREE_HOST_BINARY_ROOT. If we find it,
+    # add it as an imported target so it gets picked up on later invocations.
+    set(_LIBRARY_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_LIBRARY_NAME}")
+    if(EXISTS ${_LIBRARY_PATH})
+      add_library("${LIBRARY_TARGET}" SHARED IMPORTED GLOBAL)
+      set_property(TARGET "${LIBRARY_TARGET}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_PATH}")
+      set(${OUTPUT_PATH_VAR} "$<TARGET_FILE:${LIBRARY_TARGET}>" PARENT_SCOPE)
+    else()
+      message(FATAL_ERROR "Could not find '${LIBRARY_NAME}' at '${_LIBRARY_PATH}'. "
+              "Ensure that IREE_HOST_BINARY_ROOT points to installed binaries.")
+    endif()
+  endif()
+endfunction()
+
 #-------------------------------------------------------------------------------
 # select()-like Evaluation
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/iree_microbenchmark_suite.cmake
+++ b/build_tools/cmake/iree_microbenchmark_suite.cmake
@@ -33,6 +33,7 @@ function(iree_microbenchmark_suite)
     set(_MODULE_FILE_NAME "${_RULE_NAME}_${_SRC}.vmfb")
     set(_TARGET_NAME "${PACKAGE_NAME}_${_MODULE_FILE_NAME}")
     iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE "${_COMPILE_TOOL}")
+    iree_get_shared_library_path(_COMPILER_SHARED_LIBRARY "iree::compiler::API2::SharedImpl" "IREECompiler")
     set(_ARGS "${_RULE_FLAGS}")
     get_filename_component(_TRANSLATE_SRC_PATH "${_TRANSLATE_SRC}" REALPATH)
     list(APPEND _ARGS "${_TRANSLATE_SRC_PATH}")
@@ -48,6 +49,7 @@ function(iree_microbenchmark_suite)
       # Changes to either the compiler tool or the input source should rebuild.
       DEPENDS
         "${_COMPILE_TOOL_EXECUTABLE}"
+        "${_COMPILER_SHARED_LIBRARY}"
         "${_TRANSLATE_SRC}"
       VERBATIM
     )

--- a/build_tools/cmake/iree_microbenchmark_suite.cmake
+++ b/build_tools/cmake/iree_microbenchmark_suite.cmake
@@ -33,7 +33,6 @@ function(iree_microbenchmark_suite)
     set(_MODULE_FILE_NAME "${_RULE_NAME}_${_SRC}.vmfb")
     set(_TARGET_NAME "${PACKAGE_NAME}_${_MODULE_FILE_NAME}")
     iree_get_executable_path(_COMPILE_TOOL_EXECUTABLE "${_COMPILE_TOOL}")
-    iree_get_shared_library_path(_COMPILER_SHARED_LIBRARY "iree::compiler::API2::SharedImpl" "IREECompiler")
     set(_ARGS "${_RULE_FLAGS}")
     get_filename_component(_TRANSLATE_SRC_PATH "${_TRANSLATE_SRC}" REALPATH)
     list(APPEND _ARGS "${_TRANSLATE_SRC_PATH}")
@@ -48,8 +47,8 @@ function(iree_microbenchmark_suite)
         ${_ARGS}
       # Changes to either the compiler tool or the input source should rebuild.
       DEPENDS
+        iree::compiler::API2::RuntimeImpl
         "${_COMPILE_TOOL_EXECUTABLE}"
-        "${_COMPILER_SHARED_LIBRARY}"
         "${_TRANSLATE_SRC}"
       VERBATIM
     )

--- a/build_tools/cmake/iree_microbenchmark_suite.cmake
+++ b/build_tools/cmake/iree_microbenchmark_suite.cmake
@@ -47,7 +47,7 @@ function(iree_microbenchmark_suite)
         ${_ARGS}
       # Changes to either the compiler tool or the input source should rebuild.
       DEPENDS
-        iree::compiler::API2::RuntimeImpl
+        iree_compiler_API2_RuntimeImpl
         "${_COMPILE_TOOL_EXECUTABLE}"
         "${_TRANSLATE_SRC}"
       VERBATIM

--- a/build_tools/cmake/iree_static_linker_test.cmake
+++ b/build_tools/cmake/iree_static_linker_test.cmake
@@ -70,8 +70,6 @@ function(iree_static_linker_test)
     return()
   endif()
 
-  iree_get_executable_path(_COMPILER_TOOL "iree-compile")
-
   iree_package_name(_PACKAGE_NAME)
   iree_package_ns(_PACKAGE_NS)
   set(_NAME "${_PACKAGE_NAME}_${_RULE_NAME}")

--- a/compiler/src/iree/compiler/API2/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API2/CMakeLists.txt
@@ -119,7 +119,7 @@ if(IREE_LINK_COMPILER_SHARED_LIBRARY)
     DEPS
       ::SharedImpl
   )
-  add_library("iree::compiler::API2::RuntimeImpl" ALIAS "iree_compiler_API2_SharedImpl")
+  add_library("iree_compiler_API2_RuntimeImpl" ALIAS "iree_compiler_API2_SharedImpl")
 else()
   iree_cc_library(
     NAME
@@ -127,5 +127,5 @@ else()
     DEPS
       ::StaticImpl
   )
-  add_library("iree::compiler::API2::RuntimeImpl" ALIAS "iree_compiler_API2_StaticImpl")
+  add_library("iree_compiler_API2_RuntimeImpl" ALIAS "iree_compiler_API2_StaticImpl")
 endif()  # IREE_LINK_COMPILER_SHARED_LIBRARY

--- a/compiler/src/iree/compiler/API2/CMakeLists.txt
+++ b/compiler/src/iree/compiler/API2/CMakeLists.txt
@@ -111,19 +111,21 @@ install(
 
 # The bazel side uses a "Impl" library alias to generically represent
 # static or shared. Provide a corresponding one here.
-
+# Also add a "RuntimeImpl" library for tools to depend on.
 if(IREE_LINK_COMPILER_SHARED_LIBRARY)
-iree_cc_library(
-  NAME
-    Impl
-  DEPS
-    ::SharedImpl
-)
+  iree_cc_library(
+    NAME
+      Impl
+    DEPS
+      ::SharedImpl
+  )
+  add_library("iree::compiler::API2::RuntimeImpl" ALIAS "iree_compiler_API2_SharedImpl")
 else()
-iree_cc_library(
-  NAME
-    Impl
-  DEPS
-    ::StaticImpl
-)
+  iree_cc_library(
+    NAME
+      Impl
+    DEPS
+      ::StaticImpl
+  )
+  add_library("iree::compiler::API2::RuntimeImpl" ALIAS "iree_compiler_API2_StaticImpl")
 endif()  # IREE_LINK_COMPILER_SHARED_LIBRARY

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -282,3 +282,30 @@ if(IREE_BUILD_COMPILER)
     COMPONENT Tests
   )
 endif(IREE_BUILD_COMPILER)
+
+# Import the RuntimeImpl target when cross compiling.
+# TODO(scotttodd): Refactor to import_shared_library/import_executable funcs?
+set(_RUNTIME_IMPL_NAME "iree_compiler_API2_RuntimeImpl")
+set(_RUNTIME_IMPL_ALIAS "iree::compiler::API2::RuntimeImpl")
+if(TARGET "${_RUNTIME_IMPL_NAME}")
+  # Already defined, nothing to do.
+elseif(DEFINED IREE_HOST_BINARY_ROOT)
+  # Import.
+  set(_FULL_LIBRARY_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}IREECompiler${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  set(_LIBRARY_BIN_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_LIBRARY_NAME}")
+  set(_LIBRARY_LIB_PATH "${IREE_HOST_BINARY_ROOT}/lib/${_FULL_LIBRARY_NAME}")
+  if(EXISTS ${_LIBRARY_BIN_PATH})
+    add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
+    set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_BIN_PATH}")
+    add_library("${_RUNTIME_IMPL_ALIAS}" ALIAS "${_RUNTIME_IMPL_NAME}")
+  elseif(EXISTS ${_LIBRARY_LIB_PATH})
+    add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
+    set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_LIB_PATH}")
+    add_library("${_RUNTIME_IMPL_ALIAS}" ALIAS "${_RUNTIME_IMPL_NAME}")
+  else()
+    message(FATAL_ERROR "Could not find '${_FULL_LIBRARY_NAME}' under '${IREE_HOST_BINARY_ROOT}'. "
+            "Ensure that IREE_HOST_BINARY_ROOT points to install directory.")
+  endif()
+else()
+  # Not defined and nowhere to import from.
+endif()

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -286,7 +286,6 @@ endif(IREE_BUILD_COMPILER)
 # Import the RuntimeImpl target when cross compiling.
 # TODO(scotttodd): Refactor to import_shared_library/import_executable funcs?
 set(_RUNTIME_IMPL_NAME "iree_compiler_API2_RuntimeImpl")
-set(_RUNTIME_IMPL_ALIAS "iree::compiler::API2::RuntimeImpl")
 if(TARGET "${_RUNTIME_IMPL_NAME}")
   # Already defined, nothing to do.
 elseif(DEFINED IREE_HOST_BINARY_ROOT)
@@ -297,11 +296,9 @@ elseif(DEFINED IREE_HOST_BINARY_ROOT)
   if(EXISTS ${_LIBRARY_BIN_PATH})
     add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
     set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_BIN_PATH}")
-    add_library("${_RUNTIME_IMPL_ALIAS}" ALIAS "${_RUNTIME_IMPL_NAME}")
   elseif(EXISTS ${_LIBRARY_LIB_PATH})
     add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
     set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_LIB_PATH}")
-    add_library("${_RUNTIME_IMPL_ALIAS}" ALIAS "${_RUNTIME_IMPL_NAME}")
   else()
     message(FATAL_ERROR "Could not find '${_FULL_LIBRARY_NAME}' under '${IREE_HOST_BINARY_ROOT}'. "
             "Ensure that IREE_HOST_BINARY_ROOT points to install directory.")

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -16,6 +16,30 @@
 #
 # This file does not use bazel_to_cmake because of special logic throughout.
 
+# Import the RuntimeImpl target when cross compiling.
+# TODO(scotttodd): Refactor to import_shared_library/import_executable funcs?
+set(_RUNTIME_IMPL_NAME "iree_compiler_API2_RuntimeImpl")
+if(TARGET "${_RUNTIME_IMPL_NAME}")
+  # Already defined, nothing to do.
+elseif(DEFINED IREE_HOST_BINARY_ROOT)
+  # Import.
+  set(_FULL_LIBRARY_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}IREECompiler${CMAKE_SHARED_LIBRARY_SUFFIX}")
+  set(_LIBRARY_BIN_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_LIBRARY_NAME}")
+  set(_LIBRARY_LIB_PATH "${IREE_HOST_BINARY_ROOT}/lib/${_FULL_LIBRARY_NAME}")
+  if(EXISTS ${_LIBRARY_BIN_PATH})
+    add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
+    set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_BIN_PATH}")
+  elseif(EXISTS ${_LIBRARY_LIB_PATH})
+    add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
+    set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_LIB_PATH}")
+  else()
+    message(FATAL_ERROR "Could not find '${_FULL_LIBRARY_NAME}' under '${IREE_HOST_BINARY_ROOT}'. "
+            "Ensure that IREE_HOST_BINARY_ROOT points to install directory.")
+  endif()
+else()
+  # Not defined and nowhere to import from.
+endif()
+
 # TODO(#6353): Tools has thread dependencies in gtest, benchmark, yaml, etc.
 # This should be split between runtime/compiler with optional threading support.
 if(NOT IREE_ENABLE_THREADING)
@@ -282,27 +306,3 @@ if(IREE_BUILD_COMPILER)
     COMPONENT Tests
   )
 endif(IREE_BUILD_COMPILER)
-
-# Import the RuntimeImpl target when cross compiling.
-# TODO(scotttodd): Refactor to import_shared_library/import_executable funcs?
-set(_RUNTIME_IMPL_NAME "iree_compiler_API2_RuntimeImpl")
-if(TARGET "${_RUNTIME_IMPL_NAME}")
-  # Already defined, nothing to do.
-elseif(DEFINED IREE_HOST_BINARY_ROOT)
-  # Import.
-  set(_FULL_LIBRARY_NAME "${CMAKE_SHARED_LIBRARY_PREFIX}IREECompiler${CMAKE_SHARED_LIBRARY_SUFFIX}")
-  set(_LIBRARY_BIN_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_LIBRARY_NAME}")
-  set(_LIBRARY_LIB_PATH "${IREE_HOST_BINARY_ROOT}/lib/${_FULL_LIBRARY_NAME}")
-  if(EXISTS ${_LIBRARY_BIN_PATH})
-    add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
-    set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_BIN_PATH}")
-  elseif(EXISTS ${_LIBRARY_LIB_PATH})
-    add_library("${_RUNTIME_IMPL_NAME}" SHARED IMPORTED GLOBAL)
-    set_property(TARGET "${_RUNTIME_IMPL_NAME}" PROPERTY IMPORTED_LOCATION "${_LIBRARY_LIB_PATH}")
-  else()
-    message(FATAL_ERROR "Could not find '${_FULL_LIBRARY_NAME}' under '${IREE_HOST_BINARY_ROOT}'. "
-            "Ensure that IREE_HOST_BINARY_ROOT points to install directory.")
-  endif()
-else()
-  # Not defined and nowhere to import from.
-endif()


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/11331 (not sure if there's a more natural fix, but this works...). See also https://github.com/iree-org/iree/pull/11285.

When I change compiler code on Windows and build `iree-test-deps`, I just see `IREECompiler.dll` linking:
```
[proc] Executing command: "C:\Program Files\CMake\bin\cmake.exe" --build d:/dev/projects/iree-build --config RelWithDebInfo --target iree-test-deps --
[build] [1/2   0% :: 0.000] Re-checking globbed directories...
[build] [1/793   0% :: 4.709] Building CXX object compiler\src\iree\compiler\Codegen\WGSL\CMakeFiles\iree_compiler_Codegen_WGSL_WGSL.objects.dir\WGSLReplacePushConstants.cpp.obj
[build] [2/793   0% :: 4.757] Linking CXX static library compiler\src\iree\compiler\Codegen\WGSL\iree_compiler_Codegen_WGSL_WGSL.lib
[build] [3/793   0% :: 8.569] Linking CXX shared library tools\IREECompiler.dll
[build] Build finished with exit code 0
```

On Linux, I see both `libIREECompiler.so.0` _and_ `tools/iree-compile` linking, which then rebuilds generated files:
```
[proc] Executing command: /usr/bin/cmake --build /usr/local/google/home/scotttodd/code/iree-build --config RelWithDebInfo --target iree-test-deps --
[build] [1/2   0% :: 1.053] Re-checking globbed directories...
[build] [1/652   0% :: 6.210] Building CXX object compiler/src/iree/compiler/Codegen/WGSL/CMakeFiles/iree_compiler_Codegen_WGSL_WGSL.objects.dir/WGSLReplacePushConstants.cpp.o
[build] [2/652   0% :: 6.349] Linking CXX static library compiler/src/iree/compiler/Codegen/WGSL/libiree_compiler_Codegen_WGSL_WGSL.a
[build] [3/652   0% :: 10.221] Linking CXX shared library lib/libIREECompiler.so.0
[build] [4/652   0% :: 10.241] Creating library symlink lib/libIREECompiler.so
[build] [5/652   0% :: 10.338] Linking CXX executable tools/iree-compile
[build] [79/652   0% :: 15.200] Generating simple_mul_llvm_cpu_static_bytecode_test_module.vmfb from simple_mul.mlir
...
```

This adds an explicit dependency on `iree::compiler::API2::SharedImpl` (or an imported target when cross compiling) to the `add_custom_command()` in `iree_bytecode_module()` (and related functions), so compiler changes correctly trigger rebuilding generated files on Windows.