### PR TITLE
[SPIRV] Add multibuffering and pipelining to cooperative matrix

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -489,7 +489,9 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
     Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize);
-void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm);
+void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm,
+                                                    unsigned pipelineDepth,
+                                                    unsigned storeStage);
 
 /// Pass pipeline to lower IREE HAL executables by tiling and distributing to
 /// workgroups, promoting to use workgroup memory, and then tiling and
@@ -534,10 +536,14 @@ std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTileAndDistributePass();
 std::unique_ptr<OperationPass<func::FuncOp>> createSPIRVTileAndPromotePass(
     bool promoteCMatrix = false, bool skipThreadLevel = false);
 
-/// Pass to tile Linalg ops with buffer semantics to subgroups and vectorize
-/// to vector ops suitable for lowering to SPIR-V cooperative ops.
+/// Pass to tile Linalg ops with buffer semantics suitable for lowering to
+/// SPIR-V cooperative ops.
 std::unique_ptr<OperationPass<func::FuncOp>>
-createSPIRVTileAndVectorizeToCooperativeOpsPass();
+createSPIRVTileToCooperativeOpsPass();
+
+/// Pass to do vectorization suitable for lowering to SPIR-V cooperative ops.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createSPIRVVectorizeToCooperativeOpsPass();
 
 /// Converts vector ops to gpu subgroup MMA ops.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -509,13 +509,22 @@ def SPIRVTileAndDistribute : Pass<"iree-spirv-tile-and-distribute", "func::FuncO
   let constructor = "mlir::iree_compiler::createSPIRVTileAndDistributePass()";
 }
 
-def SPIRVTileAndVectorizeToCooperativeOps : Pass<
-    "iree-spirv-tile-and-vectorize-to-cooperative-ops", "func::FuncOp"> {
+def SPIRVTileToCooperativeOps : Pass<
+    "iree-spirv-tile-to-cooperative-ops", "func::FuncOp"> {
   let summary = "Tile Linalg ops with buffer semantics to subgroups and "
                 "vectorize to vector ops suitable for lowering to SPIR-V "
                 "cooperative ops";
   let constructor =
-    "mlir::iree_compiler::createSPIRVTileAndVectorizeToCooperativeOpsPass()";
+    "mlir::iree_compiler::createSPIRVTileToCooperativeOpsPass()";
+}
+
+def SPIRVVectorizeToCooperativeOps : Pass<
+    "iree-spirv-vectorize-to-cooperative-ops", "func::FuncOp"> {
+  let summary = "Tile Linalg ops with buffer semantics to subgroups and "
+                "vectorize to vector ops suitable for lowering to SPIR-V "
+                "cooperative ops";
+  let constructor =
+    "mlir::iree_compiler::createSPIRVVectorizeToCooperativeOpsPass()";
 }
 
 def SPIRVTileAndPromote : Pass<"iree-spirv-tile-and-promote", "func::FuncOp"> {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -25,8 +25,11 @@ namespace mlir {
 namespace iree_compiler {
 namespace detail {
 
-constexpr unsigned AMDSoftwarePipelineDepth = 2;
-constexpr unsigned AMDSoftwarePipelineStoreStage = 0;
+constexpr unsigned AMDSimtSoftwarePipelineDepth = 2;
+constexpr unsigned AMDSimtSoftwarePipelineStoreStage = 0;
+
+constexpr unsigned AMDCoopMatrixSoftwarePipelineDepth = 1;
+constexpr unsigned AMDCoopMatrixSoftwarePipelineStoreStage = 0;
 
 constexpr unsigned AMDNumSubgroupsPerWorkgroup = 4;
 // The number of tiles along M and N dimensions per workgroup.
@@ -34,9 +37,10 @@ constexpr unsigned AMDNumMNTilesPerSubgroup = 8;
 
 static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
                                         const spirv::TargetEnv &targetEnv) {
-  if (failed(setCooperativeMatrixConfig(targetEnv, op,
-                                        AMDNumSubgroupsPerWorkgroup,
-                                        AMDNumMNTilesPerSubgroup)))
+  if (failed(setCooperativeMatrixConfig(
+          targetEnv, op, AMDNumSubgroupsPerWorkgroup, AMDNumMNTilesPerSubgroup,
+          AMDCoopMatrixSoftwarePipelineDepth,
+          AMDCoopMatrixSoftwarePipelineStoreStage)))
     return failure();
   if (getLoweringConfig(op)) return success();
 
@@ -51,8 +55,9 @@ static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
     threadMNK = {8, 4, 16};
   }
   return setMatmulOpConfig(limits, op, workgroupXY, threadMNK,
-                           /*enablePromotion=*/true, AMDSoftwarePipelineDepth,
-                           AMDSoftwarePipelineStoreStage);
+                           /*enablePromotion=*/true,
+                           AMDSimtSoftwarePipelineDepth,
+                           AMDSimtSoftwarePipelineStoreStage);
 }
 
 // RDNA architecture:

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -398,10 +398,10 @@ static bool tileMatmulK(const int64_t dimK, const int64_t residualTilingFactor,
 }
 
 int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize, int64_t kTileSize,
-                     int64_t elementBits) {
-  const int64_t count =
-      (mTileSize + nTileSize) *
-      (kTileSize + detail::bankConflictReductionPaddingBits / elementBits);
+                     int64_t elementBits, bool promoteC) {
+  int64_t paddingBits = detail::bankConflictReductionPaddingBits / elementBits;
+  int64_t count = (mTileSize + nTileSize) * (kTileSize + paddingBits);
+  if (promoteC) count += mTileSize * (nTileSize + paddingBits);
   return (elementBits / 8) * count;
 }
 
@@ -486,7 +486,8 @@ static bool adjustToPromote(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
     storeStage = 1;
   }
 
-  auto usedBytes = getTileBytes(mTileSize, nTileSize, kTileSize, elementBits);
+  auto usedBytes =
+      getTileBytes(mTileSize, nTileSize, kTileSize, elementBits, false);
 
   LLVM_DEBUG(llvm::dbgs() << "initial multibuffering bytes = "
                           << getMultiBufferMemoryUsage(usedBytes, pipelineDepth,
@@ -521,7 +522,7 @@ static bool adjustToPromote(ArrayRef<int64_t> dimMNKSize, int64_t &mTileSize,
 
   int64_t totalThreads = wgSize[0] * wgSize[1] * wgSize[2];
   LLVM_DEBUG(llvm::dbgs() << "revised total thread = " << totalThreads << "\n");
-  usedBytes = getTileBytes(mTileSize, nTileSize, kTileSize, elementBits);
+  usedBytes = getTileBytes(mTileSize, nTileSize, kTileSize, elementBits, false);
   LLVM_DEBUG(llvm::dbgs() << "revised tile bytes = " << usedBytes << "\n");
   return totalThreads > subgroupSize && usedBytes <= maxBytes;
 }
@@ -794,7 +795,8 @@ namespace detail {
 LogicalResult setCooperativeMatrixConfig(
     const spirv::TargetEnv &targetEnv, linalg::LinalgOp op,
     const unsigned numSubgroupsPerWorkgroup,
-    const unsigned numMNTilesPerSubgroup) {
+    const unsigned numMNTilesPerSubgroup, unsigned softwarePipelineDepth,
+    unsigned softwarePipelineStoreStage) {
   LLVM_DEBUG(llvm::dbgs() << "trying to matmul tensorcore config...\n");
   // This configuration is only for cooperative matrix.
   if (!targetEnv.allows(spirv::Capability::CooperativeMatrixNV) ||
@@ -887,9 +889,42 @@ LogicalResult setCooperativeMatrixConfig(
   tileSizes.push_back(reductionTileSizes);
   tileSizes.push_back(vectorSizes);
 
+  // Check if the C matrix will be promoted for computing shared memory usage.
+  bool promoteC = false;
+  SmallVector<Operation *> computeOps;
+  if (!failed(getComputeOps(op->getParentOfType<func::FuncOp>(), computeOps))) {
+    unsigned count = 0;
+    for (Operation *computeOp : computeOps) {
+      if (!isa<linalg::FillOp>(computeOp)) ++count;
+    }
+    promoteC = count > 1;
+  }
+
+  // Decrease pipeline depth until it fits in shared memory.
+  auto pipelineDepth = softwarePipelineDepth;
+  auto storeStage = softwarePipelineStoreStage;
+  const int maxBytes = limits.getMaxComputeSharedMemorySize();
+  auto usedBytes =
+      getTileBytes(workgroupTileSizes[mIndex], workgroupTileSizes[nIndex],
+                   reductionTileSizes[kIndex],
+                   getElementType(lhs).getIntOrFloatBitWidth(), promoteC);
+
+  // TODO: Remove this check once either bufferization doesn't produce an extra
+  // buffer when fused with something like elementwise extf, or the shared
+  // memory calculation incorporates the fused op properly.
+  if (pipelineDepth != 0 && fusedOpMayUseExtraSharedMemory(op)) {
+    pipelineDepth = 0;
+  }
+
+  while (pipelineDepth > 0 &&
+         getMultiBufferMemoryUsage(usedBytes, pipelineDepth, storeStage) >
+             maxBytes) {
+    pipelineDepth--;
+  }
+
   return setOpConfigAndEntryPointFnTranslation(
       op->getParentOfType<func::FuncOp>(), op, tileSizes, pipeline,
-      workgroupSize, subgroupSize);
+      workgroupSize, subgroupSize, pipelineDepth, storeStage);
 }
 
 }  // namespace detail

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
@@ -25,13 +25,16 @@ namespace mlir {
 namespace iree_compiler {
 
 /// By default don't do any pipelining.
-constexpr unsigned defaultSoftwarePipelineDepth = 1;
-constexpr unsigned defaultSoftwarePipelineStoreStage = 1;
+constexpr unsigned defaultSimtSoftwarePipelineDepth = 1;
+constexpr unsigned defaultSimtSoftwarePipelineStoreStage = 1;
+
+constexpr unsigned defaultCoopMatrixSoftwarePipelineDepth = 1;
+constexpr unsigned defaultCoopMatrixSoftwarePipelineStoreStage = 0;
 
 /// Computes the total number of bytes if promoting both matmul LHS and RHS with
 /// the tiven tile sizes.
 int64_t getTileBytes(int64_t mTileSize, int64_t nTileSize, int64_t kTileSize,
-                     int64_t elementBits);
+                     int64_t elementBits, bool promoteC);
 
 /// Adjusts the shared memory usage based on the pipelining depth.
 int64_t getMultiBufferMemoryUsage(int64_t usedBytes, unsigned depth,
@@ -54,8 +57,9 @@ LogicalResult setMatmulOpConfig(
     spirv::ResourceLimitsAttr limits, linalg::LinalgOp linalgOp,
     std::array<int64_t, 2> bestWorkgroupSizeXY,
     std::array<int64_t, 3> bestThreadTileSizeMNK, bool enablePromotion = false,
-    unsigned softwarePipelineDepth = defaultSoftwarePipelineDepth,
-    unsigned softwarePipelineStoreStage = defaultSoftwarePipelineStoreStage);
+    unsigned softwarePipelineDepth = defaultSimtSoftwarePipelineDepth,
+    unsigned softwarePipelineStoreStage =
+        defaultSimtSoftwarePipelineStoreStage);
 
 /// Sets CodeGen configurations via attributes to the given matmul `linalgOp`
 /// with tile sizes for cooperative matrix, if possible for the given matmul
@@ -63,7 +67,10 @@ LogicalResult setMatmulOpConfig(
 LogicalResult setCooperativeMatrixConfig(
     const spirv::TargetEnv &targetEnv, linalg::LinalgOp op,
     const unsigned numSubgroupsPerWorkgroup,
-    const unsigned numMNTilesPerSubgroup);
+    const unsigned numMNTilesPerSubgroup,
+    unsigned softwarePipelineDepth = defaultCoopMatrixSoftwarePipelineDepth,
+    unsigned softwarePipelineStoreStage =
+        defaultCoopMatrixSoftwarePipelineStoreStage);
 
 /// Sets CodeGen configuration for GPUs from a specific vendor.
 ///

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -164,7 +164,9 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::
           SPIRVCooperativeMatrixVectorize:
-        addSPIRVCooperativeMatrixVectorizePassPipeline(pipeline);
+        addSPIRVCooperativeMatrixVectorizePassPipeline(
+            pipeline, translationInfo.value().getSoftwarePipelineDepth(),
+            translationInfo.value().getSoftwarePipelineStoreStage());
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::
           SPIRVMatmulPromoteVectorize:

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
@@ -69,7 +69,7 @@ hal.executable public @matmul_256x1024x128_div_add {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128], [32, 64], [0, 0, 32], [16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @matmul_256x1024x128_div_add
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
@@ -138,7 +138,7 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x128x256x512_div
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
@@ -205,7 +205,7 @@ hal.executable @generic_batch_matmul_32x8x512x64 {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @generic_batch_matmul_32x8x512x64
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
@@ -266,7 +266,7 @@ hal.executable public @batch_matmul_16x1024x1024x80 {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x1024x1024x80
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -75,7 +75,7 @@ hal.executable public @matmul_256x1024x128_div_add {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64], [32, 32], [0, 0, 32], [16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @matmul_256x1024x128_div_add
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
@@ -150,7 +150,7 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x128x256x512_div
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
@@ -223,7 +223,7 @@ hal.executable @generic_batch_matmul_32x8x512x64 {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @generic_batch_matmul_32x8x512x64
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
@@ -290,7 +290,7 @@ hal.executable public @batch_matmul_16x1024x1024x80 {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x1024x1024x80
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/tile_and_vectorize_to_cooperative_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-spirv-tile-and-vectorize-to-cooperative-ops, canonicalize, cse)))))' %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-spirv-tile-to-cooperative-ops, iree-spirv-vectorize-to-cooperative-ops, canonicalize, cse)))))' %s | FileCheck %s
 
 #config = #iree_codegen.lowering_config<tile_sizes = [[32, 32], [16, 16], [0, 0, 32], [16, 16, 16]]>
 #translation = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>


### PR DESCRIPTION
Multibuffering needs to happen after thread-level tiling but before vectorization. This is solved here by splitting up the createSPIRVTileAndVectorizeToCooperativeOpsPass and then puts multibuffering between the tiling and vectorization passes. 