### PR TITLE
Replace OrderedDict with dict

### DIFF
--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -7,7 +7,6 @@
 
 from dataclasses import dataclass
 from typing import Dict, List, Sequence
-import collections
 import pathlib
 
 from benchmark_suites.iree import benchmark_collections
@@ -203,7 +202,7 @@ def generate_rules(
 
   rule_builder = IreeRuleBuilder(package_name=package_name)
 
-  all_imported_models = collections.OrderedDict(
+  all_imported_models = dict(
       (config.imported_model.model.id, config.imported_model)
       for config in module_generation_configs)
 

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
@@ -6,8 +6,7 @@
 """Generates CMake rules to fetch model artifacts."""
 
 from dataclasses import dataclass
-from typing import Iterable, List, OrderedDict
-import collections
+from typing import Dict, Iterable, List
 import pathlib
 import urllib.parse
 
@@ -25,10 +24,10 @@ class ModelRule(object):
 
 def generate_model_rule_map(
     root_path: pathlib.PurePath,
-    models: Iterable[common_definitions.Model]) -> OrderedDict[str, ModelRule]:
+    models: Iterable[common_definitions.Model]) -> Dict[str, ModelRule]:
   """Returns the model rules keyed by model id in an ordered map."""
 
-  model_rules = collections.OrderedDict()
+  model_rules = {}
   for model in models:
     # Model target: <package_name>-model-<model_id>
     target_name = f"model-{model.id}"

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -5,8 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Helpers that generates paths for IREE artifacts."""
 
-from typing import Iterable, OrderedDict
-import collections
+from typing import Dict, Iterable
 import pathlib
 
 from e2e_test_artifacts import model_artifacts
@@ -68,8 +67,7 @@ def get_module_dir_path(
 
 def get_dependent_model_map(
     module_generation_configs: Iterable[iree_definitions.ModuleGenerationConfig]
-) -> OrderedDict[str, common_definitions.Model]:
+) -> Dict[str, common_definitions.Model]:
   """Returns an ordered map of the dependent models keyed by model id."""
-  return collections.OrderedDict(
-      (config.imported_model.model.id, config.imported_model.model)
-      for config in module_generation_configs)
+  return dict((config.imported_model.model.id, config.imported_model.model)
+              for config in module_generation_configs)

--- a/build_tools/python/e2e_test_framework/serialization_test.py
+++ b/build_tools/python/e2e_test_framework/serialization_test.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import List, Optional
 import json
 import pathlib
-import collections
 import enum
 import typing
 import unittest
@@ -81,25 +80,31 @@ class SerializationTest(unittest.TestCase):
     self.maxDiff = None
     self.assertEqual(
         results, {
-            "main_obj": [
-                collections.OrderedDict(
-                    b_list=["id_a", "id_b"],
-                    c_obj=collections.OrderedDict(float_val=0.1),
-                    str_val="test1",
-                    enum_val="OPTION_B"),
-                collections.OrderedDict(
-                    b_list=["id_a"],
-                    c_obj=collections.OrderedDict(float_val=0.2),
-                    str_val=None,
-                    enum_val="OPTION_C")
-            ],
-            "obj_map":
-                collections.OrderedDict({
-                    "test_b:id_a":
-                        collections.OrderedDict(key="id_a", int_val=10),
-                    "test_b:id_b":
-                        collections.OrderedDict(key="id_b", int_val=20)
-                })
+            "main_obj": [{
+                "b_list": ["id_a", "id_b"],
+                "c_obj": {
+                    "float_val": 0.1
+                },
+                "str_val": "test1",
+                "enum_val": "OPTION_B"
+            }, {
+                "b_list": ["id_a"],
+                "c_obj": {
+                    "float_val": 0.2
+                },
+                "str_val": None,
+                "enum_val": "OPTION_C"
+            }],
+            "obj_map": {
+                "test_b:id_a": {
+                    "key": "id_a",
+                    "int_val": 10
+                },
+                "test_b:id_b": {
+                    "key": "id_b",
+                    "int_val": 20
+                }
+            }
         })
 
   def test_serialize_and_pack_with_unsupported_type(self):
@@ -109,8 +114,7 @@ class SerializationTest(unittest.TestCase):
 
   def test_serialize_and_pack_with_unsupported_dict_key(self):
     self.assertRaises(
-        ValueError, lambda: serialization.serialize_and_pack(
-            collections.OrderedDict({(0, 0): "test"})))
+        ValueError, lambda: serialization.serialize_and_pack({(0, 0): "test"}))
 
   def test_serialize_and_pack_with_circular_reference(self):
     obj_a = TestCircularReference(id="0", child=None)
@@ -147,14 +151,14 @@ class SerializationTest(unittest.TestCase):
     b_obj_a = TestB(key="id_a", int_val=10)
     b_obj_b = TestB(key="id_b", int_val=20)
 
-    objs = collections.OrderedDict(
-        x=b_obj_a,
-        y=b_obj_b,
-    )
+    objs = {
+        "x": b_obj_a,
+        "y": b_obj_b,
+    }
 
     json_str = json.dumps(serialization.serialize_and_pack(objs))
-    results = serialization.unpack_and_deserialize(
-        json.loads(json_str), typing.OrderedDict[str, TestB])
+    results = serialization.unpack_and_deserialize(json.loads(json_str),
+                                                   typing.Dict[str, TestB])
 
     self.assertEqual(results, objs)
 

--- a/build_tools/python/e2e_test_framework/serialization_test.py
+++ b/build_tools/python/e2e_test_framework/serialization_test.py
@@ -80,30 +80,19 @@ class SerializationTest(unittest.TestCase):
     self.maxDiff = None
     self.assertEqual(
         results, {
-            "main_obj": [{
-                "b_list": ["id_a", "id_b"],
-                "c_obj": {
-                    "float_val": 0.1
-                },
-                "str_val": "test1",
-                "enum_val": "OPTION_B"
-            }, {
-                "b_list": ["id_a"],
-                "c_obj": {
-                    "float_val": 0.2
-                },
-                "str_val": None,
-                "enum_val": "OPTION_C"
-            }],
+            "main_obj": [
+                dict(b_list=["id_a", "id_b"],
+                     c_obj=dict(float_val=0.1),
+                     str_val="test1",
+                     enum_val="OPTION_B"),
+                dict(b_list=["id_a"],
+                     c_obj=dict(float_val=0.2),
+                     str_val=None,
+                     enum_val="OPTION_C")
+            ],
             "obj_map": {
-                "test_b:id_a": {
-                    "key": "id_a",
-                    "int_val": 10
-                },
-                "test_b:id_b": {
-                    "key": "id_b",
-                    "int_val": 20
-                }
+                "test_b:id_a": dict(key="id_a", int_val=10),
+                "test_b:id_b": dict(key="id_b", int_val=20)
             }
         })
 


### PR DESCRIPTION
Originally I used `OrderedDict` to clearly indicate that the order is preserved. But now it seems to be redundant and a little annoying to me.

The `dict` is ordered since Python 3.7 (https://mail.python.org/pipermail/python-dev/2017-December/151283.html, https://docs.python.org/3/library/stdtypes.html#mapping-types-dict), which is our lowest supported python version.