### PR TITLE
Support e2e test artifacts in compilation stats collection tool

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -138,8 +138,9 @@ Then run the command below to collect the statistics:
 
 ```sh
 build_tools/benchmarks/collect_compilation_statistics.py \
+  legacy \
   --output "compile-stats.json" \
-  legacy "${IREE_BUILD_DIR}"
+  "${IREE_BUILD_DIR}"
 ```
 
 Then `build_tools/benchmarks/diff_local_benchmarks.py` can also compare the

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -139,7 +139,7 @@ Then run the command below to collect the statistics:
 ```sh
 build_tools/benchmarks/collect_compilation_statistics.py \
   --output "compile-stats.json" \
-  "${IREE_BUILD_DIR}"
+  legacy "${IREE_BUILD_DIR}"
 ```
 
 Then `build_tools/benchmarks/diff_local_benchmarks.py` can also compare the

--- a/build_tools/benchmarks/README.md
+++ b/build_tools/benchmarks/README.md
@@ -56,7 +56,7 @@ steps to enable compilation statistics collection.
 ```sh
 ./collect_compilation_statistics.py \
   --output "compile-stats.json" \
-  "${IREE_BUILD_DIR}"
+  legacy "${IREE_BUILD_DIR}"
 ```
 
 ## Generating Benchmark Report

--- a/build_tools/benchmarks/README.md
+++ b/build_tools/benchmarks/README.md
@@ -55,8 +55,9 @@ See [here](/benchmarks/README.md#collect-compile-stats) for additional build
 steps to enable compilation statistics collection.
 ```sh
 ./collect_compilation_statistics.py \
+  legacy \
   --output "compile-stats.json" \
-  legacy "${IREE_BUILD_DIR}"
+  "${IREE_BUILD_DIR}"
 ```
 
 ## Generating Benchmark Report

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -183,14 +183,14 @@ def get_module_map_from_benchmark_suite(
       if module_path is None:
         raise RuntimeError(
             f"Can't find the module file in the flagfile: {flag_file_path}")
-      module_path = (benchmark_case_dir / module_path).resolve()
       compilation_info = CompilationInfo(
           model_name=benchmark_case.model_name,
           model_tags=tuple(benchmark_case.model_tags),
           model_source=category,
           target_arch=benchmark_case.target_arch,
           compile_tags=tuple(benchmark_case.bench_mode))
-      module_map[compilation_info] = module_path
+      module_map[compilation_info] = (benchmark_case_dir /
+                                      module_path).resolve()
 
   return module_map
 
@@ -211,15 +211,15 @@ def alpha_get_module_map_and_build_log(args: argparse.Namespace):
 def parse_arguments():
   """Returns an argument parser with common options."""
 
-  def check_dir_path(path):
-    path = pathlib.Path(path)
+  def check_dir_path(path_str: str) -> pathlib.Path:
+    path = pathlib.Path(path_str)
     if path.is_dir():
       return path
     else:
       raise argparse.ArgumentTypeError(f"{path} is not a directory.")
 
-  def check_file_path(path):
-    path = pathlib.Path(path)
+  def check_file_path(path_str: str) -> pathlib.Path:
+    path = pathlib.Path(path_str)
     if path.is_file():
       return path
     else:

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -220,10 +220,9 @@ def parse_arguments():
 
   def check_file_path(path_str: str) -> pathlib.Path:
     path = pathlib.Path(path_str)
-    if path.is_file():
-      return path
-    else:
+    if not path.is_file():
       raise argparse.ArgumentTypeError(f"{path} is not a file.")
+    return path      
 
   parser = argparse.ArgumentParser()
   parser.add_argument("--output",

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -234,7 +234,8 @@ def parse_arguments():
                       help="Print internal information during execution.")
 
   subparser = parser.add_subparsers(title="tool version", required=True)
-  legacy_parser = subparser.add_parser("legacy")
+  legacy_parser = subparser.add_parser("legacy",
+                                       help="use with legacy benchmark suites.")
   legacy_parser.set_defaults(
       get_module_map_and_build_log=legacy_get_module_map_and_build_log)
   legacy_parser.add_argument(
@@ -242,7 +243,8 @@ def parse_arguments():
       type=check_dir_path,
       help="Path to the build directory containing benchmark suites.")
 
-  alpha_parser = subparser.add_parser("alpha")
+  alpha_parser = subparser.add_parser("alpha",
+                                      help="use with e2e test artifacts.")
   alpha_parser.set_defaults(
       get_module_map_and_build_log=alpha_get_module_map_and_build_log)
   alpha_parser.add_argument(

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -237,12 +237,12 @@ def parse_arguments():
       help="Print internal information during execution.")
 
   parser = argparse.ArgumentParser(
-      description="Collects compilation statistics from benchmark suites.")
+      description="Collect compilation statistics from benchmark suites.")
 
   subparser = parser.add_subparsers(title="tool version", required=True)
   legacy_parser = subparser.add_parser("legacy",
                                        parents=[subparser_base],
-                                       help="use with legacy benchmark suites.")
+                                       help="Use with legacy benchmark suites.")
   legacy_parser.set_defaults(
       get_module_map_and_build_log=legacy_get_module_map_and_build_log)
   legacy_parser.add_argument(
@@ -252,7 +252,7 @@ def parse_arguments():
 
   alpha_parser = subparser.add_parser("alpha",
                                       parents=[subparser_base],
-                                      help="use with e2e test artifacts.")
+                                      help="Use with e2e test artifacts.")
   alpha_parser.set_defaults(
       get_module_map_and_build_log=alpha_get_module_map_and_build_log)
   alpha_parser.add_argument(

--- a/build_tools/benchmarks/collect_compilation_statistics.py
+++ b/build_tools/benchmarks/collect_compilation_statistics.py
@@ -195,34 +195,34 @@ def get_module_map_from_benchmark_suite(
   return module_map
 
 
-def legacy_get_module_map_and_build_log(args: argparse.Namespace):
+def _legacy_get_module_map_and_build_log(args: argparse.Namespace):
   module_map = get_module_map_from_benchmark_suite(
       args.build_dir / benchmark_config.BENCHMARK_SUITE_REL_PATH)
   return module_map, args.build_dir / NINJA_BUILD_LOG
 
 
-def alpha_get_module_map_and_build_log(args: argparse.Namespace):
+def _alpha_get_module_map_and_build_log(args: argparse.Namespace):
   module_map = get_module_map_from_generation_config(
       serialized_gen_config=args.generation_config.open("r"),
       e2e_test_artifacts_dir=args.e2e_test_artifacts_dir)
   return module_map, args.build_log
 
 
-def check_dir_path(path_str: str) -> pathlib.Path:
+def _check_dir_path(path_str: str) -> pathlib.Path:
   path = pathlib.Path(path_str)
   if not path.is_dir():
     raise argparse.ArgumentTypeError(f"{path} is not a directory.")
   return path
 
 
-def check_file_path(path_str: str) -> pathlib.Path:
+def _check_file_path(path_str: str) -> pathlib.Path:
   path = pathlib.Path(path_str)
   if not path.is_file():
     raise argparse.ArgumentTypeError(f"{path} is not a file.")
   return path
 
 
-def parse_arguments():
+def _parse_arguments():
   """Returns an argument parser with common options."""
 
   # Makes global options come *after* command.
@@ -244,28 +244,28 @@ def parse_arguments():
                                        parents=[subparser_base],
                                        help="Use with legacy benchmark suites.")
   legacy_parser.set_defaults(
-      get_module_map_and_build_log=legacy_get_module_map_and_build_log)
+      get_module_map_and_build_log=_legacy_get_module_map_and_build_log)
   legacy_parser.add_argument(
       "build_dir",
-      type=check_dir_path,
+      type=_check_dir_path,
       help="Path to the build directory containing benchmark suites.")
 
   alpha_parser = subparser.add_parser("alpha",
                                       parents=[subparser_base],
                                       help="Use with e2e test artifacts.")
   alpha_parser.set_defaults(
-      get_module_map_and_build_log=alpha_get_module_map_and_build_log)
+      get_module_map_and_build_log=_alpha_get_module_map_and_build_log)
   alpha_parser.add_argument(
       "--generation_config",
-      type=check_file_path,
+      type=_check_file_path,
       required=True,
       help="Exported module generation config of e2e test artifacts.")
   alpha_parser.add_argument("--build_log",
-                            type=check_file_path,
+                            type=_check_file_path,
                             required=True,
                             help="Path to the ninja build log.")
   alpha_parser.add_argument("--e2e_test_artifacts_dir",
-                            type=check_dir_path,
+                            type=_check_dir_path,
                             required=True,
                             help="Path to the e2e test artifacts directory.")
 
@@ -307,4 +307,4 @@ def main(args: argparse.Namespace):
 
 
 if __name__ == "__main__":
-  main(parse_arguments())
+  main(_parse_arguments())

--- a/build_tools/benchmarks/collect_compilation_statistics_test.py
+++ b/build_tools/benchmarks/collect_compilation_statistics_test.py
@@ -5,25 +5,39 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import json
+import pathlib
 import unittest
 import zipfile
-
 from io import BytesIO, StringIO
 
 from common.benchmark_definition import ModuleComponentSizes
-from collect_compilation_statistics import CONST_COMPONENT_NAME, VM_COMPONENT_NAME, get_module_component_info, get_module_path, match_module_cmake_target, parse_compilation_time_from_ninja_log
+from collect_compilation_statistics import CONST_COMPONENT_NAME, VM_COMPONENT_NAME, get_module_component_info, get_module_path, parse_compilation_time_from_ninja_log
+from e2e_test_artifacts import iree_artifacts
+from e2e_test_framework import serialization
+from e2e_test_framework.definitions import common_definitions, iree_definitions
+import collect_compilation_statistics
+import common.benchmark_definition
 
 
 class CollectCompilationStatistics(unittest.TestCase):
 
-  def test_match_module_cmake_target(self):
-    target = match_module_cmake_target(
-        "iree/iree-build/benchmark_suites/TFLite/vmfb/test.vmfb")
+  def test_match_module_cmake_target_with_e2e_test_artifacts(self):
+    target = collect_compilation_statistics.match_module_cmake_target(
+        pathlib.PurePath("e2e_test_artifacts/iree_abcd/module.vmfb"))
+
+    self.assertEqual(target, "e2e_test_artifacts/iree_abcd/module.vmfb")
+
+  def test_match_module_cmake_target_with_benchmark_suites(self):
+    target = collect_compilation_statistics.match_module_cmake_target(
+        pathlib.PurePath(
+            "iree/iree-build/benchmark_suites/TFLite/vmfb/test.vmfb"))
 
     self.assertEqual(target, "benchmark_suites/TFLite/vmfb/test.vmfb")
 
   def test_match_module_cmake_target_not_match(self):
-    target = match_module_cmake_target("benchmark_suites/TFLite/vmfb/test.mlir")
+    target = collect_compilation_statistics.match_module_cmake_target(
+        pathlib.PurePath("benchmark_suites/TFLite/vmfb/test.mlir"))
 
     self.assertIsNone(target)
 
@@ -78,6 +92,74 @@ class CollectCompilationStatistics(unittest.TestCase):
     moduel_path = get_module_path(flag_file)
 
     self.assertEqual(moduel_path, "/abcd-compile-stats.vmfb")
+
+  def test_get_module_list_from_generation_config(self):
+    model_a = common_definitions.Model(
+        id="1234",
+        name="tflite_m",
+        tags=[],
+        source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
+        source_url="https://example.com/xyz.tflite",
+        entry_function="main",
+        input_types=["1xf32"])
+    imported_model_a = iree_definitions.ImportedModel(
+        model=model_a, dialect_type=iree_definitions.MLIRDialectType.TOSA)
+    compile_config_a = iree_definitions.CompileConfig(
+        id="config_a",
+        tags=["defaults"],
+        compile_targets=[
+            iree_definitions.CompileTarget(
+                target_architecture=common_definitions.DeviceArchitecture.
+                X86_64_CASCADELAKE,
+                target_backend=iree_definitions.TargetBackend.LLVM_CPU,
+                target_abi=iree_definitions.TargetABI.LINUX_GNU)
+        ])
+    compile_config_b = iree_definitions.CompileConfig(
+        id="config_b",
+        tags=["defaults"],
+        compile_targets=[
+            iree_definitions.CompileTarget(
+                target_architecture=common_definitions.DeviceArchitecture.
+                RV64_GENERIC,
+                target_backend=iree_definitions.TargetBackend.LLVM_CPU,
+                target_abi=iree_definitions.TargetABI.LINUX_GNU),
+            iree_definitions.CompileTarget(
+                target_architecture=common_definitions.DeviceArchitecture.
+                RV32_GENERIC,
+                target_backend=iree_definitions.TargetBackend.LLVM_CPU,
+                target_abi=iree_definitions.TargetABI.LINUX_GNU)
+        ])
+    gen_config_a = iree_definitions.ModuleGenerationConfig(
+        imported_model=imported_model_a, compile_config=compile_config_a)
+    gen_config_b = iree_definitions.ModuleGenerationConfig(
+        imported_model=imported_model_a, compile_config=compile_config_b)
+    serialized_gen_config = json.dumps(
+        serialization.serialize_and_pack([gen_config_a, gen_config_b]))
+    root_dir = pathlib.PurePath("artifacts_dir")
+
+    module_list = collect_compilation_statistics.get_module_list_from_generation_config(
+        serialized_gen_config=StringIO(serialized_gen_config),
+        e2e_test_artifacts_dir=root_dir)
+
+    compile_info_a = common.benchmark_definition.CompilationInfo(
+        model_name=model_a.name,
+        model_tags=model_a.tags,
+        model_source=model_a.source_type.value,
+        target_arch=f"[cpu-x86_64-cascadelake-linux-gnu]",
+        compile_tags=gen_config_a.compile_config.tags)
+    module_a_path = iree_artifacts.get_module_dir_path(
+        gen_config_a, root_dir) / iree_artifacts.MODULE_FILENAME
+    compile_info_b = common.benchmark_definition.CompilationInfo(
+        model_name=model_a.name,
+        model_tags=model_a.tags,
+        model_source=model_a.source_type.value,
+        target_arch=
+        f"[cpu-riscv_64-generic-linux-gnu,cpu-riscv_32-generic-linux-gnu]",
+        compile_tags=gen_config_a.compile_config.tags)
+    module_b_path = iree_artifacts.get_module_dir_path(
+        gen_config_b, root_dir) / iree_artifacts.MODULE_FILENAME
+    self.assertEqual(module_list, [(compile_info_a, module_a_path),
+                                   (compile_info_b, module_b_path)])
 
 
 if __name__ == "__main__":

--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -11,14 +11,13 @@ shared between different stages of the same benchmark pipeline.
 """
 
 import json
-import os
 import pathlib
 import re
 import subprocess
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, Optional, Sequence
+from typing import Any, Dict, Optional, Sequence, Tuple
 
 # A map from CPU ABI to IREE's benchmark target architecture.
 CPU_ABI_TO_TARGET_ARCH_MAP = {
@@ -489,10 +488,10 @@ class BenchmarkResults(object):
 @dataclass(frozen=True)
 class CompilationInfo(object):
   model_name: str
-  model_tags: Sequence[str]
+  model_tags: Tuple[str]
   model_source: str
   target_arch: str
-  compile_tags: Sequence[str]
+  compile_tags: Tuple[str]
 
   def __str__(self):
     if self.model_tags:
@@ -505,7 +504,13 @@ class CompilationInfo(object):
 
   @staticmethod
   def from_json_object(json_object: Dict[str, Any]):
-    return CompilationInfo(**json_object)
+    return CompilationInfo(
+        model_name=json_object["model_name"],
+        model_tags=tuple(json_object["model_tags"]),
+        model_source=json_object["model_source"],
+        target_arch=json_object["target_arch"],
+        compile_tags=tuple(json_object["compile_tags"]),
+    )
 
 
 @dataclass(frozen=True)

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -210,7 +210,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             BenchmarkCase(model_name=model_tflite.name,
                           model_tags=model_tflite.tags,
                           bench_mode=exec_config_a.tags,
-                          target_arch="cpu-rv32-generic",
+                          target_arch="cpu-riscv_32-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -218,7 +218,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
             BenchmarkCase(model_name=model_tflite.name,
                           model_tags=model_tflite.tags,
                           bench_mode=exec_config_b.tags,
-                          target_arch="cpu-rv64-generic",
+                          target_arch="cpu-riscv_64-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -227,14 +227,14 @@ class BenchmarkSuiteTest(unittest.TestCase):
     self.assertEqual(
         suite.filter_benchmarks_for_category(
             category="exported_tf",
-            cpu_target_arch_filter="cpu-rv32-generic",
+            cpu_target_arch_filter="cpu-riscv_32-generic",
             model_name_filter="model_tf.*fp32",
             mode_filter="defaults"),
         [
             BenchmarkCase(model_name=model_tf.name,
                           model_tags=model_tf.tags,
                           bench_mode=exec_config_a.tags,
-                          target_arch="cpu-rv32-generic",
+                          target_arch="cpu-riscv_32-generic",
                           driver_info=IREE_DRIVERS_INFOS["iree-llvm-cpu-sync"],
                           benchmark_tool_name="iree-benchmark-module",
                           benchmark_case_dir=None,
@@ -243,7 +243,7 @@ class BenchmarkSuiteTest(unittest.TestCase):
     self.assertEqual(
         suite.filter_benchmarks_for_category(
             category="exported_tf",
-            cpu_target_arch_filter="cpu-rv32-generic",
+            cpu_target_arch_filter="cpu-riscv_32-generic",
             mode_filter="experimental"), [])
 
   @staticmethod

--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -115,7 +115,7 @@ steps:
       python3 build_tools/benchmarks/collect_compilation_statistics.py \
         --verbose \
         --output "compile-stats-results-$${BUILDKITE_BUILD_NUMBER}.json" \
-        "build-host"
+        legacy "build-host"
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-android'

--- a/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
+++ b/build_tools/buildkite/cmake/android/arm64-v8a/benchmark2.yml
@@ -113,9 +113,10 @@ steps:
         "benchmark-suites-$${BUILDKITE_BUILD_NUMBER}.tgz" ./
       tar -xzvf "benchmark-suites-$${BUILDKITE_BUILD_NUMBER}.tgz"
       python3 build_tools/benchmarks/collect_compilation_statistics.py \
+        legacy \
         --verbose \
         --output "compile-stats-results-$${BUILDKITE_BUILD_NUMBER}.json" \
-        legacy "build-host"
+        "build-host"
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-android'

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -125,9 +125,10 @@ steps:
         tar -xzvf "{}"
       ls build-targets | xargs -I "{target}" -- \
         python3 build_tools/benchmarks/collect_compilation_statistics.py \
+          legacy \
           --verbose \
           --output "compile-stats-results-{target}-$${BUILDKITE_BUILD_NUMBER}.json" \
-          legacy "build-targets/{target}"
+          "build-targets/{target}"
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||

--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -127,7 +127,7 @@ steps:
         python3 build_tools/benchmarks/collect_compilation_statistics.py \
           --verbose \
           --output "compile-stats-results-{target}-$${BUILDKITE_BUILD_NUMBER}.json" \
-          "build-targets/{target}"
+          legacy "build-targets/{target}"
     if: >
       build.pull_request.id == null ||
       build.pull_request.labels includes 'buildkite:benchmark-x86_64' ||

--- a/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
@@ -72,9 +72,10 @@ steps:
         "benchmark-suites-$${BUILDKITE_BUILD_NUMBER}.tgz" ./
       tar -xzvf "benchmark-suites-$${BUILDKITE_BUILD_NUMBER}.tgz"
       python3 build_tools/benchmarks/collect_compilation_statistics.py \
+        legacy \
         --verbose \
         --output "compile-stats-results-linux-$${BUILDKITE_BUILD_NUMBER}.json" \
-        legacy build-host/
+        build-host/
     if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark-x86_64')"
     agents:
       - "queue=build"

--- a/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
+++ b/build_tools/buildkite/cmake/linux/x86_64/benchmark.yml
@@ -74,7 +74,7 @@ steps:
       python3 build_tools/benchmarks/collect_compilation_statistics.py \
         --verbose \
         --output "compile-stats-results-linux-$${BUILDKITE_BUILD_NUMBER}.json" \
-        build-host/
+        legacy build-host/
     if: "build.pull_request.id == null || (build.pull_request.labels includes 'buildkite:benchmark-x86_64')"
     agents:
       - "queue=build"

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -139,7 +139,7 @@ class IreeRuleBuilder(object):
           f"--iree-llvm-target-triple=x86_64-unknown-{target.target_abi.value}",
           f"--iree-llvm-target-cpu={arch_info.microarchitecture.lower()}"
       ]
-    elif arch_info.architecture == "rv64":
+    elif arch_info.architecture == "riscv_64":
       flags = [
           f"--iree-llvm-target-triple=riscv64-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv64", "--iree-llvm-target-abi=lp64d",
@@ -147,7 +147,7 @@ class IreeRuleBuilder(object):
           "--riscv-v-vector-bits-min=512",
           "--riscv-v-fixed-length-vector-lmul-max=8"
       ]
-    elif arch_info.architecture == "rv32":
+    elif arch_info.architecture == "riscv_32":
       flags = [
           f"--iree-llvm-target-triple=riscv32-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv32", "--iree-llvm-target-abi=ilp32",

--- a/build_tools/python/e2e_test_framework/definitions/common_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/common_definitions.py
@@ -40,8 +40,8 @@ class DeviceArchitecture(_ArchitectureInfo, Enum):
   ARMV9_A_GENERIC = (ArchitectureType.CPU, "armv9-a", "generic")
 
   # RISC-V CPUs
-  RV64_GENERIC = (ArchitectureType.CPU, "rv64", "generic")
-  RV32_GENERIC = (ArchitectureType.CPU, "rv32", "generic")
+  RV64_GENERIC = (ArchitectureType.CPU, "riscv_64", "generic")
+  RV32_GENERIC = (ArchitectureType.CPU, "riscv_32", "generic")
 
   # Mobile GPUs
   MALI_VALHALL = (ArchitectureType.GPU, "mali", "valhall")


### PR DESCRIPTION
Adds the `--generation_config` to `collect_compilation_statistics.py` and supports collecting from e2e test artifacts. Two extra options `--build_log` and `--e2e_test_artifacts` are added to support using without a build directory.

I try to use the subparser to separate the legacy usage and the new usage. With that the logic and usage look simpler to me:

Legacy option:
```sh
build_tools/benchmarks/collect_compilation_statistics.py \
  --output=compile-stats.json \
  legacy \
  ./iree_build_dir
```
New option:
```sh
build_tools/benchmarks/collect_compilation_statistics.py \
  --output=./compile-stats.json \
  alpha \
  --generation_config=./generation_config.json \
  --build_log=./iree_build_dir/.ninja_log \
  --e2e_test_artifacts_dir=./iree_build_dir/e2e_test_artifacts 
```