### PR TITLE
Add support to the small reduction transform to statically split small vectors incrementally by 4.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -76,7 +76,11 @@ int64_t mlir::iree_compiler::nextMultipleOf(int64_t val, int64_t multiple) {
 
 FailureOr<int64_t> mlir::iree_compiler::maxDivisorOfValueBelowLimit(
     int64_t value, int64_t limit) {
-  assert(limit <= 1024 && "limit must be smaller than 1024");
+  // Conservatively return failure when `limit` is greater than 1024 to avoid
+  // prohibitively long compile time overheads.
+  // TODO: approximate with a faster implementation based on a few desirable
+  // primes.
+  if (limit > 1024) return failure();
   // If either value or limit is <= 0, the loop is skipped and we fail.
   for (int64_t i = std::min(value, limit); i > 1; --i)
     if (value % i == 0) return i;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -27,8 +27,8 @@ int64_t nextMultipleOf(int64_t val, int64_t multiple);
 
 /// Find the highest divisor of `value` that is smaller than `limit`. This is
 /// useful to capture any tiling that is guaranteed to keep the IR static.
-/// Asserts that `limit` is smaller than 1024 to avoid prohibitively long
-/// compile time overheads.
+/// Conservatively return failure when `limit` is greater than 1024 to avoid
+/// prohibitively long compile time overheads.
 // TODO: approximate with a faster implementation based on a few desirable
 // primes.
 FailureOr<int64_t> maxDivisorOfValueBelowLimit(int64_t value, int64_t limit);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -31,12 +31,16 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // Small reduction computes the whole reduction on a single thread.
 //   CHECK-LABEL: func.func @small_reduction
 //     CHECK-NOT:   memref.alloc()
-//     CHECK: gpu.thread_id  x
-//     CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<13xf32>
-//     CHECK: vector.extractelement %{{.*}}[] : vector<f32>
-//     CHECK: vector.reduction <add>, %{{.*}} : vector<13xf32> into f32
-//     CHECK: vector.broadcast %{{.*}} : f32 to vector<f32>
-//     CHECK: vector.transfer_write {{.*}} : vector<f32>, memref<1024xf32>
+//         CHECK: gpu.thread_id  x
+//         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<4xf32>
+//         CHECK: vector.reduction <add>, %{{.*}} : vector<4xf32> into f32
+//         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<4xf32>
+//         CHECK: vector.reduction <add>, %{{.*}} : vector<4xf32> into f32
+//         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<4xf32>
+//         CHECK: vector.reduction <add>, %{{.*}} : vector<4xf32> into f32
+//         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<f32>
+//         CHECK: arith.addf %{{.*}} : f32
+//         CHECK: vector.transfer_write {{.*}} : vector<f32>, memref<1024xf32>
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -129,5 +129,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_32
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
+//         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region %{{.*}} num_threads [] tile_sizes [32](mapping = [#gpu.block<x>])
 //         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [32] tile_sizes [](mapping = [#gpu.thread<x>])
+// CHECK-COUNT-4:   transform.structured.scalarize %{{.*}}
+// CHECK-COUNT-14:   transform.structured.split %{{.*}} after 4  {dimension = 1 : i64}
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}


### PR DESCRIPTION
This brings nice improvements to small sizes divisible by 4.
  
Before this PR:
```
With transform dialect: reduction_2d_static --function_input="1234567x44xf32" P50: 602210.00 ns 90.20266684379203267963 GElements/s
Without transform dialect: reduction_2d_static --function_input="1234567x44xf32" P50: 2444700.0000 ns 22.21988301223053953450 GElements/s
```

With this PR:
```
With transform dialect: reduction_2d_static --function_input="1234567x44xf32" P50: 417270.00 ns 130.18177199415246722745 GElements/s
Without transform dialect: reduction_2d_static --function_input="1234567x44xf32" P50: 2221600.0000 ns 24.45127295642779978393 GElements/s
```

For non-divisible and dynamic sizes, one needs an adaptive split that adapts to the future stride + offset of the tensor to ensure dynamic alignemnt.
This is left for future work.
The performance drop on non-naturally aligned sizes is visible with e.g.:

```
(TRANSFORM_DIALECT_NO_DEBUG=1  benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_static 1234567 39 )
```

Printing:

```
With transform dialect: reduction_2d_static --function_input="1234567x39xf32" P50: 497440.00 ns 96.79180001608234158893 GElements/s
Without transform dialect: reduction_2d_static --function_input="1234567x39xf32" P50: 10705000.000 ns 4.49772190565156468939 GElements/s
```