### PR TITLE
[vmvx] Relax requirement on fptosi lowering

### DIFF
--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -931,8 +931,8 @@ class FPToSIOpConversion : public OpConversionPattern<arith::FPToSIOp> {
       // This uses the resultType rather than dstType as any truncation
       // required will be handled via interpretation by consumer.
       if (resultType.isSignlessInteger(32) || resultType.isSignedInteger(32)) {
-        rewriter.replaceOpWithNewOp<IREE::VM::CastF32SI32Op>(
-            srcOp, resultType, adaptor.getIn());
+        rewriter.replaceOpWithNewOp<IREE::VM::CastF32SI32Op>(srcOp, resultType,
+                                                             adaptor.getIn());
         return success();
       }
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -950,8 +950,8 @@ class FPToUIOpConversion : public OpConversionPattern<arith::FPToUIOp> {
     auto resultType = getTypeConverter()->convertType(dstType);
     if (srcType.isF32()) {
       if (dstType.isSignlessInteger(32) || dstType.isUnsignedInteger(32)) {
-        rewriter.replaceOpWithNewOp<IREE::VM::CastF32UI32Op>(
-            srcOp, resultType, adaptor.getOperands()[0]);
+        rewriter.replaceOpWithNewOp<IREE::VM::CastF32UI32Op>(srcOp, resultType,
+                                                             adaptor.getIn());
         return success();
       }
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -932,7 +932,7 @@ class FPToSIOpConversion : public OpConversionPattern<arith::FPToSIOp> {
       // required will be handled via interpretation by consumer.
       if (resultType.isSignlessInteger(32) || resultType.isSignedInteger(32)) {
         rewriter.replaceOpWithNewOp<IREE::VM::CastF32SI32Op>(
-            srcOp, resultType, adaptor.getOperands()[0]);
+            srcOp, resultType, adaptor.getIn());
         return success();
       }
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -926,9 +926,11 @@ class FPToSIOpConversion : public OpConversionPattern<arith::FPToSIOp> {
       ConversionPatternRewriter &rewriter) const override {
     auto srcType = srcOp.getIn().getType();
     auto dstType = srcOp.getResult().getType();
+    auto resultType = getTypeConverter()->convertType(dstType);
     if (srcType.isF32()) {
-      if (dstType.isSignlessInteger(32) || dstType.isSignedInteger(32)) {
-        auto resultType = getTypeConverter()->convertType(dstType);
+      // This uses the resultType rather than dstType as any truncation
+      // required will be handled via interpretation by consumer.
+      if (resultType.isSignlessInteger(32) || resultType.isSignedInteger(32)) {
         rewriter.replaceOpWithNewOp<IREE::VM::CastF32SI32Op>(
             srcOp, resultType, adaptor.getOperands()[0]);
         return success();

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/conversion_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/test/conversion_ops.mlir
@@ -77,7 +77,7 @@ module @my_module {
 module @t006_fptosi_fp32_i8 {
 module @my_module {
   func.func @my_fn(%arg0 : f32) -> (i8) {
-// expected-error@+1 {{failed to legalize}}
+    // CHECK: vm.cast.f32.si32 %[[ARG0]] : f32 -> i32
     %1 = arith.fptosi %arg0 : f32 to i8
     return %1 : i8
   }


### PR DESCRIPTION
The consumption of si of small width is already handled successfully by
consumers of this op (at least in limited trial). This was not true for the ui version ---although I suspect consumer op there, but keeping it more restricted until
checked.