### PR TITLE
Don't compress e2e test artifacts when uploading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,13 +736,11 @@ jobs:
         env:
           E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
           E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
-          COMPRESSED_OUT_DIR: compressed-out
         run: |
-          zstd -T0 -r --output-dir-mirror "${COMPRESSED_OUT_DIR}" "${E2E_TEST_ARTIFACTS_DIR}/iree"
           # Not archiving the directory to allow fetching each file as needed
           # separately.
           gcloud alpha storage cp -r \
-            "${COMPRESSED_OUT_DIR}/${E2E_TEST_ARTIFACTS_DIR}/iree" \
+            "${E2E_TEST_ARTIFACTS_DIR}/iree" \
             "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/iree"
           echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -736,13 +736,14 @@ jobs:
         env:
           E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
           E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
+          COMPRESSED_OUT_DIR: compressed-out
         run: |
+          zstd -T0 -r --output-dir-mirror "${COMPRESSED_OUT_DIR}" "${E2E_TEST_ARTIFACTS_DIR}/iree"
           # Not archiving the directory to allow fetching each file as needed
-          # separately. The option `--gzip-in-flight-all` compresses the files
-          # during uploading to save traffic. The files are still uncompressed
-          # on GCS.
-          # More details: https://cloud.google.com/sdk/gcloud/reference/storage/cp#--gzip-in-flight-all
-          gcloud alpha storage cp -r --gzip-in-flight-all "${E2E_TEST_ARTIFACTS_DIR}/iree" "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/iree"
+          # separately.
+          gcloud alpha storage cp -r \
+            "${COMPRESSED_OUT_DIR}/${E2E_TEST_ARTIFACTS_DIR}/iree" \
+            "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/iree"
           echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
 
   ############################## Crosscompilation ##############################


### PR DESCRIPTION
Remove `--gzip-in-flight-all` when uploading e2e test artifacts, which reduces the uploading time from 5mins to 18s.

Tried to compress with ZSTD first but it increased the whole process to 24s. ZSTD also only saves the total size by 12%, so I think it isn't worth compressing the artifacts right now.

Fix #11356