### PR TITLE
Add command line flag for Winograd output tile size

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -170,7 +170,7 @@ createTileAndDecomposeWinogradTransformPass();
 // Creates a pass to convert linalg convolution ops into a sequence of
 // linalg_ext.winograd.* ops and linalg.batch_matmul ops using the winograd
 // tranformation.
-std::unique_ptr<Pass> createConvertConv2DToWinogradPass();
+std::unique_ptr<Pass> createConvertConv2DToWinogradPass(int outputTileSize = 6);
 
 // Marker used as attribute the depth of the split reduction transformations.
 const StringLiteral kSplitReductionDepthMarker = "__split_reduction_depth__";

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -94,6 +94,10 @@ def ConvertConv2DToWinograd :
     Pass<"iree-linalg-ext-convert-conv2d-to-winograd", ""> {
   let summary = "Convert linalg convolution ops to winograd based implementation";
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::createConvertConv2DToWinogradPass()";
+  let options = [
+    Option<"outputTileSize", "output-tile-size", "int",
+           /*default=*/"6", "Output tile size for Winograd transform">,
+  ];
 }
 
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/WinogradConstants.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/WinogradConstants.h
@@ -82,6 +82,62 @@ const float A_6x6_3x3[] = {
 
 // clang-format on
 
+//===----------------------------------------------------------------------===//
+// Output tile size = 4, Kernel size = 3
+//===----------------------------------------------------------------------===//
+// These constants were obtained from this paper:
+//
+// Lavin, A. et al (2016) Fast Algorithms for Convolution Neural Networks.
+// https://openaccess.thecvf.com/content_cvpr_2016/papers/Lavin_Fast_Algorithms_for_CVPR_2016_paper.pdf
+//
+
+// clang-format off
+
+const float BT_4x4_3x3[] = {
+  4,  0, -5,  0, 1, 0,
+  0, -4, -4,  1, 1, 0,
+  0,  4, -4, -1, 1, 0,
+  0, -2, -1,  2, 1, 0,
+  0,  2, -1, -2, 1, 0,
+  0,  4,  0, -5, 0, 1
+};
+
+const float B_4x4_3x3[] = {
+  4,  0,  0,  0,  0,  0,
+  0, -4,  4, -2,  2,  4,
+ -5, -4, -4, -1, -1,  0,
+  0,  1, -1,  2, -2, -5,
+  1,  1,  1,  1,  1,  0,
+  0,  0,  0,  0,  0,  1
+};
+
+const float G_4x4_3x3[] = {
+   1./4.,       0,       0,
+  -1./6.,  -1./6.,  -1./6.,
+  -1./6.,   1./6.,  -1./6.,
+  1./24.,  1./12.,   1./6.,
+  1./24., -1./12.,   1./6.,
+       0,       0,       1
+};
+
+const float AT_4x4_3x3[] = {
+  1, 1,  1, 1,  1, 0,
+  0, 1, -1, 2, -2, 0,
+  0, 1,  1, 4,  4, 0,
+  0, 1, -1, 8, -8, 1
+};
+
+const float A_4x4_3x3[] = {
+  1,  0, 0,  0,
+  1,  1, 1,  1,
+  1, -1, 1, -1,
+  1,  2, 4,  8,
+  1, -2, 4, -8,
+  0,  0, 0,  1
+};
+
+// clang-format on
+
 } // namespace Winograd
 } // namespace LinalgExt
 } // namespace IREE

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeWinogradPass.cpp
@@ -63,6 +63,10 @@ public:
     const int64_t inputTileSize = inputOp.getInputTileSize();
     const int64_t outputTileSize = inputOp.getOutputTileSize();
     switch (outputTileSize) {
+    case 4:
+      B = IREE::LinalgExt::Winograd::B_4x4_3x3;
+      BT = IREE::LinalgExt::Winograd::BT_4x4_3x3;
+      break;
     case 6:
       B = IREE::LinalgExt::Winograd::B_6x6_3x3;
       BT = IREE::LinalgExt::Winograd::BT_6x6_3x3;
@@ -219,6 +223,10 @@ public:
     const int64_t inputTileSize = outputOp.getInputTileSize();
     const int64_t outputTileSize = outputOp.getOutputTileSize();
     switch (outputTileSize) {
+    case 4:
+      A = IREE::LinalgExt::Winograd::A_4x4_3x3;
+      AT = IREE::LinalgExt::Winograd::AT_4x4_3x3;
+      break;
     case 6:
       A = IREE::LinalgExt::Winograd::A_6x6_3x3;
       AT = IREE::LinalgExt::Winograd::AT_6x6_3x3;


### PR DESCRIPTION
This patch adds a command line option for the
Winograd output tile size instead of hardcoding it. This patch also adds transformation matrices for
the 4x4 output tile size.