### PR TITLE
Add CI job to collect compilation statistics

### DIFF
--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -4,11 +4,11 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 #
-# Workflow for all benchmark-related jobs. It is designed to be called from
-# the main workflow ci.yml. The concurrency of this workflow is controlled by
-# the caller's job.
+# Workflow for execution-benchmark-related jobs. It is designed to be called
+# from the main workflow ci.yml. The concurrency of this workflow is controlled
+# by the caller's job.
 
-name: Benchmarks
+name: Benchmark execution
 
 on:
   workflow_call:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,6 +819,8 @@ jobs:
     outputs:
       e2e-test-artifacts-dir: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
       e2e-test-artifacts-gcs-artifact-dir: ${{ steps.upload.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+      e2e-test-artifacts-build-log: ${{ steps.build.outputs.e2e-test-artifacts-build-log }}
+      e2e-test-artifacts-build-log-gcs-artifact: ${{ steps.upload.outputs.e2e-test-artifacts-build-log-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
@@ -843,31 +845,46 @@ jobs:
             gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
             build_tools/cmake/build_e2e_test_artifacts.sh \
             "${BUILD_E2E_TEST_ARTIFACTS_DIR}"
-          echo "build-e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}" >> "${GITHUB_OUTPUT}"
+          echo "e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" >> "${GITHUB_OUTPUT}"
+          echo "e2e-test-artifacts-build-log=${BUILD_E2E_TEST_ARTIFACTS_DIR}/.ninja_log" >> "${GITHUB_OUTPUT}"
       - name: "Uploading e2e test artifacts"
         id: upload
         env:
-          BUILD_E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.build-e2e-test-artifacts-dir }}
+          E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
           E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
+          E2E_TEST_ARTIFACTS_BUILD_LOG: ${{ steps.build.outputs.e2e-test-artifacts-build-log }}
+          E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT: ${{ env.GCS_DIR }}/e2e-test-artifacts/ninja_log
         run: |
           # Uploads all IREE artifacts and MLIR files (including the imported
           # MLIR files and MLIR source models).
           # Not archiving the directory to allow fetching each file as needed
           # separately.
-          find "${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" -maxdepth 1 \
+          find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
             -name "iree_*" -o -name "model_*.mlir" | \
             gcloud alpha storage cp --read-paths-from-stdin -r \
               "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
-          gcloud alpha storage cp "${BUILD_E2E_TEST_ARTIFACTS_DIR}/.ninja_log" \
-              "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/ninja_log"
+          gcloud alpha storage cp "${E2E_TEST_ARTIFACTS_BUILD_LOG}" \
+              "${E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT}"
           echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
+          echo "e2e-test-artifacts-build-log-gcs-artifact=${E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
   compilation_benchmarks:
     needs: [setup, build_e2e_test_artifacts]
     if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
     env:
       E2E_TEST_ARTIFACTS_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
       E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+      E2E_TEST_ARTIFACTS_BUILD_LOG: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-build-log }}
+      E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-build-log-gcs-artifact }}
+    outputs:
+      compile-stats-results: ${{ steps.collect.outputs.compile-stats-results }}
+      compile-stats-results-gcs-artifact: ${{ steps.upload.outputs.compile-stats-results-gcs-artifact }}
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
@@ -884,41 +901,40 @@ jobs:
         id: "download-assets"
         env:
           COMPILATION_CONFIG: ${{ steps.export.outputs.compilation-config }}
-          E2E_TEST_ARTIFACTS_BUILD_LOG: ${{ env.E2E_TEST_ARTIFACTS_DIR }}/ninja_log
         run: |
-          mkdir -p "${E2E_TEST_ARTIFACTS_DIR}"
-          gcloud alpha storage cp "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/ninja_log" \
+          gcloud alpha storage cp "${E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT}" \
             "${E2E_TEST_ARTIFACTS_BUILD_LOG}"
+          mkdir -p "${E2E_TEST_ARTIFACTS_DIR}"
           jq -r \
             --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
             '.module_dir_paths | map("\($GCS_ARTIFACT_DIR)/\(.)") | join("\n")' \
             "${COMPILATION_CONFIG}" | \
             gcloud alpha storage cp -r --read-paths-from-stdin "${E2E_TEST_ARTIFACTS_DIR}"
-          echo "e2e-test-artifacts-build-log=${E2E_TEST_ARTIFACTS_BUILD_LOG}" >> "${GITHUB_OUTPUT}"
       - name: "Collecting compilation statistics"
-        id: collect-compile-stats
+        id: collect
         env:
-          E2E_TEST_ARTIFACTS_BUILD_LOG: ${{ steps.download-assets.outputs.e2e-test-artifacts-build-log }}
           COMPILATION_CONFIG: ${{ steps.export.outputs.compilation-config }}
           GENERATION_CONFIG: generation-config.json
-          COMPILE_STATS_RESULTS: compile-stats-results.json
+          COMPILE_STATS_RESULTS: benchmark-results/compile-stats-results.json
         run: |
           jq '.generation_configs' "${COMPILATION_CONFIG}" > "${GENERATION_CONFIG}"
+          mkdir -p benchmark-results
           ./build_tools/benchmarks/collect_compilation_statistics.py alpha \
             --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
             --build_log="${E2E_TEST_ARTIFACTS_BUILD_LOG}" \
             --generation_config="${GENERATION_CONFIG}" \
             --output="${COMPILE_STATS_RESULTS}"
           echo "compile-stats-results=${COMPILE_STATS_RESULTS}" >> "${GITHUB_OUTPUT}"
-      - name: "Uploading results"
+      - name: "Uploading benchmark results"
         id: upload
         env:
-          COMPILE_STATS_RESULTS: ${{ steps.collect-compile-stats.outputs.compile-stats-results }}
-          BENCHMARK_RESULTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/benchmark-results
+          COMPILE_STATS_RESULTS: ${{ steps.collect.outputs.compile-stats-results }}
+          COMPILE_STATS_RESULTS_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.collect.outputs.compile-stats-results }}
         run: |
           gcloud alpha storage cp \
             "${COMPILE_STATS_RESULTS}" \
-            "${BENCHMARK_RESULTS_GCS_ARTIFACT_DIR}/${COMPILE_STATS_RESULTS}"
+            "${COMPILE_STATS_RESULTS_GCS_ARTIFACT}"
+          echo "compile-stats-results-gcs-artifact=${COMPILE_STATS_RESULTS_GCS_ARTIFACT}"
 
   execution_benchmarks:
     needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,27 +843,87 @@ jobs:
             gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
             build_tools/cmake/build_e2e_test_artifacts.sh \
             "${BUILD_E2E_TEST_ARTIFACTS_DIR}"
-          echo "e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" >> "${GITHUB_OUTPUT}"
+          echo "build-e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}" >> "${GITHUB_OUTPUT}"
       - name: "Uploading e2e test artifacts"
         id: upload
         env:
-          E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
+          BUILD_E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.build-e2e-test-artifacts-dir }}
           E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
         run: |
           # Uploads all IREE artifacts and MLIR files (including the imported
           # MLIR files and MLIR source models).
           # Not archiving the directory to allow fetching each file as needed
           # separately.
-          find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
+          find "${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" -maxdepth 1 \
             -name "iree_*" -o -name "model_*.mlir" | \
             gcloud alpha storage cp --read-paths-from-stdin -r \
               "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
+          gcloud alpha storage cp "${BUILD_E2E_TEST_ARTIFACTS_DIR}/.ninja_log" \
+              "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/ninja_log"
           echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
 
-  benchmarks:
+  compilation_benchmarks:
+    needs: [setup, build_e2e_test_artifacts]
+    if: needs.setup.outputs.should-run == 'true'
+    env:
+      E2E_TEST_ARTIFACTS_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
+      E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
+      - name: "Downloading assets"
+        id: "export"
+        env:
+          COMPILATION_CONFIG: "compilation-config.json"
+        run: |
+          ./build_tools/benchmarks/export_benchmark_config.py \
+            compilation \
+            --output="${COMPILATION_CONFIG}"
+          echo "compilation-config=${COMPILATION_CONFIG}" >> "${GITHUB_OUTPUT}"
+      - name: "Downloading assets"
+        id: "download-assets"
+        env:
+          COMPILATION_CONFIG: ${{ steps.export.outputs.compilation-config }}
+          E2E_TEST_ARTIFACTS_BUILD_LOG: ${{ env.E2E_TEST_ARTIFACTS_DIR }}/ninja_log
+        run: |
+          mkdir -p "${E2E_TEST_ARTIFACTS_DIR}"
+          gcloud alpha storage cp "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/ninja_log" \
+            "${E2E_TEST_ARTIFACTS_BUILD_LOG}"
+          jq -r \
+            --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
+            '.module_dir_paths | map("\($GCS_ARTIFACT_DIR)/\(.)") | join("\n")' \
+            "${COMPILATION_CONFIG}" | \
+            gcloud alpha storage cp -r --read-paths-from-stdin "${E2E_TEST_ARTIFACTS_DIR}"
+          echo "e2e-test-artifacts-build-log=${E2E_TEST_ARTIFACTS_BUILD_LOG}" >> "${GITHUB_OUTPUT}"
+      - name: "Collecting compilation statistics"
+        id: collect-compile-stats
+        env:
+          E2E_TEST_ARTIFACTS_BUILD_LOG: ${{ steps.download-assets.outputs.e2e-test-artifacts-build-log }}
+          COMPILATION_CONFIG: ${{ steps.export.outputs.compilation-config }}
+          GENERATION_CONFIG: generation-config.json
+          COMPILE_STATS_RESULTS: compile-stats-results.json
+        run: |
+          jq '.generation_configs' "${COMPILATION_CONFIG}" > "${GENERATION_CONFIG}"
+          ./build_tools/benchmarks/collect_compilation_statistics.py alpha \
+            --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
+            --build_log="${E2E_TEST_ARTIFACTS_BUILD_LOG}" \
+            --generation_config="${GENERATION_CONFIG}" \
+            --output="${COMPILE_STATS_RESULTS}"
+          echo "compile-stats-results=${COMPILE_STATS_RESULTS}" >> "${GITHUB_OUTPUT}"
+      - name: "Uploading results"
+        id: upload
+        env:
+          COMPILE_STATS_RESULTS: ${{ steps.collect-compile-stats.outputs.compile-stats-results }}
+          BENCHMARK_RESULTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/benchmark-results
+        run: |
+          gcloud alpha storage cp \
+            "${COMPILE_STATS_RESULTS}" \
+            "${BENCHMARK_RESULTS_GCS_ARTIFACT_DIR}/${COMPILE_STATS_RESULTS}"
+
+  execution_benchmarks:
     needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
     if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
-    uses: ./.github/workflows/benchmarks.yml
+    uses: ./.github/workflows/benchmark_execution.yml
     with:
       # env.GCS_DIR is also duplicated in this workflow. See the note there on
       # why this is.
@@ -1109,7 +1169,8 @@ jobs:
       - test_benchmark_suites
 
       # Benchmark pipeline
-      - benchmarks
+      - compilation_benchmarks
+      - execution_benchmarks
     steps:
       - name: Getting combined job status
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -888,7 +888,7 @@ jobs:
     steps:
       - name: "Checking out repository"
         uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2
-      - name: "Downloading assets"
+      - name: "Exporting configs"
         id: "export"
         env:
           COMPILATION_CONFIG: "compilation-config.json"
@@ -902,14 +902,16 @@ jobs:
         env:
           COMPILATION_CONFIG: ${{ steps.export.outputs.compilation-config }}
         run: |
-          gcloud alpha storage cp "${E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT}" \
+          gcloud alpha storage cp \
+            "${E2E_TEST_ARTIFACTS_BUILD_LOG_GCS_ARTIFACT}" \
             "${E2E_TEST_ARTIFACTS_BUILD_LOG}"
           mkdir -p "${E2E_TEST_ARTIFACTS_DIR}"
           jq -r \
             --arg GCS_ARTIFACT_DIR "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" \
             '.module_dir_paths | map("\($GCS_ARTIFACT_DIR)/\(.)") | join("\n")' \
             "${COMPILATION_CONFIG}" | \
-            gcloud alpha storage cp -r --read-paths-from-stdin "${E2E_TEST_ARTIFACTS_DIR}"
+            gcloud alpha storage cp -r --read-paths-from-stdin \
+              "${E2E_TEST_ARTIFACTS_DIR}"
       - name: "Collecting compilation statistics"
         id: collect
         env:

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -11,7 +11,7 @@ Export type: "execution" outputs:
   <target device name>: {
     host_environment: HostEnvironment,
     module_dir_paths: [<paths of dependent module directories>],
-    run_configs: [E2EModelRunConfig]
+    run_configs: serialized [E2EModelRunConfig]
   },
   ...
 ]

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -17,8 +17,12 @@ Export type: "execution" outputs:
 ]
 to be used in build_tools/benchmarks/run_benchmarks_on_*.py
 
-Export type: "compilation" outputs a serialized list of module generation config
-defined for compilation statistics, to be used in
+Export type: "compilation" outputs:
+{
+  module_dir_paths: [<paths of dependent module directories>],
+  generation_configs: serialized [ModuleGenerationConfig]
+}
+of generation configs defined for compilation statistics, to be used in
 build_tools/benchmarks/collect_compilation_statistics.py
 """
 
@@ -28,7 +32,7 @@ import pathlib
 # Add build_tools python dir to the search path.
 sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
 
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Dict, Iterable, List, Optional, Set
 import argparse
 import collections
 import dataclasses
@@ -92,6 +96,17 @@ def filter_and_group_run_configs(
   return grouped_run_config_map
 
 
+def _get_distinct_module_dir_paths(
+    module_generation_configs: Iterable[
+        iree_definitions.ModuleGenerationConfig],
+    root_path: pathlib.PurePath = pathlib.PurePath()
+) -> List[str]:
+  module_dir_paths = (str(
+      iree_artifacts.get_module_dir_path(config, root_path=root_path))
+                      for config in module_generation_configs)
+  return sorted(set(module_dir_paths))
+
+
 def _export_execution_handler(args: argparse.Namespace):
   _, all_run_configs = benchmark_collections.generate_benchmarks()
   target_device_names = (set(args.target_device_names)
@@ -111,14 +126,12 @@ def _export_execution_handler(args: argparse.Namespace):
       )
     host_environment = host_environments.pop()
 
-    all_module_dir_paths = (str(
-        iree_artifacts.get_module_dir_path(config.module_generation_config))
-                            for config in run_configs)
-    module_dir_paths = sorted(set(all_module_dir_paths))
+    distinct_module_dir_paths = _get_distinct_module_dir_paths(
+        config.module_generation_config for config in run_configs)
 
     output_map[device_name] = {
         "host_environment": dataclasses.asdict(host_environment),
-        "module_dir_paths": module_dir_paths,
+        "module_dir_paths": distinct_module_dir_paths,
         "run_configs": serialization.serialize_and_pack(run_configs),
     }
 
@@ -132,7 +145,15 @@ def _export_compilation_handler(_args: argparse.Namespace):
       if benchmark_collections.COMPILE_STATS_TAG in config.compile_config.tags
   ]
 
-  return serialization.serialize_and_pack(compile_stats_gen_configs)
+  distinct_module_dir_paths = _get_distinct_module_dir_paths(
+      compile_stats_gen_configs)
+
+  return {
+      "module_dir_paths":
+          distinct_module_dir_paths,
+      "generation_configs":
+          serialization.serialize_and_pack(compile_stats_gen_configs)
+  }
 
 
 def _parse_and_strip_list_argument(arg) -> List[str]:
@@ -168,14 +189,18 @@ def _parse_arguments():
         <target device name>: {
           host_environment: HostEnvironment,
           module_dir_paths: [<paths of dependent module directories>],
-          run_configs: [E2EModelRunConfig]
+          run_configs: serialized [E2EModelRunConfig]
         },
         ...
       ]
       to be used in build_tools/benchmarks/run_benchmarks_on_*.py
 
-      Export type: "compilation" outputs a serialized list of module generation
-      config defined for compilation statistics, to be used in
+      Export type: "compilation" outputs:
+      {
+        module_dir_paths: [<paths of dependent module directories>],
+        generation_configs: serialized [ModuleGenerationConfig]
+      }
+      of generation configs defined for compilation statistics, to be used in
       build_tools/benchmarks/collect_compilation_statistics.py
       """))
 


### PR DESCRIPTION
Add CI job to collect compilation statistics from e2e test artifacts.

The compilation statistics job isn't in the sub-workflow `benchmarks.yaml` because that workflow depends on the unnecessary 4mins job `build_benchmark_tools`. And if there's no execution benchmark, `build_benchmark_tools` can be skipped.

So I decided to rename `benchmarks.yaml` to `benchmark_execution.yaml` and let the compilation statistics job stay in the main CI workflow for better workflow run time. The compilation statistics job also runs very fast (26s) so we run it unconditionally and can always post the results in comments. 

Fix #11071

benchmarks: cuda