### PR TITLE
Fix copy-pasta in TransformDialectStrategies:

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -161,7 +161,7 @@ Value mlir::iree_compiler::buildTileFuseDistToForeachThreadWithTileSizes(
       resultingFusedOpsHandles);
 }
 Value mlir::iree_compiler::
-    buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
+    buildTileFuseDistToForeachThreadAndWorkgroupCountWithTileSizes(
         ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
         ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
         SmallVectorImpl<Value> *resultingFusedOpsHandles) {
@@ -186,21 +186,21 @@ static Value buildTileFuseDistWithNumThreads(
 }
 Value mlir::iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
+    ArrayRef<OpFoldResult> numThreads, ArrayAttr threadDimMapping,
     SmallVectorImpl<Value> *resultingFusedOpsHandles) {
-  return buildTileFuseDistWithTileSizes<TileToForeachThreadOp>(
-      b, rootH, opsHToFuse, tileSizes, threadDimMapping,
+  return buildTileFuseDistWithNumThreads<TileToForeachThreadOp>(
+      b, rootH, opsHToFuse, numThreads, threadDimMapping,
       resultingFusedOpsHandles);
 }
 Value mlir::iree_compiler::
-    buildTileFuseDistToForeachThreadAndWorgroupCountWithNumThreads(
+    buildTileFuseDistToForeachThreadAndWorkgroupCountWithNumThreads(
         ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-        ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
+        ArrayRef<OpFoldResult> numThreads, ArrayAttr threadDimMapping,
         SmallVectorImpl<Value> *resultingFusedOpsHandles) {
-  return buildTileFuseDistWithTileSizes<
-      TileToForeachThreadAndWorkgroupCountRegionOp>(b, rootH, opsHToFuse,
-                                                    tileSizes, threadDimMapping,
-                                                    resultingFusedOpsHandles);
+  return buildTileFuseDistWithNumThreads<
+      TileToForeachThreadAndWorkgroupCountRegionOp>(
+      b, rootH, opsHToFuse, numThreads, threadDimMapping,
+      resultingFusedOpsHandles);
 }
 
 /// Apply patterns and vectorize (for now always applies rank-reduction).
@@ -361,7 +361,7 @@ Value mlir::iree_compiler::createReductionStrategyBlockDistributionPart(
         b.getArrayAttr({x}));
   } else {
     iree_compiler::
-        buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
+        buildTileFuseDistToForeachThreadAndWorkgroupCountWithTileSizes(
             b, optionalFusionRootH, opsHToFuse, tileSizes0Generic,
             b.getArrayAttr({x}));
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -45,7 +45,7 @@ Value buildTileFuseDistToForeachThreadWithTileSizes(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
     SmallVectorImpl<Value> *resultingFusedOpsHandles = nullptr);
-Value buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
+Value buildTileFuseDistToForeachThreadAndWorkgroupCountWithTileSizes(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
     SmallVectorImpl<Value> *resultingFusedOpsHandles = nullptr);
@@ -55,7 +55,7 @@ Value buildTileFuseDistToForeachThreadWithNumThreads(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> numThreads, ArrayAttr threadDimMapping,
     SmallVectorImpl<Value> *resultingFusedOpsHandles = nullptr);
-Value buildTileFuseDistToForeachThreadAndWorgroupCountWithNumThreads(
+Value buildTileFuseDistToForeachThreadAndWorkgroupCountWithNumThreads(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> numThreads, ArrayAttr threadDimMapping,
     SmallVectorImpl<Value> *resultingFusedOpsHandles = nullptr);


### PR DESCRIPTION
* the functions suffixed with NumThreads were incorrectly dispatching to those with TileSizes;
* worgroup -> workgroup.