### PR TITLE
Generate `non-coherent cache` loads and `noalias` for CUDA

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/CleanupBufferAllocViewPass.cpp
@@ -91,7 +91,7 @@ struct FoldReshapeIntoInterfaceTensorLoad : OpRewritePattern<TensorReshapeOp> {
         subspanOp.getLoc(), newSubspanType, subspanOp.getSet(),
         subspanOp.getBinding(), subspanOp.getDescriptorType(),
         subspanOp.getByteOffset(), subspanOp.getDynamicDims(),
-        subspanOp.getAlignmentAttr());
+        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
 
     rewriter.replaceOpWithNewOp<IREE::Flow::DispatchTensorLoadOp>(
         reshapeOp, reshapeOp.getResultType(), newSubspanOp,

--- a/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/FlattenMemRefSubspanPass.cpp
@@ -242,7 +242,7 @@ struct FlattenBindingSubspan final
     auto newOp = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
         subspanOp.getLoc(), newType, subspanOp.getSet(), subspanOp.getBinding(),
         subspanOp.getDescriptorType(), subspanOp.getByteOffset(), dynamicDims,
-        subspanOp.getAlignmentAttr());
+        subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
     if (isRankOneMemRef(oldType)) {
       rewriter.replaceOpWithNewOp<memref::CastOp>(subspanOp, oldType, newOp);
     } else {
@@ -661,7 +661,7 @@ struct FoldSubspanOffsetIntoLoadStore final : public OpRewritePattern<OpType> {
     Value newSubspan = rewriter.create<IREE::HAL::InterfaceBindingSubspanOp>(
         memref.getLoc(), subspanOp.getType(), subspanOp.getSet(),
         subspanOp.getBinding(), subspanOp.getDescriptorType(), zero,
-        subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr());
+        subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(), nullptr);
     rewriter.restoreInsertionPoint(ip);
 
     MLIRContext *context = rewriter.getContext();

--- a/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingIntoPackUnPack.cpp
@@ -135,7 +135,8 @@ struct MaterializeInterfaceBindingEncoding
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
         subspanOp, newResultType, subspanOp.getSet(), subspanOp.getBinding(),
         subspanOp.getDescriptorType(), subspanOp.getByteOffset(),
-        convertedDynamicDims.value(), subspanOp.getAlignmentAttr());
+        convertedDynamicDims.value(), subspanOp.getAlignmentAttr(),
+        subspanOp.getDescriptorFlagsAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -92,7 +92,7 @@ static Value findOrCreateSubspanBuffer(
       subspanOp->getLoc(), memRefType, subspanOp.getSet(),
       subspanOp.getBinding(), subspanOp.getDescriptorType(),
       subspanOp.getByteOffset(), subspanOp.getDynamicDims(),
-      subspanOp.getAlignmentAttr());
+      subspanOp.getAlignmentAttr(), subspanOp.getDescriptorFlagsAttr());
   if (subspanOp.getAlignment()) {
     b.create<memref::AssumeAlignmentOp>(
         subspanOp->getLoc(), buffer, subspanOp.getAlignment()->getZExtValue());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_rocdl.mlir
@@ -16,7 +16,7 @@ hal.executable @abs_ex_dispatch_0 {
     builtin.module {
       func.func @abs_ex_dispatch_0() {
         %c0 = arith.constant 0 : index
-        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<16xf32>
+        %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) flags(ReadOnly) : memref<16xf32>
         %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : memref<16xf32>
         %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : memref<16xf32>
         %3 = gpu.block_id x
@@ -34,7 +34,7 @@ hal.executable @abs_ex_dispatch_0 {
   }
 }
 // CHECK-LABEL: llvm.func @abs_ex_dispatch_0
-//  CHECK-SAME: (%{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32}, %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32},
-//  CHECK-SAME:  %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32})
+//  CHECK-SAME: (%{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32, llvm.noalias, llvm.readonly}, %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32, llvm.noalias},
+//  CHECK-SAME:  %{{.*}}: !llvm.ptr<f32> {llvm.align = 16 : i32, llvm.noalias})
 //      CHECK:    rocdl.workgroup.dim.x
 //      CHECK:    llvm.fadd

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVEmulateI64.cpp
@@ -59,7 +59,8 @@ struct ConvertHalInterfaceBindingSubspan final
         rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
             op, newResultTy, adaptor.getSet(), adaptor.getBinding(),
             adaptor.getDescriptorType(), adaptor.getByteOffset(),
-            adaptor.getDynamicDims(), adaptor.getAlignmentAttr());
+            adaptor.getDynamicDims(), adaptor.getAlignmentAttr(),
+            adaptor.getDescriptorFlagsAttr());
     LLVM_DEBUG(llvm::dbgs()
                << "WideIntegerEmulation: new op: " << newOp << "\n");
     (void)newOp;

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorizeLoadStore.cpp
@@ -473,7 +473,8 @@ class ProcessInterfaceBindingSubspan final
     rewriter.replaceOpWithNewOp<IREE::HAL::InterfaceBindingSubspanOp>(
         subspanOp, *vecMemRef, subspanOp.getSet(), subspanOp.getBinding(),
         subspanOp.getDescriptorType(), subspanOp.getByteOffset(),
-        subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr());
+        subspanOp.getDynamicDims(), subspanOp.getAlignmentAttr(),
+        subspanOp.getDescriptorFlagsAttr());
     return success();
   }
 };

--- a/compiler/src/iree/compiler/Codegen/WGSL/WGSLReplacePushConstants.cpp
+++ b/compiler/src/iree/compiler/Codegen/WGSL/WGSLReplacePushConstants.cpp
@@ -158,7 +158,7 @@ class WGSLReplacePushConstantsPass
         /*set=*/APInt(64, IREE_HAL_WEBGPU_PARAMS_BIND_GROUP_INDEX),
         /*binding=*/APInt(64, IREE_HAL_WEBGPU_PARAMS_BINDING_INDEX),
         IREE::HAL::DescriptorType::UniformBuffer,
-        /*byte_offset=*/maxConstantValue, dynamicDims, alignmentAttr);
+        /*byte_offset=*/maxConstantValue, dynamicDims, alignmentAttr, nullptr);
 
     // flow.dispatch.tensor.load -> tensor<Nxvector<4xi32>>
     auto tensorType =

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -1060,6 +1060,19 @@ void ExecutableLookupOp::getAsmResultNames(
 //===----------------------------------------------------------------------===//
 // hal.interface.binding.subspan
 //===----------------------------------------------------------------------===//
+void InterfaceBindingSubspanOp::build(
+    OpBuilder &builder, OperationState &result, Type resultType, APInt set,
+    APInt binding, IREE::HAL::DescriptorType descriptor_type, Value byte_offset,
+    ValueRange dynamic_dims, IntegerAttr alignment,
+    Optional<DescriptorFlags> flags) {
+  IREE::HAL::DescriptorFlagsAttr descriptorAttr;
+  if (flags.has_value()) {
+    descriptorAttr = IREE::HAL::DescriptorFlagsAttr::get(builder.getContext(),
+                                                         flags.value());
+  }
+  build(builder, result, resultType, set, binding, descriptor_type, byte_offset,
+        dynamic_dims, alignment, descriptorAttr);
+}
 
 LogicalResult InterfaceBindingSubspanOp::verify() {
   InterfaceBindingSubspanOp op = *this;

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.td
@@ -2191,8 +2191,24 @@ def HAL_InterfaceBindingSubspanOp : HAL_Op<"interface.binding.subspan", [
     HAL_DescriptorTypeAttr:$descriptor_type,
     Optional<HAL_DeviceSize>:$byte_offset,
     HAL_ShapeDynamicDims:$dynamic_dims,
-    OptionalAttr<IndexAttr>:$alignment
+    OptionalAttr<IndexAttr>:$alignment,
+    OptionalAttr<HAL_DescriptorFlagsAttr>:$descriptor_flags
   );
+  
+let builders = [
+    OpBuilder<(ins
+      "Type":$resultType,
+      "APInt":$set,
+      "APInt":$binding,
+      "IREE::HAL::DescriptorType":$descriptor_type,
+      "Value":$byte_offset,
+      "ValueRange":$dynamic_dims,
+      "IntegerAttr":$alignment,
+      CArg<"mlir::Optional<DescriptorFlags>", "llvm::None">:$flags
+    )>,
+  ];
+
+
   let results = (outs
     Res<AnyType, "", [MemAlloc]>:$result
   );
@@ -2203,6 +2219,7 @@ def HAL_InterfaceBindingSubspanOp : HAL_Op<"interface.binding.subspan", [
     `type` `(` custom<DescriptorType>($descriptor_type) `)`
     (`offset` `(` $byte_offset^ `)`)?
     (`alignment` `(` $alignment^ `)`)?
+    (`flags` `(` $descriptor_flags^ `)`)?
     attr-dict `:` type($result) (`{` $dynamic_dims^ `}`)?
   }];
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MaterializeInterfaces.cpp
@@ -189,7 +189,8 @@ static void convertBindingUsage(
     auto newOp = builder.create<IREE::HAL::InterfaceBindingSubspanOp>(
         oldOp.getLoc(), oldOp.getType(), APInt(64, setLayoutAttr.getOrdinal()),
         APInt(64, bindingAttr.getOrdinal()), bindingAttr.getType(),
-        oldOp.getByteOffset(), oldOp.getDynamicDims(), alignmentAttr);
+        oldOp.getByteOffset(), oldOp.getDynamicDims(), alignmentAttr,
+        bindingAttr.getFlags());
     oldOp.replaceAllUsesWith(newOp.getResult());
     oldOp.erase();
   }

--- a/tests/transform_dialect/cpu/matmul.mlir
+++ b/tests/transform_dialect/cpu/matmul.mlir
@@ -31,9 +31,9 @@ func.func @matmul_static(
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:       builtin.module {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:         func.func @matmul_static_dispatch_0_matmul_3x3x5() {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           arith.constant 0 : index
-// CODEGEN-CUSTOM-DISPATCH-FORMATION:           hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset({{.*}}) alignment(64) : memref<3x5xf32>
+// CODEGEN-CUSTOM-DISPATCH-FORMATION:           hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset({{.*}}) alignment(64) flags(ReadOnly) : memref<3x5xf32>
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           memref.assume_alignment %{{.*}}, 64 : memref<3x5xf32>
-// CODEGEN-CUSTOM-DISPATCH-FORMATION:           hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset({{.*}}) alignment(64) : memref<5x3xf32>
+// CODEGEN-CUSTOM-DISPATCH-FORMATION:           hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset({{.*}}) alignment(64) flags(ReadOnly) : memref<5x3xf32>
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           memref.assume_alignment %{{.*}}, 64 : memref<5x3xf32>
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset({{.*}}) alignment(64) : memref<3x3xf32>
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           memref.assume_alignment %{{.*}}, 64 : memref<3x3xf32>


### PR DESCRIPTION
IREE can recognize `readonly` data. If I'm not mistaken, this indicates the data is read-only and not aliased with data stored in the same region/kernel.

This PR makes advantage of this information to generates the `llvm.noalias` and `llvm.readonly` attributes to CUDA kernel function parameters. If an argument is not readonly, it still set `llvm.noalias` because the ranges used within the bindings are guaranteed not to alias.

This is crucial for two reasons. When the downstream compiler detects that it can better schedule the load instructions. It typically schedules them together that utilized bandwith better. Second, it generates 'non-coherent cache loads' (`nc` prefix to `ld.global` instruction in PTX). What PTX models say about it is as follows (this part gives room for experimentation):

```
The texture cache is larger, has higher bandwidth, and longer latency than the global memory cache.
For applications with sufficient parallelism to cover the longer latency, ld.global.nc should offer 
better performance than ld.global.
```

This PR first extends `hal.interface.binding.subspan` with `readonly` argument.
```
hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) flags(ReadOnly) : memref<16xf32>
```

In convert nvvm pass, it leverages `flags(ReadOnly)` to decide `llvm.readonly` attribute on the function argument. It also marks `llvm.noalias` every other argument. 

```
llvm.func @foo(%arg0: !llvm.ptr<f32> {llvm.align = 16 : i32, llvm.noalias, llvm.readonly})
```