### PR TITLE
vmvx-dyn-tile-size

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
@@ -14,7 +14,7 @@
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
-#include "llvm/Support/MathExtras.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
@@ -25,7 +25,9 @@ namespace mlir {
 namespace iree_compiler {
 
 using IREE::HAL::ExecutableTargetAttr;
+using IREE::LinalgExt::MaterializeEncodingFn;
 using IREE::LinalgExt::MaterializeEncodingInfo;
+using IREE::LinalgExt::RuntimeTileSizeFn;
 using IREE::LinalgExt::TensorEncoding;
 
 /// For `dispatchTensorType` that bind a `RankedTensorType` with encoding,
@@ -35,7 +37,8 @@ using IREE::LinalgExt::TensorEncoding;
 static FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensor(
     OpBuilder &builder, Location loc,
     IREE::LinalgExt::MaterializeEncodingTypeConverter &typeConverter,
-    IREE::Flow::DispatchTensorType dispatchTensorType, ValueRange dynamicDims) {
+    IREE::Flow::DispatchTensorType dispatchTensorType, ValueRange dynamicDims,
+    RuntimeTileSizeFn runtimeTileSizeFn) {
   auto boundTensorType =
       dispatchTensorType.getBoundType().dyn_cast<RankedTensorType>();
   if (!boundTensorType) {
@@ -49,22 +52,24 @@ static FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensor(
   }
 
   IREE::LinalgExt::MaterializeEncodingFn materializeEncodingFn =
-      typeConverter.getMaterializeEncodingFn();
-  FailureOr<MaterializeEncodingInfo> encodingInfo =
+      typeConverter.getEncodingFn();
+  FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
       materializeEncodingFn(boundTensorType);
-  if (failed(encodingInfo)) {
+  if (failed(materializeEncodingInfo)) {
     return failure();
   }
 
   SmallVector<OpFoldResult, 4> targetShape =
       getMixedValues(dispatchTensorType.getShape(), dynamicDims, builder);
-  SmallVector<OpFoldResult> innerTileSizes = llvm::to_vector(llvm::map_range(
-      encodingInfo->innerTileSizes,
-      [&](int64_t v) -> OpFoldResult { return builder.getIndexAttr(v); }));
+  auto innerTileSizes =
+      getInnerTileSizesOfr(builder, loc, boundTensorType,
+                           *materializeEncodingInfo, runtimeTileSizeFn);
+  if (failed(innerTileSizes)) return failure();
   SmallVector<OpFoldResult> convertedTargetShape =
       IREE::LinalgExt::PackOp::getResultShape(
-          builder, loc, targetShape, innerTileSizes, encodingInfo->innerDimsPos,
-          encodingInfo->outerDimsPerm);
+          builder, loc, targetShape, *innerTileSizes,
+          materializeEncodingInfo->innerDimsPos,
+          materializeEncodingInfo->outerDimsPerm);
   return convertedTargetShape;
 }
 
@@ -75,10 +80,12 @@ static FailureOr<SmallVector<OpFoldResult>> getPackedDimsForDispatchTensor(
 static FailureOr<SmallVector<Value>> getPackedDynamicDimsForDispatchTensor(
     OpBuilder &builder, Location loc,
     IREE::LinalgExt::MaterializeEncodingTypeConverter &typeConverter,
-    IREE::Flow::DispatchTensorType dispatchTensorType, ValueRange dynamicDims) {
+    IREE::Flow::DispatchTensorType dispatchTensorType, ValueRange dynamicDims,
+    RuntimeTileSizeFn runtimeTileSizeFn) {
   FailureOr<SmallVector<OpFoldResult>> convertedTargetShape =
       getPackedDimsForDispatchTensor(builder, loc, typeConverter,
-                                     dispatchTensorType, dynamicDims);
+                                     dispatchTensorType, dynamicDims,
+                                     runtimeTileSizeFn);
   if (failed(convertedTargetShape)) {
     return failure();
   }
@@ -149,9 +156,9 @@ static Optional<MatmulOperandRole> getMatmulOperandRole(
 }
 
 struct MatmulTileParams {
-  int M = 1;
-  int K = 1;
-  int N = 1;
+  int64_t M = 1;
+  int64_t K = 1;
+  int64_t N = 1;
 };
 
 // Generic fallback path, used outside of target architectures for which we have
@@ -160,9 +167,7 @@ struct MatmulTileParams {
 // that we had just before the actual target-aware logic was implemented, kept
 // for compatibility with existing tests. These values are historically what we
 // were using on AArch64+dotprod.
-static MatmulTileParams chooseMatmulTileParamsGeneric(MatmulType /*type*/) {
-  return {8, 4, 8};
-}
+static MatmulTileParams chooseMatmulTileParamsGeneric() { return {8, 4, 8}; }
 
 static MatmulTileParams chooseMatmulTileParamsAArch64(
     MatmulType type, ExecutableTargetAttr target) {
@@ -179,47 +184,60 @@ static MatmulTileParams chooseMatmulTileParamsAArch64(
   }
 }
 
+static MatmulTileParams chooseMatmulTileParamsVMVXMicrokernels() {
+  return {ShapedType::kDynamic, ShapedType::kDynamic, ShapedType::kDynamic};
+}
+
 static MatmulTileParams chooseMatmulTileParams(MatmulType type,
                                                ExecutableTargetAttr target) {
+  if (isVMVXBackend(target) && hasMicrokernels(target)) {
+    return chooseMatmulTileParamsVMVXMicrokernels();
+  }
   if (isAArch64(target)) {
     return chooseMatmulTileParamsAArch64(type, target);
   }
-  return chooseMatmulTileParamsGeneric(type);
+  return chooseMatmulTileParamsGeneric();
 }
 
 static MaterializeEncodingInfo chooseEncodingInfoForMatmul(
     MatmulType type, MatmulOperandRole operandRole,
     ExecutableTargetAttr target) {
   MatmulTileParams tileParams = chooseMatmulTileParams(type, target);
-  MaterializeEncodingInfo encodingInfo;
-  encodingInfo.innerDimsPos = {0, 1};
+  MaterializeEncodingInfo materializeEncodingInfo;
+  materializeEncodingInfo.innerDimsPos = {0, 1};
   if (operandRole == MatmulOperandRole::LHS) {
-    encodingInfo.innerTileSizes = {tileParams.M, tileParams.K};
+    materializeEncodingInfo.innerTileSizes = {tileParams.M, tileParams.K};
   } else if (operandRole == MatmulOperandRole::RHS) {
-    encodingInfo.innerTileSizes = {tileParams.K, tileParams.N};
+    materializeEncodingInfo.innerTileSizes = {tileParams.K, tileParams.N};
   } else if (operandRole == MatmulOperandRole::RHS_TRANSPOSE) {
-    encodingInfo.innerTileSizes = {tileParams.N, tileParams.K};
-    encodingInfo.innerDimsPos = {1, 0};
-    encodingInfo.outerDimsPerm = {1, 0};
+    materializeEncodingInfo.innerTileSizes = {tileParams.N, tileParams.K};
+    materializeEncodingInfo.innerDimsPos = {1, 0};
+    materializeEncodingInfo.outerDimsPerm = {1, 0};
   } else if (operandRole == MatmulOperandRole::RESULT) {
-    encodingInfo.innerTileSizes = {tileParams.M, tileParams.N};
+    materializeEncodingInfo.innerTileSizes = {tileParams.M, tileParams.N};
   } else {
     assert(false);  // already validated.
     return {};
   }
-  return encodingInfo;
+  return materializeEncodingInfo;
 }
 
 static void AdjustTileSizesToNarrowStaticShape(
-    MaterializeEncodingInfo &encodingInfo, ArrayRef<int64_t> shape) {
+    MaterializeEncodingInfo &materializeEncodingInfo, ArrayRef<int64_t> shape) {
   for (size_t i = 0; i < shape.size(); i++) {
-    int64_t size = shape[encodingInfo.innerDimsPos[i]];
-    if (!ShapedType::isDynamic(size)) {
-      int64_t &tileSize = encodingInfo.innerTileSizes[i];
-      while (tileSize > size) {
-        tileSize = llvm::PowerOf2Ceil(tileSize) / 2;
-      }
-    }
+    int64_t size = shape[materializeEncodingInfo.innerDimsPos[i]];
+    // Dynamic sizes are assumed to be large enough, not to be candidates for
+    // narrow kernels.
+    if (ShapedType::isDynamic(size)) continue;
+    int64_t &tileSize = materializeEncodingInfo.innerTileSizes[i];
+    // TODO: find a way to do narrow tile size selection for dynamic tile sizes.
+    if (ShapedType::isDynamic(tileSize)) continue;
+    auto generateNarrowTileSize = [&](int64_t n) {
+      if (size <= n && tileSize >= n) tileSize = n;
+    };
+    generateNarrowTileSize(1);
+    generateNarrowTileSize(2);
+    generateNarrowTileSize(4);
   }
 }
 
@@ -229,15 +247,24 @@ static FailureOr<MaterializeEncodingInfo> chooseEncodingInfo(
   if (!encoding) return failure();
   auto matmulType = getMatmulType(*encoding);
   auto matmulOperandRole = getMatmulOperandRole(*encoding);
-  MaterializeEncodingInfo encodingInfo;
+  MaterializeEncodingInfo materializeEncodingInfo;
   if (matmulType && matmulOperandRole) {
-    encodingInfo =
+    materializeEncodingInfo =
         chooseEncodingInfoForMatmul(*matmulType, *matmulOperandRole, target);
   } else {
     return failure();
   }
-  AdjustTileSizesToNarrowStaticShape(encodingInfo, tensorType.getShape());
-  return encodingInfo;
+  AdjustTileSizesToNarrowStaticShape(materializeEncodingInfo,
+                                     tensorType.getShape());
+  return materializeEncodingInfo;
+}
+
+static FailureOr<SmallVector<Value>> chooseDynamicEncodingInfoVMVXMicrokernels(
+    RankedTensorType tensorType, OpBuilder &builder, Location loc) {
+  // For now just create Values equal to 1.
+  // TODO: create a new vmvx.get_tile_sizes op here.
+  Value v = builder.create<arith::ConstantIndexOp>(loc, 1);
+  return SmallVector<Value>(tensorType.getRank(), v);
 }
 
 /// Pattern to materialize the encoding for `hal.interface.binding.subspan`
@@ -276,9 +303,9 @@ struct MaterializeInterfaceBindingEncoding
     // Get the dynamic dims of the target.
     Location loc = subspanOp.getLoc();
     FailureOr<SmallVector<Value>> convertedDynamicDims =
-        getPackedDynamicDimsForDispatchTensor(rewriter, loc, *typeConverter,
-                                              resultType,
-                                              subspanOp.getDynamicDims());
+        getPackedDynamicDimsForDispatchTensor(
+            rewriter, loc, *typeConverter, resultType,
+            subspanOp.getDynamicDims(), this->runtimeTileSizeFn);
     if (failed(convertedDynamicDims)) {
       return rewriter.notifyMatchFailure(
           subspanOp, "failed to get converted dynamic dims");
@@ -324,7 +351,8 @@ struct MaterializeFlowDispatchTensorLoadOp
     Location loc = loadOp.getLoc();
     FailureOr<SmallVector<OpFoldResult>> convertedMixedSizes =
         getPackedDimsForDispatchTensor(rewriter, loc, *typeConverter,
-                                       sourceType, loadOp.getSourceDims());
+                                       sourceType, loadOp.getSourceDims(),
+                                       this->runtimeTileSizeFn);
     if (failed(convertedMixedSizes)) {
       return rewriter.notifyMatchFailure(
           loadOp, "failed to get converted dynamic dims for result");
@@ -376,7 +404,8 @@ struct MaterializeFlowDispatchTensorStoreOp
     Location loc = storeOp.getLoc();
     FailureOr<SmallVector<OpFoldResult>> convertedMixedSizes =
         getPackedDimsForDispatchTensor(rewriter, loc, *typeConverter,
-                                       targetType, storeOp.getTargetDims());
+                                       targetType, storeOp.getTargetDims(),
+                                       this->runtimeTileSizeFn);
     if (failed(convertedMixedSizes)) {
       return rewriter.notifyMatchFailure(
           storeOp, "failed to get converted dynamic dims for result");
@@ -393,7 +422,6 @@ struct MaterializeFlowDispatchTensorStoreOp
     rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorStoreOp>(
         storeOp, adaptor.getValue(), adaptor.getTarget(), convertedDynamicDims,
         convertedOffsets, convertedMixedSizes.value(), convertedStrides);
-
     return success();
   }
 };
@@ -444,12 +472,16 @@ void IREEMaterializeEncodingPass::runOnOperation() {
           return resultType == typeConverter.convertType(resultType);
         });
 
+    IREE::LinalgExt::RuntimeTileSizeFn runtimeTileSizeFn;
+    if (isVMVXBackend(targetAttr) && hasMicrokernels(targetAttr)) {
+      runtimeTileSizeFn = chooseDynamicEncodingInfoVMVXMicrokernels;
+    }
     IREE::LinalgExt::populateMaterializeEncodingPatterns(
-        materializeEncodingPattern, target, typeConverter);
+        materializeEncodingPattern, target, typeConverter, runtimeTileSizeFn);
     materializeEncodingPattern.insert<MaterializeFlowDispatchTensorLoadOp,
                                       MaterializeFlowDispatchTensorStoreOp,
                                       MaterializeInterfaceBindingEncoding>(
-        typeConverter, context);
+        context, typeConverter, runtimeTileSizeFn);
     if (failed(applyPartialConversion(operation, target,
                                       std::move(materializeEncodingPattern)))) {
       operation.emitOpError("materialization failed");

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -278,11 +278,9 @@ static LogicalResult bufferizeLinalgExtOp(RewriterBase &rewriter,
   SmallVector<Value> newOperands = newInputBuffers;
   newOperands.append(newOutputBuffers.begin(), newOutputBuffers.end());
 
-  // PackOp has other operands besides ins and outs.
-  if (auto packOp = dyn_cast<IREE::LinalgExt::PackOp>(op.getOperation())) {
-    newOperands.append(packOp.getInnerTiles().begin(),
-                       packOp.getInnerTiles().end());
-    if (auto pad = packOp.getPaddingValue()) newOperands.push_back(pad);
+  // Append other operands besides ins and outs.
+  for (auto nonDPSOperands : op.getNonInputOrOutputOperands()) {
+    newOperands.push_back(nonDPSOperands->get());
   }
 
   // Set insertion point now that potential alloc/dealloc are introduced.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -184,7 +184,9 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
         return signalPassFailure();
       }
 
-      bool lowerToAVX2 = hasAVX2Feature(variantOp.getTarget());
+      auto target = variantOp.getTarget();
+      bool lowerToAVX2 = hasAVX2Feature(target);
+      bool enableMicrokernels = hasMicrokernels(target);
       if (!testLoweringConfiguration) {
         switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
@@ -234,7 +236,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addCPUDataTilingPipeline(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::VMVXDefault:
-            addVMVXDefaultPassPipeline(executableLoweringPipeline);
+            addVMVXDefaultPassPipeline(executableLoweringPipeline,
+                                       enableMicrokernels);
             break;
           // Transform-dialect pipelines.
           case IREE::Codegen::DispatchLoweringPassPipeline::

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -303,7 +303,8 @@ void addCPUDataTilingPipeline(OpPassManager &passManager);
 
 /// Populates the passes to lower to tiled/distributed/bufferized ops,
 /// suitable for library call dispatch and lowering to loops.
-void addVMVXDefaultPassPipeline(OpPassManager &passManager);
+void addVMVXDefaultPassPipeline(OpPassManager &passManager,
+                                bool enableMicrokernels);
 
 /// Populates the passes to lower linalg ops on buffers. Currenly this
 /// pipeline is only used for dispatches that just copy data from input

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -92,6 +92,16 @@ Optional<IntegerAttr> getConfigIntegerAttr(
   return attr;
 }
 
+Optional<BoolAttr> getConfigBoolAttr(IREE::HAL::ExecutableTargetAttr targetAttr,
+                                     StringRef integerAttr) {
+  if (!targetAttr) return llvm::None;
+  auto config = targetAttr.getConfiguration();
+  if (!config) return llvm::None;
+  auto attr = config.getAs<BoolAttr>(integerAttr);
+  if (!attr) return llvm::None;
+  return attr;
+}
+
 Optional<llvm::Triple> getTargetTriple(
     IREE::HAL::ExecutableTargetAttr targetAttr) {
   auto triple = getConfigStringAttr(targetAttr, "target_triple");
@@ -123,7 +133,12 @@ bool isRISCV(IREE::HAL::ExecutableTargetAttr targetAttr) {
 }
 
 bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr) {
-  return targetAttr.getBackend().getValue().startswith("vmvx");
+  return targetAttr && targetAttr.getBackend().getValue().startswith("vmvx");
+}
+
+bool hasMicrokernels(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  auto enableMicrokernels = getConfigBoolAttr(targetAttr, "ukernels");
+  return enableMicrokernels && enableMicrokernels->getValue();
 }
 
 // TODO(dcaballe): If we have to check for a significantly large number of

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -65,6 +65,7 @@ bool isX86(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isAArch64(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isRISCV(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
+bool hasMicrokernels(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Returns true if `targetAttr` has `feature` in its CPU features.
 bool hasFeature(IREE::HAL::ExecutableTargetAttr targetAttr, StringRef feature);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
@@ -29,6 +29,21 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
+static llvm::cl::opt<bool> clEnableMicrokernels(
+    "iree-vmvx-enable-microkernels",
+    llvm::cl::desc("Enables microkernel lowering for vmvx (experimental)"),
+    llvm::cl::init(false));
+
+static IREE::HAL::ExecutableTargetAttr getVMVXExecutableTarget(
+    MLIRContext *context, StringRef backend, StringRef format) {
+  SmallVector<NamedAttribute> config;
+  config.emplace_back(StringAttr::get(context, "ukernels"),
+                      BoolAttr::get(context, clEnableMicrokernels));
+  return IREE::HAL::ExecutableTargetAttr::get(
+      context, StringAttr::get(context, backend),
+      StringAttr::get(context, format), DictionaryAttr::get(context, config));
+}
+
 class VMVXTargetBackend final : public TargetBackend {
  public:
   VMVXTargetBackend() = default;
@@ -124,14 +139,9 @@ class VMVXTargetBackend final : public TargetBackend {
   ArrayAttr getExecutableTargets(MLIRContext *context) const {
     SmallVector<Attribute> targetAttrs;
     // This is where we would multiversion.
-    targetAttrs.push_back(getExecutableTarget(context));
+    targetAttrs.push_back(
+        getVMVXExecutableTarget(context, "vmvx", "vmvx-bytecode-fb"));
     return ArrayAttr::get(context, targetAttrs);
-  }
-
-  IREE::HAL::ExecutableTargetAttr getExecutableTarget(
-      MLIRContext *context) const {
-    return IREE::HAL::ExecutableTargetAttr::get(context, "vmvx",
-                                                "vmvx-bytecode-fb");
   }
 };
 
@@ -168,14 +178,9 @@ class VMVXInlineTargetBackend final : public TargetBackend {
   ArrayAttr getExecutableTargets(MLIRContext *context) const {
     SmallVector<Attribute> targetAttrs;
     // This is where we would multiversion.
-    targetAttrs.push_back(getExecutableTarget(context));
+    targetAttrs.push_back(
+        getVMVXExecutableTarget(context, "vmvx-inline", "vmvx-ir"));
     return ArrayAttr::get(context, targetAttrs);
-  }
-
-  IREE::HAL::ExecutableTargetAttr getExecutableTarget(
-      MLIRContext *context) const {
-    return IREE::HAL::ExecutableTargetAttr::get(context, "vmvx-inline",
-                                                "vmvx-ir");
   }
 };
 

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -140,7 +140,7 @@ py_binary(
     name = "e2e_matmul_mmt4d_%s_small_ukernel" % lhs_rhs_type,
     compiler_flags = [
         "--iree-vmvx-enable-microkernels",
-        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
+        "--iree-flow-enable-data-tiling",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -222,7 +222,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-vmvx-enable-microkernels"
-    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
+    "--iree-flow-enable-data-tiling"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "aarch64:+dotprod"
@@ -245,7 +245,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-vmvx-enable-microkernels"
-    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
+    "--iree-flow-enable-data-tiling"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )


### PR DESCRIPTION
This is on top of #11510.

WIP, but getting ready. Mostly I need to write some LIT tests and slice this PR into commits for review (or spawn sub-PRs if preferred).

This is for now just creating constant value 1 instead of actually creating a vmvx.get_tile_sizes op.

That's enough to migrate the vmvx+ukernel e2e matmul tests to `--iree-flow-enable-data-tiling`, done in this PR.

A follow-up PR will then be able to implement actual `vmvx.get_tile_sizes` providing more interesting Values than just `arith.constant`'s. But the point is that from the point of view of `MaterializeEncoding`, that shouldn't make a difference.