### PR TITLE
Rework handling of HAL::ExecutableVariant and HALExecutableExportOp i…

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/BUILD
@@ -59,6 +59,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":LLVMGPUExtensionsOpGen",
+        "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//llvm-external-projects/iree-dialects:IREEDialectsTransforms",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/CMakeLists.txt
@@ -48,6 +48,7 @@ iree_cc_library(
     MLIRTransforms
     MLIRVectorDialect
     MLIRVectorTransforms
+    iree::compiler::Codegen::Utils
     iree::compiler::Dialect::HAL::IR
   PUBLIC
 )


### PR DESCRIPTION
…n the transform dialect

The existing assumptions were too harsh and made it impossible to debug. As a consequence, the following can now run end to end without crashing.

```
export IREE_MLIR_INPUT_FILE=tests/transform_dialect/cuda/reduction_v2.mlir
iree-transform-opt-dispatch-only ${IREE_MLIR_INPUT_FILE} -b cuda  > /tmp/1.mlir
iree-opt /tmp/1.mlir --iree-hal-target-backends=cuda --iree-stream-transformation-pipeline --iree-hal-configuration-pipeline > /tmp/2.mlir
iree-opt /tmp/2.mlir --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target{test-lowering-configuration})))" --iree-codegen-llvmgpu-enable-transform-dialect-jit  > /tmp/3.mlir
iree-opt -iree-transform-dialect-interpreter -transform-dialect-drop-schedule /tmp/3.mlir
```

As a result, `/tmp/3.mlir` is an interpreted script that is easy to debug and iterate on without requiring recompiling the compiler.