### PR TITLE
Fix benchmark directory paths in buildkite pipeline

### DIFF
--- a/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/cuda/benchmark.yml
@@ -21,7 +21,7 @@ steps:
         --driver_filter_regex=cuda \
         -o "benchmark-results-gcp-gpu-a100-$${BUILDKITE_BUILD_NUMBER}.json" \
         --verbose \
-        build-linux
+        build-targets/linux-cuda
     agents:
       - "gcp:machine-type=a2-highgpu-1g"
       - "queue=benchmark-cuda"

--- a/build_tools/buildkite/cmake/linux/x86_64/benchmark2.yml
+++ b/build_tools/buildkite/cmake/linux/x86_64/benchmark2.yml
@@ -21,7 +21,7 @@ steps:
         --normal_benchmark_tool_dir=build-linux/tools/ \
         -o "benchmark-results-gcp-cpu-$${BUILDKITE_BUILD_NUMBER}.json" \
         --verbose \
-        build-linux
+        build-targets/linux-x86_64
     agents:
       - "gcp:machine-type=c2-standard-16"
       - "queue=benchmark-x86_64"


### PR DESCRIPTION
Fix the paths of benchmark directory broke by #11397