### PR TITLE
Add SPIRV backend support for Winograd output op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -930,9 +930,8 @@ static LogicalResult setFftOpConfig(spirv::ResourceLimitsAttr limits,
 // Winograd Default Configuration
 //===----------------------------------------------------------------------===//
 
-static LogicalResult setWinogradOpConfig(
-    spirv::ResourceLimitsAttr limits,
-    IREE::LinalgExt::WinogradInputTransformOp op) {
+static LogicalResult setWinogradOpConfig(spirv::ResourceLimitsAttr limits,
+                                         IREE::LinalgExt::LinalgExtOp op) {
   // Tiling is already done by tile and decompose, so we only set pipeline and
   // workgroup size. The tile sizes below are placeholders and were obtained
   // by manual tuning on the AMD Navi2 GPU on a small set of convolution
@@ -1356,10 +1355,9 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
       .Case<IREE::LinalgExt::FftOp>([limits](IREE::LinalgExt::FftOp op) {
         return setFftOpConfig(limits, op);
       })
-      .Case<IREE::LinalgExt::WinogradInputTransformOp>(
-          [&](IREE::LinalgExt::WinogradInputTransformOp op) {
-            return setWinogradOpConfig(limits, op);
-          })
+      .Case<IREE::LinalgExt::WinogradInputTransformOp,
+            IREE::LinalgExt::WinogradOutputTransformOp>(
+          [&](auto op) { return setWinogradOpConfig(limits, op); })
       .Default([](Operation *) { return success(); });
 };
 

--- a/tests/e2e/linalg_ext_ops/BUILD
+++ b/tests/e2e/linalg_ext_ops/BUILD
@@ -154,6 +154,7 @@ iree_check_single_backend_test_suite(
             #    "top-k.mlir",
             "sort.mlir",
             "winograd_input.mlir",
+            "winograd_output.mlir",
         ],
         include = ["*.mlir"],
         exclude = [
@@ -163,7 +164,6 @@ iree_check_single_backend_test_suite(
             # Re-enable this once we have new devices with up-to-date drivers.
             "top-k.mlir",
             "scan.mlir",
-            "winograd_output.mlir",
         ],
     ),
     driver = "vulkan",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -128,6 +128,7 @@ iree_check_single_backend_test_suite(
     "scatter.mlir"
     "sort.mlir"
     "winograd_input.mlir"
+    "winograd_output.mlir"
   TARGET_BACKEND
     "vulkan-spirv"
   DRIVER


### PR DESCRIPTION
This patch adds SPIRV support for the winograd output op. It reuses the same config and pipeline as the winograd input op.