### PR TITLE
Switch e2e/matmul tests on vmvx+ukernel to data-tiling

### DIFF
--- a/benchmarks/TFLite/android-arm64-v8a.cmake
+++ b/benchmarks/TFLite/android-arm64-v8a.cmake
@@ -360,7 +360,7 @@ iree_benchmark_suite(
 #     "CPU-ARM64-v8A"
 #   COMPILATION_FLAGS
 #     ${ANDROID_CPU_COMPILATION_FLAGS}
-#     "--iree-flow-mmt4d-target-options=arch=aarch64"
+#     "--iree-flow-enable-data-tiling"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   CONFIG
@@ -392,7 +392,7 @@ iree_benchmark_suite(
 #     "CPU-ARM64-v8A"
 #   COMPILATION_FLAGS
 #     ${ANDROID_CPU_COMPILATION_FLAGS}
-#     "--iree-flow-mmt4d-target-options=arch=aarch64"
+#     "--iree-flow-enable-data-tiling"
 #   BENCHMARK_TOOL
 #     iree-benchmark-module
 #   CONFIG

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -140,7 +140,7 @@ py_binary(
     name = "e2e_matmul_mmt4d_%s_small_ukernel" % lhs_rhs_type,
     compiler_flags = [
         "--iree-vmvx-enable-microkernels",
-        "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#",
+        "--iree-flow-enable-data-tiling",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -150,10 +150,6 @@ py_binary(
     target_backends_and_drivers = [
         ("vmvx", "local-task"),
     ],
-    target_cpu_features_variants = ["default"] + ([
-        "aarch64:+dotprod",
-        "aarch64:+i8mm",
-    ] if lhs_rhs_type == "i8" else []),
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for lhs_rhs_type in [
     "i8",

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -222,11 +222,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-vmvx-enable-microkernels"
-    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
-    "aarch64:+dotprod"
-    "aarch64:+i8mm"
+    "--iree-flow-enable-data-tiling"
 )
 
 iree_generated_trace_runner_test(
@@ -245,9 +241,7 @@ iree_generated_trace_runner_test(
     "local-task"
   COMPILER_FLAGS
     "--iree-vmvx-enable-microkernels"
-    "--iree-flow-mmt4d-target-options=enable_generic_slow #pass_options_variant#"
-  TARGET_CPU_FEATURES_VARIANTS
-    "default"
+    "--iree-flow-enable-data-tiling"
 )
 
 iree_generated_trace_runner_test(


### PR DESCRIPTION
This is part 5/9 of #11755: Finish the transition to `--iree-flow-enable-data-tiling`.

This switches the last holdout e2e tests that were exercisting the old mmt4d pass, making it unused.