### PR TITLE
Support transform dialect debug instructions for iree-compile

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -57,6 +57,10 @@ iree_compiler_cc_library(
     deps = [
         # Dialects
         "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        # TODO: Must we really take this dependence?
+        "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        # TODO: Must we really take this dependence?
+        "//compiler/src/iree/compiler/Dialect/Stream/IR",
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransformOps",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -73,6 +73,8 @@ iree_cc_library(
     iree::compiler::Codegen::PassHeaders
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::TransformExtensions::FlowExtensions
+    iree::compiler::Dialect::HAL::IR
+    iree::compiler::Dialect::Stream::IR
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -326,7 +326,7 @@ void TransformDialectInterpreterPass::performOptionalDebugActions(
         kTransformIreeTagAttrName,
         StringAttr::get(&getContext(), kTransformIreeTagPayloadRootValue));
   }
-  if (!debugTransformRootTag.empty()) {
+  if (debugTransformRootTag.empty()) {
     transformRegion->getParentOp()->setAttr(
         kTransformIreeTagAttrName,
         StringAttr::get(&getContext(),

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -14,10 +14,14 @@
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+// TODO: Must we really take this dependence?
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h"
+// TODO: Must we really take this dependence?
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+// TODO: Must we really take this dependence?
+#include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/ScopeExit.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Error.h"
 #include "llvm/Support/ErrorHandling.h"
@@ -104,10 +108,36 @@ static Operation *findOpWithTag(Operation *root, StringRef tagKey,
     // In debug mode, continue the traversal to see if the tag is not
     // duplicated.
 #ifndef NDEBUG
-    return WalkResult::advance();
-#else
     return WalkResult::interrupt();
+#else
+    return WalkResult::advance();
 #endif  // NDEBUG
+  });
+  return found;
+}
+
+// To make the flow compose with "iree-compile -compile-mode=hal-executable",
+// we must have a single HAL::ExecutablOp in the module **and** the
+// func::FuncOp that dispatches into it.
+// This helper traverses the IR to find this func::FuncOp.
+// TODO: revisit this filtering in the future.
+// TODO: there must be a better way than rolling our own manually and taking the
+// Stream dependence ..
+static func::FuncOp findFuncWithDispatchOfSymbol(Operation *root,
+                                                 StringRef symbolName) {
+  func::FuncOp found = nullptr;
+  root->walk([&](func::FuncOp funcOp) {
+    // TODO: Also handle Stream::AsyncDispatchOp ?
+    funcOp->walk([&](iree_compiler::IREE::Stream::CmdDispatchOp dispatchOp) {
+      if (dispatchOp.getEntryPoint().getRootReference().getValue() ==
+          symbolName) {
+        found = funcOp;
+        return WalkResult::interrupt();
+      }
+      return WalkResult::advance();
+    });
+    if (found) return WalkResult::interrupt();
+    return WalkResult::advance();
   });
   return found;
 }
@@ -223,12 +253,22 @@ class TransformDialectInterpreterPass
 
   /// Prints the CLI command running the repro with the current path.
   llvm::raw_ostream &printIreeOptReproCall(llvm::raw_ostream &os,
-                                           StringRef rootOpName);
+                                           StringRef rootOpName,
+                                           StringRef filename = {});
 
   /// Prints the module rooted at `root` to `os` and appends
-  /// `transformContainer` if it is not nested in `root`.
-  llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os, Operation *root,
-                                         Operation *transformContainer);
+  /// `transformContainer` if it is not null and not nested under `root`.
+  llvm::raw_ostream &printModuleForRepro(
+      llvm::raw_ostream &os, Operation *root,
+      Operation *transformContainer = nullptr);
+
+  // To make the flow compose with "iree-compile -compile-mode=hal-executable",
+  // we must have a single HAL::ExecutablOp in the module **and** the
+  // func::FuncOp that dispatches into it.
+  // The uniqueness also makes sense for us because only one such op is tagged
+  // by the transform dialect repro.
+  // TODO: revisit this filtering in the future.
+  Operation *separateSingleExecutableModuleCloneForRepro(Operation *root);
 
   /// Saves the payload and the transform IR into a temporary file and reports
   /// the file name to `os`.
@@ -249,8 +289,8 @@ class TransformDialectInterpreterPass
   //      IREE stack. This may be only shift the problem as we have passes
   //      building pass managers in IREE.
   //   3. build better support to embed the transformation module in the
-  //      input IR and transport it to the place of use in IREE. This is deemed
-  //      too intrusive atm.
+  //      input IR and transport it to the place of use in IREE. This is
+  //      deemed too intrusive atm.
   //   4. (future) config/resources mechanism that is being proposed in core?
   std::shared_ptr<OwningOpRef<ModuleOp>> sharedTransformModule;
 };
@@ -258,18 +298,23 @@ class TransformDialectInterpreterPass
 
 /// Prints the CLI command running the repro with the current path.
 llvm::raw_ostream &TransformDialectInterpreterPass::printIreeOptReproCall(
-    llvm::raw_ostream &os, StringRef rootOpName) {
+    llvm::raw_ostream &os, StringRef rootOpName, StringRef filename) {
+  os << "\n=== Transform Interpreter Repro ===\n";
   os << llvm::formatv(
-      "iree-opt "
-      "--pass-pipeline=\"{0}(iree-transform-dialect-interpreter{{{1}={2} "
-      "{3}={4}})\"",
-      rootOpName, debugPayloadRootTag.getArgStr(),
-      debugPayloadRootTag.empty() ? StringRef(kTransformIreeTagPayloadRootValue)
-                                  : debugPayloadRootTag,
-      debugTransformRootTag.getArgStr(),
-      debugTransformRootTag.empty()
-          ? StringRef(kTransformIreeTagTransformContainerValue)
-          : debugTransformRootTag);
+            "iree-opt "
+            "--pass-pipeline=\"{0}(iree-transform-dialect-interpreter{{{1}={2} "
+            "{3}={4}})\"",
+            rootOpName, debugPayloadRootTag.getArgStr(),
+            debugPayloadRootTag.empty()
+                ? StringRef(kTransformIreeTagPayloadRootValue)
+                : debugPayloadRootTag,
+            debugTransformRootTag.getArgStr(),
+            debugTransformRootTag.empty()
+                ? StringRef(kTransformIreeTagTransformContainerValue)
+                : debugTransformRootTag)
+     << " " << filename << "\n";
+  os << "iree-compile -compile-mode=hal-executable " << filename << "\n";
+  os << "===================================\n";
   return os;
 }
 
@@ -278,10 +323,48 @@ llvm::raw_ostream &TransformDialectInterpreterPass::printIreeOptReproCall(
 llvm::raw_ostream &TransformDialectInterpreterPass::printModuleForRepro(
     llvm::raw_ostream &os, Operation *root, Operation *transformContainer) {
   root->print(os);
-  if (!root->isAncestor(transformContainer)) {
+  if (transformContainer && !root->isAncestor(transformContainer)) {
     transformContainer->print(os);
   }
   return os;
+}
+
+/// To make the flow compose with "iree-compile -compile-mode=hal-executable",
+/// we must have a single HAL::ExecutablOp in the module **and** the
+/// func::FuncOp that dispatches into it.
+/// The uniqueness also makes sense for us because only one such op is tagged by
+/// the transform dialect repro.
+// TODO: revisit this filtering in the future.
+// TODO: there must be a better way than rolling our own manually and taking the
+// HAL dependence ..
+Operation *
+TransformDialectInterpreterPass::separateSingleExecutableModuleCloneForRepro(
+    Operation *root) {
+  // Find the executableOp we want.
+  Operation *variantOp = findOpWithTag(root, kTransformIreeTagAttrName,
+                                       kTransformIreeTagPayloadRootValue);
+  assert(isa<iree_compiler::IREE::HAL::ExecutableVariantOp>(variantOp) &&
+         "must be a HAL::ExecutableOp op");
+  auto executableOp =
+      variantOp->getParentOfType<iree_compiler::IREE::HAL::ExecutableOp>();
+  assert(executableOp && "needs non-empty be a HAL::ExecutableOp op");
+
+  // Clone a version of root with only the executableOp we want.
+  Operation *rootOpWithSingleExecutable = root->cloneWithoutRegions();
+  Region &clonedRegion = rootOpWithSingleExecutable->getRegions().front();
+  assert(clonedRegion.empty() && "expected empty region");
+  OpBuilder b(root->getContext());
+  b.createBlock(&clonedRegion, clonedRegion.end());
+  b.clone(*executableOp);
+
+  // Also clone the func::FuncOp that dispatches into executableOp otherwise
+  // "iree-compile -compile-mode=hal-executable" crashes.
+  func::FuncOp executableCallingOp =
+      findFuncWithDispatchOfSymbol(root, executableOp.getSymName());
+  assert(executableCallingOp && "missing func::Func calling the executable op");
+  b.clone(*executableCallingOp);
+
+  return rootOpWithSingleExecutable;
 }
 
 /// Saves the payload and the transform IR into a temporary file and reports
@@ -301,7 +384,9 @@ void TransformDialectInterpreterPass::saveReproToTempFile(
   }
 
   llvm::raw_fd_ostream fout(tempFile->FD, /*shouldClose=*/false);
-  printModuleForRepro(fout, root, transformContainer);
+  Operation *newRoot = separateSingleExecutableModuleCloneForRepro(root);
+  printModuleForRepro(fout, newRoot);
+  newRoot->erase();
   fout.flush();
   std::string filename = tempFile->TmpName;
 
@@ -310,10 +395,7 @@ void TransformDialectInterpreterPass::saveReproToTempFile(
     return;
   }
 
-  os << "=== Transform Interpreter Repro ===\n";
-  printIreeOptReproCall(os, root->getName().getStringRef())
-      << " " << filename << "\n";
-  os << "===================================\n";
+  printIreeOptReproCall(os, root->getName().getStringRef(), filename);
 }
 
 // Optionally perform debug actions requested by the user to dump IR and a
@@ -387,8 +469,8 @@ void TransformDialectInterpreterPass::runOnOperation() {
   // ------
   // Optionally override payloadRoot if the debugPayloadRootTag was passed.
   //
-  // If debugPayloadRootTag was passed, then we are in user-specified selection
-  // of the transformed IR. This corresponds to REPL debug mode.
+  // If debugPayloadRootTag was passed, then we are in user-specified
+  // selection of the transformed IR. This corresponds to REPL debug mode.
   // Otherwise, just apply to `target`, which is what the IREE nested
   // pipeline wants to operate on.
   if (!debugPayloadRootTag.empty()) {


### PR DESCRIPTION
Running:
```
cat tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir |  \
sed "s/\${SZ1}/123/g" |  \
sed "s/\${SZ2}/456/g" | \
iree-opt --iree-abi-transformation-pipeline \
               --iree-flow-transformation-pipeline \
               --iree-hal-target-backends=cuda \
               --iree-stream-transformation-pipeline \
               --iree-hal-configuration-pipeline | 
iree-opt - --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))" \
                 --iree-codegen-llvmgpu-enable-transform-dialect-jit \
                 --debug-only=iree-transform-dialect-save-repro \
                 --mlir-disable-threading > /dev/null
```

(alternatively, the shorter [function](https://github.com/nicolasvasilache/nicolas.vasilache.github.io/blob/master/.venv/mlirdev/bin/activate#L314)):
```
cat tests/transform_dialect/cuda/benchmark_linalg_reductions.stub.mlir |  \
   sed "s/\${SZ1}/123/g" |  \
   sed "s/\${SZ2}/456/g" | \
DUMP_TRANSFORM_REPRO=1 iree-transform-opt - -b cuda  -- --mlir-disable-threading > /dev/null
```

now prints:
```
=== Transform Interpreter Repro ===
iree-opt --pass-pipeline="builtin.module(iree-transform-dialect-interpreter{debug-payload-root-tag=iree_payload_root debug-transform-root-tag=iree_transform_container})" /tmp/iree_transform_dialect_c1a389.mlir
iree-compile -compile-mode=hal-executable /tmp/iree_transform_dialect_c1a389.mlir
===================================

=== Transform Interpreter Repro ===
iree-opt --pass-pipeline="builtin.module(iree-transform-dialect-interpreter{debug-payload-root-tag=iree_payload_root debug-transform-root-tag=iree_transform_container})" /tmp/iree_transform_dialect_4de402.mlir
iree-compile -compile-mode=hal-executable /tmp/iree_transform_dialect_4de402.mlir
===================================

=== Transform Interpreter Repro ===
iree-opt --pass-pipeline="builtin.module(iree-transform-dialect-interpreter{debug-payload-root-tag=iree_payload_root debug-transform-root-tag=iree_transform_container})" /tmp/iree_transform_dialect_97d917.mlir
iree-compile -compile-mode=hal-executable /tmp/iree_transform_dialect_97d917.mlir
===================================

=== Transform Interpreter Repro ===
iree-opt --pass-pipeline="builtin.module(iree-transform-dialect-interpreter{debug-payload-root-tag=iree_payload_root debug-transform-root-tag=iree_transform_container})" /tmp/iree_transform_dialect_d65e5c.mlir
iree-compile -compile-mode=hal-executable /tmp/iree_transform_dialect_d65e5c.mlir
===================================
```

Each command is then runnable standalone and applies the transform dialect properly using the interpreted mode (i.e. without recompiling `iree-opt` or `iree-compile`).

This allows one to manually alter the transform dialect IR and brings us all the way to execution (once ##11653 is addressed).