### PR TITLE
Fix Winograd constant folding for F16 weights

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertConv2DToWinograd.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertConv2DToWinograd.cpp
@@ -128,9 +128,7 @@ public:
 
     Operation *constOp = kernel.getDefiningOp();
     ShapedType type = constOp->getResult(0).getType().cast<ShapedType>();
-    Type elementType = type.getElementType();
-    assert(elementType.isa<FloatType>());
-    auto floatType = elementType.cast<FloatType>();
+    auto elemType = type.getElementType().cast<FloatType>();
     ArrayRef<int64_t> shape = type.getShape();
     DenseElementsAttr::iterator_range<APFloat> nonSplatValues =
         kernelAttr.getValues<APFloat>();
@@ -141,11 +139,11 @@ public:
     }
     SmallVector<int64_t> resultShape{inputTileSize * inputTileSize, shape[2],
                                      shape[3]};
-    auto resultType = RankedTensorType::get(resultShape, floatType);
+    auto resultType = RankedTensorType::get(resultShape, elemType);
     auto foldedKernelAttr =
         foldFilterTransform(shape, inputTileSize, kernelSize, resultType,
                             IREE::LinalgExt::Winograd::G_6x6_3x3, isSplat,
-                            splatValue, nonSplatValues, floatType);
+                            splatValue, nonSplatValues, elemType);
     rewriter.replaceOpWithNewOp<arith::ConstantOp>(constOp, foldedKernelAttr);
     return success();
   }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertConv2DToWinograd.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/ConvertConv2DToWinograd.cpp
@@ -68,6 +68,8 @@ static DenseElementsAttr foldFilterTransform(
   const int &ic = shape[2];
   const int &oc = shape[3];
   const int64_t numElements = inputTileSize * inputTileSize * ic * oc;
+  FloatType floatType = elementType.cast<FloatType>();
+  bool losesInfo;
   SmallVector<APFloat> output(numElements, APFloat(0.0f));
   for (int d0 = 0; d0 < inputTileSize; d0++) {
     for (int d1 = 0; d1 < inputTileSize; d1++) {
@@ -87,6 +89,10 @@ static DenseElementsAttr foldFilterTransform(
           }
           int odx = index(d0, d1, d2, d3, inputTileSize, inputTileSize, ic, oc);
           output[odx] = accum;
+          if (floatType.isF16()) {
+            output[odx].convert(APFloat::IEEEhalf(),
+                                APFloat::rmNearestTiesToEven, &losesInfo);
+          }
         }
       }
     }


### PR DESCRIPTION
When doing constant folding for weights in fp16,
we do the folding in f32 and then cast to fp16
at the very end.