### PR TITLE
Proper fixes for bufferizing LinalgExt ops that have non DPS operands.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2366,7 +2366,6 @@ func.func @unpack() {
 
 // -----
 
-
 func.func @unpack_fully_dynamic() {
   %c0 = arith.constant 0 : index
   %inner_d0 = util.unfoldable_constant 2 : index

--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -2365,6 +2365,26 @@ func.func @unpack() {
 // CHECK-SAME:   inner_dims_pos = [0, 1] inner_tiles = [2, 2] into %[[OUT]]
 
 // -----
+
+
+func.func @unpack_fully_dynamic() {
+  %c0 = arith.constant 0 : index
+  %inner_d0 = util.unfoldable_constant 2 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<2x2x2x2xi32>>
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<4x4xi32>>
+  %2 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [4, 4], strides = [1, 1] : !flow.dispatch.tensor<writeonly:tensor<4x4xi32>> -> tensor<4x4xi32>
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [2, 2, %inner_d0, %inner_d0], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<2x2x2x2xi32>> -> tensor<2x2x?x?xi32>
+  %4 = iree_linalg_ext.unpack %3 inner_dims_pos = [0, 1] inner_tiles = [%inner_d0, %inner_d0] into %2 : (tensor<2x2x?x?xi32> tensor<4x4xi32>) -> tensor<4x4xi32>
+  flow.dispatch.tensor.store %4, %1, offsets = [0, 0], sizes = [4, 4], strides = [1, 1] : tensor<4x4xi32> -> !flow.dispatch.tensor<writeonly:tensor<4x4xi32>>
+  return
+}
+
+// CHECK:      func.func @unpack_fully_dynamic
+// CHECK-DAG:  %[[D:.+]] = util.optimization_barrier %c2 : index
+// CHECK:      iree_linalg_ext.unpack
+// CHECK-SAME:   inner_dims_pos = [0, 1] inner_tiles = [%[[D]], %[[D]]]
+
+// -----
 module {
   func.func @reduction_ew() {
     %c5120 = arith.constant 5120 : index

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -278,11 +278,9 @@ static LogicalResult bufferizeLinalgExtOp(RewriterBase &rewriter,
   SmallVector<Value> newOperands = newInputBuffers;
   newOperands.append(newOutputBuffers.begin(), newOutputBuffers.end());
 
-  // PackOp has other operands besides ins and outs.
-  if (auto packOp = dyn_cast<IREE::LinalgExt::PackOp>(op.getOperation())) {
-    newOperands.append(packOp.getInnerTiles().begin(),
-                       packOp.getInnerTiles().end());
-    if (auto pad = packOp.getPaddingValue()) newOperands.push_back(pad);
+  // Append other operands besides ins and outs.
+  for (auto nonDPSOperands : op.getNonInputOrOutputOperands()) {
+    newOperands.push_back(nonDPSOperands->get());
   }
 
   // Set insertion point now that potential alloc/dealloc are introduced.


### PR DESCRIPTION
There can be non DPS operands for LinalgExt ops, this is a more general fix that was landed in https://github.com/iree-org/iree/pull/11487