### PR TITLE
Implement dynamic tile size selection for VMVX+ukernels.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding.mlir
@@ -151,6 +151,65 @@ func.func @matmul_lowering_f32f32f32_generic() {
 
 // -----
 
+func.func @matmul_lowering_i8i8i32_vmvx_ukernel() attributes {
+  hal.executable.target = #hal.executable.target<"vmvx", "vmvx-bytecode-fb", {ukernels = true}>
+} {
+  %c0 = arith.constant 0 : index
+  %M = hal.interface.constant.load[0] : index
+  %N = hal.interface.constant.load[1] : index
+  %K = hal.interface.constant.load[2] : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_LHS>>>{%M, %K}
+  %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readonly:tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RHS_TRANSPOSE>>>{%K, %N}
+  %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) offset(%c0) alignment(64)
+      : !flow.dispatch.tensor<readwrite:tensor<?x?xi32, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RESULT>>>{%M, %N}
+  %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [%M, %K], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_LHS>>>{%M, %K}
+      -> tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_LHS>>
+  %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [%K, %N], strides = [1, 1]
+      : !flow.dispatch.tensor<readonly:tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RHS_TRANSPOSE>>>{%K, %N}
+      -> tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RHS_TRANSPOSE>>
+  %5 = flow.dispatch.tensor.load %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+      : !flow.dispatch.tensor<readwrite:tensor<?x?xi32, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RESULT>>>{%M, %N}
+      -> tensor<?x?xi32, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RESULT>>
+  %6 = linalg.matmul
+      ins(%3, %4 : tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_LHS>>,
+                   tensor<?x?xi8, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RHS_TRANSPOSE>>)
+      outs(%5 : tensor<?x?xi32, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RESULT>>)
+      -> tensor<?x?xi32, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RESULT>>
+  flow.dispatch.tensor.store %6, %2, offsets = [0, 0], sizes = [%M, %N], strides = [1, 1]
+      : tensor<?x?xi32, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RESULT>>
+      -> !flow.dispatch.tensor<readwrite:tensor<?x?xi32, #iree_linalg_ext.encoding<MATMUL_I8I8I32_RESULT>>>{%M, %N}
+  return
+}
+
+//      CHECK: func @matmul_lowering_i8i8i32_vmvx_ukernel()
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0]
+//  CHECK-DAG:   %[[N:.+]] = hal.interface.constant.load[1]
+//  CHECK-DAG:   %[[K:.+]] = hal.interface.constant.load[2]
+//      CHECK:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
+// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%[[M]], %[[K]], %[[C1]], %[[C1]]}
+//      CHECK:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
+// CHECK-SAME:       !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%[[N]], %[[K]], %[[C1]], %[[C1]]}
+//      CHECK:   %[[OUTS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(2)
+// CHECK-SAME:       !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%[[M]], %[[N]], %[[C1]], %[[C1]]}
+//      CHECK:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[M]], %[[K]], 1, 1], strides = [1, 1, 1, 1]
+//      CHECK:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[N]], %[[K]], 1, 1], strides = [1, 1, 1, 1]
+//      CHECK:   %[[OUTS:.+]] = flow.dispatch.tensor.load %[[OUTS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[M]], %[[N]], 1, 1], strides = [1, 1, 1, 1]
+//      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+//      CHECK:   flow.dispatch.tensor.store %[[MMT4D]], %[[OUTS_BINDING]]
+// CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[M]], %[[N]], 1, 1], strides = [1, 1, 1, 1]
+
+// -----
+
 func.func @matmul_lowering_i8i8i32_aarch64() attributes {
   hal.executable.target = #hal.executable.target<"xyz", "xyz", {target_triple="aarch64-xyz-xyz"}>
 } {

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -9,6 +9,7 @@
 
 #include <memory>
 
+#include "iree-dialects/Dialect/LinalgExt/Utils/Utils.h"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
 #include "iree/compiler/Utils/CustomKernelsTargetInfo.h"
@@ -196,6 +197,9 @@ createFuseTensorPadWithConsumerPass();
 /// OffsetSizeAndStrideOpInterface. For example, pad(extract_slice).
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConcretizePadResultShapePass();
+
+IREE::LinalgExt::MaterializeEncodingValueFn getMaterializeEncodingValueFn(
+    IREE::HAL::ExecutableTargetAttr targetAttr);
 
 /// Materialize the encoding of operations. The layout to use for the encoded
 /// operations are backend specific.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -8,6 +8,7 @@
 #define IREE_DIALECTS_DIALECT_LINALGEXT_TRANSFORMS_PASSES_H_
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Utils/Utils.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
@@ -87,19 +88,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createTilingInterfaceTilingPass();
 
 std::unique_ptr<OperationPass<func::FuncOp>> createLinalgExtToLoopsPass();
 
-/// Container of information needed to materialize the pack operation.
-struct MaterializeEncodingInfo {
-  SmallVector<int64_t> innerDimsPos;
-  SmallVector<int64_t> innerTileSizes;
-  SmallVector<int64_t> outerDimsPerm;
-  unsigned srcRank = 0;
-};
-using MaterializeEncodingFn =
-    std::function<FailureOr<MaterializeEncodingInfo>(RankedTensorType)>;
-
 /// TypeConverter to use for materializing the encoding.
 struct MaterializeEncodingTypeConverter : public TypeConverter {
-  MaterializeEncodingTypeConverter(MaterializeEncodingFn materializeEncodingFn);
+  MaterializeEncodingTypeConverter(MaterializeEncodingFn fn);
   MaterializeEncodingFn &getMaterializeEncodingFn() {
     return materializeEncodingFn;
   }
@@ -115,10 +106,17 @@ struct MaterializeEncodingConversionTarget : public ConversionTarget {
 
 /// Base class for patterns that materialize encoding.
 template <typename OpTy>
-struct OpMaterializeEncodingPattern : public OpConversionPattern<OpTy> {
-  OpMaterializeEncodingPattern(MaterializeEncodingTypeConverter &typeConverter,
-                               MLIRContext *context, PatternBenefit benefit = 1)
-      : OpConversionPattern<OpTy>(typeConverter, context, benefit) {}
+class OpMaterializeEncodingPattern : public OpConversionPattern<OpTy> {
+public:
+  OpMaterializeEncodingPattern(
+      MLIRContext *context, MaterializeEncodingTypeConverter &typeConverter,
+      MaterializeEncodingValueFn materializeEncodingValueFn = {},
+      PatternBenefit benefit = 1)
+      : OpConversionPattern<OpTy>(typeConverter, context, benefit),
+        materializeEncodingValueFn(materializeEncodingValueFn) {}
+
+protected:
+  const MaterializeEncodingValueFn materializeEncodingValueFn;
 };
 
 /// Method to populate the patterns to convert operations that have operands
@@ -130,7 +128,8 @@ struct OpMaterializeEncodingPattern : public OpConversionPattern<OpTy> {
 void populateMaterializeEncodingPatterns(
     RewritePatternSet &patterns,
     MaterializeEncodingConversionTarget &conversionTarget,
-    MaterializeEncodingTypeConverter &typeConverter);
+    MaterializeEncodingTypeConverter &typeConverter,
+    MaterializeEncodingValueFn materializeEncodingValueFn = {});
 
 /// Pass to apply patterns specified by `populateMaterializeEncodingPass`.
 std::unique_ptr<OperationPass<func::FuncOp>> createMaterializeEncodingPass();

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Utils/Utils.h
@@ -90,6 +90,30 @@ static void permute(SmallVectorImpl<T> &vector) {
     break;
   }
 }
+/// Container of information needed to materialize the pack operation.
+struct MaterializeEncodingInfo {
+  SmallVector<int64_t> innerDimsPos;
+  SmallVector<int64_t> innerTileSizes;
+  SmallVector<int64_t> outerDimsPerm;
+  unsigned srcRank = 0;
+};
+
+using MaterializeEncodingFn =
+    std::function<FailureOr<MaterializeEncodingInfo>(RankedTensorType)>;
+
+struct MaterializeEncodingValueInfo {
+  SmallVector<Value> innerTileSizes;
+};
+
+using MaterializeEncodingValueFn =
+    std::function<FailureOr<MaterializeEncodingValueInfo>(
+        RankedTensorType, OpBuilder &, Location)>;
+
+FailureOr<SmallVector<OpFoldResult>>
+getInnerTileSizesOfr(OpBuilder &rewriter, Location loc,
+                     RankedTensorType tensorType,
+                     const MaterializeEncodingInfo &materializeEncodingInfo,
+                     MaterializeEncodingValueFn materializeEncodingValueFn);
 
 } // namespace LinalgExt
 } // namespace IREE

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding.cpp
@@ -54,16 +54,6 @@ getMaterializedType(RankedTensorType tensorType,
       .cast<RankedTensorType>();
 }
 
-/// Helper methods to get `OpFoldResult` from `int64_t` values.
-static OpFoldResult getAsOpFoldResult(OpBuilder &builder, int64_t value) {
-  return builder.getI64IntegerAttr(value);
-}
-static SmallVector<OpFoldResult> getAsOpFoldResult(OpBuilder &builder,
-                                                   ArrayRef<int64_t> values) {
-  return llvm::to_vector(llvm::map_range(
-      values, [&](int64_t v) { return getAsOpFoldResult(builder, v); }));
-}
-
 //===---------------------------------------------------------------------===//
 // Methods to convert the encoding to parameters of the Pack operation
 //===---------------------------------------------------------------------===//
@@ -130,24 +120,28 @@ static Optional<Value> getPaddingValue(Value &source) {
 /// Utility method to convert from `set_encoding` op to `pack` operation.
 /// For now this takes a `paddingValue` as input. The source is also taken
 /// as input so that these could be used with `OpConversionPatterns`.
-static FailureOr<PackOp>
-lowerSetEncodingOpToPackOp(RewriterBase &rewriter, SetEncodingOp encodingOp,
-                           Value source,
-                           MaterializeEncodingFn materializeEncodingFn) {
+static FailureOr<PackOp> lowerSetEncodingOpToPackOp(
+    RewriterBase &rewriter, SetEncodingOp encodingOp, Value source,
+    MaterializeEncodingFn materializeEncodingFn,
+    MaterializeEncodingValueFn materializeEncodingValueFn) {
   RankedTensorType resultType = encodingOp.getResultType();
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
       materializeEncodingFn(resultType);
   if (failed(materializeEncodingInfo)) {
     return rewriter.notifyMatchFailure(encodingOp, "unhandled result encoding");
   }
-
   // Create `tensor.empty` operation for the result of the pack operation.
   Location loc = encodingOp.getLoc();
   SmallVector<OpFoldResult> sourceDims = getDims(rewriter, loc, source);
-  SmallVector<OpFoldResult> innerTileSizesOfr =
-      getAsOpFoldResult(rewriter, materializeEncodingInfo->innerTileSizes);
+  FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr =
+      getInnerTileSizesOfr(rewriter, loc, resultType, *materializeEncodingInfo,
+                           materializeEncodingValueFn);
+  if (failed(innerTileSizesOfr)) {
+    return rewriter.notifyMatchFailure(
+        encodingOp, "failed to generate runtime tile size query");
+  }
   SmallVector<OpFoldResult> resultDims =
-      PackOp::getResultShape(rewriter, loc, sourceDims, innerTileSizesOfr,
+      PackOp::getResultShape(rewriter, loc, sourceDims, *innerTileSizesOfr,
                              materializeEncodingInfo->innerDimsPos,
                              materializeEncodingInfo->outerDimsPerm);
   auto initTensor = rewriter.create<tensor::EmptyOp>(
@@ -155,16 +149,16 @@ lowerSetEncodingOpToPackOp(RewriterBase &rewriter, SetEncodingOp encodingOp,
   Optional<Value> paddingValue = getPaddingValue(source);
   return rewriter.create<PackOp>(
       loc, source, initTensor, materializeEncodingInfo->innerDimsPos,
-      innerTileSizesOfr, paddingValue, materializeEncodingInfo->outerDimsPerm);
+      *innerTileSizesOfr, paddingValue, materializeEncodingInfo->outerDimsPerm);
 }
 
 /// Utility method to convert from `set_encoding` op to `pack` operation.
 /// The source is taken as input so that these could be used with
 /// `OpConversionPatterns`.
-static FailureOr<UnPackOp>
-lowerUnsetEncodingToUnpackOp(RewriterBase &rewriter, UnsetEncodingOp encodingOp,
-                             Value packedValue,
-                             MaterializeEncodingFn materializeEncodingFn) {
+static FailureOr<UnPackOp> lowerUnsetEncodingToUnpackOp(
+    RewriterBase &rewriter, UnsetEncodingOp encodingOp, Value packedValue,
+    MaterializeEncodingFn materializeEncodingFn,
+    MaterializeEncodingValueFn materializeEncodingValueFn) {
   RankedTensorType sourceType = encodingOp.getSourceType();
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
       materializeEncodingFn(sourceType);
@@ -177,12 +171,16 @@ lowerUnsetEncodingToUnpackOp(RewriterBase &rewriter, UnsetEncodingOp encodingOp,
       getDims(rewriter, loc, encodingOp.getSource());
   auto initTensor = rewriter.create<tensor::EmptyOp>(
       loc, resultDims, sourceType.getElementType());
-
-  SmallVector<OpFoldResult> innerTileSizesOfr =
-      getAsOpFoldResult(rewriter, materializeEncodingInfo->innerTileSizes);
+  FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr =
+      getInnerTileSizesOfr(rewriter, loc, sourceType, *materializeEncodingInfo,
+                           materializeEncodingValueFn);
+  if (failed(innerTileSizesOfr)) {
+    return rewriter.notifyMatchFailure(
+        encodingOp, "failed to generate runtime tile size query");
+  }
   return rewriter.create<UnPackOp>(
       loc, packedValue, initTensor, materializeEncodingInfo->innerDimsPos,
-      innerTileSizesOfr, materializeEncodingInfo->outerDimsPerm);
+      *innerTileSizesOfr, materializeEncodingInfo->outerDimsPerm);
 }
 
 /// Utility method to convert from `linalg.matmul` with
@@ -193,8 +191,8 @@ lowerUnsetEncodingToUnpackOp(RewriterBase &rewriter, UnsetEncodingOp encodingOp,
 static FailureOr<Operation *>
 lowerOpWithEncoding(RewriterBase &rewriter, linalg::MatmulOp matmulOp,
                     ValueRange convertedInputOperands,
-                    ValueRange convertedOutputOperands,
-                    MaterializeEncodingFn materializeEncodingFn) {
+                    ValueRange convertedOutputOperands, MaterializeEncodingFn,
+                    MaterializeEncodingValueFn) {
   if (!matmulOp.hasTensorSemantics())
     return failure();
   auto inputs = matmulOp.getDpsInputOperands();
@@ -227,8 +225,8 @@ lowerOpWithEncoding(RewriterBase &rewriter, linalg::MatmulOp matmulOp,
 static FailureOr<Operation *>
 lowerOpWithEncoding(RewriterBase &rewriter, linalg::FillOp fillOp,
                     ValueRange convertedInputOperands,
-                    ValueRange convertedOutputOperands,
-                    MaterializeEncodingFn materializeEncodingFn) {
+                    ValueRange convertedOutputOperands, MaterializeEncodingFn,
+                    MaterializeEncodingValueFn) {
   if (!fillOp.hasTensorSemantics())
     return failure();
   Operation *materializedFillOp = rewriter.create<linalg::FillOp>(
@@ -242,22 +240,29 @@ lowerOpWithEncoding(RewriterBase &rewriter, linalg::FillOp fillOp,
 static FailureOr<Operation *>
 lowerOpWithEncoding(RewriterBase &rewriter, tensor::EmptyOp emptyOp,
                     ValueRange convertedOperands,
-                    MaterializeEncodingFn materializeEncodingFn) {
-  auto resultType = emptyOp.getResult().getType().cast<RankedTensorType>();
+                    MaterializeEncodingFn materializeEncodingFn,
+                    MaterializeEncodingValueFn materializeEncodingValueFn) {
+  auto result = emptyOp.getResult();
+  auto resultType = result.getType().cast<RankedTensorType>();
   FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
       materializeEncodingFn(resultType);
   if (failed(materializeEncodingInfo)) {
-    return rewriter.notifyMatchFailure(
-        emptyOp, "failed to find materialization info for result type");
+    return rewriter.notifyMatchFailure(emptyOp, "unhandled result encoding");
   }
-  SmallVector<OpFoldResult> innerTileSizesOfr =
-      getAsOpFoldResult(rewriter, materializeEncodingInfo->innerTileSizes);
+  Location loc = emptyOp.getLoc();
+  FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr =
+      getInnerTileSizesOfr(rewriter, loc, resultType, *materializeEncodingInfo,
+                           materializeEncodingValueFn);
+  if (failed(innerTileSizesOfr)) {
+    return rewriter.notifyMatchFailure(
+        emptyOp, "failed to generate runtime tile size query");
+  }
   SmallVector<OpFoldResult> newShape = PackOp::getResultShape(
-      rewriter, emptyOp.getLoc(), emptyOp.getMixedSizes(), innerTileSizesOfr,
+      rewriter, loc, emptyOp.getMixedSizes(), *innerTileSizesOfr,
       materializeEncodingInfo->innerDimsPos,
       materializeEncodingInfo->outerDimsPerm);
   Operation *newEmptyOp = rewriter.create<tensor::EmptyOp>(
-      emptyOp.getLoc(), newShape, resultType.getElementType());
+      loc, newShape, resultType.getElementType());
   return newEmptyOp;
 }
 
@@ -277,13 +282,14 @@ struct SetEncodingOpToPackOpConversion
   LogicalResult
   matchAndRewrite(SetEncodingOp encodingOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    MaterializeEncodingFn &materializeEncodingFn =
+    MaterializeEncodingFn materializeEncodingFn =
         static_cast<MaterializeEncodingTypeConverter *>(getTypeConverter())
             ->getMaterializeEncodingFn();
     // Pack op needs a padding value. Maybe that is an overkill. For now, just
     // use zero.
     auto packOp = lowerSetEncodingOpToPackOp(
-        rewriter, encodingOp, adaptor.getSource(), materializeEncodingFn);
+        rewriter, encodingOp, adaptor.getSource(), materializeEncodingFn,
+        this->materializeEncodingValueFn);
     if (failed(packOp))
       return rewriter.notifyMatchFailure(encodingOp,
                                          "failed to convert to pack op");
@@ -301,11 +307,13 @@ struct UnsetEncodingOpToPackOpConversion
   LogicalResult
   matchAndRewrite(UnsetEncodingOp encodingOp, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    MaterializeEncodingFn &materializeEncodingFn =
-        static_cast<MaterializeEncodingTypeConverter *>(getTypeConverter())
+    MaterializeEncodingFn materializeEncodingFn =
+        static_cast<MaterializeEncodingTypeConverter *>(
+            this->getTypeConverter())
             ->getMaterializeEncodingFn();
     auto unpackOp = lowerUnsetEncodingToUnpackOp(
-        rewriter, encodingOp, adaptor.getSource(), materializeEncodingFn);
+        rewriter, encodingOp, adaptor.getSource(), materializeEncodingFn,
+        this->materializeEncodingValueFn);
     if (failed(unpackOp))
       return rewriter.notifyMatchFailure(encodingOp,
                                          "failed to convert to unpack op");
@@ -322,13 +330,13 @@ struct MaterializeDPSOperation : public OpMaterializeEncodingPattern<OpTy> {
   LogicalResult
   matchAndRewrite(OpTy dpsOp, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    MaterializeEncodingFn &materializeEncodingFn =
+    MaterializeEncodingFn materializeEncodingFn =
         static_cast<MaterializeEncodingTypeConverter *>(
             this->getTypeConverter())
             ->getMaterializeEncodingFn();
-    FailureOr<Operation *> convertedOp =
-        lowerOpWithEncoding(rewriter, dpsOp, adaptor.getInputs(),
-                            adaptor.getOutputs(), materializeEncodingFn);
+    FailureOr<Operation *> convertedOp = lowerOpWithEncoding(
+        rewriter, dpsOp, adaptor.getInputs(), adaptor.getOutputs(),
+        materializeEncodingFn, this->materializeEncodingValueFn);
     if (failed(convertedOp))
       return failure();
     rewriter.replaceOp(dpsOp, convertedOp.value()->getResults());
@@ -344,12 +352,13 @@ struct MaterializeOperation : public OpMaterializeEncodingPattern<OpTy> {
   LogicalResult
   matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    MaterializeEncodingFn &materializeEncodingFn =
+    MaterializeEncodingFn materializeEncodingFn =
         static_cast<MaterializeEncodingTypeConverter *>(
             this->getTypeConverter())
             ->getMaterializeEncodingFn();
     FailureOr<Operation *> convertedOp = lowerOpWithEncoding(
-        rewriter, op, adaptor.getOperands(), materializeEncodingFn);
+        rewriter, op, adaptor.getOperands(), materializeEncodingFn,
+        this->materializeEncodingValueFn);
     if (failed(convertedOp))
       return failure();
     rewriter.replaceOp(op, convertedOp.value()->getResults());
@@ -434,15 +443,16 @@ MaterializeEncodingConversionTarget::MaterializeEncodingConversionTarget(
 
 void populateMaterializeEncodingPatterns(
     RewritePatternSet &patterns, MaterializeEncodingConversionTarget &target,
-    MaterializeEncodingTypeConverter &typeConverter) {
+    MaterializeEncodingTypeConverter &typeConverter,
+    MaterializeEncodingValueFn materializeEncodingValueFn) {
 
   // Add all patterns for converting from encoded type to the materialized type
   patterns.insert<MaterializeDPSOperation<linalg::FillOp>,
                   MaterializeDPSOperation<linalg::MatmulOp>,
                   MaterializeOperation<tensor::EmptyOp>,
                   SetEncodingOpToPackOpConversion,
-                  UnsetEncodingOpToPackOpConversion>(typeConverter,
-                                                     patterns.getContext());
+                  UnsetEncodingOpToPackOpConversion>(
+      patterns.getContext(), typeConverter, materializeEncodingValueFn);
   ::mlir::memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/Passes.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/Passes.cpp
@@ -6,6 +6,7 @@
 
 #include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Pass/PassRegistry.h"
 #include "mlir/Transforms/Passes.h"

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/Utils.cpp
@@ -92,6 +92,43 @@ SmallVector<int64_t> asShapeWithAnyValueAsDynamic(ArrayRef<OpFoldResult> ofrs) {
   return result;
 }
 
+FailureOr<SmallVector<OpFoldResult>>
+getInnerTileSizesOfr(OpBuilder &rewriter, Location loc,
+                     RankedTensorType tensorType,
+                     const MaterializeEncodingInfo &materializeEncodingInfo,
+                     MaterializeEncodingValueFn materializeEncodingValueFn) {
+  ArrayRef<int64_t> staticTileSizes = materializeEncodingInfo.innerTileSizes;
+  if (llvm::all_of(staticTileSizes,
+                   [](int64_t i) { return !ShapedType::isDynamic(i); })) {
+    return getAsOpFoldResult(rewriter.getI64ArrayAttr(staticTileSizes));
+  }
+  assert(materializeEncodingValueFn &&
+         "When dynamic tile sizes are generated, a MaterializeEncodingValueFn "
+         "should be provided.");
+
+  FailureOr<MaterializeEncodingValueInfo> materializeEncodingValueInfo =
+      materializeEncodingValueFn(tensorType, rewriter, loc);
+  if (failed(materializeEncodingValueInfo)) {
+    return failure();
+  }
+  ArrayRef<Value> innerTileSizeValues =
+      materializeEncodingValueInfo->innerTileSizes;
+
+  SmallVector<OpFoldResult> result(staticTileSizes.size());
+  for (size_t i = 0; i < result.size(); ++i) {
+    if (staticTileSizes[i] == ShapedType::kDynamic) {
+      result[i] = innerTileSizeValues[i];
+    } else if (tensorType.isDynamicDim(i)) {
+      result[i] =
+          rewriter.create<arith::ConstantIndexOp>(loc, staticTileSizes[i])
+              .getResult();
+    } else {
+      result[i] = rewriter.getI64IntegerAttr(staticTileSizes[i]);
+    }
+  }
+  return result;
+}
+
 } // namespace LinalgExt
 } // namespace IREE
 } // namespace iree_compiler


### PR DESCRIPTION
This is for now just creating constant value 1 instead of actually creating a vmvx.get_tile_sizes op.  (This makes the lit test look a bit odd as that gets folded, but that will change very soon).

That's enough to migrate the vmvx+ukernel e2e matmul tests to --iree-flow-enable-data-tiling, done in the next PR.

A follow-up PR will then be able to implement actual vmvx.get_tile_sizes providing more interesting Values than just arith.constant's. 