### PR TITLE
Add debug output to transform dialect matchers

### DIFF
--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -146,6 +146,7 @@ cc_library(
     deps = [
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",


### PR DESCRIPTION
This makes it easier to understand failures-to-match. It required splitting the implementation of some function templates into a public template and private non-template part with the latter emitting the debug output to avoid polluting the header with debug-related includes. Note that this starts approaching the point where turning matchers into operations in a dialect would be preferable.