### PR TITLE
Transform match chained reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -21,6 +21,7 @@ iree_lit_test_suite(
             "affinemin_canonicalization.mlir",
             "bufferize_copy_only_dispatches.mlir",
             "canonicalize_interface_load_store.mlir",
+            "chained_reduction.mlir",
             "convert_to_destination_passing_style.mlir",
             "dead_alloc.mlir",
             "decompose_linalg_generic.mlir",
@@ -55,6 +56,7 @@ iree_lit_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
+            "chained_reduction_match_spec.mlir",
             "reductions_codegen_spec.mlir",
             "reductions_match_spec.mlir",
         ],
@@ -63,6 +65,7 @@ iree_lit_test_suite(
     # transform dialect spec files are MLIR files that specify a transformation,
     # they need to be included as data.
     data = [
+        "chained_reduction_match_spec.mlir",
         "reductions_codegen_spec.mlir",
         "reductions_match_spec.mlir",
     ],

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_lit_test_suite(
     "affinemin_canonicalization.mlir"
     "bufferize_copy_only_dispatches.mlir"
     "canonicalize_interface_load_store.mlir"
+    "chained_reduction.mlir"
     "convert_to_destination_passing_style.mlir"
     "dead_alloc.mlir"
     "decompose_linalg_generic.mlir"
@@ -52,6 +53,7 @@ iree_lit_test_suite(
     FileCheck
     iree-opt
   DATA
+    chained_reduction_match_spec.mlir
     reductions_codegen_spec.mlir
     reductions_match_spec.mlir
 )

--- a/compiler/src/iree/compiler/Codegen/Common/test/chained_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/chained_reduction.mlir
@@ -1,0 +1,64 @@
+// RUN: iree-opt %s --iree-transform-dialect-interpreter='transform-file-name=%p/chained_reduction_match_spec.mlir' --split-input-file --verify-diagnostics
+
+func.func @forward_dispatch_43_generic_16x4096x4096(%arg0: tensor<16x4096x4096xf32>) -> tensor<16x4096x4096xf32> {
+  %cst = arith.constant 0.000000e+00 : f32
+  %cst_0 = arith.constant -6.550400e+04 : f32
+  %7 = tensor.empty() : tensor<16x4096xf32>
+  %8 = tensor.empty() : tensor<16x4096x4096xf32>
+  // expected-remark @below {{fill_1}}
+  %fill_1 = linalg.fill ins(%cst_0 : f32) outs(%7 : tensor<16x4096xf32>) -> tensor<16x4096xf32>
+  // expected-remark @below {{fill_2}}
+  %fill_2 = linalg.fill ins(%cst : f32) outs(%7 : tensor<16x4096xf32>) -> tensor<16x4096xf32>
+
+  // expected-remark @below {{reduction_1}}
+  %reduction_1 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                      affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%arg0 : tensor<16x4096x4096xf32>)
+    outs(%fill_1 : tensor<16x4096xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %14 = arith.maxf %in, %out : f32
+    linalg.yield %14 : f32
+  } -> tensor<16x4096xf32>
+
+  // expected-remark @below {{middle}}
+  %trailing_1 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
+                     affine_map<(d0, d1, d2) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1, d2)>], 
+    iterator_types = ["parallel", "parallel", "parallel"]} 
+    ins(%arg0, %reduction_1 : tensor<16x4096x4096xf32>, tensor<16x4096xf32>)
+    outs(%8 : tensor<16x4096x4096xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %14 = arith.subf %in, %in_1 : f32
+    %15 = math.exp %14 : f32
+    linalg.yield %15 : f32
+  } -> tensor<16x4096x4096xf32>
+
+  // expected-remark @below {{reduction_2}}
+  %reduction_2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, 
+                     affine_map<(d0, d1, d2) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel", "reduction"]}
+    ins(%trailing_1 : tensor<16x4096x4096xf32>)
+    outs(%fill_2 : tensor<16x4096xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %16 = arith.addf %in, %out : f32
+    linalg.yield %16 : f32
+  } -> tensor<16x4096xf32>
+
+  // expected-remark @below {{trailing_2}}
+  %trailing_2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1)>,
+                     affine_map<(d0, d1, d2) -> (d0, d1, d2)>],
+    iterator_types = ["parallel", "parallel", "parallel"]}
+    ins(%trailing_1, %reduction_2 : tensor<16x4096x4096xf32>, tensor<16x4096xf32>)
+    outs(%8 : tensor<16x4096x4096xf32>) {
+  ^bb0(%in: f32, %in_1: f32, %out: f32):
+    %14 = arith.divf %in, %in_1 : f32
+    linalg.yield %14 : f32
+  } -> tensor<16x4096x4096xf32>
+  return %trailing_2 : tensor<16x4096x4096xf32>
+}

--- a/compiler/src/iree/compiler/Codegen/Common/test/chained_reduction_match_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/chained_reduction_match_spec.mlir
@@ -1,0 +1,15 @@
+// RUN: iree-opt %s
+
+transform.structured.canonicalized_sequence failures(propagate) {
+^bb0(%arg0: !pdl.operation):
+  transform.iree.register_match_callbacks
+  %0:7 = transform.iree.match_callback failures(propagate) "chained_reduction"(%arg0)
+    : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation, !pdl.operation)
+  transform.iree.emit_remark "leading_1" at %0#0 : !pdl.operation
+  transform.iree.emit_remark "fill_1" at %0#1 : !pdl.operation
+  transform.iree.emit_remark "reduction_1" at %0#2 : !pdl.operation
+  transform.iree.emit_remark "middle" at %0#3 : !pdl.operation
+  transform.iree.emit_remark "fill_2" at %0#4 : !pdl.operation
+  transform.iree.emit_remark "reduction_2" at %0#5 : !pdl.operation
+  transform.iree.emit_remark "trailing_2" at %0#6 : !pdl.operation
+}

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
@@ -104,7 +104,9 @@ LogicalResult iree_compiler::cpu::matchAndSetReductionStrategy(
   StructuredOpMatcher reduction, fill, leading, trailing;
   transform_ext::MatchedReductionCaptures captures;
   makeReductionMatcher(reduction, fill, leading, trailing, captures);
-  if (!matchPattern(op, reduction)) return failure();
+  if (!matchPattern(op, reduction.allTilableOpsCaptured<func::FuncOp>())) {
+    return failure();
+  }
 
   // 2. Construct the configuration and the strategy builder.
   // TODO: Generalize along the HW axis.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -381,7 +381,9 @@ LogicalResult mlir::iree_compiler::gpu::matchAndSetReductionStrategy(
   StructuredOpMatcher reduction, fill, leading, trailing;
   transform_ext::MatchedReductionCaptures captures;
   makeReductionMatcher(reduction, fill, leading, trailing, captures);
-  if (!matchPattern(op, reduction)) return failure();
+  if (!matchPattern(op, reduction.allTilableOpsCaptured<func::FuncOp>())) {
+    return failure();
+  }
 
   // 2. Construct the configuration and the strategy builder.
   // TODO: Generalize along the HW axis.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -557,7 +557,8 @@ void makeReductionMatcher(StructuredOpMatcher &reduction,
                           StructuredOpMatcher &fill,
                           StructuredOpMatcher &leading,
                           StructuredOpMatcher &trailing,
-                          MatchedReductionCaptures &captures);
+                          MatchedReductionCaptures &captures,
+                          bool leadingOptional = true);
 
 } // namespace transform_ext
 } // namespace mlir

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -146,17 +146,47 @@ template <typename T>
 using has_get_capture_t = decltype(std::declval<T>().getCaptured());
 } // namespace detail
 
-/// Base class for op matchers that capture the matched operation. It doesn't
-/// specify how exactly the capture happens.
+/// Base class for op matchers that capture the matched operation.
 class CapturingOpMatcher {
 public:
   virtual ~CapturingOpMatcher() = default;
 
-  /// Resets the state of the matcher to not having captured anything.
-  virtual void resetCapture() = 0;
+  /// Resets the captured value to null. This should be called if the same
+  /// pattern needs to be applied more than once as it may keep captured values
+  /// for optional nested predicates from the previous application.
+  void resetCapture() {
+    captured = nullptr;
+    SmallVector<CapturingOpMatcher *> nested;
+    getAllNested(nested);
+    for (CapturingOpMatcher *matcher : nested) {
+      matcher->captured = nullptr;
+    }
+  }
 
-  /// Returns the captured operation.
-  virtual Operation *getCaptured() const = 0;
+  /// Returns the matched operation if the match was successful.
+  Operation *getCaptured() const { return captured; }
+
+protected:
+  /// Informs the matcher that it has another, nested matcher. Derived classes
+  /// must call this to keep track of nested matchers for capture resetting
+  /// purposes.
+  template <typename T>
+  void recordNestedMatcher(T &nested) {
+    if constexpr (std::is_base_of_v<CapturingOpMatcher, T>)
+      nestedCapturingMatchers.push_back(&nested);
+  }
+
+  /// Appends all nested capturing matchers, excluding this one, to `nested`.
+  void getAllNested(SmallVectorImpl<CapturingOpMatcher *> &nested);
+
+private:
+  /// A list of (recursively) nested capturing matchers that should be reset
+  /// when the current matcher is.
+  SmallVector<CapturingOpMatcher *> nestedCapturingMatchers;
+
+protected:
+  /// Matched value.
+  linalg::LinalgOp captured = nullptr;
 };
 
 /// Structured op matcher with additional predicates attachable through the
@@ -189,9 +219,6 @@ public:
       return isa<OpType...>(op.getOperation());
     });
   }
-
-  /// Returns the matched operation if the match was successful.
-  Operation *getCaptured() const override { return captured; }
 
   /// Matches the given operation, hook for `matchPattern`.
   bool match(Operation *op);
@@ -300,7 +327,9 @@ public:
   /// be added *after* all the other predicates that capture.
   template <typename OpTy>
   StructuredOpMatcher &allTilableOpsCaptured() {
-    SmallVector<CapturingOpMatcher *> copy = nestedCapturingMatchers;
+    SmallVector<CapturingOpMatcher *> copy;
+    copy.push_back(this);
+    getAllNested(copy);
     predicates.push_back([copy = std::move(copy)](linalg::LinalgOp linalgOp) {
       Operation *parent = linalgOp->getParentOfType<OpTy>();
       return checkAllTilableMatched(parent, linalgOp, copy);
@@ -383,27 +412,7 @@ public:
     return *this;
   }
 
-  /// Resets the captured value to null. This should be called if the same
-  /// pattern needs to be applied more than once as it may keep captured values
-  /// for optional nested predicates from the previous application.
-  void resetCapture() override {
-    captured = nullptr;
-    for (CapturingOpMatcher *nested : nestedCapturingMatchers)
-      nested->resetCapture();
-  }
-
 private:
-  /// Informs the matcher that it has another, nested matcher. Practically,
-  /// records the captured value cleanup function so it runs when required.
-  template <typename T>
-  void recordNestedMatcher(T &nested) {
-    nestedCapturingMatchers.push_back(&nested);
-    if constexpr (std::is_base_of_v<StructuredOpMatcher, T>) {
-      llvm::append_range(nestedCapturingMatchers,
-                         nested.nestedCapturingMatchers);
-    }
-  }
-
   /// Checks that `matchers` captured all tilable ops nested in `parent` except
   /// for `linalgOp`. This is an implementation detail of allTilableOpsCaptured.
   static bool checkAllTilableMatched(Operation *parent,
@@ -427,13 +436,6 @@ private:
 
   /// Additional predicates to be checked on the structured op.
   SmallVector<PredicateFn> predicates;
-
-  /// A list of (recursively) nested capturing matchers that should be reset
-  /// when the current matcher is.
-  SmallVector<CapturingOpMatcher *> nestedCapturingMatchers;
-
-  /// Matched value.
-  linalg::LinalgOp captured = nullptr;
 };
 
 /// Creates a matcher of an arbitrary structured op.

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -9,8 +9,6 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
@@ -20,6 +18,15 @@ using namespace mlir;
 
 #define DEBUG_TYPE "transform-matchers"
 #define DBGS() llvm::dbgs() << "[" DEBUG_TYPE "] "
+
+void transform_ext::CapturingOpMatcher::getAllNested(
+    SmallVectorImpl<CapturingOpMatcher *> &nested) {
+  int64_t start = nested.size();
+  llvm::append_range(nested, nestedCapturingMatchers);
+  for (int64_t position = start; position < nested.size(); ++position) {
+    llvm::append_range(nested, nested[position]->nestedCapturingMatchers);
+  }
+}
 
 //===---------------------------------------------------------------------===//
 // StructuredOpMatcher and friends.

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -556,7 +556,7 @@ void transform_ext::makeReductionMatcher(
     transform_ext::StructuredOpMatcher &fill,
     transform_ext::StructuredOpMatcher &leading,
     transform_ext::StructuredOpMatcher &trailing,
-    MatchedReductionCaptures &captures) {
+    MatchedReductionCaptures &captures, bool leadingOptional) {
   // The core part of the matcher is anchored on a particular reduction op.
   reduction =
       m_StructuredOp()
@@ -637,7 +637,7 @@ void transform_ext::makeReductionMatcher(
           // Capture output elemental type.
           .output(0, CaptureElementTypeBitWidth(
                          captures.maybeLeadingOutputElementalTypeBitWidth));
-  reduction = reduction.input(0, leading, OptionalMatch());
+  reduction = reduction.input(0, leading, OptionalMatch(leadingOptional));
 
   // Optional trailing can be any map, transpose, broadcast but not reduce or
   // windowing operation for now.
@@ -653,6 +653,5 @@ void transform_ext::makeReductionMatcher(
           // Capture output elemental type.
           .output(0, CaptureElementTypeBitWidth(
                          captures.maybeTrailingOutputElementalTypeBitWidth));
-  reduction = reduction.result(0, HasAnyUse(), trailing, OptionalMatch())
-                  .allTilableOpsCaptured<func::FuncOp>();
+  reduction = reduction.result(0, HasAnyUse(), trailing, OptionalMatch());
 }


### PR DESCRIPTION
Add a new transform dialect match callback to match a pair of reductions
with trailing fully-parallel operations, similar to the case that
appears in stable diffusion. Note that currently the middle
fully-parallel operation is fused into the second reduction at the Flow
level, which would prevent the matching from working in the full pass
pipeline.