### PR TITLE
[LLVMGPU] Add basic support for target feature checks

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -51,6 +51,14 @@ llvm::cl::list<int64_t> clGPUCodegenTransformDialectTileSizes(
 }  // namespace mlir
 
 namespace {
+
+/// Structure to represent target features.
+struct TargetInfo {
+  // TODO: add finer grain control for other tensorcore types.
+  bool hasTF32TensorCore = false;
+  bool hasWarpShuffle = false;
+};
+
 struct TileWorkgroupSizePair {
   // How many scalar elements each workgroup should handle along each dimension.
   std::array<int64_t, 3> tileSize;
@@ -95,13 +103,13 @@ static void getTensorCoreConfig(
   }
 }
 
-static std::string getTargetArch(func::FuncOp entryPoint) {
+static StringRef getTargetArch(func::FuncOp entryPoint) {
   if (auto variantOp =
           entryPoint->getParentOfType<IREE::HAL::ExecutableVariantOp>()) {
     IREE::HAL::ExecutableTargetAttr targetAttr = variantOp.getTarget();
     if (auto config = targetAttr.getConfiguration()) {
       if (auto attr = config.getAs<StringAttr>("target_arch")) {
-        return attr.getValue().str();
+        return attr.getValue();
       }
     }
   }
@@ -119,11 +127,34 @@ bool isCudaTarget(func::FuncOp entryPoint) {
   return false;
 }
 
-static bool supportsTensorCore(func::FuncOp entryPoint, linalg::LinalgOp op) {
+static TargetInfo getTargetInfo(func::FuncOp entryPoint) {
+  TargetInfo info;
+  // TODO: fill out target info for other vendors.
+  if (!isCudaTarget(entryPoint)) return info;
+  // All the cuda target are assumed to have warp support.
+  info.hasWarpShuffle = true;
+  StringRef targetName = getTargetArch(entryPoint);
+  // If no target name is set assume all the features are off.
+  if (targetName == "") return info;
+  if (!StringRef(targetName).starts_with("sm_")) {
+    entryPoint.emitError("unknown target name ") << targetName;
+    return info;
+  }
+  APInt version;
+  if (targetName.substr(3).getAsInteger(10, version)) {
+    entryPoint.emitError("unknown target version ") << targetName;
+    return info;
+  }
+  int64_t smVersion = version.getZExtValue();
+  if (smVersion >= 80) info.hasTF32TensorCore = true;
+  return info;
+}
+
+static bool supportsTensorCore(func::FuncOp entryPoint, linalg::LinalgOp op,
+                               const TargetInfo &targetInfo) {
   // Limit tensor core pipeline to matmul as not all combinations of transpose
   // are supported upstream.
-  // TODO(thomasraoux): Enable batchMatmul and generic contraction.
-  if (getTargetArch(entryPoint) != "sm_80") return false;
+  if (!targetInfo.hasTF32TensorCore) return false;
   if (!(isa<linalg::MatmulOp>(op) || isa<linalg::BatchMatmulOp>(op))) {
     assert(linalg::isaContractionOpInterface(op));
     // If this is not a named op matmul check some properties to make sure that
@@ -146,7 +177,8 @@ static bool supportsTensorCore(func::FuncOp entryPoint, linalg::LinalgOp op) {
 }
 
 static LogicalResult setContractConfig(func::FuncOp entryPoint,
-                                       linalg::LinalgOp op) {
+                                       linalg::LinalgOp op,
+                                       const TargetInfo &targetInfo) {
   auto setMatmulConfig =
       [&entryPoint, &op](int64_t tileX, int64_t tileY, int64_t tileK,
                          llvm::ArrayRef<int64_t> workgroupSize,
@@ -215,7 +247,7 @@ static LogicalResult setContractConfig(func::FuncOp entryPoint,
                       sizeK != ShapedType::kDynamic;
   if (isStaticSize) {
     /// Try tensorcore config first.
-    if (supportsTensorCore(entryPoint, op)) {
+    if (supportsTensorCore(entryPoint, op, targetInfo)) {
       SmallVector<TileWorkgroupSizePair> TCtileSizeConfig;
 
       getTensorCoreConfig(TCtileSizeConfig, op.getDpsInputOperand(0)
@@ -461,10 +493,11 @@ static Optional<int64_t> getLinalgDimSize(linalg::LinalgOp op, int64_t d) {
 }
 
 /// Set configuration for reduction transform dialect based strategy.
-static LogicalResult setReductionTransformJitConfig(func::FuncOp entryPoint,
-                                                    linalg::LinalgOp op) {
+static LogicalResult setReductionTransformJitConfig(
+    func::FuncOp entryPoint, linalg::LinalgOp op,
+    const TargetInfo &targetInfo) {
   if (!clGPUEnableTransformDialectJit) return failure();
-  if (!isCudaTarget(entryPoint)) return failure();
+  if (!targetInfo.hasWarpShuffle) return failure();
   if (failed(matchAndSetGPUReductionTransformStrategy(entryPoint, op)))
     return failure();
 
@@ -477,8 +510,9 @@ static LogicalResult setReductionTransformJitConfig(func::FuncOp entryPoint,
 
 /// Set the configuration for reductions that can be mapped to warp reductions.
 static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
-                                            linalg::LinalgOp op) {
-  if (!isCudaTarget(entryPoint)) return failure();
+                                            linalg::LinalgOp op,
+                                            const TargetInfo &targetInfo) {
+  if (!targetInfo.hasWarpShuffle) return failure();
   if (!isa<linalg::GenericOp>(op)) return failure();
   // TODO(thomasraoux): Enable dynamic shape.
   if (op.hasDynamicShape()) return failure();
@@ -778,6 +812,7 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
     setLoweringConfig(computeOp, config);
     return success();
   }
+  TargetInfo targetInfo = getTargetInfo(entryPointFn);
   if (IREE::Codegen::CompilationInfoAttr compilationInfo =
           getCompilationInfo(computeOp)) {
     // If the op already has a lowering config coming from the IR use this and
@@ -787,12 +822,13 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(computeOp)) {
     if (linalg::isaContractionOpInterface(linalgOp) &&
         linalgOp.getNumParallelLoops() >= 2) {
-      return setContractConfig(entryPointFn, linalgOp);
+      return setContractConfig(entryPointFn, linalgOp, targetInfo);
     }
-    if (succeeded(setReductionTransformJitConfig(entryPointFn, linalgOp))) {
+    if (succeeded(setReductionTransformJitConfig(entryPointFn, linalgOp,
+                                                 targetInfo))) {
       return success();
     }
-    if (succeeded(setWarpReductionConfig(entryPointFn, linalgOp))) {
+    if (succeeded(setWarpReductionConfig(entryPointFn, linalgOp, targetInfo))) {
       return success();
     }
     if (succeeded(setConvolutionConfig(linalgOp, 32, 16))) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/gpu_set_num_workgroups.mlir
@@ -374,3 +374,123 @@ hal.executable private @sort_op {
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: iree_linalg_ext.sort
 //  CHECK-SAME:     lowering_config = #[[CONFIG]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @user_config {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @matmul_config_sm35 layout(#pipeline_layout)
+  builtin.module {
+    func.func @matmul_config_sm35() {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c128 = arith.constant 128 : index
+      %c1024 = arith.constant 1024 : index
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<128x256xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<256x1024xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<128x1024xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<256x1024xf32>> -> tensor<256x1024xf32>
+      %15 = tensor.empty() : tensor<128x1024xf32>
+      %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+      %17 = linalg.matmul
+          ins(%3, %4 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%16 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+      flow.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : tensor<128x1024xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x1024xf32>>
+      return
+    }
+  }
+}
+}
+
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulSimt>
+//      CHECK: hal.executable.export public @matmul_config_sm35
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @user_config {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
+  hal.executable.export public @matmul_config_sm80 layout(#pipeline_layout)
+  builtin.module {
+    func.func @matmul_config_sm80() {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c128 = arith.constant 128 : index
+      %c1024 = arith.constant 1024 : index
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<128x256xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<256x1024xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<128x1024xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<256x1024xf32>> -> tensor<256x1024xf32>
+      %15 = tensor.empty() : tensor<128x1024xf32>
+      %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+      %17 = linalg.matmul
+          ins(%3, %4 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%16 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+      flow.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : tensor<128x1024xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x1024xf32>>
+      return
+    }
+  }
+}
+}
+
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore
+//      CHECK: hal.executable.export public @matmul_config_sm80
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @user_config {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_86"}> {
+  hal.executable.export public @matmul_config_sm86 layout(#pipeline_layout)
+  builtin.module {
+    func.func @matmul_config_sm86() {
+      %cst = arith.constant 0.000000e+00 : f32
+      %c128 = arith.constant 128 : index
+      %c1024 = arith.constant 1024 : index
+      %c0 = arith.constant 0 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<128x256xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<256x1024xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<128x1024xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [128, 256], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<128x256xf32>> -> tensor<128x256xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [256, 1024], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<256x1024xf32>> -> tensor<256x1024xf32>
+      %15 = tensor.empty() : tensor<128x1024xf32>
+      %16 = linalg.fill ins(%cst : f32) outs(%15 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+      %17 = linalg.matmul
+          ins(%3, %4 : tensor<128x256xf32>, tensor<256x1024xf32>) outs(%16 : tensor<128x1024xf32>) -> tensor<128x1024xf32>
+      flow.dispatch.tensor.store %17, %2, offsets = [0, 0], sizes = [128, 1024], strides = [1, 1] : tensor<128x1024xf32> -> !flow.dispatch.tensor<writeonly:tensor<128x1024xf32>>
+      return
+    }
+  }
+}
+}
+
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<LLVMGPUMatmulTensorCore
+//      CHECK: hal.executable.export public @matmul_config_sm86
+// CHECK-SAME:     translation_info = #[[TRANSLATION]]


### PR DESCRIPTION
Remove hardcoded check for sm_80 and start basic target structure to keep track of the hardware feature supported.