### PR TITLE
Support exporting configs for compilation statistics

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,7 +64,7 @@ jobs:
           BENCHMARK_PRESETS: ${{ inputs.benchmark-presets }}
         run: |
           ./build_tools/benchmarks/export_benchmark_config.py \
-            benchmark \
+            execution \
             --benchmark_presets="${BENCHMARK_PRESETS}" \
             --output="${BENCHMARK_CONFIG}"
           echo "benchmark-config=${BENCHMARK_CONFIG}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -64,6 +64,7 @@ jobs:
           BENCHMARK_PRESETS: ${{ inputs.benchmark-presets }}
         run: |
           ./build_tools/benchmarks/export_benchmark_config.py \
+            benchmark \
             --benchmark_presets="${BENCHMARK_PRESETS}" \
             --output="${BENCHMARK_CONFIG}"
           echo "benchmark-config=${BENCHMARK_CONFIG}" >> "${GITHUB_OUTPUT}"

--- a/build_tools/benchmarks/CMakeLists.txt
+++ b/build_tools/benchmarks/CMakeLists.txt
@@ -47,3 +47,10 @@ benchmark_tool_py_test(
   SRC
     "collect_compilation_statistics_test.py"
 )
+
+benchmark_tool_py_test(
+  NAME
+    export_benchmark_config_test
+  SRC
+    "export_benchmark_config_test.py"
+)

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -4,9 +4,9 @@
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-"""Exports JSON config for benchmarking.
+"""Exports JSON config for benchmarking and compilation statistics.
 
-The exported JSON is a list of object:
+Export type: "benchmark" outputs a list of object:
 [
   <target device name>: {
     host_environment: HostEnvironment,
@@ -15,6 +15,11 @@ The exported JSON is a list of object:
   },
   ...
 ]
+Designed to be used in build_tools/benchmarks/run_benchmarks_on_*.py
+
+Export type: "compile-stats" outputs a serialized list of
+iree_definitions.ModuleGenerationConfig defined for compilation statistics.
+Designed to be used in build_tools/benchmarks/collect_compilation_statistics.py
 """
 
 import sys
@@ -157,11 +162,11 @@ def _parse_arguments():
   parser = argparse.ArgumentParser(
       description="Export JSON config for benchmarking.")
 
-  subparser = parser.add_subparsers(required=True, title="config type")
+  subparser = parser.add_subparsers(required=True, title="export type")
   benchmark_parser = subparser.add_parser(
       "benchmark",
       parents=[subparser_base],
-      help="Export config to run benchmarks.")
+      help="Export benchmark run config to run benchmarks.")
   benchmark_parser.set_defaults(handler=_benchmark_handler)
   benchmark_parser.add_argument(
       "--target_device_names",
@@ -178,7 +183,8 @@ def _parse_arguments():
   compile_stats_parser = subparser.add_parser(
       "compile-stats",
       parents=[subparser_base],
-      help="Export config to collect compilation statistics.")
+      help=("Export serialized list of module generation configs defined for "
+            "compilation statistics."))
   compile_stats_parser.set_defaults(handler=_compile_stats_handler)
 
   return parser.parse_args()

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -28,11 +28,12 @@ import pathlib
 # Add build_tools python dir to the search path.
 sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
+from typing import Callable, Dict, List, Optional, Set
 import argparse
 import collections
 import dataclasses
 import json
-from typing import Callable, Dict, List, Optional, Set
+import textwrap
 
 from benchmark_suites.iree import benchmark_collections
 from e2e_test_artifacts import iree_artifacts
@@ -160,7 +161,23 @@ def _parse_arguments():
                               help="Path to write the JSON output.")
 
   parser = argparse.ArgumentParser(
-      description="Export JSON config for benchmarking.")
+      formatter_class=argparse.RawDescriptionHelpFormatter,
+      description=textwrap.dedent("""
+      Export type: "benchmark" outputs a list of object:
+      [
+        <target device name>: {
+          host_environment: HostEnvironment,
+          module_dir_paths: [<paths of dependent module directories>],
+          run_configs: [E2EModelRunConfig]
+        },
+        ...
+      ]
+      Designed to be used in build_tools/benchmarks/run_benchmarks_on_*.py
+
+      Export type: "compile-stats" outputs a serialized list of
+      iree_definitions.ModuleGenerationConfig defined for compilation statistics.
+      Designed to be used in build_tools/benchmarks/collect_compilation_statistics.py
+      """))
 
   subparser = parser.add_subparsers(required=True, title="export type")
   benchmark_parser = subparser.add_parser(

--- a/build_tools/benchmarks/export_benchmark_config_test.py
+++ b/build_tools/benchmarks/export_benchmark_config_test.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import unittest
+
+from e2e_test_framework.definitions import common_definitions, iree_definitions
+import export_benchmark_config
+
+COMMON_MODEL = common_definitions.Model(
+    id="tflite",
+    name="model_tflite",
+    tags=[],
+    source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
+    source_url="",
+    entry_function="predict",
+    input_types=["1xf32"])
+COMMON_GEN_CONFIG = iree_definitions.ModuleGenerationConfig(
+    imported_model=iree_definitions.ImportedModel.from_model(COMMON_MODEL),
+    compile_config=iree_definitions.CompileConfig(id="1",
+                                                  tags=[],
+                                                  compile_targets=[]))
+COMMON_EXEC_CONFIG = iree_definitions.ModuleExecutionConfig(
+    id="exec",
+    tags=[],
+    loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
+    driver=iree_definitions.RuntimeDriver.LOCAL_SYNC)
+
+
+class ExportBenchmarkConfigTest(unittest.TestCase):
+
+  def test_filter_and_group_benchmarks_set_all_filters(self):
+    device_spec_a = common_definitions.DeviceSpec(
+        id="dev_a_cpu",
+        device_name="dev_a_cpu",
+        architecture=common_definitions.DeviceArchitecture.RV64_GENERIC,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    device_spec_b = common_definitions.DeviceSpec(
+        id="dev_a_gpu",
+        device_name="dev_a_gpu",
+        architecture=common_definitions.DeviceArchitecture.MALI_VALHALL,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    device_spec_c = common_definitions.DeviceSpec(
+        id="dev_c",
+        device_name="dev_c",
+        architecture=common_definitions.DeviceArchitecture.CUDA_SM80,
+        host_environment=common_definitions.HostEnvironment.LINUX_X86_64)
+    matched_run_config_a = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_a,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    unmatched_run_config_b = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_b,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    matched_run_config_c = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_c,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    matchers = [(lambda config: config.target_device_spec.architecture.
+                 architecture == "cuda"),
+                (lambda config: config.target_device_spec.host_environment.
+                 platform == "android")]
+
+    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+        run_configs=[
+            matched_run_config_a, unmatched_run_config_b, matched_run_config_c
+        ],
+        target_device_names={"dev_a_cpu", "dev_c"},
+        preset_matchers=matchers)
+
+    self.assertEqual(run_config_map, {
+        "dev_a_cpu": [matched_run_config_a],
+        "dev_c": [matched_run_config_c],
+    })
+
+  def test_filter_and_group_benchmarks_include_all(self):
+    device_spec_a = common_definitions.DeviceSpec(
+        id="dev_a_cpu",
+        device_name="dev_a_cpu",
+        architecture=common_definitions.DeviceArchitecture.RV64_GENERIC,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    device_spec_b = common_definitions.DeviceSpec(
+        id="dev_a_gpu",
+        device_name="dev_a_gpu",
+        architecture=common_definitions.DeviceArchitecture.MALI_VALHALL,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    device_spec_c = common_definitions.DeviceSpec(
+        id="dev_a_second_gpu",
+        device_name="dev_a_gpu",
+        architecture=common_definitions.DeviceArchitecture.ADRENO_GENERIC,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    run_config_a = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_a,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    run_config_b = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_b,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    run_config_c = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_c,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+
+    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+        run_configs=[run_config_a, run_config_b, run_config_c])
+
+    self.maxDiff = 100000
+
+    self.assertEqual(run_config_map, {
+        "dev_a_cpu": [run_config_a],
+        "dev_a_gpu": [run_config_b, run_config_c],
+    })
+
+  def test_filter_and_group_benchmarks_set_target_device_names(self):
+    device_spec_a = common_definitions.DeviceSpec(
+        id="dev_a",
+        device_name="dev_a",
+        architecture=common_definitions.DeviceArchitecture.RV64_GENERIC,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    device_spec_b = common_definitions.DeviceSpec(
+        id="dev_b",
+        device_name="dev_b",
+        architecture=common_definitions.DeviceArchitecture.MALI_VALHALL,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    run_config_a = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_a,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    run_config_b = iree_definitions.E2EModelRunConfig(
+        module_generation_config=COMMON_GEN_CONFIG,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_b,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+
+    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+        run_configs=[run_config_a, run_config_b],
+        target_device_names={"dev_a", "dev_b"})
+
+    self.assertEqual(run_config_map, {
+        "dev_a": [run_config_a],
+        "dev_b": [run_config_b],
+    })
+
+  def test_filter_and_group_benchmarks_set_preset_matchers(self):
+    small_model = common_definitions.Model(
+        id="small_model",
+        name="small_model",
+        tags=[],
+        source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
+        source_url="",
+        entry_function="predict",
+        input_types=["1xf32"])
+    big_model = common_definitions.Model(
+        id="big_model",
+        name="big_model",
+        tags=[],
+        source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
+        source_url="",
+        entry_function="predict",
+        input_types=["1xf32"])
+    compile_config = iree_definitions.CompileConfig(id="1",
+                                                    tags=[],
+                                                    compile_targets=[])
+    small_gen_config = iree_definitions.ModuleGenerationConfig(
+        imported_model=iree_definitions.ImportedModel.from_model(small_model),
+        compile_config=compile_config)
+    big_gen_config = iree_definitions.ModuleGenerationConfig(
+        imported_model=iree_definitions.ImportedModel.from_model(big_model),
+        compile_config=compile_config)
+    device_spec_a = common_definitions.DeviceSpec(
+        id="dev_a",
+        device_name="dev_a",
+        architecture=common_definitions.DeviceArchitecture.RV64_GENERIC,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    device_spec_b = common_definitions.DeviceSpec(
+        id="dev_b",
+        device_name="dev_b",
+        architecture=common_definitions.DeviceArchitecture.MALI_VALHALL,
+        host_environment=common_definitions.HostEnvironment.ANDROID_ARMV8_2_A)
+    run_config_a = iree_definitions.E2EModelRunConfig(
+        module_generation_config=small_gen_config,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_a,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+    run_config_b = iree_definitions.E2EModelRunConfig(
+        module_generation_config=big_gen_config,
+        module_execution_config=COMMON_EXEC_CONFIG,
+        target_device_spec=device_spec_b,
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+
+    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+        run_configs=[run_config_a, run_config_b],
+        preset_matchers=[
+            lambda config: config.module_generation_config.imported_model.model.
+            id == "small_model"
+        ])
+
+    self.assertEqual(run_config_map, {
+        "dev_a": [run_config_a],
+    })
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/build_tools/benchmarks/export_benchmark_config_test.py
+++ b/build_tools/benchmarks/export_benchmark_config_test.py
@@ -32,7 +32,7 @@ COMMON_EXEC_CONFIG = iree_definitions.ModuleExecutionConfig(
 
 class ExportBenchmarkConfigTest(unittest.TestCase):
 
-  def test_filter_and_group_benchmarks_set_all_filters(self):
+  def test_filter_and_group_run_configs_set_all_filters(self):
     device_spec_a = common_definitions.DeviceSpec(
         id="dev_a_cpu",
         device_name="dev_a_cpu",
@@ -68,7 +68,7 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
                 (lambda config: config.target_device_spec.host_environment.
                  platform == "android")]
 
-    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+    run_config_map = export_benchmark_config.filter_and_group_run_configs(
         run_configs=[
             matched_run_config_a, unmatched_run_config_b, matched_run_config_c
         ],
@@ -80,7 +80,7 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         "dev_c": [matched_run_config_c],
     })
 
-  def test_filter_and_group_benchmarks_include_all(self):
+  def test_filter_and_group_run_configs_include_all(self):
     device_spec_a = common_definitions.DeviceSpec(
         id="dev_a_cpu",
         device_name="dev_a_cpu",
@@ -112,7 +112,7 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         target_device_spec=device_spec_c,
         input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
 
-    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+    run_config_map = export_benchmark_config.filter_and_group_run_configs(
         run_configs=[run_config_a, run_config_b, run_config_c])
 
     self.maxDiff = 100000
@@ -122,7 +122,7 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         "dev_a_gpu": [run_config_b, run_config_c],
     })
 
-  def test_filter_and_group_benchmarks_set_target_device_names(self):
+  def test_filter_and_group_run_configs_set_target_device_names(self):
     device_spec_a = common_definitions.DeviceSpec(
         id="dev_a",
         device_name="dev_a",
@@ -144,7 +144,7 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         target_device_spec=device_spec_b,
         input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
 
-    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+    run_config_map = export_benchmark_config.filter_and_group_run_configs(
         run_configs=[run_config_a, run_config_b],
         target_device_names={"dev_a", "dev_b"})
 
@@ -153,7 +153,7 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         "dev_b": [run_config_b],
     })
 
-  def test_filter_and_group_benchmarks_set_preset_matchers(self):
+  def test_filter_and_group_run_configs_set_preset_matchers(self):
     small_model = common_definitions.Model(
         id="small_model",
         name="small_model",
@@ -200,7 +200,7 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         target_device_spec=device_spec_b,
         input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
 
-    run_config_map = export_benchmark_config.filter_and_group_benchmarks(
+    run_config_map = export_benchmark_config.filter_and_group_run_configs(
         run_configs=[run_config_a, run_config_b],
         preset_matchers=[
             lambda config: config.module_generation_config.imported_model.model.


### PR DESCRIPTION
Adds a new command `compile-stats` to export module generation configs which are defined for compilation statistics. The exported JSON is designed to be used with `build_tools/benchmarks/collect_compilation_statistics.py`

benchmarks: cuda