### PR TITLE
Cloud Run Function for instance self-deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 **/.ipynb_checkpoints/
 .pytype/
+**/__pycache__/**
 
 # Visual Studio files
 .vs/

--- a/build_tools/github_actions/runner/config/health_server/health_server.py
+++ b/build_tools/github_actions/runner/config/health_server/health_server.py
@@ -21,7 +21,7 @@ import argparse
 import http.server
 
 
-class HealthCheckServer(http.server.BaseHTTPRequestHandler):
+class HealthCheckHandler(http.server.BaseHTTPRequestHandler):
 
   def do_GET(self):
     self.send_response(200)
@@ -30,7 +30,7 @@ class HealthCheckServer(http.server.BaseHTTPRequestHandler):
 
 
 def main(args):
-  webServer = http.server.HTTPServer(("", args.port), HealthCheckServer)
+  webServer = http.server.HTTPServer(("", args.port), HealthCheckHandler)
   print(f"Server started on port {args.port}. Ctrl+C to stop.")
 
   try:

--- a/build_tools/github_actions/runner/instance_deleter/main.py
+++ b/build_tools/github_actions/runner/instance_deleter/main.py
@@ -91,7 +91,7 @@ def get_name_from_resource(resource: str) -> str:
   return name
 
 
-def get_from_items(items: google.cloud.compute_v1.types.Items, key: str):
+def get_from_items(items: compute.types.Items, key: str):
   # Why would the GCP Python API return something as silly as a dictionary?
   return next((item.value for item in items if item.key == key), None)
 

--- a/build_tools/github_actions/runner/instance_deleter/main.py
+++ b/build_tools/github_actions/runner/instance_deleter/main.py
@@ -82,7 +82,8 @@ session = requests.Session()
 
 ALLOWED_MIG_PATTERN = os.environ.get("ALLOWED_MIG_PATTERN")
 if ALLOWED_MIG_PATTERN is None:
-  raise RuntimeError("Missing required environemtn variable ALLOWED_MIG_PATTERN")
+  raise RuntimeError(
+      "Missing required environemtn variable ALLOWED_MIG_PATTERN")
 ALLOWED_MIG_REGEX = re.compile(ALLOWED_MIG_PATTERN)
 
 print("Server started")

--- a/build_tools/github_actions/runner/instance_deleter/main.py
+++ b/build_tools/github_actions/runner/instance_deleter/main.py
@@ -62,7 +62,7 @@ See https://cloud.google.com/functions/docs for more details.
 import os
 import re
 from http.client import (BAD_REQUEST, FORBIDDEN, INTERNAL_SERVER_ERROR,
-                         NOT_FOUND)
+                         NOT_FOUND, UNAUTHORIZED)
 
 import flask
 import functions_framework
@@ -138,10 +138,11 @@ def delete_self(request):
 
   auth_header = request.headers.get("Authorization")
   if auth_header is None:
-    return flask.abort(401, "Authorization header is missing")
+    return flask.abort(UNAUTHORIZED, "Authorization header is missing")
   if not auth_header.startswith(AUTH_HEADER_PREFIX):
     return flask.abort(
-        401, f"Authorization header does not start with expected string"
+        UNAUTHORIZED,
+        f"Authorization header does not start with expected string"
         f" {AUTH_HEADER_PREFIX}.")
 
   token = auth_header[len(AUTH_HEADER_PREFIX):]
@@ -153,7 +154,7 @@ def delete_self(request):
     token_payload = _verify_token(token)
   except (ValueError, google.auth.exceptions.GoogleAuthError) as e:
     print(e)
-    return flask.abort(401, "Decoding bearer token failed.")
+    return flask.abort(UNAUTHORIZED, "Decoding bearer token failed.")
 
   print(f"Token payload: {token_payload}")
 
@@ -161,7 +162,8 @@ def delete_self(request):
     compute_info = token_payload["google"]["compute_engine"]
   except KeyError:
     return flask.abort(
-        401, "Bearer token payload does not have expected field google.compute")
+        UNAUTHORIZED,
+        "Bearer token payload does not have expected field google.compute")
 
   project = compute_info["project_id"]
   zone = compute_info["zone"]

--- a/build_tools/github_actions/runner/instance_deleter/main.py
+++ b/build_tools/github_actions/runner/instance_deleter/main.py
@@ -55,9 +55,9 @@ See https://cloud.google.com/functions/docs for more details.
 
 import flask
 import functions_framework
-import google.auth.transport.requests
 import requests
 from google.api_core import exceptions
+from google.auth import transport
 from google.cloud import compute
 from google.oauth2 import id_token
 
@@ -72,7 +72,7 @@ print("Server started")
 
 def verify_token(token: str) -> dict:
   """Verify token signature and return the token payload"""
-  request = google.auth.transport.requests.Request(session)
+  request = transport.requests.Request(session)
   payload = id_token.verify_oauth2_token(token, request=request)
   return payload
 
@@ -91,7 +91,7 @@ def get_name_from_resource(resource: str) -> str:
   return name
 
 
-def get_from_items(items: compute.types.Items, key: str):
+def get_from_items(items: compute.Items, key: str):
   # Why would the GCP Python API return something as silly as a dictionary?
   return next((item.value for item in items if item.key == key), None)
 
@@ -156,7 +156,7 @@ def delete_self(request):
     instance = instances_client.get(instance=instance_name,
                                     project=project,
                                     zone=zone)
-  except google.api_core.exceptions.NotFound as e:
+  except exceptions.NotFound as e:
     print(e)
     return flask.abort(404, "Instance not found")
 

--- a/build_tools/github_actions/runner/instance_deleter/main.py
+++ b/build_tools/github_actions/runner/instance_deleter/main.py
@@ -1,0 +1,211 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""A Cloud Functions proxy enabling GCE VMs in a Managed Instance Group to delete themselves.
+
+GCE Managed instance groups don't have any good way to handle autoscaling for
+long-running workloads. With the autoscaler configured to scale in, instances
+get only 90 seconds warning to shut down. So we set the autoscaler to only scale
+out and have the VMs tear themselves down when they're down with their work.
+This is the approach suggested by the managed instance group team:
+
+https://drive.google.com/file/d/1XlwxF_0T7pUnbzhL5ePDoW-Q3GAaLO11
+
+But anything that brings down the VM other than a delete call to the instance
+group manager API makes the VM get considered "unhealthy", which means it gets
+recreated in exactly the same configuration, regardless of any update or
+autoscaling settings. Making the correct API call requires broad permissions on
+the instance group manager, which we don't want to give the VMs. To scope
+permissions to individual instances, this proxy service makes use of instance
+identity tokens to allow an instance to make a call only to delete itself.
+
+See
+https://cloud.google.com/compute/docs/instances/verifying-instance-identity
+
+This makes use of the GCP Cloud Functions serverless offering. It's another
+level of abstraction on top of Cloud Run, where you don't even need to create your
+own docker container. For local development:
+
+  functions-framework --target=delete_self
+  curl -X DELETE -v --header "Authorization: Bearer $(cat /tmp/token.txt)" localhost:8080
+
+You'll need to get a token that corresponds to an actual instance though or
+you'll get an error:
+
+  gcloud compute ssh github-runner-testing-presubmit-cpu-us-west1-h58j \
+    --user-output-enabled=false \
+    --command "curl -sSfL \
+        -H 'Metadata-Flavor: Google' \
+        'http://metadata/computeMetadata/v1/instance/service-accounts/default/identity?audience=localhost&format=full'" \
+    > /tmp/token.txt
+
+To deploy:
+  gcloud functions deploy instance-self-deleter \
+    --gen2 \
+    --runtime=python310 \
+    --region=us-central1 \
+    --source=. \
+    --entry-point=delete_self \
+    --trigger-http
+
+See https://cloud.google.com/functions/docs for more details.
+"""
+
+import flask
+import functions_framework
+import google.auth.transport.requests
+import requests
+from google.api_core import exceptions
+from google.cloud import compute
+from google.oauth2 import id_token
+
+AUTH_HEADER_PREFIX = "Bearer "
+
+instances_client = compute.InstancesClient()
+migs_client = compute.RegionInstanceGroupManagersClient()
+session = requests.Session()
+
+print("Server started")
+
+
+def verify_token(token: str) -> dict:
+  """Verify token signature and return the token payload"""
+  request = google.auth.transport.requests.Request(session)
+  payload = id_token.verify_oauth2_token(token, request=request)
+  return payload
+
+
+def get_region(zone: str) -> str:
+  """Extract region name from zone name"""
+  # Drop the trailing zone identifier to get the region. Yeah it kinda does seem
+  # like there should be a better way to do this...
+  region, _ = zone.rsplit("-", maxsplit=1)
+  return region
+
+
+def get_name_from_resource(resource: str) -> str:
+  """Extract just the final name component from a fully scoped resource name."""
+  _, name = resource.rsplit("/", maxsplit=1)
+  return name
+
+
+def get_from_items(items: google.cloud.compute_v1.types.Items, key: str):
+  # Why would the GCP Python API return something as silly as a dictionary?
+  return next((item.value for item in items if item.key == key), None)
+
+
+@functions_framework.http
+def delete_self(request):
+  """HTTP Cloud Function.
+    Args:
+        request (flask.Request): The request object.
+        <https://flask.palletsprojects.com/en/1.1.x/api/#incoming-request-data>
+    Returns:
+        The response text, or any set of values that can be turned into a
+        Response object using `make_response`
+        <https://flask.palletsprojects.com/en/1.1.x/api/#flask.make_response>.
+    Note:
+        For more information on how Flask integrates with Cloud
+        Functions, see the `Writing HTTP functions` page.
+        <https://cloud.google.com/functions/docs/writing/http#http_frameworks>
+  """
+  if request.method != "DELETE":
+    return flask.abort(
+        400, f"Invalid method '{request.method}'. Only DELETE is supported.")
+
+  # No path is needed, since the token contains all the information we need.
+  if request.path != "/":
+    return flask.abort(
+        400,
+        f"Invalid request path '{request.path}'. Only root path is valid).")
+
+  auth_header = request.headers.get("Authorization")
+  if auth_header is None:
+    return flask.abort(401, "Authorization header is missing")
+  if not auth_header.startswith(AUTH_HEADER_PREFIX):
+    return flask.abort(
+        401, f"Authorization header does not start with expected string"
+        f" '{AUTH_HEADER_PREFIX}'.")
+
+  token = auth_header[len(AUTH_HEADER_PREFIX):]
+
+  try:
+    # We don't verify audience here because Cloud IAM will have already done so
+    # and jwt's matching of audiences is exact, which means trailing slashes or
+    # http vs https matters and that's pretty brittle.
+    token_payload = verify_token(token)
+  except ValueError as e:
+    print(e)
+    return flask.abort(401, "Decoding bearer token failed.")
+
+  print(f"Token payload: {token_payload}")
+
+  try:
+    compute_info = token_payload["google"]["compute_engine"]
+  except KeyError as e:
+    return flask.abort(
+        401,
+        "Bearer token payload does not have expected field 'google.compute'")
+
+  project = compute_info["project_id"]
+  zone = compute_info["zone"]
+  instance_name = compute_info["instance_name"]
+  try:
+    instance = instances_client.get(instance=instance_name,
+                                    project=project,
+                                    zone=zone)
+  except google.api_core.exceptions.NotFound as e:
+    print(e)
+    return flask.abort(404, "Instance not found")
+
+  instance_id = int(compute_info["instance_id"])
+  # Verify it's *actually* the same instance. Names get reused, but IDs
+  # don't. For some reason you can't reference instances by their ID in any
+  # of the APIs.
+  if instance.id != instance_id:
+    return flask.abort(
+        400,
+        f"Existing instance of the same name '{instance.name}' has a different"
+        f" ID '{instance.id}' than token specifies '{instance_id}'.")
+
+  mig = get_from_items(instance.metadata.items, "created-by")
+
+  if mig is None:
+    return flask.abort(400, "Instance is not part of a managed instance group.")
+  mig = get_name_from_resource(mig)
+
+  try:
+    operation = migs_client.delete_instances(
+        instance_group_manager=mig,
+        project=project,
+        region=get_region(zone),
+        # For some reason we can't just use a list of instance names and need to
+        # build this RhymingRythmicJavaClasses proto. Also, unlike all the other
+        # parameters, the instance has to be a fully-specified URL for the
+        # instance, not just its name.
+        region_instance_group_managers_delete_instances_request_resource=(
+            compute.RegionInstanceGroupManagersDeleteInstancesRequest(
+                instances=[instance.self_link])))
+  except Exception as e:
+    # An error here means we screwed up the syntax of the request. That is
+    # almost certainly a server error
+    return flask.abort(
+        500, f"Error requesting that '{mig}' delete '{instance_name}'.")
+
+  try:
+    result = operation.result()
+  except exceptions.ClientError as e:
+    print(e)
+    # Unpack the actual usable error message
+    msg = f"Error requesting that '{mig}' delete '{instance_name}':" + "".join(
+        ["\n"
+         f"{err.code}: {err.message}" for err in e.response.error.errors])
+    print(msg)
+    # We're not actually totally sure whether this is a client or server error
+    # for the overall request, but let's call it a client error (the only client
+    # here is our VM instances, so I think we can be a bit loose).
+    return flask.abort(400, msg)
+
+  return f"'{instance_name}' has been marked for deletion by '{mig}'."

--- a/build_tools/github_actions/runner/instance_deleter/main_test.py
+++ b/build_tools/github_actions/runner/instance_deleter/main_test.py
@@ -1,0 +1,293 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Note that these tests are not run on CI. Doing so would require adding a ton
+# of extra dependencies and the frequency of code changes here is not worth the
+# extra maintenance burden. Please do run the tests when making changes to the
+# service though.
+
+import json
+import unittest
+from unittest import mock
+
+import google.api_core.exceptions
+import werkzeug.exceptions
+from google.cloud import compute
+from werkzeug.wrappers import Request
+
+import main
+
+# Don't rely on any of the specific values in these
+INVALID_TOKEN = "INVALID_TOKEN"
+ID1 = 1234
+ID2 = 4567
+REGION = "us-central1"
+ZONE = "us-west1-a"
+PROJECT = "iree-oss"
+INSTANCE_LINK_PREFIX = "https://www.googleapis.com/compute/v1/projects/iree-oss/zones/us-east1-b/instances/"
+INSTANCE_NAME = "some_instance_name"
+MIG_PATH_PREFIX = "projects/794014424711/regions/us-north1/instanceGroupManagers/"
+MIG_NAME = "some_mig_name"
+
+
+def get_message(ctx):
+  return ctx.exception.get_response().get_data(as_text=True)
+
+
+# A fake for oauth2 token verification that pretends the encoding scheme is just
+# JSON.
+def fake_verify_oauth2_token(token, request):
+  del request
+  return json.loads(token)
+
+
+def make_token(payload: dict):
+  return json.dumps(payload)
+
+
+@mock.patch("google.oauth2.id_token.verify_oauth2_token",
+            fake_verify_oauth2_token)
+class InstanceDeleterTest(unittest.TestCase):
+
+  def setUp(self):
+    self.addCleanup(mock.patch.stopall)
+    instances_client_patcher = mock.patch("main.instances_client",
+                                          autospec=True)
+    self.instances_client = instances_client_patcher.start()
+    migs_client_patcher = mock.patch("main.migs_client", autospec=True)
+    self.migs_client = migs_client_patcher.start()
+
+  def test_happy_path(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+
+    token = make_token({
+        "google": {
+            "compute_engine": {
+                "project_id": PROJECT,
+                "zone": f"{REGION}-a",
+                "instance_name": INSTANCE_NAME,
+                "instance_id": str(ID1),
+            }
+        }
+    })
+
+    req.headers = {"Authorization": f"Bearer {token}"}
+
+    self_link = f"{INSTANCE_LINK_PREFIX}{INSTANCE_NAME}"
+    instance = compute.Instance(
+        id=ID1,
+        name=INSTANCE_NAME,
+        zone=ZONE,
+        self_link=self_link,
+        metadata=compute.Metadata(items=[
+            compute.Items(key=main.MIG_METADATA_KEY,
+                          value=f"{MIG_PATH_PREFIX}{MIG_NAME}")
+        ]))
+    self.instances_client.get.return_value = instance
+
+    ext_operation = mock.MagicMock(
+        google.api_core.extended_operation.ExtendedOperation)
+    ext_operation.result.return_value = None
+
+    response = main.delete_self(req)
+
+    self.assertIn(MIG_NAME, response)
+    self.assertIn(INSTANCE_NAME, response)
+
+    self.migs_client.delete_instances.assert_called_once_with(
+        instance_group_manager=MIG_NAME,
+        project=PROJECT,
+        region=REGION,
+        region_instance_group_managers_delete_instances_request_resource=compute
+        .RegionInstanceGroupManagersDeleteInstancesRequest(
+            instances=[instance.self_link]))
+
+  def test_bad_method(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "GET"
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest) as ctx:
+      main.delete_self(req)
+
+    self.assertIn("Invalid method", get_message(ctx))
+
+  def test_bad_path(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+    req.path = "/foo/bar"
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest) as ctx:
+      main.delete_self(req)
+
+    self.assertIn("Invalid request path", get_message(ctx))
+
+  def test_missing_header(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+
+    with self.assertRaises(werkzeug.exceptions.Unauthorized) as ctx:
+      main.delete_self(req)
+
+    self.assertIn("Authorization header is missing", get_message(ctx))
+
+  def test_malformed_header(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+    req.headers = {"Authorization": "UnknownScheme token"}
+
+    with self.assertRaises(werkzeug.exceptions.Unauthorized) as ctx:
+      main.delete_self(req)
+
+    self.assertIn("Authorization header does not start", get_message(ctx))
+
+  def test_invalid_token(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+    req.headers = {"Authorization": f"Bearer {INVALID_TOKEN}"}
+
+    with self.assertRaises(werkzeug.exceptions.Unauthorized) as ctx:
+      main.delete_self(req)
+
+    self.assertIn("token", get_message(ctx))
+
+  def test_bad_token_payload(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+
+    token = make_token({"aud": "localhost"})
+
+    req.headers = {"Authorization": f"Bearer {token}"}
+
+    with self.assertRaises(werkzeug.exceptions.Unauthorized) as ctx:
+      main.delete_self(req)
+
+    self.assertIn("token", get_message(ctx))
+
+  def test_nonexistent_instance(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+
+    token = make_token({
+        "google": {
+            "compute_engine": {
+                "project_id": PROJECT,
+                "zone": ZONE,
+                "instance_name": INSTANCE_NAME,
+                "instance_id": str(ID1),
+            }
+        }
+    })
+
+    req.headers = {"Authorization": f"Bearer {token}"}
+
+    self.instances_client.get.side_effect = google.api_core.exceptions.NotFound(
+        "Instance not found")
+
+    with self.assertRaises(werkzeug.exceptions.NotFound) as ctx:
+      main.delete_self(req)
+
+    self.assertIn(INSTANCE_NAME, get_message(ctx))
+
+  def test_id_mismatch(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+
+    token = make_token({
+        "google": {
+            "compute_engine": {
+                "project_id": PROJECT,
+                "zone": ZONE,
+                "instance_name": INSTANCE_NAME,
+                "instance_id": str(ID1),
+            }
+        }
+    })
+
+    req.headers = {"Authorization": f"Bearer {token}"}
+
+    instance = compute.Instance(id=ID2, name=INSTANCE_NAME)
+
+    self.instances_client.get.return_value = instance
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest) as ctx:
+      main.delete_self(req)
+
+    msg = get_message(ctx)
+    self.assertIn(str(ID1), msg)
+    self.assertIn(str(ID2), msg)
+
+  def test_missing_mig_metadata(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+
+    token = make_token({
+        "google": {
+            "compute_engine": {
+                "project_id": PROJECT,
+                "zone": ZONE,
+                "instance_name": INSTANCE_NAME,
+                "instance_id": str(ID1),
+            }
+        }
+    })
+
+    req.headers = {"Authorization": f"Bearer {token}"}
+
+    instance = compute.Instance(id=ID1,
+                                name=INSTANCE_NAME,
+                                zone=ZONE,
+                                self_link=f"http://foo/bar/{INSTANCE_NAME}")
+
+    self.instances_client.get.return_value = instance
+
+    with self.assertRaises(werkzeug.exceptions.BadRequest) as ctx:
+      main.delete_self(req)
+
+    self.assertIn(main.MIG_METADATA_KEY, get_message(ctx))
+
+  def test_bad_deletion_request_server(self):
+    req = Request({}, populate_request=False, shallow=True)
+    req.method = "DELETE"
+
+    token = make_token({
+        "google": {
+            "compute_engine": {
+                "project_id": PROJECT,
+                "zone": ZONE,
+                "instance_name": INSTANCE_NAME,
+                "instance_id": str(ID1),
+            }
+        }
+    })
+
+    req.headers = {"Authorization": f"Bearer {token}"}
+
+    instance = compute.Instance(
+        id=ID1,
+        name=INSTANCE_NAME,
+        zone=ZONE,
+        self_link=f"{INSTANCE_LINK_PREFIX}{INSTANCE_NAME}",
+        metadata=compute.Metadata(items=[
+            compute.Items(key=main.MIG_METADATA_KEY,
+                          value=f"{MIG_PATH_PREFIX}{MIG_NAME}")
+        ]))
+
+    self.instances_client.get.return_value = instance
+    self.migs_client.delete_instances.side_effect = ValueError("Bad request")
+
+    with self.assertRaises(werkzeug.exceptions.InternalServerError) as ctx:
+      main.delete_self(req)
+
+    self.assertIn(MIG_NAME, get_message(ctx))
+
+  # Testing of server errors is unimplemented. ExtendedOperation is not
+  # documented well enough for me to produce a reasonable fake and a bad fake is
+  # worse than nothing.
+
+
+if __name__ == "__main__":
+  unittest.main()

--- a/build_tools/github_actions/runner/instance_deleter/requirements.txt
+++ b/build_tools/github_actions/runner/instance_deleter/requirements.txt
@@ -1,0 +1,7 @@
+functions-framework==3.2.0
+flask==2.1.0
+google-cloud-error-reporting==1.6.0
+# TODO: specific versions?
+google-cloud-compute
+google-auth
+requests

--- a/build_tools/github_actions/runner/instance_deleter/requirements.txt
+++ b/build_tools/github_actions/runner/instance_deleter/requirements.txt
@@ -1,7 +1,6 @@
-functions-framework==3.2.0
-flask==2.1.0
-google-cloud-error-reporting==1.6.0
-# TODO: specific versions?
-google-cloud-compute
-google-auth
-requests
+functions-framework>=3.2
+flask>=2.1
+google-cloud-error-reporting>=1.6
+google-cloud-compute>=1.8
+google-auth>=2.15
+requests>=2.27

--- a/build_tools/pytype/check_diff.sh
+++ b/build_tools/pytype/check_diff.sh
@@ -46,14 +46,15 @@ function check_files() {
     return "${1?}"
   fi
 
-  # We disable import-error because pytype doesn't have access to bazel.
-  # We disable pyi-error because of the way the bindings imports work.
-  # xargs is set to high arg limits to avoid multiple Bazel invocations and will
-  # hard fail if the limits are exceeded.
+  # We disable import-error and module-attr because pytype doesn't have access
+  # to all dependencies and pyi-error because of the way the bindings imports
+  # work.
+  # xargs is set to high arg limits to avoid multiple pytype invocations and
+  # will hard fail if the limits are exceeded.
   # See https://github.com/bazelbuild/bazel/issues/12479
   echo "${@:2}" | \
     xargs --max-args 1000000 --max-chars 1000000 --exit \
-      python3 -m pytype --disable=import-error,pyi-error -j $(nproc)
+      python3 -m pytype --disable=import-error,pyi-error,module-attr -j $(nproc)
   EXIT_CODE="$?"
   echo
   if [[ "${EXIT_CODE?}" -gt "${1?}" ]]; then


### PR DESCRIPTION
A Cloud Functions proxy enabling GCE VMs in a Managed Instance Group to
delete themselves. GCE Managed instance groups don't have any good way
to handle autoscaling for long-running workloads. With the autoscaler
configured to scale in, instances get only 90 seconds warning to shut
down. So we set the autoscaler to only scale out and have the VMs tear
themselves down when they're down with their work. This is the approach
suggested by the managed instance group team:
https://drive.google.com/file/d/1XlwxF_0T7pUnbzhL5ePDoW-Q3GAaLO11. But
anything that brings down the VM other than a delete call to the
instance group manager API makes the VM get considered "unhealthy",
which means it gets recreated in exactly the same configuration,
regardless of any update or autoscaling settings. Making the correct
API call requires broad permissions on the instance group manager,
which we don't want to give the VMs. To scope permissions to individual
instances, this proxy service makes use of instance identity tokens to
allow an instance to make a call only to delete itself (see
https://cloud.google.com/compute/docs/instances/verifying-instance-identity).

This makes use of the GCP Cloud Functions serverless offering. It's
another level of abstraction on top of Cloud Run, where you don't even
need to create your own docker container.

I wrote unit tests for this in addition to testing the server locally,
but I don't think it's worth adding them to the CI right now because
they come with an entire server framework of dependencies and this
isn't a part of the project I expect to see active development.
Probably more worthwhile would be finding another home for this as a
standalone project separate from IREE.

skip-ci: not tested by CI