### PR TITLE
Enable fusion for unpack + elementwise ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -2008,3 +2008,43 @@ hal.executable private @dynamic_unpack {
 // CHECK:         scf.for
 // CHECK:           scf.for
 // CHECK:             iree_linalg_ext.unpack
+
+// -----
+
+hal.executable private @unpack_elem {
+  hal.executable.variant public @embedded_elf_arm_64, target = <"llvm-cpu", "embedded-elf-arm_64", {}> {
+    hal.executable.export public @unpack_elem ordinal(0) layout(
+        #hal.pipeline.layout<push_constants = 0, sets = [
+            <0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>)
+        attributes {translation_info = #iree_codegen.translation_info<CPUDataTiling>} {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+      %c1 = arith.constant 1 : index
+      %0 = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%arg1]
+      %1 = affine.apply affine_map<()[s0] -> (s0 ceildiv 64)>()[%arg2]
+      hal.return %1, %0, %c1 : index, index, index
+    }
+    builtin.module {
+      func.func @unpack_elem() {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<16x48x8x8xf32>>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<128x384xf32>>
+        %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [16, 48, 8, 8], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<16x48x8x8xf32>> -> tensor<16x48x8x8xf32>
+        %3 = tensor.empty() : tensor<128x384xf32>
+        %4 = iree_linalg_ext.unpack {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64]]>} %2 inner_dims_pos = [0, 1] inner_tiles = [8, 8] into %3 : (tensor<16x48x8x8xf32> tensor<128x384xf32>) -> tensor<128x384xf32>
+        %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%4 : tensor<128x384xf32>) outs(%3 : tensor<128x384xf32>) {
+        ^bb0(%in: f32, %out: f32):
+          %6 = arith.addf %in, %in : f32
+          linalg.yield %6 : f32
+        } -> tensor<128x384xf32>
+        flow.dispatch.tensor.store %5, %1, offsets = [0, 0], sizes = [128, 384], strides = [1, 1] : tensor<128x384xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x384xf32>>
+        return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: func.func @unpack_elem
+// CHECK:         scf.for
+// CHECK:           scf.for
+// CHECK:             iree_linalg_ext.unpack
+// CHECK:             linalg.generic

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchLinalgOnTensors.cpp
@@ -534,9 +534,10 @@ static bool isFusableWithConsumer(OpOperand &fusedOperand,
   Operation *producer = fusedOperand.get().getDefiningOp();
   Operation *consumer = fusedOperand.getOwner();
 
-  // Fuse unset_encoding operations with `tensor.extract_slice`.
-  if (isa<LinalgExt::UnsetEncodingOp>(producer) &&
-      isa<tensor::ExtractSliceOp>(consumer)) {
+  // Fuse unset_encoding operations with `tensor.extract_slice` and elementwise
+  // generic ops.
+  auto producerUnsetEncodingOp = dyn_cast<LinalgExt::UnsetEncodingOp>(producer);
+  if (producerUnsetEncodingOp && isa<tensor::ExtractSliceOp>(consumer)) {
     auto sliceOp = cast<tensor::ExtractSliceOp>(consumer);
     return llvm::all_of(
                sliceOp.getMixedOffsets(),
@@ -545,9 +546,14 @@ static bool isFusableWithConsumer(OpOperand &fusedOperand,
              return isConstantIntValue(ofr, 1);
            });
   }
+  auto consumerLinalgOp = dyn_cast<linalg::LinalgOp>(consumer);
+  if (producerUnsetEncodingOp && consumerLinalgOp) {
+    return linalg::isElementwise(consumerLinalgOp) &&
+           consumerLinalgOp.getNumLoops() ==
+               producerUnsetEncodingOp.getType().getRank();
+  }
 
   auto producerLinalgOp = dyn_cast<linalg::LinalgOp>(producer);
-  auto consumerLinalgOp = dyn_cast<linalg::LinalgOp>(consumer);
   if (!producerLinalgOp || !consumerLinalgOp) return false;
 
   // Check that the consumer is all parallel.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -692,7 +692,8 @@ def IREELinalgExt_UnPackOp : IREELinalgExt_Op<"unpack", [
      "getLoopIteratorTypes",
      "generateScalarImplementation",
      "getResultTilePosition",
-     "getTiledImplementation"]>,
+     "getTiledImplementation",
+     "generateResultTileValue"]>,
   DeclareOpInterfaceMethods<MemoryEffectsOpInterface>
 ]>{
   let summary = "unpack operation";

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2369,6 +2369,15 @@ SmallVector<utils::IteratorType> UnPackOp::getLoopIteratorTypes() {
   return iteratorTypes;
 }
 
+FailureOr<Value>
+UnPackOp::generateResultTileValue(OpBuilder &b, unsigned resultNumber,
+                                  ArrayRef<OpFoldResult> offsets,
+                                  ArrayRef<OpFoldResult> sizes) {
+  return getTiledImplementation(b, offsets, sizes)
+      .back()
+      ->getResult(resultNumber);
+}
+
 //===----------------------------------------------------------------------===//
 // WinogradInputTransformOp
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
Some metric data w/ mobilebert fp32:

Legacy mmt4d: 39
data tiling w/ pack fusion: 59
data tiling w/ pack + unpack fusion: 57

The number of `flow.dispatch` launch:

Legacy mmt4d: 1980
data tiling w/ pack fusion: 2750
data tiling w/ pack + unpack fusion: 2390

Note that there are 361 `pack(constant)` kernel launches. The number of dispatch launches in data tiling approach is close to legacy mmt4d if we subtract pack(constant) from it.