### PR TITLE
Add benchmark preset to benchmark config export tool

### DIFF
--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -23,11 +23,11 @@ import pathlib
 # Add build_tools python dir to the search path.
 sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
-from typing import Callable, Dict, List
 import argparse
 import collections
 import dataclasses
 import json
+from typing import Callable, Dict, List
 
 from benchmark_suites.iree import benchmark_collections
 from e2e_test_framework.definitions import common_definitions, iree_definitions

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -34,31 +34,24 @@ from e2e_test_framework.definitions import common_definitions, iree_definitions
 from e2e_test_framework import serialization
 from e2e_test_artifacts import iree_artifacts
 
-
-def get_device_spec(
-    config: iree_definitions.E2EModelRunConfig
-) -> common_definitions.DeviceSpec:
-  return config.target_device_spec
-
-
 PresetMatcher = Callable[[iree_definitions.E2EModelRunConfig], bool]
 BENCHMARK_PRESET_MATCHERS: Dict[str, PresetMatcher] = {
     "x86_64":
-        lambda config: get_device_spec(config).architecture.architecture ==
+        lambda config: config.target_device_spec.architecture.architecture ==
         "x86_64",
     "cuda":
-        lambda config: get_device_spec(config).architecture.architecture ==
+        lambda config: config.target_device_spec.architecture.architecture ==
         "cuda",
     "android-cpu":
         lambda config:
-        (get_device_spec(config).architecture.type == common_definitions.
-         ArchitectureType.CPU and get_device_spec(
-             config).host_environment.platform == "android"),
+        (config.target_device_spec.architecture.type == common_definitions.
+         ArchitectureType.CPU and config.target_device_spec.host_environment.
+         platform == "android"),
     "android-gpu":
         lambda config:
-        (get_device_spec(config).architecture.type == common_definitions.
-         ArchitectureType.GPU and get_device_spec(
-             config).host_environment.platform == "android"),
+        (config.target_device_spec.architecture.type == common_definitions.
+         ArchitectureType.GPU and config.target_device_spec.host_environment.
+         platform == "android"),
 }
 
 

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -98,7 +98,7 @@ def main(args: argparse.Namespace):
         device_name not in target_device_names):
       continue
     if (device_spec_matchers is not None and
-        all(not matcher(run_config.target_device_spec)
+        not any(matcher(run_config.target_device_spec)
             for matcher in device_spec_matchers)):
       continue
     grouped_run_config_map[device_name].append(run_config)


### PR DESCRIPTION
NFC: To support benchmarking with some benchmark presets, we need to define the presets at somewhere. So there are two places:
1. Defines the presets in workflow/bash script and call export tool with some proper filters to select the benchmarks.
2. Defines the presets in the export tool.

This change chooses 2. since in order to implement 1., the export tool needs to provide a flexible way to filter benchmarks since the definitions of preset is kinda ad-hoc, there are many fields in benchmark configs can be filtered (see the definitions in code). To me adding those fields as separated filter arguments looks a little messy. Maybe we need a query language to properly do that.

And even if the export tool supports the filters, we still need an extra bash script to define and translate those presets into the filters, so I think it's simpler to define the presets in the export tool.