### PR TITLE
Add simple Python webserver for GitHub runner health check

### DIFF
--- a/build_tools/github_actions/runner/config/health_server/health_server.py
+++ b/build_tools/github_actions/runner/config/health_server/health_server.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""A really basic health check HTTP server.
+
+All it does is server a 200 to every request, basically only confirming its
+existence. This can later be extended with more functionality.
+
+Note that http.server is not in general fit for production, but our very limited
+usage of BaseHTTPRequestHandler here, not serving any files and not parsing or
+making use of request input, does not present any security concerns. Don't add
+those sorts of things. Additionally, this operates inside a firewall that blocks
+all but a few IPs and even those are internal to the network.
+"""
+
+import argparse
+import http.server
+
+
+class HealthCheckServer(http.server.BaseHTTPRequestHandler):
+
+  def do_GET(self):
+    self.send_response(200)
+    self.send_header("Content-type", "text/html")
+    self.end_headers()
+
+
+def main(args):
+  webServer = http.server.HTTPServer(("", args.port), HealthCheckServer)
+  print(f"Server started on port {args.port}. Ctrl+C to stop.")
+
+  try:
+    webServer.serve_forever()
+  except KeyboardInterrupt:
+    # Don't print an exception on interrupt. Add a newline to handle printing of
+    # "^C"
+    print()
+    pass
+
+  webServer.server_close()
+  print("Server stopped.")
+
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--port", type=int, default=8080)
+  return parser.parse_args()
+
+
+if __name__ == "__main__":
+  main(parse_args())

--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -66,3 +66,8 @@ systemctl enable github-actions-runner-deregister
 
 echo "Starting the runner service."
 systemctl start github-actions-runner-start
+
+# The health check server confirms that we've at least made it this far and
+# therefore registering the runner has succeeded.
+echo "Starting health check server"
+/runner-root/config/health_server/health_server.py

--- a/build_tools/github_actions/runner/gcp/create_instance_group.sh
+++ b/build_tools/github_actions/runner/gcp/create_instance_group.sh
@@ -15,7 +15,7 @@
 set -euo pipefail
 
 # For now, just change these parameters
-VERSION=deadbeef12-2022-08-23-1661292386
+VERSION=7138511883-62g-testing
 REGION=us-west1
 ZONES=us-west1-a,us-west1-b,us-west1-c
 AUTOSCALING=1
@@ -23,8 +23,8 @@ GROUP=presubmit
 TYPE=cpu
 # For GPU groups, these should both be set to the target group size, as
 # autoscaling currently does not work for these.
-MIN_SIZE=1
-MAX_SIZE=10
+MIN_SIZE=3
+MAX_SIZE=3
 # Whether this is a testing MIG (i.e. not prod)
 TESTING=1
 
@@ -48,6 +48,7 @@ function create_mig() {
     --zones="${ZONES}"
     --region="${REGION}"
     --target-distribution-shape=EVEN
+    --health-check=http-8080-ok
   )
 
   (set -x; gcloud beta compute instance-groups managed create "${create_args[@]}")


### PR DESCRIPTION
For now, it literally always returns an HTTP 200 response. All this does
is confirm that the startup script has completed and nothing has killed
the health server. Unlike the current approach that traps an ERR signal
and shuts down the instance, this is extensible to more sophisticated
examination of whether the GitHub runner is actually functioning. This
puts the recreation of the instance in the hand of the instance group,
which makes it more visible and doesn't work at cross-purposes with the
infrastructure we're using.

Tested: Deployed to test environment (recreated with health check via
script) and confirmed expected behavior.