### PR TITLE
[spirv] Add cleanup before multibuffering in wmma

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -890,6 +890,14 @@ LogicalResult setCooperativeMatrixConfig(
   tileSizes.push_back(reductionTileSizes);
   tileSizes.push_back(vectorSizes);
 
+  // Don't do multibuffering if the inner reduction loop is folded out.
+  auto pipelineDepth = softwarePipelineDepth;
+  auto storeStage = softwarePipelineStoreStage;
+  if (coopMatSize->kTileCount <= 1) {
+    pipelineDepth = 0;
+    storeStage = 0;
+  }
+
   // Check if the C matrix will be promoted for computing shared memory usage.
   auto matmulResult = op.getDpsInitOperand(0)->get();
   bool promoteC =
@@ -897,8 +905,6 @@ LogicalResult setCooperativeMatrixConfig(
       !isa<IREE::Flow::DispatchTensorStoreOp>(*matmulResult.getUsers().begin());
 
   // Decrease pipeline depth until it fits in shared memory.
-  auto pipelineDepth = softwarePipelineDepth;
-  auto storeStage = softwarePipelineStoreStage;
   const int maxBytes = limits.getMaxComputeSharedMemorySize();
   auto usedBytes =
       getTileBytes(workgroupTileSizes[mIndex], workgroupTileSizes[nIndex],

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Passes.cpp
@@ -293,6 +293,10 @@ void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm,
   // Tile and distribute to GPU subgroups.
   nestedModulePM.addNestedPass<func::FuncOp>(
       createSPIRVTileToCooperativeOpsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createRemoveSingleIterationLoopPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
 
   // Multi-buffer depending on pipeline depth and distribute to shared memory.
   if (pipelineDepth > 0)
@@ -327,6 +331,9 @@ void addSPIRVCooperativeMatrixVectorizePassPipeline(OpPassManager &pm,
   // cooperative ops in the next step.
   nestedModulePM.addPass(memref::createFoldMemRefAliasOpsPass());
 
+  nestedModulePM.addNestedPass<func::FuncOp>(createForOpCanonicalizationPass());
+  nestedModulePM.addPass(createCanonicalizerPass());
+  nestedModulePM.addPass(createCSEPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createSPIRVVectorToGPUSubgroupMMAOpsPass());
   nestedModulePM.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_amd_matmul_cooperative_ops.mlir
@@ -266,7 +266,7 @@ hal.executable public @batch_matmul_16x1024x1024x80 {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 128], [1, 32, 64], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x1024x1024x80
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/config_nvidia_matmul_cooperative_ops.mlir
@@ -290,7 +290,7 @@ hal.executable public @batch_matmul_16x1024x1024x80 {
 }
 
 //  CHECK-DAG: #[[$CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64], [1, 32, 32], [0, 0, 0, 16], [1, 16, 16, 16]{{\]}}>
-//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize pipeline_depth = 1 store_stage = 0>
+//  CHECK-DAG: #[[$TRANSLATION:.+]] = #iree_codegen.translation_info<SPIRVCooperativeMatrixVectorize store_stage = 0>
 //CHECK-LABEL: hal.executable.export public @batch_matmul_16x1024x1024x80
 // CHECK-SAME:   subgroup_size = 32 : index
 // CHECK-SAME:   translation_info = #[[$TRANSLATION]]


### PR DESCRIPTION
Removes single trip loops before multi-buffering and makes sure not to multi-buffer if the inner reduction loop is single trip.