### PR TITLE
Port reduction-v3 to C++

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -85,6 +85,7 @@ Value buildMapToBlockAndThreads(ImplicitLocOpBuilder &b, Value funcH,
                                 ArrayRef<int64_t> blockSize);
 
 static constexpr unsigned kCudaWarpSize = 32;
+static constexpr unsigned kCudaMaxNumThreads = 1024;
 
 /// Post-bufferization vector distribution with rank-reduction.
 /// Takes a handle to a func.func and returns an updated handle to a

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -31,22 +31,25 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
-//         CHECK:   gpu.barrier
 
-// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
-//         CHECK:   vector.transfer_read
-//         CHECK:   vector.transfer_read
-//         CHECK:   arith.addf %{{.*}} : vector<2xf32>
-//         CHECK:   vector.transfer_write
-//         CHECK:   gpu.barrier
+// Fusion occurred, no barrier before the loop
+//     CHECK-NOT: gpu.barrier
+//     CHECK:   vector.transfer_read {{.*}} vector<f32>
+// Local per-thread scf.for-based reduction.
+//         CHECK: scf.for
+//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
+// No barrier within the loop
+//     CHECK-NOT:   gpu.barrier
+//         CHECK:   scf.yield {{.*}} : vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
+//         CHECK: vector.transfer_read %{{.*}}[]
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
@@ -95,29 +98,31 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction_elementwise
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
-//         CHECK:   gpu.barrier
 
-// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
-//         CHECK:   vector.transfer_read
-//         CHECK:   vector.transfer_read
-//         CHECK:   arith.addf %{{.*}} : vector<2xf32>
-//         CHECK:   vector.transfer_write
-//         CHECK:   gpu.barrier
+// Fusion occurred, no barrier before the loop
+//     CHECK-NOT: gpu.barrier
+//     CHECK:   vector.transfer_read {{.*}} vector<f32>
+// Local per-thread scf.for-based reduction.
+//         CHECK: scf.for
+//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
+// No barrier within the loop
+//     CHECK-NOT:   gpu.barrier
+//         CHECK:   scf.yield {{.*}} : vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
+//         CHECK: vector.transfer_read %{{.*}}[]
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
-//         CHECK:   %[[PARTIAL_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
-//         CHECK:   %[[ELEM:.*]] = vector.extractelement %[[PARTIAL_VEC]][]
-//         CHECK:   %[[RES:.*]] = math.sqrt %[[ELEM]]
-//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+//         CHECK:   vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
+//         CHECK:   math.sqrt 
+//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %{{.*}}: f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
 //         CHECK:     vector.transfer_write %[[RES_VEC]]
@@ -159,26 +164,28 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_elementwise_reduction
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
-//         CHECK:   gpu.barrier
 
-// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
-//         CHECK:   vector.transfer_read
-//         CHECK:   vector.transfer_read
-//         CHECK:   %[[PARTIAL_1:.*]] = arith.addf %[[ARG:.*]], %[[ARG]]
-//         CHECK:   %[[PARTIAL_2:.*]] = arith.addf %[[PARTIAL_1]], %[[PARTIAL_1]]
-//         CHECK:   arith.addf %[[PARTIAL_2]], %{{.*}} : vector<2xf32>
-//         CHECK:   vector.transfer_write
-//         CHECK:   gpu.barrier
+// Fusion occurred, no barrier before the loop
+//     CHECK-NOT: gpu.barrier
+//     CHECK:   vector.transfer_read {{.*}} vector<f32>
+// Local per-thread scf.for-based reduction.
+//         CHECK: scf.for
+//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   arith.addf{{.*}} : vector<2xf32>
+//         CHECK:   arith.addf{{.*}} : vector<2xf32>
+//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
+// No barrier within the loop
+//     CHECK-NOT:   gpu.barrier
+//         CHECK:   scf.yield {{.*}} : vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
+//         CHECK: vector.transfer_read %{{.*}}[]
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
-
 
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
@@ -228,31 +235,33 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_elementwise_reduction_elementwise
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
-//         CHECK:   gpu.barrier
 
-// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
-//         CHECK:   vector.transfer_read
-//         CHECK:   vector.transfer_read
-//         CHECK:   %[[PARTIAL_1:.*]] = arith.addf %[[ARG:.*]], %[[ARG]]
-//         CHECK:   %[[PARTIAL_2:.*]] = arith.addf %[[PARTIAL_1]], %[[PARTIAL_1]]
-//         CHECK:   arith.addf %[[PARTIAL_2]], %{{.*}} : vector<2xf32>
-//         CHECK:   vector.transfer_write
-//         CHECK:   gpu.barrier
+// Fusion occurred, no barrier before the loop
+//     CHECK-NOT: gpu.barrier
+//     CHECK:   vector.transfer_read {{.*}} vector<f32>
+// Local per-thread scf.for-based reduction.
+//         CHECK: scf.for
+//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   arith.addf{{.*}} : vector<2xf32>
+//         CHECK:   arith.addf{{.*}} : vector<2xf32>
+//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
+// No barrier within the loop
+//     CHECK-NOT:   gpu.barrier
+//         CHECK:   scf.yield {{.*}} : vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
+//         CHECK: vector.transfer_read %{{.*}}[]
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
-//         CHECK:   %[[PARTIAL_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
-//         CHECK:   %[[ELEM:.*]] = vector.extractelement %[[PARTIAL_VEC]][]
-//         CHECK:   %[[RES:.*]] = math.sqrt %[[ELEM]]
-//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+//         CHECK:   vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
+//         CHECK:   math.sqrt
+//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %{{.*}}: f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
 //         CHECK:     vector.transfer_write %[[RES_VEC]]
@@ -292,21 +301,25 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction_larger
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x128xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<4xf32, strided<[1], offset: ?>, 3>
-//         CHECK:   gpu.barrier
 
-// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
+// Fusion occurred, no barrier before the loop
+//     CHECK-NOT: gpu.barrier
+//     CHECK:   vector.transfer_read {{.*}} vector<f32>
+// Local per-thread scf.for-based reduction.
+//         CHECK: scf.for
 //         CHECK:   vector.transfer_read
-//         CHECK:   vector.transfer_read
-//         CHECK:   arith.addf %{{.*}} : vector<4xf32>
-//         CHECK:   vector.transfer_write
-//         CHECK:   gpu.barrier
+//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
+//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
+// No barrier within the loop
+//     CHECK-NOT:   gpu.barrier
+//         CHECK:   scf.yield {{.*}} : vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+//         CHECK: vector.transfer_read %{{.*}}[]
+//         CHECK: %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
 //         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -35,15 +35,12 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region {{.*}} tile_sizes [1](mapping = [#gpu.block<x>])
 // CHECK-COUNT-3:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.iree.take_first
-//         CHECK:   transform.structured.tile_reduction_using_scf %{{.*}} by tile_sizes = [0, 64]
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [0, 32]
-//    CHECK-SAME:      (mapping = [#gpu.thread<x>])
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [0, 2](mapping = [#gpu.thread<x>])
+//         CHECK:   tile_reduction_using_foreach_thread {{.*}} by num_threads = [0, 32], tile_sizes = [0, 2], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.iree.take_first
 //         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [1](mapping = [#gpu.thread<y>])
 //         CHECK:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.structured.match ops{["func.func"]} in %arg0
-//         CHECK:   transform.iree.apply_patterns %{{.*}} {rank_reducing}
 //         CHECK:   transform.structured.vectorize
 //         CHECK:   transform.iree.bufferize {target_gpu}
 //         CHECK:   transform.structured.match ops{["func.func"]} in %{{.*}}
@@ -95,10 +92,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_128
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//         CHECK:   transform.structured.tile_reduction_using_scf %{{.*}} by tile_sizes = [0, 128]
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [0, 32]
-//    CHECK-SAME:      (mapping = [#gpu.thread<x>])
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [0, 4](mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}
 
 // -----
 
@@ -136,7 +131,5 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_32
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//         CHECK:   transform.structured.tile_reduction_using_scf %{{.*}} by tile_sizes = [0, 32]
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [0, 32]
-//    CHECK-SAME:      (mapping = [#gpu.thread<x>])
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [0, 1](mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 32], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -317,9 +317,10 @@ void transform_ext::makeReductionMatcher(
                  .output(NumEqualsTo(1));
   leading = trailing;
   reduction = m_StructuredOp()
-                  .dim(AllDims(), ShapeKind::Static)
+                  // The CUDA strategy now supports arbitray mixes of static and
+                  // dynamic sizes and adapts accordingly.
+                  // Consider separating control for other targets if needed.
                   .dim(-1, utils::IteratorType::reduction)
-                  .dim(-1, DivisibleBy(kCudaWarpSize))
                   .dim(-1, CaptureDim(reductionDimensionSize))
                   // Can be extended to projected permutation with broadcast.
                   .input(AllOperands(), IsPermutation())

--- a/tests/transform_dialect/cuda/reduction_v2.mlir
+++ b/tests/transform_dialect/cuda/reduction_v2.mlir
@@ -27,15 +27,6 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v2_codegen_spec.mlir | \
 // RUN: FileCheck %s --check-prefix=CHECK
 
-// RUN: iree-opt %s --iree-hal-target-backends=cuda \
-// RUN:     --iree-abi-transformation-pipeline \
-// RUN:     --iree-flow-transformation-pipeline  \
-// RUN:     --iree-stream-transformation-pipeline \
-// RUN:     --iree-hal-configuration-pipeline | \
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
-// RUN:      --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
-// RUN: FileCheck %s --check-prefix=CHECK
-
 // RUN: iree-compile %s --iree-hal-target-backends=cuda \
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v2_codegen_spec.mlir | \
 // RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="33x1024xf32=1" |\

--- a/tests/transform_dialect/cuda/reduction_v3.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3.mlir
@@ -34,6 +34,11 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
 // RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="123x4567xf32=1" |\
 // RUN: FileCheck %s --check-prefix=EXEC
 
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="123x4567xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
   //     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
   //     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
   //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x1024xf32, 3>

--- a/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
@@ -19,7 +19,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
      transform.structured.tile_reduction_using_foreach_thread %grid_reduction 
         by num_threads = [0, 1024], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
 
-  // Fuse the fill and pointwise to privatize them. 
+  // Fuse the fill and pointwise to privatize them.
   transform.structured.fuse_into_containing_op %block_more_parallel_fill_op_2
     into %foreach_thread
 


### PR DESCRIPTION
Using `TileReductionUsingForeachThreadOp` in `createReductionStrategyThreadDistribution` allows a
much more general mapping of reductions on GPU.
    
This PR additionally performs a few refactorings to generalize the control of the transformation
to gracefully degrade from vector<4> to vector<2> to scalar.