### PR TITLE
[spirv] Improve cooperative matrix elementwise op fusion

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -628,6 +628,10 @@ struct FoldSubspanOffsetIntoLoadStore final : public OpRewritePattern<OpType> {
     } else {
       memref = op.getMemref();
     }
+    // Look through memref cast ops. They can be generated during conversions.
+    while (auto castOp = memref.getDefiningOp<memref::CastOp>()) {
+      memref = castOp.getSource();
+    }
     auto memrefType = memref.getType().template cast<MemRefType>();
     if (!isRankOneMemRef(memrefType)) {
       return rewriter.notifyMatchFailure(op, "expected 1-D memref");

--- a/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/ConvertToSPIRVPass.cpp
@@ -57,6 +57,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LogicalResult.h"
 #include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
 namespace mlir {
 namespace iree_compiler {
@@ -272,6 +273,23 @@ struct FoldAsNoOp final : public OpConversionPattern<OpTy> {
   }
 };
 
+/// Removes memref.cast that converts static and dynamic shapes.
+struct RemoveStaticDynamicCast final : public OpRewritePattern<memref::CastOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::CastOp castOp,
+                                PatternRewriter &rewriter) const override {
+    auto srcType = castOp.getSource().getType().cast<MemRefType>();
+    auto dstType = castOp.getType().cast<MemRefType>();
+    if (srcType.getRank() == 1 && dstType.getRank() == 1 &&
+        srcType.hasStaticShape() != dstType.hasStaticShape()) {
+      rewriter.replaceOp(castOp, castOp.getSource());
+      return success();
+    }
+    return failure();
+  }
+};
+
 /// Removes unrealized_conversion_cast ops introduced during progressive
 /// lowering when possible.
 struct RemoveIdentityConversionCast final
@@ -343,6 +361,16 @@ void ConvertToSPIRVPass::runOnOperation() {
     funcOp->setAttr(
         spirv::getEntryPointABIAttrName(),
         spirv::getEntryPointABIAttr(context, workgroupSize32, subgroupSize32));
+  }
+
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    RewritePatternSet shapePatterns(context);
+    shapePatterns.insert<RemoveStaticDynamicCast>(context);
+    if (failed(
+            applyPatternsAndFoldGreedily(funcOp, std::move(shapePatterns)))) {
+      funcOp.emitOpError() << "failed running shape patterns";
+      return signalPassFailure();
+    }
   }
 
   spirv::TargetEnvAttr targetAttr = getSPIRVTargetEnvAttr(moduleOp);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -20,6 +20,7 @@
 #include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/MarkerUtils.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
@@ -138,6 +139,10 @@ class SPIRVTileAndPromotePass final
   /// Promotes C matrix to shared memory when necessary and returns success if
   /// no error happens.
   LogicalResult doPromoteCMatrix(func::FuncOp funcOp) const;
+
+  /// Returns true if the given generic op is an elementwise op that can use
+  /// cooperative matrix type eventually.
+  bool isCooperativeMatrixFusable(linalg::GenericOp genericOp) const;
 
   // Whether to promote C matrix to use shared memory.
   bool promoteCMatrix = false;
@@ -328,6 +333,10 @@ LogicalResult SPIRVTileAndPromotePass::doPromoteCMatrix(
     return success();
   }
 
+  // If the fused elementwise ops are allowed to use cooperative types, we can
+  // also avoid promoting C matrix.
+  if (isCooperativeMatrixFusable(genericOp)) return success();
+
   // Finally do promote C matrix.
   RewritePatternSet patterns(context);
   populateContractPromotionPatterns(patterns, {2});
@@ -347,6 +356,30 @@ LogicalResult SPIRVTileAndPromotePass::doPromoteCMatrix(
     llvm::dbgs() << "\n\n";
   });
   return success();
+}
+
+bool SPIRVTileAndPromotePass::isCooperativeMatrixFusable(
+    linalg::GenericOp genericOp) const {
+  if (genericOp.getNumLoops() != genericOp.getNumParallelLoops()) return false;
+  // Limit to outer dimension broadcasted cases for now.
+  for (AffineMap map : genericOp.getIndexingMapsArray()) {
+    if (!map.isMinorIdentity()) return false;
+  }
+
+  for (Operation &op : genericOp.getBlock()->without_terminator()) {
+    if (!isa<
+            // These ops are directly allowed to use cooperative matrix types.
+            arith::AddFOp, arith::AddIOp, arith::SubFOp, arith::SubIOp,
+            arith::DivFOp, arith::DivSIOp, arith::DivUIOp, arith::NegFOp,
+            arith::TruncFOp, arith::TruncIOp, arith::ExtFOp, arith::ExtSIOp,
+            arith::ExtUIOp, arith::FPToSIOp, arith::FPToUIOp, arith::SIToFPOp,
+            arith::UIToFPOp,
+            // Special cases of these ops are directly allowed to sue
+            // cooperative matrix types. Other cases can use a loop.
+            arith::MulFOp>(op))
+      return false;
+  }
+  return true;
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTileAndPromotePass(

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 
 #include "iree-dialects/Dialect/LinalgExt/Transforms/Transforms.h"
+#include "iree/compiler/Codegen/Common/GPUPatterns.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
@@ -25,6 +26,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/Debug.h"
 #include "mlir/Conversion/MemRefToSPIRV/MemRefToSPIRV.h"
+#include "mlir/Conversion/VectorToGPU/VectorToGPU.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -150,6 +152,12 @@ Optional<SmallVector<int64_t>> getCooperativeOpVectorShape(
   // Unroll vector.contract ops according to native cooperative matrix size.
   if (auto contractOp = dyn_cast<vector::ContractionOp>(op)) {
     return llvm::to_vector<>(nativeShape);
+  }
+
+  // Unroll elementwise ops according to native cooperative matrix size.
+  if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
+    if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>())
+      return llvm::to_vector<>(nativeShape.drop_back());  // Drop K dim size
   }
 
   // Unrolling vector.contract generates vector.{insert|extract}_strided_slice
@@ -368,6 +376,10 @@ class SPIRVVectorizeToCooperativeOpsPass final
       RewritePatternSet canonicalizationPatterns(context);
       vector::ContractionOp::getCanonicalizationPatterns(
           canonicalizationPatterns, context);
+      populateCombineVectorTransferReadBroadcastPatterns(
+          canonicalizationPatterns);
+      populatePrepareVectorToMMAPatterns(canonicalizationPatterns,
+                                         /*useNvGPU=*/false);
       if (failed(applyPatternsAndFoldGreedily(
               funcOp, std::move(canonicalizationPatterns)))) {
         return signalPassFailure();
@@ -401,22 +413,6 @@ class SPIRVVectorizeToCooperativeOpsPass final
 
     LLVM_DEBUG({
       llvm::dbgs() << "--- After hoisting vector transfers ---\n";
-      funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
-      llvm::dbgs() << "\n\n";
-    });
-
-    {
-      RewritePatternSet canonicalizationPatterns(context);
-      vector::populateVectorTransferPermutationMapLoweringPatterns(
-          canonicalizationPatterns);
-      if (failed(applyPatternsAndFoldGreedily(
-              funcOp, std::move(canonicalizationPatterns)))) {
-        return signalPassFailure();
-      }
-    }
-
-    LLVM_DEBUG({
-      llvm::dbgs() << "--- After canonicalizing vectors ---\n";
       funcOp.print(llvm::dbgs(), OpPrintingFlags().useLocalScope());
       llvm::dbgs() << "\n\n";
     });

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorToGPUSubgroupMMAOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorToGPUSubgroupMMAOps.cpp
@@ -41,6 +41,16 @@ struct SPIRVVectorToGPUSubgroupMMAPass final
     }
 
     convertVectorToMMAOps(funcOp);
+
+    // Make sure we actually generate GPU subgroup mma ops.
+    WalkResult result = funcOp.walk([](Operation* op) {
+      return isa<gpu::SubgroupMmaComputeOp>(op) ? WalkResult::interrupt()
+                                                : WalkResult::advance();
+    });
+    if (!result.wasInterrupted()) {
+      funcOp->emitError("failed conversion to GPU subgroup MMA ops");
+      return signalPassFailure();
+    }
   }
 };
 }  // namespace

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/pipeline_matmul_cooperative_ops.mlir
@@ -10,7 +10,7 @@
   ]>
 ]>
 
-hal.executable public @matmul_256x1024x128_div_add {
+hal.executable public @matmul_256x1024x128_div_exp {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
     spirv.target_env = #spirv.target_env<
       #spirv.vce<v1.5,
@@ -33,13 +33,13 @@ hal.executable public @matmul_256x1024x128_div_add {
         max_compute_workgroup_size = [2147483647, 65535, 65535],
         subgroup_size = 32>
        >}> {
-    hal.executable.export public @matmul_256x1024x128_div_add layout(#pipeline_layout) {
+    hal.executable.export public @matmul_256x1024x128_div_exp layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
       %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module  {
-      func.func @matmul_256x1024x128_div_add() {
+      func.func @matmul_256x1024x128_div_exp() {
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index
         %c256 = arith.constant 256 : index
@@ -64,7 +64,8 @@ hal.executable public @matmul_256x1024x128_div_add {
           outs(%17 : tensor<256x1024xf16>) {
         ^bb0(%arg2: f16, %arg3: f16, %arg4: f16, %arg5: f16):
           %28 = arith.divf %arg2, %arg3 : f16
-          %29 = arith.addf %28, %arg4 : f16
+          // spirv.GL.Exp is not permitted to use cooperative matrix types per the spec.
+          %29 = math.exp %28 : f16
           linalg.yield %29 : f16
         } -> tensor<256x1024xf16>
         flow.dispatch.tensor.store %27, %4, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !flow.dispatch.tensor<writeonly:tensor<256x1024xf16>>
@@ -89,7 +90,7 @@ hal.executable public @matmul_256x1024x128_div_add {
 //         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 //         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
 
-//         CHECK:   spirv.func @matmul_256x1024x128_div_add
+//         CHECK:   spirv.func @matmul_256x1024x128_div_exp
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
 //     CHECK-DAG:     %[[C5:.+]] = spirv.Constant 5 : i32
@@ -188,19 +189,19 @@ hal.executable public @matmul_256x1024x128_div_add {
 //         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 //         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 //         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 //         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
 //         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 //         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
 // -----
@@ -275,7 +276,6 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 
 //         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
 //         CHECK:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
-//         CHECK:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<576 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @batch_matmul_16x128x256x512_div
 
@@ -321,32 +321,14 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 // CHECK-COUNT-4:     %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C9]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 // CHECK-COUNT-8:     %{{.+}} = spirv.NV.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
 
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C9]], %[[COL_MAJOR]]
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C9]], %[[COL_MAJOR]]
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C9]], %[[COL_MAJOR]]
-//         CHECK:     %[[AC:.+]] = spirv.AccessChain %[[C_MEM]]
-//         CHECK:     spirv.NV.CooperativeMatrixStore %[[AC]], %{{.+}}, %[[C9]], %[[COL_MAJOR]]
-
-//         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.Load "StorageBuffer" %{{.+}} : vector<4xf32>
-//         CHECK:     spirv.Load "Workgroup" %{{.+}} : vector<4xf32>
-// CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+// CHECK-COUNT-4:     %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:     %{{.+}} = spirv.FDiv %{{.+}}, %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-4:     spirv.NV.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C32]], %[[COL_MAJOR]]
 
 
 // -----
+
+// Small matmul that each subgroup only handles one tile
 
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
@@ -419,7 +401,7 @@ hal.executable public @matmul_32x32x32_div {
 // CHECK-COUNT-4: spirv.NV.CooperativeMatrixLoad
 // CHECK-COUNT-2: spirv.NV.CooperativeMatrixMulAdd
 //         CHECK: spirv.NV.CooperativeMatrixLoad
-//         CHECK: spirv.FDiv
+//         CHECK: spirv.FDiv %{{.+}}, %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup>
 //         CHECK: spirv.NV.CooperativeMatrixStore
 
 // -----
@@ -547,7 +529,7 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
   ]>
 ]>
 
-hal.executable public @matmul_256x1024x128_div_add {
+hal.executable public @matmul_256x1024x128_div_exp {
   hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
     spirv.target_env = #spirv.target_env<
       #spirv.vce<v1.6,
@@ -564,13 +546,13 @@ hal.executable public @matmul_256x1024x128_div_add {
         max_compute_workgroup_size = [1024, 1024, 1024],
         subgroup_size = 64>
        >}> {
-    hal.executable.export public @matmul_256x1024x128_div_add layout(#pipeline_layout) {
+    hal.executable.export public @matmul_256x1024x128_div_exp layout(#pipeline_layout) {
     ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
       %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
       hal.return %x, %y, %z : index, index, index
     }
     builtin.module  {
-      func.func @matmul_256x1024x128_div_add() {
+      func.func @matmul_256x1024x128_div_exp() {
         %c0 = arith.constant 0 : index
         %c1024 = arith.constant 1024 : index
         %c256 = arith.constant 256 : index
@@ -595,7 +577,8 @@ hal.executable public @matmul_256x1024x128_div_add {
           outs(%17 : tensor<256x1024xf16>) {
         ^bb0(%arg2: f16, %arg3: f16, %arg4: f16, %arg5: f16):
           %28 = arith.divf %arg2, %arg3 : f16
-          %29 = arith.addf %28, %arg4 : f16
+          // spirv.GL.Exp is not permitted to use cooperative matrix types per the spec.
+          %29 = math.exp %28 : f16
           linalg.yield %29 : f16
         } -> tensor<256x1024xf16>
         flow.dispatch.tensor.store %27, %4, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1] : tensor<256x1024xf16> -> !flow.dispatch.tensor<writeonly:tensor<256x1024xf16>>
@@ -611,7 +594,7 @@ hal.executable public @matmul_256x1024x128_div_add {
 //     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
 //     CHECK-DAG:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 
-//         CHECK:   spirv.func @matmul_256x1024x128_div_add
+//         CHECK:   spirv.func @matmul_256x1024x128_div_exp
 
 //     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
 //     CHECK-DAG:     %[[C5:.+]] = spirv.Constant 5 : i32
@@ -656,13 +639,13 @@ hal.executable public @matmul_256x1024x128_div_add {
 
 //         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 // CHECK-COUNT-2:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-// CHECK-COUNT-2:     spirv.FAdd %{{.+}}, %{{.+}} : vector<4xf16>
+// CHECK-COUNT-2:     spirv.GL.Exp %{{.+}} : vector<4xf16>
 //         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
 
 // -----
@@ -731,7 +714,6 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 
 //     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 //     CHECK-DAG:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<640 x vector<4xf32>>)>, Workgroup>
-//     CHECK-DAG:   spirv.GlobalVariable @[[C_MEM:.+]] : !spirv.ptr<!spirv.struct<(!spirv.array<1088 x vector<4xf32>>)>, Workgroup>
 
 //         CHECK:   spirv.func @batch_matmul_16x128x256x512_div
 
@@ -772,12 +754,9 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 // CHECK-COUNT-4:     %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C5]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 // CHECK-COUNT-4:     %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C17]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, Workgroup> as !spirv.coopmatrix<16x16xf16, Subgroup>
 
-// CHECK-COUNT-8:     %{{.+}} = spirv.NV.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
-// CHECK-COUNT-8:     spirv.NV.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C17]], %[[COL_MAJOR]]
-
-//         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
-// CHECK-COUNT-8:     spirv.FDiv %{{.+}}, %{{.+}} : vector<4xf16>
-//         CHECK:     spirv.ControlBarrier <Workgroup>, <Workgroup>, <AcquireRelease|WorkgroupMemory>
+// CHECK-COUNT-8:     %{{.+}} = spirv.NV.CooperativeMatrixLoad %{{.+}}, %[[C32]], %[[COL_MAJOR]] : !spirv.ptr<vector<4xf32>, StorageBuffer> as !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-8:     %{{.+}} = spirv.FDiv %{{.+}}, %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup>
+// CHECK-COUNT-8:     spirv.NV.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C32]], %[[COL_MAJOR]]
 
 // -----
 
@@ -878,3 +857,90 @@ hal.executable public @generic_batch_matmul_32x128x512x64 {
 //CHECK-COUNT-16:     %{{.+}} = spirv.NV.CooperativeMatrixMulAdd %{{.+}}, %{{.+}}, %{{.+}}
 
 // CHECK-COUNT-8:     spirv.NV.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C64]], %[[COL_MAJOR]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+
+#compilation = #iree_codegen.compilation_info<
+    lowering_config  = <tile_sizes = [[1, 64, 64], [1, 16, 64], [0, 0, 0, 16], [1, 16, 16, 16]]>,
+    translation_info = <SPIRVCooperativeMatrixVectorize>,
+    workgroup_size = [32, 4, 1], subgroup_size = 32>
+
+hal.executable public @batch_matmul_f16_16x4096x4096x64_truncf_mulf {
+  hal.executable.variant @vulkan, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<
+      #spirv.vce<v1.6,
+      [Shader, Float16, StorageBuffer16BitAccess, StorageUniform16, CooperativeMatrixNV],
+      [SPV_KHR_variable_pointers, SPV_NV_cooperative_matrix]>, AMD:DiscreteGPU,
+      #spirv.resource_limits<
+        cooperative_matrix_properties_nv = [
+          #spirv.coop_matrix_props<
+            a_type = f16, b_type = f16, c_type = f16, k_size = 16,
+            m_size = 16, n_size = 16, result_type = f16, scope = <Subgroup>>
+        ],
+        max_compute_shared_memory_size = 65536,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 1024],
+        subgroup_size = 64>
+       >}> {
+    hal.executable.export public @batch_matmul_f16_16x4096x4096x64_truncf_mulf layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module  {
+      func.func @batch_matmul_f16_16x4096x4096x64_truncf_mulf() {
+        %cst = arith.constant 0.158113882 : f32
+        %cst_0 = arith.constant 0.000000e+00 : f16
+        %c0 = arith.constant 0 : index
+        %6 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<16x4096x64xf16>>
+        %7 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<16x64x4096xf16>>
+        %8 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<16x4096x4096xf16>>
+        %9 = flow.dispatch.tensor.load %6, offsets = [0, 0, 0], sizes = [16, 4096, 64], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<16x4096x64xf16>> -> tensor<16x4096x64xf16>
+        %10 = flow.dispatch.tensor.load %7, offsets = [0, 0, 0], sizes = [16, 64, 4096], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<16x64x4096xf16>> -> tensor<16x64x4096xf16>
+        %11 = tensor.empty() : tensor<16x4096x4096xf16>
+        %12 = linalg.fill ins(%cst_0 : f16) outs(%11 : tensor<16x4096x4096xf16>) -> tensor<16x4096x4096xf16>
+        %13 = linalg.batch_matmul {compilation_info = #compilation}
+          ins(%9, %10 : tensor<16x4096x64xf16>, tensor<16x64x4096xf16>)
+          outs(%12 : tensor<16x4096x4096xf16>) -> tensor<16x4096x4096xf16>
+        %14 = linalg.generic {
+              indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+              iterator_types = ["parallel", "parallel", "parallel"]}
+          ins(%13 : tensor<16x4096x4096xf16>) outs(%11 : tensor<16x4096x4096xf16>) {
+        ^bb0(%in: f16, %out: f16):
+          %15 = arith.truncf %cst : f32 to f16
+          %16 = arith.mulf %in, %15 : f16
+          linalg.yield %16 : f16
+        } -> tensor<16x4096x4096xf16>
+        flow.dispatch.tensor.store %14, %8, offsets = [0, 0, 0], sizes = [16, 4096, 4096], strides = [1, 1, 1] : tensor<16x4096x4096xf16> -> !flow.dispatch.tensor<writeonly:tensor<16x4096x4096xf16>>
+        return
+      }
+    }
+  }
+}
+
+//   CHECK-LABEL: spirv.module Logical GLSL450
+
+//     CHECK-NOT:   spirv.GlobalVariable {{.+}} Workgroup
+// CHECK-COUNT-2:   spirv.GlobalVariable @{{.+}} : !spirv.ptr<!spirv.struct<(!spirv.array<{{.+}}>)>, Workgroup>
+//     CHECK-NOT:   spirv.GlobalVariable {{.+}} Workgroup
+
+//         CHECK:   spirv.func @batch_matmul_f16_16x4096x4096x64_truncf_mulf
+
+//     CHECK-DAG:     %[[COL_MAJOR:.+]] = spirv.Constant [[COL_MAJOR]]
+//     CHECK-DAG:     %[[C512:.+]] = spirv.Constant 512 : i32
+//     CHECK-DAG:     %[[SCALAR:.+]] = spirv.Constant 0.158113882 : f32
+
+
+// CHECK-COUNT-4:     %{{.+}} = spirv.Load "Function" %{{.+}} : !spirv.coopmatrix<16x16xf16, Subgroup>
+//         CHECK:     %[[CONVERT:.+]] = spirv.FConvert %[[SCALAR]] : f32 to f16
+// CHECK-COUNT-4:     %{{.+}} = spirv.MatrixTimesScalar %{{.+}}, %[[CONVERT]] : !spirv.coopmatrix<16x16xf16, Subgroup>, f16
+
+// CHECK-COUNT-4:     spirv.NV.CooperativeMatrixStore %{{.+}}, %{{.+}}, %[[C512]], %[[COL_MAJOR]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_promote_cooperative_matrix.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_promote_cooperative_matrix.mlir
@@ -191,7 +191,8 @@ hal.executable @generic_batch_matmul_f16_32x128x512x64 {
               ins(%subview_2 : memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>)
               outs(%subview : memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>) {
               ^bb0(%in: f16, %out: f16):
-                %8 = arith.divf %out, %in : f16
+                // spirv.GL.Exp is not permitted to use cooperative matrix types per the spec.
+                %8 = math.exp %in : f16
                 linalg.yield %8 : f16
               }
             }
@@ -253,6 +254,126 @@ hal.executable @generic_batch_matmul_f16_32x128x512x64 {
 //      PROMOTEC:    ins(%{{.+}}, %[[C_ALLOC]]
 // PROMOTEC-SAME:   __internal_linalg_transform__ = "copy_to_workgroup_memory"
 //      PROMOTEC: gpu.barrier
+
+// -----
+
+// Cooperative matrix fusable elementwise ops do not need promote C.
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[1, 32, 32, 32], [1, 16, 16, 16], [0, 0, 0, 32]]>
+hal.executable @generic_batch_matmul_f16_32x128x512x64 {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<
+      #spirv.vce<v1.5,
+      [Shader, Float16, StorageBuffer16BitAccess, StorageUniform16, CooperativeMatrixNV],
+      [SPV_KHR_variable_pointers, SPV_NV_cooperative_matrix]>, NVIDIA:DiscreteGPU,
+      #spirv.resource_limits<
+        cooperative_matrix_properties_nv = [
+          #spirv.coop_matrix_props<
+            a_type = i8, b_type = i8, c_type = i32, k_size = 32,
+            m_size = 8, n_size = 8, result_type = i32, scope = <Subgroup>>,
+          #spirv.coop_matrix_props<
+            a_type = f16, b_type = f16, c_type = f16, k_size = 16,
+            m_size = 16, n_size = 16, result_type = f16, scope = <Subgroup>>,
+          #spirv.coop_matrix_props<
+            a_type = f16, b_type = f16, c_type = f32, k_size = 16,
+            m_size = 16, n_size = 16, result_type = f32, scope = <Subgroup>>
+        ],
+        max_compute_shared_memory_size = 49152,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [2147483647, 65535, 65535],
+        subgroup_size = 32>
+       >}> {
+    hal.executable.export public @generic_batch_matmul_f16_32x128x512x64 ordinal(0) layout(#pipeline_layout) attributes {
+      translation_info = #iree_codegen.translation_info<SPIRVMatmulPromoteVectorize>,
+      workgroup_size = [64 : index, 2 : index, 1 : index]
+    }
+    builtin.module {
+      func.func @generic_batch_matmul_f16_32x128x512x64() {
+        %c32 = arith.constant 32 : index
+        %c128 = arith.constant 128 : index
+        %c512 = arith.constant 512 : index
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %span0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : memref<128x32x64xf16>
+        %span1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<32x64x512xf16>
+        %span2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : memref<32x128x512xf16>
+        %span3 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : memref<32x128x512xf16>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %workgroup_id_z = hal.interface.workgroup.id[2] : index
+        %workgroup_count_z = hal.interface.workgroup.count[2] : index
+        scf.for %arg0 = %workgroup_id_z to %c32 step %workgroup_count_z {
+          %3 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_y]
+          %4 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_y]
+          scf.for %arg1 = %3 to %c128 step %4 {
+            %5 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_id_x]
+            %6 = affine.apply affine_map<()[s0] -> (s0 * 32)>()[%workgroup_count_x]
+            scf.for %arg2 = %5 to %c512 step %6 {
+              %subview = memref.subview %span2[%arg0, %arg1, %arg2] [1, 32, 32] [1, 1, 1] : memref<32x128x512xf16> to memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>
+              %subview_0 = memref.subview %span0[%arg1, %arg0, 0] [32, 1, 64] [1, 1, 1] : memref<128x32x64xf16> to memref<32x1x64xf16, strided<[2048, 64, 1], offset: ?>>
+              %subview_1 = memref.subview %span1[%arg0, 0, %arg2] [1, 64, 32] [1, 1, 1] : memref<32x64x512xf16> to memref<1x64x32xf16, strided<[32768, 512, 1], offset: ?>>
+              linalg.fill ins(%cst : f16) outs(%subview : memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>)
+              linalg.generic {
+                indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d1, d0, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d3, d2)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2)>],
+                iterator_types = ["parallel", "parallel", "parallel", "reduction"]}
+              ins(%subview_0, %subview_1 : memref<32x1x64xf16, strided<[2048, 64, 1], offset: ?>>, memref<1x64x32xf16, strided<[32768, 512, 1], offset: ?>>)
+              outs(%subview : memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>)
+              attrs = {lowering_config = #config} {
+              ^bb0(%in: f16, %in_2: f16, %out: f16):
+                %7 = arith.mulf %in, %in_2 : f16
+                %8 = arith.addf %out, %7 : f16
+                linalg.yield %8 : f16
+              }
+              %subview_2 = memref.subview %span3[%arg0, %arg1, %arg2] [1, 32, 32] [1, 1, 1] : memref<32x128x512xf16> to memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>
+              linalg.generic {
+                  indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+                  iterator_types = ["parallel", "parallel", "parallel"]}
+              ins(%subview_2 : memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>)
+              outs(%subview : memref<1x32x32xf16, strided<[65536, 512, 1], offset: ?>>) {
+              ^bb0(%in: f16, %out: f16):
+                %8 = arith.divf %out, %in : f16
+                linalg.yield %8 : f16
+              }
+            }
+          }
+        }
+        return
+      }
+    }
+  }
+}
+
+// PROMOTEC-LABEL: func.func @generic_batch_matmul_f16_32x128x512x64()
+
+//      PROMOTEC: %[[RHS_ALLOC:.+]] = memref.alloc() : memref<1x32x32xf16, 3>
+//      PROMOTEC: %[[LHS_ALLOC:.+]] = memref.alloc() : memref<32x1x32xf16, 3>
+
+//      PROMOTEC: linalg.fill
+// PROMOTEC-SAME:   __internal_linalg_transform__ = "workgroup_memory"
+
+//      PROMOTEC: scf.for %{{.+}} = %c0 to %c64 step %c32
+//      PROMOTEC:   %[[LHS_VIEW:.+]] = memref.subview %[[LHS_ALLOC]][0, 0, 0] [%c32, %c1, %c32]
+//      PROMOTEC:   %[[RHS_VIEW:.+]] = memref.subview %[[RHS_ALLOC]][0, 0, 0] [%c1, %c32, %c32]
+//      PROMOTEC:   gpu.barrier
+//      PROMOTEC:   memref.copy %{{.+}}, %[[LHS_VIEW]]
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "copy_to_workgroup_memory"
+//      PROMOTEC:   memref.copy %{{.+}}, %[[RHS_VIEW]]
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "copy_to_workgroup_memory"
+//      PROMOTEC:   gpu.barrier
+//      PROMOTEC:   linalg.generic
+// PROMOTEC-SAME:    ins(%[[LHS_VIEW]], %[[RHS_VIEW]]
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "workgroup_memory"
+
 
 // -----
 
@@ -475,5 +596,232 @@ hal.executable @batch_matmul_f16_1x64x128x512 {
 //      PROMOTEC: gpu.barrier
 //      PROMOTEC: linalg.generic
 //      PROMOTEC:    ins(%[[C_ALLOC]]
+// PROMOTEC-SAME:   __internal_linalg_transform__ = "copy_to_workgroup_memory"
+//      PROMOTEC: gpu.barrier
+
+// -----
+
+// Broadcasted elementwise ops does not need promoting C matrix.
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 128], [32, 64], [0, 0, 32], [16, 16, 16]]>
+
+hal.executable @matmul_f16_f512x4096x64 {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<
+      #spirv.vce<v1.6,
+      [Shader, Float16, StorageBuffer16BitAccess, StorageUniform16, CooperativeMatrixNV],
+      [SPV_NV_cooperative_matrix]>, AMD:DiscreteGPU,
+      #spirv.resource_limits<
+        cooperative_matrix_properties_nv = [
+          #spirv.coop_matrix_props<
+            a_type = f16, b_type = f16, c_type = f16, k_size = 16,
+            m_size = 16, n_size = 16, result_type = f16, scope = <Subgroup>>
+        ],
+        max_compute_shared_memory_size = 65536,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 1024],
+        subgroup_size = 64>
+       >}> {
+    hal.executable.export public @matmul_f16_f512x4096x64 ordinal(0) layout(#pipeline_layout) attributes {
+      translation_info = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>,
+      workgroup_size = [128 : index, 2 : index, 1 : index]
+    }
+    builtin.module {
+      func.func @matmul_f16_f512x4096x64() {
+        %c512 = arith.constant 512 : index
+        %c4096 = arith.constant 4096 : index
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : memref<512x64xf16>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<64x4096xf16>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : memref<4096xf16>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) offset(%c0) alignment(64) : memref<512x4096xf16>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %4 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_y]
+        scf.for %arg0 = %4 to %c512 step %5 {
+          %6 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
+          %7 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_count_x]
+          scf.for %arg1 = %6 to %c4096 step %7 {
+            %subview = memref.subview %3[%arg0, %arg1] [64, 128] [1, 1] : memref<512x4096xf16> to memref<64x128xf16, strided<[4096, 1], offset: ?>>
+            %subview_0 = memref.subview %0[%arg0, 0] [64, 64] [1, 1] : memref<512x64xf16> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+            %subview_1 = memref.subview %1[0, %arg1] [64, 128] [1, 1] : memref<64x4096xf16> to memref<64x128xf16, strided<[4096, 1], offset: ?>>
+            linalg.fill ins(%cst : f16) outs(%subview : memref<64x128xf16, strided<[4096, 1], offset: ?>>)
+            linalg.matmul {lowering_config = #config}
+              ins(%subview_0, %subview_1 : memref<64x64xf16, strided<[64, 1], offset: ?>>, memref<64x128xf16, strided<[4096, 1], offset: ?>>)
+              outs(%subview : memref<64x128xf16, strided<[4096, 1], offset: ?>>)
+            %subview_2 = memref.subview %2[%arg1] [128] [1] : memref<4096xf16> to memref<128xf16, strided<[1], offset: ?>>
+            linalg.generic {
+                indexing_maps = [affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+                iterator_types = ["parallel", "parallel"]}
+              ins(%subview_2 : memref<128xf16, strided<[1], offset: ?>>) outs(%subview : memref<64x128xf16, strided<[4096, 1], offset: ?>>) {
+            ^bb0(%in: f16, %out: f16):
+              %8 = arith.addf %out, %in : f16
+              linalg.yield %8 : f16
+            }
+          }
+        }
+        return
+      }
+    }
+  }
+}
+
+// PROMOTEC-LABEL: func.func @matmul_f16_f512x4096x64()
+
+//  PROMOTEC-NOT: memref.alloc()
+//  PROMOTEC-DAG: %[[LHS_ALLOC:.+]] = memref.alloc() : memref<64x32xf16, 3>
+//  PROMOTEC-DAG: %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x128xf16, 3>
+//  PROMOTEC-NOT: memref.alloc()
+
+//      PROMOTEC: %[[SPAN2:.+]] = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer)
+//      PROMOTEC: %[[SPAN3:.+]] = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer)
+//      PROMOTEC: %[[OUT_VIEW:.+]] = memref.subview %[[SPAN3]]
+
+//      PROMOTEC: linalg.fill
+// PROMOTEC-SAME:   __internal_linalg_transform__ = "workgroup_memory"
+// PROMOTEC-SAME:   outs(%[[OUT_VIEW]]
+
+//      PROMOTEC: scf.for %{{.+}} = %c0 to %c64 step %c32 {
+//      PROMOTEC:   %[[LHS_VIEW:.+]] = memref.subview %[[LHS_ALLOC]][0, 0] [%c64, %c32]
+//      PROMOTEC:   %[[RHS_VIEW:.+]] = memref.subview %[[RHS_ALLOC]][0, 0] [%c32, %c128]
+//      PROMOTEC:   gpu.barrier
+//      PROMOTEC:   memref.copy %{{.+}}, %[[LHS_VIEW]]
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "copy_to_workgroup_memory"
+//      PROMOTEC:   memref.copy %{{.+}}, %[[RHS_VIEW]]
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "copy_to_workgroup_memory"
+//      PROMOTEC:   gpu.barrier
+//      PROMOTEC:   linalg.matmul
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "workgroup_memory"
+// PROMOTEC-SAME:    ins(%[[LHS_VIEW]], %[[RHS_VIEW]]
+// PROMOTEC-SAME:    outs(%[[OUT_VIEW]]
+//      PROMOTEC: }
+
+//  PROMOTEC-NOT: gpu.barrier
+//  PROMOTEC-NOT: memref.copy
+//      PROMOTEC: %[[BCAST_VIEW:.+]] = memref.subview %[[SPAN2]][%{{.+}}] [128] [1]
+//      PROMOTEC: linalg.generic
+// PROMOTEC-SAME:    ins(%[[BCAST_VIEW]]
+// PROMOTEC-SAME:    outs(%[[OUT_VIEW]]
+// PROMOTEC-SAME:   __internal_linalg_transform__ = "workgroup_memory"
+
+// -----
+
+// Transposed+broadcasted elementwise ops need promote C.
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>,
+    #hal.descriptor_set.binding<3, storage_buffer>
+  ]>
+]>
+#config = #iree_codegen.lowering_config<tile_sizes = [[64, 128], [32, 64], [0, 0, 32], [16, 16, 16]]>
+
+hal.executable @matmul_f16_f512x4096x64 {
+  hal.executable.variant public @vulkan_spirv_fb, target = <"vulkan-spirv", "vulkan-spirv-fb", {
+    spirv.target_env = #spirv.target_env<
+      #spirv.vce<v1.6,
+      [Shader, Float16, StorageBuffer16BitAccess, StorageUniform16, CooperativeMatrixNV],
+      [SPV_NV_cooperative_matrix]>, AMD:DiscreteGPU,
+      #spirv.resource_limits<
+        cooperative_matrix_properties_nv = [
+          #spirv.coop_matrix_props<
+            a_type = f16, b_type = f16, c_type = f16, k_size = 16,
+            m_size = 16, n_size = 16, result_type = f16, scope = <Subgroup>>
+        ],
+        max_compute_shared_memory_size = 65536,
+        max_compute_workgroup_invocations = 1024,
+        max_compute_workgroup_size = [1024, 1024, 1024],
+        subgroup_size = 64>
+       >}> {
+    hal.executable.export public @matmul_f16_f512x4096x64 ordinal(0) layout(#pipeline_layout) attributes {
+      translation_info = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>,
+      workgroup_size = [128 : index, 2 : index, 1 : index]
+    }
+    builtin.module {
+      func.func @matmul_f16_f512x4096x64() {
+        %c512 = arith.constant 512 : index
+        %c4096 = arith.constant 4096 : index
+        %c0 = arith.constant 0 : index
+        %cst = arith.constant 0.000000e+00 : f16
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : memref<512x64xf16>
+        %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : memref<64x4096xf16>
+        %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64) : memref<512xf16>
+        %3 = hal.interface.binding.subspan set(0) binding(3) type(storage_buffer) offset(%c0) alignment(64) : memref<512x4096xf16>
+        %workgroup_id_x = hal.interface.workgroup.id[0] : index
+        %workgroup_count_x = hal.interface.workgroup.count[0] : index
+        %workgroup_id_y = hal.interface.workgroup.id[1] : index
+        %workgroup_count_y = hal.interface.workgroup.count[1] : index
+        %4 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
+        %5 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_y]
+        scf.for %arg0 = %4 to %c512 step %5 {
+          %6 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_id_x]
+          %7 = affine.apply affine_map<()[s0] -> (s0 * 128)>()[%workgroup_count_x]
+          scf.for %arg1 = %6 to %c4096 step %7 {
+            %subview = memref.subview %3[%arg0, %arg1] [64, 128] [1, 1] : memref<512x4096xf16> to memref<64x128xf16, strided<[4096, 1], offset: ?>>
+            %subview_0 = memref.subview %0[%arg0, 0] [64, 64] [1, 1] : memref<512x64xf16> to memref<64x64xf16, strided<[64, 1], offset: ?>>
+            %subview_1 = memref.subview %1[0, %arg1] [64, 128] [1, 1] : memref<64x4096xf16> to memref<64x128xf16, strided<[4096, 1], offset: ?>>
+            linalg.fill ins(%cst : f16) outs(%subview : memref<64x128xf16, strided<[4096, 1], offset: ?>>)
+            linalg.matmul {lowering_config = #config}
+              ins(%subview_0, %subview_1 : memref<64x64xf16, strided<[64, 1], offset: ?>>, memref<64x128xf16, strided<[4096, 1], offset: ?>>)
+              outs(%subview : memref<64x128xf16, strided<[4096, 1], offset: ?>>)
+            %subview_2 = memref.subview %2[%arg0] [64] [1] : memref<512xf16> to memref<64xf16, strided<[1], offset: ?>>
+            linalg.generic {
+                  indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
+                  iterator_types = ["parallel", "parallel"]}
+              ins(%subview_2 : memref<64xf16, strided<[1], offset: ?>>)
+              outs(%subview : memref<64x128xf16, strided<[4096, 1], offset: ?>>) {
+            ^bb0(%in: f16, %out: f16):
+              %8 = arith.addf %out, %in : f16
+              linalg.yield %8 : f16
+            }
+          }
+        }
+        return
+      }
+    }
+  }
+}
+
+// PROMOTEC-LABEL: func.func @matmul_f16_f512x4096x64()
+
+//  PROMOTEC-DAG: %[[LHS_ALLOC:.+]] = memref.alloc() : memref<64x32xf16, 3>
+//  PROMOTEC-DAG: %[[RHS_ALLOC:.+]] = memref.alloc() : memref<32x128xf16, 3>
+//  PROMOTEC-DAG: %[[C_ALLOC:.+]] = memref.alloc() : memref<64x128xf16, 3>
+
+//      PROMOTEC: linalg.fill
+// PROMOTEC-SAME:   __internal_linalg_transform__ = "workgroup_memory"
+// PROMOTEC-SAME:   outs(%[[C_ALLOC]]
+
+//      PROMOTEC: scf.for %{{.+}} = %c0 to %c64 step %c32 {
+//      PROMOTEC:   %[[LHS_VIEW:.+]] = memref.subview %[[LHS_ALLOC]][0, 0] [%c64, %c32]
+//      PROMOTEC:   %[[RHS_VIEW:.+]] = memref.subview %[[RHS_ALLOC]][0, 0] [%c32, %c128]
+//      PROMOTEC:   gpu.barrier
+//      PROMOTEC:   memref.copy %{{.+}}, %[[LHS_VIEW]]
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "copy_to_workgroup_memory"
+//      PROMOTEC:   memref.copy %{{.+}}, %[[RHS_VIEW]]
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "copy_to_workgroup_memory"
+//      PROMOTEC:   gpu.barrier
+//      PROMOTEC:   linalg.matmul
+// PROMOTEC-SAME:    __internal_linalg_transform__ = "workgroup_memory"
+// PROMOTEC-SAME:    ins(%[[LHS_VIEW]], %[[RHS_VIEW]]
+// PROMOTEC-SAME:    outs(%[[C_ALLOC]]
+//      PROMOTEC: }
+//      PROMOTEC: gpu.barrier
+//      PROMOTEC: linalg.generic
+//      PROMOTEC:    ins(%{{.+}}, %[[C_ALLOC]]
 // PROMOTEC-SAME:   __internal_linalg_transform__ = "copy_to_workgroup_memory"
 //      PROMOTEC: gpu.barrier


### PR DESCRIPTION
This commit changes the logic to avoid performing C matrix promotion if the fused elementwise ops are directly allowed in cooeprative matrix spec. This saves us workgroup memory and copies with it.