### PR TITLE
Don't emit op on error (NFC)

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/AssignTargetDevices.cpp
@@ -83,7 +83,7 @@ class AssignTargetDevicesPass
             [&os](const std::shared_ptr<
                   mlir::iree_compiler::IREE::HAL::TargetBackend>
                       b) { os << b->name(); });
-        moduleOp.emitError()
+        emitError(moduleOp.getLoc())
             << "target backend '" << targetName
             << "' not registered; registered backends: " << os.str();
         signalPassFailure();


### PR DESCRIPTION
Avoids printing the module when invalid backend is specified and shouldPrintOpOnDiagnostic() is true.