### PR TITLE
Support using e2e test artifacts directory path in benchmark tool

### DIFF
--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -110,7 +110,8 @@ class BenchmarkConfig:
 
     if args.e2e_test_artifacts_dir is not None:
       if args.run_config is None:
-        raise ValueError("--e2e_test_artifacts_dir must use with --run_config.")
+        raise ValueError(
+            "--e2e_test_artifacts_dir only supports using with --run_config.")
 
       root_benchmark_dir = args.e2e_test_artifacts_dir
     else:

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -109,17 +109,9 @@ class BenchmarkConfig:
           capture_tmp_dir=per_commit_tmp_dir / CAPTURES_REL_PATH)
 
     if args.e2e_test_artifacts_dir is not None:
-      if args.run_config is None:
-        raise ValueError(
-            "--e2e_test_artifacts_dir only supports using with --run_config.")
-
       root_benchmark_dir = args.e2e_test_artifacts_dir
     else:
       # TODO(#11076): Remove legacy path.
-      if args.build_dir is None:
-        raise ValueError(
-            "Either --e2e_test_artifacts_dir or <build-dir> must be specified.")
-
       build_dir = args.build_dir.resolve()
       if args.run_config is not None:
         root_benchmark_dir = build_dir / E2E_TEST_ARTIFACTS_REL_PATH

--- a/build_tools/benchmarks/common/benchmark_config.py
+++ b/build_tools/benchmarks/common/benchmark_config.py
@@ -108,12 +108,22 @@ class BenchmarkConfig:
           capture_tarball=args.capture_tarball.resolve(),
           capture_tmp_dir=per_commit_tmp_dir / CAPTURES_REL_PATH)
 
-    build_dir = args.build_dir.resolve()
-    if args.run_config is None:
-      # TODO(#11076): Remove legacy path.
-      root_benchmark_dir = build_dir / BENCHMARK_SUITE_REL_PATH
+    if args.e2e_test_artifacts_dir is not None:
+      if args.run_config is None:
+        raise ValueError("--e2e_test_artifacts_dir must use with --run_config.")
+
+      root_benchmark_dir = args.e2e_test_artifacts_dir
     else:
-      root_benchmark_dir = build_dir / E2E_TEST_ARTIFACTS_REL_PATH
+      # TODO(#11076): Remove legacy path.
+      if args.build_dir is None:
+        raise ValueError(
+            "Either --e2e_test_artifacts_dir or <build-dir> must be specified.")
+
+      build_dir = args.build_dir.resolve()
+      if args.run_config is not None:
+        root_benchmark_dir = build_dir / E2E_TEST_ARTIFACTS_REL_PATH
+      else:
+        root_benchmark_dir = build_dir / BENCHMARK_SUITE_REL_PATH
 
     return BenchmarkConfig(root_benchmark_dir=root_benchmark_dir,
                            benchmark_results_dir=per_commit_tmp_dir /

--- a/build_tools/benchmarks/common/benchmark_config_test.py
+++ b/build_tools/benchmarks/common/benchmark_config_test.py
@@ -11,16 +11,16 @@ import unittest
 import tempfile
 import os
 
-from common.common_arguments import build_common_argument_parser
-from common.benchmark_config import BenchmarkConfig, TraceCaptureConfig
+from common import benchmark_config, common_arguments
 
 
 class BenchmarkConfigTest(unittest.TestCase):
 
   def setUp(self):
     self.build_dir = tempfile.TemporaryDirectory()
-    self.tmp_dir = tempfile.TemporaryDirectory()
     self.build_dir_path = pathlib.Path(self.build_dir.name).resolve()
+    self.tmp_dir = tempfile.TemporaryDirectory()
+    self.tmp_dir_path = pathlib.Path(self.tmp_dir.name).resolve()
     self.normal_tool_dir = self.build_dir_path / "normal_tool"
     self.normal_tool_dir.mkdir()
     self.traced_tool_dir = self.build_dir_path / "traced_tool"
@@ -34,25 +34,27 @@ class BenchmarkConfigTest(unittest.TestCase):
     self.build_dir.cleanup()
 
   def test_build_from_args(self):
-    args = build_common_argument_parser().parse_args([
-        f"--tmp_dir={self.tmp_dir.name}",
+    args = common_arguments.build_common_argument_parser().parse_args([
+        f"--tmp_dir={self.tmp_dir_path}",
         f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
         f"--traced_benchmark_tool_dir={self.traced_tool_dir}",
         f"--trace_capture_tool={self.trace_capture_tool.name}",
         f"--capture_tarball=capture.tar", f"--driver_filter_regex=a",
         f"--model_name_regex=b", f"--mode_regex=c", f"--keep_going",
-        f"--benchmark_min_time=10", self.build_dir.name
+        f"--benchmark_min_time=10",
+        str(self.build_dir_path)
     ])
 
-    config = BenchmarkConfig.build_from_args(args=args, git_commit_hash="abcd")
+    config = benchmark_config.BenchmarkConfig.build_from_args(
+        args=args, git_commit_hash="abcd")
 
-    per_commit_tmp_dir = pathlib.Path(self.tmp_dir.name).resolve() / "abcd"
-    expected_trace_capture_config = TraceCaptureConfig(
+    per_commit_tmp_dir = self.tmp_dir_path / "abcd"
+    expected_trace_capture_config = benchmark_config.TraceCaptureConfig(
         traced_benchmark_tool_dir=self.traced_tool_dir,
         trace_capture_tool=pathlib.Path(self.trace_capture_tool.name).resolve(),
         capture_tarball=pathlib.Path("capture.tar").resolve(),
         capture_tmp_dir=per_commit_tmp_dir / "captures")
-    expected_config = BenchmarkConfig(
+    expected_config = benchmark_config.BenchmarkConfig(
         root_benchmark_dir=self.build_dir_path / "benchmark_suites",
         benchmark_results_dir=per_commit_tmp_dir / "benchmark-results",
         git_commit_hash="abcd",
@@ -66,28 +68,87 @@ class BenchmarkConfigTest(unittest.TestCase):
     self.assertEqual(config, expected_config)
 
   def test_build_from_args_benchmark_only(self):
-    args = build_common_argument_parser().parse_args([
-        f"--tmp_dir={self.tmp_dir.name}",
+    args = common_arguments.build_common_argument_parser().parse_args([
+        f"--tmp_dir={self.tmp_dir_path}",
         f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
-        self.build_dir.name
+        str(self.build_dir_path)
     ])
 
-    config = BenchmarkConfig.build_from_args(args=args, git_commit_hash="abcd")
+    config = benchmark_config.BenchmarkConfig.build_from_args(
+        args=args, git_commit_hash="abcd")
 
     self.assertIsNone(config.trace_capture_config)
 
   def test_build_from_args_invalid_capture_args(self):
-    args = build_common_argument_parser().parse_args([
-        f"--tmp_dir={self.tmp_dir.name}",
+    args = common_arguments.build_common_argument_parser().parse_args([
+        f"--tmp_dir={self.tmp_dir_path}",
         f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
         f"--traced_benchmark_tool_dir={self.traced_tool_dir}",
-        self.build_dir.name
+        str(self.build_dir_path)
     ])
 
     self.assertRaises(
-        ValueError,
-        lambda: BenchmarkConfig.build_from_args(args=args,
-                                                git_commit_hash="abcd"))
+        ValueError, lambda: benchmark_config.BenchmarkConfig.build_from_args(
+            args=args, git_commit_hash="abcd"))
+
+  def test_build_from_args_with_e2e_test_artifacts_dir(self):
+    with tempfile.TemporaryDirectory() as e2e_test_artifacts_dir:
+      run_config = pathlib.Path(e2e_test_artifacts_dir) / "run_config.json"
+      run_config.touch()
+      args = common_arguments.build_common_argument_parser().parse_args([
+          f"--tmp_dir={self.tmp_dir_path}",
+          f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
+          f"--e2e_test_artifacts_dir={e2e_test_artifacts_dir}",
+          f"--run_config={run_config}"
+      ])
+
+      config = benchmark_config.BenchmarkConfig.build_from_args(
+          args=args, git_commit_hash="abcd")
+
+      self.assertEqual(config.root_benchmark_dir,
+                       pathlib.Path(e2e_test_artifacts_dir))
+
+  def test_build_from_args_with_run_config_and_build_dir(self):
+    with tempfile.TemporaryDirectory() as e2e_test_artifacts_dir:
+      run_config = pathlib.Path(e2e_test_artifacts_dir) / "run_config.json"
+      run_config.touch()
+      args = common_arguments.build_common_argument_parser().parse_args([
+          f"--tmp_dir={self.tmp_dir_path}",
+          f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
+          f"--run_config={run_config}",
+          str(self.build_dir_path)
+      ])
+
+      config = benchmark_config.BenchmarkConfig.build_from_args(
+          args=args, git_commit_hash="abcd")
+
+      self.assertEqual(
+          config.root_benchmark_dir,
+          self.build_dir_path / benchmark_config.E2E_TEST_ARTIFACTS_REL_PATH)
+
+  def test_build_from_args_e2e_test_artifacts_dir_without_run_config(self):
+    with tempfile.TemporaryDirectory() as e2e_test_artifacts_dir:
+      run_config = pathlib.Path(e2e_test_artifacts_dir) / "run_config.json"
+      run_config.touch()
+      args = common_arguments.build_common_argument_parser().parse_args([
+          f"--tmp_dir={self.tmp_dir_path}",
+          f"--normal_benchmark_tool_dir={self.normal_tool_dir}",
+          f"--e2e_test_artifacts_dir={e2e_test_artifacts_dir}"
+      ])
+
+      self.assertRaises(
+          ValueError, lambda: benchmark_config.BenchmarkConfig.build_from_args(
+              args=args, git_commit_hash="abcd"))
+
+  def test_build_from_args_no_e2e_test_artifacts_dir_and_build_dir(self):
+    args = common_arguments.build_common_argument_parser().parse_args([
+        f"--tmp_dir={self.tmp_dir_path}",
+        f"--normal_benchmark_tool_dir={self.normal_tool_dir}"
+    ])
+
+    self.assertRaises(
+        ValueError, lambda: benchmark_config.BenchmarkConfig.build_from_args(
+            args=args, git_commit_hash="abcd"))
 
 
 if __name__ == "__main__":

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -9,150 +9,165 @@ import glob
 import os
 import argparse
 import pathlib
-from typing import List, Sequence
+from typing import List, Optional, Sequence
 
 
-def build_common_argument_parser():
-  """Returns an argument parser with common options."""
+def _check_dir_path(path):
+  path = pathlib.Path(path)
+  if path.is_dir():
+    return path
+  else:
+    raise argparse.ArgumentTypeError(path)
 
-  def check_dir_path(path):
-    path = pathlib.Path(path)
-    if path.is_dir():
-      return path
-    else:
-      raise argparse.ArgumentTypeError(path)
 
-  def check_file_path(path):
-    path = pathlib.Path(path)
-    if path.is_file():
-      return path
-    else:
-      raise argparse.ArgumentTypeError(f"'{path}' is not found")
+def _check_file_path(path):
+  path = pathlib.Path(path)
+  if path.is_file():
+    return path
+  else:
+    raise argparse.ArgumentTypeError(f"'{path}' is not found")
 
-  def check_exe_path(path):
-    path = pathlib.Path(path)
-    if os.access(path, os.X_OK):
-      return path
-    else:
-      raise argparse.ArgumentTypeError(f"'{path}' is not an executable")
 
-  parser = argparse.ArgumentParser()
-  parser.add_argument(
-      "build_dir",
-      metavar="<build-dir>",
-      type=check_dir_path,
-      default=None,
-      nargs='?',
-      help="Path to the build directory containing benchmark suites")
-  # TODO(#11076): Replace build-dir argument with e2e-test-artifacts-dir.
-  parser.add_argument(
-      "--e2e_test_artifacts_dir",
-      metavar="<e2e-test-artifacts-dir>",
-      type=check_dir_path,
-      default=None,
-      help=("Path to the IREE e2e test artifacts directory. This will override "
+def _check_exe_path(path):
+  path = pathlib.Path(path)
+  if os.access(path, os.X_OK):
+    return path
+  else:
+    raise argparse.ArgumentTypeError(f"'{path}' is not an executable")
+
+
+class Parser(argparse.ArgumentParser):
+  """Argument parser that includes common arguments and does validation."""
+
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+
+    artifacts_dir_group = self.add_mutually_exclusive_group(required=True)
+    # TODO(#11076): Replace build-dir argument with e2e-test-artifacts-dir.
+    artifacts_dir_group.add_argument(
+        "build_dir",
+        metavar="<build-dir>",
+        type=_check_dir_path,
+        default=None,
+        nargs="?",
+        help="Path to the build directory containing benchmark suites")
+    artifacts_dir_group.add_argument(
+        "--e2e_test_artifacts_dir",
+        metavar="<e2e-test-artifacts-dir>",
+        type=_check_dir_path,
+        default=None,
+        help=(
+            "Path to the IREE e2e test artifacts directory. This will override "
             "<build-dir> and eventually replace it. For now must use with "
             "--run_config"))
-  parser.add_argument(
-      "--normal_benchmark_tool_dir",
-      "--normal-benchmark-tool-dir",
-      type=check_dir_path,
-      default=None,
-      help="Path to the normal (non-tracing) iree tool directory")
-  parser.add_argument("--traced_benchmark_tool_dir",
+
+    self.add_argument(
+        "--normal_benchmark_tool_dir",
+        "--normal-benchmark-tool-dir",
+        type=_check_dir_path,
+        default=None,
+        help="Path to the normal (non-tracing) iree tool directory")
+    self.add_argument("--traced_benchmark_tool_dir",
                       "--traced-benchmark-tool-dir",
-                      type=check_dir_path,
+                      type=_check_dir_path,
                       default=None,
                       help="Path to the tracing-enabled iree tool directory")
-  parser.add_argument("--trace_capture_tool",
+    self.add_argument("--trace_capture_tool",
                       "--trace-capture-tool",
-                      type=check_exe_path,
+                      type=_check_exe_path,
                       default=None,
                       help="Path to the tool for collecting captured traces")
-  parser.add_argument(
-      "--driver-filter-regex",
-      "--driver_filter_regex",
-      type=str,
-      default=None,
-      help="Only run benchmarks matching the given driver regex")
-  parser.add_argument(
-      "--model-name-regex",
-      "--model_name_regex",
-      type=str,
-      default=None,
-      help="Only run benchmarks matching the given model name regex")
-  parser.add_argument(
-      "--mode-regex",
-      "--mode_regex",
-      type=str,
-      default=None,
-      help="Only run benchmarks matching the given benchmarking mode regex")
-  parser.add_argument("--output",
+    self.add_argument(
+        "--driver-filter-regex",
+        "--driver_filter_regex",
+        type=str,
+        default=None,
+        help="Only run benchmarks matching the given driver regex")
+    self.add_argument(
+        "--model-name-regex",
+        "--model_name_regex",
+        type=str,
+        default=None,
+        help="Only run benchmarks matching the given model name regex")
+    self.add_argument(
+        "--mode-regex",
+        "--mode_regex",
+        type=str,
+        default=None,
+        help="Only run benchmarks matching the given benchmarking mode regex")
+    self.add_argument("--output",
                       "-o",
                       default=None,
                       type=pathlib.Path,
                       help="Path to the output file")
-  parser.add_argument("--capture_tarball",
+    self.add_argument("--capture_tarball",
                       "--capture-tarball",
                       default=None,
                       type=pathlib.Path,
                       help="Path to the tarball for captures")
-  parser.add_argument("--no-clean",
+    self.add_argument("--no-clean",
                       action="store_true",
                       help="Do not clean up the temporary directory used for "
                       "benchmarking on the Android device")
-  parser.add_argument("--verbose",
+    self.add_argument("--verbose",
                       action="store_true",
                       help="Print internal information during execution")
-  parser.add_argument(
-      "--pin-cpu-freq",
-      "--pin_cpu_freq",
-      action="store_true",
-      help="Pin CPU frequency for all cores to the maximum. Requires root")
-  parser.add_argument("--pin-gpu-freq",
+    self.add_argument(
+        "--pin-cpu-freq",
+        "--pin_cpu_freq",
+        action="store_true",
+        help="Pin CPU frequency for all cores to the maximum. Requires root")
+    self.add_argument("--pin-gpu-freq",
                       "--pin_gpu_freq",
                       action="store_true",
                       help="Pin GPU frequency to the maximum. Requires root")
-  parser.add_argument(
-      "--keep_going",
-      "--keep-going",
-      action="store_true",
-      help="Continue running after a failed benchmark. The overall exit status"
-      " will still indicate failure and all errors will be reported at the end."
-  )
-  parser.add_argument(
-      "--tmp_dir",
-      "--tmp-dir",
-      "--tmpdir",
-      default=pathlib.Path("/tmp/iree-benchmarks"),
-      type=check_dir_path,
-      help="Base directory in which to store temporary files. A subdirectory"
-      " with a name matching the git commit hash will be created.")
-  parser.add_argument(
-      "--continue_from_directory",
-      "--continue-from-directory",
-      default=None,
-      type=check_dir_path,
-      help="Path to directory with previous benchmark temporary files. This"
-      " should be for the specific commit (not the general tmp-dir). Previous"
-      " benchmark and capture results from here will not be rerun and will be"
-      " combined with the new runs.")
-  parser.add_argument(
-      "--benchmark_min_time",
-      "--benchmark-min-time",
-      default=0,
-      type=float,
-      help="If specified, this will be passed as --benchmark_min_time to the"
-      "iree-benchmark-module (minimum number of seconds to repeat running "
-      "for). In that case, no --benchmark_repetitions flag will be passed."
-      " If not specified, a --benchmark_repetitions will be passed "
-      "instead.")
-  parser.add_argument("--run_config",
-                      type=check_file_path,
+    self.add_argument(
+        "--keep_going",
+        "--keep-going",
+        action="store_true",
+        help="Continue running after a failed benchmark. The overall exit status"
+        " will still indicate failure and all errors will be reported at the end."
+    )
+    self.add_argument(
+        "--tmp_dir",
+        "--tmp-dir",
+        "--tmpdir",
+        default=pathlib.Path("/tmp/iree-benchmarks"),
+        type=_check_dir_path,
+        help="Base directory in which to store temporary files. A subdirectory"
+        " with a name matching the git commit hash will be created.")
+    self.add_argument(
+        "--continue_from_directory",
+        "--continue-from-directory",
+        default=None,
+        type=_check_dir_path,
+        help="Path to directory with previous benchmark temporary files. This"
+        " should be for the specific commit (not the general tmp-dir). Previous"
+        " benchmark and capture results from here will not be rerun and will be"
+        " combined with the new runs.")
+    self.add_argument(
+        "--benchmark_min_time",
+        "--benchmark-min-time",
+        default=0,
+        type=float,
+        help="If specified, this will be passed as --benchmark_min_time to the"
+        "iree-benchmark-module (minimum number of seconds to repeat running "
+        "for). In that case, no --benchmark_repetitions flag will be passed."
+        " If not specified, a --benchmark_repetitions will be passed "
+        "instead.")
+    self.add_argument("--run_config",
+                      type=_check_file_path,
                       default=None,
                       help="JSON file of the run config")
 
-  return parser
+  def parse_args(
+      self, arg_strs: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    args = super().parse_args(arg_strs)
+
+    if args.e2e_test_artifacts_dir is not None and args.run_config is None:
+      raise self.error("--e2e_test_artifacts_dir requires --run_config.")
+
+    return args
 
 
 def expand_and_check_file_paths(paths: Sequence[str]) -> List[pathlib.Path]:

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -44,14 +44,15 @@ def build_common_argument_parser():
       default=None,
       nargs='?',
       help="Path to the build directory containing benchmark suites")
+  # TODO(#11076): Replace build-dir argument with e2e-test-artifacts-dir.
   parser.add_argument(
       "--e2e_test_artifacts_dir",
       metavar="<e2e-test-artifacts-dir>",
       type=check_dir_path,
       default=None,
-      help=(
-          "Path to the IREE e2e test artifacts directory. This will override "
-          "<build-dir> and eventually replace it. Must use with --run_config"))
+      help=("Path to the IREE e2e test artifacts directory. This will override "
+            "<build-dir> and eventually replace it. For now must use with "
+            "--run_config"))
   parser.add_argument(
       "--normal_benchmark_tool_dir",
       "--normal-benchmark-tool-dir",

--- a/build_tools/benchmarks/common/common_arguments.py
+++ b/build_tools/benchmarks/common/common_arguments.py
@@ -41,7 +41,17 @@ def build_common_argument_parser():
       "build_dir",
       metavar="<build-dir>",
       type=check_dir_path,
+      default=None,
+      nargs='?',
       help="Path to the build directory containing benchmark suites")
+  parser.add_argument(
+      "--e2e_test_artifacts_dir",
+      metavar="<e2e-test-artifacts-dir>",
+      type=check_dir_path,
+      default=None,
+      help=(
+          "Path to the IREE e2e test artifacts directory. This will override "
+          "<build-dir> and eventually replace it. Must use with --run_config"))
   parser.add_argument(
       "--normal_benchmark_tool_dir",
       "--normal-benchmark-tool-dir",

--- a/build_tools/benchmarks/common/common_arguments_test.py
+++ b/build_tools/benchmarks/common/common_arguments_test.py
@@ -9,39 +9,44 @@ import unittest
 import shutil
 import tempfile
 
-from common.common_arguments import build_common_argument_parser
+import common.common_arguments
 
 
 class CommonArgumentsTest(unittest.TestCase):
 
-  def test_build_common_argument_parser(self):
+  def test_parser(self):
     with tempfile.TemporaryDirectory() as tempdir:
-      arg_parser = build_common_argument_parser()
-      arg_parser.parse_args([
+      common.common_arguments.Parser().parse_args([
           "--normal_benchmark_tool_dir=" + tempdir,
           "--traced_benchmark_tool_dir=" + tempdir,
           "--trace_capture_tool=" + shutil.which("ls"), "."
       ])
 
-  def test_build_common_argument_parser_check_build_dir(self):
-    arg_parser = build_common_argument_parser()
+  def test_parser_check_build_dir(self):
+    arg_parser = common.common_arguments.Parser()
     with self.assertRaises(SystemExit):
       arg_parser.parse_args(["nonexistent"])
 
-  def test_build_common_argument_parser_check_normal_benchmark_tool(self):
-    arg_parser = build_common_argument_parser()
+  def test_parser_check_normal_benchmark_tool(self):
+    arg_parser = common.common_arguments.Parser()
     with self.assertRaises(SystemExit):
       arg_parser.parse_args(["--normal_benchmark_tool_dir=nonexistent", "."])
 
-  def test_build_common_argument_parser_check_traced_benchmark_tool(self):
-    arg_parser = build_common_argument_parser()
+  def test_parser_check_traced_benchmark_tool(self):
+    arg_parser = common.common_arguments.Parser()
     with self.assertRaises(SystemExit):
       arg_parser.parse_args(["--traced_benchmark_tool_dir=nonexistent", "."])
 
-  def test_build_common_argument_parser_check_trace_capture_tool(self):
-    arg_parser = build_common_argument_parser()
+  def test_parser_check_trace_capture_tool(self):
+    arg_parser = common.common_arguments.Parser()
     with self.assertRaises(SystemExit):
       arg_parser.parse_args(["--trace_capture_tool=nonexistent", "."])
+
+  def test_parser_e2e_test_artifacts_dir_requires_run_config(self):
+    arg_parser = common.common_arguments.Parser()
+    with tempfile.TemporaryDirectory() as tempdir:
+      with self.assertRaises(SystemExit):
+        arg_parser.parse_args([f"--e2e_test_artifacts_dir={tempdir}"])
 
 
 if __name__ == "__main__":

--- a/build_tools/benchmarks/run_benchmarks_on_android.py
+++ b/build_tools/benchmarks/run_benchmarks_on_android.py
@@ -53,7 +53,7 @@ from common.benchmark_suite import (MODEL_FLAGFILE_NAME, BenchmarkCase,
 from common.android_device_utils import (get_android_device_model,
                                          get_android_device_info,
                                          get_android_gpu_name)
-from common.common_arguments import build_common_argument_parser
+import common.common_arguments
 
 # Root directory to perform benchmarks in on the Android device.
 ANDROID_TMPDIR = pathlib.PurePosixPath("/data/local/tmp/iree-benchmarks")
@@ -411,5 +411,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-  args = build_common_argument_parser().parse_args()
-  main(args)
+  main(common.common_arguments.Parser().parse_args())

--- a/build_tools/benchmarks/run_benchmarks_on_linux.py
+++ b/build_tools/benchmarks/run_benchmarks_on_linux.py
@@ -24,12 +24,12 @@ from common.benchmark_driver import BenchmarkDriver
 from common.benchmark_suite import MODEL_FLAGFILE_NAME, BenchmarkCase, BenchmarkSuite
 from common.benchmark_config import BenchmarkConfig
 from common.benchmark_definition import execute_cmd, execute_cmd_and_get_output, get_git_commit_hash, get_iree_benchmark_module_arguments, wait_for_iree_benchmark_module_start
-from common.common_arguments import build_common_argument_parser
 from common.linux_device_utils import get_linux_device_info
 from e2e_test_framework.definitions import iree_definitions
 from e2e_test_framework import serialization
 from e2e_test_artifacts import iree_artifacts
 from e2e_model_tests import run_module_utils
+import common.common_arguments
 
 
 class LinuxBenchmarkDriver(BenchmarkDriver):
@@ -203,7 +203,7 @@ def main(args):
 
 
 def parse_argument():
-  arg_parser = build_common_argument_parser()
+  arg_parser = common.common_arguments.Parser()
   arg_parser.add_argument("--device_model",
                           default="Unknown",
                           help="Device model")


### PR DESCRIPTION
The e2e test artifacts directory is self-contained for benchmark artifacts. Benchmark tools should no longer need the whole build directory.

Thie change adds a new option `--e2e_test_artifacts_dir` to specify the e2e test artifacts directory. This option will eventually replace the current positional argument `<build-dir>`.