### PR TITLE
Emit better reduction schedule from JIT

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -126,81 +126,85 @@ void mlir::iree_compiler::buildPrint(ImplicitLocOpBuilder &b,
 /// appended in order.
 // TODO: apply forwarding pattern.
 template <typename TilingTransformOp, typename TileOrNumThreadSpec>
-static Value buildTileAndFuseAndDistributeImpl(
-    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<OpFoldResult> tileSizesOrNumThreads, ArrayAttr threadDimMapping,
-    SmallVectorImpl<Value> *resultingFusedOpsHandles) {
+static iree_compiler::TileAndFuseAndDistributeResult
+buildTileAndFuseAndDistributeImpl(ImplicitLocOpBuilder &b, Value rootH,
+                                  ValueRange opsHToFuse,
+                                  ArrayRef<OpFoldResult> tileSizesOrNumThreads,
+                                  ArrayAttr threadDimMapping) {
+  iree_compiler::TileAndFuseAndDistributeResult result;
   auto tileToForeachOp = b.create<TilingTransformOp>(
       rootH, tileSizesOrNumThreads, TileOrNumThreadSpec(), threadDimMapping);
-  Value foreachThreadH = tileToForeachOp.getForeachThreadOp();
-  // Batch fusion.
-  Value mergedOpsH = b.create<MergeHandlesOp>(opsHToFuse, /*deduplicate=*/true);
-  b.create<FuseIntoContainingOp>(mergedOpsH, foreachThreadH);
-  assert(!resultingFusedOpsHandles && "Handle needs unpacking");
-  return foreachThreadH;
+  result.foreachThreadH = tileToForeachOp.getForeachThreadOp();
+  result.tiledOpH = tileToForeachOp.getTiledOp();
+
+  // Batch fusion if requested.
+  if (opsHToFuse.size() > 1) {
+    Value mergedOpsH =
+        b.create<MergeHandlesOp>(opsHToFuse, /*deduplicate=*/true);
+    b.create<FuseIntoContainingOp>(mergedOpsH, result.foreachThreadH);
+  } else if (opsHToFuse.size() == 1) {
+    Value fusedH = b.create<FuseIntoContainingOp>(opsHToFuse.front(),
+                                                  result.foreachThreadH);
+    result.resultingFusedOpsHandles.push_back(fusedH);
+  }
+  return result;
 }
 
 // TODO: if someone knows how to properly export templates go for it ..
 // sigh.
 template <typename TilingTransformOp>
-static Value buildTileFuseDistWithTileSizes(
-    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
-    SmallVectorImpl<Value> *resultingFusedOpsHandles) {
+static iree_compiler::TileAndFuseAndDistributeResult
+buildTileFuseDistWithTileSizes(ImplicitLocOpBuilder &b, Value rootH,
+                               ValueRange opsHToFuse,
+                               ArrayRef<OpFoldResult> tileSizes,
+                               ArrayAttr threadDimMapping) {
   return buildTileAndFuseAndDistributeImpl<TilingTransformOp,
                                            transform::TileSizesSpec>(
-      b, rootH, opsHToFuse, tileSizes, threadDimMapping,
-      resultingFusedOpsHandles);
+      b, rootH, opsHToFuse, tileSizes, threadDimMapping);
 }
-Value mlir::iree_compiler::buildTileFuseDistToForeachThreadWithTileSizes(
+iree_compiler::TileAndFuseAndDistributeResult
+mlir::iree_compiler::buildTileFuseDistToForeachThreadWithTileSizes(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
-    SmallVectorImpl<Value> *resultingFusedOpsHandles) {
+    ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping) {
   return buildTileFuseDistWithTileSizes<TileToForeachThreadOp>(
-      b, rootH, opsHToFuse, tileSizes, threadDimMapping,
-      resultingFusedOpsHandles);
+      b, rootH, opsHToFuse, tileSizes, threadDimMapping);
 }
-Value mlir::iree_compiler::
+iree_compiler::TileAndFuseAndDistributeResult mlir::iree_compiler::
     buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
         ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-        ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
-        SmallVectorImpl<Value> *resultingFusedOpsHandles) {
+        ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping) {
   return buildTileFuseDistWithTileSizes<
-      TileToForeachThreadAndWorkgroupCountRegionOp>(b, rootH, opsHToFuse,
-                                                    tileSizes, threadDimMapping,
-                                                    resultingFusedOpsHandles);
+      TileToForeachThreadAndWorkgroupCountRegionOp>(
+      b, rootH, opsHToFuse, tileSizes, threadDimMapping);
 }
 
 /// Call buildTileAndFuseAndDistributeImpl with ArrayRef<int64_t> numThreads.
 // TODO: if someone knows how to properly export templates go for it ..
 // sigh.
 template <typename TilingTransformOp>
-static Value buildTileFuseDistWithNumThreads(
-    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<OpFoldResult> numThreads, ArrayAttr threadDimMapping,
-    SmallVectorImpl<Value> *resultingFusedOpsHandles) {
+static iree_compiler::TileAndFuseAndDistributeResult
+buildTileFuseDistWithNumThreads(ImplicitLocOpBuilder &b, Value rootH,
+                                ValueRange opsHToFuse,
+                                ArrayRef<OpFoldResult> numThreads,
+                                ArrayAttr threadDimMapping) {
   return buildTileAndFuseAndDistributeImpl<TilingTransformOp,
                                            transform::NumThreadsSpec>(
-      b, rootH, opsHToFuse, numThreads, threadDimMapping,
-      resultingFusedOpsHandles);
+      b, rootH, opsHToFuse, numThreads, threadDimMapping);
 }
-Value mlir::iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
+iree_compiler::TileAndFuseAndDistributeResult
+mlir::iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
-    SmallVectorImpl<Value> *resultingFusedOpsHandles) {
-  return buildTileFuseDistWithTileSizes<TileToForeachThreadOp>(
-      b, rootH, opsHToFuse, tileSizes, threadDimMapping,
-      resultingFusedOpsHandles);
+    ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping) {
+  return buildTileFuseDistWithNumThreads<TileToForeachThreadOp>(
+      b, rootH, opsHToFuse, tileSizes, threadDimMapping);
 }
-Value mlir::iree_compiler::
+iree_compiler::TileAndFuseAndDistributeResult mlir::iree_compiler::
     buildTileFuseDistToForeachThreadAndWorgroupCountWithNumThreads(
         ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-        ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping,
-        SmallVectorImpl<Value> *resultingFusedOpsHandles) {
-  return buildTileFuseDistWithTileSizes<
-      TileToForeachThreadAndWorkgroupCountRegionOp>(b, rootH, opsHToFuse,
-                                                    tileSizes, threadDimMapping,
-                                                    resultingFusedOpsHandles);
+        ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping) {
+  return buildTileFuseDistWithNumThreads<
+      TileToForeachThreadAndWorkgroupCountRegionOp>(
+      b, rootH, opsHToFuse, tileSizes, threadDimMapping);
 }
 
 /// Apply patterns and vectorize (for now always applies rank-reduction).

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -27,37 +27,35 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
   }
 }
 }
+
 //   CHECK-LABEL: func.func @group_reduction
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
-//     CHECK-DAG:   %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x2xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
-//     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
+//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
+//         CHECK:   gpu.barrier
 
-// Distributed reduction: everyone loads then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
+//         CHECK:   vector.transfer_read
+//         CHECK:   vector.transfer_read
+//         CHECK:   arith.addf %{{.*}} : vector<2xf32>
+//         CHECK:   vector.transfer_write
+//         CHECK:   gpu.barrier
+
+// Distributed reduction: everyone loads then 5 xor + addf expected.
+//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
-//         CHECK:     vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
+//         CHECK:     vector.transfer_write %[[RES_VEC]]
 //         CHECK:   gpu.barrier
-
-// Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
-//         CHECK:   %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
-//          TODO: cond eq 0 and cond ult 1 do not CSE atm.
-//         CHECK:   %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
-//         CHECK:   scf.if %[[CONXANDYARE0]] {
-//         CHECK:     vector.transfer_read
-//         CHECK:     vector.reduction <add>
-//         CHECK:     vector.transfer_write
-//         CHECK:   gpu.barrier
-//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
+//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
 
 // -----
 
@@ -96,37 +94,35 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_elementwise
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
-//     CHECK-DAG:   %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x2xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
-//     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
+//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
+//         CHECK:   gpu.barrier
 
-// Distributed reduction: everyone loads then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
+// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
+//         CHECK:   vector.transfer_read
+//         CHECK:   vector.transfer_read
+//         CHECK:   arith.addf %{{.*}} : vector<2xf32>
+//         CHECK:   vector.transfer_write
+//         CHECK:   gpu.barrier
+
+// Distributed reduction: everyone loads then 5 xor + addf expected.
+//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
-//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
+
+//         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
+//         CHECK:   %[[PARTIAL_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
+//         CHECK:   %[[ELEM:.*]] = vector.extractelement %[[PARTIAL_VEC]][]
+//         CHECK:   %[[RES:.*]] = math.sqrt %[[ELEM]]
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
-//         CHECK:     vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
+//         CHECK:     vector.transfer_write %[[RES_VEC]]
 //         CHECK:   gpu.barrier
-
-// Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
-// It should contain the fused elementwise operation.
-//         CHECK:   %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
-//          TODO:   cond eq 0 and cond ult 1 do not CSE atm.
-//         CHECK:   %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
-//         CHECK:   scf.if %[[CONXANDYARE0]] {
-//         CHECK:     vector.transfer_read
-//         CHECK:     vector.reduction <add>
-//         CHECK:     math.sqrt
-//         CHECK:     vector.transfer_write
-//         CHECK:   gpu.barrier
-//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
+//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
 
 // -----
 
@@ -162,40 +158,35 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_elementwise_reduction
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
-//     CHECK-DAG:   %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x2xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
-//     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
+//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
+//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
+//         CHECK:   gpu.barrier
 
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
+//         CHECK:   vector.transfer_read
+//         CHECK:   vector.transfer_read
+//         CHECK:   %[[PARTIAL_1:.*]] = arith.addf %[[ARG:.*]], %[[ARG]]
+//         CHECK:   %[[PARTIAL_2:.*]] = arith.addf %[[PARTIAL_1]], %[[PARTIAL_1]]
+//         CHECK:   arith.addf %[[PARTIAL_2]], %{{.*}} : vector<2xf32>
+//         CHECK:   vector.transfer_write
+//         CHECK:   gpu.barrier
 
-// Distributed reduction: everyone loads, does the elementwise then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
-//         CHECK:   arith.addf
-//         CHECK:   arith.addf
+// Distributed reduction: everyone loads then 5 xor + addf expected.
+//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
-//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
 
+//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
-//         CHECK:     vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
+//         CHECK:     vector.transfer_write %[[RES_VEC]]
 //         CHECK:   gpu.barrier
-
-// Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
-//         CHECK:   %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
-//          TODO: cond eq 0 and cond ult 1 do not CSE atm.
-//         CHECK:   %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
-//         CHECK:   scf.if %[[CONXANDYARE0]] {
-//         CHECK:     vector.transfer_read
-//         CHECK:     vector.reduction <add>
-//         CHECK:     vector.transfer_write
-//         CHECK:   gpu.barrier
-//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
+//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
 
 // -----
 
@@ -236,38 +227,93 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_elementwise_reduction_elementwise
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[C1:.*]] = arith.constant 1 : index
-//     CHECK-DAG:   %[[F0:.*]] = arith.constant dense<0.000000e+00> : vector<f32>
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x2xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-//     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
-//     CHECK-DAG:   %[[TIDZ:.]] = gpu.thread_id  z
+//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
+//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<2xf32, strided<[1], offset: ?>, 3>
+//         CHECK:   gpu.barrier
 
-//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][%[[TIDZ]], %[[TIDY]]]{{.*}}to memref<f32, {{.*}}, 3>
+// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
+//         CHECK:   vector.transfer_read
+//         CHECK:   vector.transfer_read
+//         CHECK:   %[[PARTIAL_1:.*]] = arith.addf %[[ARG:.*]], %[[ARG]]
+//         CHECK:   %[[PARTIAL_2:.*]] = arith.addf %[[PARTIAL_1]], %[[PARTIAL_1]]
+//         CHECK:   arith.addf %[[PARTIAL_2]], %{{.*}} : vector<2xf32>
+//         CHECK:   vector.transfer_write
+//         CHECK:   gpu.barrier
 
-// Distributed reduction: everyone loads, does the elementwise then 5 xor + addf expected
-//         CHECK:   vector.transfer_read %{{.*}}[%[[TIDZ]], %[[TIDY]], %[[TIDX]]]
-//         CHECK:   arith.addf
-//         CHECK:   arith.addf
+// Distributed reduction: everyone loads then 5 xor + addf expected.
+//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
-//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
-
+//         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
+//         CHECK:   %[[PARTIAL_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
+//         CHECK:   %[[ELEM:.*]] = vector.extractelement %[[PARTIAL_VEC]][]
+//         CHECK:   %[[RES:.*]] = math.sqrt %[[ELEM]]
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
-//         CHECK:     vector.transfer_write %[[RES_VEC]], %[[SHMEM_VIEW_EXPANDED]][]
+//         CHECK:     vector.transfer_write %[[RES_VEC]]
+//         CHECK:   gpu.barrier
+//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
+
+// -----
+
+hal.executable @group_reduction_larger {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @group_reduction_larger ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @group_reduction_larger() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant -0.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<33x256xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<33xf32>>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [33, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<33x256xf32>> -> tensor<33x256xf32>
+      %3 = tensor.empty() : tensor<33xf32>
+      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<33xf32>) -> tensor<33xf32>
+      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<33x256xf32>) outs(%4 : tensor<33xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %6 = arith.addf %in, %out : f32
+        linalg.yield %6 : f32
+      } -> tensor<33xf32>
+      flow.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<33xf32> -> !flow.dispatch.tensor<writeonly:tensor<33xf32>>
+      return
+    }
+  }
+}
+}
+
+//   CHECK-LABEL: func.func @group_reduction_larger
+//     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
+//     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x128xf32, 3>
+//     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
+//         CHECK:   %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
+//         CHECK:   %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[IDX]]]{{.*}}to memref<4xf32, strided<[1], offset: ?>, 3>
 //         CHECK:   gpu.barrier
 
-// Last part is not distributed atm and is only ran by threadIdx.x == 0 and threadIdx.y == 0.
-//         CHECK:   %[[CONDYIS0:.*]] = arith.cmpi ult, %[[TIDY]], %[[C1]] : index
-//          TODO: cond eq 0 and cond ult 1 do not CSE atm.
-//         CHECK:   %[[CONXANDYARE0:.*]] = arith.andi %{{.*}}, %[[CONDYIS0]] : i1
-//         CHECK:   scf.if %[[CONXANDYARE0]] {
-//         CHECK:     vector.transfer_read
-//         CHECK:     vector.reduction <add>
-//         CHECK:     math.sqrt
-//         CHECK:     vector.transfer_write
+// Local per-thread scf.for-based reduction, after the single-iteration scf.for was canonicalized.
+//         CHECK:   vector.transfer_read
+//         CHECK:   vector.transfer_read
+//         CHECK:   arith.addf %{{.*}} : vector<4xf32>
+//         CHECK:   vector.transfer_write
 //         CHECK:   gpu.barrier
-//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]] : memref<1x2xf32, 3>
+
+// Distributed reduction: everyone loads then 5 xor + addf expected.
+//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
+// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
+//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+//         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+//         CHECK:   scf.if %[[CONDXIS0]]
+//         CHECK:     vector.transfer_write %[[RES_VEC]]
+//         CHECK:   gpu.barrier
+//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -28,17 +28,115 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 }
 }
 
-// CHECK-LABEL: func.func @group_reduction
-//       CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//       CHECK:     transform.structured.match ops{["linalg.fill"]} in %{{.+}}
-//       CHECK:     transform.structured.match ops{["linalg.generic"]} in %{{.+}}
-//       CHECK:     transform.structured.split_reduction %{{.+}} {insert_split_dimension = 1 : i64, split_factor = 2 : i64}
-//       CHECK:     transform.iree.tile_to_foreach_thread_and_workgroup_count_region %{{.*}}   num_threads [] tile_sizes [1](mapping = [#gpu.block<x>])
-//       CHECK:     transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [] tile_sizes [1, 0, 0](mapping = [#gpu.thread<z>])
-//       CHECK:     transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [] tile_sizes [1, 1, 0](mapping = [#gpu.thread<z>, #gpu.thread<y>])
-//       CHECK:     transform.iree.bufferize {target_gpu}
-//       CHECK:     transform.iree.foreach_thread_to_workgroup
-//       CHECK:     transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.+}} {workgroup_size = [32, 2, 1]}
-//       CHECK:     transform.structured.match ops{["scf.if"]} in %{{.+}}
-//       CHECK:       transform.iree.vector.to_warp_execute_on_lane_0 %{{.+}} {warp_size = 32 : i64}
-//       CHECK:     transform.iree.vector.warp_distribute %{{.+}}
+//   CHECK-LABEL: func.func @group_reduction
+//         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
+//         CHECK:   transform.iree.match_callback failures(propagate) "reduction"(%{{.+}})
+//         CHECK:   transform.iree.take_first
+//         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region {{.*}} tile_sizes [1](mapping = [#gpu.block<x>])
+// CHECK-COUNT-3:   transform.structured.fuse_into_containing_op
+//         CHECK:   transform.iree.take_first
+//         CHECK:   transform.structured.tile_reduction_using_scf %{{.*}} {tile_sizes = [0, 64]}
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [0, 32]
+//    CHECK-SAME:      (mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [0, 2](mapping = [#gpu.thread<x>])
+//         CHECK:   transform.iree.take_first
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [1](mapping = [#gpu.thread<y>])
+//         CHECK:   transform.structured.fuse_into_containing_op
+//         CHECK:   transform.structured.match ops{["func.func"]} in %arg0
+//         CHECK:   transform.iree.apply_patterns %{{.*}} {rank_reducing}
+//         CHECK:   transform.structured.vectorize
+//         CHECK:   transform.iree.bufferize {target_gpu}
+//         CHECK:   transform.structured.match ops{["func.func"]} in %{{.*}}
+//         CHECK:   transform.iree.erase_hal_descriptor_type_from_memref
+//         CHECK:   transform.structured.match ops{["func.func"]} in %{{.*}}
+//         CHECK:   transform.iree.foreach_thread_to_workgroup
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}
+//         CHECK:   transform.iree.apply_patterns %{{.*}} {rank_reducing}
+//         CHECK:   transform.structured.match ops{["scf.if"]} in %{{.*}}
+//         CHECK:   sequence {{.*}} failures(suppress) {
+//         CHECK:     transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 32 : i64}
+//         CHECK:   }
+//         CHECK:   transform.iree.vector.warp_distribute
+
+
+// -----
+
+
+hal.executable @group_reduction_128 {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @group_reduction_128 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @group_reduction_128() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant -0.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<8x128xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<8xf32>>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 128], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x128xf32>> -> tensor<8x128xf32>
+      %3 = tensor.empty() : tensor<8xf32>
+      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<8xf32>) -> tensor<8xf32>
+      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<8x128xf32>) outs(%4 : tensor<8xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %6 = arith.addf %in, %out : f32
+        linalg.yield %6 : f32
+      } -> tensor<8xf32>
+      flow.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !flow.dispatch.tensor<writeonly:tensor<8xf32>>
+      return
+    }
+  }
+}
+}
+
+// Overall, the schedule is same as above, but with larger tile sizes.
+// Checking only the tile sizes.
+
+//   CHECK-LABEL: func.func @group_reduction_128
+//         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
+//         CHECK:   transform.structured.tile_reduction_using_scf %{{.*}} {tile_sizes = [0, 128]}
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [0, 32]
+//    CHECK-SAME:      (mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [0, 4](mapping = [#gpu.thread<x>])
+
+// -----
+
+
+hal.executable @group_reduction_32 {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @group_reduction_32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @group_reduction_32() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant -0.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<8x32xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<8xf32>>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 32], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x32xf32>> -> tensor<8x32xf32>
+      %3 = tensor.empty() : tensor<8xf32>
+      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<8xf32>) -> tensor<8xf32>
+      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<8x32xf32>) outs(%4 : tensor<8xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %6 = arith.addf %in, %out : f32
+        linalg.yield %6 : f32
+      } -> tensor<8xf32>
+      flow.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !flow.dispatch.tensor<writeonly:tensor<8xf32>>
+      return
+    }
+  }
+}
+}
+
+// Overall, the schedule is same as above, but with larger tile sizes.
+// Checking only the tile sizes.
+
+//   CHECK-LABEL: func.func @group_reduction_32
+//         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
+//         CHECK:   transform.structured.tile_reduction_using_scf %{{.*}} {tile_sizes = [0, 32]}
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [0, 32]
+//    CHECK-SAME:      (mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [0, 1](mapping = [#gpu.thread<x>])

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -40,6 +40,11 @@ struct AllDims {};
 /// for all operands of the relevant kind.
 struct AllOperands {};
 
+struct CaptureDim {
+  explicit CaptureDim(int64_t &value) : value(value) {}
+  int64_t &value;
+};
+
 /// A tag indicating to look for any user of the operation's result that would
 /// satisfy the predicate.
 struct HasAnyUse {};
@@ -152,6 +157,8 @@ public:
   /// may be negative, in which case dimensions are counted from the last one
   /// (i.e. Python-style).
   StructuredOpMatcher &dim(int64_t dimension, DivisibleBy divisibleBy);
+
+  StructuredOpMatcher &dim(int64_t dimension, CaptureDim capture);
 
   /// Adds a predicate checking that the structured op has the given number of
   /// inputs.
@@ -445,7 +452,8 @@ private:
 void makeReductionMatcher(StructuredOpMatcher &reduction,
                           StructuredOpMatcher &fill,
                           StructuredOpMatcher &leading,
-                          StructuredOpMatcher &trailing);
+                          StructuredOpMatcher &trailing,
+                          int64_t &reductionDimensionSize);
 
 /// Creates a group of matchers for:
 ///

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -1233,7 +1233,8 @@ reductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
 
   transform_ext::StructuredOpMatcher pattern, fill, leadingEltwise,
       trailingEltwise;
-  makeReductionMatcher(pattern, fill, leadingEltwise, trailingEltwise);
+  int64_t ignore;
+  makeReductionMatcher(pattern, fill, leadingEltwise, trailingEltwise, ignore);
 
   // TODO: need a mechanism for this to go around the entire IR,
   // potentially with list matches for each group.

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -98,6 +98,21 @@ transform_ext::StructuredOpMatcher::dim(int64_t dimension,
 }
 
 transform_ext::StructuredOpMatcher &
+transform_ext::StructuredOpMatcher::dim(int64_t dimension, CaptureDim capture) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    unsigned rank = linalgOp.getNumLoops();
+    int64_t transformedDimension =
+        dimension >= 0 ? dimension : rank + dimension;
+    if (transformedDimension >= rank)
+      return false;
+
+    capture.value = linalgOp.getStaticLoopRanges()[transformedDimension];
+    return true;
+  });
+  return *this;
+}
+
+transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(AllOperands tag, IsPermutation) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     // all_of with a lambda requires const-casting dance, so using a loop.
@@ -292,7 +307,8 @@ void transform_ext::makeReductionMatcher(
     transform_ext::StructuredOpMatcher &reduction,
     transform_ext::StructuredOpMatcher &fill,
     transform_ext::StructuredOpMatcher &leading,
-    transform_ext::StructuredOpMatcher &trailing) {
+    transform_ext::StructuredOpMatcher &trailing,
+    int64_t &reductionDimensionSize) {
   fill = m_StructuredOp<linalg::FillOp>();
   trailing = m_StructuredOp<linalg::GenericOp>()
                  .input(AllOperands(), IsPermutation())
@@ -304,6 +320,7 @@ void transform_ext::makeReductionMatcher(
                   .dim(AllDims(), ShapeKind::Static)
                   .dim(-1, utils::IteratorType::reduction)
                   .dim(-1, DivisibleBy(kCudaWarpSize))
+                  .dim(-1, CaptureDim(reductionDimensionSize))
                   // Can be extended to projected permutation with broadcast.
                   .input(AllOperands(), IsPermutation())
                   // TODO: we want to accept any input position here.

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -29,6 +29,7 @@ iree_lit_test_suite(
         "reduction.mlir",
         "reduction_eltwise.mlir",
         "reduction_v2.mlir",
+        "reduction_v3.mlir",
         "softmax.mlir",
         "softmax_v2.mlir",
         # First few ops of softmax only, acts as a proxy example.
@@ -42,6 +43,7 @@ iree_lit_test_suite(
         "reduction_codegen_spec.mlir",
         "reduction_eltwise_codegen_spec.mlir",
         "reduction_v2_codegen_spec.mlir",
+        "reduction_v3_codegen_spec.mlir",
         "softmax_codegen_spec.mlir",
         "softmax_v2_codegen_spec.mlir",
         #

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "reduction.mlir"
     "reduction_eltwise.mlir"
     "reduction_v2.mlir"
+    "reduction_v3.mlir"
     "softmax.mlir"
     "softmax_partial.mlir"
     "softmax_v2.mlir"
@@ -34,6 +35,7 @@ iree_lit_test_suite(
     reduction_codegen_spec.mlir
     reduction_eltwise_codegen_spec.mlir
     reduction_v2_codegen_spec.mlir
+    reduction_v3_codegen_spec.mlir
     softmax_codegen_spec.mlir
     softmax_dispatch_spec.mlir
     softmax_partial_codegen_spec.mlir

--- a/tests/transform_dialect/cuda/reduction_v3.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3.mlir
@@ -1,0 +1,62 @@
+!in_tensor_t = tensor<33x?xf32>
+!out_tensor_t = tensor<33xf32>
+
+func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
+  %cst = arith.constant -0.000000e+00 : f32
+
+  %0 = tensor.empty() : !out_tensor_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->   !out_tensor_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_t) outs(%1 : !out_tensor_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_t
+  return %2 : !out_tensor_t
+}
+
+// RUN: iree-opt %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-abi-transformation-pipeline \
+// RUN:     --iree-flow-transformation-pipeline  \
+// RUN:     --iree-stream-transformation-pipeline \
+// RUN:     --iree-hal-configuration-pipeline | \
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v3_codegen_spec.mlir | \
+// RUN: FileCheck %s --check-prefix=CHECK
+
+// RUN: iree-compile %s --iree-hal-target-backends=cuda \
+// RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/reduction_v3_codegen_spec.mlir | \
+// RUN: iree-run-module --entry_function=reduce --device=cuda --function_input="33x1024xf32=1" |\
+// RUN: FileCheck %s --check-prefix=EXEC
+
+  //     CHECK-DAG: %[[C0:.*]] = arith.constant 0 : index
+  //     CHECK-DAG: %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
+  //     CHECK-DAG: %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x1024xf32, 3>
+  
+  //         CHECK: %[[TIDX:.]] = gpu.thread_id  x
+  //         CHECK: %[[SHMEM_VIEW_EXPANDED:.*]] = memref.subview %[[SHMEM_ALLOC]][0, %[[TIDX]]]{{.*}}to memref<1x1xf32, strided<[1024, 1], offset: ?>, 3>
+  // Local per-thread scf.for-based reduction.
+  //         CHECK: scf.for
+  //         CHECK:   vector.transfer_read %{{.*}} {in_bounds = [true]} : memref<33x?xf32>, vector<1xf32>
+  //         CHECK:   arith.addf {{.*}} : vector<1xf32>
+  //         CHECK:   scf.yield %{{.*}} : vector<1xf32>
+
+  //         CHECK: %[[TIDY:.]] = gpu.thread_id  y
+  // Distributed reduction: everyone loads then 5 xor + addf expected
+  //         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %{{.*}}]
+  // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+
+  //         CHECK: %[[RES:.*]] = arith.addf %{{.*}}
+
+  //         CHECK: %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<1xf32>
+  //         CHECK: %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
+  //         CHECK: scf.if %[[CONDXIS0]]
+  //         CHECK:   vector.transfer_write %[[RES_VEC]]
+  //         CHECK: gpu.barrier
+
+// only checking the first 6 of 33
+//      EXEC: result[0]: hal.buffer_view
+// EXEC-NEXT: 33xf32=1024 1024 1024 1024 1024 1024

--- a/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
@@ -1,0 +1,60 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(suppress) {
+^bb1(%variant_op: !pdl.operation):
+  %fill = transform.structured.match ops{["linalg.fill"]} in %variant_op
+  %reduction = transform.structured.match ops{["linalg.generic"]} in %variant_op
+
+  // Step 1. First level of tiling + fusion parallelizes to blocks.
+  // ===========================================================================
+  %foreach_thread_grid, %grid_reduction =
+    transform.iree.tile_to_foreach_thread_and_workgroup_count_region %reduction tile_sizes [1]
+      ( mapping = [#gpu.block<x>] )
+  transform.structured.fuse_into_containing_op %fill into %foreach_thread_grid
+
+  // Step 2. Split the reduction to get meatier parallelism.
+  // This also parallelizes to threads
+  // ===========================================================================
+  %foreach_thread, %block_more_parallel_fill_op_2, %block_more_parallel_op_2, %block_combiner_op_2 = 
+     transform.structured.tile_reduction_using_foreach_thread %grid_reduction 
+       { num_threads = [0, 1024], tile_sizes = [0, 1], mapping = [#gpu.thread<x>] }
+  // Fuse the fill and pointwise to privatize them. 
+  transform.structured.fuse_into_containing_op %block_more_parallel_fill_op_2
+    into %foreach_thread
+  // block_combiner_op_2 op is [parallel, reduction] of 1x384 that cannot fuse.
+  // map the 1-dim to threadIdx.y to trigger mapping of the reduction to 
+  // threadIdx.x via predication via `if (x==0)`.
+  transform.structured.tile_to_foreach_thread_op %block_combiner_op_2 tile_sizes [1] 
+    ( mapping = [#gpu.thread<y>] )
+
+  // Step 3. Rank-reduce and vectorize.
+  // ===========================================================================
+  %func = transform.structured.match ops{["func.func"]} in %variant_op
+  // TODO: masked vectorization on block_more_parallel_op_2 if we want 
+  // vector<4> to work as intended.
+  // TODO: there is a conflicting pattern here that introduces a tensor.empty
+  // to collapse/expand shape + scf.for. 
+  // This is investigated in parallel.
+  // %func_2 = transform.iree.apply_patterns %func { rank_reducing }
+  %func_3 = transform.structured.vectorize %func
+
+  // Step 4. Bufferize and drop HAL descriptor from memref ops.
+  // ===========================================================================
+  %variant_op_2 = transform.iree.bufferize { target_gpu } %variant_op
+  %memref_func = transform.structured.match ops{["func.func"]} in %variant_op_2
+  transform.iree.erase_hal_descriptor_type_from_memref %memref_func
+
+  // Step 5. Post-bufferization mapping to blocks and threads.
+  // ===========================================================================
+  %func_4 = transform.structured.match ops{["func.func"]} in %variant_op_2
+  %func_5 = transform.iree.foreach_thread_to_workgroup %func_4
+  %func_6 = transform.iree.map_nested_foreach_thread_to_gpu_threads %func_5
+      { workgroup_size = [1024, 1, 1] }
+
+  // Step 6. Post-bufferization vector distribution with rank-reduction.
+  // ===========================================================================
+  %func_7 = transform.iree.apply_patterns %func_6 { rank_reducing }
+  %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_2
+  %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
+  transform.iree.vector.warp_distribute %func_7
+}


### PR DESCRIPTION
Emit the reduction schedule splitting the reduction directly to
"scf.for" rather than to a generic over inputs with expanded shape. This
allows us to ensure the generation of vector loads and stores, and to
target the vector size appropriate to the input. Also plug in the
matcher into the schedule instead of the fragile reliance on the order
of operations.
    
This is a rebase of #11498 on main.