### PR TITLE
[Flow] Move Convert1x1FilterConvToMatmul to come after DetachElementwiseFromNamedOps

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -224,9 +224,9 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
 
   // Preprocessing passes to get the program into a canonical state.
   FunctionLikeNest(passManager)
-      .addPass(IREE::Flow::createConvert1X1FilterConv2DToMatmulPass)
       .addPass(IREE::Flow::createDetachElementwiseFromNamedOpsPass)
-      .addPass(mlir::createLinalgNamedOpConversionPass);
+      .addPass(mlir::createLinalgNamedOpConversionPass)
+      .addPass(IREE::Flow::createConvert1X1FilterConv2DToMatmulPass);
 
   // Optional pre-processing passes.
   buildOptionalPreprocessingPassPipeline(passManager);


### PR DESCRIPTION
This helps to avoid later bufferization problems coming from converting a convolution with bias. e.g. before we would see this
```mlir
func.func @forward_dispatch_195_matmul_256x65536x512(%arg0: !flow.dispatch.tensor<readonly:tensor<256x512xf16>>, %arg1: !flow.dispatch.tensor<readonly:tensor<512x65536xf16>>, %arg2: !flow.dispatch.tensor<readonly:tensor<256x65536xf16>>, %arg3: !flow.dispatch.tensor<readonly:tensor<256x65536xf16>>, %arg4: !flow.dispatch.tensor<readonly:tensor<256xf16>>, %arg5: !flow.dispatch.tensor<writeonly:tensor<256x65536xf16>>) {
  %0 = flow.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [256, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x512xf16>> -> tensor<256x512xf16>
  %1 = flow.dispatch.tensor.load %arg1, offsets = [0, 0], sizes = [512, 65536], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x65536xf16>> -> tensor<512x65536xf16>
  %2 = flow.dispatch.tensor.load %arg2, offsets = [0, 0], sizes = [256, 65536], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x65536xf16>> -> tensor<256x65536xf16>
  %3 = flow.dispatch.tensor.load %arg3, offsets = [0, 0], sizes = [256, 65536], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x65536xf16>> -> tensor<256x65536xf16>
  %4 = flow.dispatch.tensor.load %arg4, offsets = [0], sizes = [256], strides = [1] : !flow.dispatch.tensor<readonly:tensor<256xf16>> -> tensor<256xf16>
  %5 = tensor.empty() : tensor<256x65536xf16>
  %6 = linalg.matmul ins(%0, %1 : tensor<256x512xf16>, tensor<512x65536xf16>) outs(%2 : tensor<256x65536xf16>) -> tensor<256x65536xf16>
  %7 = linalg.generic {indexing_maps = [#map4, #map4, #map5, #map4], iterator_types = ["parallel", "parallel"]} ins(%6, %3, %4 : tensor<256x65536xf16>, tensor<256x65536xf16>, tensor<256xf16>) outs(%5 : tensor<256x65536xf16>) {
  ^bb0(%in: f16, %in_0: f16, %in_1: f16, %out: f16):
    %8 = arith.addf %in_0, %in_1 : f16
    %9 = arith.addf %in, %8 : f16
    linalg.yield %9 : f16
  } -> tensor<256x65536xf16>
  flow.dispatch.tensor.store %7, %arg5, offsets = [0, 0], sizes = [256, 65536], strides = [1, 1] : tensor<256x65536xf16> -> !flow.dispatch.tensor<writeonly:tensor<256x65536xf16>>
  return
}

```
And after moving the pass we now get a fill pulled in and the bias addition is added to the fused elementwise op
```mlir
func.func @forward_dispatch_194_matmul_256x65536x512(%arg0: !flow.dispatch.tensor<readonly:tensor<256x512xf16>>, %arg1: !flow.dispatch.tensor<readonly:tensor<512x65536xf16>>, %arg2: !flow.dispatch.tensor<readonly:tensor<256xf16>>, %arg3: !flow.dispatch.tensor<readonly:tensor<256x65536xf16>>, %arg4: !flow.dispatch.tensor<readonly:tensor<256xf16>>, %arg5: !flow.dispatch.tensor<writeonly:tensor<256x65536xf16>>) {
  %cst = arith.constant 0.000000e+00 : f16 
  %0 = flow.dispatch.tensor.load %arg0, offsets = [0, 0], sizes = [256, 512], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x512xf16>> -> tensor<256x512xf16>
  %1 = flow.dispatch.tensor.load %arg1, offsets = [0, 0], sizes = [512, 65536], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<512x65536xf16>> -> tensor<512x65536xf16>
  %2 = flow.dispatch.tensor.load %arg2, offsets = [0], sizes = [256], strides = [1] : !flow.dispatch.tensor<readonly:tensor<256xf16>> -> tensor<256xf16>
  %3 = flow.dispatch.tensor.load %arg3, offsets = [0, 0], sizes = [256, 65536], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<256x65536xf16>> -> tensor<256x65536xf16>
  %4 = flow.dispatch.tensor.load %arg4, offsets = [0], sizes = [256], strides = [1] : !flow.dispatch.tensor<readonly:tensor<256xf16>> -> tensor<256xf16>
  %5 = tensor.empty() : tensor<256x65536xf16>
  %6 = linalg.fill ins(%cst : f16) outs(%5 : tensor<256x65536xf16>) -> tensor<256x65536xf16>
  %7 = linalg.matmul ins(%0, %1 : tensor<256x512xf16>, tensor<512x65536xf16>) outs(%6 : tensor<256x65536xf16>) -> tensor<256x65536xf16>
  %8 = linalg.generic {indexing_maps = [#map4, #map5, #map4, #map5, #map4], iterator_types = ["parallel", "parallel"]} ins(%7, %2, %3, %4 : tensor<256x65536xf16>, tensor<256xf16>, tensor<256x65536xf16>, tensor<256xf16>) outs(%5 : tensor<256x65536xf16>) {
  ^bb0(%in: f16, %in_0: f16, %in_1: f16, %in_2: f16, %out: f16): 
    %9 = arith.addf %in_1, %in_2 : f16 
    %10 = arith.addf %in, %in_0 : f16 
    %11 = arith.addf %10, %9 : f16 
    linalg.yield %11 : f16 
  } -> tensor<256x65536xf16>
  flow.dispatch.tensor.store %8, %arg5, offsets = [0, 0], sizes = [256, 65536], strides = [1, 1] : tensor<256x65536xf16> -> !flow.dispatch.tensor<writeonly:tensor<256x65536xf16>>
  return
}

```

