### PR TITLE
[NumPy] Remove references to deprecated NumPy type aliases.

### DIFF
--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils_test.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_test_utils_test.py
@@ -15,7 +15,7 @@ class TfFunctionUnitTestModule(tf_test_utils.TestModule):
 
   @tf_test_utils.tf_function_unit_test(input_signature=[])
   def no_args(self):
-    return np.array([True], dtype=np.bool)
+    return np.array([True], dtype=bool)
 
   @tf_test_utils.tf_function_unit_test(input_signature=[
       tf.TensorSpec([4]),

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils.py
@@ -8,12 +8,13 @@
 import os
 import random
 import re
-from typing import Any, Callable, Mapping, Sequence, Set, Tuple, Union
+from typing import (Any, Callable, Mapping, Optional, Sequence, Set, Tuple,
+                    Union)
 
-from absl import logging
 import iree.runtime
 import numpy as np
 import tensorflow.compat.v2 as tf
+from absl import logging
 
 InputGeneratorType = Callable[[Sequence[int], Union[tf.DType, np.dtype]],
                               np.ndarray]
@@ -31,7 +32,8 @@ def uniform(shape: Sequence[int],
             low: float = -1.0,
             high: float = 1.0) -> np.ndarray:
   """np.random.uniform with simplified API and dtype and bool support."""
-  dtype = dtype.as_numpy_dtype if isinstance(dtype, tf.DType) else dtype
+  # pytype doesn't understand the ternary with tf as "Any"
+  dtype = dtype.as_numpy_dtype if isinstance(dtype, tf.DType) else dtype  # pytype: disable=attribute-error
   if dtype == bool:
     return np.random.choice(2, shape).astype(bool)
   else:
@@ -44,7 +46,8 @@ def uniform(shape: Sequence[int],
 def ndarange(shape: Sequence[int],
              dtype: Union[tf.DType, np.dtype] = np.float32) -> np.ndarray:
   """np.ndarange for arbitrary input shapes."""
-  dtype = dtype.as_numpy_dtype if isinstance(dtype, tf.DType) else dtype
+  # pytype doesn't understand the ternary with tf as "Any"
+  dtype = dtype.as_numpy_dtype if isinstance(dtype, tf.DType) else dtype  # pytype: disable=attribute-error
   return np.arange(np.prod(shape), dtype=dtype).reshape(shape)
 
 
@@ -111,7 +114,7 @@ def get_shape_and_dtype(array: np.ndarray,
 
 
 def save_input_values(inputs: Sequence[np.ndarray],
-                      artifacts_dir: str = None) -> str:
+                      artifacts_dir: Optional[str] = None) -> str:
   """Saves input values with IREE tools format if 'artifacts_dir' is set."""
   result = []
   for array in inputs:

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/tf_utils.py
@@ -32,8 +32,8 @@ def uniform(shape: Sequence[int],
             high: float = 1.0) -> np.ndarray:
   """np.random.uniform with simplified API and dtype and bool support."""
   dtype = dtype.as_numpy_dtype if isinstance(dtype, tf.DType) else dtype
-  if dtype == np.bool:
-    return np.random.choice(2, shape).astype(np.bool)
+  if dtype == bool:
+    return np.random.choice(2, shape).astype(bool)
   else:
     values = np.random.uniform(size=shape, low=low, high=high)
     if np.issubdtype(dtype, np.integer):
@@ -230,8 +230,8 @@ def check_same(ref: Any, tar: Any, rtol: float,
     # Ignore np.bool != np.int8 because the IREE python runtime awkwardly
     # returns np.int8s instead of np.bools.
     if ref.dtype != tar.dtype and not (
-        (ref.dtype == np.bool and tar.dtype == np.int8) or
-        (ref.dtype == np.int8 and tar.dtype == np.bool)):
+        (ref.dtype == bool and tar.dtype == np.int8) or
+        (ref.dtype == np.int8 and tar.dtype == bool)):
       error = ("Expected ref and tar to have the same dtype, but got "
                f"'{ref.dtype}' and '{tar.dtype}'")
       logging.error(error)

--- a/integrations/tensorflow/test/python/iree_tf_tests/math/math_test.py
+++ b/integrations/tensorflow/test/python/iree_tf_tests/math/math_test.py
@@ -427,7 +427,7 @@ FUNCTIONS_TO_UNIT_TEST_SPECS = {
         # reduction axes return True.
         *tf_test_utils.unit_test_specs_from_args(
             names_to_input_args={
-                "all_true": [np.ones(RANK_7_SHAPE, np.bool)],
+                "all_true": [np.ones(RANK_7_SHAPE, bool)],
             },
             kwargs_to_values=REDUCE_KWARGS_TO_VALUES),
         *tf_test_utils.unit_test_specs_from_signatures(
@@ -440,7 +440,7 @@ FUNCTIONS_TO_UNIT_TEST_SPECS = {
         # reduction axes return False.
         *tf_test_utils.unit_test_specs_from_args(
             names_to_input_args={
-                "all_false": [np.zeros(RANK_7_SHAPE, np.bool)],
+                "all_false": [np.zeros(RANK_7_SHAPE, bool)],
             },
             kwargs_to_values=REDUCE_KWARGS_TO_VALUES),
         *tf_test_utils.unit_test_specs_from_signatures(

--- a/runtime/bindings/python/iree/runtime/system_api.py
+++ b/runtime/bindings/python/iree/runtime/system_api.py
@@ -89,7 +89,7 @@ def _bool_to_int8(
 
   # IREE models booleans as i8s.
   # TODO(#5359): This cast should be moved into the function abi.
-  if array.dtype == np.bool:
+  if array.dtype == bool:
     array = array.astype(np.int8)
   return array
 


### PR DESCRIPTION
This change replaces references to a number of deprecated NumPy type
aliases (np.bool, np.int, np.float, np.complex, np.object, np.str) with
their recommended replacement (bool, int, float, complex, object, str).

NumPy 1.24 drops the deprecated aliases, so we must remove uses to
support that version.

Also includes fixing or silencing some pre-existing pytype errors which
presumably came from someone ignoring the lint check.