### PR TITLE
Adding tracy memory pool visualization for Vulkan VMA buffers.

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -16,7 +16,7 @@
 
 #if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING
 static const char* IREE_HAL_CUDA_ALLOCATOR_ID = "CUDA";
-#endif
+#endif  // IREE_TRACING_FEATURE_ALLOCATION_TRACKING
 
 typedef struct iree_hal_cuda_allocator_t {
   iree_hal_resource_t resource;

--- a/runtime/src/iree/hal/drivers/vulkan/vma_buffer.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_buffer.cc
@@ -14,6 +14,10 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/vulkan/status_util.h"
 
+#if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_ALLOCATION_TRACKING
+static const char* IREE_HAL_VULKAN_VMA_ALLOCATOR_ID = "Vulkan/VMA";
+#endif  // IREE_TRACING_FEATURE_ALLOCATION_TRACKING
+
 typedef struct iree_hal_vulkan_vma_buffer_t {
   iree_hal_buffer_t base;
 
@@ -67,9 +71,8 @@ iree_status_t iree_hal_vulkan_vma_buffer_wrap(
     //     VMA_ALLOCATION_CREATE_USER_DATA_COPY_STRING_BIT flag.
     vmaSetAllocationUserData(buffer->vma, buffer->allocation, buffer);
 
-    // TODO(benvanik): figure out why this is not working - has unbalanced
-    // allocs in the tracy UI even though they are definitely balanced here.
-    // IREE_TRACE_ALLOC_NAMED("VMA", (void*)buffer->handle, byte_length);
+    IREE_TRACE_ALLOC_NAMED(IREE_HAL_VULKAN_VMA_ALLOCATOR_ID,
+                           (void*)buffer->handle, byte_length);
 
     *out_buffer = &buffer->base;
   } else {
@@ -88,7 +91,8 @@ static void iree_hal_vulkan_vma_buffer_destroy(iree_hal_buffer_t* base_buffer) {
   IREE_TRACE_ZONE_APPEND_VALUE(
       z0, (int64_t)iree_hal_buffer_allocation_size(base_buffer));
 
-  // IREE_TRACE_FREE_NAMED("VMA", (void*)buffer->handle);
+  IREE_TRACE_FREE_NAMED(IREE_HAL_VULKAN_VMA_ALLOCATOR_ID,
+                        (void*)buffer->handle);
 
   vmaDestroyBuffer(buffer->vma, buffer->handle, buffer->allocation);
   iree_allocator_free(host_allocator, buffer);


### PR DESCRIPTION
The memory map/range is invalid because we are only tracking VkBuffer handles but the reporting and plots are all correct.

Adds a new plot to the main tracy display under the default heap memory plot:
![image](https://user-images.githubusercontent.com/75337/208748407-baa73548-c618-416e-8039-abe800cf7d15.png)

Adds escaping allocations to zone hierarchies (here showing an escaping 16b buffer):
![image](https://user-images.githubusercontent.com/75337/208748518-8c05b84d-2e93-430c-8450-c6daa8ece5aa.png)

Adds memory view - note to use this you need to turn on the memory range limit and drag the end to where you want to see the state of things (here the end is in the middle of execution and shows us buffers live during execution):
![image](https://user-images.githubusercontent.com/75337/208748706-b81f03ca-40c3-494c-8441-7b286bf47ed7.png)
