### PR TITLE
[TransformDialect] Fix debug conditional that was mistakenly inverted

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -326,7 +326,7 @@ void TransformDialectInterpreterPass::performOptionalDebugActions(
         kTransformIreeTagAttrName,
         StringAttr::get(&getContext(), kTransformIreeTagPayloadRootValue));
   }
-  if (!debugTransformRootTag.empty()) {
+  if (debugTransformRootTag.empty()) {
     transformRegion->getParentOp()->setAttr(
         kTransformIreeTagAttrName,
         StringAttr::get(&getContext(),


### PR DESCRIPTION
This is a followup from #11629 that fixes a refactoring mistake (a conditional was inverted and the issues only shows up when debugging).