### PR TITLE
Improve reduction matchers and strategies for better applicability

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -196,42 +196,63 @@ void ReductionStrategyThreadDistributionSizes::computeStrategy() {
 
 /// Structure to hold the parameters related to GPU reduction strategy.
 struct GPUReductionStrategyInfos {
-  explicit GPUReductionStrategyInfos(int64_t reductionDimensionSize)
-      : reductionDimensionSize(reductionDimensionSize),
+  explicit GPUReductionStrategyInfos(MLIRContext *context, int64_t rank,
+                                     int64_t reductionDimensionSize)
+      : context(context),
+        rank(rank),
+        reductionDimensionSize(reductionDimensionSize),
         threadDistributionSizes(
-            ReductionStrategyThreadDistributionSizes(reductionDimensionSize)) {}
+            ReductionStrategyThreadDistributionSizes(reductionDimensionSize)) {
+    auto blockX =
+        mlir::gpu::GPUBlockMappingAttr::get(context, mlir::gpu::Blocks::DimX);
+    auto blockY =
+        mlir::gpu::GPUBlockMappingAttr::get(context, mlir::gpu::Blocks::DimY);
+    auto blockZ =
+        mlir::gpu::GPUBlockMappingAttr::get(context, mlir::gpu::Blocks::DimZ);
+    allBlockAttrs = SmallVector<Attribute>{blockX, blockY, blockZ};
+  }
+
+  /// Constructor quantities.
+  MLIRContext *context;
+  int64_t rank;
   int64_t reductionDimensionSize;
   ReductionStrategyThreadDistributionSizes threadDistributionSizes;
 
-  std::array<int64_t, 3> workgroupSize;
+  /// Derived quantities.
+  SmallVector<Attribute> allBlockAttrs;
+  // Tile sizes for the workgroup / determines grid size.
   SmallVector<int64_t> workgroupTileSizes;
-  SmallVector<int64_t> fillSecondTileSizes;
-  SmallVector<int64_t> genericSecondTileSizes;
+  // Launch bounds for the workgroups / block size.
+  std::array<int64_t, 3> workgroupSize;
 };
 }  // namespace
 
 static std::pair<Value, Value> createReductionStrategyBlockDistribution(
     ImplicitLocOpBuilder &b, Value maybeLeadingH, Value fillH, Value reductionH,
-    Value maybeTrailingH) {
+    Value maybeTrailingH, const GPUReductionStrategyInfos &infos) {
   auto pdlOperation = pdl::OperationType::get(b.getContext());
   auto fusionTargetSelector = b.create<TakeFirstOp>(
       pdlOperation, pdlOperation, ArrayRef<Value>{maybeTrailingH, reductionH});
   Value fusionTargetH = fusionTargetSelector.getFirst();
   Value fusionGroupH = fusionTargetSelector.getRest();
-  auto blockX = mlir::gpu::GPUBlockMappingAttr::get(b.getContext(),
-                                                    mlir::gpu::Blocks::DimX);
+  ArrayRef<Attribute> allBlocksRef(infos.allBlockAttrs);
   iree_compiler::TileAndFuseAndDistributeResult tileResult = iree_compiler::
       buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
-          b, fusionTargetH, fusionGroupH,
-          getAsOpFoldResult(b.getI64ArrayAttr({1})), b.getArrayAttr(blockX));
+          /*builder=*/b,
+          /*rootH=*/fusionTargetH,
+          /*opsToFuseH=*/fusionGroupH,
+          /*tileSizes=*/
+          getAsOpFoldResult(b.getI64ArrayAttr(infos.workgroupTileSizes)),
+          /*threadDimMapping=*/
+          b.getArrayAttr(allBlocksRef.take_front(infos.rank - 1)));
   Value foreachThreadH =
       b.create<FuseIntoContainingOp>(fillH, tileResult.foreachThreadH);
   foreachThreadH =
       b.create<FuseIntoContainingOp>(maybeLeadingH, foreachThreadH);
   auto gridReductionSelector = b.create<TakeFirstOp>(
       pdlOperation, pdlOperation,
-      ArrayRef<Value>(
-          {tileResult.resultingFusedOpsHandles.front(), tileResult.tiledOpH}));
+      ValueRange{tileResult.resultingFusedOpsHandles.front(),
+                 tileResult.tiledOpH});
 
   return std::make_pair(gridReductionSelector.getFirst(),
                         gridReductionSelector.getRest());
@@ -239,7 +260,7 @@ static std::pair<Value, Value> createReductionStrategyBlockDistribution(
 
 static void createReductionStrategyThreadDistribution(
     ImplicitLocOpBuilder &b, Value gridReductionH, Value maybeTiledTrailingH,
-    const ReductionStrategyThreadDistributionSizes &sizes) {
+    const GPUReductionStrategyInfos &infos) {
   auto pdlOperation = pdl::OperationType::get(b.getContext());
   auto threadX = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
                                                       mlir::gpu::Threads::DimX);
@@ -248,10 +269,15 @@ static void createReductionStrategyThreadDistribution(
 
   // Split the reduction into a parallel and combiner part, then tile the
   // parallel part and map it to a full warp so it works on vectors.
+  SmallVector<int64_t> leadingParallelDims(infos.rank - 1, 0);
+  SmallVector<int64_t> numThreads = leadingParallelDims;
+  numThreads.push_back(infos.threadDistributionSizes.reductionTileSize);
+  SmallVector<int64_t> tileSizes = leadingParallelDims;
+  tileSizes.push_back(infos.threadDistributionSizes.vectorTileSize);
   auto tileReduction = b.create<transform::TileReductionUsingForeachThreadOp>(
       /*target=*/gridReductionH,
-      /*numThreads=*/ArrayRef<int64_t>{0, sizes.reductionTileSize},
-      /*tileSizes=*/ArrayRef<int64_t>{0, sizes.vectorTileSize},
+      /*numThreads=*/numThreads,
+      /*tileSizes=*/tileSizes,
       /*threadDimMapping=*/b.getArrayAttr(threadX));
   Value blockParallelForeachThreadOp = tileReduction.getForeachThreadOp();
   Value blockParallelFillH = tileReduction.getFillOp();
@@ -291,14 +317,13 @@ static void createReductionCudaStrategy(
   // Step 2. Use tiling to introduce a single-iteration loop mapped to a
   // single block/workgroup. Keep everything fused.
   auto [gridReductionH, maybeTiledTrailingH] =
-      createReductionStrategyBlockDistribution(b, maybeLeadingH, fillH,
-                                               reductionH, maybeTrailingH);
+      createReductionStrategyBlockDistribution(
+          b, maybeLeadingH, fillH, reductionH, maybeTrailingH, infos);
 
   // Step 3. Split the reduction and tile the pieces to ensure vector
   // load/stores and mapping to a single warp with shuffles.
-  ReductionStrategyThreadDistributionSizes sizes(infos.reductionDimensionSize);
   createReductionStrategyThreadDistribution(b, gridReductionH,
-                                            maybeTiledTrailingH, sizes);
+                                            maybeTiledTrailingH, infos);
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
@@ -319,9 +344,8 @@ static void createReductionCudaStrategy(
 static FailureOr<GPUReductionStrategyInfos> matchGPUReduction(
     linalg::LinalgOp op) {
   StructuredOpMatcher reduction, fill, leading, trailing;
-  int64_t reductionDimensionSize;
-  makeReductionMatcher(reduction, fill, leading, trailing,
-                       reductionDimensionSize);
+  transform_ext::MatchedReductionCaptures captures;
+  makeReductionMatcher(reduction, fill, leading, trailing, captures);
   if (!matchPattern(op, reduction)) return failure();
 
   //
@@ -341,23 +365,20 @@ static FailureOr<GPUReductionStrategyInfos> matchGPUReduction(
     return failure();
   }
 
-  GPUReductionStrategyInfos info(reductionDimensionSize);
-  info.workgroupSize = {info.threadDistributionSizes.reductionTileSize, 1, 1};
-  SmallVector<unsigned> partitionedLoops =
-      cast<iree_compiler::PartitionableLoopsInterface>(op.getOperation())
-          .getPartitionableLoops(iree_compiler::kNumMaxParallelDims);
-  size_t numLoops = partitionedLoops.empty() ? 0 : partitionedLoops.back() + 1;
+  GPUReductionStrategyInfos info(op->getContext(), captures.rank,
+                                 captures.reductionDimensionSize);
 
-  // Tile all the parallel dimension to 1.
-  info.workgroupTileSizes.append(numLoops, 1);
-  info.fillSecondTileSizes = {1, 0, 0};
-  info.genericSecondTileSizes = {1, 1, 0};
+  // Tile all the parallel dimensions to 1 and create many blocks.
+  int64_t numParallelLoops = captures.rank - 1;
+  info.workgroupTileSizes.append(numParallelLoops, 1);
+  // Tile and distribute the reduction across `reductionTileSize` threads.
+  info.workgroupSize = {info.threadDistributionSizes.reductionTileSize, 1, 1};
   return info;
 }
 
 LogicalResult iree_compiler::matchAndSetGPUReductionTransformStrategy(
     func::FuncOp entryPoint, linalg::LinalgOp op) {
-  // 1. Match
+  // 1. Match.
   FailureOr<GPUReductionStrategyInfos> maybeInfos = matchGPUReduction(op);
   if (failed(maybeInfos)) return failure();
   auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -45,6 +45,7 @@ struct AllDimsExcept {
   ArrayRef<int64_t> getExcluded() const {
     return llvm::makeArrayRef(exceptions);
   }
+
 private:
   SmallVector<int64_t> exceptions;
 };

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -1259,7 +1259,7 @@ reductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
   }
 
   transform_ext::StructuredOpMatcher pattern, fill, leading, trailing;
-  int64_t ignore;
+  transform_ext::MatchedReductionCaptures ignore;
   makeReductionMatcher(pattern, fill, leading, trailing, ignore);
 
   // TODO: need a mechanism for this to go around the entire IR,

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -30,16 +30,43 @@ bool transform_ext::StructuredOpMatcher::match(Operation *op) {
   return true;
 }
 
+//===---------------------------------------------------------------------===//
+// Constraints on op rank and dims.
+//===---------------------------------------------------------------------===//
+
 transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::dim(int64_t dimension, ShapeKind kind) {
+transform_ext::StructuredOpMatcher::rank(NumGreaterEqualTo minRank) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    return linalgOp.getNumLoops() >= minRank.value;
+  });
+  return *this;
+}
+
+transform_ext::StructuredOpMatcher &
+transform_ext::StructuredOpMatcher::rank(NumLowerEqualTo maxRank) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    return linalgOp.getNumLoops() <= maxRank.value;
+  });
+  return *this;
+}
+
+transform_ext::StructuredOpMatcher &
+transform_ext::StructuredOpMatcher::dim(SmallVector<int64_t> &&dimensions,
+                                        ShapeKind kind, bool strictInBounds) {
+  predicates.push_back([dimensions = std::move(dimensions), kind,
+                        strictInBounds](linalg::LinalgOp linalgOp) -> bool {
     SmallVector<int64_t> shape = linalgOp.getStaticLoopRanges();
-    int64_t transformedDimension =
-        dimension >= 0 ? dimension : shape.size() + dimension;
-    if (transformedDimension >= shape.size())
+    for (auto dimension : dimensions) {
+      int64_t transformedDimension =
+          dimension >= 0 ? dimension : shape.size() + dimension;
+      if (transformedDimension < 0 || transformedDimension >= shape.size())
+        return !strictInBounds;
+      if (ShapedType::isDynamic(shape[transformedDimension]) ^
+          (kind == ShapeKind::Static))
+        continue;
       return false;
-    return ShapedType::isDynamic(shape[transformedDimension]) ^
-           (kind == ShapeKind::Static);
+    }
+    return true;
   });
   return *this;
 }
@@ -56,18 +83,24 @@ transform_ext::StructuredOpMatcher::dim(AllDims tag, ShapeKind kind) {
 }
 
 transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::dim(int64_t dimension,
-                                        utils::IteratorType kind) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+transform_ext::StructuredOpMatcher::dim(SmallVector<int64_t> &&dimensions,
+                                        utils::IteratorType kind,
+                                        bool strictInBounds) {
+  predicates.push_back([dimensions = std::move(dimensions), kind,
+                        strictInBounds](linalg::LinalgOp linalgOp) -> bool {
     unsigned rank = linalgOp.getNumLoops();
-    int64_t transformedDimension =
-        dimension >= 0 ? dimension : rank + dimension;
-    if (transformedDimension >= rank)
+    for (auto dimension : dimensions) {
+      int64_t transformedDimension =
+          dimension >= 0 ? dimension : rank + dimension;
+      if (transformedDimension < 0 || transformedDimension >= rank)
+        return !strictInBounds;
+      utils::IteratorType iteratorKind =
+          linalgOp.getIteratorTypesArray()[transformedDimension];
+      if (iteratorKind == kind)
+        continue;
       return false;
-
-    utils::IteratorType iteratorKind =
-        linalgOp.getIteratorTypesArray()[transformedDimension];
-    return iteratorKind == kind;
+    }
+    return true;
   });
   return *this;
 }
@@ -97,8 +130,21 @@ transform_ext::StructuredOpMatcher::dim(int64_t dimension,
   return *this;
 }
 
+//===---------------------------------------------------------------------===//
+// Capture directives.
+//===---------------------------------------------------------------------===//
 transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::dim(int64_t dimension, CaptureDim capture) {
+transform_ext::StructuredOpMatcher::rank(CaptureStaticValue<int64_t> capture) {
+  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+    capture.value = linalgOp.getNumLoops();
+    return true;
+  });
+  return *this;
+}
+
+transform_ext::StructuredOpMatcher &
+transform_ext::StructuredOpMatcher::dim(int64_t dimension,
+                                        CaptureStaticValue<int64_t> capture) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     unsigned rank = linalgOp.getNumLoops();
     int64_t transformedDimension =
@@ -112,11 +158,20 @@ transform_ext::StructuredOpMatcher::dim(int64_t dimension, CaptureDim capture) {
   return *this;
 }
 
+//===---------------------------------------------------------------------===//
+// Constraints on input operands.
+//===---------------------------------------------------------------------===//
 transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::input(AllOperands tag, IsPermutation) {
+transform_ext::StructuredOpMatcher::input(AllOperands tag, IsPermutation perm) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     // all_of with a lambda requires const-casting dance, so using a loop.
     for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
+      if (perm.projectedPermutation) {
+        if (!linalgOp.getMatchingIndexingMap(operand).isProjectedPermutation())
+          return false;
+        continue;
+      }
+      // Default: exact permutation.
       if (!linalgOp.getMatchingIndexingMap(operand).isPermutation())
         return false;
     }
@@ -201,10 +256,19 @@ transform_ext::StructuredOpMatcher::input(int64_t position, SubsetOf subset) {
   return *this;
 }
 
+//===---------------------------------------------------------------------===//
+// Constraints on output operands.
+//===---------------------------------------------------------------------===//
 transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::output(AllOperands tag, IsPermutation) {
+transform_ext::StructuredOpMatcher::output(AllOperands tag,
+                                           IsPermutation perm) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
     for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
+      if (perm.projectedPermutation) {
+        if (!linalgOp.getMatchingIndexingMap(operand).isProjectedPermutation())
+          return false;
+        continue;
+      }
       if (!linalgOp.getMatchingIndexingMap(operand).isPermutation())
         return false;
     }
@@ -267,6 +331,9 @@ transform_ext::StructuredOpMatcher::output(int64_t position, SubsetOf subset) {
   return *this;
 }
 
+//===---------------------------------------------------------------------===//
+// Constraints on results.
+//===---------------------------------------------------------------------===//
 transform_ext::StructuredOpMatcher &transform_ext::StructuredOpMatcher::result(
     int64_t position, HasAnyUse tag, SubsetOf subset, OptionalMatch optional) {
   predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
@@ -308,31 +375,97 @@ void transform_ext::makeReductionMatcher(
     transform_ext::StructuredOpMatcher &fill,
     transform_ext::StructuredOpMatcher &leading,
     transform_ext::StructuredOpMatcher &trailing,
-    int64_t &reductionDimensionSize) {
+    MatchedReductionCaptures &captures) {
+  // The core part of the matcher is anchored on a particular reduction op.
+  reduction =
+      m_StructuredOp()
+          // Op has at least a parallel a reduction dimension and at most 3
+          // parallel dimensions.
+          // TODO: relax once we have global collapse/expand_shape.
+          //
+          .rank(NumGreaterEqualTo(2))
+          .rank(NumLowerEqualTo(4))
+          .rank(CaptureStaticValue<int64_t>(captures.rank))
+          // Op has a single most-minor reduction that we capture.
+          .dim(-1, utils::IteratorType::reduction)
+          .dim(-1, CaptureStaticValue<int64_t>(captures.reductionDimensionSize))
+          // All other dimensions are parallel.
+          // This needs captures.rank to be properly captured, which does not
+          // seem to happen right now.
+          // TODO: fix this.
+          //
+          // .dim(llvm::to_vector(llvm::seq<int64_t>(0, captures.rank - 1)),
+          //      utils::IteratorType::parallel)
+          // Until then, allow progress with "strictInBounds".
+          //
+          .dim(-2, utils::IteratorType::parallel, /*strictInBounds=*/false)
+          .dim(-3, utils::IteratorType::parallel, /*strictInBounds=*/false)
+          .dim(-4, utils::IteratorType::parallel, /*strictInBounds=*/false)
+          // Single input for now, can be arbitrary projected permutations.
+          // TODO: Multiple inputs, can be arbitrary projected permutations.
+          // TODO: Watch out for multiple inputs though as a reduction turns
+          //       into a contraction when mixed with projected
+          //       permutations. A reduction is often bandwidth bound but
+          //       contraction is a different beast that is compute bound
+          //       and has a very different schedule.
+          //
+          .input(NumEqualsTo(1))
+          .input(AllOperands(), IsPermutation().setProjectedPermutation(true))
+          // Single output supported atm.
+          // TODO: Multiple outputs.
+          //
+          .output(NumEqualsTo(1))
+          // A reduction output must be a projected permutation, match it but we
+          // could also drop this technically.
+          .output(AllOperands(), IsPermutation().setProjectedPermutation(true))
+          // Only single combiner over 32 bits for now due to reduction warp
+          // distribution.
+          // TODO: relax this once reduction distribution is more powerful.
+          //
+          .output(0, ElementTypeBitWidth(32))
+          .output(0, SingleCombinerReduction());
+
+  // Mandatory FillOp must create the unique output of the reduction.
+  // TODO: Relax this, as any map, broadcast, transpose should also work.
+  //
   fill = m_StructuredOp<linalg::FillOp>();
-  trailing = m_StructuredOp<linalg::GenericOp>()
-                 .input(AllOperands(), IsPermutation())
-                 .output(AllOperands(), IsPermutation())
-                 .input(NumEqualsTo(1))
-                 .output(NumEqualsTo(1));
-  leading = trailing;
-  reduction = m_StructuredOp()
-                  // The CUDA strategy now supports arbitray mixes of static and
-                  // dynamic sizes and adapts accordingly.
-                  // Consider separating control for other targets if needed.
-                  .dim(-1, utils::IteratorType::reduction)
-                  .dim(-1, CaptureDim(reductionDimensionSize))
-                  // Can be extended to projected permutation with broadcast.
-                  .input(AllOperands(), IsPermutation())
-                  // TODO: we want to accept any input position here.
-                  .input(0, leading, OptionalMatch())
-                  .output(NumEqualsTo(1))
-                  .output(0, fill)
-                  // Only single combiner over 32 bits for now due to
-                  // reduction distribution.
-                  .output(0, ElementTypeBitWidth(32))
-                  .output(0, SingleCombinerReduction())
-                  .result(0, HasAnyUse(), trailing, OptionalMatch());
+  reduction = reduction.output(NumEqualsTo(1)).output(0, fill);
+
+  // Optional leading op can be any map, transpose, broadcast but not reduce
+  // or windowing operation for now.
+  // It must create the unique input for the reduction.
+  // TODO: match more optional leading ops, one per input of the reduction.
+  // TODO: careful about multi-output and turning into a contraction.
+  //
+  leading =
+      m_StructuredOp<linalg::GenericOp>()
+          // All parallel dimensions.
+          .dim(AllDims(), utils::IteratorType::parallel)
+          // All inputs are any projectected permutation.
+          .input(AllOperands(), IsPermutation().setProjectedPermutation(true))
+          .output(AllOperands(), IsPermutation())
+          // leading and trailing may have 0, 1 or more input as long as they do
+          // not come from unmatched ops. This extra constraint is taken care of
+          // separately. This is also a noop but we document it.
+          // TODO: Base and derived classes, atm this does not compile.
+          // .input(NumGreaterEqualTo(0))
+          // Single output supported atm.
+          // TODO: extend this.
+          //
+          .output(NumEqualsTo(1));
+  // TODO: match more optional leading ops, one per input of the reduction.
+  // TODO: careful about multi-output and turning into a contraction.
+  //
+  reduction = reduction.input(0, leading, OptionalMatch());
+
+  // Optional trailing can be any map, transpose, broadcast but not reduce or
+  // windowing operation for now.
+  // It must be fed by the unique input for the reduction.
+  // TODO: match more optional leading ops, one per input of the reduction.
+  // TODO: careful about multi-output and turning into a contraction.
+  //
+  trailing = leading;
+  reduction = reduction.result(0, HasAnyUse(), trailing, OptionalMatch());
 }
 
 void transform_ext::makeSplitReductionMatcher(

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -105,16 +105,12 @@ transform_ext::StructuredOpMatcher::dim(SmallVector<int64_t> &&dimensions,
 }
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(AllDims tag, utils::IteratorType kind) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
-    return llvm::all_of(
-        linalgOp.getIteratorTypesArray(),
-        [=](utils::IteratorType iteratorType) { return iteratorType == kind; });
-  });
-  return *this;
+  return dim(AllDimsExcept({}), kind);
 }
 
 transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::dim(AllDimsExcept &&dims, utils::IteratorType kind) {
+transform_ext::StructuredOpMatcher::dim(AllDimsExcept &&dims,
+                                        utils::IteratorType kind) {
   predicates.push_back(
       [dimensions = std::move(dims), kind](linalg::LinalgOp linalgOp) -> bool {
         int64_t rank = linalgOp.getNumLoops();
@@ -135,7 +131,6 @@ transform_ext::StructuredOpMatcher::dim(AllDimsExcept &&dims, utils::IteratorTyp
       });
   return *this;
 }
-
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(int64_t dimension,


### PR DESCRIPTION
This commit addresses multiple issues that were surfaced when trying to use the transform-dialect based strategies more pervasively:

- capture the rank
- confine the rank to [1 .. 4]
- add support to check all major dimensions are parallel
- relax permutation constraint to also allow projected permutation
- add captured rank to GPUReductionStrategyInfos and pass the struct around when building the strategy
- properly construct tile sizes to work with all ranks
- drop unused elements from the infos structure

C++ tests should be added independently.

Deferring to @ftynse for refactoring and testing this slice.