### PR TITLE
Update 'publish website' action to use new fine-grained tokens

### DIFF
--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout out repository
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
         with:
-          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
       - name: Fetching base gh-pages branch
         # We have to explicitly fetch the gh-pages branch as well to preserve history
         run: git fetch --no-tags --prune --depth=1 origin "gh-pages:gh-pages"

--- a/.github/workflows/publish_website.yml
+++ b/.github/workflows/publish_website.yml
@@ -13,6 +13,7 @@ on:
     paths:
       - "docs/website/**"
       - "build_tools/scripts/generate_release_index.py"
+      - ".github/workflows/publish_website.yml"
   # Regenerate the release pip index when a regular or pre-release is created or
   # deleted.
   release:


### PR DESCRIPTION
Part of https://github.com/iree-org/iree/issues/11479

skip-ci: Doesn't affect CI workflows
