### PR TITLE
Make runners call into deletion proxy rather than shutting down

### DIFF
--- a/build_tools/github_actions/runner/config/delete_self.sh
+++ b/build_tools/github_actions/runner/config/delete_self.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# Deregisters the GitHub actions runner using proxy token.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
+source "${SCRIPT_DIR}/functions.sh"
+
+
+# If the nice way fails, hard shutdown
+function shutdown_now() {
+  sudo /usr/sbin/shutdown -P now
+}
+
+trap shutdown_now ERR
+
+function delete_self() {
+  local self_deletion_service_url="$(get_attribute instance-self-deleter-url)"
+  local id_token=$(get_metadata "instance/service-accounts/default/identity?audience=${self_deletion_service_url}&format=full")
+
+  nice_curl -X DELETE --header "Authorization: Bearer ${id_token}" "${self_deletion_service_url}"
+}
+
+delete_self

--- a/build_tools/github_actions/runner/config/delete_self.sh
+++ b/build_tools/github_actions/runner/config/delete_self.sh
@@ -6,7 +6,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# Deregisters the GitHub actions runner using proxy token.
+# Calls the instance deletion proxy to delete this instance through the GCE API.
 
 set -euo pipefail
 

--- a/build_tools/github_actions/runner/config/deregister.sh
+++ b/build_tools/github_actions/runner/config/deregister.sh
@@ -13,9 +13,8 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname -- "$( readlink -f -- "$0"; )")";
 source "${SCRIPT_DIR}/functions.sh"
 
-TOKEN_PROXY_URL="$(get_attribute github-token-proxy-url)"
 RUNNER_SCOPE="$(get_attribute github-runner-scope)"
-DEREGISTER_TOKEN="$(get_token remove ${RUNNER_SCOPE})"
+DEREGISTER_TOKEN="$(get_runner_token remove ${RUNNER_SCOPE})"
 
 if [ -z "${DEREGISTER_TOKEN}" ]; then
   echo "failed to get remove runner token" >&2

--- a/build_tools/github_actions/runner/config/functions.sh
+++ b/build_tools/github_actions/runner/config/functions.sh
@@ -10,14 +10,36 @@
 # we end up with a lot.
 # This file should be sourced, not executed.
 
+############################## Utility functions ###############################
+
+
+# Tests if the first argument is contained in the array in the second argument.
+# Usage `is_contained "element" "${array[@]}"`
+is_contained() {
+  local e;
+  local match="$1"
+  shift
+  for e in "$@"; do
+    if [[ "${e}" == "${match}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+nice_curl() {
+  curl --silent --fail --show-error --location "$@"
+}
+
+################################################################################
+
+
 ############################## Instance metadata ###############################
 
 get_metadata() {
   local url="http://metadata.google.internal/computeMetadata/v1/${1}"
   ret=0
-  curl "${url}" \
-    --silent --fail --show-error \
-    --header "Metadata-Flavor: Google" || ret=$?
+  nice_curl --header "Metadata-Flavor: Google" "${url}" || ret=$?
   if [[ "${ret}" != 0 ]]; then
     echo "Failed fetching ${url}" >&2
     return "${ret}"
@@ -34,34 +56,15 @@ get_attribute() {
 
 ################################################################################
 
-
-############################## Utility functions ###############################
-
-# Tests if the first argument is contained in the array in the second argument.
-# Usage `is_contained "element" "${array[@]}"`
-is_contained() {
-  local e;
-  local match="$1"
-  shift
-  for e in "$@"; do
-    if [[ "${e}" == "${match}" ]]; then
-      return 0
-    fi
-  done
-  return 1
-}
-
 # Retrieves the specified token to control the self-hosted runner.
-function get_token() {
+function get_runner_token() {
   local method=$1
   local runner_scope=$2
   local token_proxy_url="$(get_attribute github-token-proxy-url)"
   local cloud_run_id_token=$(get_metadata "instance/service-accounts/default/identity?audience=${token_proxy_url}")
-  curl --silent --fail --show-error --location \
+  nice_curl \
    "${token_proxy_url}/${method}" \
    --header "Authorization: Bearer ${cloud_run_id_token}" \
    --data-binary "{\"scope\": \"${runner_scope}\"}" \
    | jq -r ".token"
 }
-
-################################################################################

--- a/build_tools/github_actions/runner/config/github-actions-runner-start.service
+++ b/build_tools/github_actions/runner/config/github-actions-runner-start.service
@@ -10,7 +10,7 @@ Restart=no
 KillMode=process
 KillSignal=SIGTERM
 TimeoutStopSec=5min
-ExecStopPost=sudo /usr/sbin/shutdown -P now
+ExecStopPost=/runner-root/config/delete_self.sh
 
 [Install]
 WantedBy=multi-user.target

--- a/build_tools/github_actions/runner/config/register.sh
+++ b/build_tools/github_actions/runner/config/register.sh
@@ -101,7 +101,7 @@ GOOGLE_CLOUD_PROJECT="$(get_metadata project/project-id)"
 
 GOOGLE_CLOUD_RUN_ID_TOKEN="$(get_metadata "instance/service-accounts/default/identity?audience=${TOKEN_PROXY_URL}")"
 
-REGISTER_TOKEN="$(get_token register ${RUNNER_SCOPE})"
+REGISTER_TOKEN="$(get_runner_token register ${RUNNER_SCOPE})"
 
 if [ -z "${REGISTER_TOKEN}" ]; then
   echo "failed to get registration runner token" >&2

--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -38,7 +38,7 @@ RUNNER_ARCHIVE_DIGEST="$(get_attribute github-runner-archive-digest)"
 cd /runner-root
 mkdir actions-runner
 cd actions-runner
-curl --silent --fail --show-error --location \
+nice_curl \
   "https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_ARCHIVE}" \
   -o "${RUNNER_ARCHIVE}"
 

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -59,6 +59,7 @@ GITHUB_RUNNER_SCOPE=iree-org
 GITHUB_RUNNER_VERSION="2.299.1"
 GITHUB_RUNNER_ARCHIVE_DIGEST="147c14700c6cb997421b9a239c012197f11ea9854cd901ee88ead6fe73a72c74"
 GITHUB_TOKEN_PROXY_URL="https://ght-proxy-zbhz5clunq-ue.a.run.app"
+INSTANCE_SELF_DELETER_URL="https://instance-self-deleter-zbhz5clunq-uc.a.run.app"
 
 declare -a METADATA=(
   "github-runner-version=${GITHUB_RUNNER_VERSION}"
@@ -67,6 +68,7 @@ declare -a METADATA=(
   "github-runner-config-repo=${TEMPLATE_CONFIG_REPO}"
   "github-runner-scope=${GITHUB_RUNNER_SCOPE}"
   "github-token-proxy-url=${GITHUB_TOKEN_PROXY_URL}"
+  "instance-self-deleter-url=${INSTANCE_SELF_DELETER_URL}"
 )
 
 declare -a common_args=(


### PR DESCRIPTION
As described in https://github.com/iree-org/iree/commit/d985a1b8fa,
managed instance group autoscaling does not behave well when instances
shut themselves down. Instead, we've introduced a proxy service that
allows them to delete themselves through the API without giving them
broad permissions.

Tested: Deployed to test cluster and verified instance behavior with
https://github.com/iree-org/iree/actions/runs/3743529186/jobs/6358175336