### PR TITLE
Fold scalar vector transfers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -72,6 +72,7 @@ void transform_dialect::ApplyPatternsOp::build(
               getEraseUnnecessaryTensorOperandsAttrName)
   ADD_PATTERN(foldMemrefAliases, getFoldMemrefAliasesAttrName)
   ADD_PATTERN(foldReassociativeReshapes, getFoldReassociativeReshapesAttrName)
+  ADD_PATTERN(foldScalarVectorTransfers, getFoldScalarVectorTransfersAttrName)
   ADD_PATTERN(promoteForeachThreadCaptureToShared,
               getPromoteForeachThreadCaptureToSharedAttrName)
   ADD_PATTERN(rankReducing, getRankReducingAttrName)
@@ -167,6 +168,10 @@ static void addFoldMemrefAliasPatterns(RewritePatternSet &patterns) {
   memref::populateFoldMemRefAliasOpPatterns(patterns);
 }
 
+static void addFoldScalarVectorTransfersPatterns(RewritePatternSet &patterns) {
+  vector::populateScalarVectorTransferLoweringPatterns(patterns);
+}
+
 static void addForeachThreadCapturePromotionPatterns(
     RewritePatternSet &patterns) {
   patterns.add<PromoteCaptureToSharedOut>(patterns.getContext());
@@ -231,6 +236,8 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
     addEraseUnnecessaryTensorOperandsPatterns(patterns);
   if (getFoldMemrefAliases()) addFoldMemrefAliasPatterns(patterns);
   if (getFoldReassociativeReshapes()) addReassociativeReshapePatterns(patterns);
+  if (getFoldScalarVectorTransfers())
+    addFoldScalarVectorTransfersPatterns(patterns);
   if (getPromoteForeachThreadCaptureToShared())
     addForeachThreadCapturePromotionPatterns(patterns);
   if (getRankReducing()) addRankReducingPatterns(patterns);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -41,6 +41,7 @@ struct ApplyPatternsOpPatterns {
   bool eraseUnnecessaryTensorOperands = false;
   bool foldMemrefAliases = false;
   bool foldReassociativeReshapes = false;
+  bool foldScalarVectorTransfers = false;
   bool promoteForeachThreadCaptureToShared = false;
   bool rankReducing = false;
   bool expandMemrefStridedMetadata = false;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -44,6 +44,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
       memref.subview.
       - fold_reassociative_reshapes: adds patterns that fold insert_slice/
       extract_slice ops with reassociative reshape ops.
+      - fold_scalar_vector_transfers: adds patterns that fold scalar vector
+      transfer ops.
       - promote_foreach_thread_capture_to_shared: adds patterns that rewrite
       uses of values captured by scf.foreach_thread with the matching
       shared_outs bbarg. This checks that the values captured are
@@ -84,6 +86,7 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
                        UnitAttr:$erase_unnecessary_tensor_operands,
                        UnitAttr:$fold_memref_aliases,
                        UnitAttr:$fold_reassociative_reshapes,
+                       UnitAttr:$fold_scalar_vector_transfers,
                        UnitAttr:$promote_foreach_thread_capture_to_shared,
                        UnitAttr:$rank_reducing,
                        UnitAttr:$expand_memref_strided_metadata,

--- a/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_codegen_spec.mlir
@@ -23,7 +23,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // ===========================================================================
   %fill_1d = transform.structured.match ops{["linalg.fill"]} filter_result_type = tensor<1xf32> in %variant_op
   %foreach_thread_block_combiner_op, %block_combiner_op =
-    transform.structured.tile_to_foreach_thread_op %grid_combiner_op tile_sizes [1] 
+    transform.structured.tile_to_foreach_thread_op %grid_combiner_op tile_sizes [1]
     ( mapping = [#gpu.thread<z>] )
   transform.structured.fuse_into_containing_op %fill_1d into %foreach_thread_block_combiner_op
 
@@ -31,7 +31,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %grid_more_parallel_op = transform.structured.match ops{["linalg.generic"]}
     attributes{iterator_types = [#linalg.iterator_type<parallel>, #linalg.iterator_type<parallel>, #linalg.iterator_type<reduction>]} in %variant_op
   %foreach_thread_block_more_parallel_op, %block_more_parallel_op =
-    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1] 
+    transform.structured.tile_to_foreach_thread_op %grid_more_parallel_op tile_sizes [1, 1]
     ( mapping = [#gpu.thread<z>, #gpu.thread<y>] )
   transform.structured.fuse_into_containing_op %fill_2d into %foreach_thread_block_more_parallel_op
 
@@ -67,4 +67,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
     transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   }
   transform.iree.vector.warp_distribute %func_8
+  // TODO: Make this part of the above apply_patterns op once the
+  // GreedyPatternRewriter is fixed.
+  %func_9 = transform.iree.apply_patterns %func_8 { fold_scalar_vector_transfers }
 }

--- a/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/reduction_v3_codegen_spec.mlir
@@ -15,8 +15,8 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // Step 2. Split the reduction to get meatier parallelism.
   // This also parallelizes to threads.
   // ===========================================================================
-  %foreach_thread, %block_more_parallel_fill_op_2, %block_more_parallel_op_2, %block_combiner_op_2 = 
-     transform.structured.tile_reduction_using_foreach_thread %grid_reduction 
+  %foreach_thread, %block_more_parallel_fill_op_2, %block_more_parallel_op_2, %block_combiner_op_2 =
+     transform.structured.tile_reduction_using_foreach_thread %grid_reduction
         by num_threads = [0, 1024], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
 
   // Fuse the fill and pointwise to privatize them.
@@ -24,15 +24,15 @@ transform.structured.canonicalized_sequence failures(propagate) {
     into %foreach_thread
 
   // block_combiner_op_2 op is [parallel, reduction] of 1x384 that cannot fuse.
-  // map the 1-dim to threadIdx.y to trigger mapping of the reduction to 
+  // map the 1-dim to threadIdx.y to trigger mapping of the reduction to
   // threadIdx.x via predication via `if (x==0)`.
-  transform.structured.tile_to_foreach_thread_op %block_combiner_op_2 num_threads [1] 
+  transform.structured.tile_to_foreach_thread_op %block_combiner_op_2 num_threads [1]
     ( mapping = [#gpu.thread<y>] )
 
   // Step 3. Rank-reduce and vectorize.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op
-  // TODO: masked vectorization on block_more_parallel_op_2 if we want 
+  // TODO: masked vectorization on block_more_parallel_op_2 if we want
   // vector<4> to work as intended.
   %func_2 = transform.iree.apply_patterns %func { rank_reducing }
   %func_3 = transform.structured.vectorize %func_2
@@ -60,4 +60,7 @@ transform.structured.canonicalized_sequence failures(propagate) {
   %if_op = transform.structured.match ops{["scf.if"]} in %variant_op_3
   %warp = transform.iree.vector.to_warp_execute_on_lane_0 %if_op { warp_size = 32 }
   transform.iree.vector.warp_distribute %func_10
+  // TODO: Make this part of the above apply_patterns op once the
+  // GreedyPatternRewriter is fixed.
+  %func_11 = transform.iree.apply_patterns %func_10 { fold_scalar_vector_transfers }
 }


### PR DESCRIPTION
Fold vector transfers of scalars to memref loads/stores. This change is purely cosmetic. It makes the IR easier to read.