### PR TITLE
Let `MaterializeEncodingInfo::innerTileSizes` be `OpFoldResult`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -192,6 +192,7 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtUtils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -147,6 +147,7 @@ iree_cc_library(
     IREELinalgExtDialect
     IREELinalgExtPasses
     IREELinalgExtTransforms
+    IREELinalgExtUtils
     LLVMSupport
     MLIRAffineDialect
     MLIRAffineUtils

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -130,8 +130,7 @@ getMaterializationInfo(IREE::LinalgExt::PackOp packOp) {
       return packOp.emitOpError(
           "unhandled distribution of pack op with dynamic inner tile size");
     }
-    encodingInfo.innerTileSizes.push_back(
-        tileSize.get<Attribute>().cast<IntegerAttr>().getInt());
+    encodingInfo.innerTileSizes.push_back(tileSize);
   }
   encodingInfo.innerDimsPos = llvm::to_vector(packOp.getInnerDimsPos());
   encodingInfo.outerDimsPerm = llvm::to_vector(packOp.getOuterDimsPerm());
@@ -256,15 +255,10 @@ struct LowerDispatchWorkgroupCountFromSetEncodingOp
     ValueRange workload = workgroupCountOp.getOperands();
     // The workload represents the unpacked shape. Get the workload of the
     // packed shape.
-    auto getAsOpFoldResults = [&](ArrayRef<int64_t> intVals) {
-      return llvm::to_vector(llvm::map_range(
-          intVals,
-          [&](int64_t i) -> OpFoldResult { return rewriter.getIndexAttr(i); }));
-    };
     SmallVector<OpFoldResult> resultShape =
         IREE::LinalgExt::PackOp::getResultShape(
             rewriter, workgroupCountOp.getLoc(), getAsOpFoldResult(workload),
-            getAsOpFoldResults(materializeEncodingInfo.innerTileSizes),
+            materializeEncodingInfo.innerTileSizes,
             materializeEncodingInfo.innerDimsPos,
             materializeEncodingInfo.outerDimsPerm);
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -669,7 +669,7 @@ def IREELinalgExt_PackOp : IREELinalgExt_Op<"pack", [
     // to allow getting the type of the destination while creating the `pack`
     // op.
     static ShapedType getPackedType(ShapedType sourceType,
-        ArrayRef<int64_t> innerTileSizes, ArrayRef<int64_t> innerDimsPos,
+        ArrayRef<OpFoldResult> innerTileSizes, ArrayRef<int64_t> innerDimsPos,
         ArrayRef<int64_t> outerDimsPerm = {});
 
     // Method to implement for specifying output range for

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -90,7 +90,7 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLinalgExtToLoopsPass();
 /// Container of information needed to materialize the pack operation.
 struct MaterializeEncodingInfo {
   SmallVector<int64_t> innerDimsPos;
-  SmallVector<int64_t> innerTileSizes;
+  SmallVector<OpFoldResult> innerTileSizes;
   SmallVector<int64_t> outerDimsPerm;
 };
 using MaterializeEncodingFn =

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -59,6 +59,10 @@ SmallVector<int64_t> computeInterchangeFromDimPos(ArrayRef<int64_t> dimsPos,
 Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
                                 Location loc, PatternRewriter &rewriter);
 
+IntegerAttr toIntegerAttr(MLIRContext *context, int64_t i);
+SmallVector<OpFoldResult> toOpFoldResult(MLIRContext *context,
+                                         ArrayRef<int64_t> array);
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -62,6 +62,7 @@ Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
 IntegerAttr toIntegerAttr(MLIRContext *context, int64_t i);
 SmallVector<OpFoldResult> toOpFoldResult(MLIRContext *context,
                                          ArrayRef<int64_t> array);
+int64_t getAttrValueOrDynamic(OpFoldResult ofr);
 
 } // namespace LinalgExt
 } // namespace IREE

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -47,15 +47,8 @@ getMaterializedType(RankedTensorType tensorType,
   if (failed(materializeEncodingInfo)) {
     return tensorType;
   }
-  SmallVector<int64_t> staticTileSizes;
-  for (OpFoldResult tileDim : materializeEncodingInfo->innerTileSizes) {
-    if (Attribute tileDimAttr = tileDim.dyn_cast<Attribute>()) {
-      staticTileSizes.push_back(tileDimAttr.cast<IntegerAttr>().getInt());
-    } else {
-      staticTileSizes.push_back(ShapedType::kDynamic);
-    }
-  }
-  return PackOp::getPackedType(tensorType, staticTileSizes,
+  return PackOp::getPackedType(tensorType,
+                               materializeEncodingInfo->innerTileSizes,
                                materializeEncodingInfo->innerDimsPos,
                                materializeEncodingInfo->outerDimsPerm)
       .cast<RankedTensorType>();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
@@ -80,6 +80,19 @@ Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
                RankedTensorType::get(shape, rewriter.getF32Type()), vector));
 }
 
+IntegerAttr toIntegerAttr(MLIRContext *context, int64_t i) {
+  return IntegerAttr::get(IntegerType::get(context, 64), APInt(64, i));
+}
+
+SmallVector<OpFoldResult> toOpFoldResult(MLIRContext *context,
+                                         ArrayRef<int64_t> array) {
+  SmallVector<OpFoldResult> result;
+  for (int64_t i : array) {
+    result.emplace_back(toIntegerAttr(context, i));
+  }
+  return result;
+}
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
@@ -93,6 +93,15 @@ SmallVector<OpFoldResult> toOpFoldResult(MLIRContext *context,
   return result;
 }
 
+int64_t getAttrValueOrDynamic(OpFoldResult ofr) {
+  if (Attribute attr = ofr.dyn_cast<Attribute>()) {
+    if (IntegerAttr iattr = attr.dyn_cast<IntegerAttr>()) {
+      return iattr.getInt();
+    }
+  }
+  return ShapedType::kDynamic;
+}
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler


### PR DESCRIPTION
This is preparation for the VMVX backend exercising dynamic tile sizes.