### PR TITLE
[Cleanup] Replace llvm::zip with llvm::zip_equal.

### DIFF
--- a/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
+++ b/compiler/src/iree/compiler/Bindings/Native/Transforms/WrapEntryPoints.cpp
@@ -130,7 +130,7 @@ static func::FuncOp createImportWrapperFunc(
         auto barrierOp = entryBuilder.create<IREE::HAL::TensorBarrierOp>(
             importOp.getLoc(), tensorArgs, waitFence);
         for (auto [argIndex, readyArg] :
-             llvm::zip(tensorArgIndices, barrierOp.getResults())) {
+             llvm::zip_equal(tensorArgIndices, barrierOp.getResults())) {
           entryArgs[argIndex] = readyArg;
         }
       }

--- a/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Conversion/TensorToFlow/Patterns.cpp
@@ -170,8 +170,8 @@ struct ConvertTensorReshapePattern : public OpRewritePattern<TensorReshapeOp> {
       return failure();
     }
     SmallVector<Value> outputDynamicShapes;
-    for (auto shape :
-         llvm::zip(reshapeOp.getResultType().getShape(), outputShape[0])) {
+    for (auto shape : llvm::zip_equal(reshapeOp.getResultType().getShape(),
+                                      outputShape[0])) {
       if (std::get<0>(shape) != ShapedType::kDynamic) continue;
       outputDynamicShapes.push_back(std::get<1>(shape));
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ConvertLinalgTensorOps.cpp
@@ -49,8 +49,8 @@ struct LinalgTensorReshapeToFlowTensorReshape
       return failure();
     }
     SmallVector<Value> outputDynamicShapes;
-    for (auto shape :
-         llvm::zip(reshapeOp.getResultType().getShape(), outputShape[0])) {
+    for (auto shape : llvm::zip_equal(reshapeOp.getResultType().getShape(),
+                                      outputShape[0])) {
       if (std::get<0>(shape) != ShapedType::kDynamic) continue;
       outputDynamicShapes.push_back(std::get<1>(shape));
     }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -103,8 +103,7 @@ static bool isStructurallyEquivalentTo(Region &lhs, Region &rhs,
     llvm::ReversePostOrderTraversal<Block *> traversal(&b);
     rhsBlocks.insert(traversal.begin(), traversal.end());
   }
-  if (lhsBlocks.size() != rhsBlocks.size())
-    return false;
+  if (lhsBlocks.size() != rhsBlocks.size()) return false;
   for (auto blockPair : llvm::zip_equal(lhsBlocks, rhsBlocks)) {
     auto &lhsBlock = std::get<0>(blockPair);
     auto &rhsBlock = std::get<1>(blockPair);

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -103,11 +103,15 @@ static bool isStructurallyEquivalentTo(Region &lhs, Region &rhs,
     llvm::ReversePostOrderTraversal<Block *> traversal(&b);
     rhsBlocks.insert(traversal.begin(), traversal.end());
   }
+  if (lhsBlocks.size() != rhsBlocks.size())
+    return false;
   for (auto blockPair : llvm::zip_equal(lhsBlocks, rhsBlocks)) {
     auto &lhsBlock = std::get<0>(blockPair);
     auto &rhsBlock = std::get<1>(blockPair);
-    for (auto opPair : llvm::zip_equal(lhsBlock->getOperations(),
-                                       rhsBlock->getOperations())) {
+    auto &lhsOperations = lhsBlock->getOperations();
+    auto &rhsOperations = rhsBlock->getOperations();
+    if (lhsOperations.size() != rhsOperations.size()) return false;
+    for (auto opPair : llvm::zip_equal(lhsOperations, rhsOperations)) {
       auto &lhsOp = std::get<0>(opPair);
       auto &rhsOp = std::get<1>(opPair);
       if (!isStructurallyEquivalentTo(lhsOp, rhsOp, mapping)) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DeduplicateExecutables.cpp
@@ -77,8 +77,8 @@ static bool isStructurallyEquivalentTo(Region &lhs, Region &rhs,
             if (lhsBlock.getNumArguments() != rhsBlock.getNumArguments()) {
               return false;
             }
-            for (auto argPair :
-                 llvm::zip(lhsBlock.getArguments(), rhsBlock.getArguments())) {
+            for (auto argPair : llvm::zip_equal(lhsBlock.getArguments(),
+                                                rhsBlock.getArguments())) {
               auto &lhsArg = std::get<0>(argPair);
               auto &rhsArg = std::get<1>(argPair);
               if (lhsArg.getType() != rhsArg.getType()) return false;
@@ -103,11 +103,11 @@ static bool isStructurallyEquivalentTo(Region &lhs, Region &rhs,
     llvm::ReversePostOrderTraversal<Block *> traversal(&b);
     rhsBlocks.insert(traversal.begin(), traversal.end());
   }
-  for (auto blockPair : llvm::zip(lhsBlocks, rhsBlocks)) {
+  for (auto blockPair : llvm::zip_equal(lhsBlocks, rhsBlocks)) {
     auto &lhsBlock = std::get<0>(blockPair);
     auto &rhsBlock = std::get<1>(blockPair);
-    for (auto opPair :
-         llvm::zip(lhsBlock->getOperations(), rhsBlock->getOperations())) {
+    for (auto opPair : llvm::zip_equal(lhsBlock->getOperations(),
+                                       rhsBlock->getOperations())) {
       auto &lhsOp = std::get<0>(opPair);
       auto &rhsOp = std::get<1>(opPair);
       if (!isStructurallyEquivalentTo(lhsOp, rhsOp, mapping)) {
@@ -145,7 +145,7 @@ static bool isStructurallyEquivalentTo(Operation &lhs, Operation &rhs,
   // If the op references blocks (such as a branch) then we expect to have them
   // in the mapping already from the parent region to do the lhs->rhs mapping.
   for (auto successorPair :
-       llvm::zip(lhs.getSuccessors(), rhs.getSuccessors())) {
+       llvm::zip_equal(lhs.getSuccessors(), rhs.getSuccessors())) {
     auto *lhsSuccessor = std::get<0>(successorPair);
     auto *rhsSuccessor = std::get<1>(successorPair);
     if (rhsSuccessor != parentMapping.lookup(lhsSuccessor)) return false;
@@ -155,7 +155,7 @@ static bool isStructurallyEquivalentTo(Operation &lhs, Operation &rhs,
   // For many ops if the result types don't match it's a good (cheap) indicator
   // that the operands won't match either so this still allows a somewhat-early
   // exit prior to the full traversal.
-  for (auto resultPair : llvm::zip(lhs.getResults(), rhs.getResults())) {
+  for (auto resultPair : llvm::zip_equal(lhs.getResults(), rhs.getResults())) {
     auto &lhsValue = std::get<0>(resultPair);
     auto &rhsValue = std::get<1>(resultPair);
     if (lhsValue.getType() != rhsValue.getType()) return false;
@@ -164,7 +164,8 @@ static bool isStructurallyEquivalentTo(Operation &lhs, Operation &rhs,
 
   // Check operands using the lhs->rhs mapping; since this op is only consuming
   // these values they should already be defined in the mapping.
-  for (auto operandPair : llvm::zip(lhs.getOperands(), rhs.getOperands())) {
+  for (auto operandPair :
+       llvm::zip_equal(lhs.getOperands(), rhs.getOperands())) {
     auto &lhsValue = std::get<0>(operandPair);
     auto &rhsValue = std::get<1>(operandPair);
     if (lhsValue.getType() != rhsValue.getType()) return false;
@@ -172,7 +173,7 @@ static bool isStructurallyEquivalentTo(Operation &lhs, Operation &rhs,
   }
 
   // Recurse into regions.
-  for (auto regionPair : llvm::zip(lhs.getRegions(), rhs.getRegions())) {
+  for (auto regionPair : llvm::zip_equal(lhs.getRegions(), rhs.getRegions())) {
     auto &lhsRegion = std::get<0>(regionPair);
     auto &rhsRegion = std::get<1>(regionPair);
 
@@ -238,7 +239,7 @@ class DeduplicateExecutablesPass
         duplicateExecutableOps.push_back(duplicateExecutableOp);
 
         // Record entry point reference replacements.
-        for (auto exportOpPair : llvm::zip(
+        for (auto exportOpPair : llvm::zip_equal(
                  duplicateExecutableOp.getBlock().getOps<ExecutableExportOp>(),
                  referenceExecutableOp.getBlock()
                      .getOps<ExecutableExportOp>())) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExpandTensorShapes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/ExpandTensorShapes.cpp
@@ -298,8 +298,8 @@ static void expandGlobalStoreOp(IREE::Util::GlobalStoreOp op,
   auto &expandedGlobal = globalMap[op.getGlobal()];
   builder.create<IREE::Util::GlobalStoreOp>(op.getLoc(), expandedValue.tensor,
                                             expandedGlobal.tensorOp.getName());
-  for (auto it :
-       llvm::zip(expandedValue.dynamicDims, expandedGlobal.dynamicDimOps)) {
+  for (auto it : llvm::zip_equal(expandedValue.dynamicDims,
+                                 expandedGlobal.dynamicDimOps)) {
     builder.create<IREE::Util::GlobalStoreOp>(op.getLoc(), std::get<0>(it),
                                               std::get<1>(it).getName());
   }
@@ -458,7 +458,8 @@ static void expandSelectOp(mlir::arith::SelectOp op, IndexSet &indexSet,
       op.getLoc(), op.getCondition(), op.getTrueValue(), op.getFalseValue());
 
   SmallVector<Value> selectedDims;
-  for (auto it : llvm::zip(trueValue.dynamicDims, falseValue.dynamicDims)) {
+  for (auto it :
+       llvm::zip_equal(trueValue.dynamicDims, falseValue.dynamicDims)) {
     selectedDims.push_back(
         builder
             .create<arith::SelectOp>(op.getLoc(), op.getCondition(),

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/ConversionTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/ConversionTarget.cpp
@@ -50,7 +50,7 @@ LogicalResult HALConversionTarget::applyDefaultBufferRewrite(
   OperationState state{srcOp->getLoc(), dstOpName};
   state.addAttributes(srcOp->getAttrs());
 
-  for (auto srcDstOperand : llvm::zip(srcOp->getOperands(), operands)) {
+  for (auto srcDstOperand : llvm::zip_equal(srcOp->getOperands(), operands)) {
     auto dstOperand = std::get<1>(srcDstOperand);
 
     // Check that any type that should have been mapped to buffer view was.

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/Patterns.cpp
@@ -298,7 +298,8 @@ struct ResourceAllocOpPattern
     auto bufferType = rewriter.getType<IREE::HAL::BufferType>();
 
     SmallVector<Value> results;
-    for (auto it : llvm::zip(allocOp.getResults(), allocOp.getStorageSizes())) {
+    for (auto it :
+         llvm::zip_equal(allocOp.getResults(), allocOp.getStorageSizes())) {
       auto resourceResult = std::get<0>(it);
       auto resourceType =
           resourceResult.getType().cast<IREE::Stream::ResourceType>();

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -691,8 +691,8 @@ struct DeduplicateExecutableConstantBlockKeys
     SmallVector<Type> resultTypes;
     SetVector<Attribute> resultKeys;
     int i = 0;
-    for (auto [resultKey, resultType] :
-         llvm::zip(blockOp.getKeys().getValue(), blockOp.getResultTypes())) {
+    for (auto [resultKey, resultType] : llvm::zip_equal(
+             blockOp.getKeys().getValue(), blockOp.getResultTypes())) {
       if (resultKeys.insert(resultKey)) {
         resultIndices.set(i);
         resultTypes.push_back(resultType);

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOps.cpp
@@ -95,22 +95,23 @@ static void printDescriptorSetBindings(OpAsmPrinter &p, Operation *op,
                                        TypeRange bufferTypes,
                                        ValueRange bufferOffsets,
                                        ValueRange bufferLengths) {
-  llvm::interleaveComma(
-      llvm::zip(ordinals, buffers, bufferTypes, bufferOffsets, bufferLengths),
-      p, [&](std::tuple<Value, Value, Type, Value, Value> it) {
-        p.printNewline();
-        p << "  ";
-        p.printOperand(std::get<0>(it));
-        p << " = (";
-        p.printOperand(std::get<1>(it));
-        p << " : ";
-        p.printType(std::get<2>(it));
-        p << ")[";
-        p.printOperand(std::get<3>(it));
-        p << ", ";
-        p.printOperand(std::get<4>(it));
-        p << "]";
-      });
+  llvm::interleaveComma(llvm::zip_equal(ordinals, buffers, bufferTypes,
+                                        bufferOffsets, bufferLengths),
+                        p,
+                        [&](std::tuple<Value, Value, Type, Value, Value> it) {
+                          p.printNewline();
+                          p << "  ";
+                          p.printOperand(std::get<0>(it));
+                          p << " = (";
+                          p.printOperand(std::get<1>(it));
+                          p << " : ";
+                          p.printType(std::get<2>(it));
+                          p << ")[";
+                          p.printOperand(std::get<3>(it));
+                          p << ", ";
+                          p.printOperand(std::get<4>(it));
+                          p << "]";
+                        });
   p.printNewline();
 }
 
@@ -140,7 +141,7 @@ LogicalResult ReturnOp::verify() {
                               << expectedTypes.size() << ")";
     }
     for (auto pair :
-         llvm::enumerate(llvm::zip(op.getOperands(), expectedTypes))) {
+         llvm::enumerate(llvm::zip_equal(op.getOperands(), expectedTypes))) {
       auto operand = std::get<0>(pair.value());
       auto expectedType = std::get<1>(pair.value());
       if (operand.getType() != expectedType) {
@@ -582,7 +583,7 @@ void DeviceSwitchOp::print(OpAsmPrinter &p) {
   p << "\n";
   p.getStream().indent(4);
   interleave(
-      llvm::zip(getConditions(), getConditionRegions()),
+      llvm::zip_equal(getConditions(), getConditionRegions()),
       [&](std::tuple<Attribute, Region &> it) {
         auto &conditionAttr = std::get<0>(it);
         auto &conditionRegion = std::get<1>(it);

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALTypes.cpp
@@ -549,7 +549,7 @@ Attribute ExecutableObjectsAttr::parse(AsmParser &p, Type type) {
 void ExecutableObjectsAttr::print(AsmPrinter &p) const {
   auto &os = p.getStream();
   os << "<{";
-  llvm::interleaveComma(llvm::zip(getTargets(), getTargetObjects()), os,
+  llvm::interleaveComma(llvm::zip_equal(getTargets(), getTargetObjects()), os,
                         [&](std::tuple<Attribute, Attribute> keyValue) {
                           p.printAttribute(std::get<0>(keyValue));
                           os << " = ";
@@ -562,7 +562,7 @@ Optional<ArrayAttr> ExecutableObjectsAttr::getApplicableObjects(
     IREE::HAL::ExecutableTargetAttr specificTargetAttr) {
   SmallVector<Attribute> allObjectAttrs;
   for (auto [targetAttr, objectsAttr] :
-       llvm::zip(getTargets(), getTargetObjects())) {
+       llvm::zip_equal(getTargets(), getTargetObjects())) {
     auto genericTargetAttr = targetAttr.cast<IREE::HAL::ExecutableTargetAttr>();
     if (genericTargetAttr.isGenericOf(specificTargetAttr)) {
       auto objectsArrayAttr = objectsAttr.cast<ArrayAttr>();

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -300,8 +300,8 @@ class CUDATargetBackend final : public TargetBackend {
       }
 
       for (auto [exportOp, workgroupSize] :
-           llvm::zip(variantOp.getOps<IREE::HAL::ExecutableExportOp>(),
-                     workgroupSizes)) {
+           llvm::zip_equal(variantOp.getOps<IREE::HAL::ExecutableExportOp>(),
+                           workgroupSizes)) {
         auto *llvmFunc = llvmModule->getFunction(exportOp.getName());
         if (llvmFunc->isDeclaration()) continue;
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/DumpExecutableBenchmarks.cpp
@@ -84,7 +84,8 @@ static DispatchParamsMap gatherDispatchParams(mlir::ModuleOp moduleOp) {
       }
 
       SmallVector<Binding> bindings;
-      for (auto it : llvm::zip(bindingAttrs, dispatchOp.getResourceLengths())) {
+      for (auto it :
+           llvm::zip_equal(bindingAttrs, dispatchOp.getResourceLengths())) {
         auto bindingAttr =
             std::get<0>(it).cast<IREE::HAL::InterfaceBindingAttr>();
         APInt resourceLength;

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/InlineDeviceSwitches.cpp
@@ -96,8 +96,8 @@ static void buildConditionDispatchTable(IREE::HAL::DeviceSwitchOp switchOp,
 
   funcBuilder.setInsertionPoint(beforeBlock, beforeBlock->end());
   for (auto condition :
-       llvm::enumerate(llvm::zip(switchOp.getConditions().getValue(),
-                                 switchOp.getConditionRegions()))) {
+       llvm::enumerate(llvm::zip_equal(switchOp.getConditions().getValue(),
+                                       switchOp.getConditionRegions()))) {
     auto conditionAttr =
         std::get<0>(condition.value()).cast<IREE::HAL::MatchAttrInterface>();
     auto &conditionRegion = std::get<1>(condition.value());

--- a/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Conversion/FlowToStream/Patterns.cpp
@@ -229,7 +229,7 @@ struct ConvertTensorTraceOp
       IREE::Flow::TensorTraceOp op, OpAdaptor adaptor,
       ConversionPatternRewriter &rewriter) const override {
     SmallVector<Value> exportedTensors;
-    for (auto it : llvm::zip(op.getOperands(), adaptor.getOperands())) {
+    for (auto it : llvm::zip_equal(op.getOperands(), adaptor.getOperands())) {
       auto tensorOperand = std::get<0>(it);
       auto resourceOperand = std::get<1>(it);
       auto source =
@@ -273,7 +273,7 @@ struct ConvertDispatchOp : public OpConversionPattern<IREE::Flow::DispatchOp> {
     SmallVector<Value> dispatchOperandLengths;
     SmallVector<Value> operandSizes;
     for (auto oldNewOperand :
-         llvm::zip(op.getArguments(), adaptor.getArguments())) {
+         llvm::zip_equal(op.getArguments(), adaptor.getArguments())) {
       auto oldOperand = std::get<0>(oldNewOperand);
       auto newOperand = std::get<1>(oldNewOperand);
       if (oldOperand.getType().isa<ShapedType>()) {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -638,7 +638,7 @@ struct CanonicalizeResourcePackIntervals
 
     // See if the sorted order is different than how they are stored in the op.
     bool orderChanged = false;
-    for (auto it : llvm::zip(slices, op.getPackedOffsets())) {
+    for (auto it : llvm::zip_equal(slices, op.getPackedOffsets())) {
       if (std::get<0>(it).packedOffset != std::get<1>(it)) {
         orderChanged = true;
         break;
@@ -2650,8 +2650,9 @@ struct FoldDuplicateAwaitResources : public OpRewritePattern<TimepointAwaitOp> {
     SmallVector<std::pair<Value, unsigned>> replacements;
     SmallVector<Value> newOperands;
     SmallVector<Value> newOperandSizes;
-    for (auto it : llvm::zip(op.getResourceOperands(),
-                             op.getResourceOperandSizes(), op.getResults())) {
+    for (auto it :
+         llvm::zip_equal(op.getResourceOperands(), op.getResourceOperandSizes(),
+                         op.getResults())) {
       auto operand = std::get<0>(it);
       auto operandSize = std::get<1>(it);
       auto result = std::get<2>(it);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ConvertToStream.cpp
@@ -142,7 +142,7 @@ struct GenericResourcePattern : public ConversionPattern {
     SmallVector<Value> newOperands;
     newOperands.reserve(op->getNumOperands());
     rewriter.setInsertionPoint(op);
-    for (auto it : llvm::zip(op->getOperands(), operands)) {
+    for (auto it : llvm::zip_equal(op->getOperands(), operands)) {
       auto oldOperand = std::get<0>(it);
       auto newOperand = std::get<1>(it);
       if (!newOperand.getType().isa<IREE::Stream::ResourceType>() &&

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -86,7 +86,7 @@ static SmallVector<Binding> findCorrelatedBindings(
   for (auto dispatchOp : dispatchOps) {
     llvm::EquivalenceClasses<unsigned> ec;
     DenseMap<Value, unsigned> leaders;
-    for (auto it : llvm::enumerate(llvm::zip(
+    for (auto it : llvm::enumerate(llvm::zip_equal(
              dispatchOp.getResources(), dispatchOp.getResourceAccesses()))) {
       auto resource = std::get<0>(it.value());
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackAllocations.cpp
@@ -92,8 +92,9 @@ class PackAllocationsPass : public PackAllocationsBase<PackAllocationsPass> {
       auto slabSize = packOp.getTotalLength();
 
       // Replace all resources with subviews into the new slab.
-      for (auto it : llvm::zip(allocOp.getResults(), packOp.getPackedOffsets(),
-                               allocOp.getStorageSizes())) {
+      for (auto it :
+           llvm::zip_equal(allocOp.getResults(), packOp.getPackedOffsets(),
+                           allocOp.getStorageSizes())) {
         auto originalValue = std::get<0>(it);
         auto subviewOffset = std::get<1>(it);
         auto subviewLength = std::get<2>(it);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackConstants.cpp
@@ -278,7 +278,7 @@ static UploadResult buildStagingUpload(
   SmallVector<Copy> copies;
   SmallVector<Value> capturedResources;
   SmallVector<Value> capturedResourceSizes;
-  for (auto it : llvm::zip(storageResources, storageBuffers)) {
+  for (auto it : llvm::zip_equal(storageResources, storageBuffers)) {
     auto &storageResource = std::get<0>(it);
     auto storageBuffer = std::get<1>(it);
 
@@ -366,7 +366,7 @@ static UploadResult buildTryMapConstantResources(
   SmallVector<Type> resultTypes;
   Value ok;
   auto zero = indexSet.get(0);
-  for (auto it : llvm::zip(storageResources, storageBuffers)) {
+  for (auto it : llvm::zip_equal(storageResources, storageBuffers)) {
     auto &storageResource = std::get<0>(it);
     auto storageBuffer = std::get<1>(it);
     auto tryMapOp = builder.create<IREE::Stream::ResourceTryMapOp>(
@@ -415,7 +415,7 @@ static UploadResult buildTryMapConstantResources(
   // Use the result of either the direct mapping or the staging upload.
   UploadResult uploadResult;
   uploadResult.timepoint = ifTimepoint;
-  for (auto it : llvm::zip(storageResources, ifResources)) {
+  for (auto it : llvm::zip_equal(storageResources, ifResources)) {
     auto &storageResource = std::get<0>(it);
     auto ifResource = std::get<1>(it);
     uploadResult.allocations.push_back({
@@ -434,8 +434,8 @@ static Value generateUpload(IREE::Stream::ResourceConstantsOp constantsOp,
   SmallVector<ConstantSlice> slices;
   slices.reserve(constantsOp.getResults().size());
   for (auto [result, resultSize, value] :
-       llvm::zip(constantsOp.getResults(), constantsOp.getResultSizes(),
-                 constantsOp.getValues())) {
+       llvm::zip_equal(constantsOp.getResults(), constantsOp.getResultSizes(),
+                       constantsOp.getValues())) {
     auto resourceType = result.getType().cast<IREE::Stream::ResourceType>();
     if (resourceType.getLifetime() != lifetime) continue;
     slices.push_back(ConstantSlice{
@@ -480,7 +480,7 @@ static Value generateUpload(IREE::Stream::ResourceConstantsOp constantsOp,
   }
 
   // Build subviews for all packed spans back into storage buffers.
-  for (auto it : llvm::zip(storageResources, uploadResult.allocations)) {
+  for (auto it : llvm::zip_equal(storageResources, uploadResult.allocations)) {
     auto &storageResource = std::get<0>(it);
     auto &allocatedStorage = std::get<1>(it);
     for (auto &span : storageResource.spans) {

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PropagateTimepoints.cpp
@@ -529,8 +529,8 @@ static void expandAsyncExecuteOp(IREE::Stream::AsyncExecuteOp op,
   if (op.getAwaitTimepoint()) {
     newTimepoints.insert(op.getAwaitTimepoint());
   }
-  for (auto it :
-       llvm::zip(op.getResourceOperands(), op.getResourceOperandSizes())) {
+  for (auto it : llvm::zip_equal(op.getResourceOperands(),
+                                 op.getResourceOperandSizes())) {
     auto operand = std::get<0>(it);
     auto operandSize = std::get<1>(it);
     auto timepointOperand =

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -61,7 +61,7 @@ static void computeRegionValueAliases(Operation *regionOp,
   auto tiedStreamOp = cast<IREE::Util::TiedOpInterface>(regionOp);
   auto yieldOp = cast<IREE::Stream::YieldOp>(block->getTerminator());
   for (auto it :
-       llvm::zip_equal(regionOp->getResults(), yieldOp.getResourceOperands())) {
+       llvm::zip(regionOp->getResults(), yieldOp.getResourceOperands())) {
     auto outerResult = std::get<0>(it);
     auto innerResult = std::get<1>(it);
     auto tiedOperandIndex =
@@ -1206,7 +1206,7 @@ static LogicalResult allocateExecutionRegion(
   }
   SmallVector<ResultReservation> resultReservations;
   for (auto it :
-       llvm::zip_equal(executeOp.getResults(), executeOp.getResultSizes())) {
+       llvm::zip(executeOp.getResults(), executeOp.getResultSizes())) {
     auto result = std::get<0>(it);
     auto resultSize = std::get<1>(it);
     auto resultType = result.getType().cast<IREE::Stream::ResourceType>();
@@ -1295,7 +1295,7 @@ static LogicalResult allocateExecutionRegion(
     });
 
     for (auto it :
-         llvm::zip_equal(reservationSet.reservations, allocOp.getResults())) {
+         llvm::zip(reservationSet.reservations, allocOp.getResults())) {
       auto &reservation = std::get<0>(it);
       auto allocResult = std::get<1>(it);
 
@@ -1395,8 +1395,8 @@ static LogicalResult allocateExecutionRegion(
   asmState = getRootAsmState(newExecuteOp->getParentOp());
   newExecuteOp.getBody().walk<WalkOrder::PreOrder>(
       [&](IREE::Stream::AsyncConcurrentOp concurrentOp) {
-        for (auto it : llvm::zip_equal(concurrentOp.getResourceOperands(),
-                                       concurrentOp.getBody().getArguments())) {
+        for (auto it : llvm::zip(concurrentOp.getResourceOperands(),
+                                 concurrentOp.getBody().getArguments())) {
           auto outerValue = std::get<0>(it);
           auto innerValue = std::get<1>(it);
           LLVM_DEBUG({
@@ -1412,8 +1412,8 @@ static LogicalResult allocateExecutionRegion(
         }
         auto yieldOp = cast<IREE::Stream::YieldOp>(
             concurrentOp.getBody().front().getTerminator());
-        for (auto it : llvm::zip_equal(yieldOp.getResourceOperands(),
-                                       concurrentOp.getResults())) {
+        for (auto it : llvm::zip(yieldOp.getResourceOperands(),
+                                 concurrentOp.getResults())) {
           auto innerValue = std::get<0>(it);
           auto outerValue = std::get<1>(it);
           LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -61,7 +61,7 @@ static void computeRegionValueAliases(Operation *regionOp,
   auto tiedStreamOp = cast<IREE::Util::TiedOpInterface>(regionOp);
   auto yieldOp = cast<IREE::Stream::YieldOp>(block->getTerminator());
   for (auto it :
-       llvm::zip(regionOp->getResults(), yieldOp.getResourceOperands())) {
+       llvm::zip_equal(regionOp->getResults(), yieldOp.getResourceOperands())) {
     auto outerResult = std::get<0>(it);
     auto innerResult = std::get<1>(it);
     auto tiedOperandIndex =
@@ -1206,7 +1206,7 @@ static LogicalResult allocateExecutionRegion(
   }
   SmallVector<ResultReservation> resultReservations;
   for (auto it :
-       llvm::zip(executeOp.getResults(), executeOp.getResultSizes())) {
+       llvm::zip_equal(executeOp.getResults(), executeOp.getResultSizes())) {
     auto result = std::get<0>(it);
     auto resultSize = std::get<1>(it);
     auto resultType = result.getType().cast<IREE::Stream::ResourceType>();
@@ -1295,7 +1295,7 @@ static LogicalResult allocateExecutionRegion(
     });
 
     for (auto it :
-         llvm::zip(reservationSet.reservations, allocOp.getResults())) {
+         llvm::zip_equal(reservationSet.reservations, allocOp.getResults())) {
       auto &reservation = std::get<0>(it);
       auto allocResult = std::get<1>(it);
 
@@ -1395,8 +1395,8 @@ static LogicalResult allocateExecutionRegion(
   asmState = getRootAsmState(newExecuteOp->getParentOp());
   newExecuteOp.getBody().walk<WalkOrder::PreOrder>(
       [&](IREE::Stream::AsyncConcurrentOp concurrentOp) {
-        for (auto it : llvm::zip(concurrentOp.getResourceOperands(),
-                                 concurrentOp.getBody().getArguments())) {
+        for (auto it : llvm::zip_equal(concurrentOp.getResourceOperands(),
+                                       concurrentOp.getBody().getArguments())) {
           auto outerValue = std::get<0>(it);
           auto innerValue = std::get<1>(it);
           LLVM_DEBUG({
@@ -1412,8 +1412,8 @@ static LogicalResult allocateExecutionRegion(
         }
         auto yieldOp = cast<IREE::Stream::YieldOp>(
             concurrentOp.getBody().front().getTerminator());
-        for (auto it : llvm::zip(yieldOp.getResourceOperands(),
-                                 concurrentOp.getResults())) {
+        for (auto it : llvm::zip_equal(yieldOp.getResourceOperands(),
+                                       concurrentOp.getResults())) {
           auto innerValue = std::get<0>(it);
           auto outerValue = std::get<1>(it);
           LLVM_DEBUG({

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleConcurrency.cpp
@@ -110,14 +110,15 @@ struct WavePartitionBuilder {
     auto &entryBlock = concurrentOp.getBody().emplaceBlock();
     SmallVector<Location> operandLocs(operandTypes.size(),
                                       concurrentOp.getLoc());
-    for (auto args : llvm::zip(
+    for (auto args : llvm::zip_equal(
              operands, entryBlock.addArguments(operandTypes, operandLocs))) {
       mapping.map(std::get<0>(args), std::get<1>(args));
     }
     builder = OpBuilder::atBlockBegin(&entryBlock);
 
     // Remap results for escaping outputs.
-    for (auto results : llvm::zip(partition->outs, concurrentOp.getResults())) {
+    for (auto results :
+         llvm::zip_equal(partition->outs, concurrentOp.getResults())) {
       parentMapping.map(std::get<0>(results), std::get<1>(results));
     }
   }
@@ -236,8 +237,8 @@ class ScheduleConcurrencyPass
     // We must do this per block as we'll be updating dominated block values.
     for (auto &partitionBuilder : partitionBuilders) {
       for (auto resultPair :
-           llvm::zip(partitionBuilder.partition->outs,
-                     partitionBuilder.concurrentOp.getResults())) {
+           llvm::zip_equal(partitionBuilder.partition->outs,
+                           partitionBuilder.concurrentOp.getResults())) {
         auto oldResult = std::get<0>(resultPair);
         auto newResult = std::get<1>(resultPair);
         oldResult.replaceAllUsesWith(newResult);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleExecution.cpp
@@ -111,14 +111,15 @@ struct ExecutePartitionBuilder {
     // Add entry block and arguments.
     auto &entryBlock = executeOp.getBody().emplaceBlock();
     SmallVector<Location> operandLocs(operandTypes.size(), executeOp.getLoc());
-    for (auto args : llvm::zip(
+    for (auto args : llvm::zip_equal(
              operands, entryBlock.addArguments(operandTypes, operandLocs))) {
       mapping.map(std::get<0>(args), std::get<1>(args));
     }
     builder = OpBuilder::atBlockBegin(&entryBlock);
 
     // Remap results for escaping outputs.
-    for (auto results : llvm::zip(partition->outs, executeOp.getResults())) {
+    for (auto results :
+         llvm::zip_equal(partition->outs, executeOp.getResults())) {
       parentMapping.map(std::get<0>(results), std::get<1>(results));
     }
   }
@@ -278,9 +279,9 @@ class ScheduleExecutionPass
 
         OpBuilder builder(executeOp);
         builder.setInsertionPointAfter(executeOp);
-        for (auto it :
-             llvm::zip(partitionBuilder.partition->outs, executeOp.getResults(),
-                       executeOp.getResultSizes())) {
+        for (auto it : llvm::zip_equal(partitionBuilder.partition->outs,
+                                       executeOp.getResults(),
+                                       executeOp.getResultSizes())) {
           auto oldResult = std::get<0>(it);
           auto newResult = std::get<1>(it);
           auto newResultSize = std::get<2>(it);

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -187,7 +187,7 @@ static void insertConstantTableLookup(mlir::func::FuncOp funcOp,
   // TODO(benvanik): invert this loop so that we preserve argument order.
 
   // Replace the arguments with lookups into the lookup table tensors.
-  for (auto it : llvm::zip(constantTable.sets, tableTensors)) {
+  for (auto it : llvm::zip_equal(constantTable.sets, tableTensors)) {
     auto &set = std::get<0>(it);
     auto tableTensor = std::get<1>(it);
     for (auto operandValues : llvm::enumerate(set.values)) {

--- a/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/ClosureOpUtils.cpp
@@ -299,13 +299,13 @@ LogicalResult optimizeClosureLikeOp(ClosureOpInterface closureOp,
   newResults.set_subtract(newClosureResults);
   assert(oldResults.size() == newResults.size() &&
          "expected non-closure results to match");
-  for (auto oldNewResult : llvm::zip(oldResults, newResults)) {
+  for (auto oldNewResult : llvm::zip_equal(oldResults, newResults)) {
     std::get<0>(oldNewResult).replaceAllUsesWith(std::get<1>(oldNewResult));
   }
 
   // Replace original uses of the closure results.
   for (auto oldNewResult :
-       llvm::zip(preservedResults, newOp.getClosureResults())) {
+       llvm::zip_equal(preservedResults, newOp.getClosureResults())) {
     std::get<0>(oldNewResult).replaceAllUsesWith(std::get<1>(oldNewResult));
   }
 

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -190,7 +190,7 @@ struct FoldConstantRanges : public OpRewritePattern<RangeExtentsOp> {
     lengths.reserve(op.getLengths().size());
     int64_t constantMin = INT64_MAX;
     int64_t constantMax = INT64_MIN;
-    for (auto range : llvm::zip(op.getOffsets(), op.getLengths())) {
+    for (auto range : llvm::zip_equal(op.getOffsets(), op.getLengths())) {
       auto offset = std::get<0>(range);
       auto length = std::get<1>(range);
       APInt rangeOffset, rangeLength;
@@ -280,7 +280,7 @@ struct DeduplicateRangeExtentsOp : public OpRewritePattern<RangeExtentsOp> {
     // preserved.
     using Range = std::tuple<Value, Value>;
     SetVector<Range> ranges;
-    for (auto range : llvm::zip(op.getOffsets(), op.getLengths())) {
+    for (auto range : llvm::zip_equal(op.getOffsets(), op.getLengths())) {
       ranges.insert(range);
     }
     if (ranges.size() == op.getOffsets().size()) return failure();

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.cpp
@@ -206,7 +206,7 @@ ParseResult parseRangeList(
 
 void printRangeList(OpAsmPrinter &p, Operation *op, OperandRange offsets,
                     OperandRange lengths) {
-  llvm::interleaveComma(llvm::zip(offsets, lengths), p, [&](auto it) {
+  llvm::interleaveComma(llvm::zip_equal(offsets, lengths), p, [&](auto it) {
     auto offset = std::get<0>(it);
     auto length = std::get<1>(it);
     p << "[";

--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/IPO.cpp
@@ -550,7 +550,7 @@ static bool applyCallChanges(FuncAnalysis &analysis, func::CallOp callOp) {
 
   // Remap live old results -> new results.
   for (auto [oldValue, newValue] :
-       llvm::zip(newResults, newCallOp.getResults())) {
+       llvm::zip_equal(newResults, newCallOp.getResults())) {
     oldValue.replaceAllUsesWith(newValue);
   }
 

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/StandardToVM/ConvertStandardToVM.cpp
@@ -383,7 +383,7 @@ class CallOpConversion : public OpConversionPattern<func::CallOp> {
     // Marshal arguments to import types.
     SmallVector<Value> importArgs;
     for (auto [operand, importType] :
-         llvm::zip(operands, importSignature.getInputs())) {
+         llvm::zip_equal(operands, importSignature.getInputs())) {
       importArgs.push_back(castToImportType(operand, importType, rewriter));
     }
 
@@ -394,7 +394,7 @@ class CallOpConversion : public OpConversionPattern<func::CallOp> {
     // Marshal results from import types.
     SmallVector<Value> callResults;
     for (auto [importResult, resultType] :
-         llvm::zip(newOp.getResults(), resultTypes)) {
+         llvm::zip_equal(newOp.getResults(), resultTypes)) {
       callResults.push_back(
           castFromImportType(importResult, resultType, rewriter));
     }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/ConvertVMToEmitC.cpp
@@ -2964,7 +2964,8 @@ class BranchOpConversion : public OpConversionPattern<IREE::VM::BranchOp> {
       destDispatch = rewriter.createBlock(dest);
 
       BlockAndValueMapping refMapping;
-      for (auto pair : llvm::zip(op.getOperands(), dest->getArguments())) {
+      for (auto pair :
+           llvm::zip_equal(op.getOperands(), dest->getArguments())) {
         Value operand = std::get<0>(pair);
         BlockArgument blockArg = std::get<1>(pair);
 

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOps.cpp
@@ -1187,7 +1187,7 @@ void CallVariadicOp::print(OpAsmPrinter &p) {
   p << ' ' << op->getAttr("callee") << '(';
   int operand = 0;
   llvm::interleaveComma(
-      llvm::zip(getSegmentSizes(), getSegmentTypes()), p,
+      llvm::zip_equal(getSegmentSizes(), getSegmentTypes()), p,
       [&](std::tuple<APInt, Attribute> segmentSizeType) {
         int segmentSize = std::get<0>(segmentSizeType).getSExtValue();
         Type segmentType =
@@ -1225,7 +1225,7 @@ void CallVariadicOp::print(OpAsmPrinter &p) {
                           });
   p << " : (";
   llvm::interleaveComma(
-      llvm::zip(getSegmentSizes(), getSegmentTypes()), p,
+      llvm::zip_equal(getSegmentSizes(), getSegmentTypes()), p,
       [&](std::tuple<APInt, Attribute> segmentSizeType) {
         int segmentSize = std::get<0>(segmentSizeType).getSExtValue();
         Type segmentType =

--- a/compiler/src/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/C/TranslateToCpp.cpp
@@ -93,7 +93,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
   Block &successor = *branchOp.getSuccessor();
 
   for (auto pair :
-       llvm::zip(branchOp.getOperands(), successor.getArguments())) {
+       llvm::zip_equal(branchOp.getOperands(), successor.getArguments())) {
     Value &operand = std::get<0>(pair);
     BlockArgument &argument = std::get<1>(pair);
     os << emitter.getOrCreateName(argument) << " = "
@@ -117,7 +117,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
      << ") {\n";
 
   // If condition is true.
-  for (auto pair : llvm::zip(condBranchOp.getTrueOperands(),
+  for (auto pair : llvm::zip_equal(condBranchOp.getTrueOperands(),
                              trueSuccessor.getArguments())) {
     Value &operand = std::get<0>(pair);
     BlockArgument &argument = std::get<1>(pair);
@@ -132,7 +132,7 @@ static LogicalResult printOperation(CppEmitter &emitter,
   os << emitter.getOrCreateName(trueSuccessor) << ";\n";
   os << "} else {\n";
   // If condition is false.
-  for (auto pair : llvm::zip(condBranchOp.getFalseOperands(),
+  for (auto pair : llvm::zip_equal(condBranchOp.getFalseOperands(),
                              falseSuccessor.getArguments())) {
     Value &operand = std::get<0>(pair);
     BlockArgument &argument = std::get<1>(pair);
@@ -265,7 +265,7 @@ static LogicalResult printOperation(CppEmitter &emitter, scf::ForOp forOp) {
     }
   }
 
-  for (auto pair : llvm::zip(iterArgs, operands)) {
+  for (auto pair : llvm::zip_equal(iterArgs, operands)) {
     if (failed(emitter.emitType(forOp.getLoc(), std::get<0>(pair).getType())))
       return failure();
     os << " " << emitter.getOrCreateName(std::get<0>(pair)) << " = ";
@@ -306,7 +306,7 @@ static LogicalResult printOperation(CppEmitter &emitter, scf::ForOp forOp) {
 
   Operation *yieldOp = forRegion.getBlocks().front().getTerminator();
   // Copy yield operands into iterArgs at the end of a loop iteration.
-  for (auto pair : llvm::zip(iterArgs, yieldOp->getOperands())) {
+  for (auto pair : llvm::zip_equal(iterArgs, yieldOp->getOperands())) {
     BlockArgument iterArg = std::get<0>(pair);
     Value operand = std::get<1>(pair);
     os << emitter.getOrCreateName(iterArg) << " = "
@@ -316,7 +316,7 @@ static LogicalResult printOperation(CppEmitter &emitter, scf::ForOp forOp) {
   os.unindent() << "}";
 
   // Copy iterArgs into results after the for loop.
-  for (auto pair : llvm::zip(results, iterArgs)) {
+  for (auto pair : llvm::zip_equal(results, iterArgs)) {
     OpResult result = std::get<0>(pair);
     BlockArgument iterArg = std::get<1>(pair);
     os << "\n"
@@ -382,7 +382,7 @@ static LogicalResult printOperation(CppEmitter &emitter, scf::YieldOp yieldOp) {
   }
 
   if (failed(interleaveWithError(
-          llvm::zip(parentOp.getResults(), yieldOp.getOperands()),
+          llvm::zip_equal(parentOp.getResults(), yieldOp.getOperands()),
           [&](auto pair) -> LogicalResult {
             auto result = std::get<0>(pair);
             auto operand = std::get<1>(pair);

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/MaterializeConstants.cpp
@@ -112,7 +112,7 @@ class MaterializeConstantsPass
     Value elementSizeI32 = setterBuilder.create<arith::ConstantIntOp>(
         buffer.getLoc(), sizeof(uint32_t), 32);
     for (auto [ordinalGlobalOp, valueGlobalOp] :
-         llvm::zip(ordinalGlobalOps, valueGlobalOps)) {
+         llvm::zip_equal(ordinalGlobalOps, valueGlobalOps)) {
       Value loadedOrdinal = setterBuilder.create<IREE::Util::GlobalLoadOp>(
           ordinalGlobalOp.getLoc(), ordinalGlobalOp);
       Value bufferOffset = setterBuilder.create<arith::MulIOp>(

--- a/compiler/src/iree/compiler/InputConversion/MHLO/BroadcastingToLinalgPatterns.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/BroadcastingToLinalgPatterns.cpp
@@ -570,7 +570,8 @@ struct ConvertTrivialNonBroadcastBinaryOp : public ConversionPattern {
     if (!lhsType.hasStaticShape() || !rhsType.hasStaticShape())
       return rewriter.notifyMatchFailure(op, "not static shapes");
 
-    for (auto extents : llvm::zip(lhsType.getShape(), rhsType.getShape())) {
+    for (auto extents :
+         llvm::zip_equal(lhsType.getShape(), rhsType.getShape())) {
       auto lhs_extent = std::get<0>(extents);
       auto rhs_extent = std::get<1>(extents);
       if (lhs_extent != rhs_extent) {

--- a/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
+++ b/compiler/src/iree/compiler/InputConversion/MHLO/MHLOToMHLOPreprocessing.cpp
@@ -1054,9 +1054,9 @@ struct FuseWidenOperands : public OpRewritePattern<Op> {
       operands.push_back(operand);
     }
 
-    if (llvm::all_of(llvm::zip(operands, op->getOperands()), [](auto pair) {
-          return std::get<0>(pair) == std::get<1>(pair);
-        }))
+    if (llvm::all_of(
+            llvm::zip_equal(operands, op->getOperands()),
+            [](auto pair) { return std::get<0>(pair) == std::get<1>(pair); }))
       return failure();
 
     rewriter.replaceOpWithNewOp<Op>(op, op->getResultTypes(), operands,

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/Conversion/StreamToHALInline/Patterns.cpp
@@ -72,7 +72,7 @@ struct ResourceAllocOpPattern
 
     SmallVector<Value> results;
     for (auto [resourceResult, storageSize] :
-         llvm::zip(allocOp.getResults(), allocOp.getStorageSizes())) {
+         llvm::zip_equal(allocOp.getResults(), allocOp.getStorageSizes())) {
       auto allocateOp = rewriter.create<IREE::HAL::Inline::BufferAllocateOp>(
           allocOp.getLoc(), deviceBufferType, hostBufferType, minAlignment,
           storageSize);
@@ -434,8 +434,8 @@ struct CmdDispatchOpPattern
     SmallVector<Value> bindingBuffers;
     SmallVector<Value> bindingOffsets;
     for (auto [resource, resourceSize, resourceOffset] :
-         llvm::zip(adaptor.getResources(), adaptor.getResourceSizes(),
-                   adaptor.getResourceOffsets())) {
+         llvm::zip_equal(adaptor.getResources(), adaptor.getResourceSizes(),
+                         adaptor.getResourceOffsets())) {
       auto storage = getResourceStorage(loc, resource, resourceSize, rewriter);
       bindingBuffers.push_back(storage.buffer);
       bindingOffsets.push_back(resourceOffset);

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/Conversion/HALLoaderToVM/Patterns.cpp
@@ -104,9 +104,9 @@ struct ExecutableDispatchOpConversion
         static_cast<int16_t>(adaptor.getBindingBuffers().size()),
     };
     callOperands.append(pushConstants.begin(), pushConstants.end());
-    for (auto it :
-         llvm::zip(adaptor.getBindingBuffers(), adaptor.getBindingOffsets(),
-                   adaptor.getBindingLengths())) {
+    for (auto it : llvm::zip_equal(adaptor.getBindingBuffers(),
+                                   adaptor.getBindingOffsets(),
+                                   adaptor.getBindingLengths())) {
       callOperands.push_back(std::get<0>(it));
       callOperands.push_back(
           castToImportType(std::get<1>(it), rewriter.getI64Type(), rewriter));

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderOps.cpp
@@ -65,7 +65,7 @@ static void printDispatchBindings(OpAsmPrinter &p, Operation *op,
                                   ValueRange bufferOffsets,
                                   ValueRange bufferLengths) {
   llvm::interleaveComma(
-      llvm::zip(buffers, bufferTypes, bufferOffsets, bufferLengths), p,
+      llvm::zip_equal(buffers, bufferTypes, bufferOffsets, bufferLengths), p,
       [&](std::tuple<Value, Type, Value, Value> it) {
         p.printNewline();
         p << "  ";
@@ -165,7 +165,7 @@ struct FoldBindingSubspansIntoDispatchOp
     SmallVector<Value> bindingOffsets;
     SmallVector<Value> bindingLengths;
     for (auto [bindingBuffer, bindingOffset] :
-         llvm::zip(op.getBindingBuffers(), op.getBindingOffsets())) {
+         llvm::zip_equal(op.getBindingBuffers(), op.getBindingOffsets())) {
       auto subspanOp =
           IREE::Util::BufferSubspanOp::findSubspanOp(bindingBuffer);
       if (!subspanOp) {


### PR DESCRIPTION
This is generated by running `sed --in-place 's/llvm::zip(/llvm::zip_equal(/' **/*.cpp` under `compiler/src/iree/compiler` and run formatting tools.

This also finds and fixes a bug in DeduplicateExecutables.cpp

It crashes in ScheduleAllocation.cpp if we replace llvm::zip with llvm::zip_equal. So it's not changed by the PR.