### PR TITLE
Use local SSDs instead of ramdisks on GPU runners

### DIFF
--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -29,7 +29,7 @@ if [[ "${RUNNER_TYPE}" == gpu ]]; then
   mount --options discard,defaults,nobarrier /dev/nvme0n1 /runner-root
 else
   echo "Mounting tmpfs for working directory"
-  mount --types tmpfs --options size=50g tmpfs /runner-root
+  mount --types tmpfs --options size=100g tmpfs /runner-root
 fi
 
 cp -r "${SCRIPT_DIR}" /runner-root/config

--- a/build_tools/github_actions/runner/config/setup.sh
+++ b/build_tools/github_actions/runner/config/setup.sh
@@ -26,10 +26,10 @@ if [[ "${RUNNER_TYPE}" == gpu ]]; then
   echo "Formatting and mounting local SSD for working directory"
   mkfs.ext4 -F /dev/nvme0n1
   # Options suggested from https://cloud.google.com/compute/docs/disks/optimizing-local-ssd-performance#disable_flush
-  mount --options discard,defaults,nobarrier --source /dev/nvme0n1 --target /runner-root
+  mount --options discard,defaults,nobarrier /dev/nvme0n1 /runner-root
 else
   echo "Mounting tmpfs for working directory"
-  mount -t tmpfs -o size=50g tmpfs /runner-root
+  mount --types tmpfs --options size=50g tmpfs /runner-root
 fi
 
 cp -r "${SCRIPT_DIR}" /runner-root/config

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -130,6 +130,8 @@ function create_template() {
       --maintenance-policy=TERMINATE
       --accelerator=count=1,type=nvidia-tesla-a100
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${GPU_IMAGE},mode=rw,size=${GPU_DISK_SIZE_GB},type=pd-balanced"
+      # See comment in build_tools/github_actions/runner/config/setup.sh
+      --local-ssd=interface=NVME
     )
     local_ssd_count=1
   elif [[ "${type}" == cpu ]]; then
@@ -138,15 +140,10 @@ function create_template() {
       --maintenance-policy=MIGRATE
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
     )
-    # This is the lowest number of local SSDs you can have on this machine type.
-    local_ssd_count=16
   else
     echo "Got unrecognized type '${type}'" >2
     exit 1
   fi
-  for i in $(seq "${local_ssd_count}"); do
-    cmd+=(--local-ssd=interface=NVME)
-  done
 
   if (( DRY_RUN==1 )); then
     # Prefix the command with a noop. It will still be printed by set -x

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -133,7 +133,6 @@ function create_template() {
       # See comment in build_tools/github_actions/runner/config/setup.sh
       --local-ssd=interface=NVME
     )
-    local_ssd_count=1
   elif [[ "${type}" == cpu ]]; then
     cmd+=(
       --machine-type=n1-standard-96
@@ -144,7 +143,6 @@ function create_template() {
     echo "Got unrecognized type '${type}'" >2
     exit 1
   fi
-
   if (( DRY_RUN==1 )); then
     # Prefix the command with a noop. It will still be printed by set -x
     cmd=(":" "${cmd[@]}")


### PR DESCRIPTION
While there is plenty of RAM on the CPU runners, the GPU runners are
pretty limited. We unfortunately would need to mount a silly number of
disks for CPU instances, so we stick with a ramdisk there.

Fixes https://github.com/iree-org/iree/issues/10739

Tested: deployed to test runners and ran on test PR:
https://github.com/iree-org/iree/actions/runs/3791229247
