### PR TITLE
Split iree.bufferize_op and cherry-pick linalg patterns

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -52,9 +52,11 @@ using namespace mlir;
 
 // TODO: significantly better namespacing.
 using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
+using iree_compiler::IREE::transform_dialect::ApplyPatternsOpPatterns;
 using iree_compiler::IREE::transform_dialect::ConfigExtractPart;
 using iree_compiler::IREE::transform_dialect::ForeachThreadToWorkgroupOp;
 using iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
+using iree_compiler::IREE::transform_dialect::IREEEliminateEmptyTensorsOp;
 using iree_compiler::IREE::transform_dialect::
     IREEEraseHALDescriptorTypeFromMemRefOp;
 using iree_compiler::IREE::transform_dialect::
@@ -209,13 +211,20 @@ Value mlir::iree_compiler::
 // TODO: configure patterns.
 Value mlir::iree_compiler::buildVectorize(ImplicitLocOpBuilder &b,
                                           Value funcH) {
-  funcH = b.create<ApplyPatternsOp>(funcH, /*rankReducing=*/true);
+  ApplyPatternsOpPatterns patterns;
+  patterns.rankReducing = true;
+  funcH = b.create<ApplyPatternsOp>(funcH, patterns);
   return b.create<VectorizeOp>(funcH);
 }
 
 /// Bufferize and drop HAL descriptor from memref ops.
 Value mlir::iree_compiler::buildBufferize(ImplicitLocOpBuilder &b,
                                           Value variantH, bool targetGpu) {
+  Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
+  ApplyPatternsOpPatterns patterns;
+  patterns.foldReassociativeReshapes = true;
+  funcH = b.create<ApplyPatternsOp>(funcH, patterns);
+  variantH = b.create<IREEEliminateEmptyTensorsOp>(variantH);
   variantH = b.create<IREEBufferizeOp>(variantH, /*targetGpu=*/true);
   Value memrefFunc =
       b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
@@ -240,7 +249,9 @@ static constexpr unsigned kCudaWarpSize = 32;
 Value mlir::iree_compiler::buildDistributeVectors(ImplicitLocOpBuilder &b,
                                                   Value variantH, Value funcH,
                                                   int64_t warpSize) {
-  funcH = b.create<ApplyPatternsOp>(funcH, /*rankReducing=*/true);
+  ApplyPatternsOpPatterns patterns;
+  patterns.rankReducing = true;
+  funcH = b.create<ApplyPatternsOp>(funcH, patterns);
   Value ifH = b.create<MatchOp>(funcH, scf::IfOp::getOperationName());
   // Locally suppress failures for this op only because it doesn't cover the
   // `threadIdx.x == 0 && threadIdx.y == 0` case at the moment.
@@ -296,9 +307,9 @@ static ReductionSplitResult createExpansionBubbleUp(
   }
 
   auto funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
-  auto applyPatterns = b.create<ApplyPatternsOp>(funcH, /*rankReducing=*/false);
-  applyPatterns->setAttr(applyPatterns.getBubbleCollapseExpandAttrName(),
-                         b.getUnitAttr());
+  ApplyPatternsOpPatterns patterns;
+  patterns.bubbleCollapseExpand = true;
+  b.create<ApplyPatternsOp>(funcH, patterns);
   std::tie(result.originalFillH, result.splitFillH) =
       matchAndUnpack<2>(b, variantH, linalg::FillOp::getOperationName());
   if (hasTrailingEltwise) {

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -56,16 +56,30 @@ void mlir::iree_compiler::registerTransformDialectCommonExtension(
 //===---------------------------------------------------------------------===//
 // ApplyPatternsOp
 //===---------------------------------------------------------------------===//
-void transform_dialect::ApplyPatternsOp::build(OpBuilder &builder,
-                                               OperationState &result,
-                                               Value target,
-                                               bool rankReducing) {
+void transform_dialect::ApplyPatternsOp::build(
+    OpBuilder &builder, OperationState &result, Value target,
+    const ApplyPatternsOpPatterns &patterns) {
   MLIRContext *ctx = builder.getContext();
   result.addOperands(target);
-  if (rankReducing) {
-    result.addAttribute(ApplyPatternsOp::getRankReducingAttrName(result.name),
-                        builder.getUnitAttr());
-  }
+  auto unitAttr = builder.getUnitAttr();
+#define ADD_PATTERN(NAME, ATTR) \
+  if (patterns.NAME)            \
+    result.addAttribute(ApplyPatternsOp::ATTR(result.name), unitAttr);
+  ADD_PATTERN(additionalIreePatterns, getAdditionalIreePatternsAttrName)
+  ADD_PATTERN(bubbleCollapseExpand, getBubbleCollapseExpandAttrName)
+  ADD_PATTERN(canonicalization, getCanonicalizationAttrName)
+  ADD_PATTERN(eraseUnnecessaryTensorOperands,
+              getEraseUnnecessaryTensorOperandsAttrName)
+  ADD_PATTERN(foldReassociativeReshapes, getFoldReassociativeReshapesAttrName)
+  ADD_PATTERN(promoteForeachThreadCaptureToShared,
+              getPromoteForeachThreadCaptureToSharedAttrName)
+  ADD_PATTERN(rankReducing, getRankReducingAttrName)
+  ADD_PATTERN(expandMemrefStridedMetadata,
+              getExpandMemrefStridedMetadataAttrName)
+  ADD_PATTERN(swapPaddingElideConditional,
+              getSwapPaddingElideConditionalAttrName)
+  ADD_PATTERN(swappingPatterns, getSwappingPatternsAttrName)
+#undef ADD_PATTERN
   result.addTypes({pdl::OperationType::get(ctx)});
 }
 
@@ -153,6 +167,15 @@ static void addForeachThreadCapturePromotionPatterns(
   patterns.add<PromoteCaptureToSharedOut>(patterns.getContext());
 }
 
+static void addReassociativeReshapePatterns(RewritePatternSet &patterns) {
+  tensor::populateReassociativeReshapeFoldingPatterns(patterns);
+}
+
+static void addEraseUnnecessaryTensorOperandsPatterns(
+    RewritePatternSet &patterns) {
+  linalg::populateEraseUnnecessaryInputsPatterns(patterns);
+}
+
 static void addRankReducingPatterns(RewritePatternSet &patterns) {
   populateReshapeToInterfaceTensorPatterns(patterns);
   vector::populateCastAwayVectorLeadingOneDimPatterns(patterns);
@@ -199,6 +222,9 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
   MLIRContext *ctx = target->getContext();
   RewritePatternSet patterns(ctx);
   if (getCanonicalization()) addAllRegisteredCanonicalizationPatterns(patterns);
+  if (getEraseUnnecessaryTensorOperands())
+    addEraseUnnecessaryTensorOperandsPatterns(patterns);
+  if (getFoldReassociativeReshapes()) addReassociativeReshapePatterns(patterns);
   if (getPromoteForeachThreadCaptureToShared())
     addForeachThreadCapturePromotionPatterns(patterns);
   if (getRankReducing()) addRankReducingPatterns(patterns);
@@ -877,35 +903,7 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
     memCpyFn = gpuComprehensiveBufferizeCopyFn;
   }
 
-  //   0. Run enabling transformations.
-  {
-    RewritePatternSet patterns(getContext());
-    tensor::populateReassociativeReshapeFoldingPatterns(patterns);
-    TrackingListener listener(state);
-    GreedyRewriteConfig config;
-    LogicalResult result = applyPatternsAndFoldGreedily(
-        state.getTopLevel(), std::move(patterns), config, &listener);
-    LogicalResult listenerResult = listener.checkErrorState();
-    if (failed(result)) {
-      return mlir::emitDefiniteFailure(state.getTopLevel(),
-                                       "greedy pattern application failed");
-    }
-    if (failed(listenerResult))
-      return mlir::emitDefiniteFailure(state.getTopLevel(),
-                                       "listener tracking failed");
-  }
-
-  //   1. Eliminate tensor.empty, without the pass baggage.
-  WalkResult res = state.getTopLevel()->walk([&](ModuleOp moduleOp) {
-    if (failed(eliminateEmptyTensors(moduleOp.getOperation(),
-                                     getBufferizationOptions())))
-      return WalkResult::interrupt();
-    return WalkResult::advance();
-  });
-  if (res.wasInterrupted())
-    return DiagnosedSilenceableFailure::definiteFailure();
-
-  //   2. Rewrite tensor.empty to tensor.alloc, without the pass baggage.
+  //   1. Rewrite tensor.empty to tensor.alloc, without the pass baggage.
   {
     RewritePatternSet patterns(getContext());
     patterns.add<EmptyTensorLoweringPattern>(patterns.getContext());
@@ -923,14 +921,14 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
                                        "listener tracking failed");
   }
 
-  //   3. Run one-shot-bufferize, without the pass baggage.
+  //   2. Run one-shot-bufferize, without the pass baggage.
   OneShotBufferizationOptions options = getBufferizationOptions();
   options.allocationFn = allocationFn;
   options.deallocationFn = deallocationFn;
   options.memCpyFn = memCpyFn;
   options.testAnalysisOnly = getTestAnalysisOnly();
   options.printConflicts = getPrintConflicts();
-  res = state.getTopLevel()->walk([&](ModuleOp moduleOp) {
+  WalkResult res = state.getTopLevel()->walk([&](ModuleOp moduleOp) {
     if (failed(runIREEOneShotBufferize(moduleOp, options)))
       return WalkResult::interrupt();
     return WalkResult::advance();
@@ -938,7 +936,7 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
   if (res.wasInterrupted())
     return DiagnosedSilenceableFailure::definiteFailure();
 
-  //   4. Post-bufferization passes are fine.
+  //   3. Post-bufferization passes are fine.
   PassManager pm(getContext());
   addIREEPostBufferizationPasses(pm);
   res = state.getTopLevel()->walk([&](ModuleOp moduleOp) {
@@ -956,6 +954,31 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
 
   results.set(getOperation()->getOpResult(0), payload.front());
   return DiagnosedSilenceableFailure::success();
+}
+
+//===---------------------------------------------------------------------===//
+// IREEEliminateEmptyTensorsOp
+//===---------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure
+transform_dialect::IREEEliminateEmptyTensorsOp::apply(
+    transform::TransformResults &results, transform::TransformState &state) {
+  ArrayRef<Operation *> payloads = state.getPayloadOps(getTarget());
+  for (Operation *payload : payloads) {
+    if (failed(eliminateEmptyTensors(payload, getBufferizationOptions()))) {
+      getOperation()->emitError() << "failed to eliminate tensor.empty ops";
+      return DiagnosedSilenceableFailure::definiteFailure();
+    }
+  }
+  results.set(getOperation()->getOpResult(0), payloads);
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_dialect::IREEEliminateEmptyTensorsOp::build(
+    OpBuilder &builder, OperationState &result, Value target) {
+  result.addOperands(target);
+  MLIRContext *ctx = builder.getContext();
+  result.addTypes(pdl::OperationType::get(ctx));
 }
 
 //===---------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -29,6 +29,26 @@ struct TileSizesSpec;
 struct NumThreadsSpec;
 class TransformTypeInterface;
 }  // namespace transform
+
+namespace iree_compiler {
+namespace IREE {
+namespace transform_dialect {
+/// Selected patterns for ApplyPatternOp.
+struct ApplyPatternsOpPatterns {
+  bool additionalIreePatterns = false;
+  bool bubbleCollapseExpand = false;
+  bool canonicalization = false;
+  bool eraseUnnecessaryTensorOperands = false;
+  bool foldReassociativeReshapes = false;
+  bool promoteForeachThreadCaptureToShared = false;
+  bool rankReducing = false;
+  bool expandMemrefStridedMetadata = false;
+  bool swapPaddingElideConditional = false;
+  bool swappingPatterns = false;
+};
+}  // namespace transform_dialect
+}  // namespace IREE
+}  // namespace iree_compiler
 }  // namespace mlir
 
 #define GET_OP_CLASSES
@@ -43,7 +63,7 @@ void registerTransformDialectCommonExtension(DialectRegistry &registry);
 
 namespace IREE {
 namespace transform_dialect {
-// Hook to register common transformations to the transform dialect.
+/// Hook to register common transformations to the transform dialect.
 class CommonExtensions
     : public transform::TransformDialectExtension<CommonExtensions> {
  public:

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -38,6 +38,10 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
       down across Linalg ops.
       - canonicalization: adds all the canonicalization patterns of all
       registered dialects and ops.
+      - erase_unnecessary_tensor_operands: add patterns that erase unnecessary
+      tensor operands.
+      - fold_reassociative_reshapes: adds patterns that fold insert_slice/
+      extract_slice ops with reassociative reshape ops.
       - promote_foreach_thread_capture_to_shared: adds patterns that rewrite
       uses of values captured by scf.foreach_thread with the matching
       shared_outs bbarg. This checks that the values captured are
@@ -75,6 +79,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
                        UnitAttr:$additional_iree_patterns,
                        UnitAttr:$bubble_collapse_expand,
                        UnitAttr:$canonicalization,
+                       UnitAttr:$erase_unnecessary_tensor_operands,
+                       UnitAttr:$fold_reassociative_reshapes,
                        UnitAttr:$promote_foreach_thread_capture_to_shared,
                        UnitAttr:$rank_reducing,
                        UnitAttr:$expand_memref_strided_metadata,
@@ -87,7 +93,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
 
   let builders = [
     // TODO: Some bitvector to scale better than n-bools.
-    OpBuilder<(ins "Value":$target, "bool":$rankReducing)>
+    OpBuilder<(ins "Value":$target,
+                   "const ApplyPatternsOpPatterns &":$patterns)>
   ];
 
   let extraClassDeclaration = [{
@@ -110,8 +117,8 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
     using the following attributes:
       - target_gpu: if set, GPU allocations are emitted.
 
-    Return modes:
-    =============
+    #### Return modes
+
     This operation calls the upstream one-shot bufferization pass with extra
     registered patterns for IREE.
 
@@ -121,7 +128,7 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
     If any of the pass on any of the ModuleOp fails, the transformation
     definitely fails. Otherwise the transformation succeeds.
 
-    No handles are consumed or produced.
+    This transform consumes the target handle and produces a result handle.
   }];
 
   let arguments = (
@@ -137,6 +144,35 @@ def IREEBufferizeOp : Op<Transform_Dialect, "iree.bufferize",
 
   let builders = [
     OpBuilder<(ins "Value":$target, CArg<"bool", "false">:$targetGpu)>
+  ];
+}
+
+def IREEEliminateEmptyTensorsOp : Op<
+    Transform_Dialect, "iree.eliminate_empty_tensors",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     DeclareOpInterfaceMethods<TransformOpInterface>]> {
+  let description = [{
+    This is a pre-processing pass for iree.bufferize. It tries to remove
+    tensor.empty ops by replacing them with a suitable destination tensors,
+    which can reduce the number of allocations when bufferizing.
+
+    This transform is not part of iree.bufferize because additional
+    canonicalization are sometimes possible after eliminate_empty_tensors but
+    before iree.bufferize.
+
+    #### Return modes
+
+    This transform consumes the target handle and produces a result handle.
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$result);
+  let assemblyFormat = "attr-dict $target";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/transform_dialect_bufferize.mlir
@@ -35,7 +35,8 @@ hal.executable private @pad_matmul_static_dispatch_0 {
 
 transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
-  %variant_op_2 = transform.iree.bufferize %variant_op
-  %func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  %func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %func
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -37,9 +37,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
 //     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
 //         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+//         CHECK:   %[[ADDED:.*]] = arith.addi %[[TIDZ]], %[[workgroup_id_x]]
 
 // Distributed reduction: everyone loads then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+//         CHECK:   vector.transfer_read %{{.*}}[%[[ADDED]], %[[TIDY]], %[[TIDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
@@ -104,9 +105,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
 //     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
 //         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+//         CHECK:   %[[ADDED:.*]] = arith.addi %[[TIDZ]], %[[workgroup_id_x]]
 
 // Distributed reduction: everyone loads then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+//         CHECK:   vector.transfer_read %{{.*}}[%[[ADDED]], %[[TIDY]], %[[TIDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
@@ -171,9 +173,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
 
 //         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+//         CHECK:   %[[ADDED:.*]] = arith.addi %[[TIDZ]], %[[workgroup_id_x]]
 
 // Distributed reduction: everyone loads, does the elementwise then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+//         CHECK:   vector.transfer_read %{{.*}}[%[[ADDED]], %[[TIDY]], %[[TIDX]]]
 //         CHECK:   arith.addf
 //         CHECK:   arith.addf
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
@@ -245,9 +248,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
 
 //         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+//         CHECK:   %[[ADDED:.*]] = arith.addi %[[TIDZ]], %[[workgroup_id_x]]
 
 // Distributed reduction: everyone loads, does the elementwise then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+//         CHECK:   vector.transfer_read %{{.*}}[%[[ADDED]], %[[TIDY]], %[[TIDX]]]
 //         CHECK:   arith.addf
 //         CHECK:   arith.addf
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_bufferize.mlir
@@ -29,8 +29,9 @@ hal.executable private @pad_matmul_static_dispatch_0  {
 
   transform.structured.canonicalized_sequence failures(propagate) {
   ^bb1(%variant_op: !pdl.operation):
-    %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-    %func = transform.structured.match ops{["func.func"]} in %variant_op_2
+    %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+    %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+    %func = transform.structured.match ops{["func.func"]} in %variant_op_3
     transform.iree.erase_hal_descriptor_type_from_memref %func
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_bufferize_spec.mlir
@@ -1,6 +1,7 @@
 transform.structured.canonicalized_sequence failures(propagate) {
 ^bb1(%variant_op: !pdl.operation):
-  %variant_op_2 = transform.iree.bufferize %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_codegen_foreach_to_gpu_spec.mlir
@@ -8,12 +8,13 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %foreach_thread_2, %tiled_matmul = transform.structured.tile_to_foreach_thread_op %1 num_threads [7, 9]
   ( mapping = [#gpu.thread<x>, #gpu.thread<y>] )
 
-  %variant_op_2 = transform.iree.bufferize %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Get the function to which to apply to.
-  %2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op_2
+  %2 = transform.structured.match ops{["linalg.matmul"]} in %variant_op_3
   %func = transform.get_closest_isolated_parent %2 : (!pdl.operation) -> !pdl.operation
   transform.iree.map_nested_foreach_thread_to_gpu_threads %func { workgroup_size = [10, 11]}
 }

--- a/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
+++ b/tests/transform_dialect/cpu/matmul_codegen_default_spec.mlir
@@ -13,12 +13,13 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 2. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  %variant_op_2 = transform.iree.bufferize %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 3. Post-bufferization mapping workgroup.
   // =========================================================
-  %func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.foreach_thread_to_workgroup %func
 }

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -29,6 +29,7 @@ iree_lit_test_suite(
         "reduction.mlir",
         "reduction_eltwise.mlir",
         "reduction_v2.mlir",
+        "reduction_v2_uneven.mlir",
         "softmax.mlir",
         "softmax_v2.mlir",
         # First few ops of softmax only, acts as a proxy example.

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "reduction.mlir"
     "reduction_eltwise.mlir"
     "reduction_v2.mlir"
+    "reduction_v2_uneven.mlir"
     "softmax.mlir"
     "softmax_partial.mlir"
     "softmax_v2.mlir"

--- a/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
@@ -64,13 +64,14 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_3
   %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
   %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
       { workgroup_size = [32, 2, 1] }
@@ -78,10 +79,10 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
   %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  transform.sequence %variant_op_3 : !pdl.operation failures(suppress) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
@@ -71,13 +71,14 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_3
   %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
   %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
       { workgroup_size = [32, 2, 1] }
@@ -85,10 +86,10 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
   %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  transform.sequence %variant_op_3 : !pdl.operation failures(suppress) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }

--- a/tests/transform_dialect/cuda/reduction.mlir
+++ b/tests/transform_dialect/cuda/reduction.mlir
@@ -51,9 +51,10 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
   //     CHECK-DAG: %[[TIDZ:.]] = gpu.thread_id  z
 
   //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+  //         CHECK: %[[ADDED:.*]] = arith.addi %[[TIDZ]], %[[workgroup_id_x]]
 
   // Distributed reduction: everyone loads then 5 xor + addf expected
-  //         CHECK: vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+  //         CHECK: vector.transfer_read %{{.*}}[%[[ADDED]], %[[TIDY]], %[[TIDX]]]
   // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
   //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -43,26 +43,28 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_4 = transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes }
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
-  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
-  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
+  %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_3
+  %func_6 = transform.iree.foreach_thread_to_workgroup %func_5
+  %func_7 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_6
       { workgroup_size = [32, 2, 1] }
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %func_8 = transform.iree.apply_patterns %func_7 { rank_reducing }
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  transform.sequence %variant_op_3 : !pdl.operation failures(suppress) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_7
+  transform.iree.vector.warp_distribute %func_8
 }

--- a/tests/transform_dialect/cuda/reduction_eltwise.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise.mlir
@@ -59,9 +59,10 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
   //     CHECK-DAG: %[[TIDZ:.]] = gpu.thread_id  z
 
   //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+  //         CHECK: %[[ADDED:.*]] = arith.addi %[[TIDZ]], %[[workgroup_id_x]]
 
   // Distributed reduction: everyone loads then 5 xor + addf expected
-  //         CHECK: vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+  //         CHECK: vector.transfer_read %{{.*}}[%[[ADDED]], %[[TIDY]], %[[TIDX]]]
   // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
   //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}

--- a/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_eltwise_codegen_spec.mlir
@@ -47,26 +47,28 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 5. Bufferize and drop HAL decriptor from memref ops.
   // ===========================================================================
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_4 = transform.iree.apply_patterns %func_3 { fold_reassociative_reshapes }
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 6. Post-bufferization mapping to blocks and threads.
   // ===========================================================================
-  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
-  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
-  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
+  %func_5 = transform.structured.match ops{["func.func"]} in %variant_op_3
+  %func_6 = transform.iree.foreach_thread_to_workgroup %func_5
+  %func_7 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_6
       { workgroup_size = [32, 2, 1] }
 
   // Step 7. Post-bufferization vector distribution with rank-reduction.
   // ===========================================================================
-  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %func_8 = transform.iree.apply_patterns %func_7 { rank_reducing }
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   // Don't complain about unsupported if (threadIdx.x == 0 && threadIdx.y == 0)
   // at this point.
-  transform.sequence %variant_op_2 : !pdl.operation failures(suppress) {
+  transform.sequence %variant_op_3 : !pdl.operation failures(suppress) {
   ^bb0(%arg0: !pdl.operation):
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
-  transform.iree.vector.warp_distribute %func_7
+  transform.iree.vector.warp_distribute %func_8
 }

--- a/tests/transform_dialect/cuda/reduction_v2_uneven.mlir
+++ b/tests/transform_dialect/cuda/reduction_v2_uneven.mlir
@@ -1,0 +1,67 @@
+!in_tensor_t = tensor<33x34567xf32>
+!out_tensor_t = tensor<33xf32>
+
+func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->   !out_tensor_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_t
+  return %2 : !out_tensor_t
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v2_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v2_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="33x34567xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+  //     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  //     CHECK-DAG: %[[C1:.*]] = arith.constant 1 : index
+  //     CHECK-DAG: %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<4xf32>
+  //     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+  //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 128 : i64} : memref<1x128xf32, 3>
+  
+  //         CHECK: %[[TIDX:.]] = gpu.thread_id  x
+  //         CHECK: %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
+  //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<4xf32, strided<[1], offset: ?>, 3>
+  //         CHECK: gpu.barrier
+  // Local per-thread scf.for-based reduction.
+  //         CHECK: scf.for
+  //     CHECK-NOT:   memref.alloc
+  //         CHECK:   linalg.generic
+  // TODO: remote unnecessary barrier within the loop
+  //         CHECK:   gpu.barrier
+
+  //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+  // Distributed reduction: everyone loads then 5 xor + addf expected
+  //         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
+  // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+  //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}
+
+  //         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+  //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+  //         CHECK: scf.if %[[CONDXIS0]]
+  //         CHECK:   vector.transfer_write %[[RES_VEC]]
+  //         CHECK: gpu.barrier
+
+// only checking the first 6 of 33
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 33xf32=34567 34567 34567 34567 34567 34567

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -75,22 +75,23 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // =========================================================
-  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3
   %func_3 = transform.iree.foreach_thread_to_workgroup %func_2
   transform.iree.map_nested_foreach_thread_to_gpu_threads %func_3
     { workgroup_size = [32, 4, 1] }
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===================================================================
-  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing }
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   transform.iree.vector.warp_distribute %end_func_2
 }

--- a/tests/transform_dialect/cuda/softmax_partial_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_partial_codegen_spec.mlir
@@ -59,22 +59,23 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // =========================================================
-  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3
   %func_3 = transform.iree.foreach_thread_to_workgroup %func_2
   transform.iree.map_nested_foreach_thread_to_gpu_threads %func_3
     { workgroup_size = [32, 4, 1] }
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===================================================================
-  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing }
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   transform.iree.vector.warp_distribute %end_func_2
 }

--- a/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_v2_codegen_spec.mlir
@@ -66,22 +66,23 @@ transform.structured.canonicalized_sequence failures(propagate) {
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   // =========================================================
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // =========================================================
-  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3
   %func_3 = transform.iree.foreach_thread_to_workgroup %func_2
   transform.iree.map_nested_foreach_thread_to_gpu_threads %func_3
     { workgroup_size = [32, 4, 1] }
 
   // Step 6. Post-bufferization vector distribution with rank-reduction.
   // ===================================================================
-  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %end_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   %end_func_2 = transform.iree.apply_patterns %end_func { rank_reducing }
-  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   transform.iree.vector.warp_distribute %end_func_2
 }

--- a/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d_codegen_spec.mlir
@@ -10,12 +10,13 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op
   transform.iree.apply_patterns %func { rank_reducing }
-  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
-  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %variant_op_2 = transform.iree.eliminate_empty_tensors %variant_op
+  %variant_op_3 = transform.iree.bufferize { target_gpu } %variant_op_2
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.erase_hal_descriptor_type_from_memref %memref_func
 
   // Step 3. Map to GPU thread blocks.
   // ===========================================================================
-  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_2 = transform.structured.match ops{["func.func"]} in %variant_op_3
   transform.iree.foreach_thread_to_workgroup %func_2
 }


### PR DESCRIPTION
Extract reassociative reshape patterns and empty tensor elimination from `iree.bufferize`. Add `fold_reassociative_reshapes` and `erase_unnecessary_tensor_operands` to `apply_patterns`.

Splitting the bufferization op allows for other canonicalizations to kick in in-between.
