### PR TITLE
Adds MIG template for x86_64 benchmarking in Github CI

### DIFF
--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -37,6 +37,15 @@ if [[ "${DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
         --run_config="${RUN_CONFIG}" \
         --output="${BENCHMARK_RESULTS}" \
         --verbose
+elif [[ "${DEVICE_NAME}" == "c2-standard-16" ]]; then
+  ${DOCKER_WRAPPER} \
+    gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+      ./build_tools/benchmarks/run_benchmarks_on_linux.py \
+        --normal_benchmark_tool_dir="${NORMAL_BENCHMARK_TOOLS_DIR}" \
+        --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
+        --run_config="${RUN_CONFIG}" \
+        --output="${BENCHMARK_RESULTS}" \
+        --verbose
 else
   echo "${DEVICE_NAME} is not supported yet."
   exit 1

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -45,6 +45,8 @@ elif [[ "${DEVICE_NAME}" == "c2-standard-16" ]]; then
         --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
         --run_config="${RUN_CONFIG}" \
         --output="${BENCHMARK_RESULTS}" \
+        --device_model=GCP-c2-standard-16 \
+        --cpu_uarch=CascadeLake \
         --verbose
 else
   echo "${DEVICE_NAME} is not supported yet."

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -39,7 +39,7 @@ if [[ "${DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
         --verbose
 elif [[ "${DEVICE_NAME}" == "c2-standard-16" ]]; then
   ${DOCKER_WRAPPER} \
-    gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+    gcr.io/iree-oss/base-bleeding-edge@sha256:479eefb76447c865cf58c5be7ca9fe33f48584b474a1da3dfaa125aad2510463 \
       ./build_tools/benchmarks/run_benchmarks_on_linux.py \
         --normal_benchmark_tool_dir="${NORMAL_BENCHMARK_TOOLS_DIR}" \
         --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -50,7 +50,7 @@ SKIP_PATH_PATTERNS = [
 RUNNER_ENV_DEFAULT = "prod"
 RUNNER_ENV_OPTIONS = [RUNNER_ENV_DEFAULT, "testing"]
 
-BENCHMARK_PRESET_OPTIONS = ["all", "cuda"]
+BENCHMARK_PRESET_OPTIONS = ["all", "cuda", "x86_64"]
 
 
 def skip_path(path: str) -> bool:

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -149,6 +149,12 @@ function create_template() {
       --maintenance-policy=MIGRATE
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
     )
+  elif [[ "${type}" == cpu-c2-std-16 ]]; then
+    cmd+=(
+      --machine-type=c2-standard-16
+      --maintenance-policy=MIGRATE
+      --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
+    )
   else
     echo "Got unrecognized type '${type}'" >2
     exit 1
@@ -163,7 +169,7 @@ function create_template() {
 }
 
 for group in presubmit postsubmit; do
-  for type in gpu cpu; do
+  for type in gpu cpu cpu-c2-std-16; do
     create_template "${group}" "${type}"
   done
 done

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -149,7 +149,7 @@ function create_template() {
       --maintenance-policy=MIGRATE
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
     )
-  elif [[ "${type}" == cpu-c2-std-16 ]]; then
+  elif [[ "${type}" == cpu-c2-16 ]]; then
     cmd+=(
       --machine-type=c2-standard-16
       --maintenance-policy=MIGRATE
@@ -169,7 +169,7 @@ function create_template() {
 }
 
 for group in presubmit postsubmit; do
-  for type in gpu cpu cpu-c2-std-16; do
+  for type in gpu cpu cpu-c2-16; do
     create_template "${group}" "${type}"
   done
 done


### PR DESCRIPTION
Adds templates and support for x86_64 benchmarks on c2-standard-16 machines.

`github-runner-testing-presubmit-cpu-c2-standard-16-us-west1` is too long for the name of an instance group, so I choose `github-runner-testing-presubmit-cpu-c2-std-16-us-west1`.

benchmarks: x86_64
runner-env: testing