### PR TITLE
Avoid suppressing all failures in transform scripts

### DIFF
--- a/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s
 
-transform.structured.canonicalized_sequence failures(suppress) {
+transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
 
@@ -79,6 +79,11 @@ transform.structured.canonicalized_sequence failures(suppress) {
   // ===========================================================================
   %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
-  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
+  // at this point.
+  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  ^bb0(%arg0: !pdl.operation):
+    transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  }
   transform.iree.vector.warp_distribute %func_7
 }

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s
 
-transform.structured.canonicalized_sequence failures(suppress) {
+transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
 
@@ -86,6 +86,11 @@ transform.structured.canonicalized_sequence failures(suppress) {
   // ===========================================================================
   %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
-  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
+  // at this point.
+  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  ^bb0(%arg0: !pdl.operation):
+    transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  }
   transform.iree.vector.warp_distribute %func_7
 }

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s
 
-transform.structured.canonicalized_sequence failures(suppress) {
+transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
 
@@ -58,6 +58,11 @@ transform.structured.canonicalized_sequence failures(suppress) {
   // ===========================================================================
   %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
-  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
+  // at this point.
+  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  ^bb0(%arg0: !pdl.operation):
+    transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  }
   transform.iree.vector.warp_distribute %func_7
 }

--- a/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s
 
-transform.structured.canonicalized_sequence failures(suppress) {
+transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
   
@@ -62,6 +62,11 @@ transform.structured.canonicalized_sequence failures(suppress) {
   // ===========================================================================
   %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
-  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
+  // at this point.
+  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  ^bb0(%arg0: !pdl.operation):
+    transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  }
   transform.iree.vector.warp_distribute %func_7
 }

--- a/tests/transform_dialect/cuda/reduction_v2_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v2_codegen_spec.mlir
@@ -1,6 +1,6 @@
 // RUN: iree-opt %s
 
-transform.structured.canonicalized_sequence failures(suppress) {
+transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
   %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
   %reduction = transform.structured.match ops{["linalg.generic"]} in %variant_op


### PR DESCRIPTION
Suppressing all errors in the top-level sequence significantly worsens the debugging experience, especially in the current integration setup where some passes will still apply and some IR will be emitted. Localize error suppression around the only op that we actually expect to fail.