### PR TITLE
Add a matcher predicate checking for completeness

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -348,23 +348,6 @@ static FailureOr<GPUReductionStrategyInfos> matchGPUReduction(
   makeReductionMatcher(reduction, fill, leading, trailing, captures);
   if (!matchPattern(op, reduction)) return failure();
 
-  //
-  // !!We must match exactly all payload ops when the dispatch is pre-formed!!
-  //
-  int64_t mustMatchNumPayloadOps =
-      transform_ext::getNumPayloadOpsThatWeMustMatch(
-          op->getParentOfType<func::FuncOp>());
-  int64_t numMatchedOps = 2;  // Mandatory operations.
-  if (leading.getCaptured()) ++numMatchedOps;
-  if (trailing.getCaptured()) ++numMatchedOps;
-  if (numMatchedOps != mustMatchNumPayloadOps) {
-    LLVM_DEBUG({
-      DBGS() << "Failed to match " << mustMatchNumPayloadOps
-             << " payload ops, matched " << numMatchedOps << " instead\n";
-    });
-    return failure();
-  }
-
   GPUReductionStrategyInfos info(op->getContext(), captures.rank,
                                  captures.reductionDimensionSize);
 

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -146,6 +146,7 @@ cc_library(
     deps = [
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:Rewrite",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
@@ -82,29 +82,6 @@ public:
   StructuredTransformOpsExtension();
 };
 
-//===---------------------------------------------------------------------===//
-// IMPORTANT WARNING FOR ALL MATCH CALLBACK OPS !!!
-//===---------------------------------------------------------------------===//
-// We need to temporarily encode additional constraints in C++ that we
-// cannot yet express in the Matchers.
-//
-// These extra constraints are necessary because of the layering IREE
-// imposes on us: the dispatch regions are already pre-formed and we must
-// match **exactly** (best effort..) to avoid leaving dangling payload IR
-// in the dispatch that is not transformed (and leads to catastrophic
-// performance bugs or even miscompiles).
-// A future more robust system will let us form our own dispatches and we
-// won't need to be as strict on matching **exactly**.
-//
-// It is important that these additional C++ constraints can all be
-// expressed as separable matchers (and in the future as contraint IR).
-//
-// In the following, we make the assumption that TilingInterface ops are
-// exactly the payload ops that we must not miss.
-// This is best effort and if anything else must not be missed, it should also
-// be added here.
-int64_t getNumPayloadOpsThatWeMustMatch(Operation *root);
-
 } // namespace transform_ext
 } // namespace mlir
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -497,7 +497,7 @@ void ::transform_ext::CanonicalizedSequenceOp::build(
     OpBuilder &builder, OperationState &state,
     transform::FailurePropagationMode failurePropagationMode,
     ::transform_ext::CanonicalizedSequenceOp::BodyBuilderFn bodyBuilder) {
-  assert(state.name.isRegistered() && "not registered!!");
+  assert(state.name.isRegistered() && "not registered!");
   assert(bodyBuilder && "requires a body builder");
   MLIRContext *ctx = builder.getContext();
   state.addAttribute(
@@ -1208,33 +1208,6 @@ testMatchCallbackCallback(transform_ext::MatchCallbackResult &res, Location loc,
   return DiagnosedSilenceableFailure::success();
 }
 
-//===---------------------------------------------------------------------===//
-// IMPORTANT WARNING FOR ALL MATCH CALLBACK OPS !!!
-//===---------------------------------------------------------------------===//
-// We need to temporarily encode additional constraints in C++ that we
-// cannot yet express in the Matchers.
-//
-// These extra constraints are necessary because of the layering IREE
-// imposes on us: the dispatch regions are already pre-formed and we must
-// match **exactly** (best effort..) to avoid leaving dangling payload IR
-// in the dispatch that is not transformed (and leads to catastrophic
-// performance bugs or even miscompiles).
-// A future more robust system will let us form our own dispatches and we
-// won't need to be as strict on matching **exactly**.
-//
-// It is important that these additional C++ constraints can all be
-// expressed as separable matchers (and in the future as contraint IR).
-//
-// In the following, we make the assumption that TilingInterface ops are
-// exactly the payload ops that we must not miss.
-// This is best effort and if anything else must not be missed, it should also
-// be added here.
-int64_t transform_ext::getNumPayloadOpsThatWeMustMatch(Operation *root) {
-  int64_t mustMatchNumPayloadOps = 0;
-  root->walk([&](TilingInterface op) { mustMatchNumPayloadOps++; });
-  return mustMatchNumPayloadOps;
-}
-
 /// Match callback for a reduction with optional leading and trailing
 /// elementwise operations. Matches *the first* occurrence of such a reduction
 /// within an op associated with the given handle.
@@ -1266,12 +1239,6 @@ reductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
   // potentially with list matches for each group.
   Operation *root = state.getPayloadOps(handles[0])[0];
 
-  //
-  // !!We must match exactly all payload ops when the dispatch is pre-formed!!
-  //
-  int64_t mustMatchNumPayloadOps =
-      transform_ext::getNumPayloadOpsThatWeMustMatch(root);
-
   WalkResult walkResult = root->walk([&](Operation *op) {
     pattern.resetCapture();
     if (!matchPattern(op, pattern))
@@ -1288,22 +1255,6 @@ reductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
       if (trailing.getCaptured())
         DBGS() << trailing.getCaptured() << "\n";
     });
-
-    //
-    // !!We must match exactly all payload ops when the dispatch is pre-formed!!
-    //
-    int64_t numMatchedOps = 2; // Mandatory operations.
-    if (leading.getCaptured())
-      ++numMatchedOps;
-    if (trailing.getCaptured())
-      ++numMatchedOps;
-    if (numMatchedOps != mustMatchNumPayloadOps) {
-      LLVM_DEBUG({
-        DBGS() << "Failed to match " << mustMatchNumPayloadOps
-               << " payload ops, matched " << numMatchedOps << " instead\n";
-      });
-      return WalkResult::advance();
-    }
 
     res.addPotentiallyEmptyPayloadGroup(leading.getCaptured());
     res.addPayloadGroup({fill.getCaptured()});
@@ -1351,12 +1302,6 @@ splitReductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
   // potentially with list matches for each group.
   Operation *root = state.getPayloadOps(handles[0])[0];
 
-  //
-  // !!We must match exactly all payload ops when the dispatch is pre-formed!!
-  //
-  int64_t mustMatchNumPayloadOps =
-      transform_ext::getNumPayloadOpsThatWeMustMatch(root);
-
   WalkResult walkResult = root->walk([&](Operation *op) {
     combiner_reduction.resetCapture();
     if (!matchPattern(op, combiner_reduction))
@@ -1377,22 +1322,6 @@ splitReductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
       if (trailing.getCaptured())
         DBGS() << trailing.getCaptured() << "\n";
     });
-
-    //
-    // !!We must match exactly all payload ops when the dispatch is pre-formed!!
-    //
-    int64_t numMatchedOps = 4; // Mandatory operations.
-    if (leading.getCaptured())
-      ++numMatchedOps;
-    if (trailing.getCaptured())
-      ++numMatchedOps;
-    if (numMatchedOps != mustMatchNumPayloadOps) {
-      LLVM_DEBUG({
-        DBGS() << "Failed to match " << mustMatchNumPayloadOps
-               << " payload ops, matched " << numMatchedOps << " instead\n";
-      });
-      return WalkResult::advance();
-    }
 
     res.addPotentiallyEmptyPayloadGroup(leading.getCaptured());
     res.addPayloadGroup({original_fill.getCaptured()});

--- a/llvm-external-projects/iree-dialects/lib/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/CMakeLists.txt
@@ -4,11 +4,12 @@ add_mlir_library(IREEDialectsTransforms
   ListenerCSE.cpp
   ListenerGreedyPatternRewriteDriver.cpp
   TransformMatchers.cpp
-  
+
   LINK_LIBS PRIVATE
   # TODO: break dialect dependency by implementing the transformation separately
   # and registering it.
   MLIRAsyncDialect
+  MLIRFuncDialect
   MLIRLinalgDialect
   MLIRLinalgTransforms
 

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -7,6 +7,7 @@
 #include "iree-dialects/Transforms/TransformMatchers.h"
 
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 
 using namespace mlir;
@@ -488,7 +489,8 @@ void transform_ext::makeReductionMatcher(
   // TODO: careful about multi-output and turning into a contraction.
   //
   trailing = leading;
-  reduction = reduction.result(0, HasAnyUse(), trailing, OptionalMatch());
+  reduction = reduction.result(0, HasAnyUse(), trailing, OptionalMatch())
+                  .allTilableOpsCaptured<func::FuncOp>();
 }
 
 void transform_ext::makeSplitReductionMatcher(
@@ -529,5 +531,6 @@ void transform_ext::makeSplitReductionMatcher(
           .output(0, SubsetOf(original_fill))
           .output(0, ElementTypeBitWidth(32))
           .output(0, SingleCombinerReduction())
-          .result(0, HasAnyUse(), SubsetOf(trailing), OptionalMatch());
+          .result(0, HasAnyUse(), SubsetOf(trailing), OptionalMatch())
+          .allTilableOpsCaptured<func::FuncOp>();
 }

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -381,6 +381,7 @@ transform_ext::StructuredOpMatcher &transform_ext::StructuredOpMatcher::result(
         traverseSubsetsForwardAnyUse(linalgOp->getResult(transformedPosition));
     return subset.matcher.match(user) || optional.value;
   });
+  recordNestedMatcher(subset.matcher);
   return *this;
 }
 


### PR DESCRIPTION
To avoid performance bugs, we have been checking that the matcher captured all operations in a function / dispatch region via an ad-hoc mechanism. Move that into a matcher predicate and make it more robust to duplicate captures.