### PR TITLE
Post to Discord when CI fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,7 +636,7 @@ jobs:
     env:
       BUILD_DIR: build-runtime
     steps:
-      - run: exit 1
+      - run: exit 0
       # - name: "Checking out repository"
       #   uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
       # - name: "Checking out runtime submodules"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,28 +68,32 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
     outputs:
-      should-run: ${{ steps.configure.outputs.should-run }}
-      ci-stage: ${{ steps.configure.outputs.ci-stage }}
-      runner-env: ${{ steps.configure.outputs.runner-env }}
-      runner-group: ${{ steps.configure.outputs.runner-group }}
-      write-caches: ${{ steps.configure.outputs.write-caches }}
-      benchmark-presets: ${{ steps.configure.outputs.benchmark-presets }}
+      ci-stage: postsubmit
     steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          # We need the parent commit to do a diff
-          fetch-depth: 2
-      - name: "Configuring CI options"
-        id: configure
-        run: |
-          # Just informative logging. There should only be two commits in the
-          # history here, but limiting the depth helps when copying from a local
-          # repo instead of using checkout, e.g. with
-          # https://github.com/nektos/act where there will be more.
-          git log --oneline --graph --max-count=3
+      - run: exit 0
+    # outputs:
+    #   should-run: ${{ steps.configure.outputs.should-run }}
+    #   ci-stage: ${{ steps.configure.outputs.ci-stage }}
+    #   runner-env: ${{ steps.configure.outputs.runner-env }}
+    #   runner-group: ${{ steps.configure.outputs.runner-group }}
+    #   write-caches: ${{ steps.configure.outputs.write-caches }}
+    #   benchmark-presets: ${{ steps.configure.outputs.benchmark-presets }}
+    # steps:
+    #   - name: "Checking out repository"
+    #     uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+    #     with:
+    #       # We need the parent commit to do a diff
+    #       fetch-depth: 2
+    #   - name: "Configuring CI options"
+    #     id: configure
+    #     run: |
+    #       # Just informative logging. There should only be two commits in the
+    #       # history here, but limiting the depth helps when copying from a local
+    #       # repo instead of using checkout, e.g. with
+    #       # https://github.com/nektos/act where there will be more.
+    #       git log --oneline --graph --max-count=3
 
-          ./build_tools/github_actions/configure_ci.py
+    #       ./build_tools/github_actions/configure_ci.py
 
 
   ################################### Basic ####################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1117,11 +1117,21 @@ jobs:
       # # Benchmark pipeline
       # - benchmarks
     steps:
-      - name: Getting combined job status
+      - name: Getting failed jobs
+        id: failed_jobs
         run: |
-          echo '${{ toJson(needs.*.result) }}' \
-            | jq --exit-status 'all(.=="success" or .=="skipped")' > /dev/null
-      - uses: sarisia/actions-status-discord@c193626e5ce172002b8161e116aa897de7ab5383 # v1.10.2
+          FAILING_JOBS="$(echo '${{ toJson(needs.*) }}' \
+            | jq --raw-output \
+            'map_values(select(.status!="success" and .status!="skipped")) | keys | join(",")' \
+          )"
+          echo "failed-jobs=${FAILING_JOBS}" >> $GITHUB_OUTPUT
+          if [[ "${FAILING_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILING_JOBS}"
+            exit 1
+          fi
+      - name: Posting to Discord
+        uses: sarisia/actions-status-discord@c193626e5ce172002b8161e116aa897de7ab5383 # v1.10.2
         if: failure() && needs.setup.outputs.ci-stage == 'postsubmit'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          description: "The following jobs failed: ${{ steps.failed_jobs.failed_jobs }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ on:
   push:
     branches:
       - main
-      # DO NOT SUBMIT
-      - gcmn-ci-notifications
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -95,195 +93,195 @@ jobs:
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"
   ##############################################################################
-  # build_all:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: full-build-dir
-  #   outputs:
-  #     # Pass through the build directory as output so it's available to
-  #     # dependent jobs.
-  #     build-dir: ${{ env.BUILD_DIR }}
-  #     build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
-  #     build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Building IREE"
-  #       env:
-  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-  #           ./build_tools/cmake/build_all.sh \
-  #           "${BUILD_DIR}"
-  #     # The archive step below doesn't include these files. Remove them first to
-  #     # save disk space.
-  #     # TODO(#10739): This step can be removed once we enlarge the disk sapce.
-  #     - name: "Removing unused files"
-  #       run: |
-  #         find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
-  #           -print \
-  #           -delete
-  #     # Things get more complicated here than when we're just building the
-  #     # runtime. The build directory is way bigger. We're also using on our own
-  #     # runners on GCE. So uploading to GitHub actions artifact storage hosted
-  #     # on Azure is dirt slow. We drop static libraries and object files, which
-  #     # aren't needed for testing. Then we do some minimal compression locally
-  #     # *in parallel* and upload to GCS. This can be further optimized.
-  #     # Especially decompression is still pretty slow. See #9881.
-  #     - name: "Creating build dir archive"
-  #       id: archive
-  #       env:
-  #         BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
-  #       run: |
-  #         tar -I 'zstd -T0' \
-  #           -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
-  #         echo "build-dir-archive=${BUILD_DIR_ARCHIVE}" >> "${GITHUB_OUTPUT}"
-  #     - name: "Uploading build dir archive"
-  #       id: upload
-  #       env:
-  #         BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
-  #         BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
-  #       run: |
-  #         gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
-  #         echo "build-dir-gcs-artifact=${BUILD_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+  build_all:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: full-build-dir
+    outputs:
+      # Pass through the build directory as output so it's available to
+      # dependent jobs.
+      build-dir: ${{ env.BUILD_DIR }}
+      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
+      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Building IREE"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/build_all.sh \
+            "${BUILD_DIR}"
+      # The archive step below doesn't include these files. Remove them first to
+      # save disk space.
+      # TODO(#10739): This step can be removed once we enlarge the disk sapce.
+      - name: "Removing unused files"
+        run: |
+          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
+            -print \
+            -delete
+      # Things get more complicated here than when we're just building the
+      # runtime. The build directory is way bigger. We're also using on our own
+      # runners on GCE. So uploading to GitHub actions artifact storage hosted
+      # on Azure is dirt slow. We drop static libraries and object files, which
+      # aren't needed for testing. Then we do some minimal compression locally
+      # *in parallel* and upload to GCS. This can be further optimized.
+      # Especially decompression is still pretty slow. See #9881.
+      - name: "Creating build dir archive"
+        id: archive
+        env:
+          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
+        run: |
+          tar -I 'zstd -T0' \
+            -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
+          echo "build-dir-archive=${BUILD_DIR_ARCHIVE}" >> "${GITHUB_OUTPUT}"
+      - name: "Uploading build dir archive"
+        id: upload
+        env:
+          BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
+          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
+        run: |
+          gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
+          echo "build-dir-gcs-artifact=${BUILD_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  # # TODO(#11350): re-enable this job when it works again
-  # build_test_all_windows:
-  #   needs: setup
-  #   if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
-  #   runs-on: managed-windows-cpu
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     BUILD_DIR: build-windows
-  #     IREE_VULKAN_DISABLE: 1
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Setting up Python"
-  #       uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
-  #       with:
-  #         python-version: "3.10"  # Needs pybind >= 2.10.1 for Python >= 3.11
-  #     - name: "Installing Python packages"
-  #       run: |
-  #         python3 -m venv .venv
-  #         .venv/Scripts/activate.bat
-  #         python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
-  #     - name: "Configuring MSVC"
-  #       uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
-  #     - name: "Building IREE"
-  #       run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
-  #     - name: "Testing IREE"
-  #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+  # TODO(#11350): re-enable this job when it works again
+  build_test_all_windows:
+    needs: setup
+    if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    runs-on: managed-windows-cpu
+    defaults:
+      run:
+        shell: bash
+    env:
+      BUILD_DIR: build-windows
+      IREE_VULKAN_DISABLE: 1
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Setting up Python"
+        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+        with:
+          python-version: "3.10"  # Needs pybind >= 2.10.1 for Python >= 3.11
+      - name: "Installing Python packages"
+        run: |
+          python3 -m venv .venv
+          .venv/Scripts/activate.bat
+          python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+      - name: "Configuring MSVC"
+        uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
+      - name: "Building IREE"
+        run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+      - name: "Testing IREE"
+        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
-  # build_test_all_bazel:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Building with Bazel"
-  #       env:
-  #         IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
-  #           gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
-  #           ./build_tools/bazel/build_core.sh
+  build_test_all_bazel:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Building with Bazel"
+        env:
+          IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
+            gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
+            ./build_tools/bazel/build_core.sh
 
-  # test_all:
-  #   needs: [setup, build_all]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting build dir archive"
-  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Testing all"
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env IREE_CUDA_DISABLE=1 \
-  #           gcr.io/iree-oss/swiftshader@sha256:27b843417fd548fab1b636d2b65d2b8b8c09f42a65cd5dde7ecfb9881e4332ac \
-  #           ./build_tools/cmake/ctest_all.sh \
-  #           "${BUILD_DIR}"
+  test_all:
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Testing all"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_CUDA_DISABLE=1 \
+            gcr.io/iree-oss/swiftshader@sha256:27b843417fd548fab1b636d2b65d2b8b8c09f42a65cd5dde7ecfb9881e4332ac \
+            ./build_tools/cmake/ctest_all.sh \
+            "${BUILD_DIR}"
 
-  # test_gpu:
-  #   needs: [setup, build_all]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - gpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: Querying GPU information
-  #       run: |
-  #         ./build_tools/scripts/check_cuda.sh
-  #         ./build_tools/scripts/check_vulkan.sh
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting build dir archive"
-  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Testing with GPU"
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env IREE_VULKAN_F16_DISABLE=0 \
-  #           --env IREE_CUDA_DISABLE=0 \
-  #           --env CTEST_PARALLEL_LEVEL=2 \
-  #           --gpus all \
-  #           --env NVIDIA_DRIVER_CAPABILITIES=all \
-  #           gcr.io/iree-oss/nvidia@sha256:b0751e9f2fcb104d9d3d56fab6c6e79405bdcd2e503e53f2bf4f2b66d13cd88b \
-  #           bash -euo pipefail -c \
-  #             "./build_tools/scripts/check_cuda.sh
-  #             ./build_tools/scripts/check_vulkan.sh
-  #             ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+  test_gpu:
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - gpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: Querying GPU information
+        run: |
+          ./build_tools/scripts/check_cuda.sh
+          ./build_tools/scripts/check_vulkan.sh
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Testing with GPU"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_VULKAN_F16_DISABLE=0 \
+            --env IREE_CUDA_DISABLE=0 \
+            --env CTEST_PARALLEL_LEVEL=2 \
+            --gpus all \
+            --env NVIDIA_DRIVER_CAPABILITIES=all \
+            gcr.io/iree-oss/nvidia@sha256:b0751e9f2fcb104d9d3d56fab6c6e79405bdcd2e503e53f2bf4f2b66d13cd88b \
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_cuda.sh
+              ./build_tools/scripts/check_vulkan.sh
+              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -291,777 +289,775 @@ jobs:
   build_test_runtime:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
     steps:
-        - run: exit 0
-      # - name: "Checking out repository"
-      #   uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      # - name: "Checking out runtime submodules"
-      #   run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      # - name: "Building runtime"
-      #   # Note ccache is read-only here since this job runs on a GitHub-hosted runner
-      #   # and GitHub runners don't have write access to GCS
-      #   run: |
-      #     ./build_tools/github_actions/docker_run.sh \
-      #       --env "BUILD_PRESET=test" \
-      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-      #       ./build_tools/cmake/build_runtime.sh \
-      #       "${BUILD_DIR}"
-      # - name: "Testing runtime"
-      #   run: |
-      #     ./build_tools/github_actions/docker_run.sh \
-      #       --env IREE_VULKAN_DISABLE=1 \
-      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-      #       ./build_tools/cmake/ctest_all.sh \
-      #       "${BUILD_DIR}"
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Building runtime"
+        # Note ccache is read-only here since this job runs on a GitHub-hosted runner
+        # and GitHub runners don't have write access to GCS
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "BUILD_PRESET=test" \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/build_runtime.sh \
+            "${BUILD_DIR}"
+      - name: "Testing runtime"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_VULKAN_DISABLE=1 \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/ctest_all.sh \
+            "${BUILD_DIR}"
 
-  # build_test_runtime_windows:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on: managed-windows-cpu
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   env:
-  #     BUILD_DIR: build-runtime-windows
-  #     IREE_VULKAN_DISABLE: 1
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Configuring MSVC"
-  #       uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
-  #     - name: "Building runtime"
-  #       env:
-  #         BUILD_PRESET: "test"
-  #       run: ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
-  #     - name: "Testing runtime"
-  #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+  build_test_runtime_windows:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on: managed-windows-cpu
+    defaults:
+      run:
+        shell: bash
+    env:
+      BUILD_DIR: build-runtime-windows
+      IREE_VULKAN_DISABLE: 1
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Configuring MSVC"
+        uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
+      - name: "Building runtime"
+        env:
+          BUILD_PRESET: "test"
+        run: ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
+      - name: "Testing runtime"
+        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
-  # ################################# Tensorflow #################################
-  # # Jobs that build the IREE-Tensorflow integrations
-  # ##############################################################################
-  # build_tf_integrations:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   outputs:
-  #     binaries-dir: ${{ steps.build.outputs.binaries-dir }}
-  #     binaries-archive: ${{ steps.archive.outputs.binaries-archive }}
-  #     binaries-gcs-artifact: ${{ steps.upload.outputs.binaries-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Building TF binaries"
-  #       id: build
-  #       env:
-  #         IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
-  #         IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
-  #           --env "IREE_TF_BINARIES_OUTPUT_DIR=${IREE_TF_BINARIES_OUTPUT_DIR}" \
-  #           gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
-  #           build_tools/cmake/build_tf_binaries.sh
-  #         echo "binaries-dir=${IREE_TF_BINARIES_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
-  #     - name: "Creating archive of binaries"
-  #       id: archive
-  #       env:
-  #         BINARIES_ARCHIVE: tf-binaries.tar
-  #         BINARIES_DIR: ${{ steps.build.outputs.binaries-dir }}
-  #       run: |
-  #         tar -cf "${BINARIES_ARCHIVE}" "${BINARIES_DIR}"
-  #         echo "binaries-archive=${BINARIES_ARCHIVE}" >> "${GITHUB_OUTPUT}"
-  #     - name: "Uploading binaries archive"
-  #       id: upload
-  #       env:
-  #         BINARIES_ARCHIVE: ${{ steps.archive.outputs.binaries-archive }}
-  #         BINARIES_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.binaries-archive }}
-  #       run: |
-  #         gcloud alpha storage cp "${BINARIES_ARCHIVE}" "${BINARIES_GCS_ARTIFACT}"
-  #         echo "binaries-gcs-artifact=${BINARIES_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+  ################################# Tensorflow #################################
+  # Jobs that build the IREE-Tensorflow integrations
+  ##############################################################################
+  build_tf_integrations:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    outputs:
+      binaries-dir: ${{ steps.build.outputs.binaries-dir }}
+      binaries-archive: ${{ steps.archive.outputs.binaries-archive }}
+      binaries-gcs-artifact: ${{ steps.upload.outputs.binaries-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Building TF binaries"
+        id: build
+        env:
+          IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
+          IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
+            --env "IREE_TF_BINARIES_OUTPUT_DIR=${IREE_TF_BINARIES_OUTPUT_DIR}" \
+            gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
+            build_tools/cmake/build_tf_binaries.sh
+          echo "binaries-dir=${IREE_TF_BINARIES_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
+      - name: "Creating archive of binaries"
+        id: archive
+        env:
+          BINARIES_ARCHIVE: tf-binaries.tar
+          BINARIES_DIR: ${{ steps.build.outputs.binaries-dir }}
+        run: |
+          tar -cf "${BINARIES_ARCHIVE}" "${BINARIES_DIR}"
+          echo "binaries-archive=${BINARIES_ARCHIVE}" >> "${GITHUB_OUTPUT}"
+      - name: "Uploading binaries archive"
+        id: upload
+        env:
+          BINARIES_ARCHIVE: ${{ steps.archive.outputs.binaries-archive }}
+          BINARIES_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.binaries-archive }}
+        run: |
+          gcloud alpha storage cp "${BINARIES_ARCHIVE}" "${BINARIES_GCS_ARTIFACT}"
+          echo "binaries-gcs-artifact=${BINARIES_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  # test_tf_integrations:
-  #   needs: [setup, build_all, build_tf_integrations]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Downloading TF binaries archive"
-  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Extracting TF binaries archive"
-  #       run: tar -xvf "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Symlinking TF binaries"
-  #       run: |
-  #         ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting build dir archive"
-  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Running TF integrations tests"
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
-  #           build_tools/cmake/run_tf_tests.sh \
-  #           "${BUILD_DIR}"
+  test_tf_integrations:
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Downloading TF binaries archive"
+        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+      - name: "Extracting TF binaries archive"
+        run: tar -xvf "${TF_BINARIES_ARCHIVE}"
+      - name: "Symlinking TF binaries"
+        run: |
+          ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Running TF integrations tests"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
+            build_tools/cmake/run_tf_tests.sh \
+            "${BUILD_DIR}"
 
-  # test_tf_integrations_gpu:
-  #   needs: [setup, build_all, build_tf_integrations]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - gpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Downloading TF binaries archive"
-  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Extracting TF binaries archive"
-  #       run: tar -xvf "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Symlinking TF binaries"
-  #       run: |
-  #         ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting build dir archive"
-  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Running TF integrations tests"
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env IREE_LLVM_CPU_DISABLE=1 \
-  #           --gpus all \
-  #           --env NVIDIA_DRIVER_CAPABILITIES=all \
-  #           gcr.io/iree-oss/frontends-nvidia@sha256:3e3965b6b9e431be296900440e5bc66ed46a8f6d6fa80ead7c7a75866f3bd416 \
-  #           bash -euo pipefail -c \
-  #             "./build_tools/scripts/check_cuda.sh
-  #             ./build_tools/scripts/check_vulkan.sh
-  #             build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
+  test_tf_integrations_gpu:
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - gpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Downloading TF binaries archive"
+        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+      - name: "Extracting TF binaries archive"
+        run: tar -xvf "${TF_BINARIES_ARCHIVE}"
+      - name: "Symlinking TF binaries"
+        run: |
+          ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Running TF integrations tests"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_LLVM_CPU_DISABLE=1 \
+            --gpus all \
+            --env NVIDIA_DRIVER_CAPABILITIES=all \
+            gcr.io/iree-oss/frontends-nvidia@sha256:3e3965b6b9e431be296900440e5bc66ed46a8f6d6fa80ead7c7a75866f3bd416 \
+            bash -euo pipefail -c \
+              "./build_tools/scripts/check_cuda.sh
+              ./build_tools/scripts/check_vulkan.sh
+              build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
 
-  # ######################## Community Model Coverage ############################
-  # # Jobs that test IREE behavior on a set of models.
-  # ##############################################################################
-  # test_shark_model_suite:
-  #   needs: [setup, build_all, build_tf_integrations]
-  #   # Disabled while failing. See https://github.com/iree-org/iree/issues/10653
-  #   if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - gpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Downloading TF binaries archive"
-  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Extracting TF binaries archive"
-  #       run: tar -xf "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Symlinking TF binaries"
-  #       run: |
-  #         ./integrations/tensorflow/symlink_binaries.sh "$(realpath "${TF_BINARIES_DIR}")"
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting build dir archive"
-  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Downloading SHARK"
-  #       id: download_shark
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         repository: nod-ai/SHARK
-  #         path: ${{ github.workspace }}/SHARK
-  #     - name: "Testing Shark Model Suite"
-  #       run: |
-  #         cd "${GITHUB_WORKSPACE}/SHARK"
-  #         NO_BACKEND=1 ./setup_venv.sh
-  #         source shark.venv/bin/activate
-  #         export TFPYBASE="${GITHUB_WORKSPACE}/integrations/tensorflow/python_projects"
-  #         export PYTHONPATH="${PYTHONPATH}:${BUILD_DIR}/compiler/bindings/python:${BUILD_DIR}/runtime/bindings/python"
-  #         export PYTHONPATH="${PYTHONPATH}:$TFPYBASE/iree_tf:$TFPYBASE/iree_tflite"
-  #         export SHARK_SKIP_TESTS="--ignore=shark/tests/test_shark_importer.py \
-  #           --ignore=benchmarks/tests/test_hf_benchmark.py \
-  #           --ignore=benchmarks/tests/test_benchmark.py"
-  #         export MODEL_LIST="bert_base_cased or mobilebert_uncased or MiniLM_L12_H384_uncased or module_resnet50 or mobilenet_v3 or squeezenet1_0 or vit_base_patch16_224"
-  #         pytest tank/test_models.py -k "cpu and ($MODEL_LIST)" $SHARK_SKIP_TESTS
-  #         pytest tank/test_models.py -k "vulkan and ($MODEL_LIST)" $SHARK_SKIP_TESTS
-  #         pytest tank/test_models.py -k "cuda and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+  ######################## Community Model Coverage ############################
+  # Jobs that test IREE behavior on a set of models.
+  ##############################################################################
+  test_shark_model_suite:
+    needs: [setup, build_all, build_tf_integrations]
+    # Disabled while failing. See https://github.com/iree-org/iree/issues/10653
+    if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - gpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Downloading TF binaries archive"
+        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+      - name: "Extracting TF binaries archive"
+        run: tar -xf "${TF_BINARIES_ARCHIVE}"
+      - name: "Symlinking TF binaries"
+        run: |
+          ./integrations/tensorflow/symlink_binaries.sh "$(realpath "${TF_BINARIES_DIR}")"
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}"
+      - name: "Downloading SHARK"
+        id: download_shark
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          repository: nod-ai/SHARK
+          path: ${{ github.workspace }}/SHARK
+      - name: "Testing Shark Model Suite"
+        run: |
+          cd "${GITHUB_WORKSPACE}/SHARK"
+          NO_BACKEND=1 ./setup_venv.sh
+          source shark.venv/bin/activate
+          export TFPYBASE="${GITHUB_WORKSPACE}/integrations/tensorflow/python_projects"
+          export PYTHONPATH="${PYTHONPATH}:${BUILD_DIR}/compiler/bindings/python:${BUILD_DIR}/runtime/bindings/python"
+          export PYTHONPATH="${PYTHONPATH}:$TFPYBASE/iree_tf:$TFPYBASE/iree_tflite"
+          export SHARK_SKIP_TESTS="--ignore=shark/tests/test_shark_importer.py \
+            --ignore=benchmarks/tests/test_hf_benchmark.py \
+            --ignore=benchmarks/tests/test_benchmark.py"
+          export MODEL_LIST="bert_base_cased or mobilebert_uncased or MiniLM_L12_H384_uncased or module_resnet50 or mobilenet_v3 or squeezenet1_0 or vit_base_patch16_224"
+          pytest tank/test_models.py -k "cpu and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+          pytest tank/test_models.py -k "vulkan and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+          pytest tank/test_models.py -k "cuda and ($MODEL_LIST)" $SHARK_SKIP_TESTS
 
-  # # TODO(#11263): Drop this job once the IREE_BUILD_BENCHMARKS is removed.
-  # test_build_benchmark_suites:
-  #   needs: [setup, build_all, build_tf_integrations]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-  #     BUILD_BENCHMARKS_DIR: build-benchmarks
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting install from build dir archive"
-  #       run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
-  #     - name: "Downloading TF binaries archive"
-  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Extracting TF binaries archive"
-  #       run: tar -xf "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Building benchmarks"
-  #       id: build
-  #       run: |
-  #         build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
-  #           --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-  #           --env "IREE_BUILD_BENCHMARKS_DIR=${BUILD_BENCHMARKS_DIR}" \
-  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-  #           build_tools/cmake/build_benchmarks.sh
+  # TODO(#11263): Drop this job once the IREE_BUILD_BENCHMARKS is removed.
+  test_build_benchmark_suites:
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+      BUILD_BENCHMARKS_DIR: build-benchmarks
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting install from build dir archive"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
+      - name: "Downloading TF binaries archive"
+        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+      - name: "Extracting TF binaries archive"
+        run: tar -xf "${TF_BINARIES_ARCHIVE}"
+      - name: "Building benchmarks"
+        id: build
+        run: |
+          build_tools/github_actions/docker_run.sh \
+            --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
+            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+            --env "IREE_BUILD_BENCHMARKS_DIR=${BUILD_BENCHMARKS_DIR}" \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            build_tools/cmake/build_benchmarks.sh
 
-  # ############################### Configurations ###############################
-  # # Jobs that build IREE in some non-default configuration
-  # ##############################################################################
-  # asan:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Building and testing with AddressSanitizer"
-  #       env:
-  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-  #       run: |
-  #         # Note that this uses the latest version of the clang compiler, etc.
-  #         # This gives us access to the latest features and validates that IREE
-  #         # builds using the latest versions.
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-  #           --env "CCACHE_NAMESPACE=swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be" \
-  #           gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
-  #           ./build_tools/cmake/build_and_test_asan.sh
+  ############################### Configurations ###############################
+  # Jobs that build IREE in some non-default configuration
+  ##############################################################################
+  asan:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Building and testing with AddressSanitizer"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          # Note that this uses the latest version of the clang compiler, etc.
+          # This gives us access to the latest features and validates that IREE
+          # builds using the latest versions.
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be" \
+            gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
+            ./build_tools/cmake/build_and_test_asan.sh
 
-  # tsan:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Building and testing with ThreadSanitizer"
-  #       env:
-  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-  #           ./build_tools/cmake/build_and_test_tsan.sh
+  tsan:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Building and testing with ThreadSanitizer"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/build_and_test_tsan.sh
 
   small_runtime:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
     steps:
-      - run: exit 0
-      # - name: "Checking out repository"
-      #   uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      # - name: "Checking out runtime submodules"
-      #   run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      # - name: "Building size-optimized runtime"
-      #   # Note ccache is read-only here since this job runs on a GitHub-hosted runner
-      #   # and GitHub runners don't have write access to GCS
-      #   run: |
-      #     ./build_tools/github_actions/docker_run.sh \
-      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-      #       ./build_tools/cmake/build_runtime_small.sh \
-      #       "${BUILD_DIR}"
-      # - name: "Testing runtime"
-      #   run: |
-      #     ./build_tools/github_actions/docker_run.sh \
-      #       --env IREE_VULKAN_DISABLE=1 \
-      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-      #       ./build_tools/cmake/ctest_all.sh \
-      #       "${BUILD_DIR}"
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Building size-optimized runtime"
+        # Note ccache is read-only here since this job runs on a GitHub-hosted runner
+        # and GitHub runners don't have write access to GCS
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/build_runtime_small.sh \
+            "${BUILD_DIR}"
+      - name: "Testing runtime"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env IREE_VULKAN_DISABLE=1 \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/ctest_all.sh \
+            "${BUILD_DIR}"
 
-  # gcc:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: build-gcc
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Building IREE with gcc"
-  #       env:
-  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env CC=/usr/bin/gcc-9 \
-  #           --env CXX=/usr/bin/g++-9 \
-  #           --env "IREE_TARGET_BACKEND_WEBGPU=OFF" \
-  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-  #           ./build_tools/cmake/build_all.sh \
-  #           "${BUILD_DIR}"
+  gcc:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: build-gcc
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Building IREE with gcc"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env CC=/usr/bin/gcc-9 \
+            --env CXX=/usr/bin/g++-9 \
+            --env "IREE_TARGET_BACKEND_WEBGPU=OFF" \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/build_all.sh \
+            "${BUILD_DIR}"
 
-  # tracing:
-  #   needs: setup
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     BUILD_DIR: build-tracing
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #       with:
-  #         submodules: true
-  #     - name: "Building IREE with tracing enabled"
-  #       env:
-  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-  #       run: |
-  #         # TODO(#11394): Enable Web GPU
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-  #           ./build_tools/cmake/build_tracing.sh \
-  #           "${BUILD_DIR}"
+  tracing:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      BUILD_DIR: build-tracing
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: "Building IREE with tracing enabled"
+        env:
+          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+        run: |
+          # TODO(#11394): Enable Web GPU
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            ./build_tools/cmake/build_tracing.sh \
+            "${BUILD_DIR}"
 
   ############################### Configurations ###############################
   # Jobs that build and run IREE e2e tests/benchmarks                          #
   ##############################################################################
 
-  # build_benchmark_tools:
-  #   needs: [setup, build_all, build_tf_integrations]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   outputs:
-  #     # We can't collect all outputs from the matrix jobs due to Github's
-  #     # limitation (https://github.com/orgs/community/discussions/17245).
-  #     # Therefore, the output is the GCS directory that stores all benchmark
-  #     # tools archives. The following jobs need to construct the archive names
-  #     # by themselves and combine with path of GCS directory here to fetch the
-  #     # archives.
-  #     benchmark-tools-gcs-artifact-dir: ${{ steps.upload.outputs.benchmark-tools-gcs-artifact-dir }}
-  #   strategy:
-  #     matrix:
-  #       target:
-  #         - platform: "linux"
-  #           arch: "x86_64"
-  #           docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
-  #           # Builds tools on the host and assumes the builder is Linux x86_64.
-  #           build_script: "./build_tools/cmake/build_runtime.sh"
-  #         - platform: "linux"
-  #           arch: "riscv_64"
-  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-  #           build_script: "./build_tools/cmake/build_riscv.sh"
-  #   env:
-  #     PLATFORM: ${{ matrix.target.platform }}
-  #     ARCH: ${{ matrix.target.arch }}
-  #     DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-  #     BUILD_SCRIPT: ${{ matrix.target.build_script }}
-  #     BUILD_TOOLS_DIR: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools-dir
-  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting host binaries"
-  #       run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
-  #     - name: "Compiling the benchmark tools"
-  #       id: build
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-  #           --env "IREE_TARGET_ARCH=${ARCH}" \
-  #           --env "BUILD_PRESET=benchmark" \
-  #           --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-  #           "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build"
-  #     - name: "Compiling the benchmark tools with tracing"
-  #       id: build-with-tracing
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-  #           --env "IREE_TARGET_ARCH=${ARCH}" \
-  #           --env "BUILD_PRESET=benchmark-with-tracing" \
-  #           --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-  #           "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build-traced"
-  #     - name: "Creating the benchmark tools archive"
-  #       id: archive
-  #       env:
-  #         BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools.tar
-  #       run: |
-  #         tar -cf "${BENCHMARK_TOOLS_ARCHIVE}" \
-  #           "${BUILD_TOOLS_DIR}"/*/tools/iree-benchmark-module \
-  #           "${BUILD_TOOLS_DIR}"/*/tools/build_config.txt
-  #         echo "benchmark-tools-archive=${BENCHMARK_TOOLS_ARCHIVE}" >> "${GITHUB_OUTPUT}"
-  #     - name: "Uploading the benchmark tools archive"
-  #       id: upload
-  #       env:
-  #         BENCHMARK_TOOLS_ARCHIVE: ${{ steps.archive.outputs.benchmark-tools-archive }}
-  #         BENCHMARK_TOOLS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/benchmark-tools
-  #       run: |
-  #         gcloud alpha storage cp "${BENCHMARK_TOOLS_ARCHIVE}" "${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}/"
-  #         echo "benchmark-tools-gcs-artifact-dir=${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
+  build_benchmark_tools:
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    outputs:
+      # We can't collect all outputs from the matrix jobs due to Github's
+      # limitation (https://github.com/orgs/community/discussions/17245).
+      # Therefore, the output is the GCS directory that stores all benchmark
+      # tools archives. The following jobs need to construct the archive names
+      # by themselves and combine with path of GCS directory here to fetch the
+      # archives.
+      benchmark-tools-gcs-artifact-dir: ${{ steps.upload.outputs.benchmark-tools-gcs-artifact-dir }}
+    strategy:
+      matrix:
+        target:
+          - platform: "linux"
+            arch: "x86_64"
+            docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
+            # Builds tools on the host and assumes the builder is Linux x86_64.
+            build_script: "./build_tools/cmake/build_runtime.sh"
+          - platform: "linux"
+            arch: "riscv_64"
+            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+            build_script: "./build_tools/cmake/build_riscv.sh"
+    env:
+      PLATFORM: ${{ matrix.target.platform }}
+      ARCH: ${{ matrix.target.arch }}
+      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
+      BUILD_SCRIPT: ${{ matrix.target.build_script }}
+      BUILD_TOOLS_DIR: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools-dir
+      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+      - name: "Extracting host binaries"
+        run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
+      - name: "Compiling the benchmark tools"
+        id: build
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+            --env "IREE_TARGET_ARCH=${ARCH}" \
+            --env "BUILD_PRESET=benchmark" \
+            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+            "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build"
+      - name: "Compiling the benchmark tools with tracing"
+        id: build-with-tracing
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+            --env "IREE_TARGET_ARCH=${ARCH}" \
+            --env "BUILD_PRESET=benchmark-with-tracing" \
+            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+            "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build-traced"
+      - name: "Creating the benchmark tools archive"
+        id: archive
+        env:
+          BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools.tar
+        run: |
+          tar -cf "${BENCHMARK_TOOLS_ARCHIVE}" \
+            "${BUILD_TOOLS_DIR}"/*/tools/iree-benchmark-module \
+            "${BUILD_TOOLS_DIR}"/*/tools/build_config.txt
+          echo "benchmark-tools-archive=${BENCHMARK_TOOLS_ARCHIVE}" >> "${GITHUB_OUTPUT}"
+      - name: "Uploading the benchmark tools archive"
+        id: upload
+        env:
+          BENCHMARK_TOOLS_ARCHIVE: ${{ steps.archive.outputs.benchmark-tools-archive }}
+          BENCHMARK_TOOLS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/benchmark-tools
+        run: |
+          gcloud alpha storage cp "${BENCHMARK_TOOLS_ARCHIVE}" "${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}/"
+          echo "benchmark-tools-gcs-artifact-dir=${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
 
-  # build_e2e_test_artifacts:
-  #   needs: [setup, build_all, build_tf_integrations]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-  #   outputs:
-  #     e2e-test-artifacts-dir: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
-  #     e2e-test-artifacts-gcs-artifact-dir: ${{ steps.upload.outputs.e2e-test-artifacts-gcs-artifact-dir }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting install from build dir archive"
-  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-  #     - name: "Downloading TF binaries archive"
-  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Extracting TF binaries archive"
-  #       run: tar -xf "${TF_BINARIES_ARCHIVE}"
-  #     - name: "Building e2e test artifacts"
-  #       id: build
-  #       env:
-  #         BUILD_E2E_TEST_ARTIFACTS_DIR: build-e2e-test-artifacts
-  #       run: |
-  #         build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
-  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-  #           build_tools/cmake/build_e2e_test_artifacts.sh \
-  #           "${BUILD_E2E_TEST_ARTIFACTS_DIR}"
-  #         echo "e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" >> "${GITHUB_OUTPUT}"
-  #     - name: "Uploading e2e test artifacts"
-  #       id: upload
-  #       env:
-  #         E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
-  #         E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
-  #       run: |
-  #         # Uploads all IREE artifacts and MLIR files (including the imported
-  #         # MLIR files and MLIR source models).
-  #         # Not archiving the directory to allow fetching each file as needed
-  #         # separately.
-  #         find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
-  #           -name "iree_*" -o -name "model_*.mlir" | \
-  #           gcloud alpha storage cp --read-paths-from-stdin -r \
-  #             "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
-  #         echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
+  build_e2e_test_artifacts:
+    needs: [setup, build_all, build_tf_integrations]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+    outputs:
+      e2e-test-artifacts-dir: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
+      e2e-test-artifacts-gcs-artifact-dir: ${{ steps.upload.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+      - name: "Extracting install from build dir archive"
+        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      - name: "Downloading TF binaries archive"
+        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+      - name: "Extracting TF binaries archive"
+        run: tar -xf "${TF_BINARIES_ARCHIVE}"
+      - name: "Building e2e test artifacts"
+        id: build
+        env:
+          BUILD_E2E_TEST_ARTIFACTS_DIR: build-e2e-test-artifacts
+        run: |
+          build_tools/github_actions/docker_run.sh \
+            --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
+            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+            build_tools/cmake/build_e2e_test_artifacts.sh \
+            "${BUILD_E2E_TEST_ARTIFACTS_DIR}"
+          echo "e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" >> "${GITHUB_OUTPUT}"
+      - name: "Uploading e2e test artifacts"
+        id: upload
+        env:
+          E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
+          E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
+        run: |
+          # Uploads all IREE artifacts and MLIR files (including the imported
+          # MLIR files and MLIR source models).
+          # Not archiving the directory to allow fetching each file as needed
+          # separately.
+          find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
+            -name "iree_*" -o -name "model_*.mlir" | \
+            gcloud alpha storage cp --read-paths-from-stdin -r \
+              "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
+          echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
 
-  # benchmarks:
-  #   needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
-  #   if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
-  #   uses: ./.github/workflows/benchmarks.yml
-  #   with:
-  #     # env.GCS_DIR is also duplicated in this workflow. See the note there on
-  #     # why this is.
-  #     runner-group: ${{ needs.setup.outputs.runner-group }}
-  #     runner-env: ${{ needs.setup.outputs.runner-env }}
-  #     e2e-test-artifacts-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
-  #     e2e-test-artifacts-gcs-artifact-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
-  #     benchmark-tools-gcs-artifact-dir: ${{ needs.build_benchmark_tools.outputs.benchmark-tools-gcs-artifact-dir }}
-  #     benchmark-presets: ${{ needs.setup.outputs.benchmark-presets }}
+  benchmarks:
+    needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
+    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
+    uses: ./.github/workflows/benchmarks.yml
+    with:
+      # env.GCS_DIR is also duplicated in this workflow. See the note there on
+      # why this is.
+      runner-group: ${{ needs.setup.outputs.runner-group }}
+      runner-env: ${{ needs.setup.outputs.runner-env }}
+      e2e-test-artifacts-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
+      e2e-test-artifacts-gcs-artifact-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+      benchmark-tools-gcs-artifact-dir: ${{ needs.build_benchmark_tools.outputs.benchmark-tools-gcs-artifact-dir }}
+      benchmark-presets: ${{ needs.setup.outputs.benchmark-presets }}
 
-  # ############################## Crosscompilation ##############################
-  # # Jobs that cross-compile IREE for other platforms
-  # ##############################################################################
+  ############################## Crosscompilation ##############################
+  # Jobs that cross-compile IREE for other platforms
+  ##############################################################################
 
-  # # emscripten is not in the test matrix because it is set as
-  # # postsubmission-only.
-  # cross_compile_and_test:
-  #   needs: [setup, build_all]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   strategy:
-  #     matrix:
-  #       target:
-  #         - platform: android
-  #           arch: armv8.2-a
-  #           abi: arm64-v8a
-  #           docker_image: "gcr.io/iree-oss/android@sha256:e5f45760ab2dc8a1d72dc6e9d90056719bedac5678ee90e6d9f9b958172b4834"
-  #           build_script: "./build_tools/cmake/build_android.sh"
-  #           # No test_script
-  #         - platform: linux
-  #           arch: riscv_64
-  #           abi: lp64d
-  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-  #           build_script: "./build_tools/cmake/build_riscv.sh"
-  #           test_script: "./build_tools/cmake/test_riscv.sh"
-  #         - platform: linux
-  #           arch: riscv_32
-  #           abi: ilp32d
-  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-  #           build_script: "./build_tools/cmake/build_riscv.sh"
-  #           test_script: "./build_tools/cmake/test_riscv.sh"
-  #         - platform: generic
-  #           arch: riscv_32
-  #           abi: ilp32
-  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-  #           build_script: "./build_tools/cmake/build_riscv.sh"
-  #           test_script: "./tests/riscv32/smoke.sh"
-  #   env:
-  #     PLATFORM: ${{ matrix.target.platform }}
-  #     ARCH: ${{ matrix.target.arch }}
-  #     ABI: ${{ matrix.target.abi }}
-  #     DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-  #     BUILD_SCRIPT: ${{ matrix.target.build_script }}
-  #     TEST_SCRIPT: ${{ matrix.target.test_script }}
-  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #     TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
-  #     IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting build dir archive"
-  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-  #     - name: "Build cross-compiling target"
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-  #           --env "CCACHE_NAMESPACE=${DOCKER_IMAGE}" \
-  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-  #           --env "IREE_TARGET_ARCH=${ARCH}" \
-  #           --env "IREE_TARGET_ABI=${ABI}" \
-  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-  #           --env "BUILD_PRESET=test" \
-  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-  #           "${DOCKER_IMAGE}" \
-  #           "${BUILD_SCRIPT}"
-  #     - name: "Test cross-compiling target"
-  #       if: ${{ matrix.target.test_script }}
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-  #           --env "IREE_TARGET_ARCH=${ARCH}" \
-  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-  #           --env "BUILD_PRESET=test" \
-  #           "${DOCKER_IMAGE}" \
-  #           "${TEST_SCRIPT}"
+  # emscripten is not in the test matrix because it is set as
+  # postsubmission-only.
+  cross_compile_and_test:
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    strategy:
+      matrix:
+        target:
+          - platform: android
+            arch: armv8.2-a
+            abi: arm64-v8a
+            docker_image: "gcr.io/iree-oss/android@sha256:e5f45760ab2dc8a1d72dc6e9d90056719bedac5678ee90e6d9f9b958172b4834"
+            build_script: "./build_tools/cmake/build_android.sh"
+            # No test_script
+          - platform: linux
+            arch: riscv_64
+            abi: lp64d
+            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+            build_script: "./build_tools/cmake/build_riscv.sh"
+            test_script: "./build_tools/cmake/test_riscv.sh"
+          - platform: linux
+            arch: riscv_32
+            abi: ilp32d
+            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+            build_script: "./build_tools/cmake/build_riscv.sh"
+            test_script: "./build_tools/cmake/test_riscv.sh"
+          - platform: generic
+            arch: riscv_32
+            abi: ilp32
+            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+            build_script: "./build_tools/cmake/build_riscv.sh"
+            test_script: "./tests/riscv32/smoke.sh"
+    env:
+      PLATFORM: ${{ matrix.target.platform }}
+      ARCH: ${{ matrix.target.arch }}
+      ABI: ${{ matrix.target.abi }}
+      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
+      BUILD_SCRIPT: ${{ matrix.target.build_script }}
+      TEST_SCRIPT: ${{ matrix.target.test_script }}
+      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
+      IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      - name: "Build cross-compiling target"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+            --env "CCACHE_NAMESPACE=${DOCKER_IMAGE}" \
+            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+            --env "IREE_TARGET_ARCH=${ARCH}" \
+            --env "IREE_TARGET_ABI=${ABI}" \
+            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+            --env "BUILD_PRESET=test" \
+            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+            "${DOCKER_IMAGE}" \
+            "${BUILD_SCRIPT}"
+      - name: "Test cross-compiling target"
+        if: ${{ matrix.target.test_script }}
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+            --env "IREE_TARGET_ARCH=${ARCH}" \
+            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+            --env "BUILD_PRESET=test" \
+            "${DOCKER_IMAGE}" \
+            "${TEST_SCRIPT}"
 
-  # emscripten:
-  #   needs: [setup, build_all]
-  #   if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   env:
-  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting install from build dir archive"
-  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-  #     - name: "Building the runtime for the web using Emscripten"
-  #       run: |
-  #         build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-  #           gcr.io/iree-oss/emscripten@sha256:20847a0a9503852d9594f3c4e7e633b913b450240b097d378dcd42d22ac0948e \
-  #           build_tools/cmake/build_runtime_emscripten.sh
+  emscripten:
+    needs: [setup, build_all]
+    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    env:
+      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+      - name: "Extracting install from build dir archive"
+        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      - name: "Building the runtime for the web using Emscripten"
+        run: |
+          build_tools/github_actions/docker_run.sh \
+            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+            gcr.io/iree-oss/emscripten@sha256:20847a0a9503852d9594f3c4e7e633b913b450240b097d378dcd42d22ac0948e \
+            build_tools/cmake/build_runtime_emscripten.sh
 
-  # test_benchmark_suites:
-  #   needs: [setup, build_all, build_e2e_test_artifacts]
-  #   if: needs.setup.outputs.should-run == 'true'
-  #   runs-on:
-  #     - self-hosted  # must come first
-  #     - runner-group=${{ needs.setup.outputs.runner-group }}
-  #     - environment=${{ needs.setup.outputs.runner-env }}
-  #     - cpu
-  #     - os-family=Linux
-  #   strategy:
-  #     matrix:
-  #       target:
-  #         - platform: linux
-  #           arch: riscv_64
-  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-  #           run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
-  #         - platform: linux
-  #           arch: riscv_32
-  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-  #           run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
-  #         - platform: linux
-  #           arch: x86_64
-  #           docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
-  #           run_scripts: "./build_tools/cmake/test_benchmark_suites_on_linux.sh"
-  #   env:
-  #     PLATFORM: ${{ matrix.target.platform }}
-  #     ARCH: ${{ matrix.target.arch }}
-  #     DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-  #     RUN_SCRIPTS: ${{ matrix.target.run_scripts }}
-  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-  #     TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
-  #     E2E_TEST_ARTIFACTS_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
-  #     E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
-  #   steps:
-  #     - name: "Checking out repository"
-  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-  #     - name: "Checking out runtime submodules"
-  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
-  #     - name: "Downloading build dir archive"
-  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-  #     - name: "Extracting build dir archive"
-  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-  #     # TODO(#11136): Only download the needed artifacts instead of everything.
-  #     - name: "Downloading e2e test artifacts"
-  #       run: |
-  #         mkdir -p ${E2E_TEST_ARTIFACTS_DIR}
-  #         gcloud alpha storage cp -r "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/*" "${E2E_TEST_ARTIFACTS_DIR}"
-  #     - name: "Download benchmark expected output"
-  #       env:
-  #         EXPECTED_OUTPUT_GSC_ARTIFACT: gs://iree-model-artifacts/deeplab_v3_fp32_input_0_expected_output.npy
-  #         EXPECTED_OUTPUT_FILE: deeplab_v3_fp32_input_0_expected_output.npy
-  #       run: |
-  #         gcloud alpha storage cp "${EXPECTED_OUTPUT_GSC_ARTIFACT}" "${E2E_TEST_ARTIFACTS_DIR}/${EXPECTED_OUTPUT_FILE}"
-  #     - name: "Build iree-run-module and test benchmark suite modules"
-  #       run: |
-  #         ./build_tools/github_actions/docker_run.sh \
-  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-  #           --env "IREE_TARGET_ARCH=${ARCH}" \
-  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-  #           --env "BUILD_PRESET=benchmark-suite-test" \
-  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-  #           --env "E2E_TEST_ARTIFACTS_DIR=${E2E_TEST_ARTIFACTS_DIR}" \
-  #           "${DOCKER_IMAGE}" \
-  #           bash -euo pipefail -c \
-  #             "${RUN_SCRIPTS}"
+  test_benchmark_suites:
+    needs: [setup, build_all, build_e2e_test_artifacts]
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    strategy:
+      matrix:
+        target:
+          - platform: linux
+            arch: riscv_64
+            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+            run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
+          - platform: linux
+            arch: riscv_32
+            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+            run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
+          - platform: linux
+            arch: x86_64
+            docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
+            run_scripts: "./build_tools/cmake/test_benchmark_suites_on_linux.sh"
+    env:
+      PLATFORM: ${{ matrix.target.platform }}
+      ARCH: ${{ matrix.target.arch }}
+      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
+      RUN_SCRIPTS: ${{ matrix.target.run_scripts }}
+      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+      TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
+      E2E_TEST_ARTIFACTS_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
+      E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - name: "Checking out runtime submodules"
+        run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      - name: "Downloading build dir archive"
+        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+      - name: "Extracting build dir archive"
+        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+      # TODO(#11136): Only download the needed artifacts instead of everything.
+      - name: "Downloading e2e test artifacts"
+        run: |
+          mkdir -p ${E2E_TEST_ARTIFACTS_DIR}
+          gcloud alpha storage cp -r "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/*" "${E2E_TEST_ARTIFACTS_DIR}"
+      - name: "Download benchmark expected output"
+        env:
+          EXPECTED_OUTPUT_GSC_ARTIFACT: gs://iree-model-artifacts/deeplab_v3_fp32_input_0_expected_output.npy
+          EXPECTED_OUTPUT_FILE: deeplab_v3_fp32_input_0_expected_output.npy
+        run: |
+          gcloud alpha storage cp "${EXPECTED_OUTPUT_GSC_ARTIFACT}" "${E2E_TEST_ARTIFACTS_DIR}/${EXPECTED_OUTPUT_FILE}"
+      - name: "Build iree-run-module and test benchmark suite modules"
+        run: |
+          ./build_tools/github_actions/docker_run.sh \
+            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+            --env "IREE_TARGET_ARCH=${ARCH}" \
+            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+            --env "BUILD_PRESET=benchmark-suite-test" \
+            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+            --env "E2E_TEST_ARTIFACTS_DIR=${E2E_TEST_ARTIFACTS_DIR}" \
+            "${DOCKER_IMAGE}" \
+            bash -euo pipefail -c \
+              "${RUN_SCRIPTS}"
 
   ##############################################################################
 
@@ -1077,45 +1073,45 @@ jobs:
       - setup
 
       # Basic
-      # - build_all
-      # - build_test_all_windows
-      # - build_test_all_bazel
-      # - test_all
-      # - test_gpu
+      - build_all
+      - build_test_all_windows
+      - build_test_all_bazel
+      - test_all
+      - test_gpu
 
       # Subsets
       - build_test_runtime
-      # - build_test_runtime_windows
+      - build_test_runtime_windows
 
       # Tensorflow
-      # - build_tf_integrations
-      # - test_tf_integrations
-      # - test_tf_integrations_gpu
+      - build_tf_integrations
+      - test_tf_integrations
+      - test_tf_integrations_gpu
 
-      # # Model Coverage
-      # - test_build_benchmark_suites
-      # - test_shark_model_suite
+      # Model Coverage
+      - test_build_benchmark_suites
+      - test_shark_model_suite
 
-      # # Configurations
-      # - asan
-      # - tsan
+      # Configurations
+      - asan
+      - tsan
       - small_runtime
-      # - gcc
-      # - tracing
+      - gcc
+      - tracing
 
-      # # Crosscompilation
-      # - cross_compile_and_test
-      # - emscripten
+      # Crosscompilation
+      - cross_compile_and_test
+      - emscripten
 
-      # # Artifacts for e2e testing and benchmarking
-      # - build_benchmark_tools
-      # - build_e2e_test_artifacts
+      # Artifacts for e2e testing and benchmarking
+      - build_benchmark_tools
+      - build_e2e_test_artifacts
 
-      # # Test modules from benchmark pipeline
-      # - test_benchmark_suites
+      # Test modules from benchmark pipeline
+      - test_benchmark_suites
 
-      # # Benchmark pipeline
-      # - benchmarks
+      # Benchmark pipeline
+      - benchmarks
     steps:
       - name: Getting failed jobs
         id: failed_jobs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1122,6 +1122,6 @@ jobs:
           echo '${{ toJson(needs.*.result) }}' \
             | jq --exit-status 'all(.=="success" or .=="skipped")' > /dev/null
       - uses: sarisia/actions-status-discord@c193626e5ce172002b8161e116aa897de7ab5383 # v1.10.2
-        if: failure() && needs.setup.ci-stage == 'postsubmit'
+        if: failure() && needs.setup.outputs.ci-stage == 'postsubmit'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,26 +295,27 @@ jobs:
     env:
       BUILD_DIR: build-runtime
     steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Building runtime"
-        # Note ccache is read-only here since this job runs on a GitHub-hosted runner
-        # and GitHub runners don't have write access to GCS
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "BUILD_PRESET=test" \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/build_runtime.sh \
-            "${BUILD_DIR}"
-      - name: "Testing runtime"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_DISABLE=1 \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+        - run: exit 0
+      # - name: "Checking out repository"
+      #   uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      # - name: "Checking out runtime submodules"
+      #   run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      # - name: "Building runtime"
+      #   # Note ccache is read-only here since this job runs on a GitHub-hosted runner
+      #   # and GitHub runners don't have write access to GCS
+      #   run: |
+      #     ./build_tools/github_actions/docker_run.sh \
+      #       --env "BUILD_PRESET=test" \
+      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+      #       ./build_tools/cmake/build_runtime.sh \
+      #       "${BUILD_DIR}"
+      # - name: "Testing runtime"
+      #   run: |
+      #     ./build_tools/github_actions/docker_run.sh \
+      #       --env IREE_VULKAN_DISABLE=1 \
+      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+      #       ./build_tools/cmake/ctest_all.sh \
+      #       "${BUILD_DIR}"
 
   # build_test_runtime_windows:
   #   needs: setup
@@ -635,25 +636,26 @@ jobs:
     env:
       BUILD_DIR: build-runtime
     steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Building size-optimized runtime"
-        # Note ccache is read-only here since this job runs on a GitHub-hosted runner
-        # and GitHub runners don't have write access to GCS
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/build_runtime_small.sh \
-            "${BUILD_DIR}"
-      - name: "Testing runtime"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_DISABLE=1 \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+      - run: exit 1
+      # - name: "Checking out repository"
+      #   uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      # - name: "Checking out runtime submodules"
+      #   run: ./build_tools/scripts/git/update_runtime_submodules.sh
+      # - name: "Building size-optimized runtime"
+      #   # Note ccache is read-only here since this job runs on a GitHub-hosted runner
+      #   # and GitHub runners don't have write access to GCS
+      #   run: |
+      #     ./build_tools/github_actions/docker_run.sh \
+      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+      #       ./build_tools/cmake/build_runtime_small.sh \
+      #       "${BUILD_DIR}"
+      # - name: "Testing runtime"
+      #   run: |
+      #     ./build_tools/github_actions/docker_run.sh \
+      #       --env IREE_VULKAN_DISABLE=1 \
+      #       gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+      #       ./build_tools/cmake/ctest_all.sh \
+      #       "${BUILD_DIR}"
 
   # gcc:
   #   needs: setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,7 +291,7 @@ jobs:
   build_test_runtime:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
-    runs-on: ubuntu-20.04-64core
+    runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
     steps:
@@ -632,7 +632,7 @@ jobs:
   small_runtime:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
-    runs-on: ubuntu-20.04-64core
+    runs-on: ubuntu-20.04
     env:
       BUILD_DIR: build-runtime
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1117,13 +1117,13 @@ jobs:
         id: failed_jobs
         run: |
           echo '${{ toJson(needs) }}'
-          FAILING_JOBS="$(echo '${{ toJson(needs) }}' \
+          FAILED_JOBS="$(echo '${{ toJson(needs) }}' \
             | jq --raw-output \
             'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
           )"
-          echo "failed-jobs=${FAILING_JOBS}" >> $GITHUB_OUTPUT
-          if [[ "${FAILING_JOBS}" != "" ]]; then
-            echo "The following jobs failed: ${FAILING_JOBS}"
+          echo "failed-jobs=${FAILED_JOBS}" >> $GITHUB_OUTPUT
+          if [[ "${FAILED_JOBS}" != "" ]]; then
+            echo "The following jobs failed: ${FAILED_JOBS}"
             exit 1
           fi
       - name: Posting to Discord

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ on:
   push:
     branches:
       - main
+      # DO NOT SUBMIT
+      - gcmn-ci-notifications
 
 concurrency:
   # A PR number if a pull request and otherwise the commit hash. This cancels
@@ -93,195 +95,195 @@ jobs:
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"
   ##############################################################################
-  build_all:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: full-build-dir
-    outputs:
-      # Pass through the build directory as output so it's available to
-      # dependent jobs.
-      build-dir: ${{ env.BUILD_DIR }}
-      build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
-      build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Building IREE"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/build_all.sh \
-            "${BUILD_DIR}"
-      # The archive step below doesn't include these files. Remove them first to
-      # save disk space.
-      # TODO(#10739): This step can be removed once we enlarge the disk sapce.
-      - name: "Removing unused files"
-        run: |
-          find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
-            -print \
-            -delete
-      # Things get more complicated here than when we're just building the
-      # runtime. The build directory is way bigger. We're also using on our own
-      # runners on GCE. So uploading to GitHub actions artifact storage hosted
-      # on Azure is dirt slow. We drop static libraries and object files, which
-      # aren't needed for testing. Then we do some minimal compression locally
-      # *in parallel* and upload to GCS. This can be further optimized.
-      # Especially decompression is still pretty slow. See #9881.
-      - name: "Creating build dir archive"
-        id: archive
-        env:
-          BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
-        run: |
-          tar -I 'zstd -T0' \
-            -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
-          echo "build-dir-archive=${BUILD_DIR_ARCHIVE}" >> "${GITHUB_OUTPUT}"
-      - name: "Uploading build dir archive"
-        id: upload
-        env:
-          BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
-          BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
-        run: |
-          gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
-          echo "build-dir-gcs-artifact=${BUILD_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+  # build_all:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: full-build-dir
+  #   outputs:
+  #     # Pass through the build directory as output so it's available to
+  #     # dependent jobs.
+  #     build-dir: ${{ env.BUILD_DIR }}
+  #     build-dir-archive: ${{ steps.archive.outputs.build-dir-archive }}
+  #     build-dir-gcs-artifact: ${{ steps.upload.outputs.build-dir-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Building IREE"
+  #       env:
+  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+  #           ./build_tools/cmake/build_all.sh \
+  #           "${BUILD_DIR}"
+  #     # The archive step below doesn't include these files. Remove them first to
+  #     # save disk space.
+  #     # TODO(#10739): This step can be removed once we enlarge the disk sapce.
+  #     - name: "Removing unused files"
+  #       run: |
+  #         find "${BUILD_DIR}" -type f -name "*.a" -o -type f -name "*.o" \
+  #           -print \
+  #           -delete
+  #     # Things get more complicated here than when we're just building the
+  #     # runtime. The build directory is way bigger. We're also using on our own
+  #     # runners on GCE. So uploading to GitHub actions artifact storage hosted
+  #     # on Azure is dirt slow. We drop static libraries and object files, which
+  #     # aren't needed for testing. Then we do some minimal compression locally
+  #     # *in parallel* and upload to GCS. This can be further optimized.
+  #     # Especially decompression is still pretty slow. See #9881.
+  #     - name: "Creating build dir archive"
+  #       id: archive
+  #       env:
+  #         BUILD_DIR_ARCHIVE: ${{ env.BUILD_DIR }}.tar.zst
+  #       run: |
+  #         tar -I 'zstd -T0' \
+  #           -cf ${BUILD_DIR_ARCHIVE} ${BUILD_DIR}
+  #         echo "build-dir-archive=${BUILD_DIR_ARCHIVE}" >> "${GITHUB_OUTPUT}"
+  #     - name: "Uploading build dir archive"
+  #       id: upload
+  #       env:
+  #         BUILD_DIR_ARCHIVE: ${{ steps.archive.outputs.build-dir-archive }}
+  #         BUILD_DIR_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.build-dir-archive }}
+  #       run: |
+  #         gcloud alpha storage cp "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR_GCS_ARTIFACT}"
+  #         echo "build-dir-gcs-artifact=${BUILD_DIR_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  # TODO(#11350): re-enable this job when it works again
-  build_test_all_windows:
-    needs: setup
-    if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
-    runs-on: managed-windows-cpu
-    defaults:
-      run:
-        shell: bash
-    env:
-      BUILD_DIR: build-windows
-      IREE_VULKAN_DISABLE: 1
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Setting up Python"
-        uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
-        with:
-          python-version: "3.10"  # Needs pybind >= 2.10.1 for Python >= 3.11
-      - name: "Installing Python packages"
-        run: |
-          python3 -m venv .venv
-          .venv/Scripts/activate.bat
-          python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
-      - name: "Configuring MSVC"
-        uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
-      - name: "Building IREE"
-        run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
-      - name: "Testing IREE"
-        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+  # # TODO(#11350): re-enable this job when it works again
+  # build_test_all_windows:
+  #   needs: setup
+  #   if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+  #   runs-on: managed-windows-cpu
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     BUILD_DIR: build-windows
+  #     IREE_VULKAN_DISABLE: 1
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Setting up Python"
+  #       uses: actions/setup-python@75f3110429a8c05be0e1bf360334e4cced2b63fa # v2.3.3
+  #       with:
+  #         python-version: "3.10"  # Needs pybind >= 2.10.1 for Python >= 3.11
+  #     - name: "Installing Python packages"
+  #       run: |
+  #         python3 -m venv .venv
+  #         .venv/Scripts/activate.bat
+  #         python3 -m pip install -r runtime/bindings/python/iree/runtime/build_requirements.txt
+  #     - name: "Configuring MSVC"
+  #       uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
+  #     - name: "Building IREE"
+  #       run: ./build_tools/cmake/build_all.sh "${BUILD_DIR}"
+  #     - name: "Testing IREE"
+  #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
-  build_test_all_bazel:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Building with Bazel"
-        env:
-          IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
-            gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
-            ./build_tools/bazel/build_core.sh
+  # build_test_all_bazel:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Building with Bazel"
+  #       env:
+  #         IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
+  #           gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
+  #           ./build_tools/bazel/build_core.sh
 
-  test_all:
-    needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Testing all"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_CUDA_DISABLE=1 \
-            gcr.io/iree-oss/swiftshader@sha256:27b843417fd548fab1b636d2b65d2b8b8c09f42a65cd5dde7ecfb9881e4332ac \
-            ./build_tools/cmake/ctest_all.sh \
-            "${BUILD_DIR}"
+  # test_all:
+  #   needs: [setup, build_all]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting build dir archive"
+  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Testing all"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env IREE_CUDA_DISABLE=1 \
+  #           gcr.io/iree-oss/swiftshader@sha256:27b843417fd548fab1b636d2b65d2b8b8c09f42a65cd5dde7ecfb9881e4332ac \
+  #           ./build_tools/cmake/ctest_all.sh \
+  #           "${BUILD_DIR}"
 
-  test_gpu:
-    needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: Querying GPU information
-        run: |
-          ./build_tools/scripts/check_cuda.sh
-          ./build_tools/scripts/check_vulkan.sh
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Testing with GPU"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_VULKAN_F16_DISABLE=0 \
-            --env IREE_CUDA_DISABLE=0 \
-            --env CTEST_PARALLEL_LEVEL=2 \
-            --gpus all \
-            --env NVIDIA_DRIVER_CAPABILITIES=all \
-            gcr.io/iree-oss/nvidia@sha256:b0751e9f2fcb104d9d3d56fab6c6e79405bdcd2e503e53f2bf4f2b66d13cd88b \
-            bash -euo pipefail -c \
-              "./build_tools/scripts/check_cuda.sh
-              ./build_tools/scripts/check_vulkan.sh
-              ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
+  # test_gpu:
+  #   needs: [setup, build_all]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - gpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: Querying GPU information
+  #       run: |
+  #         ./build_tools/scripts/check_cuda.sh
+  #         ./build_tools/scripts/check_vulkan.sh
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting build dir archive"
+  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Testing with GPU"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env IREE_VULKAN_F16_DISABLE=0 \
+  #           --env IREE_CUDA_DISABLE=0 \
+  #           --env CTEST_PARALLEL_LEVEL=2 \
+  #           --gpus all \
+  #           --env NVIDIA_DRIVER_CAPABILITIES=all \
+  #           gcr.io/iree-oss/nvidia@sha256:b0751e9f2fcb104d9d3d56fab6c6e79405bdcd2e503e53f2bf4f2b66d13cd88b \
+  #           bash -euo pipefail -c \
+  #             "./build_tools/scripts/check_cuda.sh
+  #             ./build_tools/scripts/check_vulkan.sh
+  #             ./build_tools/cmake/ctest_all.sh ${BUILD_DIR}"
 
   ################################## Subsets ###################################
   # Jobs that build some subset of IREE
@@ -314,317 +316,317 @@ jobs:
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
 
-  build_test_runtime_windows:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on: managed-windows-cpu
-    defaults:
-      run:
-        shell: bash
-    env:
-      BUILD_DIR: build-runtime-windows
-      IREE_VULKAN_DISABLE: 1
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Configuring MSVC"
-        uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
-      - name: "Building runtime"
-        env:
-          BUILD_PRESET: "test"
-        run: ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
-      - name: "Testing runtime"
-        run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
+  # build_test_runtime_windows:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on: managed-windows-cpu
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   env:
+  #     BUILD_DIR: build-runtime-windows
+  #     IREE_VULKAN_DISABLE: 1
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Configuring MSVC"
+  #       uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d # v1.12.0
+  #     - name: "Building runtime"
+  #       env:
+  #         BUILD_PRESET: "test"
+  #       run: ./build_tools/cmake/build_runtime.sh "${BUILD_DIR}"
+  #     - name: "Testing runtime"
+  #       run: ./build_tools/cmake/ctest_all.sh "${BUILD_DIR}"
 
-  ################################# Tensorflow #################################
-  # Jobs that build the IREE-Tensorflow integrations
-  ##############################################################################
-  build_tf_integrations:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    outputs:
-      binaries-dir: ${{ steps.build.outputs.binaries-dir }}
-      binaries-archive: ${{ steps.archive.outputs.binaries-archive }}
-      binaries-gcs-artifact: ${{ steps.upload.outputs.binaries-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Building TF binaries"
-        id: build
-        env:
-          IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
-          IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
-            --env "IREE_TF_BINARIES_OUTPUT_DIR=${IREE_TF_BINARIES_OUTPUT_DIR}" \
-            gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
-            build_tools/cmake/build_tf_binaries.sh
-          echo "binaries-dir=${IREE_TF_BINARIES_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
-      - name: "Creating archive of binaries"
-        id: archive
-        env:
-          BINARIES_ARCHIVE: tf-binaries.tar
-          BINARIES_DIR: ${{ steps.build.outputs.binaries-dir }}
-        run: |
-          tar -cf "${BINARIES_ARCHIVE}" "${BINARIES_DIR}"
-          echo "binaries-archive=${BINARIES_ARCHIVE}" >> "${GITHUB_OUTPUT}"
-      - name: "Uploading binaries archive"
-        id: upload
-        env:
-          BINARIES_ARCHIVE: ${{ steps.archive.outputs.binaries-archive }}
-          BINARIES_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.binaries-archive }}
-        run: |
-          gcloud alpha storage cp "${BINARIES_ARCHIVE}" "${BINARIES_GCS_ARTIFACT}"
-          echo "binaries-gcs-artifact=${BINARIES_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+  # ################################# Tensorflow #################################
+  # # Jobs that build the IREE-Tensorflow integrations
+  # ##############################################################################
+  # build_tf_integrations:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   outputs:
+  #     binaries-dir: ${{ steps.build.outputs.binaries-dir }}
+  #     binaries-archive: ${{ steps.archive.outputs.binaries-archive }}
+  #     binaries-gcs-artifact: ${{ steps.upload.outputs.binaries-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Building TF binaries"
+  #       id: build
+  #       env:
+  #         IREE_TF_BINARIES_OUTPUT_DIR: iree-tf-binaries
+  #         IREE_WRITE_REMOTE_BAZEL_CACHE: ${{ needs.setup.outputs.write-caches }}
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_WRITE_REMOTE_BAZEL_CACHE=${IREE_WRITE_REMOTE_BAZEL_CACHE}" \
+  #           --env "IREE_TF_BINARIES_OUTPUT_DIR=${IREE_TF_BINARIES_OUTPUT_DIR}" \
+  #           gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
+  #           build_tools/cmake/build_tf_binaries.sh
+  #         echo "binaries-dir=${IREE_TF_BINARIES_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
+  #     - name: "Creating archive of binaries"
+  #       id: archive
+  #       env:
+  #         BINARIES_ARCHIVE: tf-binaries.tar
+  #         BINARIES_DIR: ${{ steps.build.outputs.binaries-dir }}
+  #       run: |
+  #         tar -cf "${BINARIES_ARCHIVE}" "${BINARIES_DIR}"
+  #         echo "binaries-archive=${BINARIES_ARCHIVE}" >> "${GITHUB_OUTPUT}"
+  #     - name: "Uploading binaries archive"
+  #       id: upload
+  #       env:
+  #         BINARIES_ARCHIVE: ${{ steps.archive.outputs.binaries-archive }}
+  #         BINARIES_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.archive.outputs.binaries-archive }}
+  #       run: |
+  #         gcloud alpha storage cp "${BINARIES_ARCHIVE}" "${BINARIES_GCS_ARTIFACT}"
+  #         echo "binaries-gcs-artifact=${BINARIES_GCS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
 
-  test_tf_integrations:
-    needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Downloading TF binaries archive"
-        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-      - name: "Extracting TF binaries archive"
-        run: tar -xvf "${TF_BINARIES_ARCHIVE}"
-      - name: "Symlinking TF binaries"
-        run: |
-          ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Running TF integrations tests"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
-            build_tools/cmake/run_tf_tests.sh \
-            "${BUILD_DIR}"
+  # test_tf_integrations:
+  #   needs: [setup, build_all, build_tf_integrations]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Downloading TF binaries archive"
+  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Extracting TF binaries archive"
+  #       run: tar -xvf "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Symlinking TF binaries"
+  #       run: |
+  #         ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting build dir archive"
+  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Running TF integrations tests"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           gcr.io/iree-oss/frontends-swiftshader@sha256:8dbbfe9d0b9d72e8af591f9390ef8865536cc67bd262285335b7a83b2218548d \
+  #           build_tools/cmake/run_tf_tests.sh \
+  #           "${BUILD_DIR}"
 
-  test_tf_integrations_gpu:
-    needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Downloading TF binaries archive"
-        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-      - name: "Extracting TF binaries archive"
-        run: tar -xvf "${TF_BINARIES_ARCHIVE}"
-      - name: "Symlinking TF binaries"
-        run: |
-          ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Running TF integrations tests"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env IREE_LLVM_CPU_DISABLE=1 \
-            --gpus all \
-            --env NVIDIA_DRIVER_CAPABILITIES=all \
-            gcr.io/iree-oss/frontends-nvidia@sha256:3e3965b6b9e431be296900440e5bc66ed46a8f6d6fa80ead7c7a75866f3bd416 \
-            bash -euo pipefail -c \
-              "./build_tools/scripts/check_cuda.sh
-              ./build_tools/scripts/check_vulkan.sh
-              build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
+  # test_tf_integrations_gpu:
+  #   needs: [setup, build_all, build_tf_integrations]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - gpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Downloading TF binaries archive"
+  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Extracting TF binaries archive"
+  #       run: tar -xvf "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Symlinking TF binaries"
+  #       run: |
+  #         ./integrations/tensorflow/symlink_binaries.sh "${TF_BINARIES_DIR}"
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting build dir archive"
+  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Running TF integrations tests"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env IREE_LLVM_CPU_DISABLE=1 \
+  #           --gpus all \
+  #           --env NVIDIA_DRIVER_CAPABILITIES=all \
+  #           gcr.io/iree-oss/frontends-nvidia@sha256:3e3965b6b9e431be296900440e5bc66ed46a8f6d6fa80ead7c7a75866f3bd416 \
+  #           bash -euo pipefail -c \
+  #             "./build_tools/scripts/check_cuda.sh
+  #             ./build_tools/scripts/check_vulkan.sh
+  #             build_tools/cmake/run_tf_tests.sh ${BUILD_DIR}"
 
-  ######################## Community Model Coverage ############################
-  # Jobs that test IREE behavior on a set of models.
-  ##############################################################################
-  test_shark_model_suite:
-    needs: [setup, build_all, build_tf_integrations]
-    # Disabled while failing. See https://github.com/iree-org/iree/issues/10653
-    if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - gpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Downloading TF binaries archive"
-        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-      - name: "Extracting TF binaries archive"
-        run: tar -xf "${TF_BINARIES_ARCHIVE}"
-      - name: "Symlinking TF binaries"
-        run: |
-          ./integrations/tensorflow/symlink_binaries.sh "$(realpath "${TF_BINARIES_DIR}")"
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}"
-      - name: "Downloading SHARK"
-        id: download_shark
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          repository: nod-ai/SHARK
-          path: ${{ github.workspace }}/SHARK
-      - name: "Testing Shark Model Suite"
-        run: |
-          cd "${GITHUB_WORKSPACE}/SHARK"
-          NO_BACKEND=1 ./setup_venv.sh
-          source shark.venv/bin/activate
-          export TFPYBASE="${GITHUB_WORKSPACE}/integrations/tensorflow/python_projects"
-          export PYTHONPATH="${PYTHONPATH}:${BUILD_DIR}/compiler/bindings/python:${BUILD_DIR}/runtime/bindings/python"
-          export PYTHONPATH="${PYTHONPATH}:$TFPYBASE/iree_tf:$TFPYBASE/iree_tflite"
-          export SHARK_SKIP_TESTS="--ignore=shark/tests/test_shark_importer.py \
-            --ignore=benchmarks/tests/test_hf_benchmark.py \
-            --ignore=benchmarks/tests/test_benchmark.py"
-          export MODEL_LIST="bert_base_cased or mobilebert_uncased or MiniLM_L12_H384_uncased or module_resnet50 or mobilenet_v3 or squeezenet1_0 or vit_base_patch16_224"
-          pytest tank/test_models.py -k "cpu and ($MODEL_LIST)" $SHARK_SKIP_TESTS
-          pytest tank/test_models.py -k "vulkan and ($MODEL_LIST)" $SHARK_SKIP_TESTS
-          pytest tank/test_models.py -k "cuda and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+  # ######################## Community Model Coverage ############################
+  # # Jobs that test IREE behavior on a set of models.
+  # ##############################################################################
+  # test_shark_model_suite:
+  #   needs: [setup, build_all, build_tf_integrations]
+  #   # Disabled while failing. See https://github.com/iree-org/iree/issues/10653
+  #   if: false && needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - gpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Downloading TF binaries archive"
+  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Extracting TF binaries archive"
+  #       run: tar -xf "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Symlinking TF binaries"
+  #       run: |
+  #         ./integrations/tensorflow/symlink_binaries.sh "$(realpath "${TF_BINARIES_DIR}")"
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting build dir archive"
+  #       run: tar -xf "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Downloading SHARK"
+  #       id: download_shark
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         repository: nod-ai/SHARK
+  #         path: ${{ github.workspace }}/SHARK
+  #     - name: "Testing Shark Model Suite"
+  #       run: |
+  #         cd "${GITHUB_WORKSPACE}/SHARK"
+  #         NO_BACKEND=1 ./setup_venv.sh
+  #         source shark.venv/bin/activate
+  #         export TFPYBASE="${GITHUB_WORKSPACE}/integrations/tensorflow/python_projects"
+  #         export PYTHONPATH="${PYTHONPATH}:${BUILD_DIR}/compiler/bindings/python:${BUILD_DIR}/runtime/bindings/python"
+  #         export PYTHONPATH="${PYTHONPATH}:$TFPYBASE/iree_tf:$TFPYBASE/iree_tflite"
+  #         export SHARK_SKIP_TESTS="--ignore=shark/tests/test_shark_importer.py \
+  #           --ignore=benchmarks/tests/test_hf_benchmark.py \
+  #           --ignore=benchmarks/tests/test_benchmark.py"
+  #         export MODEL_LIST="bert_base_cased or mobilebert_uncased or MiniLM_L12_H384_uncased or module_resnet50 or mobilenet_v3 or squeezenet1_0 or vit_base_patch16_224"
+  #         pytest tank/test_models.py -k "cpu and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+  #         pytest tank/test_models.py -k "vulkan and ($MODEL_LIST)" $SHARK_SKIP_TESTS
+  #         pytest tank/test_models.py -k "cuda and ($MODEL_LIST)" $SHARK_SKIP_TESTS
 
-  # TODO(#11263): Drop this job once the IREE_BUILD_BENCHMARKS is removed.
-  test_build_benchmark_suites:
-    needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-      BUILD_BENCHMARKS_DIR: build-benchmarks
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting install from build dir archive"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
-      - name: "Downloading TF binaries archive"
-        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-      - name: "Extracting TF binaries archive"
-        run: tar -xf "${TF_BINARIES_ARCHIVE}"
-      - name: "Building benchmarks"
-        id: build
-        run: |
-          build_tools/github_actions/docker_run.sh \
-            --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
-            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            --env "IREE_BUILD_BENCHMARKS_DIR=${BUILD_BENCHMARKS_DIR}" \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            build_tools/cmake/build_benchmarks.sh
+  # # TODO(#11263): Drop this job once the IREE_BUILD_BENCHMARKS is removed.
+  # test_build_benchmark_suites:
+  #   needs: [setup, build_all, build_tf_integrations]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+  #     BUILD_BENCHMARKS_DIR: build-benchmarks
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting install from build dir archive"
+  #       run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
+  #     - name: "Downloading TF binaries archive"
+  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Extracting TF binaries archive"
+  #       run: tar -xf "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Building benchmarks"
+  #       id: build
+  #       run: |
+  #         build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
+  #           --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+  #           --env "IREE_BUILD_BENCHMARKS_DIR=${BUILD_BENCHMARKS_DIR}" \
+  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+  #           build_tools/cmake/build_benchmarks.sh
 
-  ############################### Configurations ###############################
-  # Jobs that build IREE in some non-default configuration
-  ##############################################################################
-  asan:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Building and testing with AddressSanitizer"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          # Note that this uses the latest version of the clang compiler, etc.
-          # This gives us access to the latest features and validates that IREE
-          # builds using the latest versions.
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be" \
-            gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
-            ./build_tools/cmake/build_and_test_asan.sh
+  # ############################### Configurations ###############################
+  # # Jobs that build IREE in some non-default configuration
+  # ##############################################################################
+  # asan:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Building and testing with AddressSanitizer"
+  #       env:
+  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #       run: |
+  #         # Note that this uses the latest version of the clang compiler, etc.
+  #         # This gives us access to the latest features and validates that IREE
+  #         # builds using the latest versions.
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+  #           --env "CCACHE_NAMESPACE=swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be" \
+  #           gcr.io/iree-oss/swiftshader-bleeding-edge@sha256:c22afc61198e14a98e06e5261149de74c629acd2bc61b82e57ec90e5461b69be \
+  #           ./build_tools/cmake/build_and_test_asan.sh
 
-  tsan:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Building and testing with ThreadSanitizer"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/build_and_test_tsan.sh
+  # tsan:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Building and testing with ThreadSanitizer"
+  #       env:
+  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+  #           ./build_tools/cmake/build_and_test_tsan.sh
 
   small_runtime:
     needs: setup
@@ -653,411 +655,411 @@ jobs:
             ./build_tools/cmake/ctest_all.sh \
             "${BUILD_DIR}"
 
-  gcc:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: build-gcc
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Building IREE with gcc"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env CC=/usr/bin/gcc-9 \
-            --env CXX=/usr/bin/g++-9 \
-            --env "IREE_TARGET_BACKEND_WEBGPU=OFF" \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/build_all.sh \
-            "${BUILD_DIR}"
+  # gcc:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: build-gcc
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Building IREE with gcc"
+  #       env:
+  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env CC=/usr/bin/gcc-9 \
+  #           --env CXX=/usr/bin/g++-9 \
+  #           --env "IREE_TARGET_BACKEND_WEBGPU=OFF" \
+  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+  #           ./build_tools/cmake/build_all.sh \
+  #           "${BUILD_DIR}"
 
-  tracing:
-    needs: setup
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      BUILD_DIR: build-tracing
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-        with:
-          submodules: true
-      - name: "Building IREE with tracing enabled"
-        env:
-          IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-        run: |
-          # TODO(#11394): Enable Web GPU
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            ./build_tools/cmake/build_tracing.sh \
-            "${BUILD_DIR}"
+  # tracing:
+  #   needs: setup
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     BUILD_DIR: build-tracing
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #       with:
+  #         submodules: true
+  #     - name: "Building IREE with tracing enabled"
+  #       env:
+  #         IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #       run: |
+  #         # TODO(#11394): Enable Web GPU
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+  #           --env "CCACHE_NAMESPACE=gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206" \
+  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+  #           ./build_tools/cmake/build_tracing.sh \
+  #           "${BUILD_DIR}"
 
   ############################### Configurations ###############################
   # Jobs that build and run IREE e2e tests/benchmarks                          #
   ##############################################################################
 
-  build_benchmark_tools:
-    needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    outputs:
-      # We can't collect all outputs from the matrix jobs due to Github's
-      # limitation (https://github.com/orgs/community/discussions/17245).
-      # Therefore, the output is the GCS directory that stores all benchmark
-      # tools archives. The following jobs need to construct the archive names
-      # by themselves and combine with path of GCS directory here to fetch the
-      # archives.
-      benchmark-tools-gcs-artifact-dir: ${{ steps.upload.outputs.benchmark-tools-gcs-artifact-dir }}
-    strategy:
-      matrix:
-        target:
-          - platform: "linux"
-            arch: "x86_64"
-            docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
-            # Builds tools on the host and assumes the builder is Linux x86_64.
-            build_script: "./build_tools/cmake/build_runtime.sh"
-          - platform: "linux"
-            arch: "riscv_64"
-            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-            build_script: "./build_tools/cmake/build_riscv.sh"
-    env:
-      PLATFORM: ${{ matrix.target.platform }}
-      ARCH: ${{ matrix.target.arch }}
-      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-      BUILD_SCRIPT: ${{ matrix.target.build_script }}
-      BUILD_TOOLS_DIR: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools-dir
-      BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
-      - name: "Extracting host binaries"
-        run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
-      - name: "Compiling the benchmark tools"
-        id: build
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-            --env "IREE_TARGET_ARCH=${ARCH}" \
-            --env "BUILD_PRESET=benchmark" \
-            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build"
-      - name: "Compiling the benchmark tools with tracing"
-        id: build-with-tracing
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-            --env "IREE_TARGET_ARCH=${ARCH}" \
-            --env "BUILD_PRESET=benchmark-with-tracing" \
-            --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
-            "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build-traced"
-      - name: "Creating the benchmark tools archive"
-        id: archive
-        env:
-          BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools.tar
-        run: |
-          tar -cf "${BENCHMARK_TOOLS_ARCHIVE}" \
-            "${BUILD_TOOLS_DIR}"/*/tools/iree-benchmark-module \
-            "${BUILD_TOOLS_DIR}"/*/tools/build_config.txt
-          echo "benchmark-tools-archive=${BENCHMARK_TOOLS_ARCHIVE}" >> "${GITHUB_OUTPUT}"
-      - name: "Uploading the benchmark tools archive"
-        id: upload
-        env:
-          BENCHMARK_TOOLS_ARCHIVE: ${{ steps.archive.outputs.benchmark-tools-archive }}
-          BENCHMARK_TOOLS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/benchmark-tools
-        run: |
-          gcloud alpha storage cp "${BENCHMARK_TOOLS_ARCHIVE}" "${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}/"
-          echo "benchmark-tools-gcs-artifact-dir=${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
+  # build_benchmark_tools:
+  #   needs: [setup, build_all, build_tf_integrations]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   outputs:
+  #     # We can't collect all outputs from the matrix jobs due to Github's
+  #     # limitation (https://github.com/orgs/community/discussions/17245).
+  #     # Therefore, the output is the GCS directory that stores all benchmark
+  #     # tools archives. The following jobs need to construct the archive names
+  #     # by themselves and combine with path of GCS directory here to fetch the
+  #     # archives.
+  #     benchmark-tools-gcs-artifact-dir: ${{ steps.upload.outputs.benchmark-tools-gcs-artifact-dir }}
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         - platform: "linux"
+  #           arch: "x86_64"
+  #           docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
+  #           # Builds tools on the host and assumes the builder is Linux x86_64.
+  #           build_script: "./build_tools/cmake/build_runtime.sh"
+  #         - platform: "linux"
+  #           arch: "riscv_64"
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+  #           build_script: "./build_tools/cmake/build_riscv.sh"
+  #   env:
+  #     PLATFORM: ${{ matrix.target.platform }}
+  #     ARCH: ${{ matrix.target.arch }}
+  #     DOCKER_IMAGE: ${{ matrix.target.docker_image }}
+  #     BUILD_SCRIPT: ${{ matrix.target.build_script }}
+  #     BUILD_TOOLS_DIR: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools-dir
+  #     BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting host binaries"
+  #       run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
+  #     - name: "Compiling the benchmark tools"
+  #       id: build
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+  #           --env "IREE_TARGET_ARCH=${ARCH}" \
+  #           --env "BUILD_PRESET=benchmark" \
+  #           --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+  #           "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build"
+  #     - name: "Compiling the benchmark tools with tracing"
+  #       id: build-with-tracing
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+  #           --env "IREE_TARGET_ARCH=${ARCH}" \
+  #           --env "BUILD_PRESET=benchmark-with-tracing" \
+  #           --env "IREE_HOST_BINARY_ROOT=${BUILD_DIR}/install" \
+  #           "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build-traced"
+  #     - name: "Creating the benchmark tools archive"
+  #       id: archive
+  #       env:
+  #         BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools.tar
+  #       run: |
+  #         tar -cf "${BENCHMARK_TOOLS_ARCHIVE}" \
+  #           "${BUILD_TOOLS_DIR}"/*/tools/iree-benchmark-module \
+  #           "${BUILD_TOOLS_DIR}"/*/tools/build_config.txt
+  #         echo "benchmark-tools-archive=${BENCHMARK_TOOLS_ARCHIVE}" >> "${GITHUB_OUTPUT}"
+  #     - name: "Uploading the benchmark tools archive"
+  #       id: upload
+  #       env:
+  #         BENCHMARK_TOOLS_ARCHIVE: ${{ steps.archive.outputs.benchmark-tools-archive }}
+  #         BENCHMARK_TOOLS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/benchmark-tools
+  #       run: |
+  #         gcloud alpha storage cp "${BENCHMARK_TOOLS_ARCHIVE}" "${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}/"
+  #         echo "benchmark-tools-gcs-artifact-dir=${BENCHMARK_TOOLS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
 
-  build_e2e_test_artifacts:
-    needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
-      TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
-      TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
-    outputs:
-      e2e-test-artifacts-dir: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
-      e2e-test-artifacts-gcs-artifact-dir: ${{ steps.upload.outputs.e2e-test-artifacts-gcs-artifact-dir }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting install from build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-      - name: "Downloading TF binaries archive"
-        run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
-      - name: "Extracting TF binaries archive"
-        run: tar -xf "${TF_BINARIES_ARCHIVE}"
-      - name: "Building e2e test artifacts"
-        id: build
-        env:
-          BUILD_E2E_TEST_ARTIFACTS_DIR: build-e2e-test-artifacts
-        run: |
-          build_tools/github_actions/docker_run.sh \
-            --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
-            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-            gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
-            build_tools/cmake/build_e2e_test_artifacts.sh \
-            "${BUILD_E2E_TEST_ARTIFACTS_DIR}"
-          echo "e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" >> "${GITHUB_OUTPUT}"
-      - name: "Uploading e2e test artifacts"
-        id: upload
-        env:
-          E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
-          E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
-        run: |
-          # Uploads all IREE artifacts and MLIR files (including the imported
-          # MLIR files and MLIR source models).
-          # Not archiving the directory to allow fetching each file as needed
-          # separately.
-          find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
-            -name "iree_*" -o -name "model_*.mlir" | \
-            gcloud alpha storage cp --read-paths-from-stdin -r \
-              "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
-          echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
+  # build_e2e_test_artifacts:
+  #   needs: [setup, build_all, build_tf_integrations]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #     TF_BINARIES_DIR: ${{ needs.build_tf_integrations.outputs.binaries-dir }}
+  #     TF_BINARIES_ARCHIVE: ${{ needs.build_tf_integrations.outputs.binaries-archive }}
+  #     TF_BINARIES_GCS_ARTIFACT: ${{ needs.build_tf_integrations.outputs.binaries-gcs-artifact }}
+  #   outputs:
+  #     e2e-test-artifacts-dir: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
+  #     e2e-test-artifacts-gcs-artifact-dir: ${{ steps.upload.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting install from build dir archive"
+  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+  #     - name: "Downloading TF binaries archive"
+  #       run: gcloud alpha storage cp "${TF_BINARIES_GCS_ARTIFACT}" "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Extracting TF binaries archive"
+  #       run: tar -xf "${TF_BINARIES_ARCHIVE}"
+  #     - name: "Building e2e test artifacts"
+  #       id: build
+  #       env:
+  #         BUILD_E2E_TEST_ARTIFACTS_DIR: build-e2e-test-artifacts
+  #       run: |
+  #         build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_TF_BINARIES_DIR=${TF_BINARIES_DIR}" \
+  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+  #           gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206 \
+  #           build_tools/cmake/build_e2e_test_artifacts.sh \
+  #           "${BUILD_E2E_TEST_ARTIFACTS_DIR}"
+  #         echo "e2e-test-artifacts-dir=${BUILD_E2E_TEST_ARTIFACTS_DIR}/e2e_test_artifacts" >> "${GITHUB_OUTPUT}"
+  #     - name: "Uploading e2e test artifacts"
+  #       id: upload
+  #       env:
+  #         E2E_TEST_ARTIFACTS_DIR: ${{ steps.build.outputs.e2e-test-artifacts-dir }}
+  #         E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ env.GCS_DIR }}/e2e-test-artifacts
+  #       run: |
+  #         # Uploads all IREE artifacts and MLIR files (including the imported
+  #         # MLIR files and MLIR source models).
+  #         # Not archiving the directory to allow fetching each file as needed
+  #         # separately.
+  #         find "${E2E_TEST_ARTIFACTS_DIR}" -maxdepth 1 \
+  #           -name "iree_*" -o -name "model_*.mlir" | \
+  #           gcloud alpha storage cp --read-paths-from-stdin -r \
+  #             "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}"
+  #         echo "e2e-test-artifacts-gcs-artifact-dir=${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}" >> "${GITHUB_OUTPUT}"
 
-  benchmarks:
-    needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
-    uses: ./.github/workflows/benchmarks.yml
-    with:
-      # env.GCS_DIR is also duplicated in this workflow. See the note there on
-      # why this is.
-      runner-group: ${{ needs.setup.outputs.runner-group }}
-      runner-env: ${{ needs.setup.outputs.runner-env }}
-      e2e-test-artifacts-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
-      e2e-test-artifacts-gcs-artifact-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
-      benchmark-tools-gcs-artifact-dir: ${{ needs.build_benchmark_tools.outputs.benchmark-tools-gcs-artifact-dir }}
-      benchmark-presets: ${{ needs.setup.outputs.benchmark-presets }}
+  # benchmarks:
+  #   needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
+  #   if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
+  #   uses: ./.github/workflows/benchmarks.yml
+  #   with:
+  #     # env.GCS_DIR is also duplicated in this workflow. See the note there on
+  #     # why this is.
+  #     runner-group: ${{ needs.setup.outputs.runner-group }}
+  #     runner-env: ${{ needs.setup.outputs.runner-env }}
+  #     e2e-test-artifacts-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
+  #     e2e-test-artifacts-gcs-artifact-dir: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+  #     benchmark-tools-gcs-artifact-dir: ${{ needs.build_benchmark_tools.outputs.benchmark-tools-gcs-artifact-dir }}
+  #     benchmark-presets: ${{ needs.setup.outputs.benchmark-presets }}
 
-  ############################## Crosscompilation ##############################
-  # Jobs that cross-compile IREE for other platforms
-  ##############################################################################
+  # ############################## Crosscompilation ##############################
+  # # Jobs that cross-compile IREE for other platforms
+  # ##############################################################################
 
-  # emscripten is not in the test matrix because it is set as
-  # postsubmission-only.
-  cross_compile_and_test:
-    needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    strategy:
-      matrix:
-        target:
-          - platform: android
-            arch: armv8.2-a
-            abi: arm64-v8a
-            docker_image: "gcr.io/iree-oss/android@sha256:e5f45760ab2dc8a1d72dc6e9d90056719bedac5678ee90e6d9f9b958172b4834"
-            build_script: "./build_tools/cmake/build_android.sh"
-            # No test_script
-          - platform: linux
-            arch: riscv_64
-            abi: lp64d
-            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-            build_script: "./build_tools/cmake/build_riscv.sh"
-            test_script: "./build_tools/cmake/test_riscv.sh"
-          - platform: linux
-            arch: riscv_32
-            abi: ilp32d
-            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-            build_script: "./build_tools/cmake/build_riscv.sh"
-            test_script: "./build_tools/cmake/test_riscv.sh"
-          - platform: generic
-            arch: riscv_32
-            abi: ilp32
-            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-            build_script: "./build_tools/cmake/build_riscv.sh"
-            test_script: "./tests/riscv32/smoke.sh"
-    env:
-      PLATFORM: ${{ matrix.target.platform }}
-      ARCH: ${{ matrix.target.arch }}
-      ABI: ${{ matrix.target.abi }}
-      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-      BUILD_SCRIPT: ${{ matrix.target.build_script }}
-      TEST_SCRIPT: ${{ matrix.target.test_script }}
-      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
-      IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-      - name: "Build cross-compiling target"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
-            --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
-            --env "CCACHE_NAMESPACE=${DOCKER_IMAGE}" \
-            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-            --env "IREE_TARGET_ARCH=${ARCH}" \
-            --env "IREE_TARGET_ABI=${ABI}" \
-            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-            --env "BUILD_PRESET=test" \
-            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-            "${DOCKER_IMAGE}" \
-            "${BUILD_SCRIPT}"
-      - name: "Test cross-compiling target"
-        if: ${{ matrix.target.test_script }}
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-            --env "IREE_TARGET_ARCH=${ARCH}" \
-            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-            --env "BUILD_PRESET=test" \
-            "${DOCKER_IMAGE}" \
-            "${TEST_SCRIPT}"
+  # # emscripten is not in the test matrix because it is set as
+  # # postsubmission-only.
+  # cross_compile_and_test:
+  #   needs: [setup, build_all]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         - platform: android
+  #           arch: armv8.2-a
+  #           abi: arm64-v8a
+  #           docker_image: "gcr.io/iree-oss/android@sha256:e5f45760ab2dc8a1d72dc6e9d90056719bedac5678ee90e6d9f9b958172b4834"
+  #           build_script: "./build_tools/cmake/build_android.sh"
+  #           # No test_script
+  #         - platform: linux
+  #           arch: riscv_64
+  #           abi: lp64d
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+  #           build_script: "./build_tools/cmake/build_riscv.sh"
+  #           test_script: "./build_tools/cmake/test_riscv.sh"
+  #         - platform: linux
+  #           arch: riscv_32
+  #           abi: ilp32d
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+  #           build_script: "./build_tools/cmake/build_riscv.sh"
+  #           test_script: "./build_tools/cmake/test_riscv.sh"
+  #         - platform: generic
+  #           arch: riscv_32
+  #           abi: ilp32
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+  #           build_script: "./build_tools/cmake/build_riscv.sh"
+  #           test_script: "./tests/riscv32/smoke.sh"
+  #   env:
+  #     PLATFORM: ${{ matrix.target.platform }}
+  #     ARCH: ${{ matrix.target.arch }}
+  #     ABI: ${{ matrix.target.abi }}
+  #     DOCKER_IMAGE: ${{ matrix.target.docker_image }}
+  #     BUILD_SCRIPT: ${{ matrix.target.build_script }}
+  #     TEST_SCRIPT: ${{ matrix.target.test_script }}
+  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #     TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
+  #     IREE_WRITE_REMOTE_CCACHE: ${{ needs.setup.outputs.write-caches }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting build dir archive"
+  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+  #     - name: "Build cross-compiling target"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
+  #           --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \
+  #           --env "CCACHE_NAMESPACE=${DOCKER_IMAGE}" \
+  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+  #           --env "IREE_TARGET_ARCH=${ARCH}" \
+  #           --env "IREE_TARGET_ABI=${ABI}" \
+  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+  #           --env "BUILD_PRESET=test" \
+  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+  #           "${DOCKER_IMAGE}" \
+  #           "${BUILD_SCRIPT}"
+  #     - name: "Test cross-compiling target"
+  #       if: ${{ matrix.target.test_script }}
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+  #           --env "IREE_TARGET_ARCH=${ARCH}" \
+  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+  #           --env "BUILD_PRESET=test" \
+  #           "${DOCKER_IMAGE}" \
+  #           "${TEST_SCRIPT}"
 
-  emscripten:
-    needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    env:
-      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting install from build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-      - name: "Building the runtime for the web using Emscripten"
-        run: |
-          build_tools/github_actions/docker_run.sh \
-            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-            gcr.io/iree-oss/emscripten@sha256:20847a0a9503852d9594f3c4e7e633b913b450240b097d378dcd42d22ac0948e \
-            build_tools/cmake/build_runtime_emscripten.sh
+  # emscripten:
+  #   needs: [setup, build_all]
+  #   if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   env:
+  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting install from build dir archive"
+  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+  #     - name: "Building the runtime for the web using Emscripten"
+  #       run: |
+  #         build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+  #           gcr.io/iree-oss/emscripten@sha256:20847a0a9503852d9594f3c4e7e633b913b450240b097d378dcd42d22ac0948e \
+  #           build_tools/cmake/build_runtime_emscripten.sh
 
-  test_benchmark_suites:
-    needs: [setup, build_all, build_e2e_test_artifacts]
-    if: needs.setup.outputs.should-run == 'true'
-    runs-on:
-      - self-hosted  # must come first
-      - runner-group=${{ needs.setup.outputs.runner-group }}
-      - environment=${{ needs.setup.outputs.runner-env }}
-      - cpu
-      - os-family=Linux
-    strategy:
-      matrix:
-        target:
-          - platform: linux
-            arch: riscv_64
-            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-            run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
-          - platform: linux
-            arch: riscv_32
-            docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
-            run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
-          - platform: linux
-            arch: x86_64
-            docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
-            run_scripts: "./build_tools/cmake/test_benchmark_suites_on_linux.sh"
-    env:
-      PLATFORM: ${{ matrix.target.platform }}
-      ARCH: ${{ matrix.target.arch }}
-      DOCKER_IMAGE: ${{ matrix.target.docker_image }}
-      RUN_SCRIPTS: ${{ matrix.target.run_scripts }}
-      HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
-      HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
-      HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
-      TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
-      E2E_TEST_ARTIFACTS_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
-      E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
-    steps:
-      - name: "Checking out repository"
-        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-      - name: "Checking out runtime submodules"
-        run: ./build_tools/scripts/git/update_runtime_submodules.sh
-      - name: "Downloading build dir archive"
-        run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
-      - name: "Extracting build dir archive"
-        run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
-      # TODO(#11136): Only download the needed artifacts instead of everything.
-      - name: "Downloading e2e test artifacts"
-        run: |
-          mkdir -p ${E2E_TEST_ARTIFACTS_DIR}
-          gcloud alpha storage cp -r "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/*" "${E2E_TEST_ARTIFACTS_DIR}"
-      - name: "Download benchmark expected output"
-        env:
-          EXPECTED_OUTPUT_GSC_ARTIFACT: gs://iree-model-artifacts/deeplab_v3_fp32_input_0_expected_output.npy
-          EXPECTED_OUTPUT_FILE: deeplab_v3_fp32_input_0_expected_output.npy
-        run: |
-          gcloud alpha storage cp "${EXPECTED_OUTPUT_GSC_ARTIFACT}" "${E2E_TEST_ARTIFACTS_DIR}/${EXPECTED_OUTPUT_FILE}"
-      - name: "Build iree-run-module and test benchmark suite modules"
-        run: |
-          ./build_tools/github_actions/docker_run.sh \
-            --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
-            --env "IREE_TARGET_ARCH=${ARCH}" \
-            --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
-            --env "BUILD_PRESET=benchmark-suite-test" \
-            --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
-            --env "E2E_TEST_ARTIFACTS_DIR=${E2E_TEST_ARTIFACTS_DIR}" \
-            "${DOCKER_IMAGE}" \
-            bash -euo pipefail -c \
-              "${RUN_SCRIPTS}"
+  # test_benchmark_suites:
+  #   needs: [setup, build_all, build_e2e_test_artifacts]
+  #   if: needs.setup.outputs.should-run == 'true'
+  #   runs-on:
+  #     - self-hosted  # must come first
+  #     - runner-group=${{ needs.setup.outputs.runner-group }}
+  #     - environment=${{ needs.setup.outputs.runner-env }}
+  #     - cpu
+  #     - os-family=Linux
+  #   strategy:
+  #     matrix:
+  #       target:
+  #         - platform: linux
+  #           arch: riscv_64
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+  #           run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
+  #         - platform: linux
+  #           arch: riscv_32
+  #           docker_image: "gcr.io/iree-oss/riscv@sha256:5034a40068f14d91d5caf07d615f323561416caee8afda32ae622746a4dd8b04"
+  #           run_scripts: "./build_tools/cmake/build_riscv.sh && ./build_tools/cmake/test_riscv.sh"
+  #         - platform: linux
+  #           arch: x86_64
+  #           docker_image: "gcr.io/iree-oss/base@sha256:605d86ccf4197e978a24867fabb7fc100334c926b067ee0518e46d0a4396e206"
+  #           run_scripts: "./build_tools/cmake/test_benchmark_suites_on_linux.sh"
+  #   env:
+  #     PLATFORM: ${{ matrix.target.platform }}
+  #     ARCH: ${{ matrix.target.arch }}
+  #     DOCKER_IMAGE: ${{ matrix.target.docker_image }}
+  #     RUN_SCRIPTS: ${{ matrix.target.run_scripts }}
+  #     HOST_BUILD_DIR: ${{ needs.build_all.outputs.build-dir }}
+  #     HOST_BUILD_DIR_ARCHIVE: ${{ needs.build_all.outputs.build-dir-archive }}
+  #     HOST_BUILD_DIR_GCS_ARTIFACT: ${{ needs.build_all.outputs.build-dir-gcs-artifact }}
+  #     TARGET_BUILD_DIR: build-${{ matrix.target.platform }}-${{ matrix.target.arch }}
+  #     E2E_TEST_ARTIFACTS_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-dir }}
+  #     E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR: ${{ needs.build_e2e_test_artifacts.outputs.e2e-test-artifacts-gcs-artifact-dir }}
+  #   steps:
+  #     - name: "Checking out repository"
+  #       uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+  #     - name: "Checking out runtime submodules"
+  #       run: ./build_tools/scripts/git/update_runtime_submodules.sh
+  #     - name: "Downloading build dir archive"
+  #       run: gcloud alpha storage cp "${HOST_BUILD_DIR_GCS_ARTIFACT}" "${HOST_BUILD_DIR_ARCHIVE}"
+  #     - name: "Extracting build dir archive"
+  #       run: tar -xf "${HOST_BUILD_DIR_ARCHIVE}" "${HOST_BUILD_DIR}/install"
+  #     # TODO(#11136): Only download the needed artifacts instead of everything.
+  #     - name: "Downloading e2e test artifacts"
+  #       run: |
+  #         mkdir -p ${E2E_TEST_ARTIFACTS_DIR}
+  #         gcloud alpha storage cp -r "${E2E_TEST_ARTIFACTS_GCS_ARTIFACT_DIR}/*" "${E2E_TEST_ARTIFACTS_DIR}"
+  #     - name: "Download benchmark expected output"
+  #       env:
+  #         EXPECTED_OUTPUT_GSC_ARTIFACT: gs://iree-model-artifacts/deeplab_v3_fp32_input_0_expected_output.npy
+  #         EXPECTED_OUTPUT_FILE: deeplab_v3_fp32_input_0_expected_output.npy
+  #       run: |
+  #         gcloud alpha storage cp "${EXPECTED_OUTPUT_GSC_ARTIFACT}" "${E2E_TEST_ARTIFACTS_DIR}/${EXPECTED_OUTPUT_FILE}"
+  #     - name: "Build iree-run-module and test benchmark suite modules"
+  #       run: |
+  #         ./build_tools/github_actions/docker_run.sh \
+  #           --env "IREE_TARGET_PLATFORM=${PLATFORM}" \
+  #           --env "IREE_TARGET_ARCH=${ARCH}" \
+  #           --env "IREE_TARGET_BUILD_DIR=${TARGET_BUILD_DIR}" \
+  #           --env "BUILD_PRESET=benchmark-suite-test" \
+  #           --env "IREE_HOST_BINARY_ROOT=${HOST_BUILD_DIR}/install" \
+  #           --env "E2E_TEST_ARTIFACTS_DIR=${E2E_TEST_ARTIFACTS_DIR}" \
+  #           "${DOCKER_IMAGE}" \
+  #           bash -euo pipefail -c \
+  #             "${RUN_SCRIPTS}"
 
   ##############################################################################
 
@@ -1070,48 +1072,54 @@ jobs:
     if: always()
     runs-on: ubuntu-20.04
     needs:
+      - setup
+
       # Basic
-      - build_all
-      - build_test_all_windows
-      - build_test_all_bazel
-      - test_all
-      - test_gpu
+      # - build_all
+      # - build_test_all_windows
+      # - build_test_all_bazel
+      # - test_all
+      # - test_gpu
 
       # Subsets
       - build_test_runtime
-      - build_test_runtime_windows
+      # - build_test_runtime_windows
 
       # Tensorflow
-      - build_tf_integrations
-      - test_tf_integrations
-      - test_tf_integrations_gpu
+      # - build_tf_integrations
+      # - test_tf_integrations
+      # - test_tf_integrations_gpu
 
-      # Model Coverage
-      - test_build_benchmark_suites
-      - test_shark_model_suite
+      # # Model Coverage
+      # - test_build_benchmark_suites
+      # - test_shark_model_suite
 
-      # Configurations
-      - asan
-      - tsan
+      # # Configurations
+      # - asan
+      # - tsan
       - small_runtime
-      - gcc
-      - tracing
+      # - gcc
+      # - tracing
 
-      # Crosscompilation
-      - cross_compile_and_test
-      - emscripten
+      # # Crosscompilation
+      # - cross_compile_and_test
+      # - emscripten
 
-      # Artifacts for e2e testing and benchmarking
-      - build_benchmark_tools
-      - build_e2e_test_artifacts
+      # # Artifacts for e2e testing and benchmarking
+      # - build_benchmark_tools
+      # - build_e2e_test_artifacts
 
-      # Test modules from benchmark pipeline
-      - test_benchmark_suites
+      # # Test modules from benchmark pipeline
+      # - test_benchmark_suites
 
-      # Benchmark pipeline
-      - benchmarks
+      # # Benchmark pipeline
+      # - benchmarks
     steps:
       - name: Getting combined job status
         run: |
           echo '${{ toJson(needs.*.result) }}' \
             | jq --exit-status 'all(.=="success" or .=="skipped")' > /dev/null
+      - uses: sarisia/actions-status-discord@c193626e5ce172002b8161e116aa897de7ab5383 # v1.10.2
+        if: failure() && needs.setup.ci-stage == "postsubmit"
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,32 +68,28 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       PR_BODY: ${{ github.event.pull_request.body }}
     outputs:
-      ci-stage: postsubmit
+      should-run: ${{ steps.configure.outputs.should-run }}
+      ci-stage: ${{ steps.configure.outputs.ci-stage }}
+      runner-env: ${{ steps.configure.outputs.runner-env }}
+      runner-group: ${{ steps.configure.outputs.runner-group }}
+      write-caches: ${{ steps.configure.outputs.write-caches }}
+      benchmark-presets: ${{ steps.configure.outputs.benchmark-presets }}
     steps:
-      - run: exit 0
-    # outputs:
-    #   should-run: ${{ steps.configure.outputs.should-run }}
-    #   ci-stage: ${{ steps.configure.outputs.ci-stage }}
-    #   runner-env: ${{ steps.configure.outputs.runner-env }}
-    #   runner-group: ${{ steps.configure.outputs.runner-group }}
-    #   write-caches: ${{ steps.configure.outputs.write-caches }}
-    #   benchmark-presets: ${{ steps.configure.outputs.benchmark-presets }}
-    # steps:
-    #   - name: "Checking out repository"
-    #     uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
-    #     with:
-    #       # We need the parent commit to do a diff
-    #       fetch-depth: 2
-    #   - name: "Configuring CI options"
-    #     id: configure
-    #     run: |
-    #       # Just informative logging. There should only be two commits in the
-    #       # history here, but limiting the depth helps when copying from a local
-    #       # repo instead of using checkout, e.g. with
-    #       # https://github.com/nektos/act where there will be more.
-    #       git log --oneline --graph --max-count=3
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          # We need the parent commit to do a diff
+          fetch-depth: 2
+      - name: "Configuring CI options"
+        id: configure
+        run: |
+          # Just informative logging. There should only be two commits in the
+          # history here, but limiting the depth helps when copying from a local
+          # repo instead of using checkout, e.g. with
+          # https://github.com/nektos/act where there will be more.
+          git log --oneline --graph --max-count=3
 
-    #       ./build_tools/github_actions/configure_ci.py
+          ./build_tools/github_actions/configure_ci.py
 
 
   ################################### Basic ####################################

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1124,9 +1124,10 @@ jobs:
       - name: Getting failed jobs
         id: failed_jobs
         run: |
-          FAILING_JOBS="$(echo '${{ toJson(needs.*) }}' \
+          echo '${{ toJson(needs) }}'
+          FAILING_JOBS="$(echo '${{ toJson(needs) }}' \
             | jq --raw-output \
-            'map_values(select(.status!="success" and .status!="skipped")) | keys | join(",")' \
+            'map_values(select(.result!="success" and .result!="skipped")) | keys | join(",")' \
           )"
           echo "failed-jobs=${FAILING_JOBS}" >> $GITHUB_OUTPUT
           if [[ "${FAILING_JOBS}" != "" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1134,4 +1134,4 @@ jobs:
         if: failure() && needs.setup.outputs.ci-stage == 'postsubmit'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
-          description: "The following jobs failed: ${{ steps.failed_jobs.failed_jobs }}"
+          description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1120,6 +1120,6 @@ jobs:
           echo '${{ toJson(needs.*.result) }}' \
             | jq --exit-status 'all(.=="success" or .=="skipped")' > /dev/null
       - uses: sarisia/actions-status-discord@c193626e5ce172002b8161e116aa897de7ab5383 # v1.10.2
-        if: failure() && needs.setup.ci-stage == "postsubmit"
+        if: failure() && needs.setup.ci-stage == 'postsubmit'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
This turns out to be a million times easier than sending emails. I don't
love it, but it's a whole lot better than the current situation.

The result currently looks like this (the bot avatar and name as well as
the channel it posts to can be configured on the Discord side):

![image](https://user-images.githubusercontent.com/5732088/209882576-96c1e9d7-91ce-4a15-84b3-11ebfceca81e.png)


Another option would be creating an issue on each failure. I like that
a lot better for tracking purposes, but I don't think it has the same
visibility and there's still no way to create rotations on GitHub, so
we couldn't auto-assign the issue easily. It would also be quite noisy.
We could always post to the same issue, but then the issue isn't that
useful for tracking.

My intent is to start this out in the #github channel and then graduate
it to the #builds channel if everything seems to be working. For now I
also went with an action that does all the Discord message formatting
for you. If we wanted more customization, we could switch to a
different one (there are quite a few). There's someone in the issues
for this action complaining that the release is unauditable:
https://github.com/sarisia/actions-status-discord/issues/364, but the
author shows how you can get the audit trail and I'm not too worried.

I guess if this is considered adequate then:
Fixes https://github.com/iree-org/iree/issues/9857

Tested: turned on runs on pushes to another branch and pushed to it.
