### PR TITLE
[vulkan] Add support for VK_EXT_subgroup_size_control

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VulkanSPIRV/VulkanSPIRVTarget.cpp
@@ -23,6 +23,7 @@
 #include "llvm/Support/ToolOutputFile.h"
 #include "mlir/AsmParser/AsmParser.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/SPIRV/IR/SPIRVAttributes.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
@@ -148,12 +149,23 @@ class VulkanSPIRVTargetBackend : public TargetBackend {
     // list of entry point names here that are then passed in
     // VkShaderModuleCreateInfo.
     SmallVector<StringRef, 8> entryPointNames;
+    SmallVector<uint32_t, 8> subgroupSizes;
     spvModuleOp.walk([&](spirv::EntryPointOp exportOp) {
       entryPointNames.push_back(exportOp.getFn());
+      auto fn = spvModuleOp.lookupSymbol<spirv::FuncOp>(exportOp.getFn());
+      auto abi = fn->getAttrOfType<spirv::EntryPointABIAttr>(
+          spirv::getEntryPointABIAttrName());
+      if (abi && abi.getSubgroupSize()) {
+        subgroupSizes.push_back(*abi.getSubgroupSize());
+      } else {
+        subgroupSizes.push_back(0);
+      }
     });
     auto entryPointsRef = builder.createStringVec(entryPointNames);
+    auto subgroupSizesRef = builder.createInt32Vec(subgroupSizes);
 
     iree_SpirVExecutableDef_entry_points_add(builder, entryPointsRef);
+    iree_SpirVExecutableDef_subgroup_sizes_add(builder, subgroupSizesRef);
     iree_SpirVExecutableDef_code_add(builder, spvCodeRef);
     iree_SpirVExecutableDef_end_as_root(builder);
 

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.cc
@@ -207,6 +207,9 @@ iree_hal_vulkan_populate_enabled_device_extensions(
     } else if (strcmp(extension_name,
                       VK_EXT_CALIBRATED_TIMESTAMPS_EXTENSION_NAME) == 0) {
       extensions.calibrated_timestamps = true;
+    } else if (strcmp(extension_name,
+                      VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME) == 0) {
+      extensions.subgroup_size_control = true;
     }
   }
   return extensions;

--- a/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
+++ b/runtime/src/iree/hal/drivers/vulkan/extensibility_util.h
@@ -80,6 +80,8 @@ typedef struct iree_hal_vulkan_device_extensions_t {
   bool host_query_reset : 1;
   // VK_EXT_calibrated_timestamps is enabled.
   bool calibrated_timestamps : 1;
+  // VK_EXT_subgroup_size_control is enabled.
+  bool subgroup_size_control : 1;
 } iree_hal_vulkan_device_extensions_t;
 
 // Returns a bitfield with all of the provided extension names.

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -211,6 +211,16 @@ IREE_API_EXPORT iree_status_t iree_hal_vulkan_query_extensibility_set(
           "VK_LAYER_KHRONOS_timeline_semaphore");
 
   //===--------------------------------------------------------------------===//
+  // Optional CodeGen features
+  //===--------------------------------------------------------------------===//
+  // VK_EXT_subgroup_size_control:
+  // This extensions allows us to control the subgroup size used by Vulkan
+  // implementations, which can boost performance. It's promoted to core
+  // since Vulkan v1.3.
+  ADD_EXT(IREE_HAL_VULKAN_EXTENSIBILITY_DEVICE_EXTENSIONS_OPTIONAL,
+          VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME);
+
+  //===--------------------------------------------------------------------===//
   // Optional debugging features
   //===--------------------------------------------------------------------===//
   // Used only when explicitly requested as they drastically change the
@@ -910,6 +920,16 @@ iree_status_t iree_hal_vulkan_device_create(
     host_query_reset_features.pNext = features2.pNext;
     features2.pNext = &host_query_reset_features;
     host_query_reset_features.hostQueryReset = VK_TRUE;
+  }
+
+  VkPhysicalDeviceSubgroupSizeControlFeatures subgroup_control_features;
+  if (enabled_device_extensions.subgroup_size_control) {
+    memset(&subgroup_control_features, 0, sizeof(subgroup_control_features));
+    subgroup_control_features.sType =
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES;
+    subgroup_control_features.pNext = features2.pNext;
+    features2.pNext = &subgroup_control_features;
+    subgroup_control_features.subgroupSizeControl = VK_TRUE;
   }
 
   auto logical_device = new VkDeviceHandle(

--- a/runtime/src/iree/schemas/spirv_executable_def.fbs
+++ b/runtime/src/iree/schemas/spirv_executable_def.fbs
@@ -17,6 +17,9 @@ table SpirVExecutableDef {
   // A map of entry point ordinals to string names as used in the shader module.
   entry_points:[string];
 
+  // Required subgroup size for each entry point. 0 means no requirement.
+  subgroup_sizes:[uint32];
+
   // SPIR-V code words.
   code:[uint32];
 }


### PR DESCRIPTION
This commit plumbs through support for VK_EXT_subgroup_size_control in Vulkan HAL driver. The extension is marked as optional and requested when available. SPIR-V executable FlatBuffer gains a field to encode the requested subgroup size from CodeGen, 0 meaning no requirement.

This is to be used in a later commit to enable selecting wave32 mode for AMD RDNA architectures.