### PR TITLE
Add a reduction-v3 strategy for dynamic cases.

### DIFF
--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -29,6 +29,7 @@ iree_lit_test_suite(
         "reduction.mlir",
         "reduction_eltwise.mlir",
         "reduction_v2.mlir",
+        "reduction_v3.mlir",
         "softmax.mlir",
         "softmax_v2.mlir",
         # First few ops of softmax only, acts as a proxy example.
@@ -42,6 +43,7 @@ iree_lit_test_suite(
         "reduction_codegen_spec.mlir",
         "reduction_eltwise_codegen_spec.mlir",
         "reduction_v2_codegen_spec.mlir",
+        "reduction_v3_codegen_spec.mlir",
         "softmax_codegen_spec.mlir",
         "softmax_v2_codegen_spec.mlir",
         #

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "reduction.mlir"
     "reduction_eltwise.mlir"
     "reduction_v2.mlir"
+    "reduction_v3.mlir"
     "softmax.mlir"
     "softmax_partial.mlir"
     "softmax_v2.mlir"
@@ -34,6 +35,7 @@ iree_lit_test_suite(
     reduction_codegen_spec.mlir
     reduction_eltwise_codegen_spec.mlir
     reduction_v2_codegen_spec.mlir
+    reduction_v3_codegen_spec.mlir
     softmax_codegen_spec.mlir
     softmax_dispatch_spec.mlir
     softmax_partial_codegen_spec.mlir

--- a/tests/transform_dialect/cuda/reduction_v3.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3.mlir
@@ -1,0 +1,62 @@
+!in_tensor_t = tensor<33x?xf32>
+!out_tensor_t = tensor<33xf32>
+
+func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->   !out_tensor_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_t
+  return %2 : !out_tensor_t
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v3_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v3_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="33x1024xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+  //     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  //     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+  //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x1024xf32, 3>
+  
+  //         CHECK: %[[TIDX:.]] = gpu.thread_id  x
+  //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[TIDX]]]{{.*}}to memref<1x1xf32, strided<[1024, 1], offset: ?>, 3>
+  // Local per-thread scf.for-based reduction.
+  //         CHECK: scf.for
+  //         CHECK:   vector.transfer_read %{{.*}} {in_bounds = [true]} : memref<33x?xf32>, vector<1xf32>
+  //         CHECK:   arith.addf {{.*}} : vector<1xf32>
+  //         CHECK:   scf.yield %{{.*}} : vector<1xf32>
+
+  //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+  // Distributed reduction: everyone loads then 5 xor + addf expected
+  //         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %{{.*}}]
+  // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+  //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}
+
+  //         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<1xf32>
+  //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+  //         CHECK: scf.if %[[CONDXIS0]]
+  //         CHECK:   vector.transfer_write %[[RES_VEC]]
+  //         CHECK: gpu.barrier
+
+// only checking the first 6 of 33
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 33xf32=1024 1024 1024 1024 1024 1024

--- a/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
@@ -1,0 +1,60 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(suppress) {
+^bb1(%variant_op: !pdl.operation):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+  %reduction = transform.structured.match ops{["linalg.generic"]} in %variant_op
+
+  // Step 1. First level of tiling + fusion parallelizes to blocks.
+  // ===========================================================================
+  %foreach_thread_grid, %grid_reduction =
+    transform.iree.tile_to_foreach_thread_and_workgroup_count_region %reduction tile_sizes [1]
+      ( mapping = [#gpu.block<x>] )
+  transform.structured.fuse_into_containing_op %fill into %foreach_thread_grid
+
+  // Step 2. Split the reduction to get meatier parallelism.
+  // This also parallelizes to threads
+  // ===========================================================================
+  %foreach_thread, %block_more_parallel_fill_op_2, %block_more_parallel_op_2, %block_combiner_op_2 = 
+     transform.structured.tile_reduction_using_foreach_thread %grid_reduction 
+       { num_threads = [0, 1024], tile_sizes = [0, 1], mapping = [#gpu.thread<x>] }
+  // Fuse the fill and pointwise to privatize them. 
+  transform.structured.fuse_into_containing_op %block_more_parallel_fill_op_2
+    into %foreach_thread
+  // block_combiner_op_2 op is [parallel, reduction] of 1x384 that cannot fuse.
+  // map the 1-dim to threadIdx.y to trigger mapping of the reduction to 
+  // threadIdx.x via predication via `if (x==0)`.
+  transform.structured.tile_to_foreach_thread_op %block_combiner_op_2 tile_sizes [1] 
+    ( mapping = [#gpu.thread<y>] )
+
+  // Step 3. Rank-reduce and vectorize.
+  // ===========================================================================
+  %func = transform.structured.match ops{["func.func"]} in %variant_op
+  // TODO: masked vectorization on block_more_parallel_op_2 if we want 
+  // vector<4> to work as intended.
+  // TODO: there is a conflicting pattern here that introduces a tensor.empty
+  // to collapse/expand shape + scf.for. 
+  // This is investigated in parallel.
+  // %func_2 = transform.iree.apply_patterns %func { rank_reducing }
+  %func_3 = transform.structured.vectorize %func
+
+  // Step 4. Bufferize and drop HAL descriptor from memref ops.
+  // ===========================================================================
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+
+  // Step 5. Post-bufferization mapping to blocks and threads.
+  // ===========================================================================
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
+  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
+      { workgroup_size = [1024, 1, 1] }
+
+  // Step 6. Post-bufferization vector distribution with rank-reduction.
+  // ===========================================================================
+  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  transform.iree.vector.warp_distribute %func_7
+}


### PR DESCRIPTION
This is a rebase of #11497 on main post-LLVM-integrate changes.