### PR TITLE
Update release workflows to use new fine-grained tokens

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -202,7 +202,7 @@ jobs:
         id: upload-release-assets
         uses: dwenegar/upload-release-assets@5bc3024cf83521df8ebfadf00ad0c4614fd59148 # v1
         env:
-          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
         with:
           release_id: ${{ github.event.inputs.release_id }}
           # Only upload iree artifacts.
@@ -218,6 +218,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1
         with:
           workflow: Validate and Publish Release
-          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
           inputs: '{"release_id": "${{ github.event.inputs.release_id }}", "package_version": "${{ github.event.inputs.package_version }}", "build_run_id": "${{ github.run_id }}"}'

--- a/.github/workflows/oneshot_candidate_release.yml
+++ b/.github/workflows/oneshot_candidate_release.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
         with:
-          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
 
       - name: Compute version
         run: |
@@ -28,7 +28,7 @@ jobs:
       - name: Pushing changes
         uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
         with:
-          github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          github_token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
           branch: ${{ github.ref_name }}
           tags: true
 
@@ -36,7 +36,7 @@ jobs:
         id: create_release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
-          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
         with:
           tag_name: ${{ env.tag_name }}
           release_name: iree candidate ${{ env.tag_name }}
@@ -49,6 +49,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1
         with:
           workflow: Build Native Release Packages
-          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
           inputs: '{"package_suffix": "", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}"}'

--- a/.github/workflows/schedule_candidate_release.yml
+++ b/.github/workflows/schedule_candidate_release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checking out repository
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
         with:
-          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
           ref: ${{ steps.last_green_commit.outputs.result }}
 
       - name: Compute version
@@ -44,7 +44,7 @@ jobs:
         id: create_release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
-          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
         with:
           tag_name: ${{ env.tag_name }}
           release_name: iree candidate ${{ env.tag_name }}
@@ -58,6 +58,6 @@ jobs:
         uses: benc-uk/workflow-dispatch@4c044c1613fabbe5250deadc65452d54c4ad4fc7 # v1
         with:
           workflow: Build Native Release Packages
-          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
           ref: "${{ env.tag_name }}"
           inputs: '{"package_suffix": "", "package_version": "${{ env.package_version }}", "release_id": "${{ steps.create_release.outputs.id }}", "commit": "${{ steps.last_green_commit.outputs.result }}"}'

--- a/.github/workflows/validate_and_publish_release.yml
+++ b/.github/workflows/validate_and_publish_release.yml
@@ -25,7 +25,7 @@ jobs:
         id: download_packages
         uses: dawidd6/action-download-artifact@b2abf1705491048a2d7074f7d90513044fd25d39 # v2
         with:
-          github_token: ${{secrets.WRITE_ACCESS_TOKEN}}
+          github_token: ${{secrets.FG_WRITE_ACCESS_TOKEN}}
           workflow: build_package.yml
           run_id: ${{ github.event.inputs.build_run_id }}
       - name: Extract and display downloaded files
@@ -79,14 +79,14 @@ jobs:
         id: publish_release
         uses: eregon/publish-release@d6aee8c288e653387d895ee64d559fc0dd63339d # v1.0.3
         env:
-          GITHUB_TOKEN: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
         with:
           release_id: ${{ github.event.inputs.release_id }}
 
       - name: Checking out repository
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
         with:
-          token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
           # Get all history. Otherwise the latest-snapshot branch can't be
           # fast-forwarded.
           fetch-depth: 0
@@ -94,6 +94,6 @@ jobs:
       - name: Updating latest-snapshot branch
         uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6 # v0.6.0
         with:
-          github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+          github_token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
           branch: latest-snapshot
           force: true

--- a/docs/developers/debugging/releases.md
+++ b/docs/developers/debugging/releases.md
@@ -107,7 +107,7 @@ And change the branch from 'main' to the branch you are developing on
 - name: Pushing changes
   uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
   with:
-    github_token: ${{ secrets.WRITE_ACCESS_TOKEN }}
+    github_token: ${{ secrets.FG_WRITE_ACCESS_TOKEN }}
     branch: main
     tags: true
 ```


### PR DESCRIPTION
Part of https://github.com/iree-org/iree/issues/11479

The last two workflows worked fine. Let's see if we can just switch
everything over. I'll roll back if this messes up the release.

skip-ci: doesn't affect CI workflows
