### PR TITLE
Transform match test

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
+#include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -54,6 +54,7 @@ iree_lit_test_suite(
         include = ["*.mlir"],
         exclude = [
             "reductions_codegen_spec.mlir",
+            "reductions_match_spec.mlir",
         ],
     ),
     cfg = "//compiler:lit.cfg.py",
@@ -61,6 +62,7 @@ iree_lit_test_suite(
     # they need to be included as data.
     data = [
         "reductions_codegen_spec.mlir",
+        "reductions_match_spec.mlir",
     ],
     tools = [
         "//tools:iree-opt",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_lit_test_suite(
     iree-opt
   DATA
     reductions_codegen_spec.mlir
+    reductions_match_spec.mlir
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions.mlir
@@ -1,4 +1,5 @@
 // RUN: iree-opt %s --iree-transform-dialect-interpreter='transform-file-name=%p/reductions_codegen_spec.mlir' --split-input-file | FileCheck %s
+// RUN: iree-opt %s --iree-transform-dialect-interpreter='transform-file-name=%p/reductions_match_spec.mlir' --split-input-file --verify-diagnostics
 
 // Check that the same transform script applies to reductions with optional
 // leading and trailing elementwise operations, potentially reordered
@@ -13,7 +14,9 @@ func.func @reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
   %cst = arith.constant -0.000000e+00 : f32
 
   %0 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{fill}}
   %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->   !out_tensor_t
+  // expected-remark @below {{reduction}}
   %2 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0)>],
@@ -44,8 +47,10 @@ func.func @eltwise_reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
   %cst = arith.constant -0.000000e+00 : f32
 
   %0 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{fill}}
   %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
   %2 = tensor.empty() : !in_tensor_t
+  // expected-remark @below {{leading}}
   %3 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0, d1)>],
@@ -57,6 +62,7 @@ func.func @eltwise_reduce(%arg : !in_tensor_t) -> (!out_tensor_t) {
       linalg.yield %5 : f32
     } -> !in_tensor_t
 
+  // expected-remark @below {{reduction}}
   %6 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0)>],
@@ -89,7 +95,9 @@ func.func @reduce_eltwise(%arg : !in_tensor_t) -> (!out_tensor_t) {
   %cst = arith.constant -0.000000e+00 : f32
 
   %0 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{fill}}
   %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) -> !out_tensor_t
+  // expected-remark @below {{reduction}}
   %5 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0)>],
@@ -101,6 +109,7 @@ func.func @reduce_eltwise(%arg : !in_tensor_t) -> (!out_tensor_t) {
       } -> !out_tensor_t
 
   %6 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{trailing}}
   %7 = linalg.generic {
     indexing_maps = [affine_map<(d0) -> (d0)>,
                      affine_map<(d0) -> (d0)>],
@@ -133,8 +142,10 @@ func.func @eltwise_reduce_eltwise(%arg : !in_tensor_t) -> (!out_tensor_t) {
   %cst = arith.constant -0.000000e+00 : f32
 
   %0 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{fill}}
   %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
   %2 = tensor.empty() : !in_tensor_t
+  // expected-remark @below {{leading}}
   %3 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0, d1)>],
@@ -146,6 +157,7 @@ func.func @eltwise_reduce_eltwise(%arg : !in_tensor_t) -> (!out_tensor_t) {
       linalg.yield %5 : f32
     } -> !in_tensor_t
 
+  // expected-remark @below {{reduction}}
   %6 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0)>],
@@ -157,6 +169,7 @@ func.func @eltwise_reduce_eltwise(%arg : !in_tensor_t) -> (!out_tensor_t) {
       } -> !out_tensor_t
 
   %7 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{trailing}}
   %8 = linalg.generic {
     indexing_maps = [affine_map<(d0) -> (d0)>,
                      affine_map<(d0) -> (d0)>],
@@ -191,6 +204,7 @@ func.func @eltwise_reduce_eltwise_swapped(%arg : !in_tensor_t) -> (!out_tensor_t
   %cst = arith.constant -0.000000e+00 : f32
 
   %2 = tensor.empty() : !in_tensor_t
+  // expected-remark @below {{leading}}
   %3 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0, d1)>],
@@ -203,7 +217,9 @@ func.func @eltwise_reduce_eltwise_swapped(%arg : !in_tensor_t) -> (!out_tensor_t
     } -> !in_tensor_t
 
   %0 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{fill}}
   %1 = linalg.fill ins(%cst : f32) outs(%0 : !out_tensor_t) ->  !out_tensor_t
+  // expected-remark @below {{reduction}}
   %6 = linalg.generic {
     indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
                      affine_map<(d0, d1) -> (d0)>],
@@ -215,6 +231,7 @@ func.func @eltwise_reduce_eltwise_swapped(%arg : !in_tensor_t) -> (!out_tensor_t
       } -> !out_tensor_t
 
   %7 = tensor.empty() : !out_tensor_t
+  // expected-remark @below {{trailing}}
   %8 = linalg.generic {
     indexing_maps = [affine_map<(d0) -> (d0)>,
                      affine_map<(d0) -> (d0)>],

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions_match_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions_match_spec.mlir
@@ -1,0 +1,15 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb0(%arg0: !pdl.operation):
+  transform.iree.register_match_callbacks
+
+  %leading, %fill, %reduction, %trailing =
+    transform.iree.match_callback failures(propagate) "reduction"(%arg0)
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+
+  transform.iree.emit_remark "leading" at %leading : !pdl.operation
+  transform.iree.emit_remark "fill" at %fill : !pdl.operation
+  transform.iree.emit_remark "reduction" at %reduction : !pdl.operation
+  transform.iree.emit_remark "trailing" at %trailing : !pdl.operation
+}

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -146,6 +146,7 @@ cc_library(
     deps = [
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
@@ -201,4 +201,26 @@ def TakeFirstOp :
   let cppNamespace = "mlir::transform_ext";
 }
 
+def EmitRemarkOp :
+    Op<Transform_Dialect, "iree.emit_remark",
+       [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
+        TransformOpInterface, TransformEachOpTrait]> {
+  let description = [{
+    Emits a diagnostic remark with the given message located at payload ops
+    associated with the given handle. This can be used, e.g., for debugging.
+  }];
+
+  let arguments = (ins TransformTypeInterface:$handle,
+                       StrAttr:$message);
+  let assemblyFormat = "$message `at` $handle attr-dict `:` type($handle)";
+  let cppNamespace = "mlir::transform_ext";
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+      ::mlir::Operation *target,
+      ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+      ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // STRUCTURED_TRANSFORM_OPS_EXT

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -12,8 +12,6 @@
 #include <functional>
 
 #include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 #include "mlir/IR/Matchers.h"
 #include "llvm/ADT/SmallPtrSet.h"

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -1250,7 +1250,7 @@ reductionCallback(transform_ext::MatchCallbackResult &res, Location loc,
       if (leading.getCaptured())
         DBGS() << leading.getCaptured() << "\n";
       DBGS() << "fill: " << fill.getCaptured() << "\n";
-      DBGS() << "pattern: " << fill.getCaptured() << "\n";
+      DBGS() << "pattern: " << pattern.getCaptured() << "\n";
       DBGS() << "trailing:\n";
       if (trailing.getCaptured())
         DBGS() << trailing.getCaptured() << "\n";
@@ -1386,4 +1386,23 @@ void transform_ext::TakeFirstOp::getEffects(
   mlir::transform::onlyReadsHandle(getInputs(), effects);
   mlir::transform::producesHandle(getFirst(), effects);
   mlir::transform::producesHandle(getRest(), effects);
+}
+
+//===---------------------------------------------------------------------===//
+// EmitRemarkOp
+//===---------------------------------------------------------------------===//
+
+DiagnosedSilenceableFailure transform_ext::EmitRemarkOp::applyToOne(
+    Operation *target, SmallVectorImpl<::mlir::Operation *> &results,
+    mlir::transform::TransformState &state) {
+  for (Operation *payload : state.getPayloadOps(getHandle())) {
+    payload->emitRemark(getMessage());
+  }
+  return DiagnosedSilenceableFailure::success();
+}
+
+void transform_ext::EmitRemarkOp::getEffects(
+    SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
+  mlir::transform::onlyReadsHandle(getHandle(), effects);
+  mlir::transform::onlyReadsPayload(effects);
 }


### PR DESCRIPTION
Add a mechanism for testing the result of transform dialect-related
matchers as follows. A new transform op emits remarks at the location of
payload ops associated with the given handle. This op is used to each
handle produced by `match_callback` to mark the matched payload ops.
Thus iree-opt-based tests can check the matcher directly with the
`-verify-diagnostics` flag.