### PR TITLE
[cmake] Move inclusion of tools directory up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,7 +756,10 @@ if(IREE_BUILD_BENCHMARKS)
   add_subdirectory(benchmarks)
 endif()
 
-# tools/ can depend on compiler/ and runtime/
+# tools/ can depend on compiler/ and runtime/.
+# Note: tools sub directory is added before compiler/ so that phony targets for
+# files with the same names from different rules are disambiguated towards
+# those in tools/.
 add_subdirectory(tools)
 
 if(IREE_BUILD_COMPILER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,15 +756,14 @@ if(IREE_BUILD_BENCHMARKS)
   add_subdirectory(benchmarks)
 endif()
 
+# tools/ can depend on compiler/ and runtime/
+add_subdirectory(tools)
+
 if(IREE_BUILD_COMPILER)
   add_subdirectory(compiler)
 endif()
 
 add_subdirectory(runtime)
-
-# tools/ can depend on compiler/ and runtime/
-add_subdirectory(tools)
-
 
 if(IREE_ENABLE_CLANG_TIDY)
   set(CMAKE_CXX_CLANG_TIDY "")


### PR DESCRIPTION
Results in phony rules generated for both tools and Python to refer to those in tools/ in short form. That is, iree-compile phony target now refers to tools/iree-compile rather than the one inside _mlir_libs:

```sh
$ rg -e "build iree-dump-module" -e "build iree-lld" -e "build iree-compile"  build.ninja
211387:build iree-compile: phony tools/iree-compile
211391:build iree-dump-module: phony tools/iree-dump-module
211397:build iree-lld: phony compiler/bindings/python/iree/compiler/_mlir_libs/iree-lld
```

Fixes #9329.