### PR TITLE
Upload all MLIR files in e2e test artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -737,12 +737,12 @@ jobs:
           E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
           E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
         run: |
+          # Uploads all IREE artifacts and MLIR files (including the imported
+          # MLIR files and MLIR source models).
           # Not archiving the directory to allow fetching each file as needed
           # separately.
-          # TODO(#11076): The command below doesn't include the MLIR files from
-          # `model_` when the model importing is not required. Need a proper
-          # tool to list all dependent files.
-          find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 -name "iree_*" | \
+          find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
+            -name "iree_*" -o -name "model_*.mlir" | \
             gcloud alpha storage cp --read-paths-from-stdin -r \
               "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
           echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
As https://github.com/iree-org/iree/pull/11511#discussion_r1046542347, right now we only upload the IREE imported MLIR files. But when the source model is in MLIR format, `e2e_test_artifacts` doesn't import the model but directly uses the `model_*.mlir` file. This change also uploads those source models in MLIR format.

It's useful to upload all imported MLIRs and source models in MLIR format since those files are helpful for debugging and local run. Having all MLIR files uploaded makes it easier to download all of them from one place and keeps the version consistent.

We don't have the source model in MLIR currently, so this change has no effect right now.
