### PR TITLE
[spirv] Enable use wave32 mode for AMD architectures

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -844,9 +844,16 @@ LogicalResult setCooperativeMatrixConfig(
   auto pipeline = IREE::Codegen::DispatchLoweringPassPipeline::
       SPIRVCooperativeMatrixVectorize;
 
-  std::array<int64_t, 3> workgroupSize{
-      coopMatSize->nWarpCount * limits.getSubgroupSize(),
-      coopMatSize->mWarpCount, 1};
+  Optional<int64_t> subgroupSize = limits.getSubgroupSize();
+  // AMD RDNA architectures supports both wave32 and wave64 modes. Prefer to use
+  // wave32 mode for better performance.
+  if (targetEnv.getVendorID() == spirv::Vendor::AMD) {
+    if (Optional<int> minSize = limits.getMinSubgroupSize())
+      subgroupSize = *minSize;
+  }
+
+  std::array<int64_t, 3> workgroupSize{coopMatSize->nWarpCount * *subgroupSize,
+                                       coopMatSize->mWarpCount, 1};
 
   SmallVector<int64_t> vectorSizes(kIndex + 1, 0);
   if (isBM) vectorSizes[bIndex] = 1;
@@ -879,8 +886,6 @@ LogicalResult setCooperativeMatrixConfig(
   tileSizes.push_back(subgroupTileSizes);
   tileSizes.push_back(reductionTileSizes);
   tileSizes.push_back(vectorSizes);
-
-  Optional<int64_t> subgroupSize = limits.getSubgroupSize();
 
   return setOpConfigAndEntryPointFnTranslation(
       op->getParentOfType<func::FuncOp>(), op, tileSizes, pipeline,

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -37,6 +37,19 @@ spirv::TargetEnvAttr getSPIRVTargetEnvAttr(Operation *op) {
   return config.getAs<spirv::TargetEnvAttr>(spirv::getTargetEnvAttrName());
 }
 
+llvm::Optional<int> getSPIRVSubgroupSize(func::FuncOp funcOp) {
+  auto moduleOp = funcOp->getParentOfType<ModuleOp>();
+  llvm::StringMap<IREE::HAL::ExecutableExportOp> exportOps =
+      getAllEntryPoints(moduleOp);
+  auto exportOp = exportOps.lookup(funcOp.getName());
+  if (!exportOp) return llvm::None;
+  if (auto size = exportOp.getSubgroupSize()) return size->getSExtValue();
+
+  spirv::TargetEnvAttr target = getSPIRVTargetEnvAttr(funcOp);
+  if (!target) return llvm::None;
+  return target.getResourceLimits().getSubgroupSize();
+}
+
 FailureOr<SmallVector<int64_t>> getSPIRVTileSize(func::FuncOp funcOp,
                                                  int tilingLevel) {
   SmallVector<Operation *> computeOps;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.h
@@ -21,8 +21,13 @@
 namespace mlir {
 namespace iree_compiler {
 
-/// Given an operation, return the `spirv.target_env` attribute.
+/// Given an operation, returns the `spirv.target_env` attribute.
 spirv::TargetEnvAttr getSPIRVTargetEnvAttr(Operation *op);
+
+/// Given a FuncOp, returns the subgroup size to use for CodeGen, by first
+/// querying the hal.executable.export op, and then the SPIR-V target
+/// environment. Returns llvm::None on failures.
+llvm::Optional<int> getSPIRVSubgroupSize(func::FuncOp funcOp);
 
 /// Returns the attribute name carrying information about distribution.
 const char *getSPIRVDistributeAttrName();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Codegen/SPIRV/KernelConfig.h"
 #include "iree/compiler/Codegen/SPIRV/Utils.h"
 #include "llvm/Support/Debug.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Passes.h"
 #include "mlir/Dialect/SPIRV/IR/TargetAndABI.h"
 
@@ -50,7 +51,9 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
   const auto limits = targetEnv.getResourceLimits();
   LLVM_DEBUG(llvm::dbgs() << "target environment: " << targetEnvAttr << "\n");
 
-  const int subgroupSize = limits.getSubgroupSize();
+  auto funcOp = op->getParentOfType<func::FuncOp>();
+  const Optional<int> subgroupSize = getSPIRVSubgroupSize(funcOp);
+  if (!subgroupSize) return funcOp->emitError("failed to query subgroup size");
   const int maxSharedMemory = limits.getMaxComputeSharedMemorySize();
   const int maxThreads = limits.getMaxComputeWorkgroupInvocations();
   const auto maxWorkGroupSize = llvm::to_vector<3>(llvm::map_range(
@@ -85,9 +88,9 @@ LogicalResult verifySPIRVMatmulPromoteVectorizePassPipeline(
   }
 
   // Verify the total workgroup size should be multiple of subgroupSize.
-  if (totalWorkgroupSize % subgroupSize != 0) {
+  if (totalWorkgroupSize % *subgroupSize != 0) {
     return op->emitOpError("expected total workgroup size to be multiple of ")
-           << subgroupSize;
+           << *subgroupSize;
   }
 
   ArrayRef<int64_t> lhsShape =
@@ -182,7 +185,9 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
   const auto limits = targetEnv.getResourceLimits();
   LLVM_DEBUG(llvm::dbgs() << "target environment: " << targetEnvAttr << "\n");
 
-  const int subgroupSize = limits.getSubgroupSize();
+  auto funcOp = op->getParentOfType<func::FuncOp>();
+  const Optional<int> subgroupSize = getSPIRVSubgroupSize(funcOp);
+  if (!subgroupSize) return funcOp->emitError("failed to query subgroup size");
   const int maxSharedMemory = limits.getMaxComputeSharedMemorySize();
   const int maxThreads = limits.getMaxComputeWorkgroupInvocations();
   const auto maxWorkGroupSize = llvm::to_vector<3>(llvm::map_range(
@@ -217,16 +222,16 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
   }
 
   // Verify the total workgroup size should be multiple of subgroupSize.
-  if (totalWorkgroupSize % subgroupSize != 0) {
+  if (totalWorkgroupSize % *subgroupSize != 0) {
     return op->emitOpError("expected total workgroup size to be multiple of ")
-           << subgroupSize;
+           << *subgroupSize;
   }
 
   // Verify the total workgroup size should be equal or larger than 2 *
   // subgroupSize.
-  if (totalWorkgroupSize / subgroupSize < 2) {
+  if (totalWorkgroupSize / *subgroupSize < 2) {
     return op->emitOpError("expected total workgroup size to be >= ")
-           << 2 * subgroupSize;
+           << 2 * *subgroupSize;
   }
 
   // Verify that there are four level of tile sizes.
@@ -310,7 +315,7 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
 
   // Verify workgroup_size_x = warp_size * wg_tile_n / subgroup_tile_n.
   if (workgroupSize[0] * subgroupTileSizes[1] !=
-      subgroupSize * workgroupTileSizes[1]) {
+      *subgroupSize * workgroupTileSizes[1]) {
     return op->emitOpError(
         "expected workgroup x component equals to (warp_size * wg_tile_n / "
         "subgroup_tile_n)");

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
@@ -25,7 +25,7 @@ hal.executable public @matmul_256x1024x128_div_add {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_256x1024x128_div_add layout(#pipeline_layout)
     builtin.module {
@@ -71,9 +71,9 @@ hal.executable public @matmul_256x1024x128_div_add {
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 128], [32, 64], [0, 0, 32], [16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
 //CHECK-LABEL: hal.executable.export public @matmul_256x1024x128_div_add
-// CHECK-SAME:   subgroup_size = 64 : index
+// CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
-// CHECK-SAME:   workgroup_size = [128 : index, 2 : index, 1 : index]
+// CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @matmul_256x1024x128_div_add()
 //      CHECK:   linalg.matmul
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -105,7 +105,7 @@ hal.executable public @batch_matmul_16x128x256x512_div {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @batch_matmul_16x128x256x512_div layout(#pipeline_layout)
     builtin.module {
@@ -140,9 +140,9 @@ hal.executable public @batch_matmul_16x128x256x512_div {
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x128x256x512_div
-// CHECK-SAME:   subgroup_size = 64 : index
+// CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
-// CHECK-SAME:   workgroup_size = [128 : index, 2 : index, 1 : index]
+// CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_16x128x256x512_div()
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -173,7 +173,7 @@ hal.executable @generic_batch_matmul_32x8x512x64 {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
      >}> {
     hal.executable.export @generic_batch_matmul_32x8x512x64 layout(#pipeline_layout)
     builtin.module {
@@ -207,9 +207,9 @@ hal.executable @generic_batch_matmul_32x8x512x64 {
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 32], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
 //CHECK-LABEL: hal.executable.export public @generic_batch_matmul_32x8x512x64
-// CHECK-SAME:   subgroup_size = 64 : index
+// CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
-// CHECK-SAME:   workgroup_size = [128 : index, 2 : index, 1 : index]
+// CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @generic_batch_matmul_32x8x512x64()
 //      CHECK:   linalg.generic
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -243,7 +243,7 @@ hal.executable public @batch_matmul_16x1024x1024x80 {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @batch_matmul_16x1024x1024x80 layout(#pipeline_layout)
     builtin.module {
@@ -268,9 +268,9 @@ hal.executable public @batch_matmul_16x1024x1024x80 {
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
 //  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x1024x1024x80
-// CHECK-SAME:   subgroup_size = 64 : index
+// CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]
-// CHECK-SAME:   workgroup_size = [128 : index, 2 : index, 1 : index]
+// CHECK-SAME:   workgroup_size = [64 : index, 2 : index, 1 : index]
 //      CHECK: func.func @batch_matmul_16x1024x1024x80()
 //      CHECK:   linalg.batch_matmul
 // CHECK-SAME:     lowering_config = #[[$CONFIG]]
@@ -301,7 +301,7 @@ hal.executable public @matmul_256x1024x8 {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_256x1024x8 layout(#pipeline_layout)
     builtin.module {

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/illegal_configuration.mlir
@@ -378,7 +378,7 @@ hal.executable private @matmul_tensors {
 #compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[64, 64], [32, 32], [0, 0, 16]]>,
     translation_info = <SPIRVCooperativeMatrixVectorize>,
-    workgroup_size = [128, 2, 1]>
+    workgroup_size = [128, 2, 1], subgroup_size = 64>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -401,7 +401,7 @@ hal.executable public @matmul_tensor {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_tensor layout(#pipeline_layout)
     builtin.module {
@@ -431,7 +431,7 @@ hal.executable public @matmul_tensor {
 #compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[64, 64], [32, 32], [0, 0, 16], [8, 8, 8]]>,
     translation_info = <SPIRVCooperativeMatrixVectorize>,
-    workgroup_size = [128, 2, 1]>
+    workgroup_size = [128, 2, 1], subgroup_size = 64>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -454,7 +454,7 @@ hal.executable public @matmul_tensor {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_tensor layout(#pipeline_layout)
     builtin.module {
@@ -484,7 +484,7 @@ hal.executable public @matmul_tensor {
 #compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[32, 32], [8, 8], [0, 0, 4], [16, 16, 16]]>,
     translation_info = <SPIRVCooperativeMatrixVectorize>,
-    workgroup_size = [256, 4, 1]>
+    workgroup_size = [256, 4, 1], subgroup_size = 64>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -507,7 +507,7 @@ hal.executable public @matmul_tensor {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_tensor layout(#pipeline_layout)
     builtin.module {
@@ -537,7 +537,7 @@ hal.executable public @matmul_tensor {
 #compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[64, 64], [32, 32], [0, 0, 16], [16, 16, 16]]>,
     translation_info = <SPIRVCooperativeMatrixVectorize>,
-    workgroup_size = [64, 2, 1]>
+    workgroup_size = [64, 2, 1], subgroup_size = 64>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -560,7 +560,7 @@ hal.executable public @matmul_tensor {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_tensor layout(#pipeline_layout)
     builtin.module {
@@ -590,7 +590,7 @@ hal.executable public @matmul_tensor {
 #compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[64, 64], [32, 32], [0, 0, 16], [16, 16, 16]]>,
     translation_info = <SPIRVCooperativeMatrixVectorize>,
-    workgroup_size = [128, 4, 1]>
+    workgroup_size = [128, 4, 1], subgroup_size = 64>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -613,7 +613,7 @@ hal.executable public @matmul_tensor {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_tensor layout(#pipeline_layout)
     builtin.module {
@@ -643,7 +643,7 @@ hal.executable public @matmul_tensor {
 #compilation = #iree_codegen.compilation_info<
     lowering_config  = <tile_sizes = [[32, 32], [32, 32], [0, 0, 16], [16, 16, 16]]>,
     translation_info = <SPIRVCooperativeMatrixVectorize>,
-    workgroup_size = [64, 1, 1]>
+    workgroup_size = [64, 1, 1], subgroup_size = 64>
 #pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
   #hal.descriptor_set.layout<0, bindings = [
     #hal.descriptor_set.binding<0, storage_buffer>,
@@ -666,7 +666,7 @@ hal.executable public @matmul_tensor {
         max_compute_shared_memory_size = 65536,
         max_compute_workgroup_invocations = 1024,
         max_compute_workgroup_size = [1024, 1024, 1024],
-        subgroup_size = 64>
+        subgroup_size = 64, min_subgroup_size = 32, max_subgroup_size = 64>
        >}> {
     hal.executable.export public @matmul_tensor layout(#pipeline_layout)
     builtin.module {


### PR DESCRIPTION
This commit connects previous changes for supporting VK_EXT_subgroup_size_control and enables it for AMD architectures with cooperative matrix support.