### PR TITLE
Add a second CUDA transform reduction strategy for small reduction sizes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -25,12 +25,31 @@ int64_t previousMultipleOf(int64_t val, int64_t multiple);
 ///        a.k.a `ceildiv(val, multiple) * multiple`.
 int64_t nextMultipleOf(int64_t val, int64_t multiple);
 
+/// Find the highest divisor of `value` that is smaller than `limit`. This is
+/// useful to capture any tiling that is guaranteed to keep the IR static.
+/// Asserts that `limit` is smaller than 1024 to avoid prohibitively long
+/// compile time overheads.
+// TODO: approximate with a faster implementation based on a few desirable
+// primes.
+FailureOr<int64_t> maxDivisorOfValueBelowLimit(int64_t value, int64_t limit);
+
 //===----------------------------------------------------------------------===//
 // Low-level reusable builder APIs, these should follow MLIR-style builders.
 //===----------------------------------------------------------------------===//
 
 /// Prints `handles` in order. Prints the whole IR if `handles` is empty.
 void buildPrint(ImplicitLocOpBuilder &b, ValueRange handles = {});
+
+/// Dynamically selects the first non-empty handle; i.e. if (h1, h2) is:
+///   - (non-empty, non-empty), returns (h1, h2)
+///   - (empty, non-empty), returns (h2, empty)
+///   - (non-empty, empty), returns (h1, empty)
+///   - (empty, empty), returns (empty, empty)
+/// This is used as a normalization operation that replaces conditionals, either
+/// in C++ or in transform IR.
+/// This can be thought of as a control-flow -> data-dependent conversion.
+std::pair<Value, Value> buildSelectFirstNonEmpty(ImplicitLocOpBuilder &b,
+                                                 Value handle1, Value handle2);
 
 /// Result of the combined transform performing tiling, fusion and
 /// distribution to parallel constructs.

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -12,6 +12,7 @@
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
@@ -19,9 +20,8 @@
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
-#include "mlir/IR/MLIRContext.h"
-#include "mlir/Support/LogicalResult.h"
 
 using namespace mlir;
 
@@ -38,11 +38,11 @@ using iree_compiler::IREE::transform_dialect::VectorToWarpExecuteOnLane0Op;
 using iree_compiler::IREE::transform_dialect::VectorWarpDistributionOp;
 using transform::FuseIntoContainingOp;
 using transform::MatchOp;
+using transform::ScalarizeOp;
 using transform::SequenceOp;
 using transform_ext::MatchCallbackOp;
 using transform_ext::RegisterMatchCallbacksOp;
 using transform_ext::StructuredOpMatcher;
-using transform_ext::TakeFirstOp;
 
 /// Matches a C++ callback previously registered under `callbackName` and
 /// taking arguments `args`.
@@ -104,10 +104,9 @@ Value mlir::iree_compiler::buildDistributeVectors(ImplicitLocOpBuilder &b,
 
 namespace {
 /// Structure to hold the parameters related to GPU reduction strategy.
-struct GPUReductionBlockStrategy {
-  explicit GPUReductionBlockStrategy(
-      MLIRContext *context,
-      const transform_ext::MatchedReductionCaptures &captures)
+struct GPUReductionStrategy {
+  GPUReductionStrategy(MLIRContext *context,
+                       const transform_ext::MatchedReductionCaptures &captures)
       : context(context), captures(captures) {
     auto blockX =
         mlir::gpu::GPUBlockMappingAttr::get(context, mlir::gpu::Blocks::DimX);
@@ -116,7 +115,19 @@ struct GPUReductionBlockStrategy {
     auto blockZ =
         mlir::gpu::GPUBlockMappingAttr::get(context, mlir::gpu::Blocks::DimZ);
     allBlockAttrs = SmallVector<Attribute>{blockX, blockY, blockZ};
+    auto threadX =
+        mlir::gpu::GPUThreadMappingAttr::get(context, mlir::gpu::Threads::DimX);
+    auto threadY =
+        mlir::gpu::GPUThreadMappingAttr::get(context, mlir::gpu::Threads::DimY);
+    auto threadZ =
+        mlir::gpu::GPUThreadMappingAttr::get(context, mlir::gpu::Threads::DimZ);
+    allThreadAttrs = SmallVector<Attribute>{threadX, threadY, threadZ};
   }
+
+  virtual ~GPUReductionStrategy() {}
+
+  virtual bool isProfitable() = 0;
+  virtual std::array<int64_t, 3> getNumThreadsInBlock() const = 0;
 
   /// Constructor quantities.
   MLIRContext *context;
@@ -124,11 +135,12 @@ struct GPUReductionBlockStrategy {
 
   /// Derived quantities.
   SmallVector<Attribute> allBlockAttrs;
+  SmallVector<Attribute> allThreadAttrs;
   // Tile sizes for the workgroup / determines grid size.
   SmallVector<int64_t> workgroupTileSizes;
 };
 
-/// Encodes a strategy for a 1-d reduction mapped to a block.
+/// Encodes a 3-staged strategy for a 1-d reduction mapped to a block.
 ///
 /// This happens in a staged fashion to encode good tradeoffs between amount
 /// of parallelism, occupancy and granularity of the load/store operations.
@@ -142,10 +154,10 @@ struct GPUReductionBlockStrategy {
 /// controlled by a `warpShuffleSize` parameter passed to the constructor which
 /// must be a 1,2 or 4-multiple of the machine warp size.
 ///
-/// Stage 2: the second stage of the reduction is normalized to reduce from a
-/// "k-warps" abstraction (k determined in Step 1) to a single `warpShuffleSize`
-/// that can be reduced unambiguously well on a single warp during Stage 3.
-/// This second/ stage is optional and only occurs when k > 1.
+/// Stage 2 (optional): the second stage of the reduction is normalized to
+/// reduce from a "k-warps" abstraction (k determined in Step 1) to a single
+/// `warpShuffleSize` that can be reduced unambiguously well on a single warp
+/// during Stage 3. This second stage is optional and only occurs when k > 1.
 ///
 /// Stage 1: the first stage of the reduction is normalized to run on "k-warps"
 /// of maximal vector size for both the hardware and the problem sizes.
@@ -163,31 +175,34 @@ struct GPUReductionBlockStrategy {
 ///
 // TODO: Support various elemental types.
 // TODO: Split to ensure 4 on most of the problem and use a 1-epilogue.
-class ReductionStrategyStagedThreadDistribution
-    : public GPUReductionBlockStrategy {
+class ReductionStrategyStagedThreadDistribution : public GPUReductionStrategy {
  public:
   ReductionStrategyStagedThreadDistribution(
       MLIRContext *context,
       const transform_ext::MatchedReductionCaptures &captures,
       int64_t maxNumThreadsToUse, int64_t warpShuffleSize)
-      : GPUReductionBlockStrategy(context, captures) {
+      : GPUReductionStrategy(context, captures) {
     compute(maxNumThreadsToUse, warpShuffleSize);
   }
+
   ReductionStrategyStagedThreadDistribution(
       const ReductionStrategyStagedThreadDistribution &) = default;
 
   ReductionStrategyStagedThreadDistribution &operator=(
       const ReductionStrategyStagedThreadDistribution &) = default;
 
-  int64_t getVectorSizeStage1() const { return vectorSizeStage1; }
-
   int64_t getNumThreadsXInBlock() const { return reductionTileSizeStage1; }
   int64_t getNumThreadsYInBlock() const { return 1; }
   int64_t getNumThreadsZInBlock() const { return 1; }
-  std::array<int64_t, 3> getNumThreadsInBlock() const {
+  std::array<int64_t, 3> getNumThreadsInBlock() const override {
     return {getNumThreadsXInBlock(), getNumThreadsYInBlock(),
             getNumThreadsZInBlock()};
   }
+
+  // Always profitable.
+  bool isProfitable() override { return true; }
+
+  int64_t getVectorSizeStage1() const { return vectorSizeStage1; }
 
   bool hasStage2() const { return reductionTileSizeStage2.has_value(); }
   int64_t getWarpShuffleSize() const { return reductionTileSizeStage2.value(); }
@@ -210,7 +225,7 @@ class ReductionStrategyStagedThreadDistribution
   /// k > 1).
   std::optional<int64_t> reductionTileSizeStage2;
 
-  /// Compute the staged strategy based on the `reductionDimensionSize`, the
+  /// Compute the staged strategy based on the reductionDimensionSize, the
   /// `maxNumThreadsToUse` and the `warpShuffleSize`.
   /// The latter 2 numbers control the tradeoff between parallelism and shared
   /// memory consumption.
@@ -221,13 +236,25 @@ class ReductionStrategyStagedThreadDistribution
 
 void ReductionStrategyStagedThreadDistribution::compute(
     int64_t maxNumThreadsToUse, int64_t warpShuffleSize) {
-  assert(warpShuffleSize > 0 && "warpShuffleSize must > 0");
+  assert(maxNumThreadsToUse > 0 && "maxNumThreadsToUse must be > 0");
+  assert(maxNumThreadsToUse >= iree_compiler::kCudaWarpSize &&
+         "not even a warp?");
+  assert(warpShuffleSize > 0 && "warpShuffleSize must be > 0");
   assert(warpShuffleSize % iree_compiler::kCudaWarpSize == 0 &&
          "warpShuffleSize must be a multiple of warpSize");
   assert(warpShuffleSize <= 4 * iree_compiler::kCudaWarpSize &&
          "must be smaller or equal to 4 * warp_size");
 
-  // Stage 1.
+  // Block-level
+  // ===========
+  // Tile all the parallel dimensions to 1 and create many blocks.
+  int64_t numParallelLoops = captures.reductionRank - 1;
+  workgroupTileSizes.append(numParallelLoops, 1);
+
+  // Thread-level
+  // ============
+  // Stage 1
+  // -------
   // Maximal vector size that divides the problem size.
   // TODO: Split to ensure 4 on most of the problem and use a 1-epilogue.
   int64_t reductionDimensionSize = captures.reductionDimensionSize;
@@ -237,7 +264,6 @@ void ReductionStrategyStagedThreadDistribution::compute(
     vectorSizeStage1 = 2;
   else
     vectorSizeStage1 = 1;
-
   // Tile reduction to the maximal multiple `warpShuffleSize` allowed.
   // This locally reduces the large unknown reduction into a guaranteed
   // multiple of `warpShuffleSize`.
@@ -250,7 +276,10 @@ void ReductionStrategyStagedThreadDistribution::compute(
     reductionTileSizeStage1 =
         iree_compiler::previousMultipleOf(maxNumThreadsToUse, warpShuffleSize);
   }
-  // Stage 2 is only needed if `reductionTileSizeStage1` consists of multiple
+
+  // Stage 2
+  // -------
+  // Only needed if `reductionTileSizeStage1` consists of multiple
   // `warpShuffleSize`; otherwise, we just skip this step.
   if (reductionTileSizeStage1 > warpShuffleSize) {
     // Tile reduction exactly to `warpShuffleSize` which will be used in the 3rd
@@ -266,18 +295,141 @@ void ReductionStrategyStagedThreadDistribution::compute(
     else
       vectorSizeStage2 = 1;
   }
+
+  // Stage 3
+  // -------
+  // Stage 3 is non-ambiguous and does not ned to be configured (always uses
+  // warp shuffles).
+}
+
+/// Encodes a strategy targeted at (very) small reductions, for which other
+/// strategies perform poorly.
+///
+/// In the case of small reductions, we cannot make an efficient use of warp
+/// shuffles. Instead, try to take advantage of caches.
+/// This strategy aims at running the reduction sequentially within each thread
+/// and taking parallelism from outer dimensions that we would otherwise use
+/// for block-level parallelism.
+///
+/// There are 2 cases:
+///   1. we can find good divisors of outer parallel dimensions and avoid
+///      creating dynamic tile sizes. We can then vectorize to the reduction
+///      size.
+///   2. we cannot find good divisors, we pay the price of dynamic loops.
+///
+// TODO: Refine 1. with linalg splitting on the reduction dimension.
+// TODO: Refine 2. with linalg splitting on the parallel dimension.
+//
+// Note: All this is to be able to handle very small and small-ish reductions
+// without catastrophic regressions.
+// TODO: Add a strategy based on segmented scans, which can allow us to force
+// sizes that don't divide properly into warp shuffles.
+class SmallReductionStrategy : public GPUReductionStrategy {
+ public:
+  /// `hasTrailingElementwise` is currently used to guard against pathological
+  /// cases where IREE can't bound a buffer and crashes.
+  // TODO: Fix codegen/Common/PadDynamicAlloc.cpp which calls into upstream
+  // code that tries to compose affine maps too aggressively when it could
+  // instead resolve bounding by being more eager.
+  SmallReductionStrategy(
+      MLIRContext *context,
+      const transform_ext::MatchedReductionCaptures &captures,
+      int64_t maxNumThreadsToUse, bool hasTrailingElementwise)
+      : GPUReductionStrategy(context, captures) {
+    compute(maxNumThreadsToUse, hasTrailingElementwise);
+  }
+
+  SmallReductionStrategy(const SmallReductionStrategy &) = default;
+  SmallReductionStrategy &operator=(const SmallReductionStrategy &) = default;
+
+  int64_t getNumThreadsXInBlock() const { return getNumThreadsInBlock()[0]; }
+  int64_t getNumThreadsYInBlock() const { return getNumThreadsInBlock()[1]; }
+  int64_t getNumThreadsZInBlock() const { return getNumThreadsInBlock()[2]; }
+  std::array<int64_t, 3> getNumThreadsInBlock() const override {
+    std::array<int64_t, 3> res{1, 1, 1};
+    for (int64_t i = 0, e = workgroupTileSizes.size(); i < e; ++i)
+      res[i] = workgroupTileSizes[i];
+    return res;
+  }
+
+  bool isProfitable() override { return profitable; }
+
+ private:
+  bool profitable = false;
+
+  /// Compute the small strategy based on the problem size and the
+  /// `maxNumThreadsToUse`.
+  /// `hasTrailingElementwise` is currently used to guard against pathological
+  /// cases where IREE can't bound a buffer and crashes.
+  // TODO: Fix IREE's odegen/Common/PadDynamicAlloc.cpp.
+  void compute(int64_t maxNumThreadsToUse, bool hasTrailingElementwise);
+};
+
+void SmallReductionStrategy::compute(int64_t maxNumThreadsToUse,
+                                     bool hasTrailingElementwise) {
+  assert(maxNumThreadsToUse > 0 && "maxNumThreadsToUse must be > 0");
+  assert(maxNumThreadsToUse >= iree_compiler::kCudaWarpSize &&
+         "not even a warp?");
+
+  // Block-level
+  // ===========
+  // TODO: capture more dims than just the most minor parallel and have a more
+  // powerful `maybeDivisor` evaluation.
+  FailureOr<int64_t> maybeDivisor =
+      mlir::iree_compiler::maxDivisorOfValueBelowLimit(
+          captures.mostMinorParallelDimensionSize, maxNumThreadsToUse);
+
+  // Trailing elementwise unaligned tiling created bounded local buffers that
+  // are dynamic. Attempting to bound them in Common/PadDynamicAlloc.cpp results
+  // in a crash in the associated upstream util.
+  // TODO: Capture static parallel dimensions and allow if workgroupTileSizes
+  // divides the parallel dimension evenly.
+  // TODO: More generally fix PadDynamicAlloc and the associated upstream util.
+  if (failed(maybeDivisor) && hasTrailingElementwise) return;
+
+  // Dynamic reductions are never supported by default because we can never
+  // know offhand whether we are in a small-reduction regime mode. Since this
+  // mode does not coalesce reads, perf will suffer catastrophically on larger
+  // runtime reduction.
+  // TODO: explicit hint from above that we really want to do that.
+  // TODO: evolve towards expressing this constraint with a perf-directed
+  // matcher that composes with the existing structural matchers.
+  if (ShapedType::isDynamic(captures.reductionDimensionSize)) return;
+
+  // Otherwise, still only support the small cases for now and fall back to
+  // other strategies otherwise.
+  // TODO: evolve towards expressing this constraint with a perf-directed
+  // matcher that composes with the existing structural matchers.
+  if (captures.reductionDimensionSize >= 2 * iree_compiler::kCudaWarpSize)
+    return;
+
+  // If the captured dimension has no satisfactory divisor, just tile the last
+  // parallel dimension by 2 * iree_compiler::kCudaWarpSize.
+  int64_t numParallelLoops = captures.reductionRank - 1;
+  workgroupTileSizes.append(numParallelLoops, 1);
+  workgroupTileSizes.back() =
+      hasTrailingElementwise
+          ? *maybeDivisor
+          : std::min((int64_t)maxNumThreadsToUse,
+                     (int64_t)(2 * iree_compiler::kCudaWarpSize));
+
+  // Thread-level
+  // ============
+  // Just running sequentially on each thread and relying on cache for
+  // locality.
+  // TODO: evolve towards expressing constraints with perf-directed matchers.
+  profitable = true;
 }
 
 }  // namespace
 
-static std::tuple<Value, Value, Value> createReductionStrategyBlockDistribution(
-    ImplicitLocOpBuilder &b, Value maybeLeadingH, Value fillH, Value reductionH,
-    Value maybeTrailingH, const GPUReductionBlockStrategy &strategy) {
-  auto pdlOperation = pdl::OperationType::get(b.getContext());
-  auto fusionTargetSelector = b.create<TakeFirstOp>(
-      pdlOperation, pdlOperation, ArrayRef<Value>{maybeTrailingH, reductionH});
-  Value fusionTargetH = fusionTargetSelector.getFirst();
-  Value fusionGroupH = fusionTargetSelector.getRest();
+static std::tuple<Value, Value, Value, Value>
+createReductionStrategyBlockDistribution(ImplicitLocOpBuilder &b,
+                                         Value maybeLeadingH, Value fillH,
+                                         Value reductionH, Value maybeTrailingH,
+                                         const GPUReductionStrategy &strategy) {
+  auto [fusionTargetH, fusionGroupH] =
+      iree_compiler::buildSelectFirstNonEmpty(b, maybeTrailingH, reductionH);
   ArrayRef<Attribute> allBlocksRef(strategy.allBlockAttrs);
   iree_compiler::TileToForeachThreadAndFuseAndDistributeResult tileResult =
       iree_compiler::
@@ -291,22 +443,14 @@ static std::tuple<Value, Value, Value> createReductionStrategyBlockDistribution(
               b.getArrayAttr(allBlocksRef.take_front(
                   strategy.captures.reductionRank - 1)));
   fillH = b.create<FuseIntoContainingOp>(fillH, tileResult.foreachThreadH);
-  if (strategy.captures.maybeLeadingRank > 0) {
-    maybeLeadingH = b.create<FuseIntoContainingOp>(maybeLeadingH,
-                                                   tileResult.foreachThreadH);
-  }
-  // Here, TakeFirstOp acts as a normalizer:
-  //   1. if fusionTargetH is maybeTrailingH then getFirst() is reductionH and
-  //      getRest() is maybeTrailingH.
-  //   2. if fusionTargetH is reductionH then getFirst() is reductionH and
-  //      getRest() is empty.
-  auto gridReductionSelector = b.create<TakeFirstOp>(
-      pdlOperation, pdlOperation,
-      ValueRange{tileResult.resultingFusedOpsHandles.front(),
-                 tileResult.tiledOpH});
-  Value gridReductionH = gridReductionSelector.getFirst();
-  maybeTrailingH = gridReductionSelector.getRest();
-  return std::make_tuple(maybeLeadingH, gridReductionH, maybeTrailingH);
+  maybeLeadingH =
+      b.create<FuseIntoContainingOp>(maybeLeadingH, tileResult.foreachThreadH);
+
+  auto [gridReductionH, maybeGridTrailingH] =
+      iree_compiler::buildSelectFirstNonEmpty(
+          b, tileResult.resultingFusedOpsHandles.front(), tileResult.tiledOpH);
+  return std::make_tuple(maybeLeadingH, fillH, gridReductionH,
+                         maybeGridTrailingH);
 }
 
 static std::tuple<Value, Value, Value>
@@ -415,6 +559,28 @@ static void createReductionStrategyStagedThreadDistribution(
   }
 }
 
+/// Take care of the last common steps in a GPU strategy (i.e. vectorize,
+/// bufferize, maps to blocks and threads and distribute vectors).
+static void createCommonTrailingStrategy(ImplicitLocOpBuilder &b,
+                                         Value variantH,
+                                         const GPUReductionStrategy &strategy) {
+  // Step N-2. Bufferize and drop HAL decriptor from memref ops.
+  Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
+  funcH = iree_compiler::buildVectorize(b, funcH);
+  variantH = iree_compiler::buildBufferize(b, variantH,
+                                           /*targetGpu=*/true);
+
+  // Step N-1. Post-bufferization mapping to blocks and threads.
+  // Need to match again since bufferize invalidated all handles.
+  // TODO: assumes a single func::FuncOp to transform, may need hardening.
+  funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
+  funcH = iree_compiler::buildMapToBlockAndThreads(
+      b, funcH, strategy.getNumThreadsInBlock());
+
+  // Step N. Post-bufferization vector distribution with rank-reduction.
+  iree_compiler::buildDistributeVectors(b, variantH, funcH);
+}
+
 /// Builds the transform IR tiling reductions for CUDA targets. Supports
 /// reductions in the last dimension, with optional leading and trailing
 /// elementwise operations.
@@ -431,31 +597,83 @@ static void createCudaReductionStrategyStagedThreadDistribution(
 
   // Step 2. Use tiling to introduce a single-iteration loop mapped to a
   // single block/workgroup. Keep everything fused.
-  auto [maybeLeadingHFused, gridReductionH, maybeTiledTrailingH] =
+  auto [maybeLeadingHBlock, gridFillH, gridReductionH,
+        maybeTiledTrailingHBlock] =
       createReductionStrategyBlockDistribution(
           b, maybeLeadingH, fillH, reductionH, maybeTrailingH, strategy);
-  maybeLeadingH = maybeLeadingHFused;
 
   // Step 3. Split the reduction and tile the pieces to ensure vector
   // load/stores and mapping to a single warp with shuffles.
+  // TODO: consider fusing gridFillH.
   createReductionStrategyStagedThreadDistribution(
-      b, gridReductionH, maybeLeadingH, maybeTiledTrailingH, strategy);
+      b, gridReductionH, maybeLeadingHBlock, maybeTiledTrailingHBlock,
+      strategy);
 
-  // Step 4. Bufferize and drop HAL decriptor from memref ops.
-  Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
-  funcH = iree_compiler::buildVectorize(b, funcH);
-  variantH = iree_compiler::buildBufferize(b, variantH,
-                                           /*targetGpu=*/true);
+  // Step 4-6. Common trailing steps.
+  createCommonTrailingStrategy(b, variantH, strategy);
+}
 
-  // Step 5. Post-bufferization mapping to blocks and threads.
-  // Need to match again since bufferize invalidated all handles.
-  // TODO: assumes a single func::FuncOp to transform, may need hardening.
-  funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
-  funcH = iree_compiler::buildMapToBlockAndThreads(
-      b, funcH, strategy.getNumThreadsInBlock());
+static std::tuple<Value, Value, Value>
+createSmallReductionStrategyThreadDistribution(
+    ImplicitLocOpBuilder &b, Value maybeLeadingH, Value fillH, Value reductionH,
+    Value maybeTrailingH, const GPUReductionStrategy &strategy) {
+  auto [fusionTargetH, fusionGroupH] =
+      iree_compiler::buildSelectFirstNonEmpty(b, maybeTrailingH, reductionH);
+  ArrayRef<Attribute> allThreadsRef(strategy.allThreadAttrs);
+  iree_compiler::TileToForeachThreadAndFuseAndDistributeResult tileResult =
+      iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
+          /*builder=*/b,
+          /*rootH=*/fusionTargetH,
+          /*opsToFuseH=*/fusionGroupH,
+          /*numThreads=*/
+          getAsOpFoldResult(b.getI64ArrayAttr(strategy.workgroupTileSizes)),
+          /*threadDimMapping=*/
+          b.getArrayAttr(
+              allThreadsRef.take_front(strategy.captures.reductionRank - 1)));
+  fillH = b.create<FuseIntoContainingOp>(fillH, tileResult.foreachThreadH);
+  maybeLeadingH =
+      b.create<FuseIntoContainingOp>(maybeLeadingH, tileResult.foreachThreadH);
 
-  // Step 6. Post-bufferization vector distribution with rank-reduction.
-  iree_compiler::buildDistributeVectors(b, variantH, funcH);
+  // Scalarize all ops to ensure vectorization.
+  auto pdlOperation = pdl::OperationType::get(b.getContext());
+  fillH = b.create<ScalarizeOp>(pdlOperation, fillH);
+  maybeLeadingH = b.create<ScalarizeOp>(pdlOperation, maybeLeadingH);
+  Value tiledH = b.create<ScalarizeOp>(pdlOperation, tileResult.tiledOpH);
+  Value fusedH = b.create<ScalarizeOp>(
+      pdlOperation, tileResult.resultingFusedOpsHandles.front());
+
+  auto [blockReductionH, maybeBlockTrailingH] =
+      iree_compiler::buildSelectFirstNonEmpty(b, fusedH, tiledH);
+  return std::make_tuple(maybeLeadingH, blockReductionH, maybeBlockTrailingH);
+}
+
+/// Builds the transform IR tiling reductions for CUDA targets. Supports
+/// reductions in the last dimension, with optional leading and trailing
+/// elementwise operations.
+static void createCudaSmallReductionStrategy(
+    ImplicitLocOpBuilder &b, Value variantH,
+    const SmallReductionStrategy &strategy) {
+  // Step 1. Call the matcher. Note that this is the same matcher as used to
+  // trigger this compilation path, so it must always apply.
+  b.create<RegisterMatchCallbacksOp>();
+  auto [maybeLeadingH, fillH, reductionH, maybeTrailingH] =
+      unpackRegisteredMatchCallback<4>(
+          b, "reduction", transform::FailurePropagationMode::Propagate,
+          variantH);
+
+  // Step 2. Apply block-level part of the strategy, keeps everything fused.
+  auto [maybeLeadingHBlock, gridFillH, gridReductionH,
+        maybeTiledTrailingHBlock] =
+      createReductionStrategyBlockDistribution(
+          b, maybeLeadingH, fillH, reductionH, maybeTrailingH, strategy);
+
+  // Step 3. Apply thread-level part of the strategy, keeps everything fused.
+  createSmallReductionStrategyThreadDistribution(
+      b, maybeLeadingHBlock, gridFillH, gridReductionH,
+      maybeTiledTrailingHBlock, strategy);
+
+  // Step 4-6. Common trailing steps.
+  createCommonTrailingStrategy(b, variantH, strategy);
 }
 
 struct GPUReductionConfig {
@@ -490,14 +708,26 @@ static ReductionStrategyStagedThreadDistribution
 configureGPUReductionStrategyStagedThreadDistribution(
     MLIRContext *context,
     const transform_ext::MatchedReductionCaptures &captures) {
+  // TODO: Generalize along the HW axis.
   GPUReductionConfig gpuReductionConfig = getReductionConfigRTX2080Ti(captures);
   ReductionStrategyStagedThreadDistribution strategy(
       context, captures, gpuReductionConfig.maxNumThreads,
       gpuReductionConfig.warpShuffleSize);
+  LLVM_DEBUG(DBGS() << "use staged reduction strategy\n");
+  return strategy;
+}
 
-  // Tile all the parallel dimensions to 1 and create many blocks.
-  int64_t numParallelLoops = strategy.captures.reductionRank - 1;
-  strategy.workgroupTileSizes.append(numParallelLoops, 1);
+static FailureOr<SmallReductionStrategy> configureGPUSmallReductionStrategy(
+    MLIRContext *context,
+    const transform_ext::MatchedReductionCaptures &captures,
+    bool hasTrailingElementwise) {
+  // TODO: Generalize along the HW axis.
+  GPUReductionConfig gpuReductionConfig = getReductionConfigRTX2080Ti(captures);
+  SmallReductionStrategy strategy(context, captures,
+                                  gpuReductionConfig.maxNumThreads,
+                                  hasTrailingElementwise);
+  if (!strategy.isProfitable()) return failure();
+  LLVM_DEBUG(DBGS() << "use small reduction strategy\n");
   return strategy;
 }
 
@@ -512,6 +742,12 @@ LogicalResult iree_compiler::matchAndSetGPUReductionTransformStrategy(
   // 2. Construct the configuration and the strategy builder.
   auto strategyBuilder = [&](ImplicitLocOpBuilder &b, Value variant) {
     // TODO: Better strategy for very small reductions.
+    FailureOr<SmallReductionStrategy> maybeSmallStrategy =
+        configureGPUSmallReductionStrategy(op->getContext(), captures,
+                                           trailing.getCaptured());
+    if (succeeded(maybeSmallStrategy))
+      return createCudaSmallReductionStrategy(b, variant, *maybeSmallStrategy);
+
     ReductionStrategyStagedThreadDistribution strategy =
         configureGPUReductionStrategyStagedThreadDistribution(op->getContext(),
                                                               captures);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -129,5 +129,5 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_32
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [32] tile_sizes [](mapping = [#gpu.thread<x>])
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -570,6 +570,8 @@ private:
 
 struct MatchedReductionCaptures {
   int64_t reductionRank = 0;
+  // TODO: capture all dims.
+  int64_t mostMinorParallelDimensionSize = 0;
   int64_t reductionDimensionSize = 0;
   int64_t maybeLeadingRank = 0;
   int64_t maybeTrailingRank = 0;

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -435,8 +435,8 @@ void transform_ext::makeReductionMatcher(
   // The core part of the matcher is anchored on a particular reduction op.
   reduction =
       m_StructuredOp()
-          // Op has at least a parallel a reduction dimension and at most 3
-          // parallel dimensions.
+          // Op has at least a parallel a reduction dimension and at
+          // most 3 parallel dimensions.
           // TODO: relax once we have global collapse/expand_shape.
           //
           .rank(NumGreaterEqualTo(2))
@@ -444,6 +444,8 @@ void transform_ext::makeReductionMatcher(
           .rank(CaptureStaticValue<int64_t>(captures.reductionRank))
           // Op has a single most-minor reduction that we capture.
           .dim(-1, utils::IteratorType::reduction)
+          .dim(-2, CaptureStaticValue<int64_t>(
+                       captures.mostMinorParallelDimensionSize))
           .dim(-1, CaptureStaticValue<int64_t>(captures.reductionDimensionSize))
           // All other dimensions are parallel.
           .dim(AllDimsExcept({-1}), utils::IteratorType::parallel)


### PR DESCRIPTION
This revision adds a new strategy for the small reduction domain.
For small reductions, we rely on L1 cache locality and do not try to parallelize individual reductions: every thread performs the full reduction locally.

This is empirically determined profitable up until a reduction size of 64.
This can be fine-tuned later when we have better support for filtering and profitability considerations.

Running the iree-samples/transform_dialect script:
```
(  benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_static 1234567 15 )
```

before:
```
With transform dialect: reduction_2d_static --function_input="1234567x15xf32" P50: 1278300.0000 ns 14.48682234217319877962 GElements/s
Without transform dialect: reduction_2d_static --function_input="1234567x15xf32" P50: 2778900.0000 ns 6.66396955629925510093 GElements/s
```

with this PR:
```
With transform dialect: reduction_2d_static --function_input="1234567x15xf32" P50: 150060.00 ns 123.40733706517393042782 GElements/s
Without transform dialect: reduction_2d_static --function_input="1234567x15xf32" P50: 2808400.0000 ns 6.59396987608602763139 GElements/s
```