### PR TITLE
Add Winograd support for NCHW convolutions

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -904,8 +904,8 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     The input tile is assumed to be square with each side of size m + r - 1,
     where the convolutional kernel is m x m and the output tile size is r x r.
     B is a constant 2-d square matrix of the same shape as the input tile I.
-    The input to the operator is an image of shape (N, H, W, C) and the
-    output is an operator of shape (m + r - 1, m + r - 1, N, H', W', C)
+    The input to the operator is an image of shape (N, H, W, C) or (N, C, H, W)
+    and the output is an operator of shape (m + r - 1, m + r - 1, N, H', W', C)
     where H' = ceil((H - m + 1)/r) and W' = ceil((W - m + 1)/r). The result
     of this operator is first collapsed and then fed to a batch matmul op.
   }];
@@ -960,6 +960,21 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     SmallVector<int64_t> imageDimensions() {
       return llvm::to_vector(getImageDimensions());
     }
+    SmallVector<int64_t> nhwcImageDimensions() {
+      return SmallVector<int64_t>{1, 2};
+    }
+    SmallVector<int64_t> nchwImageDimensions() {
+      return SmallVector<int64_t>{2, 3};
+    }
+    bool isNhwc() {
+      return imageDimensions() == nhwcImageDimensions();
+    }
+    bool isNchw() {
+      return imageDimensions() == nchwImageDimensions();
+    }
+    int channelDim() {
+      return isNhwc() ? 3 : 1;
+    }
     int64_t getIterationDomainRank() {
       SmallVector<int64_t> imageDims = imageDimensions();
       return getInputOperandRank() - imageDims.size();
@@ -996,9 +1011,9 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     and the output tile size is r x r. A is a constant 2-d matrix of
     shape (m + r - 1) x r. The input to the operator is a tensor of
     shape (m + r - 1, m + r - 1, N, H', W', C) and the output is a
-    tensor of shape (N, H, W, C) where H = r H' and W = r W'. This operator
-    is followed by a tensor.extract_slice which extracts only the non-padded
-    part of the output.
+    tensor of shape (N, H, W, C) or (N, C, H, W) where H = r H' and W = r W'.
+    This operator is followed by a tensor.extract_slice which extracts
+    only the non-padded part of the output.
   }];
 
   let arguments = (ins Variadic<AnyShaped>:$inputs,
@@ -1041,6 +1056,21 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     }
     SmallVector<int64_t> imageDimensions() {
       return llvm::to_vector(getImageDimensions());
+    }
+    SmallVector<int64_t> nhwcImageDimensions() {
+      return SmallVector<int64_t>{1, 2};
+    }
+    SmallVector<int64_t> nchwImageDimensions() {
+      return SmallVector<int64_t>{2, 3};
+    }
+    bool isNhwc() {
+      return imageDimensions() == nhwcImageDimensions();
+    }
+    bool isNchw() {
+      return imageDimensions() == nchwImageDimensions();
+    }
+    int channelDim() {
+      return isNhwc() ? 3 : 1;
     }
     int64_t getInputOperandRank() {
       return getInputOperandType().getRank();

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -960,17 +960,21 @@ def IREELinalgExt_WinogradInputTransformOp : IREELinalgExt_Op<"winograd.input_tr
     SmallVector<int64_t> imageDimensions() {
       return llvm::to_vector(getImageDimensions());
     }
-    SmallVector<int64_t> nhwcImageDimensions() {
-      return SmallVector<int64_t>{1, 2};
+    std::array<int64_t, 2> nhwcImageDimensions() {
+      return {1, 2};
     }
-    SmallVector<int64_t> nchwImageDimensions() {
-      return SmallVector<int64_t>{2, 3};
+    std::array<int64_t, 2> nchwImageDimensions() {
+      return {2, 3};
     }
     bool isNhwc() {
-      return imageDimensions() == nhwcImageDimensions();
+      std::array<int64_t, 2> nhwcImageDims = nhwcImageDimensions();
+      SmallVector<int64_t> imageDims = imageDimensions();
+      return imageDims == ArrayRef<int64_t>(nhwcImageDims);
     }
     bool isNchw() {
-      return imageDimensions() == nchwImageDimensions();
+      std::array<int64_t, 2> nchwImageDims = nchwImageDimensions();
+      SmallVector<int64_t> imageDims = imageDimensions();
+      return imageDims == ArrayRef<int64_t>(nchwImageDims);
     }
     int channelDim() {
       return isNhwc() ? 3 : 1;
@@ -1057,17 +1061,21 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
     SmallVector<int64_t> imageDimensions() {
       return llvm::to_vector(getImageDimensions());
     }
-    SmallVector<int64_t> nhwcImageDimensions() {
-      return SmallVector<int64_t>{1, 2};
+    std::array<int64_t, 2> nhwcImageDimensions() {
+      return {1, 2};
     }
-    SmallVector<int64_t> nchwImageDimensions() {
-      return SmallVector<int64_t>{2, 3};
+    std::array<int64_t, 2> nchwImageDimensions() {
+      return {2, 3};
     }
     bool isNhwc() {
-      return imageDimensions() == nhwcImageDimensions();
+      std::array<int64_t, 2> nhwcImageDims = nhwcImageDimensions();
+      SmallVector<int64_t> imageDims = imageDimensions();
+      return imageDims == ArrayRef<int64_t>(nhwcImageDims);
     }
     bool isNchw() {
-      return imageDimensions() == nchwImageDimensions();
+      std::array<int64_t, 2> nchwImageDims = nchwImageDimensions();
+      SmallVector<int64_t> imageDims = imageDimensions();
+      return imageDims == ArrayRef<int64_t>(nchwImageDims);
     }
     int channelDim() {
       return isNhwc() ? 3 : 1;

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -63,6 +63,34 @@ Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
 // Value's to kDynamic, even if they are arith.constant values.
 SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs);
 
+enum class Permutation {
+  NCHW_TO_NHWC,
+  NHWC_TO_NCHW,
+  TTNHWC_TO_TTNCHW,
+  TTNCHW_TO_TTNHWC,
+};
+
+// Permutes the elements of a SmallVector depending on the permutation specified
+template <Permutation P, typename T>
+static void permute(SmallVectorImpl<T> &vector) {
+  switch (P) {
+  case Permutation::NCHW_TO_NHWC:
+    std::rotate(vector.begin() + 1, vector.begin() + 2, vector.end());
+    break;
+  case Permutation::NHWC_TO_NCHW:
+    std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 1);
+    break;
+  case Permutation::TTNCHW_TO_TTNHWC:
+    std::rotate(vector.begin() + 3, vector.begin() + 4, vector.end());
+    break;
+  case Permutation::TTNHWC_TO_TTNCHW:
+    std::rotate(vector.rbegin(), vector.rbegin() + 1, vector.rend() - 3);
+    break;
+  default:
+    break;
+  }
+}
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2446,11 +2446,9 @@ LogicalResult WinogradInputTransformOp::verify() {
   if (imageDims.size() != 2) {
     return op->emitOpError("expected only 2 image dimensions");
   }
-  for (auto dim : imageDims) {
-    if ((dim < 0) || (dim > 3)) {
-      return op->emitOpError(
-          "expect image dimensions to be in the range: [0, 3]");
-    }
+  if (!isNchw() && !isNhwc()) {
+    return op->emitOpError(
+        "expect image dimensions to be either [1, 2] or [2, 3]");
   }
   const int64_t outputTileSize = getOutputTileSize();
   const int64_t kernelSize = getKernelSize();
@@ -2470,6 +2468,9 @@ LogicalResult WinogradInputTransformOp::verify() {
       expectedOutputShape[outputIndex] =
           std::ceil((float)(inputShape[i] - kernelSize + 1) / outputTileSize);
     }
+  }
+  if (isNchw()) {
+    permute<Permutation::TTNCHW_TO_TTNHWC>(expectedOutputShape);
   }
   if (!areShapesCompatible(expectedOutputShape, outputShape)) {
     return op->emitOpError("incompatible output shape");
@@ -2514,12 +2515,13 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   Location loc = getLoc();
   auto one = builder.getIndexAttr(1);
   auto zero = builder.getIndexAttr(0);
+  const int cDim = channelDim();
 
   assert(offsets.size() == 2);
   SmallVector<OpFoldResult> inputOffsets(getInputOperandRank(), zero);
   SmallVector<OpFoldResult> outputOffsets(getOutputOperandRank(), zero);
   outputOffsets[2] = inputOffsets[0] = offsets[0];
-  outputOffsets[5] = inputOffsets[3] = offsets[1];
+  outputOffsets[5] = inputOffsets[cDim] = offsets[1];
 
   SmallVector<OpFoldResult> inputStrides(getInputOperandRank(), one);
   SmallVector<OpFoldResult> outputStrides(getOutputOperandRank(), one);
@@ -2532,7 +2534,7 @@ WinogradInputTransformOp::getTiledImplementation(OpBuilder &builder,
   SmallVector<OpFoldResult> outputSizes =
       getAsOpFoldResult(builder.getIndexArrayAttr(outputShape));
   outputSizes[2] = inputSizes[0] = sizes[0];
-  outputSizes[5] = inputSizes[3] = sizes[1];
+  outputSizes[5] = inputSizes[cDim] = sizes[1];
 
   SmallVector<Value> tiledOperands;
   tiledOperands.emplace_back(
@@ -2594,7 +2596,7 @@ LogicalResult WinogradOutputTransformOp::verify() {
   }
   auto inputType = input().getType().cast<ShapedType>();
   auto outputType = output().getType().cast<ShapedType>();
-  ArrayRef<int64_t> inputShape = inputType.getShape();
+  SmallVector<int64_t> inputShape(inputType.getShape());
   if (inputShape.size() != 6) {
     return op->emitOpError("expected input operand to have rank 6");
   }
@@ -2614,11 +2616,12 @@ LogicalResult WinogradOutputTransformOp::verify() {
   if (imageDims.size() != 2) {
     return op->emitOpError("expected only 2 image dimensions");
   }
-  for (auto dim : imageDims) {
-    if ((dim < 0) || (dim > 3)) {
-      return op->emitOpError(
-          "expect image dimensions to be in the range: [0, 3]");
-    }
+  if (!isNchw() && !isNhwc()) {
+    return op->emitOpError(
+        "expect image dimensions to be either [1, 2] or [2, 3]");
+  }
+  if (isNchw()) {
+    permute<Permutation::TTNHWC_TO_TTNCHW>(inputShape);
   }
   const int64_t outputTileSize = getOutputTileSize();
   SmallVector<int64_t> expectedOutputShape(getOutputOperandRank(), 1);
@@ -2673,12 +2676,13 @@ SmallVector<Operation *> WinogradOutputTransformOp::getTiledImplementation(
   Location loc = getLoc();
   auto one = builder.getIndexAttr(1);
   auto zero = builder.getIndexAttr(0);
+  const int cDim = channelDim();
 
   assert(offsets.size() == 2);
   SmallVector<OpFoldResult> inputOffsets(getInputOperandRank(), zero);
   SmallVector<OpFoldResult> outputOffsets(getOutputOperandRank(), zero);
   inputOffsets[2] = outputOffsets[0] = offsets[0];
-  inputOffsets[5] = outputOffsets[3] = offsets[1];
+  inputOffsets[5] = outputOffsets[cDim] = offsets[1];
 
   SmallVector<OpFoldResult> inputStrides(getInputOperandRank(), one);
   SmallVector<OpFoldResult> outputStrides(getOutputOperandRank(), one);
@@ -2691,7 +2695,7 @@ SmallVector<Operation *> WinogradOutputTransformOp::getTiledImplementation(
   SmallVector<OpFoldResult> outputSizes =
       getAsOpFoldResult(builder.getIndexArrayAttr(outputShape));
   inputSizes[2] = outputSizes[0] = sizes[0];
-  inputSizes[5] = outputSizes[3] = sizes[1];
+  inputSizes[5] = outputSizes[cDim] = sizes[1];
 
   SmallVector<Value> tiledOperands;
   tiledOperands.emplace_back(
@@ -2719,10 +2723,11 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
     resultSizes = getAsOpFoldResult(builder.getIndexArrayAttr(resultShape));
     resultOffsets = SmallVector<OpFoldResult>(getOutputOperandRank(),
                                               builder.getIndexAttr(0));
+    const int cDim = channelDim();
     resultOffsets[0] = offsets[0];
-    resultOffsets[3] = offsets[1];
+    resultOffsets[cDim] = offsets[1];
     resultSizes[0] = sizes[0];
-    resultSizes[3] = sizes[1];
+    resultSizes[cDim] = sizes[1];
     return success();
   }
   return failure();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
@@ -49,6 +49,10 @@ class ReifyWinogradInputTransform final
 public:
   using OpRewritePattern::OpRewritePattern;
 
+  /// The input to this op is either (N, H, W, C) or (N, C, H, W)
+  /// but the output to this op is always (T, T, N, H', W', C).
+  /// Since the first two dimensions are used for the inner matrix
+  /// multiplication, we create the loop nest over (N, H', W', C).
   LogicalResult matchAndRewrite(WinogradInputTransformOp inputOp,
                                 PatternRewriter &rewriter) const override {
     Location loc = inputOp.getLoc();
@@ -82,9 +86,13 @@ public:
     Value output = inputOp.output();
     auto outputType = output.getType().cast<ShapedType>();
     auto inputType = input.getType().cast<ShapedType>();
-    ArrayRef<int64_t> inputShape = inputType.getShape();
+    SmallVector<int64_t> inputShape(inputType.getShape());
+    const bool isNchw = inputOp.isNchw();
+    if (isNchw) {
+      permute<Permutation::NCHW_TO_NHWC>(inputShape);
+    }
     Type elementType = outputType.getElementType();
-    SmallVector<int64_t> imageDims = inputOp.imageDimensions();
+    SmallVector<int64_t> imageDims = inputOp.nhwcImageDimensions();
     const size_t numImageDims = imageDims.size();
     llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
                                                   imageDims.end());
@@ -141,17 +149,23 @@ public:
     rewriter.setInsertionPointToStart(loopNest.loops.back().getBody());
     auto tensorType = RankedTensorType::get(
         SmallVector<int64_t>(numImageDims, ShapedType::kDynamic), elementType);
+    if (isNchw) {
+      permute<Permutation::NHWC_TO_NCHW>(offsets);
+      permute<Permutation::NHWC_TO_NCHW>(sizes);
+    }
     Value dynamicSlice = rewriter.create<tensor::ExtractSliceOp>(
         loc, tensorType, input, offsets, sizes, strides);
 
     // Copy input slice into zeroed padded scratch space
     strides = SmallVector<OpFoldResult>(numImageDims, one);
     offsets = SmallVector<OpFoldResult>(numImageDims, zero);
-    sizes = SmallVector<OpFoldResult>{sizes[1], sizes[2]};
+    SmallVector<OpFoldResult> sliceSizes;
+    for (const int64_t dim : inputOp.imageDimensions())
+      sliceSizes.push_back(sizes[dim]);
     linalg::FillOp fillOp = rewriter.create<linalg::FillOp>(
         loc, ValueRange{zeroF32}, ValueRange{scratch});
     Value inputSlice = rewriter.create<tensor::InsertSliceOp>(
-        loc, dynamicSlice, fillOp.result(), offsets, sizes, strides);
+        loc, dynamicSlice, fillOp.result(), offsets, sliceSizes, strides);
 
     // Extract output slice
     strides = SmallVector<OpFoldResult>(inputOp.getOutputOperandRank(), one);
@@ -205,6 +219,8 @@ class ReifyWinogradOutputTransform final
 public:
   using OpRewritePattern::OpRewritePattern;
 
+  /// The input to this op is always (T, T, N, H', W', C)
+  /// but the output is either (N, H, W, C) or (N, C, H, W).
   LogicalResult matchAndRewrite(WinogradOutputTransformOp outputOp,
                                 PatternRewriter &rewriter) const override {
     Location loc = outputOp.getLoc();
@@ -239,7 +255,7 @@ public:
     auto outputType = output.getType().cast<ShapedType>();
     ArrayRef<int64_t> outputShape = outputType.getShape();
     Type elementType = outputType.getElementType();
-    SmallVector<int64_t> imageDims = outputOp.imageDimensions();
+    SmallVector<int64_t> imageDims = outputOp.nhwcImageDimensions();
     const size_t numImageDims = imageDims.size();
     llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
                                                   imageDims.end());
@@ -305,6 +321,10 @@ public:
     tensorType = RankedTensorType::get(
         SmallVector<int64_t>(numImageDims, outputTileSize), elementType);
     Value iterArg = loopNest.loops.back().getRegionIterArg(0);
+    if (outputOp.isNchw()) {
+      permute<Permutation::NHWC_TO_NCHW>(offsets);
+      permute<Permutation::NHWC_TO_NCHW>(sizes);
+    }
     Value outputSlice = rewriter.create<tensor::ExtractSliceOp>(
         loc, tensorType, iterArg, offsets, sizes, strides);
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
@@ -92,7 +92,7 @@ public:
       permute<Permutation::NCHW_TO_NHWC>(inputShape);
     }
     Type elementType = outputType.getElementType();
-    SmallVector<int64_t> imageDims = inputOp.nhwcImageDimensions();
+    const std::array<int64_t, 2> imageDims = inputOp.nhwcImageDimensions();
     const size_t numImageDims = imageDims.size();
     llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
                                                   imageDims.end());
@@ -255,7 +255,7 @@ public:
     auto outputType = output.getType().cast<ShapedType>();
     ArrayRef<int64_t> outputShape = outputType.getShape();
     Type elementType = outputType.getElementType();
-    SmallVector<int64_t> imageDims = outputOp.nhwcImageDimensions();
+    const std::array<int64_t, 2> imageDims = outputOp.nhwcImageDimensions();
     const size_t numImageDims = imageDims.size();
     llvm::SmallSetVector<int64_t, 2> imageDimsSet(imageDims.begin(),
                                                   imageDims.end());

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/conv2d_to_winograd.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/conv2d_to_winograd.mlir
@@ -75,3 +75,72 @@ func.func @conv2d_non_splat_weights(%inputs : tensor<1x4x4x1xf32>, %arg2: tensor
 // CHECK-SAME:     tensor<1x6x6x1xf32> to tensor<1x2x2x1xf32>
 // CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x2x2x1xf32>
 // CHECK:      }
+
+// -----
+
+func.func @conv_16433136_nchw_fchw(%arg0: tensor<1x4x16x16xf32>, %arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32> {
+  %c0 = arith.constant dense<0.1> : tensor<16x4x3x3xf32>
+  %0 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %c0: tensor<1x4x16x16xf32>, tensor<16x4x3x3xf32>)
+    outs(%arg2: tensor<1x16x14x14xf32>) -> tensor<1x16x14x14xf32>
+  return %0 : tensor<1x16x14x14xf32>
+}
+// CHECK:      func.func @conv_16433136_nchw_fchw(%[[ARG0]]: tensor<1x4x16x16xf32>, %[[ARG1]]: tensor<1x16x14x14xf32>)
+// CHECK-SAME:   -> tensor<1x16x14x14xf32> {
+// CHECK:        %[[CST]] = arith.constant dense_resource<__elided__> : tensor<64x4x16xf32>
+// CHECK:        %[[CST_0]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D0]] = tensor.empty() : tensor<8x8x1x3x3x4xf32>
+// CHECK:        %[[D1]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[ARG0]] : tensor<1x4x16x16xf32>) outs(%[[D0]] :
+// CHECK-SAME:     tensor<8x8x1x3x3x4xf32>) -> tensor<8x8x1x3x3x4xf32>
+// CHECK:        %[[COLLAPSED]] = tensor.collapse_shape %[[D1]]
+// CHECK:        %[[D2]] = tensor.empty() : tensor<64x9x16xf32>
+// CHECK:        %[[D3]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D2]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
+// CHECK:        %[[D4]] = linalg.batch_matmul ins(%[[COLLAPSED]], %[[CST]] : tensor<64x9x4xf32>, tensor<64x4x16xf32>)
+// CHECK-SAME:     outs(%[[D3]] : tensor<64x9x16xf32>) -> tensor<64x9x16xf32>
+// CHECK:        %[[EXPANDED]] = tensor.expand_shape %[[D4]]
+// CHECK:        %[[D5]] = tensor.empty() : tensor<1x16x18x18xf32>
+// CHECK:        %[[D6]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[EXPANDED]] : tensor<8x8x1x3x3x16xf32>) outs(%[[D5]] :
+// CHECK-SAME:     tensor<1x16x18x18xf32>) -> tensor<1x16x18x18xf32>
+// CHECK:        %[[EXTRACTED_SLICE]] = tensor.extract_slice %[[D6]][0, 0, 0, 0] [1, 16, 14, 14] [1, 1, 1, 1] :
+// CHECK-SAME:     tensor<1x16x18x18xf32> to tensor<1x16x14x14xf32>
+// CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x16x14x14xf32>
+// CHECK:      }
+// CHECK:    }
+
+// -----
+
+func.func @conv2d_nchw_non_splat_weights(%inputs : tensor<1x1x4x4xf32>, %arg2: tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32> {
+  %c0 = arith.constant dense<[[[[ 1.0,  3.0,  5.0  ],
+                                [ 7.0,  9.0,  11.0 ],
+                                [ 13.0, 15.0, 17.0 ]]]]> : tensor<1x1x3x3xf32>
+  %0 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%inputs, %c0: tensor<1x1x4x4xf32>, tensor<1x1x3x3xf32>)
+    outs(%arg2: tensor<1x1x2x2xf32>) -> tensor<1x1x2x2xf32>
+  return %0 : tensor<1x1x2x2xf32>
+}
+// CHECK:      func.func @conv2d_nchw_non_splat_weights(%[[ARG0]]: tensor<1x1x4x4xf32>, %[[ARG1]]: tensor<1x1x2x2xf32>)
+// CHECK-SAME:   -> tensor<1x1x2x2xf32> {
+// CHECK:        %[[CST]] = arith.constant dense_resource<__elided__> : tensor<64x1x1xf32>
+// CHECK:        %[[CST_0]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D0]] = tensor.empty() : tensor<8x8x1x1x1x1xf32>
+// CHECK:        %[[D1]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[ARG0]] : tensor<1x1x4x4xf32>) outs(%[[D0]] : tensor<8x8x1x1x1x1xf32>)
+// CHECK-SAME:     -> tensor<8x8x1x1x1x1xf32>
+// CHECK:        %[[COLLAPSED]] = tensor.collapse_shape %[[D1]]
+// CHECK:        %[[D2]] = tensor.empty() : tensor<64x1x1xf32>
+// CHECK:        %[[D3]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D2]] : tensor<64x1x1xf32>) -> tensor<64x1x1xf32>
+// CHECK:        %[[D4]] = linalg.batch_matmul ins(%[[COLLAPSED]], %[[CST]] : tensor<64x1x1xf32>, tensor<64x1x1xf32>)
+// CHECK-SAME:     outs(%[[D3]] : tensor<64x1x1xf32>) -> tensor<64x1x1xf32>
+// CHECK:        %[[EXPANDED]] = tensor.expand_shape %[[D4]]
+// CHECK:        %[[D5]] = tensor.empty() : tensor<1x1x6x6xf32>
+// CHECK:        %[[D6]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[EXPANDED]] : tensor<8x8x1x1x1x1xf32>) outs(%[[D5]] :
+// CHECK-SAME:     tensor<1x1x6x6xf32>) -> tensor<1x1x6x6xf32>
+// CHECK:        %[[EXTRACTED_SLICE]] = tensor.extract_slice %[[D6]][0, 0, 0, 0] [1, 1, 2, 2] [1, 1, 1, 1] :
+// CHECK-SAME:     tensor<1x1x6x6xf32> to tensor<1x1x2x2xf32>
+// CHECK:        return %[[EXTRACTED_SLICE]] : tensor<1x1x2x2xf32>
+// CHECK:      }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -692,3 +692,33 @@ func.func @illegal_winograd_output_shape(%arg0: tensor<8x8x1x2x2x32xf32>) -> ten
 }
 
 // -----
+
+func.func @illegal_winograd_input_shape_nchw(%arg0: tensor<1x32x10x10xf32>) -> tensor<8x8x1x32x6x6xf32> {
+  %0 = tensor.empty() : tensor<8x8x1x32x6x6xf32>
+  // expected-error @+1 {{incompatible output shape}}
+  %1 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+    ins(%arg0 : tensor<1x32x10x10xf32>) outs(%0 : tensor<8x8x1x32x6x6xf32>) -> tensor<8x8x1x32x6x6xf32>
+  return %1 : tensor<8x8x1x32x6x6xf32>
+}
+
+// -----
+
+func.func @illegal_winograd_input_image_dimensions(%arg0: tensor<1x1280x10x10xf32>) -> tensor<8x8x1x2x2x1280xf32> {
+  %0 = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
+  // expected-error @+1 {{expect image dimensions to be either [1, 2] or [2, 3]}}
+  %1 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([0, 3])
+    ins(%arg0 : tensor<1x1280x10x10xf32>) outs(%0 : tensor<8x8x1x2x2x1280xf32>) -> tensor<8x8x1x2x2x1280xf32>
+  return %1 : tensor<8x8x1x2x2x1280xf32>
+}
+
+// -----
+
+func.func @illegal_winograd_output_image_dimensions(%arg0: tensor<8x8x1x2x2x32xf32>) -> tensor<1x32x12x12xf32> {
+  %0 = tensor.empty() : tensor<1x32x12x12xf32>
+  // expected-error @+1 {{expect image dimensions to be either [1, 2] or [2, 3]}}
+  %1 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([0, 3])
+        ins(%arg0 : tensor<8x8x1x2x2x32xf32>) outs(%0 : tensor<1x32x12x12xf32>) -> tensor<1x32x12x12xf32>
+  return %1 : tensor<1x32x12x12xf32>
+}
+
+// -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -998,3 +998,39 @@ func.func @winograd_output_transform(%arg0: tensor<8x8x?x?x?x?xf32>, %arg1: tens
 // CHECK:      }
 
 // -----
+
+func.func @winograd_input_transform_nchw(%arg0: tensor<1x1280x10x10xf32>) -> tensor<8x8x1x2x2x1280xf32> {
+  %0 = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
+  %1 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+    ins(%arg0 : tensor<1x1280x10x10xf32>) outs(%0 : tensor<8x8x1x2x2x1280xf32>) -> tensor<8x8x1x2x2x1280xf32>
+  return %1 : tensor<8x8x1x2x2x1280xf32>
+}
+// CHECK:      func.func @winograd_input_transform_nchw(%[[ARG0]]: tensor<1x1280x10x10xf32>) ->
+// CHECK-SAME:   tensor<8x8x1x2x2x1280xf32> {
+// CHECK:        %[[D0]] = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
+// CHECK:        %[[D1]] = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[ARG0]] : tensor<1x1280x10x10xf32>) outs(%[[D0]] :
+// CHECK-SAME:     tensor<8x8x1x2x2x1280xf32>) -> tensor<8x8x1x2x2x1280xf32>
+// CHECK:        return %[[D1]] : tensor<8x8x1x2x2x1280xf32>
+// CHECK:      }
+// CHECK:    }
+
+// -----
+
+func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x2x2x1280xf32>) -> tensor<1x1280x12x12xf32> {
+  %0 = tensor.empty() : tensor<1x1280x12x12xf32>
+  %1 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+    ins(%arg0 : tensor<8x8x1x2x2x1280xf32>) outs(%0 : tensor<1x1280x12x12xf32>) -> tensor<1x1280x12x12xf32>
+  return %1 : tensor<1x1280x12x12xf32>
+}
+// CHECK:      func.func @winograd_output_transform_nchw(%[[ARG0]]: tensor<8x8x1x2x2x1280xf32>) ->
+// CHECK-SAME:   tensor<1x1280x12x12xf32> {
+// CHECK:        %[[D0]] = tensor.empty() : tensor<1x1280x12x12xf32>
+// CHECK:        %[[D1]] = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3)
+// CHECK-SAME:     image_dimensions([2, 3]) ins(%[[ARG0]] : tensor<8x8x1x2x2x1280xf32>) outs(%[[D0]] :
+// CHECK-SAME:     tensor<1x1280x12x12xf32>) -> tensor<1x1280x12x12xf32>
+// CHECK:        return %[[D1]] : tensor<1x1280x12x12xf32>
+// CHECK:      }
+// CHECK:    }
+
+// -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_winograd.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_winograd.mlir
@@ -193,3 +193,200 @@ module {
 // CHECK:        }
 // CHECK:        return %[[D2]] : tensor<1x12x12x32xf32>
 // CHECK:      }
+
+// -----
+
+#map = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+#map1 = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+module {
+  func.func @winograd_input_transform_nchw(%arg0: tensor<1x1280x10x10xf32>) -> tensor<8x8x1x2x2x1280xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c1280 = arith.constant 1280 : index
+    %c32 = arith.constant 32 : index
+    %0 = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
+    %1 = scf.for %arg1 = %c0 to %c1 step %c1 iter_args(%arg2 = %0) -> (tensor<8x8x1x2x2x1280xf32>) {
+      %2 = affine.min #map(%arg1)[%c1, %c1]
+      %3 = scf.for %arg3 = %c0 to %c1280 step %c32 iter_args(%arg4 = %arg2) -> (tensor<8x8x1x2x2x1280xf32>) {
+        %4 = affine.min #map1(%arg3)[%c32, %c1280]
+        %extracted_slice = tensor.extract_slice %arg0[%arg1, %arg3, 0, 0] [%2, %4, 10, 10] [1, 1, 1, 1] : tensor<1x1280x10x10xf32> to tensor<?x?x10x10xf32>
+        %extracted_slice_0 = tensor.extract_slice %0[0, 0, %arg1, 0, 0, %arg3] [8, 8, %2, 2, 2, %4] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x1280xf32> to tensor<8x8x?x2x2x?xf32>
+        %5 = iree_linalg_ext.winograd.input_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3]) ins(%extracted_slice : tensor<?x?x10x10xf32>) outs(%extracted_slice_0 : tensor<8x8x?x2x2x?xf32>) -> tensor<8x8x?x2x2x?xf32>
+        %inserted_slice = tensor.insert_slice %5 into %arg4[0, 0, %arg1, 0, 0, %arg3] [8, 8, %2, 2, 2, %4] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> into tensor<8x8x1x2x2x1280xf32>
+        scf.yield %inserted_slice : tensor<8x8x1x2x2x1280xf32>
+      }
+      scf.yield %3 : tensor<8x8x1x2x2x1280xf32>
+    }
+    return %1 : tensor<8x8x1x2x2x1280xf32>
+  }
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0) -> (d0 * 6)>
+// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0) -> (-d0 + 10, 8)>
+// CHECK:      func.func @winograd_input_transform_nchw(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<1x1280x10x10xf32>) ->
+// CHECK-SAME:   tensor<8x8x1x2x2x1280xf32> {
+// CHECK:        %[[C32:.+]] = arith.constant 32 : index
+// CHECK:        %[[C1280:.+]] = arith.constant 1280 : index
+// CHECK:        %[[C1:.+]] = arith.constant 1 : index
+// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[CST:.+]] = arith.constant dense<
+// CHECK:        %[[CST_0:.+]] = arith.constant dense<
+// CHECK:        %[[CST_1:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[C2:.+]] = arith.constant 2 : index
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<8x8xf32>
+// CHECK:        %[[D1:.+]] = tensor.empty() : tensor<8x8x1x2x2x1280xf32>
+// CHECK:        %[[D2:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1]] step %[[C1]]
+// CHECK-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D1]]) -> (tensor<8x8x1x2x2x1280xf32>) {
+// CHECK-DAG:        %[[D3:.+]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
+// CHECK:          %[[D4:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1280]] step %[[C32]]
+// CHECK-SAME:       iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[ARG2]]) -> (tensor<8x8x1x2x2x1280xf32>) {
+// CHECK-DAG:          %[[D5:.+]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C1280]]]
+// CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG1]], %[[ARG3]], 0, 0] [%[[D3]],
+// CHECK-SAME:         %[[D5]], 10, 10] [1, 1, 1, 1] : tensor<1x1280x10x10xf32> to tensor<?x?x10x10xf32>
+// CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D1]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
+// CHECK-SAME:         %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x1280xf32> to
+// CHECK-SAME:         tensor<8x8x?x2x2x?xf32>
+// CHECK:            %[[D6:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D3]] step %[[C1]]
+// CHECK-SAME:         iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[EXTRACTED_SLICE_2]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// CHECK:              %[[D7:.+]] = scf.for %[[ARG7:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK-SAME:           iter_args(%[[ARG8:[a-zA-Z0-9_]+]] = %[[ARG6]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// CHECK-DAG:              %[[D8:.+]] = affine.apply #[[MAP2]](%[[ARG7]])
+// CHECK-DAG:              %[[D9:.+]] = affine.min #[[MAP3]](%[[D8]])
+// CHECK:                %[[D10:.+]] = scf.for %[[ARG9:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C2]] step %[[C1]]
+// CHECK-SAME:             iter_args(%[[ARG10:[a-zA-Z0-9_]+]] = %[[ARG8]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// CHECK-DAG:                %[[D11:.+]] = affine.apply #[[MAP2]](%[[ARG9]])
+// CHECK-DAG:                %[[D12:.+]] = affine.min #[[MAP3]](%[[D11]])
+// CHECK:                  %[[D13:.+]] = scf.for %[[ARG11:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D5]] step %[[C1]]
+// CHECK-SAME:               iter_args(%[[ARG12:[a-zA-Z0-9_]+]] = %[[ARG10]]) -> (tensor<8x8x?x2x2x?xf32>) {
+// CHECK:                    %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG5]],
+// CHECK-SAME:                 %[[ARG11]], %[[D8]], %[[D11]]] [1, 1, %[[D9]], %[[D12]]] [1, 1, 1, 1] :
+// CHECK-SAME:                 tensor<?x?x10x10xf32> to tensor<?x?xf32>
+// CHECK:                    %[[D14:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[D0]] : tensor<8x8xf32>) ->
+// CHECK-SAME:                 tensor<8x8xf32>
+// CHECK:                    %[[INSERTED_SLICE_4:.+]] = tensor.insert_slice %[[EXTRACTED_SLICE_3]] into %[[D14]][0, 0]
+// CHECK-SAME:                 [%[[D9]], %[[D12]]] [1, 1] : tensor<?x?xf32> into tensor<8x8xf32>
+// CHECK:                    %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[ARG12]][0, 0, %[[ARG5]], %[[ARG7]],
+// CHECK-SAME:                 %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> to
+// CHECK-SAME:                 tensor<8x8xf32>
+// CHECK:                    %[[D15:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_5]] :
+// CHECK-SAME:                 tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK:                    %[[D16:.+]] = linalg.matmul ins(%[[INSERTED_SLICE_4]], %[[CST_0]] : tensor<8x8xf32>,
+// CHECK-SAME:                 tensor<8x8xf32>) outs(%[[D15]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK:                    %[[D17:.+]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_5]] :
+// CHECK-SAME:                 tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK:                    %[[D18:.+]] = linalg.matmul ins(%[[CST]], %[[D16]] : tensor<8x8xf32>, tensor<8x8xf32>)
+// CHECK-SAME:                 outs(%[[D17]] : tensor<8x8xf32>) -> tensor<8x8xf32>
+// CHECK:                    %[[INSERTED_SLICE_6:.+]] = tensor.insert_slice %[[D18]] into %[[ARG12]][0, 0, %[[ARG5]],
+// CHECK-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] : tensor<8x8xf32>
+// CHECK-SAME:                 into tensor<8x8x?x2x2x?xf32>
+// CHECK:                    scf.yield %[[INSERTED_SLICE_6]] : tensor<8x8x?x2x2x?xf32>
+// CHECK:                  }
+// CHECK:                  scf.yield %[[D13]] : tensor<8x8x?x2x2x?xf32>
+// CHECK:                }
+// CHECK:                scf.yield %[[D10]] : tensor<8x8x?x2x2x?xf32>
+// CHECK:              }
+// CHECK:              scf.yield %[[D7]] : tensor<8x8x?x2x2x?xf32>
+// CHECK:            }
+// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D6]] into %[[ARG4]][0, 0, %[[ARG1]], 0, 0,
+// CHECK-SAME:         %[[ARG3]]] [8, 8, %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x?x2x2x?xf32> into
+// CHECK-SAME:         tensor<8x8x1x2x2x1280xf32>
+// CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<8x8x1x2x2x1280xf32>
+// CHECK:          }
+// CHECK:          scf.yield %[[D4]] : tensor<8x8x1x2x2x1280xf32>
+// CHECK:        }
+// CHECK:        return %[[D2]] : tensor<8x8x1x2x2x1280xf32>
+// CHECK:      }
+// CHECK:    }
+
+// -----
+
+#map = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+#map1 = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+module {
+  func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x2x2x32xf32>) -> tensor<1x32x12x12xf32> {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c32 = arith.constant 32 : index
+    %0 = tensor.empty() : tensor<1x32x12x12xf32>
+    %1 = scf.for %arg1 = %c0 to %c1 step %c1 iter_args(%arg2 = %0) -> (tensor<1x32x12x12xf32>) {
+      %2 = affine.min #map(%arg1)[%c1, %c1]
+      %3 = scf.for %arg3 = %c0 to %c32 step %c32 iter_args(%arg4 = %arg2) -> (tensor<1x32x12x12xf32>) {
+        %4 = affine.min #map1(%arg3)[%c32, %c32]
+        %extracted_slice = tensor.extract_slice %arg0[0, 0, %arg1, 0, 0, %arg3] [8, 8, %2, 2, 2, %4] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x32xf32> to tensor<8x8x?x2x2x?xf32>
+        %extracted_slice_0 = tensor.extract_slice %0[%arg1, %arg3, 0, 0] [%2, %4, 12, 12] [1, 1, 1, 1] : tensor<1x32x12x12xf32> to tensor<?x?x12x12xf32>
+        %5 = iree_linalg_ext.winograd.output_transform output_tile_size(6) kernel_size(3) image_dimensions([2, 3]) ins(%extracted_slice : tensor<8x8x?x2x2x?xf32>) outs(%extracted_slice_0 : tensor<?x?x12x12xf32>) -> tensor<?x?x12x12xf32>
+        %inserted_slice = tensor.insert_slice %5 into %arg4[%arg1, %arg3, 0, 0] [%2, %4, 12, 12] [1, 1, 1, 1] : tensor<?x?x12x12xf32> into tensor<1x32x12x12xf32>
+        scf.yield %inserted_slice : tensor<1x32x12x12xf32>
+      }
+      scf.yield %3 : tensor<1x32x12x12xf32>
+    }
+    return %1 : tensor<1x32x12x12xf32>
+  }
+}
+// CHECK-DAG:  #[[MAP]] = affine_map<(d0)[s0, s1] -> (1, -d0 + s1)>
+// CHECK-DAG:  #[[MAP1]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// CHECK-DAG:  #[[MAP2]] = affine_map<(d0) -> (d0 * 6)>
+// CHECK:      func.func @winograd_output_transform_nchw(%[[ARG0]]: tensor<8x8x1x2x2x32xf32>) -> tensor<1x32x12x12xf32>
+// CHECK-SAME:   {
+// CHECK:        %[[C32]] = arith.constant 32 : index
+// CHECK:        %[[C1]] = arith.constant 1 : index
+// CHECK:        %[[C0]] = arith.constant 0 : index
+// CHECK:        %[[CST]] = arith.constant dense<
+// CHECK:        %[[CST_0]] = arith.constant dense<
+// CHECK:        %[[CST_1]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[C2]] = arith.constant 2 : index
+// CHECK:        %[[D0]] = tensor.empty() : tensor<8x6xf32>
+// CHECK:        %[[D1]] = tensor.empty() : tensor<1x32x12x12xf32>
+// CHECK:        %[[D2]] = scf.for %[[ARG1]] = %[[C0]] to %[[C1]] step %[[C1]] iter_args(%[[ARG2]] = %[[D1]]) ->
+// CHECK-SAME:     (tensor<1x32x12x12xf32>) {
+// CHECK-DAG:        %[[D3]] = affine.min #[[MAP]](%[[ARG1]])[%[[C1]], %[[C1]]]
+// CHECK:          %[[D4]] = scf.for %[[ARG3]] = %[[C0]] to %[[C32]] step %[[C32]] iter_args(%[[ARG4]] = %[[ARG2]]) ->
+// CHECK-SAME:       (tensor<1x32x12x12xf32>) {
+// CHECK-DAG:          %[[D5]] = affine.min #[[MAP1]](%[[ARG3]])[%[[C32]], %[[C32]]]
+// CHECK:            %[[EXTRACTED_SLICE]] = tensor.extract_slice %[[ARG0]][0, 0, %[[ARG1]], 0, 0, %[[ARG3]]] [8, 8,
+// CHECK-SAME:         %[[D3]], 2, 2, %[[D5]]] [1, 1, 1, 1, 1, 1] : tensor<8x8x1x2x2x32xf32> to tensor<8x8x?x2x2x?xf32>
+// CHECK:            %[[EXTRACTED_SLICE_2]] = tensor.extract_slice %[[D1]][%[[ARG1]], %[[ARG3]], 0, 0] [%[[D3]],
+// CHECK-SAME:         %[[D5]], 12, 12] [1, 1, 1, 1] : tensor<1x32x12x12xf32> to tensor<?x?x12x12xf32>
+// CHECK:            %[[D6]] = scf.for %[[ARG5]] = %[[C0]] to %[[D3]] step %[[C1]] iter_args(%[[ARG6]] =
+// CHECK-SAME:         %[[EXTRACTED_SLICE_2]]) -> (tensor<?x?x12x12xf32>) {
+// CHECK:              %[[D7]] = scf.for %[[ARG7]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG8]] = %[[ARG6]]) ->
+// CHECK-SAME:           (tensor<?x?x12x12xf32>) {
+// CHECK-DAG:              %[[D8]] = affine.apply #[[MAP2]](%[[ARG7]])
+// CHECK:                %[[D9]] = scf.for %[[ARG9]] = %[[C0]] to %[[C2]] step %[[C1]] iter_args(%[[ARG10]] = %[[ARG8]])
+// CHECK-SAME:             -> (tensor<?x?x12x12xf32>) {
+// CHECK-DAG:                %[[D10]] = affine.apply #[[MAP2]](%[[ARG9]])
+// CHECK:                  %[[D11]] = scf.for %[[ARG11]] = %[[C0]] to %[[D5]] step %[[C1]] iter_args(%[[ARG12]] =
+// CHECK-SAME:               %[[ARG10]]) -> (tensor<?x?x12x12xf32>) {
+// CHECK:                    %[[EXTRACTED_SLICE_3]] = tensor.extract_slice %[[EXTRACTED_SLICE]][0, 0, %[[ARG5]],
+// CHECK-SAME:                 %[[ARG7]], %[[ARG9]], %[[ARG11]]] [8, 8, 1, 1, 1, 1] [1, 1, 1, 1, 1, 1] :
+// CHECK-SAME:                 tensor<8x8x?x2x2x?xf32> to tensor<8x8xf32>
+// CHECK:                    %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[ARG12]][%[[ARG5]], %[[ARG11]], %[[D8]],
+// CHECK-SAME:                 %[[D10]]] [1, 1, 6, 6] [1, 1, 1, 1] : tensor<?x?x12x12xf32> to tensor<6x6xf32>
+// CHECK:                    %[[D12]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[D0]] : tensor<8x6xf32>) ->
+// CHECK-SAME:                 tensor<8x6xf32>
+// CHECK:                    %[[D13]] = linalg.matmul ins(%[[EXTRACTED_SLICE_3]], %[[CST_0]] : tensor<8x8xf32>,
+// CHECK-SAME:                 tensor<8x6xf32>) outs(%[[D12]] : tensor<8x6xf32>) -> tensor<8x6xf32>
+// CHECK:                    %[[D14]] = linalg.fill ins(%[[CST_1]] : f32) outs(%[[EXTRACTED_SLICE_4]] : tensor<6x6xf32>)
+// CHECK-SAME:                 -> tensor<6x6xf32>
+// CHECK:                    %[[D15]] = linalg.matmul ins(%[[CST]], %[[D13]] : tensor<6x8xf32>, tensor<8x6xf32>)
+// CHECK-SAME:                 outs(%[[D14]] : tensor<6x6xf32>) -> tensor<6x6xf32>
+// CHECK:                    %[[INSERTED_SLICE_5:.+]] = tensor.insert_slice %[[D15]] into %[[ARG12]][%[[ARG5]],
+// CHECK-SAME:                 %[[ARG11]], %[[D8]], %[[D10]]] [1, 1, 6, 6] [1, 1, 1, 1] : tensor<6x6xf32> into
+// CHECK-SAME:                 tensor<?x?x12x12xf32>
+// CHECK:                    scf.yield %[[INSERTED_SLICE_5]] : tensor<?x?x12x12xf32>
+// CHECK:                  }
+// CHECK:                  scf.yield %[[D11]] : tensor<?x?x12x12xf32>
+// CHECK:                }
+// CHECK:                scf.yield %[[D9]] : tensor<?x?x12x12xf32>
+// CHECK:              }
+// CHECK:              scf.yield %[[D7]] : tensor<?x?x12x12xf32>
+// CHECK:            }
+// CHECK:            %[[INSERTED_SLICE]] = tensor.insert_slice %[[D6]] into %[[ARG4]][%[[ARG1]], %[[ARG3]], 0, 0]
+// CHECK-SAME:         [%[[D3]], %[[D5]], 12, 12] [1, 1, 1, 1] : tensor<?x?x12x12xf32> into tensor<1x32x12x12xf32>
+// CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<1x32x12x12xf32>
+// CHECK:          }
+// CHECK:          scf.yield %[[D4]] : tensor<1x32x12x12xf32>
+// CHECK:        }
+// CHECK:        return %[[D2]] : tensor<1x32x12x12xf32>
+// CHECK:      }

--- a/tests/e2e/linalg_ext_ops/winograd_input.mlir
+++ b/tests/e2e/linalg_ext_ops/winograd_input.mlir
@@ -22,3 +22,28 @@ func.func @winograd_input() {
 
   return
 }
+
+func.func @winograd_input_nchw() {
+  %input = util.unfoldable_constant dense<1.0> : tensor<1x1x6x6xf32>
+
+  %init = tensor.empty() : tensor<8x8x1x1x1x1xf32>
+  %1 = iree_linalg_ext.winograd.input_transform
+       output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+       ins(%input : tensor<1x1x6x6xf32>)
+       outs(%init : tensor<8x8x1x1x1x1xf32>) -> tensor<8x8x1x1x1x1xf32>
+  %2 = flow.tensor.reshape %1 : tensor<8x8x1x1x1x1xf32> -> tensor<8x8xf32>
+
+  check.expect_almost_eq_const(
+      %2,
+      dense<[[ 1.0000, -5.5000, -1.0000, -1.0000, -1.0000, -1.0000, -1.0000, -1.0000],
+             [-5.5000, 30.2500,  5.5000,  5.5000,  5.5000,  5.5000,  5.5000,  5.5000],
+             [-1.0000,  5.5000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000],
+             [-1.0000,  5.5000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000],
+             [-1.0000,  5.5000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000],
+             [-1.0000,  5.5000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000],
+             [-1.0000,  5.5000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000],
+             [-1.0000,  5.5000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000,  1.0000]]> : tensor<8x8xf32>
+  ) : tensor<8x8xf32>
+
+  return
+}

--- a/tests/e2e/linalg_ext_ops/winograd_output.mlir
+++ b/tests/e2e/linalg_ext_ops/winograd_output.mlir
@@ -21,3 +21,25 @@ func.func @winograd_output() {
   return
 }
 
+func.func @winograd_output_nchw() {
+  %input = util.unfoldable_constant dense<1.0> : tensor<8x8x1x1x1x1xf32>
+
+  %init = tensor.empty() : tensor<1x1x6x6xf32>
+  %1 = iree_linalg_ext.winograd.output_transform
+       output_tile_size(6) kernel_size(3) image_dimensions([2, 3])
+       ins(%input : tensor<8x8x1x1x1x1xf32>)
+       outs(%init : tensor<1x1x6x6xf32>) -> tensor<1x1x6x6xf32>
+  %2 = flow.tensor.reshape %1 : tensor<1x1x6x6xf32> -> tensor<6x6xf32>
+
+  check.expect_almost_eq_const(
+      %2,
+      dense<[[   49.00000,     0.00000,    73.50000,     0.00000,   238.87500,     7.00000],
+             [    0.00000,     0.00000,     0.00000,     0.00000,     0.00000,     0.00000],
+             [   73.50000,     0.00000,   110.25000,     0.00000,   358.31250,    10.50000],
+             [    0.00000,     0.00000,     0.00000,     0.00000,     0.00000,     0.00000],
+             [  238.87500,     0.00000,   358.31250,     0.00000,  1164.51562,    34.12500],
+             [    7.00000,     0.00000,    10.50000,     0.00000,    34.12500,     1.00000]]> : tensor<6x6xf32>
+  ) : tensor<6x6xf32>
+
+  return
+}


### PR DESCRIPTION
This patch adds support for NCHW convolutions.
In order to avoid the cost of additional transposes, the winograd input op is modified so that regardless of whether the input is (N, H, W, C) or (N, C, H, W), the output is always (T, T, N, H, W, C). Similarly, the winograd output op is modified to have the input always be (T, T, N, H, W, C), but have the output be either (N, H, W, C) or (N, C, H, W) depending on the specified image dimensions. The tiling and decomposition passes are also modified to account for this.