### PR TITLE
Generate compile statistics modules in e2e test artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -749,13 +749,17 @@ endif()
 # TODO(#11263): This conditional block should be merged with the block above
 # once we remove IREE_BUILD_BENCHMARKS.
 if(IREE_BUILD_EXPERIMENTAL_E2E_TEST_ARTIFACTS)
+  # iree-e2e-compile-stats-suites compiles the benchmark models with specific
+  # flags to collect the compilation statistics.
+  add_custom_target(iree-e2e-compile-stats-suites)
+
   # iree-e2e-test-artifacts builds all e2e test artifacts, including benchmarks
   # and model tests.
   add_custom_target(iree-e2e-test-artifacts)
-
   add_dependencies(iree-e2e-test-artifacts
     iree-benchmark-import-models
     iree-benchmark-suites
+    iree-e2e-compile-stats-suites
   )
 endif()
 

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -210,7 +210,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             BenchmarkCase(model_name=model_tflite.name,
                           model_tags=model_tflite.tags,
                           bench_mode=exec_config_a.tags,
-                          target_arch="cpu-rv32-generic",
+                          target_arch="cpu-riscv_32-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -218,7 +218,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             BenchmarkCase(model_name=model_tflite.name,
                           model_tags=model_tflite.tags,
                           bench_mode=exec_config_b.tags,
-                          target_arch="cpu-rv64-generic",
+                          target_arch="cpu-riscv_64-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -227,14 +227,14 @@ class BenchmarkSuiteTest(unittest.TestCase):
     self.assertEqual(
         suite.filter_benchmarks_for_category(
             category="exported_tf",
-            cpu_target_arch_filter="cpu-rv32-generic",
+            cpu_target_arch_filter="cpu-riscv_32-generic",
             model_name_filter="model_tf.*fp32",
             mode_filter="defaults"),
         [
             BenchmarkCase(model_name=model_tf.name,
                           model_tags=model_tf.tags,
                           bench_mode=exec_config_a.tags,
-                          target_arch="cpu-rv32-generic",
+                          target_arch="cpu-riscv_32-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -243,7 +243,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
     self.assertEqual(
         suite.filter_benchmarks_for_category(
             category="exported_tf",
-            cpu_target_arch_filter="cpu-rv32-generic",
+            cpu_target_arch_filter="cpu-riscv_32-generic",
             mode_filter="experimental"), [])
 
   @staticmethod

--- a/build_tools/python/benchmark_suites/iree/benchmark_collections.py
+++ b/build_tools/python/benchmark_suites/iree/benchmark_collections.py
@@ -6,11 +6,17 @@
 """Generates all benchmarks."""
 
 from typing import List, Tuple
+
 from e2e_test_framework.definitions import iree_definitions
 from benchmark_suites.iree import (riscv_benchmarks, x86_64_benchmarks,
                                    adreno_benchmarks, armv8_a_benchmarks,
                                    cuda_benchmarks, mali_benchmarks,
                                    vmvx_benchmarks)
+
+COMPILE_STATS_ID_SUFFIX = "-compile-stats"
+# Tag that indicates this compile config is generated for collecting compilation
+# statistics.
+COMPILE_STATS_TAG = "compile-stats"
 
 
 def generate_benchmarks(
@@ -26,11 +32,31 @@ def generate_benchmarks(
       mali_benchmarks.Android_Mali_Benchmarks(),
       vmvx_benchmarks.Android_VMVX_Benchmarks()
   ]
-  all_module_generation_configs = []
-  all_run_configs = []
+  all_gen_configs: List[iree_definitions.ModuleGenerationConfig] = []
+  all_run_configs: List[iree_definitions.E2EModelRunConfig] = []
   for benchmark in benchmarks:
     module_generation_configs, run_configs = benchmark.generate()
-    all_module_generation_configs += module_generation_configs
+    all_gen_configs += module_generation_configs
     all_run_configs += run_configs
 
-  return (all_module_generation_configs, all_run_configs)
+  compile_stats_gen_configs = []
+  # For now we simply track compilation statistics of all modules.
+  for gen_config in all_gen_configs:
+    compile_config = gen_config.compile_config
+    compile_stats_config = iree_definitions.CompileConfig(
+        id=compile_config.id + COMPILE_STATS_ID_SUFFIX,
+        tags=compile_config.tags + [COMPILE_STATS_TAG],
+        compile_targets=compile_config.compile_targets,
+        extra_flags=compile_config.extra_flags + [
+            # Enable zip polyglot to provide component sizes.
+            "--iree-vm-emit-polyglot-zip=true",
+            # Disable debug symbols to provide correct component sizes.
+            "--iree-llvm-debug-symbols=false"
+        ])
+    compile_stats_gen_configs.append(
+        iree_definitions.ModuleGenerationConfig(
+            imported_model=gen_config.imported_model,
+            compile_config=compile_stats_config))
+  all_gen_configs += compile_stats_gen_configs
+
+  return (all_gen_configs, all_run_configs)

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -10,10 +10,15 @@ from typing import Dict, List, Sequence
 import collections
 import pathlib
 
+from benchmark_suites.iree import benchmark_collections
 from e2e_test_artifacts import iree_artifacts
 from e2e_test_artifacts.cmake_generator import model_rule_generator
 from e2e_test_framework.definitions import common_definitions, iree_definitions
 import cmake_builder.rules
+
+BENCHMARK_IMPORT_MODELS_CMAKE_TARGET = "iree-benchmark-import-models"
+BENCHMARK_SUITES_CMAKE_TARGET = "iree-benchmark-suites"
+E2E_COMPILE_STATS_SUITES = "iree-e2e-compile-stats-suites"
 
 
 @dataclass(frozen=True)
@@ -59,14 +64,14 @@ class IreeRuleBuilder(object):
     if model.source_type == common_definitions.ModelSourceType.EXPORTED_TFLITE:
       cmake_rules = [
           cmake_builder.rules.build_iree_import_tflite_model(
-              target_path=self._build_target_path(target_name),
+              target_path=self.build_target_path(target_name),
               source=str(source_model_rule.file_path),
               output_mlir_file=str(output_file_path))
       ]
     elif model.source_type == common_definitions.ModelSourceType.EXPORTED_TF:
       cmake_rules = [
           cmake_builder.rules.build_iree_import_tf_model(
-              target_path=self._build_target_path(target_name),
+              target_path=self.build_target_path(target_name),
               source=str(source_model_rule.file_path),
               entry_function=model.entry_function,
               output_mlir_file=str(output_file_path))
@@ -75,11 +80,6 @@ class IreeRuleBuilder(object):
       raise ValueError(
           f"Unsupported source type '{model.source_type}' of the model '{model.id}'."
       )
-
-    cmake_rules.append(
-        cmake_builder.rules.build_add_dependencies(
-            target="iree-benchmark-import-models",
-            deps=[self._build_target_path(target_name)]))
 
     return IreeModelImportRule(target_name=target_name,
                                output_file_path=output_file_path,
@@ -104,10 +104,7 @@ class IreeRuleBuilder(object):
             target_name=target_name,
             src=str(model_import_rule.output_file_path),
             module_name=str(output_file_path),
-            flags=compile_flags),
-        cmake_builder.rules.build_add_dependencies(
-            target="iree-benchmark-suites",
-            deps=[self._build_target_path(target_name)])
+            flags=compile_flags)
     ]
 
     # TODO(#10155): Dump the compile flags from iree_bytecode_module into a flagfile.
@@ -115,6 +112,12 @@ class IreeRuleBuilder(object):
     return IreeModuleCompileRule(target_name=target_name,
                                  output_module_path=output_file_path,
                                  cmake_rules=cmake_rules)
+
+  def build_target_path(self, target_name: str):
+    """Returns the full target path by combining the package name and the target
+    name.
+    """
+    return f"{self._package_name}_{target_name}"
 
   def _generate_compile_flags(self,
                               compile_config: iree_definitions.CompileConfig,
@@ -139,7 +142,7 @@ class IreeRuleBuilder(object):
           f"--iree-llvm-target-triple=x86_64-unknown-{target.target_abi.value}",
           f"--iree-llvm-target-cpu={arch_info.microarchitecture.lower()}"
       ]
-    elif arch_info.architecture == "rv64":
+    elif arch_info.architecture == "riscv_64":
       flags = [
           f"--iree-llvm-target-triple=riscv64-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv64", "--iree-llvm-target-abi=lp64d",
@@ -147,7 +150,7 @@ class IreeRuleBuilder(object):
           "--riscv-v-vector-bits-min=512",
           "--riscv-v-fixed-length-vector-lmul-max=8"
       ]
-    elif arch_info.architecture == "rv32":
+    elif arch_info.architecture == "riscv_32":
       flags = [
           f"--iree-llvm-target-triple=riscv32-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv32", "--iree-llvm-target-abi=ilp32",
@@ -179,12 +182,6 @@ class IreeRuleBuilder(object):
     else:
       raise ValueError(f"Unsupported architecture: '{arch_info.architecture}'")
     return flags
-
-  def _build_target_path(self, target_name: str):
-    """Returns the full target path by combining the variable of package name
-    and the target name.
-    """
-    return f"{self._package_name}_{target_name}"
 
 
 def generate_rules(
@@ -226,6 +223,8 @@ def generate_rules(
     model_import_rule_map[model_id] = model_import_rule
     cmake_rules.extend(model_import_rule.cmake_rules)
 
+  module_target_names = []
+  compile_stats_module_target_names = []
   for gen_config in module_generation_configs:
     model_import_rule = model_import_rule_map[
         gen_config.imported_model.model.id]
@@ -236,6 +235,35 @@ def generate_rules(
         imported_model=gen_config.imported_model,
         compile_config=gen_config.compile_config,
         output_file_path=module_dir_path / iree_artifacts.MODULE_FILENAME)
+    if benchmark_collections.COMPILE_STATS_TAG in gen_config.compile_config.tags:
+      compile_stats_module_target_names.append(module_compile_rule.target_name)
+    else:
+      module_target_names.append(module_compile_rule.target_name)
     cmake_rules.extend(module_compile_rule.cmake_rules)
+
+  if len(model_import_rule_map) > 0:
+    cmake_rules.append(
+        cmake_builder.rules.build_add_dependencies(
+            target=BENCHMARK_IMPORT_MODELS_CMAKE_TARGET,
+            deps=[
+                rule_builder.build_target_path(rule.target_name)
+                for rule in model_import_rule_map.values()
+            ]))
+  if len(module_target_names) > 0:
+    cmake_rules.append(
+        cmake_builder.rules.build_add_dependencies(
+            target=BENCHMARK_SUITES_CMAKE_TARGET,
+            deps=[
+                rule_builder.build_target_path(target_name)
+                for target_name in module_target_names
+            ]))
+  if len(compile_stats_module_target_names) > 0:
+    cmake_rules.append(
+        cmake_builder.rules.build_add_dependencies(
+            target=E2E_COMPILE_STATS_SUITES,
+            deps=[
+                rule_builder.build_target_path(target_name)
+                for target_name in compile_stats_module_target_names
+            ]))
 
   return cmake_rules

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
@@ -106,6 +106,13 @@ class IreeRuleBuilderTest(unittest.TestCase):
                      f"iree-module-{model_a.id}-{compile_config_a.id}")
     self.assertEqual(rule.output_module_path, output_file_path)
 
+  def test_build_target_path(self):
+    builder = iree_rule_generator.IreeRuleBuilder(package_name="xyz")
+
+    path = builder.build_target_path("target-abc")
+
+    self.assertEqual(path, f"xyz_target-abc")
+
 
 class IreeGeneratorTest(unittest.TestCase):
 

--- a/build_tools/python/e2e_test_framework/definitions/common_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/common_definitions.py
@@ -40,8 +40,8 @@ class DeviceArchitecture(_ArchitectureInfo, Enum):
   ARMV9_A_GENERIC = (ArchitectureType.CPU, "armv9-a", "generic")
 
   # RISC-V CPUs
-  RV64_GENERIC = (ArchitectureType.CPU, "rv64", "generic")
-  RV32_GENERIC = (ArchitectureType.CPU, "rv32", "generic")
+  RV64_GENERIC = (ArchitectureType.CPU, "riscv_64", "generic")
+  RV32_GENERIC = (ArchitectureType.CPU, "riscv_32", "generic")
 
   # Mobile GPUs
   MALI_VALHALL = (ArchitectureType.GPU, "mali", "valhall")

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -7,10 +7,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-c36c63b0-220a-4d78-8ade-c45ce47d89d3
-)
-
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-0e466f69-91d6-4e50-b62b-a82b6213a231"
@@ -18,10 +14,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/model_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.tflite"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
-)
-
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-0e466f69-91d6-4e50-b62b-a82b6213a231
 )
 
 iree_import_tflite_model(
@@ -33,10 +25,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-5afc3014-d29d-4e88-a840-fbaf678acf2b
-)
-
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-cc69d69f-6d1f-4a1a-a31e-e021888d0d28"
@@ -44,10 +32,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/model_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.tflite"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
-)
-
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-cc69d69f-6d1f-4a1a-a31e-e021888d0d28
 )
 
 iree_import_tflite_model(
@@ -59,10 +43,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-e3997104-a3d2-46b4-9fbf-39069906d123
-)
-
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-73a0402e-271b-4aa8-a6a5-ac05839ca569"
@@ -70,10 +50,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/model_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.tflite"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
-)
-
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-73a0402e-271b-4aa8-a6a5-ac05839ca569
 )
 
 iree_import_tflite_model(
@@ -85,10 +61,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-78eab9e5-9ff1-4769-9b55-933c81cc9a0f
-)
-
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-7d45f8e5-bb5e-48d0-928d-8f125104578f"
@@ -96,10 +68,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/model_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.0_224.tflite"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
-)
-
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-7d45f8e5-bb5e-48d0-928d-8f125104578f
 )
 
 iree_import_tflite_model(
@@ -111,10 +79,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-58855e40-eba9-4a71-b878-6b35e3460244
-)
-
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-bc1338be-e3df-44fd-82e4-40ba9560a073"
@@ -124,10 +88,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-bc1338be-e3df-44fd-82e4-40ba9560a073
-)
-
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-4a6f545e-1b4e-41a5-9236-792aa578184b"
@@ -135,10 +95,6 @@ iree_import_tflite_model(
     "${ROOT_ARTIFACTS_DIR}/model_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.tflite"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
-)
-
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-4a6f545e-1b4e-41a5-9236-792aa578184b
 )
 
 iree_import_tf_model(
@@ -152,10 +108,6 @@ iree_import_tf_model(
     "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493
-)
-
 iree_import_tf_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-39d157ad-f0ec-4a76-963b-d783beaed60f"
@@ -165,10 +117,6 @@ iree_import_tf_model(
     "forward"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
-)
-
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-39d157ad-f0ec-4a76-963b-d783beaed60f
 )
 
 iree_import_tf_model(
@@ -182,10 +130,6 @@ iree_import_tf_model(
     "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
 )
 
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-ebe7897f-5613-435b-a330-3cb967704e5e
-)
-
 iree_import_tf_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-c393b4fa-beb4-45d5-982a-c6328aa05d08"
@@ -195,10 +139,6 @@ iree_import_tf_model(
     "forward"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
-)
-
-add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-c393b4fa-beb4-45d5-982a-c6328aa05d08
 )
 
 iree_bytecode_module(
@@ -216,10 +156,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -233,10 +169,6 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
     "--iree-llvm-target-cpu=cascadelake"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
 )
 
 iree_bytecode_module(
@@ -254,10 +186,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -271,10 +199,6 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
     "--iree-llvm-target-cpu=cascadelake"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
 )
 
 iree_bytecode_module(
@@ -292,10 +216,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -309,10 +229,6 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
     "--iree-llvm-target-cpu=cascadelake"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
 )
 
 iree_bytecode_module(
@@ -330,10 +246,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -347,10 +259,6 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
     "--iree-llvm-target-cpu=cascadelake"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
 )
 
 iree_bytecode_module(
@@ -368,10 +276,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -385,10 +289,6 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
     "--iree-llvm-target-cpu=cascadelake"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
 )
 
 iree_bytecode_module(
@@ -406,10 +306,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -423,10 +319,6 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
     "--iree-llvm-target-cpu=cascadelake"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
 )
 
 iree_bytecode_module(
@@ -444,10 +336,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -463,10 +351,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
@@ -480,10 +364,6 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
     "--iree-llvm-target-cpu=cascadelake"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
 )
 
 iree_bytecode_module(
@@ -503,10 +383,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6"
@@ -522,10 +398,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6
 )
 
 iree_bytecode_module(
@@ -545,10 +417,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6"
@@ -564,10 +432,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6
 )
 
 iree_bytecode_module(
@@ -587,10 +451,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6"
@@ -606,10 +466,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6
 )
 
 iree_bytecode_module(
@@ -629,10 +485,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6"
@@ -648,10 +500,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6
 )
 
 iree_bytecode_module(
@@ -671,10 +519,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6"
@@ -690,10 +534,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6
 )
 
 iree_bytecode_module(
@@ -713,10 +553,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6"
@@ -732,10 +568,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6
 )
 
 iree_bytecode_module(
@@ -755,10 +587,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6"
@@ -776,10 +604,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030"
@@ -792,10 +616,6 @@ iree_bytecode_module(
     "--iree-input-type=mhlo"
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030
 )
 
 iree_bytecode_module(
@@ -812,10 +632,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030"
@@ -830,10 +646,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030"
@@ -846,10 +658,6 @@ iree_bytecode_module(
     "--iree-input-type=mhlo"
     "--iree-hal-cuda-llvm-target-arch=sm_80"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030
 )
 
 iree_bytecode_module(
@@ -871,10 +679,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65"
@@ -892,10 +696,6 @@ iree_bytecode_module(
     "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65
 )
 
 iree_bytecode_module(
@@ -917,10 +717,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65"
@@ -938,10 +734,6 @@ iree_bytecode_module(
     "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65
 )
 
 iree_bytecode_module(
@@ -963,10 +755,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65"
@@ -984,10 +772,6 @@ iree_bytecode_module(
     "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65
 )
 
 iree_bytecode_module(
@@ -1009,10 +793,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4"
@@ -1032,10 +812,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
@@ -1048,10 +824,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
 )
 
 iree_bytecode_module(
@@ -1068,10 +840,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
@@ -1084,10 +852,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
 )
 
 iree_bytecode_module(
@@ -1104,10 +868,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
@@ -1120,10 +880,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
 )
 
 iree_bytecode_module(
@@ -1140,10 +896,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
@@ -1156,10 +908,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-llvm-target-triple=aarch64-none-linux-android29"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
 )
 
 iree_bytecode_module(
@@ -1179,10 +927,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f"
@@ -1198,10 +942,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f
 )
 
 iree_bytecode_module(
@@ -1221,10 +961,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f"
@@ -1240,10 +976,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f
 )
 
 iree_bytecode_module(
@@ -1263,10 +995,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f"
@@ -1282,10 +1010,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-llvmcpu-enable-pad-consumer-fusion"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f
 )
 
 iree_bytecode_module(
@@ -1306,10 +1030,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b"
@@ -1322,10 +1042,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b
 )
 
 iree_bytecode_module(
@@ -1342,10 +1058,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b"
@@ -1358,10 +1070,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b
 )
 
 iree_bytecode_module(
@@ -1378,10 +1086,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b"
@@ -1396,10 +1100,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b"
@@ -1412,10 +1112,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b
 )
 
 iree_bytecode_module(
@@ -1433,10 +1129,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad"
@@ -1450,10 +1142,6 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad
 )
 
 iree_bytecode_module(
@@ -1471,10 +1159,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad"
@@ -1488,10 +1172,6 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad
 )
 
 iree_bytecode_module(
@@ -1509,10 +1189,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad"
@@ -1526,10 +1202,6 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad
 )
 
 iree_bytecode_module(
@@ -1548,10 +1220,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466"
@@ -1566,10 +1234,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=16"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466
 )
 
 iree_bytecode_module(
@@ -1588,10 +1252,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466"
@@ -1608,10 +1268,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
@@ -1624,10 +1280,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
 )
 
 iree_bytecode_module(
@@ -1644,10 +1296,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
@@ -1660,10 +1308,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
 )
 
 iree_bytecode_module(
@@ -1680,10 +1324,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
@@ -1698,10 +1338,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
@@ -1714,10 +1350,6 @@ iree_bytecode_module(
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
 )
 
 iree_bytecode_module(
@@ -1735,10 +1367,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16"
@@ -1752,10 +1380,6 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
     "--iree-flow-demote-f32-to-f16"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16
 )
 
 iree_bytecode_module(
@@ -1773,10 +1397,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
@@ -1790,10 +1410,6 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
 )
 
 iree_bytecode_module(
@@ -1811,10 +1427,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
@@ -1828,10 +1440,6 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
 )
 
 iree_bytecode_module(
@@ -1849,10 +1457,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
@@ -1866,10 +1470,6 @@ iree_bytecode_module(
     "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
 )
 
 iree_bytecode_module(
@@ -1888,10 +1488,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16"
@@ -1906,10 +1502,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-flow-demote-f32-to-f16"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16
 )
 
 iree_bytecode_module(
@@ -1928,10 +1520,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
@@ -1946,10 +1534,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346
 )
 
 iree_bytecode_module(
@@ -1968,10 +1552,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
@@ -1986,10 +1566,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346
 )
 
 iree_bytecode_module(
@@ -2008,10 +1584,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
@@ -2026,10 +1598,6 @@ iree_bytecode_module(
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
     "--iree-hal-benchmark-dispatch-repeat-count=32"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346
 )
 
 iree_bytecode_module(
@@ -2049,10 +1617,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16"
@@ -2070,10 +1634,6 @@ iree_bytecode_module(
   PUBLIC
 )
 
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16
-)
-
 iree_bytecode_module(
   NAME
     "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4"
@@ -2085,10 +1645,6 @@ iree_bytecode_module(
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
   PUBLIC
-)
-
-add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4
 )
 
 iree_bytecode_module(
@@ -2104,6 +1660,1933 @@ iree_bytecode_module(
   PUBLIC
 )
 
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=cuda"
+    "--iree-input-type=mhlo"
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv64"
+    "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv64"
+    "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv64"
+    "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv64"
+    "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv64"
+    "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv64"
+    "--iree-llvm-target-abi=lp64d"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv32"
+    "--iree-llvm-target-abi=ilp32"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
+    "--iree-llvm-target-cpu=generic-rv32"
+    "--iree-llvm-target-abi=ilp32"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--riscv-v-vector-bits-min=512"
+    "--riscv-v-fixed-length-vector-lmul-max=8"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_f672a6b9-99fc-47ce-8b1b-8e5f44a541a1-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-llvm-target-cpu-features=+dotprod"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-linux-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vmvx"
+    "--iree-input-type=tosa"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vmvx"
+    "--iree-input-type=tosa"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+add_dependencies(iree-benchmark-import-models
+  ${PACKAGE_NAME}_iree-imported-model-c36c63b0-220a-4d78-8ade-c45ce47d89d3
+  ${PACKAGE_NAME}_iree-imported-model-0e466f69-91d6-4e50-b62b-a82b6213a231
+  ${PACKAGE_NAME}_iree-imported-model-5afc3014-d29d-4e88-a840-fbaf678acf2b
+  ${PACKAGE_NAME}_iree-imported-model-cc69d69f-6d1f-4a1a-a31e-e021888d0d28
+  ${PACKAGE_NAME}_iree-imported-model-e3997104-a3d2-46b4-9fbf-39069906d123
+  ${PACKAGE_NAME}_iree-imported-model-73a0402e-271b-4aa8-a6a5-ac05839ca569
+  ${PACKAGE_NAME}_iree-imported-model-78eab9e5-9ff1-4769-9b55-933c81cc9a0f
+  ${PACKAGE_NAME}_iree-imported-model-7d45f8e5-bb5e-48d0-928d-8f125104578f
+  ${PACKAGE_NAME}_iree-imported-model-58855e40-eba9-4a71-b878-6b35e3460244
+  ${PACKAGE_NAME}_iree-imported-model-bc1338be-e3df-44fd-82e4-40ba9560a073
+  ${PACKAGE_NAME}_iree-imported-model-4a6f545e-1b4e-41a5-9236-792aa578184b
+  ${PACKAGE_NAME}_iree-imported-model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493
+  ${PACKAGE_NAME}_iree-imported-model-39d157ad-f0ec-4a76-963b-d783beaed60f
+  ${PACKAGE_NAME}_iree-imported-model-ebe7897f-5613-435b-a330-3cb967704e5e
+  ${PACKAGE_NAME}_iree-imported-model-c393b4fa-beb4-45d5-982a-c6328aa05d08
+)
+
 add_dependencies(iree-benchmark-suites
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6
+  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030
+  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030
+  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030
+  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65
+  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4
   ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-75336abd-8108-462c-9ce3-15443e3f32f4
+)
+
+add_dependencies(iree-e2e-compile-stats-suites
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
+  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
+  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
+  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
+  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
+  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
+  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats
+  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765_demote_f32_to_16-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223_demote_f32_to_16-compile-stats
+  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
+  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
+  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
+  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
+  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16-compile-stats
+  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346_demote_f32_to_16-compile-stats
+  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats
+  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats
 )


### PR DESCRIPTION
Generates the modules for compilation statistics from all benchmark modules.

A new cmake target `iree-e2e-compile-stats-suites` is added to only build all compilation statistics, and `iree-benchmark-suites` only builds modules for benchmark runs.