### PR TITLE
Remove shutdown error trap from runner setup

### DIFF
--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -11,9 +11,6 @@
 
 set -xeEuo pipefail
 
-# If the startup script fails, shut down the VM.
-trap '/usr/sbin/shutdown -P now' ERR
-
 SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
 source "${SCRIPT_DIR}/functions.sh"
 


### PR DESCRIPTION
This is no longer necessary with health checks added in
https://github.com/iree-org/iree/pull/11526 which has now been rolled
out to all instance groups.