### PR TITLE
Make "having microkernels" a target attribute.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -184,7 +184,9 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
         return signalPassFailure();
       }
 
-      bool lowerToAVX2 = hasAVX2Feature(variantOp.getTarget());
+      auto target = variantOp.getTarget();
+      bool lowerToAVX2 = hasAVX2Feature(target);
+      bool enableMicrokernels = hasMicrokernels(target);
       if (!testLoweringConfiguration) {
         switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUDefault:
@@ -234,7 +236,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addCPUDataTilingPipeline(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::VMVXDefault:
-            addVMVXDefaultPassPipeline(executableLoweringPipeline);
+            addVMVXDefaultPassPipeline(executableLoweringPipeline,
+                                       enableMicrokernels);
             break;
           // Transform-dialect pipelines.
           case IREE::Codegen::DispatchLoweringPassPipeline::

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -303,7 +303,8 @@ void addCPUDataTilingPipeline(OpPassManager &passManager);
 
 /// Populates the passes to lower to tiled/distributed/bufferized ops,
 /// suitable for library call dispatch and lowering to loops.
-void addVMVXDefaultPassPipeline(OpPassManager &passManager);
+void addVMVXDefaultPassPipeline(OpPassManager &passManager,
+                                bool enableMicrokernels);
 
 /// Populates the passes to lower linalg ops on buffers. Currenly this
 /// pipeline is only used for dispatches that just copy data from input

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -92,6 +92,16 @@ Optional<IntegerAttr> getConfigIntegerAttr(
   return attr;
 }
 
+Optional<BoolAttr> getConfigBoolAttr(IREE::HAL::ExecutableTargetAttr targetAttr,
+                                     StringRef integerAttr) {
+  if (!targetAttr) return llvm::None;
+  auto config = targetAttr.getConfiguration();
+  if (!config) return llvm::None;
+  auto attr = config.getAs<BoolAttr>(integerAttr);
+  if (!attr) return llvm::None;
+  return attr;
+}
+
 Optional<llvm::Triple> getTargetTriple(
     IREE::HAL::ExecutableTargetAttr targetAttr) {
   auto triple = getConfigStringAttr(targetAttr, "target_triple");
@@ -123,7 +133,12 @@ bool isRISCV(IREE::HAL::ExecutableTargetAttr targetAttr) {
 }
 
 bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr) {
-  return targetAttr.getBackend().getValue().startswith("vmvx");
+  return targetAttr && targetAttr.getBackend().getValue().startswith("vmvx");
+}
+
+bool hasMicrokernels(IREE::HAL::ExecutableTargetAttr targetAttr) {
+  auto enableMicrokernels = getConfigBoolAttr(targetAttr, "ukernels");
+  return enableMicrokernels && enableMicrokernels->getValue();
 }
 
 // TODO(dcaballe): If we have to check for a significantly large number of

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -53,6 +53,11 @@ Optional<StringAttr> getConfigStringAttr(
 Optional<IntegerAttr> getConfigIntegerAttr(
     IREE::HAL::ExecutableTargetAttr targetAttr, StringRef integerAttr);
 
+/// Returns the BoolAttr with the name `integerAttr` in the `targetAttr`, if
+/// found.
+Optional<BoolAttr> getConfigBoolAttr(IREE::HAL::ExecutableTargetAttr targetAttr,
+                                     StringRef integerAttr);
+
 /// Returns the LLVM Target triple associated with the `targetAttr`, if set.
 Optional<llvm::Triple> getTargetTriple(
     IREE::HAL::ExecutableTargetAttr targetAttr);

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -65,6 +65,7 @@ bool isX86(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isAArch64(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isRISCV(IREE::HAL::ExecutableTargetAttr targetAttr);
 bool isVMVXBackend(IREE::HAL::ExecutableTargetAttr targetAttr);
+bool hasMicrokernels(IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Returns true if `targetAttr` has `feature` in its CPU features.
 bool hasFeature(IREE::HAL::ExecutableTargetAttr targetAttr, StringRef feature);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/VMVX/VMVXTarget.cpp
@@ -29,6 +29,21 @@ namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
+static llvm::cl::opt<bool> clEnableMicrokernels(
+    "iree-vmvx-enable-microkernels",
+    llvm::cl::desc("Enables microkernel lowering for vmvx (experimental)"),
+    llvm::cl::init(false));
+
+static IREE::HAL::ExecutableTargetAttr getVMVXExecutableTarget(
+    MLIRContext *context, StringRef backend, StringRef format) {
+  SmallVector<NamedAttribute> config;
+  config.emplace_back(StringAttr::get(context, "ukernels"),
+                      BoolAttr::get(context, clEnableMicrokernels));
+  return IREE::HAL::ExecutableTargetAttr::get(
+      context, StringAttr::get(context, backend),
+      StringAttr::get(context, format), DictionaryAttr::get(context, config));
+}
+
 class VMVXTargetBackend final : public TargetBackend {
  public:
   VMVXTargetBackend() = default;
@@ -124,14 +139,9 @@ class VMVXTargetBackend final : public TargetBackend {
   ArrayAttr getExecutableTargets(MLIRContext *context) const {
     SmallVector<Attribute> targetAttrs;
     // This is where we would multiversion.
-    targetAttrs.push_back(getExecutableTarget(context));
+    targetAttrs.push_back(
+        getVMVXExecutableTarget(context, "vmvx", "vmvx-bytecode-fb"));
     return ArrayAttr::get(context, targetAttrs);
-  }
-
-  IREE::HAL::ExecutableTargetAttr getExecutableTarget(
-      MLIRContext *context) const {
-    return IREE::HAL::ExecutableTargetAttr::get(context, "vmvx",
-                                                "vmvx-bytecode-fb");
   }
 };
 
@@ -168,14 +178,9 @@ class VMVXInlineTargetBackend final : public TargetBackend {
   ArrayAttr getExecutableTargets(MLIRContext *context) const {
     SmallVector<Attribute> targetAttrs;
     // This is where we would multiversion.
-    targetAttrs.push_back(getExecutableTarget(context));
+    targetAttrs.push_back(
+        getVMVXExecutableTarget(context, "vmvx-inline", "vmvx-ir"));
     return ArrayAttr::get(context, targetAttrs);
-  }
-
-  IREE::HAL::ExecutableTargetAttr getExecutableTarget(
-      MLIRContext *context) const {
-    return IREE::HAL::ExecutableTargetAttr::get(context, "vmvx-inline",
-                                                "vmvx-ir");
   }
 };
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -59,6 +59,10 @@ SmallVector<int64_t> computeInterchangeFromDimPos(ArrayRef<int64_t> dimsPos,
 Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
                                 Location loc, PatternRewriter &rewriter);
 
+// Converts OpFoldResults to int64_t shape entries, unconditionally mapping all
+// Value's to kDynamic, even if they are arith.constant values.
+SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs);
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1747,6 +1747,47 @@ SmallVector<int64_t> PackOp::getStaticTiles() {
   return ::getStaticTiles(*this);
 }
 
+// Helper for PackOp::{getResultShape,getPackedType}. Returns the shape of the
+// packed type. Having a shared helper helps implement these two methods in a
+// way that ensures that they agree on which dimensions are dynamic.
+static SmallVector<int64_t> getPackOpResultTypeShape(
+    ArrayRef<int64_t> sourceShape, ArrayRef<int64_t> innerTileSizes,
+    ArrayRef<int64_t> innerDimsPos, ArrayRef<int64_t> outerDimsPerm) {
+  SmallVector<int64_t> resultShape = llvm::to_vector(sourceShape);
+  for (auto tiledDim : llvm::enumerate(innerDimsPos)) {
+    if (ShapedType::isDynamic(resultShape[tiledDim.value()]))
+      continue;
+    if (ShapedType::isDynamic(innerTileSizes[tiledDim.index()])) {
+      resultShape[tiledDim.value()] = ShapedType::kDynamic;
+      continue;
+    }
+    resultShape[tiledDim.value()] = ceilDiv(resultShape[tiledDim.value()],
+                                            innerTileSizes[tiledDim.index()]);
+  }
+
+  // Swap tile loops if outer_dims_perm is available.
+  resultShape = interchange<int64_t>(resultShape, outerDimsPerm, /*offset=*/0);
+
+  // Append the inner tile dimensions.
+  resultShape.append(innerTileSizes.begin(), innerTileSizes.end());
+  return resultShape;
+}
+
+// Converts OpFoldResults to int64_t shape entries, unconditionally mapping all
+// Value's to kDynamic, even if they are arith.constant values.
+static SmallVector<int64_t>
+asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
+  SmallVector<int64_t> result;
+  for (auto o : ofrs) {
+    // Have to do this first, as getConstantIntValue special-cases constants.
+    if (o.dyn_cast<Value>())
+      result.push_back(ShapedType::kDynamic);
+    else
+      result.push_back(getConstantIntValue(o).value_or(ShapedType::kDynamic));
+  }
+  return result;
+}
+
 SmallVector<OpFoldResult> PackOp::getResultShape(
     OpBuilder &builder, Location loc, ArrayRef<OpFoldResult> sourceDims,
     ArrayRef<OpFoldResult> innerTileSizes, ArrayRef<int64_t> innerDimsPos,
@@ -1766,6 +1807,23 @@ SmallVector<OpFoldResult> PackOp::getResultShape(
         interchange<OpFoldResult>(resultDims, outerDimsPerm, /*offset=*/0);
   }
   resultDims.append(innerTileSizes.begin(), innerTileSizes.end());
+
+  SmallVector<int64_t> resultTypeShape =
+      getPackOpResultTypeShape(asShapeWithAnyValueAsDynamic(sourceDims),
+                               asShapeWithAnyValueAsDynamic(innerTileSizes),
+                               innerDimsPos, outerDimsPerm);
+
+  // Fix-up `resultDims` to ensure that they are Value's if and only if the
+  // result type shape says it's a dynamic dim. This is needed as callers may
+  // use dispatchIndexOpFoldResults on the result, and rely on exact number of
+  // dynamic dims returned by that.
+  for (unsigned i = 0; i < resultDims.size(); ++i) {
+    if (!ShapedType::isDynamic(resultTypeShape[i]))
+      continue;
+    resultDims[i] =
+        getValueOrCreateConstantIndexOp(builder, loc, resultDims[i]);
+  }
+
   return resultDims;
 }
 
@@ -1777,29 +1835,16 @@ ShapedType PackOp::getPackedType(ShapedType sourceType,
                                  ArrayRef<int64_t> innerTileSizes,
                                  ArrayRef<int64_t> innerDimsPos,
                                  ArrayRef<int64_t> outerDimsPerm) {
-  SmallVector<int64_t> resultShape = llvm::to_vector(sourceType.getShape());
-  for (auto tiledDim : llvm::enumerate(innerDimsPos)) {
-    if (ShapedType::isDynamic(resultShape[tiledDim.value()]))
-      continue;
-    if (ShapedType::isDynamic(innerTileSizes[tiledDim.index()])) {
-      resultShape[tiledDim.value()] = ShapedType::kDynamic;
-      continue;
-    }
-    resultShape[tiledDim.value()] = ceilDiv(resultShape[tiledDim.value()],
-                                            innerTileSizes[tiledDim.index()]);
-  }
+  SmallVector<int64_t> resultTypeShape = getPackOpResultTypeShape(
+      sourceType.getShape(), innerTileSizes, innerDimsPos, outerDimsPerm);
 
-  // Swap tile loops if outer_dims_perm is available.
-  resultShape = interchange<int64_t>(resultShape, outerDimsPerm, /*offset=*/0);
-
-  // Append the inner tile dimensions.
-  resultShape.append(innerTileSizes.begin(), innerTileSizes.end());
   return TypeSwitch<ShapedType, ShapedType>(sourceType)
       .Case<RankedTensorType>([&](auto shapedType) {
-        return RankedTensorType::get(resultShape, shapedType.getElementType());
+        return RankedTensorType::get(resultTypeShape,
+                                     shapedType.getElementType());
       })
       .Case<MemRefType>([&](auto shapedType) {
-        return MemRefType::get(resultShape, shapedType.getElementType());
+        return MemRefType::get(resultTypeShape, shapedType.getElementType());
       })
       .Default([&](Type t) {
         assert(false && "unexpected type");

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1773,21 +1773,6 @@ static SmallVector<int64_t> getPackOpResultTypeShape(
   return resultShape;
 }
 
-// Converts OpFoldResults to int64_t shape entries, unconditionally mapping all
-// Value's to kDynamic, even if they are arith.constant values.
-static SmallVector<int64_t>
-asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
-  SmallVector<int64_t> result;
-  for (auto o : ofrs) {
-    // Have to do this first, as getConstantIntValue special-cases constants.
-    if (o.dyn_cast<Value>())
-      result.push_back(ShapedType::kDynamic);
-    else
-      result.push_back(getConstantIntValue(o).value_or(ShapedType::kDynamic));
-  }
-  return result;
-}
-
 SmallVector<OpFoldResult> PackOp::getResultShape(
     OpBuilder &builder, Location loc, ArrayRef<OpFoldResult> sourceDims,
     ArrayRef<OpFoldResult> innerTileSizes, ArrayRef<int64_t> innerDimsPos,

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
@@ -80,6 +80,18 @@ Value createValueFrom2DConstant(const float *val, int64_t rows, int64_t cols,
                RankedTensorType::get(shape, rewriter.getF32Type()), vector));
 }
 
+SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
+  SmallVector<int64_t> result;
+  for (auto o : ofrs) {
+    // Have to do this first, as getConstantIntValue special-cases constants.
+    if (o.dyn_cast<Value>())
+      result.push_back(ShapedType::kDynamic);
+    else
+      result.push_back(getConstantIntValue(o).value_or(ShapedType::kDynamic));
+  }
+  return result;
+}
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler


### PR DESCRIPTION
We need that information in `MaterializeEncodingPass`, as we need to switch to dynamic tile sizes in that case.