### PR TITLE
 Make `PackOp::{getResultShape,getPackedType}` agree on dynamic dims.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -59,6 +59,10 @@ SmallVector<int64_t> computeInterchangeFromDimPos(ArrayRef<int64_t> dimsPos,
 Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
                                 Location loc, PatternRewriter &rewriter);
 
+// Converts OpFoldResults to int64_t shape entries, unconditionally mapping all
+// Value's to kDynamic, even if they are arith.constant values.
+SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs);
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1747,6 +1747,47 @@ SmallVector<int64_t> PackOp::getStaticTiles() {
   return ::getStaticTiles(*this);
 }
 
+// Helper for PackOp::{getResultShape,getPackedType}. Returns the shape of the
+// packed type. Having a shared helper helps implement these two methods in a
+// way that ensures that they agree on which dimensions are dynamic.
+static SmallVector<int64_t> getPackOpResultTypeShape(
+    ArrayRef<int64_t> sourceShape, ArrayRef<int64_t> innerTileSizes,
+    ArrayRef<int64_t> innerDimsPos, ArrayRef<int64_t> outerDimsPerm) {
+  SmallVector<int64_t> resultShape = llvm::to_vector(sourceShape);
+  for (auto tiledDim : llvm::enumerate(innerDimsPos)) {
+    if (ShapedType::isDynamic(resultShape[tiledDim.value()]))
+      continue;
+    if (ShapedType::isDynamic(innerTileSizes[tiledDim.index()])) {
+      resultShape[tiledDim.value()] = ShapedType::kDynamic;
+      continue;
+    }
+    resultShape[tiledDim.value()] = ceilDiv(resultShape[tiledDim.value()],
+                                            innerTileSizes[tiledDim.index()]);
+  }
+
+  // Swap tile loops if outer_dims_perm is available.
+  resultShape = interchange<int64_t>(resultShape, outerDimsPerm, /*offset=*/0);
+
+  // Append the inner tile dimensions.
+  resultShape.append(innerTileSizes.begin(), innerTileSizes.end());
+  return resultShape;
+}
+
+// Converts OpFoldResults to int64_t shape entries, unconditionally mapping all
+// Value's to kDynamic, even if they are arith.constant values.
+static SmallVector<int64_t>
+asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
+  SmallVector<int64_t> result;
+  for (auto o : ofrs) {
+    // Have to do this first, as getConstantIntValue special-cases constants.
+    if (o.dyn_cast<Value>())
+      result.push_back(ShapedType::kDynamic);
+    else
+      result.push_back(getConstantIntValue(o).value_or(ShapedType::kDynamic));
+  }
+  return result;
+}
+
 SmallVector<OpFoldResult> PackOp::getResultShape(
     OpBuilder &builder, Location loc, ArrayRef<OpFoldResult> sourceDims,
     ArrayRef<OpFoldResult> innerTileSizes, ArrayRef<int64_t> innerDimsPos,
@@ -1766,6 +1807,23 @@ SmallVector<OpFoldResult> PackOp::getResultShape(
         interchange<OpFoldResult>(resultDims, outerDimsPerm, /*offset=*/0);
   }
   resultDims.append(innerTileSizes.begin(), innerTileSizes.end());
+
+  SmallVector<int64_t> resultTypeShape =
+      getPackOpResultTypeShape(asShapeWithAnyValueAsDynamic(sourceDims),
+                               asShapeWithAnyValueAsDynamic(innerTileSizes),
+                               innerDimsPos, outerDimsPerm);
+
+  // Fix-up `resultDims` to ensure that they are Value's if and only if the
+  // result type shape says it's a dynamic dim. This is needed as callers may
+  // use dispatchIndexOpFoldResults on the result, and rely on exact number of
+  // dynamic dims returned by that.
+  for (unsigned i = 0; i < resultDims.size(); ++i) {
+    if (!ShapedType::isDynamic(resultTypeShape[i]))
+      continue;
+    resultDims[i] =
+        getValueOrCreateConstantIndexOp(builder, loc, resultDims[i]);
+  }
+
   return resultDims;
 }
 
@@ -1777,29 +1835,16 @@ ShapedType PackOp::getPackedType(ShapedType sourceType,
                                  ArrayRef<int64_t> innerTileSizes,
                                  ArrayRef<int64_t> innerDimsPos,
                                  ArrayRef<int64_t> outerDimsPerm) {
-  SmallVector<int64_t> resultShape = llvm::to_vector(sourceType.getShape());
-  for (auto tiledDim : llvm::enumerate(innerDimsPos)) {
-    if (ShapedType::isDynamic(resultShape[tiledDim.value()]))
-      continue;
-    if (ShapedType::isDynamic(innerTileSizes[tiledDim.index()])) {
-      resultShape[tiledDim.value()] = ShapedType::kDynamic;
-      continue;
-    }
-    resultShape[tiledDim.value()] = ceilDiv(resultShape[tiledDim.value()],
-                                            innerTileSizes[tiledDim.index()]);
-  }
+  SmallVector<int64_t> resultTypeShape = getPackOpResultTypeShape(
+      sourceType.getShape(), innerTileSizes, innerDimsPos, outerDimsPerm);
 
-  // Swap tile loops if outer_dims_perm is available.
-  resultShape = interchange<int64_t>(resultShape, outerDimsPerm, /*offset=*/0);
-
-  // Append the inner tile dimensions.
-  resultShape.append(innerTileSizes.begin(), innerTileSizes.end());
   return TypeSwitch<ShapedType, ShapedType>(sourceType)
       .Case<RankedTensorType>([&](auto shapedType) {
-        return RankedTensorType::get(resultShape, shapedType.getElementType());
+        return RankedTensorType::get(resultTypeShape,
+                                     shapedType.getElementType());
       })
       .Case<MemRefType>([&](auto shapedType) {
-        return MemRefType::get(resultShape, shapedType.getElementType());
+        return MemRefType::get(resultTypeShape, shapedType.getElementType());
       })
       .Default([&](Type t) {
         assert(false && "unexpected type");

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1773,21 +1773,6 @@ static SmallVector<int64_t> getPackOpResultTypeShape(
   return resultShape;
 }
 
-// Converts OpFoldResults to int64_t shape entries, unconditionally mapping all
-// Value's to kDynamic, even if they are arith.constant values.
-static SmallVector<int64_t>
-asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
-  SmallVector<int64_t> result;
-  for (auto o : ofrs) {
-    // Have to do this first, as getConstantIntValue special-cases constants.
-    if (o.dyn_cast<Value>())
-      result.push_back(ShapedType::kDynamic);
-    else
-      result.push_back(getConstantIntValue(o).value_or(ShapedType::kDynamic));
-  }
-  return result;
-}
-
 SmallVector<OpFoldResult> PackOp::getResultShape(
     OpBuilder &builder, Location loc, ArrayRef<OpFoldResult> sourceDims,
     ArrayRef<OpFoldResult> innerTileSizes, ArrayRef<int64_t> innerDimsPos,

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
@@ -80,6 +80,18 @@ Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
                RankedTensorType::get(shape, rewriter.getF32Type()), vector));
 }
 
+SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
+  SmallVector<int64_t> result;
+  for (auto o : ofrs) {
+    // Have to do this first, as getConstantIntValue special-cases constants.
+    if (o.dyn_cast<Value>())
+      result.push_back(ShapedType::kDynamic);
+    else
+      result.push_back(getConstantIntValue(o).value_or(ShapedType::kDynamic));
+  }
+  return result;
+}
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler


### PR DESCRIPTION
Callers of `PackOp::getResultShape` often pass the result to `dispatchIndexOpFoldResults`, making it matter which `OpFoldResult` contain a `Value`.

But the implementation of `PackOp::getResultShape` calls `makeComposedFoldedAffineApply`, which folds arith.constant values.

This resulted in compilation errors in test cases with dynamic tile sizes with `arith.constant` size values.