### PR TITLE
Make Bazel Cuda work for dependencies on IREE

### DIFF
--- a/build_tools/embed_data/build_defs.bzl
+++ b/build_tools/embed_data/build_defs.bzl
@@ -6,6 +6,13 @@
 
 """Embeds data files into a C module."""
 
+def clean_dep(dep):
+    """Returns an absolute Bazel path to 'dep'.
+
+    This is necessary when calling these functions from another workspace.
+    """
+    return str(Label(dep))
+
 def c_embed_data(
         name,
         srcs,
@@ -15,7 +22,7 @@ def c_embed_data(
         strip_prefix = None,
         flatten = False,
         identifier = None,
-        generator = None,
+        generator = clean_dep("//build_tools/embed_data:generate_embed_data"),
         **kwargs):
     """Embeds 'srcs' into a C module.
 
@@ -55,10 +62,9 @@ def c_embed_data(
       strip_prefix: Strips this verbatim prefix from filenames (in the TOC).
       flatten: Removes all directory components from filenames (in the TOC).
       identifier: The identifier to use in generated names (defaults to name).
-      generator: Overrides the 'generate_embed_data' generator target.
+      generator: tool to use generate the embed data files.
       **kwargs: Args to pass to the cc_library.
     """
-    generator = generator or "//build_tools/embed_data:generate_embed_data"
     generator_location = "$(location %s)" % generator
     if identifier == None:
         identifier = name

--- a/build_tools/third_party/cuda/BUILD.template
+++ b/build_tools/third_party/cuda/BUILD.template
@@ -4,8 +4,10 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("@iree_core//build_tools/embed_data:build_defs.bzl", "c_embed_data")
+# Variables and string substitutions don't work here because of course they don't
+load("%IREE_REPO_ALIAS%//build_tools/embed_data:build_defs.bzl", "c_embed_data")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -46,7 +48,7 @@ c_embed_data(
     ],
     c_file_output = "iree_cuda/libdevice_embedded.c",
     flatten = True,
-    generator = "@iree_core//build_tools/embed_data:generate_embed_data",
+    generator = "%IREE_REPO_ALIAS%//build_tools/embed_data:generate_embed_data",
     h_file_output = "iree_cuda/libdevice_embedded.h",
     includes = [
         "iree_cuda",


### PR DESCRIPTION
Somehow the way Label is evaluated differs if your Bazel macro is in
the main repository, in which case it gets evaluated relative to the
BUILD file's repository vs if the macro is being used as part of an
external repository, in which case it is evaluated relative to the
macro's repository (which is the documented behavior).

Hardcoding the repo alias would break anyone using this function from
an external repository who doesn't call the IREE repo "iree_core".
Removing `clean_dep` would break anyone using `iree_c_embed_data` from
an external repository. The latter isn't really supported, but it
doesn't make things any harder in the end.