### PR TITLE
Preserve `encoding` attr on `PackOp` for `TileAndDistributeToWorkgroups`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/materialize_encoding.mlir
@@ -41,7 +41,8 @@ func.func @set_encoding_op() {
 //  CHECK-SAME:       !flow.dispatch.tensor<writeonly:tensor<?x?x8x4xf32>>{%[[TILED_OUTD0]], %[[TILED_OUTD1]]}
 //       CHECK:   %[[INPUT:.+]] = flow.dispatch.tensor.load %[[INPUT_BINDING]]
 //       CHECK:   %[[EMPTY:.+]] = tensor.empty(%[[TILED_OUTD0]], %[[TILED_OUTD1]])
-//       CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack %[[INPUT]] padding_value(%[[CST]] : f32)
+//       CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack
+//  CHECK-SAME:       %[[INPUT]] padding_value(%[[CST]] : f32)
 //  CHECK-SAME:       inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[EMPTY]]
 //       CHECK:   flow.dispatch.tensor.store %[[PACK]], %[[OUTPUT_BINDING]]
 //  CHECK-SAME:       offsets = [0, 0, 0, 0], sizes = [%[[TILED_OUTD0]], %[[TILED_OUTD1]], 8, 4], strides = [1, 1, 1, 1]

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2217,6 +2217,19 @@ SmallVector<Operation *>
 UnPackOp::getTiledImplementation(OpBuilder &builder,
                                  ArrayRef<OpFoldResult> offsets,
                                  ArrayRef<OpFoldResult> sizes) {
+  Operation *unpackOp = *this;
+  // Dynamic inner tile sizes currently trigger infinite application of
+  // tile-and-distribute on the unpack op, each tile calling
+  // getTiledImplementation -> getSlice creating more and more extract_slice.
+  // As a temporary work-around, we annotate unpack ops with a custom
+  // already_tiled attribute to keep track of what's already been tiled.
+  // For some reason this causes errors in non-dynamic-shape cases, but it's
+  // not needed there anyway, so we simply check for dynamic inner tiles before
+  // applying this tweak.
+  if (ShapedType::isDynamicShape(getStaticInnerTiles())) {
+    if (unpackOp->hasAttr("already_tiled"))
+      return {unpackOp};
+  }
   // TODO(hanchung): Extend it to handle memref version.
   // Tiling on buffers needs extra buffer because tiled unpack op could produce
   // more data for incomplete tiles. Tiling on tensors satisfies IREE's needs.
@@ -2368,6 +2381,8 @@ UnPackOp::getTiledImplementation(OpBuilder &builder,
 
   Operation *tiledUnpackOp =
       mlir::clone(builder, getOperation(), tiledResultTypes, tiledOperands);
+  tiledUnpackOp->setAttr(StringAttr::get(getContext(), "already_tiled"),
+                         BoolAttr::get(getContext(), true));
 
   if (isPerfectTilingCase)
     return {tiledUnpackOp};

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding.mlir
@@ -16,7 +16,8 @@ func.func @pack_unpack_gemm_lhs(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
 //  CHECK-DAG:   %[[OUTER_D0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
 //  CHECK-DAG:   %[[OUTER_D1:.+]] = affine.apply #[[MAP1]]()[%[[D1]]]
 //      CHECK:   %[[PACK_DEST:.+]] = tensor.empty(%[[OUTER_D0]], %[[OUTER_D1]]) : tensor<?x?x8x4xf32>
-//      CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[PACK_DEST]]
+//      CHECK:   %[[PACK:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[PACK_DEST]]
 //      CHECK:   %[[UNPACK_DEST:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32>
 //      CHECK:   %[[UNPACK:.+]] = iree_linalg_ext.unpack %[[PACK]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[UNPACK_DEST]]
 //      CHECK:   return %[[UNPACK]]
@@ -29,7 +30,8 @@ func.func @pack_unpack_gemm_rhs(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   return %1 : tensor<?x?xf32>
 }
 // CHECK-LABEL: func @pack_unpack_gemm_rhs(
-//       CHECK:   linalg_ext.pack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [4, 8]
+//       CHECK:   linalg_ext.pack
+//  CHECK-SAME:     inner_dims_pos = [0, 1] inner_tiles = [4, 8]
 //       CHECK:   linalg_ext.unpack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [4, 8]
 
 // -----
@@ -40,7 +42,8 @@ func.func @pack_unpack_gemm_rhs_transpose(%arg0 : tensor<?x?xf32>) -> tensor<?x?
   return %1 : tensor<?x?xf32>
 }
 // CHECK-LABEL: func @pack_unpack_gemm_rhs_transpose(
-//       CHECK:   linalg_ext.pack %{{.+}} outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4]
+//       CHECK:   linalg_ext.pack
+//  CHECK-SAME:     outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4]
 //       CHECK:   linalg_ext.unpack %{{.+}} outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4]
 
 // -----
@@ -51,7 +54,8 @@ func.func @pack_unpack_gemm_result(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   return %1 : tensor<?x?xf32>
 }
 // CHECK-LABEL: func @pack_unpack_gemm_result(
-//       CHECK:   linalg_ext.pack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [8, 8]
+//       CHECK:   linalg_ext.pack
+//  CHECK-SAME:     inner_dims_pos = [0, 1] inner_tiles = [8, 8]
 //       CHECK:   linalg_ext.unpack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [8, 8]
 
 // -----
@@ -85,13 +89,16 @@ func.func @pack_gemm(%arg0 : tensor<100x250xf32>, %arg1 : tensor<250x500xf32>, %
 // CHECK-SAME:     %[[ARG2:.+]]: tensor<100x500xf32>
 //      CHECK:   %[[CST:.+]] = arith.constant 0.0
 //      CHECK:   %[[INIT_LHS:.+]] = tensor.empty() : tensor<13x63x8x4xf32>
-//      CHECK:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack %[[ARG0]] padding_value(%[[CST]] : f32)
+//      CHECK:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG0]] padding_value(%[[CST]] : f32)
 // CHECK-SAME:       into %[[INIT_LHS]]
 //      CHECK:   %[[INIT_RHS:.+]] = tensor.empty() : tensor<63x63x8x4xf32>
-//      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack %[[ARG1]] padding_value(%[[CST]] : f32)
+//      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG1]] padding_value(%[[CST]] : f32)
 // CHECK-SAME:       into %[[INIT_RHS]]
 //      CHECK:   %[[INIT_RESULT:.+]] = tensor.empty() : tensor<13x63x8x8xf32>
-//      CHECK:   %[[PACK_RESULT:.+]] = iree_linalg_ext.pack %[[ARG2]] padding_value(%[[CST]] : f32)
+//      CHECK:   %[[PACK_RESULT:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG2]] padding_value(%[[CST]] : f32)
 // CHECK-SAME:       into %[[INIT_RESULT]]
 //      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
 // CHECK-SAME:       ins(%[[PACK_LHS]], %[[PACK_RHS]] :
@@ -116,9 +123,12 @@ func.func @pack_gemm_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32>
-//      CHECK:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack %[[ARG0]]
-//      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack %[[ARG1]]
-//      CHECK:   %[[PACK_RESULT:.+]] = iree_linalg_ext.pack %[[ARG2]]
+//      CHECK:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG0]]
+//      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG1]]
+//      CHECK:   %[[PACK_RESULT:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG2]]
 //      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
 // CHECK-SAME:       ins(%[[PACK_LHS]], %[[PACK_RHS]] :
 // CHECK-SAME:       outs(%[[PACK_RESULT]] :
@@ -153,9 +163,10 @@ func.func @pack_gemm_fill_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf3
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[OUT_D0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
-//  CHECK-DAG:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack %[[ARG0]]
-//  CHECK-DAG:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack %[[ARG1]]
 //  CHECK-DAG:   %[[OUT_D1:.+]] = affine.apply #[[MAP0]]()[%[[D1]]]
+//  CHECK-DAG:   %[[PACK_LHS:.+]] = iree_linalg_ext.pack {{.*}}%[[ARG0]]
+//      CHECK:   %[[PACK_RHS:.+]] = iree_linalg_ext.pack
+// CHECK-SAME:     %[[ARG1]]
 //  CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[OUT_D0]], %[[OUT_D1]]) : tensor<?x?x8x8xf32>
 //      CHECK:   %[[FILL:.+]] = linalg.fill
 // CHECK-SAME:       outs(%[[EMPTY]] :

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
@@ -1153,7 +1153,7 @@ func.func @NCnc_to_NC(%input: tensor<8x8x32x16xf32>, %output: tensor<256x128xf32
 // CHECK-SAME:        : tensor<8x8x32x16xf32> to tensor<?x?x32x16xf32>
 // CHECK:             %[[EMPTY:.+]] = tensor.empty
 // CHECK:             %[[UNPACK:.+]] = iree_linalg_ext.unpack
-// CHECK-SAME:          {__internal_linalg_transform__ = "tiling_pack_output"}
+// CHECK-SAME:          {__internal_linalg_transform__ = "tiling_pack_output"
 // CHECK-SAME:          %[[SLICE]] inner_dims_pos = [0, 1] inner_tiles = [32, 16]
 // CHECK-SAME:          into %[[EMPTY]]
 // CHECK:             %[[UNPACK_SLICE:.+]] = tensor.extract_slice %[[UNPACK]]


### PR DESCRIPTION
During `TileAndDistributeToWorkgroups`, in the case of dynamic tile sizes, the `LowerDispatchWorkgroupCountFromSetEncodingOp` pattern needs to call `materializeEncodingValueFn`, passing it a tensor type, expecting that tensor type to have a `TensorEncodingAttr`. The problem is that `MaterializeEncodingPass` has already run, rewriting the `SetEncoding` op and its result tensor, which used to hold the `TensorEncodingAttr`, into a `PackOp` op, whose new result tensor does not anymore have a `TensorEncodingAttr`.

As a work-around for that, we make `MaterializeEncoding` preserve the `TensorEncodingAttr` as an attribute on the `PackOp` itself, so `TileAndDistributeToWorkgroups` can read it and reconstruct a `tensorTypeWithEncoding`, so `LowerDispatchWorkgroupCountFromSetEncodingOp` can call `materializeEncodingValueFn`.