### PR TITLE
Support runtime tracing with Tracy in bazel builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,6 +668,7 @@ include(flatbuffer_c_library)
 
 add_subdirectory(build_tools/third_party/libyaml EXCLUDE_FROM_ALL)
 add_subdirectory(build_tools/third_party/llvm-project EXCLUDE_FROM_ALL)
+add_subdirectory(build_tools/third_party/tracy_client EXCLUDE_FROM_ALL)
 add_subdirectory(build_tools/third_party/vulkan_memory_allocator EXCLUDE_FROM_ALL)
 
 iree_set_googletest_cmake_options()

--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -10,7 +10,7 @@
 
 # Equivalent to CMake flag IREE_ENABLE_RUNTIME_TRACING.
 # Builds the runtime with tracing support enabled.
-build:iree_enable_runtime_tracing --@tracy_client//:runtime_enable=true
+build --flag_alias=iree_enable_runtime_tracing=@tracy_client//:runtime_enable
 
 ###############################################################################
 # Common flags that apply to all configurations.

--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -5,6 +5,14 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ###############################################################################
+# Short-hand config settings for IREE specific features.
+###############################################################################
+
+# Equivalent to CMake flag IREE_ENABLE_RUNTIME_TRACING.
+# Builds the runtime with tracing support enabled.
+build:iree_enable_runtime_tracing --@tracy_client//:runtime_enable=true
+
+###############################################################################
 # Common flags that apply to all configurations.
 # Use sparingly for things common to all compilers and platforms.
 ###############################################################################

--- a/build_tools/bazel/workspace.bzl
+++ b/build_tools/bazel/workspace.bzl
@@ -94,3 +94,10 @@ def configure_iree_submodule_deps(iree_repo_alias = "@", iree_path = "./"):
         build_file = iree_repo_alias + "//:build_tools/third_party/torch-mlir-dialects/BUILD.overlay",
         path = paths.join(iree_path, "third_party/torch-mlir-dialects"),
     )
+
+    maybe(
+        native.new_local_repository,
+        name = "tracy_client",
+        build_file = iree_repo_alias + "//:build_tools/third_party/tracy_client/BUILD.overlay",
+        path = paths.join(iree_path, "third_party/tracy"),
+    )

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_targets.py
@@ -111,6 +111,9 @@ EXPLICIT_TARGET_MAPPING = {
         "TorchMLIRTMTensorDialect"
     ],
 
+    # Tracy.
+    "@tracy_client//:runtime_impl": ["tracy_client::runtime_impl"],
+
     # Vulkan
     "@vulkan_headers": ["Vulkan::Headers"],
     # Misc single targets

--- a/build_tools/third_party/tracy/README.md
+++ b/build_tools/third_party/tracy/README.md
@@ -1,0 +1,7 @@
+# Tracy server build support
+
+This directory contains build support for building tracy server binaries
+on supported platforms.
+
+For the client, see the sibling directory tracy_client, which is platform
+neutral.

--- a/build_tools/third_party/tracy_client/BUILD.overlay
+++ b/build_tools/third_party/tracy_client/BUILD.overlay
@@ -1,0 +1,64 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+package(default_visibility = ["//visibility:public"])
+
+# Flags to enable/disable.
+# These can be passed on the command line as:
+#   --@tracy_client//:runtime_enable
+bool_flag(
+    name = "runtime_enable",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "_runtime_enabled",
+    flag_values = {
+        ":runtime_enable": "True",
+    },
+)
+
+# The 'enable_impl' and 'disable_impl' targets are referenced by aliases
+# based on config settings for different parts of the codebase that can
+# have tracing independently enabled.
+cc_library(
+    name = "enable_impl",
+    hdrs = glob([
+        "public/libbacktrace/*.h",
+        "public/libbacktrace/*.hpp",
+        "public/libbacktrace/*.cpp",
+        "public/tracy/*.h",
+        "public/tracy/*.hpp",
+        "public/*.cpp",
+        "public/common/*.h",
+        "public/common/*.hpp",
+        "public/common/*.cpp",
+        "public/client/*.h",
+        "public/client/*.hpp",
+        "public/client/*.cpp",
+    ]),
+    defines = [
+        "IREE_TRACING_MODE=2",
+    ],
+    includes = [
+        "public",
+    ],
+)
+
+cc_library(
+    name = "disable_impl",
+)
+
+# Conditionally enable for the runtime.
+alias(
+    name = "runtime_impl",
+    actual = select({
+        ":_runtime_enabled": ":enable_impl",
+        "//conditions:default": ":disable_impl",
+    }),
+)

--- a/build_tools/third_party/tracy_client/CMakeLists.txt
+++ b/build_tools/third_party/tracy_client/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# The runtime tracing library will depend on this target unconditionally.
+# It conditionally either includes the necessary headers/defines or no-ops.
+if(IREE_ENABLE_RUNTIME_TRACING)
+  external_cc_library(
+    PACKAGE
+      tracy_client
+    NAME
+      runtime_impl
+    ROOT
+      "${IREE_ROOT_DIR}/third_party/tracy/public"
+    HDRS
+      "tracy/Tracy.hpp"
+      "tracy/TracyC.h"
+    INCLUDES
+      "${IREE_ROOT_DIR}/third_party/tracy/public"
+    DEPS
+      ${CMAKE_DL_LIBS}
+    DEFINES
+      "IREE_TRACING_MODE=2"
+  )
+else()
+  external_cc_library(
+    PACKAGE
+      tracy_client
+    NAME
+      runtime_impl
+    ROOT
+      "${IREE_ROOT_DIR}/third_party/tracy/public"
+  )
+endif()

--- a/runtime/src/iree/base/BUILD
+++ b/runtime/src/iree/base/BUILD
@@ -168,8 +168,10 @@ iree_runtime_cc_test(
 
 iree_runtime_cc_library(
     name = "tracing",
+    srcs = ["tracing.cc"],
     hdrs = ["tracing.h"],
     deps = [
         ":core_headers",
+        "@tracy_client//:runtime_impl",
     ],
 )

--- a/runtime/src/iree/base/CMakeLists.txt
+++ b/runtime/src/iree/base/CMakeLists.txt
@@ -161,34 +161,18 @@ iree_cc_test(
 # to excusively static linkage scenarios and note that it's unstable. It's just
 # really really useful and the only way for applications to interleave with our
 # tracing (today).
-if(IREE_ENABLE_RUNTIME_TRACING)
-  iree_cc_library(
-    NAME
-      tracing
-    HDRS
-      "tracing.h"
-      "${IREE_ROOT_DIR}/third_party/tracy/public/tracy/Tracy.hpp"
-      "${IREE_ROOT_DIR}/third_party/tracy/public/tracy/TracyC.h"
-    SRCS
-      "tracing.cc"
-    DEPS
-      ${CMAKE_DL_LIBS}
-      ::core_headers
-    DEFINES
-      "IREE_TRACING_MODE=2"
-    PUBLIC
-  )
-else()
-  iree_cc_library(
-    NAME
-      tracing
-    HDRS
-      "tracing.h"
-    DEPS
-      ::core_headers
-    PUBLIC
-  )
-endif()
+iree_cc_library(
+  NAME
+    tracing
+  HDRS
+    "tracing.h"
+  SRCS
+    "tracing.cc"
+  DEPS
+    ::core_headers
+    tracy_client::runtime_impl
+  PUBLIC
+)
 
 if(EMSCRIPTEN)
   iree_cc_library(

--- a/runtime/src/iree/base/tracing.cc
+++ b/runtime/src/iree/base/tracing.cc
@@ -12,7 +12,7 @@
 // We do this here instead of relying on an external build target so that we can
 // ensure our configuration specified in tracing.h is picked up.
 #if IREE_TRACING_FEATURES != 0
-#include "third_party/tracy/public/TracyClient.cpp"
+#include "TracyClient.cpp"
 #endif  // IREE_TRACING_FEATURES
 
 #ifdef __cplusplus

--- a/runtime/src/iree/base/tracing.h
+++ b/runtime/src/iree/base/tracing.h
@@ -181,7 +181,7 @@
 // Flush the settings we have so far; settings after this point will be
 // overriding values set by Tracy itself.
 #if defined(TRACY_ENABLE)
-#include "third_party/tracy/public/tracy/TracyC.h"  // IWYU pragma: export
+#include "tracy/TracyC.h"  // IWYU pragma: export
 #endif
 
 // Disable callstack capture if our depth is 0; this allows us to avoid any
@@ -503,7 +503,7 @@ enum {
 #ifdef __cplusplus
 
 #if defined(TRACY_ENABLE)
-#include "third_party/tracy/public/tracy/Tracy.hpp"  // IWYU pragma: export
+#include "tracy/Tracy.hpp"  // IWYU pragma: export
 #endif
 
 #if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION

--- a/runtime/src/iree/hal/drivers/vulkan/BUILD
+++ b/runtime/src/iree/hal/drivers/vulkan/BUILD
@@ -83,6 +83,7 @@ iree_runtime_cc_library(
         "//runtime/src/iree/hal/utils:resource_set",
         "//runtime/src/iree/hal/utils:semaphore_base",
         "//runtime/src/iree/schemas:spirv_executable_def_c_fbs",
+        "@tracy_client//:runtime_impl",
         "@vulkan_headers",
         "@vulkan_memory_allocator//:impl_header_only",
     ],

--- a/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/vulkan/CMakeLists.txt
@@ -77,6 +77,7 @@ iree_cc_library(
     iree::hal::utils::resource_set
     iree::hal::utils::semaphore_base
     iree::schemas::spirv_executable_def_c_fbs
+    tracy_client::runtime_impl
     vulkan_memory_allocator
   PUBLIC
 )

--- a/runtime/src/iree/hal/drivers/vulkan/tracing.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/tracing.cc
@@ -8,11 +8,11 @@
 
 #if IREE_TRACING_FEATURES & IREE_TRACING_FEATURE_INSTRUMENTATION
 
+#include "client/TracyProfiler.hpp"
+#include "common/TracyAlloc.hpp"
 #include "iree/base/api.h"
 #include "iree/base/target_platform.h"
-#include "third_party/tracy/public/client/TracyProfiler.hpp"
-#include "third_party/tracy/public/common/TracyAlloc.hpp"
-#include "third_party/tracy/public/tracy/Tracy.hpp"
+#include "tracy/Tracy.hpp"
 
 // Total number of queries the per-queue query pool will contain. This
 // translates to the maximum number of outstanding queries before collection is


### PR DESCRIPTION
* Can be enabled with one of:
  * The long-hand flag: --@tracy_client//:runtime_enable=true
  * Short-hand: --iree_enable_runtime_tracing (matches CMake option naming)

I don't love how the Tracy headers are laid out and how Bazel forces us into relativising them. I don't see an easy way to get around this, though (without recreating the sub-module with an additional layer of nesting).

Note for Google integrators: No-op'ing this for internal builds should just require removing the "@tracy_client//:runtime_impl" dep from `runtime/src/iree/base:tracing` (or importing Tracy and redirecting that appropriately).