### PR TITLE
[Transform][Debug] Extra transform interpreter targeting with attributes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -59,6 +59,59 @@
 
 using namespace mlir;
 
+/// Finds the single top-level transform operation with `root` as ancestor.
+/// Reports an error if there is more than one such operation and returns the
+/// first one found. Reports an error returns nullptr if no such operation
+/// found.
+static Operation *findTopLevelTransform(Operation *root, StringRef debugStr) {
+  transform::TransformOpInterface topLevelTransform = nullptr;
+  WalkResult walkResult = root->walk<WalkOrder::PreOrder>(
+      [&](transform::TransformOpInterface transformOp) {
+        if (!topLevelTransform) {
+          topLevelTransform = transformOp;
+          return WalkResult::skip();
+        }
+        auto diag = transformOp.emitError()
+                    << "more than one top-level transform op";
+        diag.attachNote(topLevelTransform.getLoc())
+            << "previous top-level transform op";
+        return WalkResult::interrupt();
+      });
+  if (walkResult.wasInterrupted()) return nullptr;
+  if (!topLevelTransform) {
+    auto diag = root->emitError()
+                << "could not find a nested top-level transform op";
+    diag.attachNote() << "use the '" << debugStr
+                      << "' option to provide transform as external file";
+    return nullptr;
+  }
+  return topLevelTransform;
+}
+
+/// Finds an operation nested in `root` that has the transform dialect tag
+/// attribute with the value specified as `tag`. Assumes only one operation
+/// may have the tag. Returns nullptr if there is no such operation.
+static Operation *findOpWithTag(Operation *root, StringRef tagKey,
+                                StringRef tagValue) {
+  Operation *found = nullptr;
+  root->walk<WalkOrder::PreOrder>([tagKey, tagValue, &found](Operation *op) {
+    auto attr = op->getAttrOfType<StringAttr>(tagKey);
+    if (!attr || attr.getValue() != tagValue) return WalkResult::advance();
+
+    assert(found == nullptr && "more than one op with the same tag");
+    found = op;
+
+    // In debug mode, continue the traversal to see if the tag is not
+    // duplicated.
+#ifndef NDEBUG
+    return WalkResult::advance();
+#else
+    return WalkResult::interrupt();
+#endif  // NDEBUG
+  });
+  return found;
+}
+
 namespace {
 
 /// Pass declaration.
@@ -141,166 +194,12 @@ class TransformDialectInterpreterPass
     return success();
   }
 
-  void runOnOperation() override {
-    Operation *target = getOperation();
-    bool parsedTransform = (sharedTransformModule && *sharedTransformModule);
-
-    // Step 1
-    // ------
-    // Get the default payloadRoot and transformRegion that one expects
-    // when running the IREE nested pass pipeline or the interpreter.
-    Operation *payloadRoot = target;
-    Region *transformRegion = nullptr;
-    // If a parsed transform was specified separately, use it immediately.
-    // Otherwise, the transform is embedded in the IR: go inspect the IR and
-    // get the first top-level transform we find.
-    if (parsedTransform) {
-      transformRegion = &(*sharedTransformModule)->getRegion();
-    } else {
-      // TODO: In large IR we will likely want more control in selecting a
-      // particular transform to focus on, this may warrant a user-specified
-      // attribute that one would manually injected in the IR when operating in
-      // interpreted mode.
-      Operation *topLevelTransform = findTopLevelTransform(target);
-      if (!topLevelTransform) return signalPassFailure();
-      transformRegion = topLevelTransform->getParentRegion();
-    }
-    assert(transformRegion && "unexpected detached root transform op");
-
-    // Step 2
-    // ------
-    // Optionally override payloadRoot if the payloadRootTag was passed.
-    //
-    // If payloadRootTag was passed, then we are in user-specified selection
-    // of the transformed IR. This corresponds to REPL debug mode.
-    // Otherwise, just apply to `target`, which is what the IREE nested
-    // pipeline wants to operate on.
-    if (!payloadRootTag.empty()) {
-      payloadRoot = findOpWithTag(target, payloadRootTag);
-      if (!payloadRoot) {
-        target->emitError()
-            << "couldn't find the root payload op with "
-            << kTransformIreeTagAttrName << "=\""
-            << kTransformIreeTagPayloadRootValue << "\" attribute";
-        return signalPassFailure();
-      }
-    }
-
-    // Step 3
-    // ------
-    // Optionally override transformRegion if the transformRootTag was passed.
-    //
-    // If transformRootTag was passed, then we are in user-specified
-    // selection of the transforming IR. This corresponds to REPL debug mode.
-    // Otherwise, just apply to the existing `transformRegion`, which is what
-    // the IREE nested pipeline wants to operate on.
-    if (!transformRootTag.empty()) {
-      Operation *transformRoot =
-          findOpWithTag(transformRegion->getParentOp(),
-                        kTransformIreeTagTransformContainerValue);
-      if (!transformRoot) {
-        transformRegion->getParentOp()->emitError()
-            << "couldn't find the transform container op with "
-            << kTransformIreeTagAttrName << "=\""
-            << kTransformIreeTagTransformContainerValue << "\" attribute";
-        return signalPassFailure();
-      }
-      if (transformRoot->getNumRegions() != 1 ||
-          !transformRoot->getRegion(0).hasOneBlock()) {
-        transformRoot->emitError() << "expected transform container op to have "
-                                      "one single-block region";
-        return signalPassFailure();
-      }
-      transformRegion = &transformRoot->getRegion(0);
-    }
-
-    // Step 4
-    // ------
-    // Optionally perform debug actions requested by the user to dump IR and a
-    // repro to stderr and/or a fie.
-    performOptionalDebugActions(target, transformRegion);
-
-    // Step 5
-    // ------
-    // Apply the transform to the IR
-    // TODO: lift this assertion.
-    assert(transformRegion->getBlocks().size() == 1 &&
-           "expected single-region block");
-    if (failed(transform::applyTransformsInRegion(*transformRegion,
-                                                  payloadRoot))) {
-      payloadRoot->emitOpError() << "transform dialect interpreter failed";
-      return signalPassFailure();
-    }
-  }
+  void runOnOperation() override;
 
  private:
   // Optionally perform debug actions requested by the user to dump IR and a
   // repro to stderr and/or a fie.
-  void performOptionalDebugActions(Operation *target, Region *transformRegion) {
-    // Add temporary debug / repro attributes, these must never leak out.
-    if (payloadRootTag.empty()) {
-      target->setAttr(
-          kTransformIreeTagAttrName,
-          StringAttr::get(&getContext(), kTransformIreeTagPayloadRootValue));
-    }
-    if (!transformRootTag.empty()) {
-      transformRegion->getParentOp()->setAttr(
-          kTransformIreeTagAttrName,
-          StringAttr::get(&getContext(),
-                          kTransformIreeTagTransformContainerValue));
-    }
-
-    DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_STDERR, {
-      Operation *root = getRootOperation(target);
-      llvm::dbgs() << "=== Transform Interpreter Repro ===\n";
-      printIreeOptReproCall(llvm::dbgs() << "cat <<EOF | ",
-                            root->getName().getStringRef());
-      printModuleForRepro(llvm::dbgs(), root, transformRegion->getParentOp());
-      llvm::dbgs() << "\nEOF\n";
-      llvm::dbgs() << "===================================\n";
-    });
-    DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_FILE, {
-      saveReproToTempFile(llvm::dbgs(), target, transformRegion->getParentOp());
-    });
-
-    // Drop the temporary debug / repro attributes, these must never leak out.
-    if (transformRootTag.empty()) {
-      transformRegion->getParentOp()->removeAttr(
-          kTransformIreeTagTransformContainerValue);
-    }
-    if (payloadRootTag.empty()) {
-      target->removeAttr(kTransformIreeTagAttrName);
-    }
-  }
-
-  /// Finds the single top-level transform operation with `root` as ancestor.
-  /// Reports an error if there is more than one such operation and returns the
-  /// first one found. Reports an error returns nullptr if no such operation
-  /// found.
-  Operation *findTopLevelTransform(Operation *root) {
-    transform::TransformOpInterface topLevelTransform = nullptr;
-    WalkResult walkResult = root->walk<WalkOrder::PreOrder>(
-        [&](transform::TransformOpInterface transformOp) {
-          if (!topLevelTransform) {
-            topLevelTransform = transformOp;
-            return WalkResult::skip();
-          }
-          auto diag = transformOp.emitError()
-                      << "more than one top-level transform op";
-          diag.attachNote(topLevelTransform.getLoc())
-              << "previous top-level transform op";
-          return WalkResult::interrupt();
-        });
-    if (walkResult.wasInterrupted()) return nullptr;
-    if (!topLevelTransform) {
-      auto diag = root->emitError()
-                  << "could not find a nested top-level transform op";
-      diag.attachNote() << "use the '" << transformFileName.getArgStr()
-                        << "' option to provide transform as external file";
-      return nullptr;
-    }
-    return topLevelTransform;
-  }
+  void performOptionalDebugActions(Operation *target, Region *transformRegion);
 
   /// Name of the attribute used for targeting the transform dialect interpreter
   /// at specific operations.
@@ -314,29 +213,6 @@ class TransformDialectInterpreterPass
   constexpr static llvm::StringLiteral
       kTransformIreeTagTransformContainerValue = "iree_transform_container";
 
-  /// Finds an operation nested in `root` that has the transform dialect tag
-  /// attribute with the value specified as `tag`. Assumes only one operation
-  /// may have the tag. Returns nullptr if there is no such operation.
-  static Operation *findOpWithTag(Operation *root, StringRef tag) {
-    Operation *found = nullptr;
-    root->walk<WalkOrder::PreOrder>([tag, &found](Operation *op) {
-      auto attr = op->getAttrOfType<StringAttr>(kTransformIreeTagAttrName);
-      if (!attr || attr.getValue() != tag) return WalkResult::advance();
-
-      assert(found == nullptr && "more than one op with the same tag");
-      found = op;
-
-      // In debug mode, continue the traversal to see if the tag is not
-      // duplicated.
-#ifndef NDEBUG
-      return WalkResult::advance();
-#else
-      return WalkResult::interrupt();
-#endif  // NDEBUG
-    });
-    return found;
-  }
-
   /// Returns the ancestor of `target` that doesn't have a parent.
   Operation *getRootOperation(Operation *target) {
     Operation *root = target;
@@ -346,63 +222,17 @@ class TransformDialectInterpreterPass
 
   /// Prints the CLI command running the repro with the current path.
   llvm::raw_ostream &printIreeOptReproCall(llvm::raw_ostream &os,
-                                           StringRef rootOpName) {
-    os << llvm::formatv(
-        "iree-opt "
-        "--pass-pipeline=\"{0}(iree-transform-dialect-interpreter{{{1}={2} "
-        "{3}={4}})\"",
-        rootOpName, payloadRootTag.getArgStr(),
-        payloadRootTag.empty() ? StringRef(kTransformIreeTagPayloadRootValue)
-                               : payloadRootTag,
-        transformRootTag.getArgStr(),
-        transformRootTag.empty()
-            ? StringRef(kTransformIreeTagTransformContainerValue)
-            : transformRootTag);
-    return os;
-  }
+                                           StringRef rootOpName);
 
   /// Prints the module rooted at `root` to `os` and appends
   /// `transformContainer` if it is not nested in `root`.
   llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os, Operation *root,
-                                         Operation *transformContainer) {
-    root->print(os);
-    if (!root->isAncestor(transformContainer)) {
-      transformContainer->print(os);
-    }
-    return os;
-  }
+                                         Operation *transformContainer);
 
   /// Saves the payload and the transform IR into a temporary file and reports
   /// the file name to `os`.
   void saveReproToTempFile(llvm::raw_ostream &os, Operation *target,
-                           Operation *transformContainer) {
-    using llvm::sys::fs::TempFile;
-    Operation *root = getRootOperation(target);
-
-    SmallVector<char, 128> tmpPath;
-    llvm::sys::path::system_temp_directory(/*erasedOnReboot=*/true, tmpPath);
-    llvm::sys::path::append(tmpPath, "iree_transform_dialect_%%%%%%.mlir");
-    llvm::Expected<TempFile> tempFile = TempFile::create(tmpPath);
-    if (!tempFile) {
-      os << "could not open temporary file to save the repro\n";
-      return;
-    }
-
-    llvm::raw_fd_ostream fout(tempFile->FD, /*shouldClose=*/false);
-    printModuleForRepro(fout, root, transformContainer);
-    fout.flush();
-    std::string filename = tempFile->TmpName;
-
-    if (tempFile->keep()) {
-      os << "could not preserve the temporary file with the repro\n";
-      return;
-    }
-
-    os << "=== Transform Interpreter Repro ===\n";
-    printIreeOptReproCall(os, root->getName().getStringRef())
-        << " " << filename << "\n";
-    os << "===================================\n";
-  }
+                           Operation *transformContainer);
 
   // The parsed transform module to be used for transformations.
   // TODO: Figure a better way to build a transform module and transport it in
@@ -424,6 +254,200 @@ class TransformDialectInterpreterPass
   std::shared_ptr<OwningOpRef<ModuleOp>> sharedTransformModule;
 };
 }  // namespace
+
+/// Prints the CLI command running the repro with the current path.
+llvm::raw_ostream &TransformDialectInterpreterPass::printIreeOptReproCall(
+    llvm::raw_ostream &os, StringRef rootOpName) {
+  os << llvm::formatv(
+      "iree-opt "
+      "--pass-pipeline=\"{0}(iree-transform-dialect-interpreter{{{1}={2} "
+      "{3}={4}})\"",
+      rootOpName, payloadRootTag.getArgStr(),
+      payloadRootTag.empty() ? StringRef(kTransformIreeTagPayloadRootValue)
+                             : payloadRootTag,
+      transformRootTag.getArgStr(),
+      transformRootTag.empty()
+          ? StringRef(kTransformIreeTagTransformContainerValue)
+          : transformRootTag);
+  return os;
+}
+
+/// Prints the module rooted at `root` to `os` and appends
+/// `transformContainer` if it is not nested in `root`.
+llvm::raw_ostream &TransformDialectInterpreterPass::printModuleForRepro(
+    llvm::raw_ostream &os, Operation *root, Operation *transformContainer) {
+  root->print(os);
+  if (!root->isAncestor(transformContainer)) {
+    transformContainer->print(os);
+  }
+  return os;
+}
+
+/// Saves the payload and the transform IR into a temporary file and reports
+/// the file name to `os`.
+void TransformDialectInterpreterPass::saveReproToTempFile(
+    llvm::raw_ostream &os, Operation *target, Operation *transformContainer) {
+  using llvm::sys::fs::TempFile;
+  Operation *root = getRootOperation(target);
+
+  SmallVector<char, 128> tmpPath;
+  llvm::sys::path::system_temp_directory(/*erasedOnReboot=*/true, tmpPath);
+  llvm::sys::path::append(tmpPath, "iree_transform_dialect_%%%%%%.mlir");
+  llvm::Expected<TempFile> tempFile = TempFile::create(tmpPath);
+  if (!tempFile) {
+    os << "could not open temporary file to save the repro\n";
+    return;
+  }
+
+  llvm::raw_fd_ostream fout(tempFile->FD, /*shouldClose=*/false);
+  printModuleForRepro(fout, root, transformContainer);
+  fout.flush();
+  std::string filename = tempFile->TmpName;
+
+  if (tempFile->keep()) {
+    os << "could not preserve the temporary file with the repro\n";
+    return;
+  }
+
+  os << "=== Transform Interpreter Repro ===\n";
+  printIreeOptReproCall(os, root->getName().getStringRef())
+      << " " << filename << "\n";
+  os << "===================================\n";
+}
+
+// Optionally perform debug actions requested by the user to dump IR and a
+// repro to stderr and/or a fie.
+void TransformDialectInterpreterPass::performOptionalDebugActions(
+    Operation *target, Region *transformRegion) {
+  // Add temporary debug / repro attributes, these must never leak out.
+  if (payloadRootTag.empty()) {
+    target->setAttr(
+        kTransformIreeTagAttrName,
+        StringAttr::get(&getContext(), kTransformIreeTagPayloadRootValue));
+  }
+  if (!transformRootTag.empty()) {
+    transformRegion->getParentOp()->setAttr(
+        kTransformIreeTagAttrName,
+        StringAttr::get(&getContext(),
+                        kTransformIreeTagTransformContainerValue));
+  }
+
+  DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_STDERR, {
+    Operation *root = getRootOperation(target);
+    llvm::dbgs() << "=== Transform Interpreter Repro ===\n";
+    printIreeOptReproCall(llvm::dbgs() << "cat <<EOF | ",
+                          root->getName().getStringRef());
+    printModuleForRepro(llvm::dbgs(), root, transformRegion->getParentOp());
+    llvm::dbgs() << "\nEOF\n";
+    llvm::dbgs() << "===================================\n";
+  });
+  DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_FILE, {
+    saveReproToTempFile(llvm::dbgs(), target, transformRegion->getParentOp());
+  });
+
+  // Drop the temporary debug / repro attributes, these must never leak out.
+  if (transformRootTag.empty()) {
+    transformRegion->getParentOp()->removeAttr(
+        kTransformIreeTagTransformContainerValue);
+  }
+  if (payloadRootTag.empty()) {
+    target->removeAttr(kTransformIreeTagAttrName);
+  }
+}
+
+void TransformDialectInterpreterPass::runOnOperation() {
+  Operation *target = getOperation();
+  bool parsedTransform = (sharedTransformModule && *sharedTransformModule);
+
+  // Step 1
+  // ------
+  // Get the default payloadRoot and transformRegion that one expects
+  // when running the IREE nested pass pipeline or the interpreter.
+  Operation *payloadRoot = target;
+  Region *transformRegion = nullptr;
+  // If a parsed transform was specified separately, use it immediately.
+  // Otherwise, the transform is embedded in the IR: go inspect the IR and
+  // get the first top-level transform we find.
+  if (parsedTransform) {
+    transformRegion = &(*sharedTransformModule)->getRegion();
+  } else {
+    // TODO: In large IR we will likely want more control in selecting a
+    // particular transform to focus on, this may warrant a user-specified
+    // attribute that one would manually injected in the IR when operating in
+    // interpreted mode.
+    Operation *topLevelTransform =
+        findTopLevelTransform(target, transformFileName.getArgStr());
+    if (!topLevelTransform) return signalPassFailure();
+    transformRegion = topLevelTransform->getParentRegion();
+  }
+  assert(transformRegion && "unexpected detached root transform op");
+
+  // Step 2
+  // ------
+  // Optionally override payloadRoot if the payloadRootTag was passed.
+  //
+  // If payloadRootTag was passed, then we are in user-specified selection
+  // of the transformed IR. This corresponds to REPL debug mode.
+  // Otherwise, just apply to `target`, which is what the IREE nested
+  // pipeline wants to operate on.
+  if (!payloadRootTag.empty()) {
+    payloadRoot =
+        findOpWithTag(target, kTransformIreeTagAttrName, payloadRootTag);
+    if (!payloadRoot) {
+      target->emitError() << "couldn't find the root payload op with "
+                          << kTransformIreeTagAttrName << "=\""
+                          << kTransformIreeTagPayloadRootValue
+                          << "\" attribute";
+      return signalPassFailure();
+    }
+  }
+
+  // Step 3
+  // ------
+  // Optionally override transformRegion if the transformRootTag was passed.
+  //
+  // If transformRootTag was passed, then we are in user-specified
+  // selection of the transforming IR. This corresponds to REPL debug mode.
+  // Otherwise, just apply to the existing `transformRegion`, which is what
+  // the IREE nested pipeline wants to operate on.
+  if (!transformRootTag.empty()) {
+    Operation *transformRoot =
+        findOpWithTag(transformRegion->getParentOp(), kTransformIreeTagAttrName,
+                      kTransformIreeTagTransformContainerValue);
+    if (!transformRoot) {
+      transformRegion->getParentOp()->emitError()
+          << "couldn't find the transform container op with "
+          << kTransformIreeTagAttrName << "=\""
+          << kTransformIreeTagTransformContainerValue << "\" attribute";
+      return signalPassFailure();
+    }
+    if (transformRoot->getNumRegions() != 1 ||
+        !transformRoot->getRegion(0).hasOneBlock()) {
+      transformRoot->emitError() << "expected transform container op to have "
+                                    "one single-block region";
+      return signalPassFailure();
+    }
+    transformRegion = &transformRoot->getRegion(0);
+  }
+
+  // Step 4
+  // ------
+  // Optionally perform debug actions requested by the user to dump IR and a
+  // repro to stderr and/or a fie.
+  performOptionalDebugActions(target, transformRegion);
+
+  // Step 5
+  // ------
+  // Apply the transform to the IR
+  // TODO: lift this assertion.
+  assert(transformRegion->getBlocks().size() == 1 &&
+         "expected single-region block");
+  if (failed(
+          transform::applyTransformsInRegion(*transformRegion, payloadRoot))) {
+    payloadRoot->emitOpError() << "transform dialect interpreter failed";
+    return signalPassFailure();
+  }
+}
 
 namespace mlir {
 namespace iree_compiler {

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -18,7 +18,14 @@
 #include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Error.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Arith/Transforms/BufferizableOpInterfaceImpl.h"
@@ -46,6 +53,8 @@
 #include "mlir/Support/FileUtilities.h"
 
 #define DEBUG_TYPE "iree-transform-dialect-interpreter"
+#define DEBUG_TYPE_DUMP_STDERR "iree-transform-dialect-dump-repro"
+#define DEBUG_TYPE_DUMP_FILE "iree-transform-dialect-save-repro"
 #define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 using namespace mlir;
@@ -105,11 +114,17 @@ class TransformDialectInterpreterPass
     linalg::registerTransformDialectExtension(registry);
   }
 
-  TransformDialectInterpreterPass(StringRef transformFileName = StringRef()) {
+  TransformDialectInterpreterPass(StringRef transformFileName = StringRef(),
+                                  StringRef payloadRootTag = StringRef(),
+                                  StringRef transformRootTag = StringRef()) {
     this->transformFileName = transformFileName.str();
+    this->payloadRootTag = payloadRootTag.str();
+    this->transformRootTag = transformRootTag.str();
   }
   TransformDialectInterpreterPass(const TransformDialectInterpreterPass &pass) {
     this->transformFileName = pass.transformFileName;
+    this->payloadRootTag = pass.payloadRootTag;
+    this->transformRootTag = pass.transformRootTag;
     // TODO: if we really don't like shared_ptr, we could also clone the
     // transformModule here.
     sharedTransformModule = pass.sharedTransformModule;
@@ -132,43 +147,219 @@ class TransformDialectInterpreterPass
 
     Region *transformRegion = nullptr;
     if (!parsedTransform) {
-      transform::TransformOpInterface topLevelTransform = nullptr;
-      WalkResult walkResult = target->walk<WalkOrder::PreOrder>(
-          [&](transform::TransformOpInterface transformOp) {
-            if (!topLevelTransform) {
-              topLevelTransform = transformOp;
-              return WalkResult::skip();
-            }
-            auto diag = transformOp.emitError()
-                        << "more than one top-level transform op";
-            diag.attachNote(topLevelTransform.getLoc())
-                << "previous top-level transform op";
-            return WalkResult::interrupt();
-          });
-      if (walkResult.wasInterrupted()) return signalPassFailure();
-      if (!topLevelTransform) {
-        auto diag = target->emitError()
-                    << "could not find a nested top-level transform op";
-        diag.attachNote() << "use the '" << transformFileName.getArgStr()
-                          << "' option to provide transform as external file";
-        return signalPassFailure();
-      }
-
+      Operation *topLevelTransform = findTopLevelTransform(target);
+      if (!topLevelTransform) return signalPassFailure();
       transformRegion = topLevelTransform->getParentRegion();
     } else {
       transformRegion = &(*sharedTransformModule)->getRegion();
+    }
+    assert(transformRegion && "unexpected detached root transform op");
+
+    Operation *payloadRoot = target;
+    if (payloadRootTag.empty()) {
+      target->setAttr(
+          kTransformIreeTagAttrName,
+          StringAttr::get(&getContext(), kTransformIreeTagPayloadRootValue));
+    } else {
+      payloadRoot = findOpWithTag(target, payloadRootTag);
+      if (!payloadRoot) {
+        target->emitError()
+            << "couldn't find the root payload op with "
+            << kTransformIreeTagAttrName << "=\""
+            << kTransformIreeTagPayloadRootValue << "\" attribute";
+        return signalPassFailure();
+      }
+    }
+
+    if (transformRootTag.empty()) {
+      transformRegion->getParentOp()->setAttr(
+          kTransformIreeTagAttrName,
+          StringAttr::get(&getContext(),
+                          kTransformIreeTagTransformContainerValue));
+    } else {
+      Operation *transformRoot =
+          findOpWithTag(transformRegion->getParentOp(),
+                        kTransformIreeTagTransformContainerValue);
+      if (!transformRoot) {
+        transformRegion->getParentOp()->emitError()
+            << "couldn't find the transform container op with "
+            << kTransformIreeTagAttrName << "=\""
+            << kTransformIreeTagTransformContainerValue << "\" attribute";
+        return signalPassFailure();
+      }
+      if (transformRoot->getNumRegions() != 1 ||
+          !transformRoot->getRegion(0).hasOneBlock()) {
+        transformRoot->emitError() << "expected transform container op to have "
+                                      "one single-block region";
+        return signalPassFailure();
+      }
+      transformRegion = &transformRoot->getRegion(0);
+    }
+
+    DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_STDERR, {
+      Operation *root = getRootOperation(target);
+      llvm::dbgs() << "=== Transform Interpreter Repro ===\n";
+      printIreeOptReproCall(llvm::dbgs() << "cat <<EOF | ",
+                            root->getName().getStringRef());
+      printModuleForRepro(llvm::dbgs(), root, transformRegion->getParentOp());
+      llvm::dbgs() << "\nEOF\n";
+      llvm::dbgs() << "===================================\n";
+    });
+
+    DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_FILE, {
+      saveReproToTempFile(llvm::dbgs(), target, transformRegion->getParentOp());
+    });
+
+    if (payloadRootTag.empty()) {
+      target->removeAttr(kTransformIreeTagAttrName);
+    }
+    if (transformRootTag.empty()) {
+      transformRegion->getParentOp()->removeAttr(
+          kTransformIreeTagTransformContainerValue);
     }
 
     // TODO: lift this assertion.
     assert(transformRegion->getBlocks().size() == 1 &&
            "expected single-region block");
-    if (failed(transform::applyTransformsInRegion(*transformRegion, target))) {
-      target->emitOpError() << "transform dialect interpreter failed";
+    if (failed(transform::applyTransformsInRegion(*transformRegion,
+                                                  payloadRoot))) {
+      payloadRoot->emitOpError() << "transform dialect interpreter failed";
       return signalPassFailure();
     }
   }
 
  private:
+  /// Finds the single top-level transform operation with `root` as ancestor.
+  /// Reports an error if there is more than one such operation and returns the
+  /// first one found. Reports an error returns nullptr if no such operation
+  /// found.
+  Operation *findTopLevelTransform(Operation *root) {
+    transform::TransformOpInterface topLevelTransform = nullptr;
+    WalkResult walkResult = root->walk<WalkOrder::PreOrder>(
+        [&](transform::TransformOpInterface transformOp) {
+          if (!topLevelTransform) {
+            topLevelTransform = transformOp;
+            return WalkResult::skip();
+          }
+          auto diag = transformOp.emitError()
+                      << "more than one top-level transform op";
+          diag.attachNote(topLevelTransform.getLoc())
+              << "previous top-level transform op";
+          return WalkResult::interrupt();
+        });
+    if (walkResult.wasInterrupted()) return nullptr;
+    if (!topLevelTransform) {
+      auto diag = root->emitError()
+                  << "could not find a nested top-level transform op";
+      diag.attachNote() << "use the '" << transformFileName.getArgStr()
+                        << "' option to provide transform as external file";
+      return nullptr;
+    }
+    return topLevelTransform;
+  }
+
+  /// Name of the attribute used for targeting the transform dialect interpreter
+  /// at specific operations.
+  constexpr static llvm::StringLiteral kTransformIreeTagAttrName =
+      "transform.iree_tag";
+  /// Value of the attribute indicating the root payload operation.
+  constexpr static llvm::StringLiteral kTransformIreeTagPayloadRootValue =
+      "iree_payload_root";
+  /// Value of the attribute indicating the container of transform operations
+  /// (containing the top-level transform operation).
+  constexpr static llvm::StringLiteral
+      kTransformIreeTagTransformContainerValue = "iree_transform_container";
+
+  /// Finds an operation nested in `root` that has the transform dialect tag
+  /// attribute with the value specified as `tag`. Assumes only one operation
+  /// may have the tag. Returns nullptr if there is no such operation.
+  static Operation *findOpWithTag(Operation *root, StringRef tag) {
+    Operation *found = nullptr;
+    root->walk<WalkOrder::PreOrder>([tag, &found](Operation *op) {
+      auto attr = op->getAttrOfType<StringAttr>(kTransformIreeTagAttrName);
+      if (!attr || attr.getValue() != tag) return WalkResult::advance();
+
+      assert(found == nullptr && "more than one op with the same tag");
+      found = op;
+
+      // In debug mode, continue the traversal to see if the tag is not
+      // duplicated.
+#ifndef NDEBUG
+      return WalkResult::advance();
+#else
+      return WalkResult::interrupt();
+#endif  // NDEBUG
+    });
+    return found;
+  }
+
+  /// Returns the ancestor of `target` that doesn't have a parent.
+  Operation *getRootOperation(Operation *target) {
+    Operation *root = target;
+    while (root->getParentOp()) root = root->getParentOp();
+    return root;
+  }
+
+  /// Prints the CLI command running the repro with the current path.
+  llvm::raw_ostream &printIreeOptReproCall(llvm::raw_ostream &os,
+                                           StringRef rootOpName) {
+    os << llvm::formatv(
+        "iree-opt "
+        "--pass-pipeline=\"{0}(iree-transform-dialect-interpreter{{{1}={2} "
+        "{3}={4}})\"",
+        rootOpName, payloadRootTag.getArgStr(),
+        payloadRootTag.empty() ? StringRef(kTransformIreeTagPayloadRootValue)
+                               : payloadRootTag,
+        transformRootTag.getArgStr(),
+        transformRootTag.empty()
+            ? StringRef(kTransformIreeTagTransformContainerValue)
+            : transformRootTag);
+    return os;
+  }
+
+  /// Prints the module rooted at `root` to `os` and appends
+  /// `transformContainer` if it is not nested in `root`.
+  llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os, Operation *root,
+                                         Operation *transformContainer) {
+    root->print(os);
+    if (!root->isAncestor(transformContainer)) {
+      transformContainer->print(os);
+    }
+    return os;
+  }
+
+  /// Saves the payload and the transform IR into a temporary file and reports
+  /// the file name to `os`.
+  void saveReproToTempFile(llvm::raw_ostream &os, Operation *target,
+                           Operation *transformContainer) {
+    using llvm::sys::fs::TempFile;
+    Operation *root = getRootOperation(target);
+
+    SmallVector<char, 128> tmpPath;
+    llvm::sys::path::system_temp_directory(/*erasedOnReboot=*/true, tmpPath);
+    llvm::sys::path::append(tmpPath, "iree_transform_dialect_%%%%%%.mlir");
+    llvm::Expected<TempFile> tempFile = TempFile::create(tmpPath);
+    if (!tempFile) {
+      os << "could not open temporary file to save the repro\n";
+      return;
+    }
+
+    llvm::raw_fd_ostream fout(tempFile->FD, /*shouldClose=*/false);
+    printModuleForRepro(fout, root, transformContainer);
+    fout.flush();
+    std::string filename = tempFile->TmpName;
+
+    if (tempFile->keep()) {
+      os << "could not preserve the temporary file with the repro\n";
+      return;
+    }
+
+    os << "=== Transform Interpreter Repro ===\n";
+    printIreeOptReproCall(os, root->getName().getStringRef())
+        << " " << filename << "\n";
+    os << "===================================\n";
+  }
+
   // The parsed transform module to be used for transformations.
   // TODO: Figure a better way to build a transform module and transport it in
   // the proper places in the IR as it is transformed by IREE so that it is
@@ -194,8 +385,10 @@ namespace mlir {
 namespace iree_compiler {
 /// Create a Transform dialect interpreter pass.
 std::unique_ptr<Pass> createTransformDialectInterpreterPass(
-    llvm::StringRef transformFileName) {
-  return std::make_unique<TransformDialectInterpreterPass>(transformFileName);
+    llvm::StringRef transformFileName, llvm::StringRef payloadRootTag,
+    llvm::StringRef transformRootTag) {
+  return std::make_unique<TransformDialectInterpreterPass>(
+      transformFileName, payloadRootTag, transformRootTag);
 }
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -95,14 +95,14 @@ llvm::cl::opt<bool> clCPUEnableTransformDialectJit(
     "iree-codegen-llvmcpu-enable-transform-dialect-jit",
     llvm::cl::desc("enable the usage of the transform dialect JIT"),
     llvm::cl::init(false));
-llvm::cl::opt<std::string> clCPUCodegenTransformDialectPayloadTag(
-    "iree-codegen-llvmcpu-transform-dialect-payload-tag",
+llvm::cl::opt<std::string> clCPUCodegenTransformDialectDebugPayloadTag(
+    "iree-codegen-llvmcpu-transform-dialect-debug-payload-tag",
     llvm::cl::desc("tag attribute value for the transform dialect interpreter "
                    "payload root operation"),
     llvm::cl::init(""));
 
-llvm::cl::opt<std::string> clCPUCodegenTransformDialectTransformTag(
-    "iree-codegen-llvmcpu-transform-dialect-transform-tag",
+llvm::cl::opt<std::string> clCPUCodegenTransformDialectDebugTransformTag(
+    "iree-codegen-llvmcpu-transform-dialect-debug-transform-tag",
     llvm::cl::desc(
         "tag attribute value for the transform dialect transform op container"),
     llvm::cl::init(""));

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -95,6 +95,17 @@ llvm::cl::opt<bool> clCPUEnableTransformDialectJit(
     "iree-codegen-llvmcpu-enable-transform-dialect-jit",
     llvm::cl::desc("enable the usage of the transform dialect JIT"),
     llvm::cl::init(false));
+llvm::cl::opt<std::string> clCPUCodegenTransformDialectPayloadTag(
+    "iree-codegen-llvmcpu-transform-dialect-payload-tag",
+    llvm::cl::desc("tag attribute value for the transform dialect interpreter "
+                   "payload root operation"),
+    llvm::cl::init(""));
+
+llvm::cl::opt<std::string> clCPUCodegenTransformDialectTransformTag(
+    "iree-codegen-llvmcpu-transform-dialect-transform-tag",
+    llvm::cl::desc(
+        "tag attribute value for the transform dialect transform op container"),
+    llvm::cl::init(""));
 
 using IREE::Codegen::DispatchLoweringPassPipeline;
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -72,8 +72,8 @@ static llvm::cl::opt<bool> clEnableReassociateFpReductions(
 // Defined externally in KernelDispatch.cpp to control the codegen pass
 // pipeline.
 extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectFileName;
-extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectPayloadTag;
-extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectTransformTag;
+extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectDebugPayloadTag;
+extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectDebugTransformTag;
 
 //===---------------------------------------------------------------------===//
 // Default Linalg code generation options for CPU backend
@@ -657,8 +657,8 @@ void addTransformDialectPasses(OpPassManager &passManager) {
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
           clCPUCodegenTransformDialectFileName,
-          clCPUCodegenTransformDialectPayloadTag,
-          clCPUCodegenTransformDialectTransformTag));
+          clCPUCodegenTransformDialectDebugPayloadTag,
+          clCPUCodegenTransformDialectDebugTransformTag));
   // Dropping the schedule is needed:
   //   1. if we want to embed the transform in the module: we should drop the
   //      schedule once applied.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -72,6 +72,8 @@ static llvm::cl::opt<bool> clEnableReassociateFpReductions(
 // Defined externally in KernelDispatch.cpp to control the codegen pass
 // pipeline.
 extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectFileName;
+extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectPayloadTag;
+extern llvm::cl::opt<std::string> clCPUCodegenTransformDialectTransformTag;
 
 //===---------------------------------------------------------------------===//
 // Default Linalg code generation options for CPU backend
@@ -654,7 +656,9 @@ void addTransformDialectPasses(OpPassManager &passManager) {
   // Give control to the transform dialect.
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
-          clCPUCodegenTransformDialectFileName));
+          clCPUCodegenTransformDialectFileName,
+          clCPUCodegenTransformDialectPayloadTag,
+          clCPUCodegenTransformDialectTransformTag));
   // Dropping the schedule is needed:
   //   1. if we want to embed the transform in the module: we should drop the
   //      schedule once applied.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -41,6 +41,18 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectJit(
     "iree-codegen-llvmgpu-enable-transform-dialect-jit",
     llvm::cl::desc("enable the usage of the transform dialect JIT"),
     llvm::cl::init(false));
+
+llvm::cl::opt<std::string> clGPUCodegenTransformDialectPayloadTag(
+    "iree-codegen-llvmgpu-transform-dialect-payload-tag",
+    llvm::cl::desc("tag attribute value for the transform dialect interpreter "
+                   "payload root operation"),
+    llvm::cl::init(""));
+
+llvm::cl::opt<std::string> clGPUCodegenTransformDialectTransformTag(
+    "iree-codegen-llvmgpu-transform-dialect-transform-tag",
+    llvm::cl::desc(
+        "tag attribute value for the transform dialect transform op container"),
+    llvm::cl::init(""));
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -42,14 +42,14 @@ llvm::cl::opt<bool> clGPUEnableTransformDialectJit(
     llvm::cl::desc("enable the usage of the transform dialect JIT"),
     llvm::cl::init(false));
 
-llvm::cl::opt<std::string> clGPUCodegenTransformDialectPayloadTag(
-    "iree-codegen-llvmgpu-transform-dialect-payload-tag",
+llvm::cl::opt<std::string> clGPUCodegenTransformDialectDebugPayloadTag(
+    "iree-codegen-llvmgpu-transform-dialect-debug-payload-tag",
     llvm::cl::desc("tag attribute value for the transform dialect interpreter "
                    "payload root operation"),
     llvm::cl::init(""));
 
-llvm::cl::opt<std::string> clGPUCodegenTransformDialectTransformTag(
-    "iree-codegen-llvmgpu-transform-dialect-transform-tag",
+llvm::cl::opt<std::string> clGPUCodegenTransformDialectDebugTransformTag(
+    "iree-codegen-llvmgpu-transform-dialect-debug-transform-tag",
     llvm::cl::desc(
         "tag attribute value for the transform dialect transform op container"),
     llvm::cl::init(""));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -410,16 +410,16 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
 }
 
 extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectFileName;
-extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectPayloadTag;
-extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectTransformTag;
+extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectDebugPayloadTag;
+extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectDebugTransformTag;
 
 void addGPUTransformDialectPasses(OpPassManager &passManager) {
   // Give control to the transform dialect.
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
           clGPUCodegenTransformDialectFileName,
-          clGPUCodegenTransformDialectPayloadTag,
-          clGPUCodegenTransformDialectTransformTag));
+          clGPUCodegenTransformDialectDebugPayloadTag,
+          clGPUCodegenTransformDialectDebugTransformTag));
 
   // Dropping the schedule is needed:
   //   1. if we want to embed the transform in the module: we should drop the

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -410,12 +410,16 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
 }
 
 extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectFileName;
+extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectPayloadTag;
+extern llvm::cl::opt<std::string> clGPUCodegenTransformDialectTransformTag;
 
 void addGPUTransformDialectPasses(OpPassManager &passManager) {
   // Give control to the transform dialect.
   passManager.addPass(
       mlir::iree_compiler::createTransformDialectInterpreterPass(
-          clGPUCodegenTransformDialectFileName));
+          clGPUCodegenTransformDialectFileName,
+          clGPUCodegenTransformDialectPayloadTag,
+          clGPUCodegenTransformDialectTransformTag));
 
   // Dropping the schedule is needed:
   //   1. if we want to embed the transform in the module: we should drop the

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -172,8 +172,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPadDynamicAlloc();
 /// registrations necessary for IREE.
 std::unique_ptr<Pass> createTransformDialectInterpreterPass(
     llvm::StringRef transformFileName = llvm::StringRef(),
-    llvm::StringRef payloadRootTag = llvm::StringRef(),
-    llvm::StringRef transformRootTag = llvm::StringRef());
+    llvm::StringRef debugPayloadRootTag = llvm::StringRef(),
+    llvm::StringRef debugTransformRootTag = llvm::StringRef());
 
 /// Convert Linalg ops to Vector.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUVectorizationPass(

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -171,7 +171,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createPadDynamicAlloc();
 /// Create an IREE-specific Transform dialect interpreter pass with all
 /// registrations necessary for IREE.
 std::unique_ptr<Pass> createTransformDialectInterpreterPass(
-    llvm::StringRef transformFileName = llvm::StringRef());
+    llvm::StringRef transformFileName = llvm::StringRef(),
+    llvm::StringRef payloadRootTag = llvm::StringRef(),
+    llvm::StringRef transformRootTag = llvm::StringRef());
 
 /// Convert Linalg ops to Vector.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUVectorizationPass(

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -243,7 +243,7 @@ def TransformDialectInterpreter :
             "Optional filename containing a transform dialect specification to "
             "apply. If left empty, the IR is assumed to contain one top-level "
             "transform dialect operation somewhere in the module.">,
-    Option<"payloadRootTag", "payload-root-tag", "std::string",
+    Option<"debugPayloadRootTag", "debug-payload-root-tag", "std::string",
             /*default=*/"\"\"",
             "Select the operation with 'transform.iree_tag' attribute having "
             "the given value as payload IR root. This allows user control on "
@@ -251,7 +251,7 @@ def TransformDialectInterpreter :
             "intimate knowledge of the IREE nested pass pipeline.\\n"
             "If empty (normal operation mode), select the pass anchor "
             "operation in the IREE pipeline, as the payload IR root.">,
-    Option<"transformRootTag", "transform-root-tag", "std::string",
+    Option<"debugTransformRootTag", "debug-transform-root-tag", "std::string",
             /*default=*/"\"\"",
             "Select the operation with 'transform.iree_tag' attribute having "
             "the given value as container IR for top-level transform ops. This "

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -243,6 +243,16 @@ def TransformDialectInterpreter :
             "Optional filename containing a transform dialect specification to "
             "apply. If left empty, the IR is assumed to contain one top-level "
             "transform dialect operation somewhere in the module.">,
+    Option<"payloadRootTag", "payload-root-tag", "std::string",
+            /*default=*/"\"\"",
+            "Select the operation with 'transform.iree_tag' attribute having "
+            "the given value as payload root. If not provided, select the "
+            "pass anchor operation as payload root.">,
+    Option<"transformRootTag", "transform-root-tag", "std::string",
+            /*default=*/"\"\"",
+            "Select the operation with 'transform.iree_tag' attribute having "
+            "the given value as container for top-level transform ops. If not "
+            "provided, select the container of top-level transform op.">
   ];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -246,13 +246,20 @@ def TransformDialectInterpreter :
     Option<"payloadRootTag", "payload-root-tag", "std::string",
             /*default=*/"\"\"",
             "Select the operation with 'transform.iree_tag' attribute having "
-            "the given value as payload root. If not provided, select the "
-            "pass anchor operation as payload root.">,
+            "the given value as payload IR root. This allows user control on "
+            "what operation to transform in debug mode, without requiring "
+            "intimate knowledge of the IREE nested pass pipeline.\\n"
+            "If empty (normal operation mode), select the pass anchor "
+            "operation in the IREE pipeline, as the payload IR root.">,
     Option<"transformRootTag", "transform-root-tag", "std::string",
             /*default=*/"\"\"",
             "Select the operation with 'transform.iree_tag' attribute having "
-            "the given value as container for top-level transform ops. If not "
-            "provided, select the container of top-level transform op.">
+            "the given value as container IR for top-level transform ops. This "
+            "allows user control on what transformation to apply in debug "
+            "mode, without requiring intimate knowledge of the IREE nested "
+            "pass pipeline.\\n"
+            "If empty (normal operation mode), select the container of the "
+            "top-level transform op.">
   ];
 }
 


### PR DESCRIPTION
Introduce an additional targeting mechanism to the transform dialect interpreter pass. 

The purpose of this addition is to greatly improve debugging velocity by navigating more smoothly between:
  1. C++ builders that produce transform IR
  2. Transform IR textual manipulation and local application with the interpreter.
  3. Re-injection of manually altered transform IR in the system to run end-to-end and prove/disprove a hypothesis.

Note that steps 2 and 3 above create an interpreted sandbox in which one can very efficiently modify strategies and produce IR at any point without either recompiling the compiler or sifting through walls of text from `print-ir-after-all`.

This mechanism makes the pass walk the operation it is running on to find another operation, marked with the `transform.iree_tag` string attribute with the specified value, that is used as payload root. Similarly, the pass walks either the operation it runs on or the transform IR module when it was loaded externally to find an operation marked with `transform.iree_tag` string attribute with the specified value that is used as the container for transform ops. Note that this does not control individual transformations. It is also not expected to be used in normal lowering pipeline.

This connects better to IREE's deeply nested attribute-controlled pass pipeline machinery. It has the immediate benefit of enabling repro generation, also added in this patch. The repro can be dumped to standard debug output stream (when running interactively) or to a file using the `-debug-only=iree-transform-dialect-dump-repro` or `-debug-only=iree-transform-dialect-save-repro` command line flag, respectively. The repro command is printed to the standard debug stream.