### PR TITLE
Use multi-warp reduction in the staged reduction strategy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.h
@@ -17,8 +17,8 @@ namespace iree_compiler {
 // Low-level reusable builder APIs, these should follow MLIR-style builders.
 //===----------------------------------------------------------------------===//
 
-static constexpr unsigned kCudaWarpSize = 32;
-static constexpr unsigned kCudaMaxNumThreads = 1024;
+static constexpr int64_t kCudaWarpSize = 32;
+static constexpr int64_t kCudaMaxNumThreads = 1024;
 
 /// Post-bufferization mapping to blocks and threads.
 /// Takes a handle to a func.func and returns an updated handle to a

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -33,14 +33,14 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-NOT:   memref.alloc()
 //         CHECK: gpu.thread_id  x
 //         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<4xf32>
-//         CHECK: vector.reduction <add>, %{{.*}} : vector<4xf32> into f32
+//         CHECK: vector.multi_reduction <add>, %{{.*}} : vector<4xf32> to f32
 //         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<4xf32>
-//         CHECK: vector.reduction <add>, %{{.*}} : vector<4xf32> into f32
+//         CHECK: vector.multi_reduction <add>, %{{.*}} : vector<4xf32> to f32
 //         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<4xf32>
-//         CHECK: vector.reduction <add>, %{{.*}} : vector<4xf32> into f32
-//         CHECK: vector.transfer_read {{.*}}: memref<1024x13xf32>, vector<f32>
+//         CHECK: vector.multi_reduction <add>, %{{.*}} : vector<4xf32> to f32
+//         CHECK: vector.broadcast {{.*}}: f32 to vector<f32>
 //         CHECK: arith.addf %{{.*}} : f32
-//         CHECK: vector.transfer_write {{.*}} : vector<f32>, memref<1024xf32>
+//         CHECK: vector.transfer_write {{.*}} : vector<f32>, memref<f32
 
 // -----
 
@@ -75,162 +75,34 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
 
 // Fusion occurred, no barrier before the loop
 //     CHECK-NOT: gpu.barrier
 // Local per-thread scf.for-based reduction.
 //         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
-//         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
-//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
-// No barrier within the loop
-//     CHECK-NOT:   gpu.barrier
+//         CHECK:   vector.transfer_read {{.*}} memref<8x64xf32>, vector<f32>
+//         CHECK:   vector.transfer_read {{.*}} memref<1x64xf32, 3>, vector<f32>
+//         CHECK:   arith.addf {{.*}} : f32
 //         CHECK:   vector.transfer_write {{.*}} vector<f32>
+// No barrier within the loop.
+//     CHECK-NOT:   gpu.barrier
+//         CHECK:   }
+// Barrier after the loop.
+//         CHECK:   gpu.barrier
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: vector.transfer_read %{{.*}} memref<8xf32>, vector<f32>
-//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
+//         CHECK: vector.transfer_read %{{.*}} memref<1x64xf32, 3>, vector<1xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
-//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
-//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
-//         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
-//         CHECK:   scf.if %[[CONDXIS0]]
-//         CHECK:     vector.transfer_write %[[RES_VEC]]
-//         CHECK:   gpu.barrier
-//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
-
-// -----
-
-hal.executable @group_reduction_elementwise {
-hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
-  hal.executable.export public @group_reduction_elementwise ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index):
-    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @group_reduction_elementwise() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant -0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<8x64xf32>>
-      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<8xf32>>
-      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x64xf32>> -> tensor<8x64xf32>
-      %3 = tensor.empty() : tensor<8xf32>
-      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<8xf32>) -> tensor<8xf32>
-      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<8x64xf32>) outs(%4 : tensor<8xf32>) {
-      ^bb0(%in: f32, %out: f32):
-        %7 = arith.addf %in, %out : f32
-        linalg.yield %7 : f32
-      } -> tensor<8xf32>
-      %6 = linalg.generic {indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>], iterator_types = ["parallel"]} ins(%5 : tensor<8xf32>) outs(%3 : tensor<8xf32>) {
-      ^bb0(%in: f32, %out: f32):
-        %7 = math.sqrt %in : f32
-        linalg.yield %7 : f32
-      } -> tensor<8xf32>
-      flow.dispatch.tensor.store %6, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !flow.dispatch.tensor<writeonly:tensor<8xf32>>
-      return
-    }
-  }
-}
-}
-
-//   CHECK-LABEL: func.func @group_reduction_elementwise
-//     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
-//     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-
-// Fusion occurred, no barrier before the loop
-//     CHECK-NOT: gpu.barrier
-// Local per-thread scf.for-based reduction.
-//         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
-//         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
-//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
-// No barrier within the loop
-//     CHECK-NOT:   gpu.barrier
-//         CHECK:   vector.transfer_write {{.*}} vector<f32>
-
-// Distributed reduction: everyone loads then 5 xor + addf expected.
-//         CHECK: vector.transfer_read %{{.*}} memref<1xf32, 3>, vector<f32>
-//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
-// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
-
-//         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
-//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
-//         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
-//         CHECK:   scf.if %[[CONDXIS0]]
-//         CHECK:     vector.transfer_write %[[RES_VEC]]
-
-//         CHECK:   gpu.barrier
-//         CHECK:   math.sqrt 
-//         CHECK:   gpu.barrier
-//         CHECK:   memref.dealloc %[[SHMEM_ALLOC]]
-
-// -----
-
-hal.executable @group_elementwise_reduction {
-hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
-  hal.executable.export public @group_elementwise_reduction ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
-    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @group_elementwise_reduction() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant -0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<8x64xf32>>
-      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<8xf32>>
-      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x64xf32>> -> tensor<8x64xf32>
-      %3 = tensor.empty() : tensor<8xf32>
-      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<8xf32>) -> tensor<8xf32>
-      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<8x64xf32>) outs(%4 : tensor<8xf32>) {
-      ^bb0(%in: f32, %out: f32):
-        %6 = arith.addf %in, %in : f32
-        %7 = arith.addf %6, %6 : f32
-        %8 = arith.addf %7, %out : f32
-        linalg.yield %8 : f32
-      } -> tensor<8xf32>
-      flow.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !flow.dispatch.tensor<writeonly:tensor<8xf32>>
-      return
-    }
-  }
-}
-}
-
-//   CHECK-LABEL: func.func @group_elementwise_reduction
-//     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
-//     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
-//     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
-
-// Fusion occurred, no barrier before the loop
-//     CHECK-NOT: gpu.barrier
-// Local per-thread scf.for-based reduction.
-//         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
-//         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   arith.addf{{.*}} : vector<4xf32>
-//         CHECK:   arith.addf{{.*}} : vector<4xf32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
-//         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
-// No barrier within the loop
-//     CHECK-NOT:   gpu.barrier
-//         CHECK:   vector.transfer_write {{.*}} vector<f32>
-
-// Distributed reduction: everyone loads then 5 xor + addf expected.
-//         CHECK: vector.transfer_read %{{.*}} memref<8xf32>, vector<f32>
-//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
-// CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
-
-//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
-//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
+//         CHECK: arith.minui
+//         CHECK: memref.load
+//         CHECK: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+//         CHECK: gpu.shuffle  idx
+//         CHECK:   %[[RES:.*]] = arith.addf %{{.*}} : f32
+//         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %{{.*}} : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
 //         CHECK:     vector.transfer_write %[[RES_VEC]]
@@ -277,28 +149,35 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_elementwise_reduction_elementwise
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x32xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
 
 // Fusion occurred, no barrier before the loop
 //     CHECK-NOT: gpu.barrier
 // Local per-thread scf.for-based reduction.
 //         CHECK: scf.for
-//         CHECK:   vector.transfer_read {{.*}} vector<4xf32>
 //         CHECK:   vector.transfer_read {{.*}} vector<f32>
-//         CHECK:   arith.addf{{.*}} : vector<4xf32>
-//         CHECK:   arith.addf{{.*}} : vector<4xf32>
-//         CHECK:   vector.reduction <add>{{.*}} : vector<4xf32> into f32
+//         CHECK:   vector.transfer_read {{.*}} vector<f32>
+//         CHECK:   arith.addf{{.*}} : f32
+//         CHECK:   arith.addf{{.*}} : f32
+//         CHECK:   arith.addf{{.*}} : f32
 //         CHECK:   vector.broadcast {{.*}} : f32 to vector<f32>
+//         CHECK:   vector.transfer_write {{.*}} vector<f32>
 // No barrier within the loop
 //     CHECK-NOT:   gpu.barrier
-//         CHECK:   vector.transfer_write {{.*}} vector<f32>
+//         CHECK: }
+// Barrier after the loop
+//         CHECK:   gpu.barrier
 
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: vector.transfer_read %{{.*}} memref<1xf32, 3>, vector<f32>
-//         CHECK: vector.transfer_read %{{.*}} memref<1x32xf32, 3>, vector<1xf32>
+//         CHECK: vector.transfer_read %{{.*}} memref<1x64xf32, 3>, vector<1xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
+//         CHECK: arith.minui
+//         CHECK: memref.load
+//         CHECK: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+//         CHECK: gpu.shuffle  idx
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[PARTIAL]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
@@ -323,12 +202,12 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
     func.func @group_reduction_larger() {
       %c0 = arith.constant 0 : index
       %cst = arith.constant -0.000000e+00 : f32
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<33x256xf32>>
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<33x1024xf32>>
       %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<33xf32>>
-      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [33, 256], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<33x256xf32>> -> tensor<33x256xf32>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [33, 1024], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<33x1024xf32>> -> tensor<33x1024xf32>
       %3 = tensor.empty() : tensor<33xf32>
       %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<33xf32>) -> tensor<33xf32>
-      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<33x256xf32>) outs(%4 : tensor<33xf32>) {
+      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<33x1024xf32>) outs(%4 : tensor<33xf32>) {
       ^bb0(%in: f32, %out: f32):
         %6 = arith.addf %in, %out : f32
         linalg.yield %6 : f32
@@ -343,7 +222,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction_larger
 //     CHECK-DAG:   %[[C0:.*]] = arith.constant 0 : index
 //     CHECK-DAG:   %[[workgroup_id_x:.*]] = hal.interface.workgroup.id[0] : index
-//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x64xf32, 3>
+//     CHECK-DAG:   %[[SHMEM_ALLOC:.*]] = memref.alloc() {alignment = 64 : i64} : memref<1x256xf32, 3>
 //     CHECK-DAG:   %[[TIDX:.]] = gpu.thread_id  x
 
 // Fusion occurred, no barrier before the loop
@@ -361,10 +240,13 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //     CHECK-DAG:   %[[TIDY:.]] = gpu.thread_id  y
 // Distributed reduction: everyone loads then 5 xor + addf expected.
 //         CHECK: vector.transfer_read %{{.*}} memref<33xf32>, vector<f32>
-//         CHECK: %[[IDX:.*]] = affine.apply{{.*}}%[[TIDX]]
-//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[IDX]]]{{.*}} memref<1x64xf32, 3>, vector<2xf32>
+//         CHECK: vector.transfer_read %{{.*}}[%[[TIDY]], %[[TIDX]]]{{.*}} memref<1x256xf32, 3>, vector<1xf32>
 // CHECK-COUNT-5: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
 
+//         CHECK: arith.minui
+//         CHECK: memref.load
+// CHECK-COUNT-3: gpu.shuffle  xor{{.*}}{{[[:space:]].*}}{{.*}} arith.addf
+//         CHECK: gpu.shuffle  idx
 //         CHECK:   %[[RES:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[RES]] : f32 to vector<f32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -35,7 +35,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region {{.*}} tile_sizes [1](mapping = [#gpu.block<x>])
 // CHECK-COUNT-2:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.iree.take_first
-//         CHECK:   tile_reduction_using_foreach_thread {{.*}} by num_threads = [0, 32], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
+//         CHECK:   tile_reduction_using_foreach_thread {{.*}} by num_threads = [0, 64], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
 //         CHECK:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [1](mapping = [#gpu.thread<y>])
 //         CHECK:   transform.structured.match ops{["func.func"]} in %arg0
@@ -45,11 +45,11 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.erase_hal_descriptor_type_from_memref
 //         CHECK:   transform.structured.match ops{["func.func"]} in %{{.*}}
 //         CHECK:   transform.iree.foreach_thread_to_workgroup
-//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
 //         CHECK:   transform.iree.apply_patterns %{{.*}} {fold_memref_aliases, rank_reducing}
 //         CHECK:   transform.structured.match ops{["scf.if"]} in %{{.*}}
 //         CHECK:   sequence {{.*}} failures(suppress) {
-//         CHECK:     transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 32 : i64}
+//         CHECK:     transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 64 : i64}
 //         CHECK:   }
 //         CHECK:   transform.iree.vector.warp_distribute
 
@@ -90,8 +90,9 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_128
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 64], tile_sizes = [0, 4], mapping = [#gpu.thread<x>]
-//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
+//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 128], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [128, 1, 1]}
+//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 128 : i64}
 
 // -----
 
@@ -129,8 +130,9 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 
 //   CHECK-LABEL: func.func @group_reduction_32
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
-//         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region %{{.*}} num_threads [] tile_sizes [32](mapping = [#gpu.block<x>])
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [32] tile_sizes [](mapping = [#gpu.thread<x>])
+//         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region %{{.*}} num_threads [] tile_sizes [64](mapping = [#gpu.block<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [64] tile_sizes [](mapping = [#gpu.thread<x>])
 // CHECK-COUNT-4:   transform.structured.scalarize %{{.*}}
 // CHECK-COUNT-14:   transform.structured.split %{{.*}} after 4  {dimension = 1 : i64}
-//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [32, 1, 1]}
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
+//     CHECK-NOT:   transform.iree.vector.to_warp_execute_on_lane_0

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -67,6 +67,11 @@ struct CaptureDim : public CaptureStaticValue<int64_t> {
   using Base::Base;
 };
 
+/// Captures the (static) sizes of multiple dimensions.
+struct CaptureDims : public CaptureStaticValue<SmallVector<int64_t>> {
+  using Base::Base;
+};
+
 /// Captures the rank of the operation.
 struct CaptureRank : public CaptureStaticValue<int64_t> {
   using Base::Base;
@@ -238,9 +243,9 @@ public:
   //===-------------------------------------------------------------------===//
   // Capture directives.
   //===-------------------------------------------------------------------===//
-  StructuredOpMatcher &rank(CaptureStaticValue<int64_t> capture);
-  StructuredOpMatcher &dim(int64_t dimension,
-                           CaptureStaticValue<int64_t> capture);
+  StructuredOpMatcher &rank(CaptureRank capture);
+  StructuredOpMatcher &dim(int64_t dimension, CaptureDim capture);
+  StructuredOpMatcher &dim(AllDims tag, CaptureDims captures);
 
   //===-------------------------------------------------------------------===//
   // Constraints on input operands.
@@ -459,15 +464,15 @@ inline StructuredOpMatcher m_StructuredOp() {
 class MatchCallbackResult {
 public:
   /// Returns the number of lists of payload operations.
-  unsigned getNumPayloadGroups() const { return payloadGroupLengths.size(); }
+  int64_t getNumPayloadGroups() const { return payloadGroupLengths.size(); }
 
   /// Returns the `position`-th list of payload operations.
-  ArrayRef<Operation *> getPayloadGroup(unsigned position) const;
+  ArrayRef<Operation *> getPayloadGroup(int64_t position) const;
 
   /// Adds a new list of payload operations to the list of lists. The new list
   /// must not contain null operations.
   template <typename Range>
-  unsigned addPayloadGroup(Range operations) {
+  int64_t addPayloadGroup(Range operations) {
     int64_t originalLength = payloadOperations.size();
     assert(llvm::all_of(operations, [](Operation *op) -> bool { return op; }) &&
            "null operation");
@@ -538,9 +543,9 @@ private:
 
 struct MatchedReductionCaptures {
   int64_t reductionRank = 0;
-  // TODO: capture all dims.
-  int64_t mostMinorParallelDimensionSize = 0;
-  int64_t reductionDimensionSize = 0;
+  SmallVector<int64_t> leadingOpSizes = {};
+  SmallVector<int64_t> reductionOpSizes = {};
+  SmallVector<int64_t> trailingOpSizes = {};
   int64_t maybeLeadingRank = 0;
   int64_t maybeTrailingRank = 0;
 };


### PR DESCRIPTION
This revision adds support for warp reduction at the whole block level.
The multi-warp reduction allows a simpler strategy that does not need special handling for the second stage.
It also exhibits more parallelism and removes the need for a sequential loop to reduce `k * warps` to a `single warp`.
Previously, we would reduce `N -> k-warps -> 1-warp (using 1-warp and k iterations of a for loop) -> 1 value`.
Now we reduce `N -> k-warps -> k (using k-warps) -> 1 value`.

Additional empirical performance improvements are added on top:
* Use multi-warp reduction in the staged reduction strategy
* Add support to capture all sizes
* Add Split support to the elementwise part
* Tighten the dimensioning of strategies
* Update tests
