### PR TITLE
Rank-reducing / hoisting / vectorization interplay repro.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -76,7 +76,11 @@ int64_t mlir::iree_compiler::nextMultipleOf(int64_t val, int64_t multiple) {
 
 FailureOr<int64_t> mlir::iree_compiler::maxDivisorOfValueBelowLimit(
     int64_t value, int64_t limit) {
-  assert(limit <= 1024 && "limit must be smaller than 1024");
+  // Conservatively return failure when `limit` is greater than 1024 to avoid
+  // prohibitively long compile time overheads.
+  // TODO: approximate with a faster implementation based on a few desirable
+  // primes.
+  if (limit > 1024) return failure();
   // If either value or limit is <= 0, the loop is skipped and we fail.
   for (int64_t i = std::min(value, limit); i > 1; --i)
     if (value % i == 0) return i;
@@ -234,8 +238,9 @@ Value mlir::iree_compiler::buildVectorize(ImplicitLocOpBuilder &b,
                                           Value funcH) {
   ApplyPatternsOpPatterns patterns;
   patterns.rankReducing = true;
+  funcH = b.create<VectorizeOp>(funcH);
   funcH = b.create<ApplyPatternsOp>(funcH, patterns);
-  return b.create<VectorizeOp>(funcH);
+  return funcH;
 }
 
 /// Bufferize and drop HAL descriptor from memref ops.

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -27,8 +27,8 @@ int64_t nextMultipleOf(int64_t val, int64_t multiple);
 
 /// Find the highest divisor of `value` that is smaller than `limit`. This is
 /// useful to capture any tiling that is guaranteed to keep the IR static.
-/// Asserts that `limit` is smaller than 1024 to avoid prohibitively long
-/// compile time overheads.
+/// Conservatively return failure when `limit` is greater than 1024 to avoid
+/// prohibitively long compile time overheads.
 // TODO: approximate with a faster implementation based on a few desirable
 // primes.
 FailureOr<int64_t> maxDivisorOfValueBelowLimit(int64_t value, int64_t limit);

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.cpp
@@ -644,6 +644,25 @@ createSmallReductionStrategyThreadDistribution(
 
   auto [blockReductionH, maybeBlockTrailingH] =
       iree_compiler::buildSelectFirstNonEmpty(b, fusedH, tiledH);
+
+  // Splitting into explicit vector<4> helps a lot on alignment.
+  // TODO: first split should be dynamic and based on the future stride.
+  assert(!ShapedType::isDynamic(strategy.captures.reductionDimensionSize) &&
+         "reduction must be static to split a constant number of times");
+  for (int64_t i = 0, e = (strategy.captures.reductionDimensionSize - 1) / 4;
+       i < e; ++i) {
+    auto split = b.create<transform::SplitOp>(
+        pdlOperation, pdlOperation, blockReductionH,
+        b.getI64IntegerAttr(strategy.captures.reductionRank - 1), Value(),
+        b.getI64IntegerAttr(4));
+    blockReductionH = split.getSecond();
+    auto split2 = b.create<transform::SplitOp>(
+        pdlOperation, pdlOperation, maybeBlockTrailingH,
+        b.getI64IntegerAttr(strategy.captures.reductionRank - 1), Value(),
+        b.getI64IntegerAttr(4));
+    maybeBlockTrailingH = split2.getSecond();
+  }
+
   return std::make_tuple(maybeLeadingH, blockReductionH, maybeBlockTrailingH);
 }
 


### PR DESCRIPTION
This PR shows that swapping ApplyPatternsOp and VectorizeOp is currently necessary for hoisting to occur properly.
This is related to collapse/expand around scf.for that do not fold away nicely and in turn block hoisting on tensors.
    
```
(benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   \
reduction_2d_static f32 1234567 42)
```
    
takes a 4x hit when hoisting does not occur.
    
@matthias-springer