### PR TITLE
Move IREE LLVM backends to use opaque pointers.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -212,7 +212,6 @@ class CUDATargetBackend final : public TargetBackend {
     // Perform the translation in a separate context to avoid any
     // multi-threading issues.
     llvm::LLVMContext context;
-    context.setOpaquePointers(false);
 
     // We name our files after the executable name so that they are easy to
     // track both during compilation (logs/artifacts/etc), as outputs (final

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -163,7 +163,6 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     // Perform the translation in a separate context to avoid any
     // multi-threading issues.
     llvm::LLVMContext context;
-    context.setOpaquePointers(false);
 
     // We name our files after the executable name so that they are easy to
     // track both during compilation (logs/artifacts/etc), as outputs (final
@@ -264,11 +263,6 @@ class LLVMCPUTargetBackend final : public TargetBackend {
       // Tag the function parameters in case they got removed during conversion.
       // (%arg0: environment, %arg1: dispatch_state, %arg2: workgroup_state)
       for (unsigned i = 0; i <= 2; ++i) {
-        llvmFunc->addParamAttr(
-            i, llvm::Attribute::getWithByRefType(
-                   context, llvmFunc->getArg(i)
-                                ->getType()
-                                ->getNonOpaquePointerElementType()));
         llvmFunc->addParamAttr(i, llvm::Attribute::NonNull);
         llvmFunc->addParamAttr(i, llvm::Attribute::NoAlias);
         llvmFunc->addParamAttr(i, align16);
@@ -710,7 +704,6 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     // Set the native vector size. This creates a dummy llvm module just to
     // build the TTI the right way.
     llvm::LLVMContext llvmContext;
-    llvmContext.setOpaquePointers(false);
     auto llvmModule =
         std::make_unique<llvm::Module>("dummy_module", llvmContext);
     llvm::Type *voidType = llvm::Type::getVoidTy(llvmContext);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/ROCM/ROCMTarget.cpp
@@ -108,7 +108,6 @@ class ROCMTargetBackend final : public TargetBackend {
     // Perform the translation in a separate context to avoid any
     // multi-threading issues.
     llvm::LLVMContext context;
-    context.setOpaquePointers(false);
 
     // We name our files after the executable name so that they are easy to
     // track both during compilation (logs/artifacts/etc), as outputs (final


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/issues/9319 in preparation of impending switch to use opaque pointers