### PR TITLE
Fix performance bugs and add a benchmarking stub

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -259,8 +259,6 @@ Value mlir::iree_compiler::buildMapToBlockAndThreads(
   return b.create<MapNestedForeachThreadToGpuThreadsOp>(funcH, blockSize);
 }
 
-static constexpr unsigned kCudaWarpSize = 32;
-
 /// Post-bufferization vector distribution with rank-reduction.
 /// Takes a handle to a func.func and returns an updated handle to a
 /// func.func.

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -18,7 +18,7 @@ namespace iree_compiler {
 //===----------------------------------------------------------------------===//
 
 /// Prints `handles` in order. Prints the whole IR if `handles` is empty.
-static void buildPrint(ImplicitLocOpBuilder &b, ValueRange handles = {});
+void buildPrint(ImplicitLocOpBuilder &b, ValueRange handles = {});
 
 /// Result of the combined transform performing tiling, fusion and distribution
 /// to parallel constructs.
@@ -27,7 +27,7 @@ struct TileToScfForAndFuseResult {
   SmallVector<Value> forLoops;
   /// Handles to fused operations other than the final consumer operation. May
   /// be empty if fusion was not performed iteratively.
-  /// /// This is currently empty
+  /// This is currently empty
   // TODO: support returning handles from `fuse_into_containing_op` and remove
   // the restriction above.
   SmallVector<Value> resultingFusedOpsHandles;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -22,7 +22,26 @@ static void buildPrint(ImplicitLocOpBuilder &b, ValueRange handles = {});
 
 /// Result of the combined transform performing tiling, fusion and distribution
 /// to parallel constructs.
-struct TileAndFuseAndDistributeResult {
+struct TileToScfForAndFuseResult {
+  /// Vector of `scf.for` loops containing the tiled and fused operations.
+  SmallVector<Value> forLoops;
+  /// Handles to fused operations other than the final consumer operation. May
+  /// be empty if fusion was not performed iteratively.
+  /// /// This is currently empty
+  // TODO: support returning handles from `fuse_into_containing_op` and remove
+  // the restriction above.
+  SmallVector<Value> resultingFusedOpsHandles;
+  /// Handle to the tiled final consumer operation.
+  Value tiledOpH;
+};
+
+TileToScfForAndFuseResult buildTileFuseToScfFor(
+    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
+    ArrayRef<OpFoldResult> tileSizes);
+
+/// Result of the combined transform performing tiling, fusion and distribution
+/// to parallel constructs.
+struct TileToForeachThreadAndFuseAndDistributeResult {
   /// Outer `scf.foreach_thread` loop containing the tiled and fused operations.
   Value foreachThreadH;
   /// Handles to fused operations other than the final consumer operation. May
@@ -51,19 +70,23 @@ struct TileAndFuseAndDistributeResult {
 /// enabling transform will be introduced and may result in better fusions.
 ///
 // TODO: if someone knows how to properly export templates go for it .. sigh.
-TileAndFuseAndDistributeResult buildTileFuseDistToForeachThreadWithTileSizes(
-    ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
-    ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping);
-TileAndFuseAndDistributeResult
+TileToForeachThreadAndFuseAndDistributeResult
+buildTileFuseDistToForeachThreadWithTileSizes(ImplicitLocOpBuilder &b,
+                                              Value rootH,
+                                              ValueRange opsHToFuse,
+                                              ArrayRef<OpFoldResult> tileSizes,
+                                              ArrayAttr threadDimMapping);
+TileToForeachThreadAndFuseAndDistributeResult
 buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping);
 
 /// See buildTileFuseDistWithTileSizes.
-TileAndFuseAndDistributeResult buildTileFuseDistToForeachThreadWithNumThreads(
+TileToForeachThreadAndFuseAndDistributeResult
+buildTileFuseDistToForeachThreadWithNumThreads(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> numThreads, ArrayAttr threadDimMapping);
-TileAndFuseAndDistributeResult
+TileToForeachThreadAndFuseAndDistributeResult
 buildTileFuseDistToForeachThreadAndWorgroupCountWithNumThreads(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> numThreads, ArrayAttr threadDimMapping);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesCPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesCPU.cpp
@@ -6,44 +6,19 @@
 
 #include "iree/compiler/Codegen/Common/TransformDialectStrategiesCPU.h"
 
-#include <numeric>
-#include <type_traits>
-
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
 #include "iree-dialects/Transforms/TransformMatchers.h"
 #include "iree/compiler/Codegen/Common/TransformDialectStrategies.h"
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
-#include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
-#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/LLVMCPU/TransformExtensions/LLVMCPUExtensions.h"
 #include "iree/compiler/Codegen/Passes.h"
-#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
-#include "mlir/Analysis/SliceAnalysis.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
-#include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
-#include "mlir/Dialect/Transform/IR/TransformDialect.h"
-#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
-#include "mlir/IR/Location.h"
-#include "mlir/IR/Matchers.h"
-#include "mlir/IR/Types.h"
-#include "mlir/IR/Value.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassRegistry.h"
 
 using namespace mlir;
 
@@ -51,48 +26,13 @@ using namespace mlir;
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 // TODO: significantly better namespacing.
-using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
-using iree_compiler::IREE::transform_dialect::ConfigExtractPart;
 using iree_compiler::IREE::transform_dialect::ForeachThreadToWorkgroupOp;
-using iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
-using iree_compiler::IREE::transform_dialect::
-    IREEEraseHALDescriptorTypeFromMemRefOp;
-using iree_compiler::IREE::transform_dialect::
-    MapNestedForeachThreadToGpuThreadsOp;
-using iree_compiler::IREE::transform_dialect::
-    TileToForeachThreadAndWorkgroupCountRegionOp;
-using iree_compiler::IREE::transform_dialect::VectorToWarpExecuteOnLane0Op;
-using iree_compiler::IREE::transform_dialect::VectorWarpDistributionOp;
-using transform::FuseIntoContainingOp;
 using transform::MatchOp;
-using transform::MergeHandlesOp;
-using transform::PrintOp;
-using transform::SequenceOp;
 using transform::SplitHandlesOp;
-using transform::SplitReductionOp;
-using transform::TileToForeachThreadOp;
-using transform::VectorizeOp;
 using transform_ext::AllDims;
-using transform_ext::IsPermutation;
 using transform_ext::m_StructuredOp;
 using transform_ext::NumEqualsTo;
 using transform_ext::ShapeKind;
-using transform_ext::StructuredOpMatcher;
-
-/// Matches `args` within `targetH` and unpacks a number of handles `N`.
-/// Assumes there are exactly `N` matched ops (but could be relaxed).
-/// Returns the tuple of handles.
-template <int N, typename... MatchingArgs>
-auto matchAndUnpack(ImplicitLocOpBuilder &b, Value targetH,
-                    MatchingArgs... args) {
-  Value matchedH = b.create<MatchOp>(targetH, args...);
-  auto matchOp = b.create<SplitHandlesOp>(matchedH,
-                                          /*numHandles=*/N);
-  assert(matchOp->getNumResults() == N && "Unexpected number of results");
-  std::array<Value, N> a;
-  for (int64_t i = 0; i < N; ++i) a[i] = matchOp->getResult(i);
-  return std::tuple_cat(a);
-}
 
 //===----------------------------------------------------------------------===//
 // Higher-level problem-specific strategy creation APIs, these should favor

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.h"
 
 #include <numeric>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 
@@ -124,101 +125,162 @@ auto unpackRegisteredMatchCallback(ImplicitLocOpBuilder &b,
 
 namespace {
 
-/// Compute good tile and vector sizes for the reduction dimension of a 1-D
-/// reduction dimension for a TileReductionUsingForeachThreadOp strategy.
+/// Encodes a strategy for a 1-d reduction mapped to a block.
 ///
-/// Dynamic case: use as many threads as allowed along threadIdx.x with vector
-/// size of 1 (i.e. coalesced accesses).
-/// This can be further refined with splitting or vector masking when
-/// available.
+/// This happens in a staged fashion to encode good tradeoffs between amount
+/// of parallelism, occupancy and granularity of the load/store operations.
+/// The tradeoff is controlled at a distance by specifying a
+/// `maxNumThreadsToUse` upper bound.
 ///
-/// Static case: perfectly tile by:
-///   - 128 to obtain 32*k threads working on vector<4xf32> with k as high as
-///   possible within the limits of maxNumThreadsToUse, when possible;
-///   - 64 to obtain 32*k threads working on vector<2xf32> with k as high as
-///   possible within the limits of maxNumThreadsToUse, when possible;
-///   - reductionDimensionSize within the limits of maxNumThreadsToUse,
-///   otherwise.
-// TODO: refine even further based on mod 2 and mod 4 only + min
-// canonicalizations.
-// TODO: refine sizes based on the bitwidth of the elemental type.
-class ReductionStrategyThreadDistributionSizes {
+/// Bottom-up perspective:
+/// ======================
+/// Stage 3: the warp shuffle step is normalized to run on a single warp using
+/// a vector<warp_shufle_vector_size x T> element. The size of this vector is
+/// controlled by a `warpShuffleSize` parameter passed to the constructor which
+/// must be a 1,2 or 4-multiple of the machine warp size.
+///
+/// Stage 2: the second stage of the reduction is normalized to reduce from a
+/// "k-warps" abstraction (k determined in Step 1) to a single `warpShuffleSize`
+/// that can be reduced unambiguously well on a single warp during Stage 3.
+/// This second/ stage is optional and only occurs when k > 1.
+///
+/// Stage 1: the first stage of the reduction is normalized to run on "k-warps"
+/// of maximal vector size for both the hardware and the problem sizes.
+/// The overprovisioning to "k-warps" allows multiple warps to run in parallel.
+/// The `reductionTileSizeStage1` is this "k-warps" quantity and is also the
+/// number of threads (i.e. blockDim.x) used to parallelize the problem.
+/// This also results in `reductionTileSizeStage1` live values that are
+/// allocated in shared memory and creates a tradeoff between parallelism and
+/// occupancy.
+/// The normalization guarantees that whatever the problem size P, we reduce
+/// from `tensor<P x T>` to `tensor<reductionTileSizeStage1 x T>` by using the
+/// largest possible `vector.transfer` operations. The vector size is chosen as
+/// follows: when the `reductionDimensionSize` is a multiple of 4, choose 4;
+/// otherwise try with 2; otherwise just use 1.
+///
+// TODO: refine with support for various elemental types.
+// TODO: when it makes sense, consider splitting to ensure 4 on most of the
+// problem and use a 1-epilogue.
+class ReductionStrategyThreadDistribution {
  public:
-  ReductionStrategyThreadDistributionSizes(
-      int64_t reductionDimensionSize = 0,
-      int64_t maxNumThreadsToUse = iree_compiler::kCudaMaxNumThreads)
-      : reductionDimensionSize(reductionDimensionSize),
-        maxNumThreadsToUse(maxNumThreadsToUse) {
-    computeStrategy();
+  ReductionStrategyThreadDistribution() = default;
+  ReductionStrategyThreadDistribution(int64_t reductionDimensionSize,
+                                      int64_t maxNumThreadsToUse,
+                                      int64_t warpShuffleSize) {
+    compute(reductionDimensionSize, maxNumThreadsToUse, warpShuffleSize);
   }
-  ReductionStrategyThreadDistributionSizes(
-      const ReductionStrategyThreadDistributionSizes &) = default;
+  ReductionStrategyThreadDistribution(
+      const ReductionStrategyThreadDistribution &) = default;
 
-  ReductionStrategyThreadDistributionSizes &operator=(
-      const ReductionStrategyThreadDistributionSizes &) = default;
+  ReductionStrategyThreadDistribution &operator=(
+      const ReductionStrategyThreadDistribution &) = default;
 
-  int64_t reductionTileSize;
-  int64_t vectorTileSize;
+  int64_t getVectorSizeStage1() { return vectorSizeStage1; }
+  int64_t getNumThreadsXInBlock() { return reductionTileSizeStage1; }
+
+  bool hasStage2() { return reductionTileSizeStage2.has_value(); }
+  int64_t getWarpShuffleSize() { return reductionTileSizeStage2.value(); }
+  int64_t getVectorSizeStage2() { return vectorSizeStage2.value(); }
 
  private:
-  void computeStrategy();
+  /// Maximal vector size (among {1, 2, 4}) that divides the
+  /// `reductionDimensionSize` and is used for vector transfers in Stage 1.
+  int64_t vectorSizeStage1;
+  /// Maximal "k-warp" size within the limits of the `maxNumThreadsToUse` and
+  /// `reductionDimensionSize` parameters.
+  /// This is also the blockDim.x of the kernel.
+  int64_t reductionTileSizeStage1;
+  /// Maximal vector size allowing to reduce from "k-warp" to single warp: when
+  /// `k` is a multiple of 4, choose 4; otherwise try with 2; otherwise just
+  /// use 1.
+  std::optional<int64_t> vectorSizeStage2;
+  /// `reductionTileSizeStage2` is exactly set to `warpShuffleSize` passed to
+  /// the constructor, only when reductionTileSizeStage1 > warpShuffleSize (i.e.
+  /// k > 1).
+  std::optional<int64_t> reductionTileSizeStage2;
 
-  int64_t reductionDimensionSize;
+  /// Compute the staged strategy based on the `reductionDimensionSize`, the
+  /// `maxNumThreadsToUse` and the `warpShuffleSize`.
+  /// The latter 2 numbers control the tradeoff between parallelism and shared
+  /// memory consumption.
   // TODO: Characterize shared memory consumption of this strategy and limit
   // accordingly for good occupancy.
-  int64_t maxNumThreadsToUse;
+  // TODO: refine with elemental type bitwidth and GPU memory transaction
+  // size.
+  void compute(int64_t reductionDimensionSize, int64_t maxNumThreadsToUse,
+               int64_t warpShuffleSize);
 };
 
 static int64_t maxMultipleOf(int64_t val, int64_t multiple) {
-  assert(val > 0 && "expected nonnegative quantity");
-  assert(multiple > 0 && "expected nonnegative quantity");
+  assert(val > 0 && "expected nonnegative val");
+  assert(multiple > 0 && "expected nonnegative multiple");
   return (val / multiple) * multiple;
 }
+
 static int64_t nextMultipleOf(int64_t val, int64_t multiple) {
-  assert(val > 0 && "expected nonnegative quantity");
-  assert(multiple > 0 && "expected nonnegative quantity");
+  assert(val > 0 && "expected nonnegative val");
+  assert(multiple > 0 && "expected nonnegative multiple");
   return ((val + multiple - 1) / multiple) * multiple;
 }
 
-void ReductionStrategyThreadDistributionSizes::computeStrategy() {
-  vectorTileSize = 1;
-  reductionTileSize = maxNumThreadsToUse;
-  if (reductionDimensionSize <= 0) return;
+void ReductionStrategyThreadDistribution::compute(
+    int64_t reductionDimensionSize, int64_t maxNumThreadsToUse,
+    int64_t warpShuffleSize) {
+  assert(warpShuffleSize > 0 && "warpShuffleSize must > 0");
+  assert(warpShuffleSize % iree_compiler::kCudaWarpSize == 0 &&
+         "warpShuffleSize must be a multiple of warpSize");
+  assert(warpShuffleSize <= 4 * iree_compiler::kCudaWarpSize &&
+         "must be smaller or equal to 4 * warp_size");
 
-  // When we know the problem size is divisible by k, we know we want to
-  // target vector<kxf32>. Over-provision to the next multiple of the warp
-  // size fo ensure we tile to a multiple of the warp size to allow proper
-  // distribution across warp shuffles.
-  // TODO: refine with elemental type bitwidth and GPU memory transaction size.
-  if (reductionDimensionSize % 4 == 0) {
-    reductionTileSize = std::min(
-        nextMultipleOf(reductionDimensionSize / 4,
-                       iree_compiler::kCudaWarpSize),
-        maxMultipleOf(maxNumThreadsToUse, iree_compiler::kCudaWarpSize));
-    vectorTileSize = 4;
-  } else if (reductionDimensionSize % 2 == 0) {
-    reductionTileSize = std::min(
-        nextMultipleOf(reductionDimensionSize / 2,
-                       iree_compiler::kCudaWarpSize),
-        maxMultipleOf(maxNumThreadsToUse, iree_compiler::kCudaWarpSize));
-    vectorTileSize = 2;
+  // Stage 1.
+  // Maximal vector size that divides the problem size.
+  // TODO: investigate splitting/peeling for more vector operations.
+  if (reductionDimensionSize > 0 && reductionDimensionSize % 4 == 0)
+    vectorSizeStage1 = 4;
+  else if (reductionDimensionSize > 0 && reductionDimensionSize % 2 == 0)
+    vectorSizeStage1 = 2;
+  else
+    vectorSizeStage1 = 1;
+
+  // Tile reduction to the maximal multiple `warpShuffleSize` allowed.
+  // This locally reduces the large unknown reduction into a guaranteed
+  // multiple of `warpShuffleSize`.
+  if (reductionDimensionSize > 0) {
+    reductionTileSizeStage1 =
+        std::min(nextMultipleOf(reductionDimensionSize / vectorSizeStage1,
+                                warpShuffleSize),
+                 maxMultipleOf(maxNumThreadsToUse, warpShuffleSize));
   } else {
-    reductionTileSize = std::min(
-        nextMultipleOf(reductionDimensionSize, iree_compiler::kCudaWarpSize),
-        maxMultipleOf(maxNumThreadsToUse, iree_compiler::kCudaWarpSize));
-    vectorTileSize = 1;
+    reductionTileSizeStage1 =
+        maxMultipleOf(maxNumThreadsToUse, warpShuffleSize);
+  }
+  // Stage 2 is only needed if `reductionTileSizeStage1` consists of multiple
+  // `warpShuffleSize`; otherwise, we just skip this step.
+  if (reductionTileSizeStage1 > warpShuffleSize) {
+    // Tile reduction exactly to `warpShuffleSize` which will be used in the 3rd
+    // stage to distribute to warp shuffles.
+    reductionTileSizeStage2 = warpShuffleSize;
+    // The vector size we use depends on the number of `warpShuffleSize`s in
+    // `reductionTileSizeStage1`.
+    int64_t factor = reductionTileSizeStage1 / warpShuffleSize;
+    if (factor % 4 == 0)
+      vectorSizeStage2 = 4;
+    else if (factor % 2 == 0)
+      vectorSizeStage2 = 2;
+    else
+      vectorSizeStage2 = 1;
   }
 }
 
 /// Structure to hold the parameters related to GPU reduction strategy.
 struct GPUReductionStrategyInfos {
-  explicit GPUReductionStrategyInfos(MLIRContext *context, int64_t rank,
-                                     int64_t reductionDimensionSize)
+  explicit GPUReductionStrategyInfos(
+      MLIRContext *context, transform_ext::MatchedReductionCaptures captures)
       : context(context),
-        rank(rank),
-        reductionDimensionSize(reductionDimensionSize),
-        threadDistributionSizes(
-            ReductionStrategyThreadDistributionSizes(reductionDimensionSize)) {
+        reductionRank(captures.reductionRank),
+        reductionDimensionSize(captures.reductionDimensionSize),
+        maybeLeadingRank(captures.maybeLeadingRank),
+        maybeTrailingRank(captures.maybeTrailingRank) {
     auto blockX =
         mlir::gpu::GPUBlockMappingAttr::get(context, mlir::gpu::Blocks::DimX);
     auto blockY =
@@ -228,13 +290,21 @@ struct GPUReductionStrategyInfos {
     allBlockAttrs = SmallVector<Attribute>{blockX, blockY, blockZ};
   }
 
+  void computeThreadDistribution(int64_t maxNumThreads,
+                                 int64_t warpShuffleSize) {
+    threadDistribution = std::make_unique<ReductionStrategyThreadDistribution>(
+        reductionDimensionSize, maxNumThreads, warpShuffleSize);
+  }
+
   /// Constructor quantities.
   MLIRContext *context;
-  int64_t rank;
+  int64_t reductionRank;
   int64_t reductionDimensionSize;
-  ReductionStrategyThreadDistributionSizes threadDistributionSizes;
+  int64_t maybeLeadingRank;
+  int64_t maybeTrailingRank;
 
   /// Derived quantities.
+  std::unique_ptr<ReductionStrategyThreadDistribution> threadDistribution;
   SmallVector<Attribute> allBlockAttrs;
   // Tile sizes for the workgroup / determines grid size.
   SmallVector<int64_t> workgroupTileSizes;
@@ -243,7 +313,7 @@ struct GPUReductionStrategyInfos {
 };
 }  // namespace
 
-static std::pair<Value, Value> createReductionStrategyBlockDistribution(
+static std::tuple<Value, Value, Value> createReductionStrategyBlockDistribution(
     ImplicitLocOpBuilder &b, Value maybeLeadingH, Value fillH, Value reductionH,
     Value maybeTrailingH, const GPUReductionStrategyInfos &infos) {
   auto pdlOperation = pdl::OperationType::get(b.getContext());
@@ -261,35 +331,42 @@ static std::pair<Value, Value> createReductionStrategyBlockDistribution(
               /*tileSizes=*/
               getAsOpFoldResult(b.getI64ArrayAttr(infos.workgroupTileSizes)),
               /*threadDimMapping=*/
-              b.getArrayAttr(allBlocksRef.take_front(infos.rank - 1)));
-  Value foreachThreadH =
-      b.create<FuseIntoContainingOp>(fillH, tileResult.foreachThreadH);
-  foreachThreadH =
-      b.create<FuseIntoContainingOp>(maybeLeadingH, foreachThreadH);
+              b.getArrayAttr(allBlocksRef.take_front(infos.reductionRank - 1)));
+  fillH = b.create<FuseIntoContainingOp>(fillH, tileResult.foreachThreadH);
+  if (infos.maybeLeadingRank > 0) {
+    maybeLeadingH = b.create<FuseIntoContainingOp>(maybeLeadingH,
+                                                   tileResult.foreachThreadH);
+  }
+  // Here, TakeFirstOp acts as a normalizer:
+  //   1. if fusionTargetH is maybeTrailingH then getFirst() is reductionH and
+  //      getRest() is maybeTrailingH.
+  //   2. if fusionTargetH is reductionH then getFirst() is reductionH and
+  //      getRest() is empty.
   auto gridReductionSelector = b.create<TakeFirstOp>(
       pdlOperation, pdlOperation,
       ValueRange{tileResult.resultingFusedOpsHandles.front(),
                  tileResult.tiledOpH});
-
-  return std::make_pair(gridReductionSelector.getFirst(),
-                        gridReductionSelector.getRest());
+  Value gridReductionH = gridReductionSelector.getFirst();
+  maybeTrailingH = gridReductionSelector.getRest();
+  return std::make_tuple(maybeLeadingH, gridReductionH, maybeTrailingH);
 }
 
-static void createReductionStrategyThreadDistribution(
-    ImplicitLocOpBuilder &b, Value gridReductionH, Value maybeTiledTrailingH,
-    const GPUReductionStrategyInfos &infos) {
+static std::tuple<Value, Value, Value>
+createReductionStrategyThreadDistributionStep(ImplicitLocOpBuilder &b,
+                                              Value gridReductionH,
+                                              int64_t reductionRank,
+                                              int64_t reductionTileSizeStage,
+                                              int64_t reductionVectorSize) {
   auto threadX = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
                                                       mlir::gpu::Threads::DimX);
-  auto threadY = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
-                                                      mlir::gpu::Threads::DimY);
-
   // Split the reduction into a parallel and combiner part, then tile the
-  // parallel part and map it to a full warp so it works on vectors.
-  SmallVector<int64_t> leadingParallelDims(infos.rank - 1, 0);
+  // parallel part and map it to `reductionTileSizeStage` threads, each working
+  // on `reductionVectorSize`.
+  SmallVector<int64_t> leadingParallelDims(reductionRank - 1, 0);
   SmallVector<int64_t> numThreads = leadingParallelDims;
-  numThreads.push_back(infos.threadDistributionSizes.reductionTileSize);
+  numThreads.push_back(reductionTileSizeStage);
   SmallVector<int64_t> tileSizes = leadingParallelDims;
-  tileSizes.push_back(infos.threadDistributionSizes.vectorTileSize);
+  tileSizes.push_back(reductionVectorSize);
   auto tileReduction = b.create<transform::TileReductionUsingForeachThreadOp>(
       /*target=*/gridReductionH,
       /*numThreads=*/numThreads,
@@ -298,32 +375,85 @@ static void createReductionStrategyThreadDistribution(
   Value blockParallelForeachThreadOp = tileReduction.getForeachThreadOp();
   Value blockParallelFillH = tileReduction.getFillOp();
   Value blockCombinerOpH = tileReduction.getCombiningLinalgOp();
-
   // Fuse the fill and pointwise to privatize them.
   blockParallelFillH = b.create<FuseIntoContainingOp>(
       blockParallelFillH, blockParallelForeachThreadOp);
+  return std::make_tuple(blockParallelForeachThreadOp, blockParallelFillH,
+                         blockCombinerOpH);
+}
 
+static void createElementwiseStrategyThreadStep(ImplicitLocOpBuilder &b,
+                                                Value elementwiseH,
+                                                int64_t rank,
+                                                int64_t numThreadsXInBlock) {
+  assert(rank > 0 && "nonnegative rank expected");
+  SmallVector<int64_t> trailingTileSizes(rank, 0);
+  SmallVector<int64_t> scfForTileSizes = trailingTileSizes,
+                       foreachTileSizes = trailingTileSizes;
+  // The following assumes we only want to tile the most-minor dimension of the
+  // trailing operation. This may be a completely wrong choice.
+  // TODO: more robustness to permutations of most-minor dimensions.
+  // TODO: capture most minor size and compute tile size based on it.
+  scfForTileSizes.back() = numThreadsXInBlock;
+  foreachTileSizes.back() = numThreadsXInBlock;
+  // TODO: only tile by scf.for if we wish to normalize the tiling (i.e. if
+  // the result has a lot more values than the number of threads in block).
+  // This allows us to avoid uncoalesced accesses.
+  auto res = iree_compiler::buildTileFuseToScfFor(
+      b, elementwiseH, {},
+      getAsOpFoldResult(b.getI64ArrayAttr({scfForTileSizes})));
+  auto threadX = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
+                                                      mlir::gpu::Threads::DimX);
+  iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
+      b, res.tiledOpH, {},
+      getAsOpFoldResult(b.getI64ArrayAttr(foreachTileSizes)),
+      b.getArrayAttr({threadX}));
+}
+
+static void createReductionStrategyThreadDistribution(
+    ImplicitLocOpBuilder &b, Value gridReductionH, Value maybeTiledLeadingH,
+    Value maybeTiledTrailingH, const GPUReductionStrategyInfos &infos) {
+  // Map the potential maybeTiledLeadingH.
+  if (infos.maybeLeadingRank > 0) {
+    createElementwiseStrategyThreadStep(
+        b, maybeTiledLeadingH, infos.maybeLeadingRank,
+        infos.threadDistribution->getNumThreadsXInBlock());
+  }
+
+  // Staged reduction step 1: break gridReductionH apart.
+  auto [blockParallelForeachThreadOp, blockParallelFillH, blockCombinerOpH] =
+      createReductionStrategyThreadDistributionStep(
+          b, gridReductionH, infos.reductionRank,
+          infos.threadDistribution->getNumThreadsXInBlock(),
+          infos.threadDistribution->getVectorSizeStage1());
+
+  // Staged reduction step 2: break blockCombinerOpH apart.
+  // Note, if necessary, we could have additional intermediate steps.
+  Value warpParallelForeachThreadOp, warpParallelFillH, warpCombinerOpH;
+  if (infos.threadDistribution->hasStage2()) {
+    std::tie(warpParallelForeachThreadOp, warpParallelFillH, warpCombinerOpH) =
+        createReductionStrategyThreadDistributionStep(
+            b, blockCombinerOpH, infos.reductionRank,
+            infos.threadDistribution->getWarpShuffleSize(),
+            infos.threadDistribution->getVectorSizeStage1());
+  } else {
+    warpCombinerOpH = blockCombinerOpH;
+  }
+
+  // Staged reduction step 3: break blockCombinerOpH apart.
   // Map the combiner reduction to one thread along y so it can be mapped
   // further via predication.
+  auto threadY = mlir::gpu::GPUThreadMappingAttr::get(b.getContext(),
+                                                      mlir::gpu::Threads::DimY);
   iree_compiler::buildTileFuseDistToForeachThreadWithTileSizes(
-      b, blockCombinerOpH, {}, getAsOpFoldResult(b.getI64ArrayAttr({1})),
+      b, warpCombinerOpH, {}, getAsOpFoldResult(b.getI64ArrayAttr({1})),
       b.getArrayAttr(threadY));
 
   // Map the potential maybeTiledTrailingH.
-  if (maybeTiledTrailingH) {
-    assert(infos.rank >= 1);
-    SmallVector<int64_t> trailingTileSizes(infos.rank - 1, 0);
-    if (infos.rank > 1) {
-      trailingTileSizes.back() =
-          infos.threadDistributionSizes.reductionTileSize;
-    }
-    auto res = iree_compiler::buildTileFuseToScfFor(
-        b, maybeTiledTrailingH, {},
-        getAsOpFoldResult(b.getI64ArrayAttr(trailingTileSizes)));
-    iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
-        b, res.tiledOpH, {},
-        getAsOpFoldResult(b.getI64ArrayAttr(trailingTileSizes)),
-        b.getArrayAttr({threadX}));
+  if (infos.maybeTrailingRank > 0) {
+    createElementwiseStrategyThreadStep(
+        b, maybeTiledTrailingH, infos.maybeTrailingRank,
+        infos.threadDistribution->getNumThreadsXInBlock());
   }
 }
 
@@ -343,19 +473,21 @@ static void createReductionCudaStrategy(
 
   // Step 2. Use tiling to introduce a single-iteration loop mapped to a
   // single block/workgroup. Keep everything fused.
-  auto [gridReductionH, maybeTiledTrailingH] =
+  auto [maybeLeadingHFused, gridReductionH, maybeTiledTrailingH] =
       createReductionStrategyBlockDistribution(
           b, maybeLeadingH, fillH, reductionH, maybeTrailingH, infos);
+  maybeLeadingH = maybeLeadingHFused;
 
   // Step 3. Split the reduction and tile the pieces to ensure vector
   // load/stores and mapping to a single warp with shuffles.
-  createReductionStrategyThreadDistribution(b, gridReductionH,
+  createReductionStrategyThreadDistribution(b, gridReductionH, maybeLeadingH,
                                             maybeTiledTrailingH, infos);
 
   // Step 4. Bufferize and drop HAL decriptor from memref ops.
   Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
   funcH = iree_compiler::buildVectorize(b, funcH);
-  variantH = iree_compiler::buildBufferize(b, variantH, /*targetGpu=*/true);
+  variantH = iree_compiler::buildBufferize(b, variantH,
+                                           /*targetGpu=*/true);
 
   // Step 5. Post-bufferization mapping to blocks and threads.
   // Need to match again since bufferize invalidated all handles.
@@ -375,15 +507,34 @@ static FailureOr<GPUReductionStrategyInfos> matchGPUReduction(
   makeReductionMatcher(reduction, fill, leading, trailing, captures);
   if (!matchPattern(op, reduction)) return failure();
 
-  GPUReductionStrategyInfos info(op->getContext(), captures.rank,
-                                 captures.reductionDimensionSize);
+  GPUReductionStrategyInfos infos(op->getContext(), captures);
+  // TODO: lift some of this logic as hints and/or heuristics to also work
+  // properly in the dynamic case.
+  int64_t maxNumThreads = 8 * iree_compiler::kCudaWarpSize;
+  int64_t warpShuffleSize = 2 * iree_compiler::kCudaWarpSize;
+  if (captures.reductionDimensionSize > 0) {
+    if (captures.reductionDimensionSize <= iree_compiler::kCudaWarpSize) {
+      maxNumThreads = warpShuffleSize = iree_compiler::kCudaWarpSize;
+    } else if (captures.reductionDimensionSize <=
+               2 * iree_compiler::kCudaWarpSize) {
+      maxNumThreads = 2 * iree_compiler::kCudaWarpSize;
+      warpShuffleSize = iree_compiler::kCudaWarpSize;
+    } else if (captures.reductionDimensionSize <=
+               4 * iree_compiler::kCudaWarpSize) {
+      maxNumThreads = 4 * iree_compiler::kCudaWarpSize;
+      warpShuffleSize = 2 * iree_compiler::kCudaWarpSize;
+    }
+  }
+  infos.computeThreadDistribution(maxNumThreads, warpShuffleSize);
 
   // Tile all the parallel dimensions to 1 and create many blocks.
-  int64_t numParallelLoops = captures.rank - 1;
-  info.workgroupTileSizes.append(numParallelLoops, 1);
-  // Tile and distribute the reduction across `reductionTileSize` threads.
-  info.workgroupSize = {info.threadDistributionSizes.reductionTileSize, 1, 1};
-  return info;
+  int64_t numParallelLoops = captures.reductionRank - 1;
+  infos.workgroupTileSizes.append(numParallelLoops, 1);
+  // Tile and distribute the reduction across `reductionTileSizeStage1`
+  // threads.
+  infos.workgroupSize = {infos.threadDistribution->getNumThreadsXInBlock(), 1,
+                         1};
+  return infos;
 }
 
 LogicalResult iree_compiler::matchAndSetGPUReductionTransformStrategy(

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -6,47 +6,20 @@
 
 #include "iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.h"
 
-#include <numeric>
-#include <tuple>
-#include <type_traits>
-#include <utility>
-
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
 #include "iree-dialects/Transforms/TransformMatchers.h"
 #include "iree/compiler/Codegen/Common/TransformDialectStrategies.h"
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
-#include "iree/compiler/Codegen/PassDetail.h"
-#include "iree/compiler/Codegen/Passes.h"
-#include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
-#include "llvm/Support/CommandLine.h"
-#include "llvm/Support/Debug.h"
-#include "mlir/Analysis/SliceAnalysis.h"
-#include "mlir/Dialect/Affine/IR/AffineOps.h"
-#include "mlir/Dialect/Arith/IR/Arith.h"
-#include "mlir/Dialect/Bufferization/IR/Bufferization.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
-#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
-#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
-#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
-#include "mlir/Dialect/Vector/IR/VectorOps.h"
-#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
-#include "mlir/IR/Location.h"
-#include "mlir/IR/Matchers.h"
-#include "mlir/IR/Types.h"
-#include "mlir/IR/Value.h"
-#include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassRegistry.h"
 
 using namespace mlir;
 
@@ -54,51 +27,13 @@ using namespace mlir;
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 // TODO: significantly better namespacing.
-using iree_compiler::IREE::transform_dialect::ApplyPatternsOp;
-using iree_compiler::IREE::transform_dialect::ConfigExtractPart;
 using iree_compiler::IREE::transform_dialect::ForeachThreadToWorkgroupOp;
-using iree_compiler::IREE::transform_dialect::IREEBufferizeOp;
-using iree_compiler::IREE::transform_dialect::
-    IREEEraseHALDescriptorTypeFromMemRefOp;
-using iree_compiler::IREE::transform_dialect::
-    MapNestedForeachThreadToGpuThreadsOp;
-using iree_compiler::IREE::transform_dialect::
-    TileToForeachThreadAndWorkgroupCountRegionOp;
-using iree_compiler::IREE::transform_dialect::VectorToWarpExecuteOnLane0Op;
-using iree_compiler::IREE::transform_dialect::VectorWarpDistributionOp;
 using transform::FuseIntoContainingOp;
 using transform::MatchOp;
-using transform::MergeHandlesOp;
-using transform::PrintOp;
-using transform::SequenceOp;
-using transform::SplitHandlesOp;
-using transform::SplitReductionOp;
-using transform::TileToForeachThreadOp;
-using transform::VectorizeOp;
-using transform_ext::AllDims;
-using transform_ext::IsPermutation;
-using transform_ext::m_StructuredOp;
 using transform_ext::MatchCallbackOp;
-using transform_ext::NumEqualsTo;
 using transform_ext::RegisterMatchCallbacksOp;
-using transform_ext::ShapeKind;
 using transform_ext::StructuredOpMatcher;
 using transform_ext::TakeFirstOp;
-
-/// Matches `args` within `targetH` and unpacks a number of handles `N`.
-/// Assumes there are exactly `N` matched ops (but could be relaxed).
-/// Returns the tuple of handles.
-template <int N, typename... MatchingArgs>
-auto matchAndUnpack(ImplicitLocOpBuilder &b, Value targetH,
-                    MatchingArgs... args) {
-  Value matchedH = b.create<MatchOp>(targetH, args...);
-  auto matchOp = b.create<SplitHandlesOp>(matchedH,
-                                          /*numHandles=*/N);
-  assert(matchOp->getNumResults() == N && "Unexpected number of results");
-  std::array<Value, N> a;
-  for (int64_t i = 0; i < N; ++i) a[i] = matchOp->getResult(i);
-  return std::tuple_cat(a);
-}
 
 /// Matches a C++ callback previously registered under `callbackName` and
 /// taking arguments `args`.

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -311,14 +311,18 @@ static void createReductionStrategyThreadDistribution(
 
   // Map the potential maybeTiledTrailingH.
   if (maybeTiledTrailingH) {
+    assert(infos.rank >= 1);
+    SmallVector<int64_t> trailingTileSizes(infos.rank - 1, 0);
+    if (infos.rank > 1) {
+      trailingTileSizes.back() =
+          infos.threadDistributionSizes.reductionTileSize;
+    }
     auto res = iree_compiler::buildTileFuseToScfFor(
         b, maybeTiledTrailingH, {},
-        getAsOpFoldResult(b.getI64ArrayAttr(
-            {0, infos.threadDistributionSizes.reductionTileSize})));
+        getAsOpFoldResult(b.getI64ArrayAttr(trailingTileSizes)));
     iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
         b, res.tiledOpH, {},
-        getAsOpFoldResult(b.getI64ArrayAttr(
-            {0, infos.threadDistributionSizes.reductionTileSize})),
+        getAsOpFoldResult(b.getI64ArrayAttr(trailingTileSizes)),
         b.getArrayAttr({threadX}));
   }
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -38,9 +38,9 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-NOT: gpu.barrier
 // Local per-thread scf.for-based reduction.
 //         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
 //         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
 //         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
 // No barrier within the loop
 //     CHECK-NOT:   gpu.barrier
@@ -105,9 +105,9 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-NOT: gpu.barrier
 // Local per-thread scf.for-based reduction.
 //         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
 //         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
 //         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
 // No barrier within the loop
 //     CHECK-NOT:   gpu.barrier
@@ -120,12 +120,13 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
-//         CHECK:   vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
-//         CHECK:   math.sqrt 
-//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %{{.*}}: f32 to vector<f32>
+//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
 //         CHECK:     vector.transfer_write %[[RES_VEC]]
+
+//         CHECK:   gpu.barrier
+//         CHECK:   math.sqrt 
 //         CHECK:   gpu.barrier
 //         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
 
@@ -171,11 +172,11 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-NOT: gpu.barrier
 // Local per-thread scf.for-based reduction.
 //         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
 //         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   arith.addf{{.*}} : vector<2xf32>
-//         CHECK:   arith.addf{{.*}} : vector<2xf32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   arith.addf{{.*}} : vector<4xf32>
+//         CHECK:   arith.addf{{.*}} : vector<4xf32>
+//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
 //         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
 // No barrier within the loop
 //     CHECK-NOT:   gpu.barrier
@@ -242,11 +243,11 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-NOT: gpu.barrier
 // Local per-thread scf.for-based reduction.
 //         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<2xf32>
+//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
 //         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   arith.addf{{.*}} : vector<2xf32>
-//         CHECK:   arith.addf{{.*}} : vector<2xf32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<2xf32> into f32
+//         CHECK:   arith.addf{{.*}} : vector<4xf32>
+//         CHECK:   arith.addf{{.*}} : vector<4xf32>
+//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
 //         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
 // No barrier within the loop
 //     CHECK-NOT:   gpu.barrier
@@ -259,12 +260,13 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
-//         CHECK:   vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
-//         CHECK:   math.sqrt
-//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %{{.*}}: f32 to vector<f32>
+//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
 //         CHECK:     vector.transfer_write %[[RES_VEC]]
+
+//         CHECK:   gpu.barrier
+//         CHECK:   math.sqrt
 //         CHECK:   gpu.barrier
 //         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -47,9 +47,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   vector.transfer_write {{.*}} vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
-//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%{{.*}}]
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
+//         CHECK: vector.transfer_read %{{.*}} memref<8xf32>, vector<f32>
+//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
@@ -114,9 +113,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   vector.transfer_write {{.*}} vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
-//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%{{.*}}]
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
+//         CHECK: vector.transfer_read %{{.*}} memref<1xf32, 3>, vector<f32>
+//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
@@ -183,9 +181,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   vector.transfer_write {{.*}} vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
-//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%{{.*}}]
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
+//         CHECK: vector.transfer_read %{{.*}} memref<8xf32>, vector<f32>
+//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
@@ -254,9 +251,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   vector.transfer_write {{.*}} vector<f32>
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
-//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%{{.*}}]
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]
+//         CHECK: vector.transfer_read %{{.*}} memref<1xf32, 3>, vector<f32>
+//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
@@ -318,11 +314,11 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-NOT:   gpu.barrier
 //         CHECK:   vector.transfer_write {{.*}} vector<f32>
 
+//     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
 // Distributed reduction: everyone loads then 5 xor + addf expected.
-//         CHECK: %[[TIDY:.]] = gpu.thread_id  y
-//         CHECK: vector.transfer_read %{{.*}}[%{{.*}}]
+//         CHECK: vector.transfer_read %{{.*}} memref<33xf32>, vector<f32>
 //         CHECK: %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]{{.*}} memref<1x64xf32, 3>, vector<2xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -33,13 +33,11 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.match_callback failures(propagate) "reduction"(%{{.+}})
 //         CHECK:   transform.iree.take_first
 //         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region {{.*}} tile_sizes [1](mapping = [#gpu.block<x>])
-// CHECK-COUNT-3:   transform.structured.fuse_into_containing_op
+// CHECK-COUNT-2:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.iree.take_first
 //         CHECK:   tile_reduction_using_foreach_thread {{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
 //         CHECK:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [1](mapping = [#gpu.thread<y>])
-//         CHECK:   transform.structured.tile %{{.*}}[32]
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [32] tile_sizes [](mapping = [#gpu.thread<x>])
 //         CHECK:   transform.structured.match ops{["func.func"]} in %arg0
 //         CHECK:   transform.structured.vectorize
 //         CHECK:   transform.iree.bufferize {target_gpu}
@@ -92,8 +90,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_128
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
-//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}
+//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 64], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -35,11 +35,11 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region {{.*}} tile_sizes [1](mapping = [#gpu.block<x>])
 // CHECK-COUNT-3:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.iree.take_first
-//         CHECK:   tile_reduction_using_foreach_thread {{.*}} by num_threads = [0, 32], tile_sizes = [0, 2], mapping = [#gpu.thread<x>]
+//         CHECK:   tile_reduction_using_foreach_thread {{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
 //         CHECK:   transform.structured.fuse_into_containing_op
-//         CHECK:   transform.iree.take_first
 //         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [1](mapping = [#gpu.thread<y>])
-//         CHECK:   transform.structured.fuse_into_containing_op
+//         CHECK:   transform.structured.tile %{{.*}}[32]
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} num_threads [32] tile_sizes [](mapping = [#gpu.thread<x>])
 //         CHECK:   transform.structured.match ops{["func.func"]} in %arg0
 //         CHECK:   transform.structured.vectorize
 //         CHECK:   transform.iree.bufferize {target_gpu}
@@ -131,5 +131,5 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_32
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 32], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -569,8 +569,10 @@ private:
 //===---------------------------------------------------------------------===//
 
 struct MatchedReductionCaptures {
-  int64_t rank;
-  int64_t reductionDimensionSize;
+  int64_t reductionRank = 0;
+  int64_t reductionDimensionSize = 0;
+  int64_t maybeLeadingRank = 0;
+  int64_t maybeTrailingRank = 0;
 };
 
 /// Creates a group of matchers for:

--- a/tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir
+++ b/tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir
@@ -1,6 +1,10 @@
-// iree-transform-compile   /usr/local/google/home/ntv/github/iree/tests/transform_dialect/cuda/warp_reduction_dispatch.mlir -b cuda -- --iree-hal-benchmark-dispatch-repeat-count=5 | \
-// /usr/local/cuda-11.4/bin/nvprof  --print-gpu-trace  iree-run-module --entry_function=warp_reduction_dispatch --device=cuda --function_input="512x10240xf32=1"
-
+// Example usage:
+//
+// cat tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir | \
+// sed "s/\${SZ1}/32/g" | \
+// sed "s/\${SZ2}/32/g" | \
+// iree-transform-compile - -b cuda -- --iree-hal-benchmark-dispatch-repeat-count=5 | \
+// /usr/local/cuda-11.4/bin/nvprof  --print-gpu-trace  iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input="32x32xf32=1"
 
 !in_tensor_reduction_2d_static_t = tensor<${SZ1}x${SZ2}xf32>
 !out_tensor_reduction_2d_static_t = tensor<${SZ1}xf32>

--- a/tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir
+++ b/tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir
@@ -1,10 +1,22 @@
-// Example usage:
+// Example usages:
+//
+// With the IREE pipeline:
 //
 // cat tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir | \
-// sed "s/\${SZ1}/32/g" | \
-// sed "s/\${SZ2}/32/g" | \
-// iree-transform-compile - -b cuda -- --iree-hal-benchmark-dispatch-repeat-count=5 | \
-// /usr/local/cuda-11.4/bin/nvprof  --print-gpu-trace  iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input="32x32xf32=1"
+// sed "s/\${SZ1}/1024/g" | \
+// sed "s/\${SZ2}/1024/g" | \
+// iree-compile - --iree-hal-target-backends=cuda --iree-hal-benchmark-dispatch-repeat-count=5 | \
+// nvprof --print-gpu-trace iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input="1024x1024xf32=1" 2>&1 | \
+// grep reduction
+//
+// With the transform dialect:
+//
+// cat tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir | \
+// sed "s/\${SZ1}/1024/g" | \
+// sed "s/\${SZ2}/1024/g" | \
+// iree-compile - --iree-hal-target-backends=cuda --iree-codegen-llvmgpu-enable-transform-dialect-jit --iree-hal-benchmark-dispatch-repeat-count=5 | \
+// nvprof --print-gpu-trace iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input="1024x1024xf32=1" 2>&1 | \
+// grep reduction
 
 !in_tensor_reduction_2d_static_t = tensor<${SZ1}x${SZ2}xf32>
 !out_tensor_reduction_2d_static_t = tensor<${SZ1}xf32>

--- a/tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir
+++ b/tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir
@@ -1,0 +1,115 @@
+// iree-transform-compile   /usr/local/google/home/ntv/github/iree/tests/transform_dialect/cuda/warp_reduction_dispatch.mlir -b cuda -- --iree-hal-benchmark-dispatch-repeat-count=5 | \
+// /usr/local/cuda-11.4/bin/nvprof  --print-gpu-trace  iree-run-module --entry_function=warp_reduction_dispatch --device=cuda --function_input="512x10240xf32=1"
+
+
+!in_tensor_reduction_2d_static_t = tensor<${SZ1}x${SZ2}xf32>
+!out_tensor_reduction_2d_static_t = tensor<${SZ1}xf32>
+
+func.func @reduction_2d_static(%arg : !in_tensor_reduction_2d_static_t) -> (!out_tensor_reduction_2d_static_t) {
+  %c0 = arith.constant 0 : index
+  %cst = arith.constant -0.000000e+00 : f32
+  
+  %d0 = tensor.dim %arg, %c0 : !in_tensor_reduction_2d_static_t
+  %0 = tensor.empty() : !out_tensor_reduction_2d_static_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_reduction_2d_static_t) ->   !out_tensor_reduction_2d_static_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_reduction_2d_static_t) outs(%1 : !out_tensor_reduction_2d_static_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_reduction_2d_static_t
+  return %2 : !out_tensor_reduction_2d_static_t
+}
+
+func.func @reduction_2d_elementwise_static(%arg : !in_tensor_reduction_2d_static_t) -> (!in_tensor_reduction_2d_static_t) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant -0.000000e+00 : f32
+  
+  %d0 = tensor.dim %arg, %c0 : !in_tensor_reduction_2d_static_t
+  %d1 = tensor.dim %arg, %c1 : !in_tensor_reduction_2d_static_t
+  %0 = tensor.empty() : !out_tensor_reduction_2d_static_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_reduction_2d_static_t) ->   !out_tensor_reduction_2d_static_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_reduction_2d_static_t) outs(%1 : !out_tensor_reduction_2d_static_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_reduction_2d_static_t
+
+  %cst_0 = arith.constant 3.840000e+02 : f32
+  %i = tensor.empty() : !in_tensor_reduction_2d_static_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%2 : !out_tensor_reduction_2d_static_t) outs(%i : !in_tensor_reduction_2d_static_t) {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %12 = arith.divf %arg0, %cst_0 : f32
+        linalg.yield %12 : f32
+      } -> !in_tensor_reduction_2d_static_t
+
+  return %3 : !in_tensor_reduction_2d_static_t
+}
+
+!in_tensor_reduction_2d_dynamic_t = tensor<?x?xf32>
+!out_tensor_reduction_2d_dynamic_t = tensor<?xf32>
+
+func.func @reduction_2d_dynamic(%arg : !in_tensor_reduction_2d_dynamic_t) -> (!out_tensor_reduction_2d_dynamic_t) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 0 : index
+  %cst = arith.constant -0.000000e+00 : f32
+  
+  %d0 = tensor.dim %arg, %c0 : !in_tensor_reduction_2d_dynamic_t
+  %d1 = tensor.dim %arg, %c1 : !in_tensor_reduction_2d_dynamic_t
+  %0 = tensor.empty(%d0) : !out_tensor_reduction_2d_dynamic_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_reduction_2d_dynamic_t) ->   !out_tensor_reduction_2d_dynamic_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_reduction_2d_dynamic_t) outs(%1 : !out_tensor_reduction_2d_dynamic_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_reduction_2d_dynamic_t
+  return %2 : !out_tensor_reduction_2d_dynamic_t
+}
+
+func.func @reduction_2d_elementwise_dynamic(%arg : !in_tensor_reduction_2d_dynamic_t) -> (!in_tensor_reduction_2d_dynamic_t) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant -0.000000e+00 : f32
+  
+  %d0 = tensor.dim %arg, %c0 : !in_tensor_reduction_2d_dynamic_t
+  %d1 = tensor.dim %arg, %c1 : !in_tensor_reduction_2d_dynamic_t
+  %0 = tensor.empty(%d0) : !out_tensor_reduction_2d_dynamic_t
+  %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_reduction_2d_dynamic_t) ->   !out_tensor_reduction_2d_dynamic_t
+  %2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]}
+    ins(%arg : !in_tensor_reduction_2d_dynamic_t) outs(%1 : !out_tensor_reduction_2d_dynamic_t) {
+      ^bb0(%arg3: f32, %arg4: f32):
+        %3 = arith.addf %arg3, %arg4 : f32
+        linalg.yield %3 : f32
+      } -> !out_tensor_reduction_2d_dynamic_t
+
+  %cst_0 = arith.constant 3.840000e+02 : f32
+  %i = tensor.empty(%d0, %d1) : !in_tensor_reduction_2d_dynamic_t
+  %3 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%2 : !out_tensor_reduction_2d_dynamic_t) outs(%i : !in_tensor_reduction_2d_dynamic_t) {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %12 = arith.divf %arg0, %cst_0 : f32
+        linalg.yield %12 : f32
+      } -> !in_tensor_reduction_2d_dynamic_t
+
+  return %3 : !in_tensor_reduction_2d_dynamic_t
+}


### PR DESCRIPTION
This revision introduces a 3 stage stategy for mapping reductions
along with a simple heuristic that finds the right tile sizes and vector sizes as a function
of the reduction size, the max number of threads and the warp shuffle size.
    
This provides a first set of tunable knobs for this strategy that can evolve into something more general in the future.
    
A simple benchmarking stub file is added that can be used with `sed`-based commands.
It is currently unclear where the control for such benchmarking should live and what relevant sizes should be.

Example of usage using the current IREE pipeline:
```
cat tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir | \
sed "s/\${SZ1}/1024/g" | \
sed "s/\${SZ2}/1024/g" | \
iree-compile - --iree-hal-target-backends=cuda --iree-hal-benchmark-dispatch-repeat-count=5 | \
nvprof --print-gpu-trace iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input="1024x1024xf32=1" 2>&1 | \
grep reduction
```
reports (note the super slow first run that pulls data from CPU memory):
```
EXEC @reduction_2d_static
==426762== Profiling application: iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input=1024x1024xf32=1
423.07ms  3.1230ms           (1024 1 1)       (256 1 1)        16        0B       32B  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [33]
426.19ms  7.2960us           (1024 1 1)       (256 1 1)        16        0B       32B  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [34]
426.20ms  6.8810us           (1024 1 1)       (256 1 1)        16        0B       32B  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [35]
426.21ms  7.0080us           (1024 1 1)       (256 1 1)        16        0B       32B  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [36]
426.21ms  7.0090us           (1024 1 1)       (256 1 1)        16        0B       32B  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [37]
```

Example of usage with this PR:
```
cat tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir | \
sed "s/\${SZ1}/1024/g" | \
sed "s/\${SZ2}/1024/g" | \
iree-compile - --iree-hal-target-backends=cuda --iree-codegen-llvmgpu-enable-transform-dialect-jit --iree-hal-benchmark-dispatch-repeat-count=5 | \
nvprof --print-gpu-trace iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input="1024x1024xf32=1" 2>&1 | \
grep reduction
```
reports (note the super slow first run that pulls data from CPU memory):
```
EXEC @reduction_2d_static
==426762== Profiling application: iree-run-module --entry_function=reduction_2d_static --device=cuda --function_input=1024x1024xf32=1
423.72ms  3.3241ms           (1024 1 1)       (256 1 1)        16        0B  1.2500KB  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [33]
427.05ms  7.5850us           (1024 1 1)       (256 1 1)        16        0B  1.2500KB  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [34]
427.05ms  7.3280us           (1024 1 1)       (256 1 1)        16        0B  1.2500KB  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [35]
427.06ms  7.1690us           (1024 1 1)       (256 1 1)        16        0B  1.2500KB  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [36]
427.07ms  7.2000us           (1024 1 1)       (256 1 1)        16        0B  1.2500KB  NVIDIA GeForce          1        13                     -                -  reduction_2d_static_dispatch_0_generic_1024x1024 [37]
```