### PR TITLE
Reworking task API to provide iree_task_executors_create_from_flags.

### DIFF
--- a/runtime/src/iree/base/allocator.h
+++ b/runtime/src/iree/base/allocator.h
@@ -161,6 +161,12 @@ typedef enum iree_allocator_command_e {
   //   params: unused
   //   inout_ptr: pointer to free
   IREE_ALLOCATOR_COMMAND_FREE,
+
+  // TODO(benvanik): add optional IREE_ALLOCATOR_COMMAND_BIND like mbind:
+  // https://man7.org/linux/man-pages/man2/mbind.2.html
+  // This would take a pointer/length and a NUMA node ID to bind the memory to.
+  // We may want flags for controlling whether this is a new allocation getting
+  // bound or an existing one that is migrating to use MPOL_MF_MOVE.
 } iree_allocator_command_t;
 
 // Parameters for various allocation commands.

--- a/runtime/src/iree/base/internal/threading_pthreads.c
+++ b/runtime/src/iree/base/internal/threading_pthreads.c
@@ -339,6 +339,11 @@ void iree_thread_request_affinity(iree_thread_t* thread,
   pthread_setaffinity_np(thread->handle, sizeof(cpu_set), &cpu_set);
 #endif  // IREE_PLATFORM_*
 
+  // TODO(benvanik): make a set_mempolicy syscall where available to set the
+  // NUMA allocation pinning for the calling thread. We'll likely want an
+  // iree_allocator_t control operation for this to allow users to plug in
+  // their own implementations and also let the HAL pin allocated buffers.
+
   IREE_TRACE_ZONE_END(z0);
 }
 

--- a/runtime/src/iree/task/api.c
+++ b/runtime/src/iree/task/api.c
@@ -54,41 +54,103 @@ iree_status_t iree_task_executor_options_initialize_from_flags(
 //===----------------------------------------------------------------------===//
 
 IREE_FLAG(
+    string, task_topology_nodes, "current",
+    "Comma-separated list of NUMA nodes that topologies will be defined for.\n"
+    "Each node specified will be configured based on the other topology\n"
+    "flags. 'all' can be used to indicate all available NUMA nodes and\n"
+    "'current' will inherit the node of the calling thread.");
+
+IREE_FLAG(
     string, task_topology_mode, "physical_cores",
     "Available modes:\n"
     " --task_topology_group_count=non-zero:\n"
     "   Uses whatever the specified group count is and ignores the set mode.\n"
+    "   All threads will be unpinned and run on system-determined processors.\n"
     " 'physical_cores':\n"
-    "   Creates one group per physical core in the machine up to\n"
-    "   the value specified by --task_topology_max_group_count.\n");
+    "   Creates one group per physical core in each NUMA node up to\n"
+    "   the value specified by --task_topology_max_group_count=.");
 
 IREE_FLAG(
     int32_t, task_topology_group_count, 0,
     "Defines the total number of task system workers that will be created.\n"
     "Workers will be distributed across cores. Specifying 0 will use a\n"
     "heuristic defined by --task_topology_mode= to automatically select the\n"
-    "worker count and distribution.");
+    "worker count and distribution.\n"
+    "WARNING: setting this flag directly is not recommended; use\n"
+    "--task_topology_max_group_count= instead.");
 
 IREE_FLAG(
     int32_t, task_topology_max_group_count, 8,
     "Sets a maximum value on the worker count that can be automatically\n"
     "detected and used when --task_topology_group_count=0 and is ignored\n"
-    "otherwise.\n");
+    "otherwise.");
 
-// TODO(benvanik): add --task_topology_dump to dump out the current machine
-// configuration as seen by the topology utilities.
+// Builds a bitmask of NUMA nodes that topologies should be created for.
+//
+// NOTE: because of the mask being 64-bits we have a 64-node limit.
+// We could change this mask to be variable-sized (ala cpu_set) if we wanted to
+// go higher than that. Since this entire set of functionality is part of the
+// private implementation and not something core to the task system it's easy to
+// change in the future if we get >4096-core machines.
+static iree_status_t iree_task_topologies_select_nodes_from_flags(
+    uint64_t* out_node_mask) {
+  IREE_ASSERT_ARGUMENT(out_node_mask);
+  *out_node_mask = 0ull;
+
+  // Query the total number of NUMA nodes in the system. On implementations
+  // where this information isn't available this will return 1.
+  const iree_host_size_t available_node_count =
+      iree_max(1u, iree_min(64u, iree_task_topology_query_node_count()));
+
+  // Build a bitmask based on the flags.
+  iree_string_view_t nodes_flag =
+      iree_make_cstring_view(FLAG_task_topology_nodes);
+  uint64_t node_mask = 0ull;
+  if (iree_string_view_is_empty(nodes_flag) ||
+      iree_string_view_equal(nodes_flag, IREE_SV("current"))) {
+    // Use a single default node.
+    node_mask = 1ull << iree_task_topology_query_current_node();
+  } else if (iree_string_view_equal(nodes_flag, IREE_SV("all"))) {
+    // Use all nodes in the system (set bits starting at 0 for each node).
+    node_mask = UINT64_MAX >> (64 - available_node_count);
+  } else {
+    // Use some subset of nodes.
+    iree_string_view_t remaining = nodes_flag;
+    while (!iree_string_view_is_empty(remaining)) {
+      iree_string_view_t node_value;
+      iree_string_view_split(remaining, ',', &node_value, &remaining);
+      uint32_t node_id = 0;
+      if (!iree_string_view_atoi_uint32(node_value, &node_id)) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "invalid NUMA node ID specified: '%.*s'",
+                                (int)node_value.size, node_value.data);
+      } else if (node_id >= available_node_count) {
+        return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                                "NUMA node ID out of valid range [0,%" PRIhsz
+                                "): %u",
+                                available_node_count, node_id);
+      }
+      node_mask |= 1ull << node_id;
+    }
+  }
+
+  *out_node_mask = node_mask;
+  return iree_ok_status();
+}
 
 iree_status_t iree_task_topology_initialize_from_flags(
-    iree_task_topology_t* out_topology) {
+    iree_task_topology_node_id_t node_id, iree_task_topology_t* out_topology) {
   IREE_ASSERT_ARGUMENT(out_topology);
   iree_task_topology_initialize(out_topology);
 
   if (FLAG_task_topology_group_count != 0) {
+    // Unpinned topology. Let the system try to figure it out.
     iree_task_topology_initialize_from_group_count(
         FLAG_task_topology_group_count, out_topology);
   } else if (strcmp(FLAG_task_topology_mode, "physical_cores") == 0) {
+    // Physical cores sourced from a specific NUMA node.
     iree_task_topology_initialize_from_physical_cores(
-        FLAG_task_topology_max_group_count, out_topology);
+        node_id, FLAG_task_topology_max_group_count, out_topology);
   } else {
     return iree_make_status(
         IREE_STATUS_INVALID_ARGUMENT,
@@ -101,28 +163,182 @@ iree_status_t iree_task_topology_initialize_from_flags(
 }
 
 //===----------------------------------------------------------------------===//
+// Topology diagnostics
+//===----------------------------------------------------------------------===//
+
+static void iree_task_flags_print_action_flag(iree_string_view_t flag_name,
+                                              void* storage, FILE* file) {
+  fprintf(file, "# --%.*s\n", (int)flag_name.size, flag_name.data);
+}
+
+static iree_status_t iree_task_flags_dump_task_topologies(
+    iree_string_view_t flag_name, void* storage, iree_string_view_t value) {
+  // Select which nodes in the machine we will be creating topologies for.
+  uint64_t node_mask = 0ull;
+  IREE_RETURN_IF_ERROR(
+      iree_task_topologies_select_nodes_from_flags(&node_mask));
+
+  // TODO(benvanik): macros to make this iteration easier (ala cpu_set
+  // iterators).
+  iree_host_size_t topology_count = iree_math_count_ones_u64(node_mask);
+  uint64_t node_mask_bits = node_mask;
+  iree_task_topology_node_id_t node_base_id = 0;
+  for (iree_host_size_t i = 0; i < topology_count; ++i) {
+    int node_offset =
+        iree_task_affinity_set_count_trailing_zeros(node_mask_bits);
+    iree_task_topology_node_id_t node_id = node_base_id + node_offset;
+    node_base_id += node_offset + 1;
+    node_mask_bits = iree_shr(node_mask_bits, node_offset + 1);
+    iree_task_topology_t topology;
+    IREE_RETURN_IF_ERROR(
+        iree_task_topology_initialize_from_flags(node_id, &topology));
+    fprintf(stdout,
+            "# "
+            "===-------------------------------------------------------------"
+            "-----------===\n");
+    fprintf(stdout, "# topology[%" PRIhsz "]: %" PRIhsz " worker groups\n", i,
+            topology.group_count);
+    fprintf(stdout,
+            "# "
+            "===-------------------------------------------------------------"
+            "-----------===\n");
+    fprintf(stdout, "#\n");
+    for (iree_host_size_t j = 0; j < topology.group_count; ++j) {
+      const iree_task_topology_group_t* group = &topology.groups[j];
+      fprintf(stdout, "# group[%d]: '%s'\n", group->group_index, group->name);
+      fprintf(stdout, "#      processor: %u\n", group->processor_index);
+      fprintf(stdout, "#       affinity: ");
+      if (group->ideal_thread_affinity.specified) {
+        fprintf(stdout, "group=%u, id=%u, smt=%u",
+                group->ideal_thread_affinity.group,
+                group->ideal_thread_affinity.id,
+                group->ideal_thread_affinity.smt);
+      } else {
+        fprintf(stdout, "(unspecified)");
+      }
+      fprintf(stdout, "\n");
+      fprintf(stdout, "#  cache sharing: ");
+      if (group->constructive_sharing_mask == 0) {
+        fprintf(stdout, "(none)\n");
+      } else if (group->constructive_sharing_mask ==
+                 IREE_TASK_TOPOLOGY_GROUP_MASK_ALL) {
+        fprintf(stdout, "(all/undefined)\n");
+      } else {
+        fprintf(stdout, "%d group(s): ",
+                iree_math_count_ones_u64(group->constructive_sharing_mask));
+        for (iree_host_size_t ic = 0, jc = 0;
+             ic < IREE_TASK_TOPOLOGY_GROUP_BIT_COUNT; ++ic) {
+          if ((group->constructive_sharing_mask >> ic) & 1) {
+            if (jc > 0) fprintf(stdout, ", ");
+            fprintf(stdout, "%" PRIhsz, ic);
+            ++jc;
+          }
+        }
+        fprintf(stdout, "\n");
+      }
+      fprintf(stdout, "#\n");
+    }
+  }
+
+  exit(0);
+  return iree_ok_status();
+}
+
+IREE_FLAG_CALLBACK(
+    iree_task_flags_dump_task_topologies, iree_task_flags_print_action_flag,
+    NULL, dump_task_topologies,
+    "Dumps the flag-specified topology used for creating task executors.");
+
+//===----------------------------------------------------------------------===//
 // Task system factory functions
 //===----------------------------------------------------------------------===//
 
-iree_status_t iree_task_executor_create_from_flags(
-    iree_allocator_t host_allocator, iree_task_executor_t** out_executor) {
-  IREE_ASSERT_ARGUMENT(out_executor);
-  *out_executor = NULL;
-  IREE_TRACE_ZONE_BEGIN(z0);
+iree_status_t iree_task_executors_create_from_flags(
+    iree_allocator_t host_allocator, iree_host_size_t executor_capacity,
+    iree_task_executor_t** executors, iree_host_size_t* out_executor_count) {
+  IREE_ASSERT_ARGUMENT(out_executor_count);
+  *out_executor_count = 0;
+  if (executors) {
+    memset(executors, 0, executor_capacity * sizeof(*executors));
+  }
 
+  // Each executor will have the same options based on the global flags.
+  // A user constructing their own executors can differ the options.
   iree_task_executor_options_t options;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_task_executor_options_initialize_from_flags(&options));
+  IREE_RETURN_IF_ERROR(
+      iree_task_executor_options_initialize_from_flags(&options));
 
-  iree_task_topology_t topology;
-  IREE_RETURN_AND_END_ZONE_IF_ERROR(
-      z0, iree_task_topology_initialize_from_flags(&topology));
+  // Select which nodes in the machine we will be creating topologies for.
+  uint64_t node_mask = 0ull;
+  IREE_RETURN_IF_ERROR(
+      iree_task_topologies_select_nodes_from_flags(&node_mask));
+  const iree_host_size_t topology_count = iree_math_count_ones_u64(node_mask);
 
-  iree_status_t status = iree_task_executor_create(
-      options, &topology, host_allocator, out_executor);
+  // Since this utility function creates one executor per topology returned by
+  // the query we can check the executor capacity immediately.
+  if (topology_count > executor_capacity || !executors) {
+    // Need more capacity.
+    *out_executor_count = topology_count;
+    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
+  } else if (topology_count == 0) {
+    // No executors required, early-exit.
+    *out_executor_count = 0;
+    return iree_ok_status();
+  }
 
-  iree_task_topology_deinitialize(&topology);
+  // NOTE: the flags could use some ergonomics improvement or renaming to
+  // indicate how they differ. Trying to specify a generic group count _and_
+  // multiple NUMA nodes won't produce expected results (IMO) so we error out
+  // on that here instead of letting users think they are running with
+  // NUMA-aware scheduling. We could lighten this restriction in the future if
+  // there are use cases for arbitrarily-scheduled worker groups that have just
+  // their allocations pinned to NUMA nodes.
+  if (FLAG_task_topology_group_count != 0 && topology_count > 1) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "multiple nodes specified with --task_topology_group_count=; you "
+        "probably meant --task_topology_max_group_count= in order to get "
+        "proper NUMA-aware scheduling");
+  }
 
-  IREE_TRACE_ZONE_END(z0);
+  // Create one executor per topology.
+  // TODO(benvanik): macros to make this iteration easier (ala cpu_set
+  // iterators).
+  iree_status_t status = iree_ok_status();
+  uint64_t node_mask_bits = node_mask;
+  iree_task_topology_node_id_t node_base_id = 0;
+  for (iree_host_size_t i = 0; i < topology_count; ++i) {
+    int node_offset =
+        iree_task_affinity_set_count_trailing_zeros(node_mask_bits);
+    iree_task_topology_node_id_t node_id = node_base_id + node_offset;
+    node_base_id += node_offset + 1;
+    node_mask_bits = iree_shr(node_mask_bits, node_offset + 1);
+
+    // Query topology for the node this executor is pinned to.
+    iree_task_topology_t topology;
+    status = iree_task_topology_initialize_from_flags(node_id, &topology);
+    if (!iree_status_is_ok(status)) break;
+
+    // TODO(benvanik): if group count is 0 then don't create the executor. Today
+    // the executor creation will fail with 0 groups so the program won't get in
+    // a weird state but it's probably not what a user would expect.
+
+    // Create executor with the given topology.
+    status = iree_task_executor_create(options, &topology, host_allocator,
+                                       &executors[i]);
+
+    // Executor has consumed the topology and it can be dropped now.
+    iree_task_topology_deinitialize(&topology);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_executor_count = topology_count;
+  } else {
+    // Release executors for the caller in case we partially initialized them.
+    for (iree_host_size_t i = 0; i < topology_count; ++i) {
+      iree_task_executor_release(executors[i]);
+    }
+  }
   return status;
 }

--- a/runtime/src/iree/task/api.h
+++ b/runtime/src/iree/task/api.h
@@ -25,25 +25,33 @@ iree_status_t iree_task_executor_options_initialize_from_flags(
     iree_task_executor_options_t* out_options);
 
 // Initializes |out_topology| from the command line flags.
-// Used in place of iree_task_topology_initialize.
+// Depending on the mode flags |node_id| will be used to pin the topology to a
+// specific NUMA node.
 iree_status_t iree_task_topology_initialize_from_flags(
-    iree_task_topology_t* out_topology);
+    iree_task_topology_node_id_t node_id, iree_task_topology_t* out_topology);
 
 //===----------------------------------------------------------------------===//
 // Task system factory functions
 //===----------------------------------------------------------------------===//
 
-// Creates a task system executor from the current command line flags.
-// This configures a topology and all of the executor parameters and returns
-// a newly created instance in |out_executor| that must be released by the
-// caller.
+// Creates zero or more task executors from the current command line flags.
+// This creates one executor per topology selected using the same executor
+// parameters as specified by flags. |executors| is populated with retained
+// executor instances and callers must reserve the |executors| memory before
+// calling and release all executors using iree_task_executor_release when done
+// with them.
 //
-// This utility method is useful when only a single executor exists within a
-// process as the flags are globals. When multiple executors may exist or
-// programmatic configuration is needed use the iree_task_executor_create method
-// directly.
-iree_status_t iree_task_executor_create_from_flags(
-    iree_allocator_t host_allocator, iree_task_executor_t** out_executor);
+// This utility method is useful when only a single type of executor exists
+// within a process as the flags are globals. When multiple executors may exist
+// or programmatic configuration is needed use the iree_task_executor_create
+// method directly.
+//
+// Returns the total number of executors in |out_executor_count|.
+// Returns IREE_STATUS_OUT_OF_RANGE if |executor_capacity| is insufficient and
+// the caller needs to provide more storage in |executors|.
+iree_status_t iree_task_executors_create_from_flags(
+    iree_allocator_t host_allocator, iree_host_size_t executor_capacity,
+    iree_task_executor_t** executors, iree_host_size_t* out_executor_count);
 
 //===----------------------------------------------------------------------===//
 // Task system simple invocation utilities

--- a/runtime/src/iree/task/executor_demo.cc
+++ b/runtime/src/iree/task/executor_demo.cc
@@ -46,6 +46,7 @@ extern "C" int main(int argc, char* argv) {
   iree_task_topology_t topology;
 #if 1
   iree_task_topology_initialize_from_physical_cores(
+      IREE_TASK_TOPOLOGY_NODE_ID_ANY,
       /*max_core_count=*/6, &topology);
 #else
   iree_task_topology_initialize_from_group_count(/*group_count=*/6, &topology);

--- a/runtime/src/iree/task/topology_test.cc
+++ b/runtime/src/iree/task/topology_test.cc
@@ -138,7 +138,8 @@ TEST(TopologyTest, FromPhysicalCores) {
   static constexpr iree_host_size_t kMaxGroupCount = 4;
   iree_task_topology_t topology;
   iree_task_topology_initialize(&topology);
-  iree_task_topology_initialize_from_physical_cores(kMaxGroupCount, &topology);
+  iree_task_topology_initialize_from_physical_cores(
+      IREE_TASK_TOPOLOGY_NODE_ID_ANY, kMaxGroupCount, &topology);
   EnsureTopologyValid(kMaxGroupCount, &topology);
   iree_task_topology_deinitialize(&topology);
 }

--- a/samples/simple_embedding/README.md
+++ b/samples/simple_embedding/README.md
@@ -85,8 +85,11 @@ replaced with the multithreaded "task device", which uses a "task executor":
 ```c
 ...
 iree_task_executor_t* executor = NULL;
+iree_host_size_t executor_count = 0;
 iree_status_t status =
-    iree_task_executor_create_from_flags(iree_allocator_system(), &executor);
+    iree_task_executors_create_from_flags(iree_allocator_system(),
+                                          1, &executor, &executor_count);
+IREE_ASSERT_EQ(count, 1, "NUMA unsupported");
 
 iree_string_view_t identifier = iree_make_cstring_view("local-task");
 if (iree_status_is_ok(status)) {


### PR DESCRIPTION
This allows for multiple executors to be created from flags that can then be passed into the local-task creation routines. Topology queries are slightly extended to allow for specifying which node the physical cores are selected from when initializing with that mode but otherwise the programmatic control by users not using flags remains the same.

The new `--task_topology_nodes=` flag can be used to control which NUMA nodes get executors. By default (or if `current` is specified) the node is inherited from the calling thread but `all` can be specified to create one executor per NUMA node. In addition a comma-separated list of node IDs can be passed to subset the nodes (`0,1,4`). The inheritance is kind of sketchy as the node is queried at driver creation time (usually just during startup) but should play well with numactl launches of the process.

NOTE: because the `--task_topology_group_count` flag does no thread affinity placement it is not directly useful with multiple NUMA nodes as each worker may run on any processor. Always use `--task_topology_max_group_count` instead. I've made this an error for now but in the future we may want to allow some mixed modes.

To make debugging the topology detection easier the `--dump_task_topologies` flag now prints all configured topologies to stdout. Example output: https://gist.github.com/benvanik/35611e9a343b9f0093187e83cfe6db67

Some TODOs were added for where future work is required around binding host allocations to NUMA nodes.

This is inspired by the work of @aviator19941 in #11371 but switched around to create the multiple executors based on the flags, use the existing `iree_thread_affinity_t` to hold the node identifier, and make it possible for programmatic control over the topology node pinning. That PR had a way to filter the nodes a particular device would use based on URI parameters that is not yet in here as we'd need to rework the executor ownership rules on drivers.
Closes #11371.