### PR TITLE
Revert "Switch e2e tests and benchmarks to `--iree-flow-enable-data-tiling` on `llvm-cpu`"

### DIFF
--- a/benchmarks/TFLite/android-arm64-v8a.cmake
+++ b/benchmarks/TFLite/android-arm64-v8a.cmake
@@ -221,7 +221,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   COMPILATION_FLAGS
     ${ANDROID_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   BENCHMARK_TOOL
@@ -252,7 +252,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   COMPILATION_FLAGS
     ${ANDROID_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
     "--iree-llvm-target-cpu-features=+dotprod"
   BENCHMARK_TOOL
     iree-benchmark-module
@@ -290,7 +290,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   COMPILATION_FLAGS
     ${ANDROID_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   BENCHMARK_TOOL
@@ -323,7 +323,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   COMPILATION_FLAGS
     ${ANDROID_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
     "--iree-llvm-target-cpu-features=+dotprod"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
@@ -428,7 +428,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   COMPILATION_FLAGS
     ${ANDROID_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
 
@@ -462,7 +462,7 @@ iree_benchmark_suite(
     "CPU-ARM64-v8A"
   COMPILATION_FLAGS
     ${ANDROID_CPU_COMPILATION_FLAGS}
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
     "--iree-llvm-target-cpu-features=+dotprod"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"

--- a/build_tools/benchmarks/comparisons/setup_mobile.sh
+++ b/build_tools/benchmarks/comparisons/setup_mobile.sh
@@ -120,7 +120,7 @@ for i in $(ls ${ROOT_DIR}/models/tflite/); do
     --iree-input-type=tosa \
     --iree-hal-target-backends=llvm-cpu \
     --iree-llvm-target-triple=aarch64-none-linux-android29 \
-    --iree-flow-enable-data-tiling \
+    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod" \
     --iree-llvm-target-cpu-features=+dotprod \
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops" \
     "--iree-llvmcpu-enable-pad-consumer-fusion" \
@@ -135,7 +135,7 @@ for i in $(ls ${ROOT_DIR}/models/tflite/); do
     --iree-input-type=tosa \
     --iree-hal-target-backends=llvm-cpu \
     --iree-llvm-target-triple=aarch64-none-linux-android29 \
-    --iree-flow-enable-data-tiling \
+    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod" \
     --iree-llvm-target-cpu-features=+dotprod \
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops" \
     "--iree-llvmcpu-enable-pad-consumer-fusion" \

--- a/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
+++ b/build_tools/python/benchmark_suites/iree/armv8_a_benchmarks.py
@@ -41,7 +41,7 @@ class Android_ARMv8_A_Benchmarks(object):
       tags=["experimental-flags", "mmt4d"],
       compile_targets=[ARMV8_A_CPU_TARGET],
       extra_flags=[
-          "--iree-flow-enable-data-tiling",
+          "--iree-flow-mmt4d-target-options=arch=aarch64",
           "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops",
           "--iree-llvmcpu-enable-pad-consumer-fusion"
       ])
@@ -50,7 +50,7 @@ class Android_ARMv8_A_Benchmarks(object):
       tags=["experimental-flags", "mmt4d", "dotprod"],
       compile_targets=[ARMV8_A_CPU_TARGET],
       extra_flags=[
-          "--iree-flow-enable-data-tiling",
+          "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod",
           "--iree-llvm-target-cpu-features=+dotprod",
           "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops",
           "--iree-llvmcpu-enable-pad-consumer-fusion"

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -39,7 +39,7 @@ py_binary(
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_mmt4d_%s_small" % lhs_rhs_type,
     compiler_flags = [
-        "--iree-flow-enable-data-tiling",
+        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -63,7 +63,7 @@ py_binary(
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_mmt4d_%s_large" % lhs_rhs_type,
     compiler_flags = [
-        "--iree-flow-enable-data-tiling",
+        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -91,7 +91,7 @@ py_binary(
     name = "e2e_matmul_mmt4d_%s_intrinsics_%s" % (lhs_rhs_type, size),
     compiler_flags = [
         "--iree-codegen-mmt4d-use-intrinsics",
-        "--iree-flow-enable-data-tiling",
+        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -57,7 +57,7 @@ iree_generated_trace_runner_test(
   DRIVERS
     "local-task"
   COMPILER_FLAGS
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "aarch64:+dotprod"
@@ -79,7 +79,7 @@ iree_generated_trace_runner_test(
   DRIVERS
     "local-task"
   COMPILER_FLAGS
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )
@@ -99,7 +99,7 @@ iree_generated_trace_runner_test(
   DRIVERS
     "local-task"
   COMPILER_FLAGS
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "aarch64:+dotprod"
@@ -121,7 +121,7 @@ iree_generated_trace_runner_test(
   DRIVERS
     "local-task"
   COMPILER_FLAGS
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )
@@ -142,7 +142,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-codegen-mmt4d-use-intrinsics"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
     "aarch64:+dotprod"
@@ -165,7 +165,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-codegen-mmt4d-use-intrinsics"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
   TARGET_CPU_FEATURES_VARIANTS
     "default"
 )

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -103,7 +103,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
@@ -289,7 +289,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
@@ -495,7 +495,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
@@ -724,7 +724,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
@@ -933,7 +933,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64 features=+dotprod"
     "--iree-llvm-target-cpu-features=+dotprod"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
@@ -1215,7 +1215,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
@@ -1438,7 +1438,7 @@ iree_bytecode_module(
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
+    "--iree-flow-mmt4d-target-options=arch=aarch64"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC


### PR DESCRIPTION
Due to the #11434, I think we can revert iree-org/iree#11411 first.