### PR TITLE
Fix out of bounds access in `emitGPUGroupReduction`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/warp_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/warp_reduction.mlir
@@ -430,7 +430,8 @@ hal.executable private @simple_reduce_multi_warp  {
 //       CHECK:       memref.store %[[S9]], %[[A]][%[[WID]]] : memref<2xf32, 3>
 //       CHECK:     }
 //       CHECK:     gpu.barrier
-//       CHECK:     %[[LOAD_VAL:.*]] = memref.load %[[A]][%[[LANE_ID]]] : memref<2xf32, 3>
+//       CHECK:     %[[LANE_ID_IN_BOUNDS:.*]] = arith.minui %[[LANE_ID]]
+//       CHECK:     %[[LOAD_VAL:.*]] = memref.load %[[A]][%[[LANE_ID_IN_BOUNDS]]] : memref<2xf32, 3>
 //       CHECK:     %[[S10:.*]], %{{.*}} = gpu.shuffle  xor %[[LOAD_VAL]], %[[C1]], %[[C32]] : f32
 //       CHECK:     %[[S11:.*]] = arith.addf %[[LOAD_VAL]], %[[S10]] : f32
 //       CHECK:     %[[S12:.*]], %{{.*}} = gpu.shuffle  idx %[[S11]], %[[C0I]], %[[C32]] : f32
@@ -545,7 +546,8 @@ hal.executable private @reduce_odd_num_warp  {
 //       CHECK:   %[[LANE_ID:.+]] = arith.remui %[[ID]], %[[C32]] : index
 
 //       CHECK:   gpu.barrier
-//       CHECK:   %[[V:.+]] = memref.load %[[ALLOC]][%[[LANE_ID]]] : memref<3xf32, 3>
+//       CHECK:   %[[LANE_ID_IN_BOUNDS:.*]] = arith.minui %[[LANE_ID]]
+//       CHECK:   %[[V:.+]] = memref.load %[[ALLOC]][%[[LANE_ID_IN_BOUNDS]]] : memref<3xf32, 3>
 //       CHECK:   %[[C:.+]] = arith.cmpi sge, %[[LANE_ID]], %[[C3]] : index
 //       CHECK:   %[[SEL:.+]] = arith.select %[[C]], %[[CF]], %[[V]] : f32
 //       CHECK:   %[[S0:.+]], %{{.*}} = gpu.shuffle  xor %[[SEL]], %[[C1]], %[[C32I]] : f32

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
@@ -79,7 +79,8 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:      memref.store %[[R6]], %[[ALLOC]][%[[WID]]] : memref<16xf32, 3>
 //         CHECK:    }
 //         CHECK:    gpu.barrier
-//         CHECK:    %[[LOAD_VAL:.+]] = memref.load %[[ALLOC]][%[[LANE_ID]]] : memref<16xf32, 3>
+//         CHECK:    %[[LANE_ID_IN_BOUNDS:.*]] = arith.minui %[[LANE_ID]]
+//         CHECK:    %[[LOAD_VAL:.+]] = memref.load %[[ALLOC]][%[[LANE_ID_IN_BOUNDS]]] : memref<16xf32, 3>
 //         CHECK:    %[[S5:.+]], %{{.*}} = gpu.shuffle  xor %[[LOAD_VAL]], %[[C1]], %[[C32]] : f32
 //         CHECK:    %[[R7:.+]] = arith.addf %[[LOAD_VAL]], %[[S5]] : f32
 //         CHECK:    %[[S6:.+]], %{{.*}} = gpu.shuffle  xor %[[R7]], %[[C2]], %[[C32]] : f32
@@ -169,6 +170,7 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:      memref.store {{.*}} : memref<16xf32, 3>
 //         CHECK:    }
 //         CHECK:    gpu.barrier
+//         CHECK:    arith.minui
 //         CHECK:    memref.load
 //         CHECK:    gpu.shuffle  xor
 //         CHECK:    arith.addf

--- a/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/test/lowering_reduction.mlir
@@ -80,7 +80,8 @@ hal.executable @warp_reduction_dispatch {
 //         CHECK:      memref.store %[[R6]], %[[ALLOC]][%[[WID]]] : memref<4xf32, 3>
 //         CHECK:    }
 //         CHECK:    gpu.barrier
-//         CHECK:    %[[LOAD_VAL:.+]] = memref.load %[[ALLOC]][%[[LANE_ID]]] : memref<4xf32, 3>
+//         CHECK:    %[[LANE_ID_IN_BOUNDS:.*]] = arith.minui %[[LANE_ID]]
+//         CHECK:    %[[LOAD_VAL:.+]] = memref.load %[[ALLOC]][%[[LANE_ID_IN_BOUNDS]]] : memref<4xf32, 3>
 //         CHECK:    %[[S5:.+]], %{{.*}} = gpu.shuffle  xor %[[LOAD_VAL]], %[[C1]], %[[C32]] : f32
 //         CHECK:    %[[R7:.+]] = arith.addf %[[LOAD_VAL]], %[[S5]] : f32
 //         CHECK:    %[[S6:.+]], %{{.*}} = gpu.shuffle  xor %[[R7]], %[[C2]], %[[C32]] : f32
@@ -182,5 +183,5 @@ hal.executable @warp_reduction_dispatch {
 //         CHECK:      %[[SLICE2:.+]] = vector.extract_strided_slice %[[READ]] {offsets = [4], sizes = [4], strides = [1]}
 //         CHECK:      %[[DIV1:.+]] = arith.divf %[[SLICE2]], %[[SPLAT]] : vector<4xf16>
 //         CHECK:      %[[SLICE3:.+]] = vector.insert_strided_slice %[[DIV1]], %[[SLICE1]] {offsets = [4], strides = [1]}
-//         CHECK:      vector.transfer_write %[[SLICE3]], %[[SPAN1]][%[[WGIDY]], %[[WGIDX]], %56] {in_bounds = [true]} : vector<8xf16>, memref<10x9216x9216xf16{{.*}}>
+//         CHECK:      vector.transfer_write %[[SLICE3]], %[[SPAN1]][%[[WGIDY]], %[[WGIDX]], %{{.*}}] {in_bounds = [true]} : vector<8xf16>, memref<10x9216x9216xf16{{.*}}>
 //         CHECK:    }

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -497,7 +497,10 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
     });
     builder.create<gpu::BarrierOp>(loc);
     // Further reduce the outputs from each warps with a single warp reduce.
-    Value loadVal = builder.create<memref::LoadOp>(loc, alloc, laneId);
+    Value memrefSize = builder.create<arith::ConstantIndexOp>(loc, numWarp - 1);
+    Value laneIdInBounds =
+        builder.create<arith::MinUIOp>(loc, laneId, memrefSize);
+    Value loadVal = builder.create<memref::LoadOp>(loc, alloc, laneIdInBounds);
     Value cstNumWarp = builder.create<arith::ConstantIndexOp>(loc, numWarp);
     if (!llvm::isPowerOf2_32(numWarp)) {
       // Pad with identity element if numel < warpSize for valid warp reduction.


### PR DESCRIPTION
Previously, we would emit IR such as:
```
%2 = gpu.thread_id  x
...
%15 = arith.remui %2, %c32 : index
...
%17 = memref.load %alloc_11[%15] : memref<3xf32, 3>
```
with `gpu.thread_id x` ranging in `[0 .. 95]`.

This performs a clear out-of-bounds read for threads `[3 .. 31] + 32 * {0, 1, 2}`. Interestingly, the error does not seem to result in crashes in simple divisible IR such as line 42 in: https://gist.github.com/nicolasvasilache/004f9f23ba0bde9b3517e5f0d6fb6989

It does result in crashes in more complex, non-divisible cases, such as line 79 in: https://gist.github.com/nicolasvasilache/e145eab16df75d494eceac34e45331ce

It is unclear atm whether this is a case that the nvcc compiler managed to optimize away or whether something more advanced is going on.

This PR additionally confines the lane index to be in the bounds of the memref:

```
%2 = gpu.thread_id  x
...
%15 = arith.remui %2, %c32 : index
%16 = arith.minui %15, %c2: index
%17 = memref.load %alloc_11[%16] : memref<3xf32, 3>
```

With this change, crashes are now gone.