### PR TITLE
[spirv] Allow some widely available capabilities in Unknown target

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/TargetTriple.cpp
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/TargetTriple.cpp
@@ -468,9 +468,11 @@ CapabilitiesAttr getCapabilities(const TargetTriple &triple,
     case TargetTripleArch::Unknown:
       // Use the largest subgroup size we can find across various vendors.
       subgroupSize = 64;
+
       // The following capabilities have 90%+ device coverage (Vulkan 1.1+)
-      // from https://vulkan.gpuinfo.org/listfeaturesextensions.php.
-      variablePointers = variablePointersStorageBuffer = false;
+      // from https://vulkan.gpuinfo.org/listfeaturescore11.php.
+      storageBuffer16BitAccess = uniformAndStorageBuffer16BitAccess = true;
+      variablePointers = variablePointersStorageBuffer = true;
       // Use Vulkan default for others.
       break;
   }

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
@@ -13,7 +13,7 @@
 // #vk.target_env in input assembly and convert them.
 
 // DEFAULT: #spirv.target_env<#spirv.vce<v1.3,
-// DEFAULT-SAME: [Shader, GroupNonUniform], [SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
+// DEFAULT-SAME: [Shader, StorageBuffer16BitAccess, StorageUniform16, GroupNonUniform, VariablePointers, VariablePointersStorageBuffer], [SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
 // DEFAULT-SAME: api=Vulkan, #spirv.resource_limits<max_compute_workgroup_size = [128, 128, 64], subgroup_size = 64, cooperative_matrix_properties_nv = []>>
 
 // ADRENO: #spirv.target_env<#spirv.vce<v1.4,


### PR DESCRIPTION
These are all beyond 90% device coverages with Vulkan 1.1 and above.