### PR TITLE
Add support for elemental types with bitwidth other than 32 to the transform dialect strategy

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.cpp
@@ -192,7 +192,7 @@ mlir::iree_compiler::buildTileFuseDistToForeachThreadWithTileSizes(
 }
 iree_compiler::TileToForeachThreadAndFuseAndDistributeResult
 mlir::iree_compiler::
-    buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
+    buildTileFuseDistToForeachThreadAndWorkgroupCountWithTileSizes(
         ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
         ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping) {
   return buildTileFuseDistWithTileSizes<
@@ -361,7 +361,7 @@ Value mlir::iree_compiler::createReductionStrategyBlockDistributionPart(
         b.getArrayAttr({x}));
   } else {
     iree_compiler::
-        buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
+        buildTileFuseDistToForeachThreadAndWorkgroupCountWithTileSizes(
             b, optionalFusionRootH, opsHToFuse, tileSizes0Generic,
             b.getArrayAttr({x}));
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategies.h
@@ -110,7 +110,7 @@ buildTileFuseDistToForeachThreadWithTileSizes(ImplicitLocOpBuilder &b,
                                               ArrayRef<OpFoldResult> tileSizes,
                                               ArrayAttr threadDimMapping);
 TileToForeachThreadAndFuseAndDistributeResult
-buildTileFuseDistToForeachThreadAndWorgroupCountWithTileSizes(
+buildTileFuseDistToForeachThreadAndWorkgroupCountWithTileSizes(
     ImplicitLocOpBuilder &b, Value rootH, ValueRange opsHToFuse,
     ArrayRef<OpFoldResult> tileSizes, ArrayAttr threadDimMapping);
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectStrategiesGPU.h
@@ -19,6 +19,7 @@ namespace iree_compiler {
 
 static constexpr int64_t kCudaWarpSize = 32;
 static constexpr int64_t kCudaMaxNumThreads = 1024;
+static constexpr int64_t kCudaMaxVectorLoadBitWidth = 128;
 
 /// Post-bufferization mapping to blocks and threads.
 /// Takes a handle to a func.func and returns an updated handle to a

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -49,7 +49,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.iree.apply_patterns %{{.*}} {fold_memref_aliases, rank_reducing}
 //         CHECK:   transform.structured.match ops{["scf.if"]} in %{{.*}}
 //         CHECK:   sequence {{.*}} failures(suppress) {
-//         CHECK:     transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 64 : i64}
+//         CHECK:     transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 32 : i64}
 //         CHECK:   }
 //         CHECK:   transform.iree.vector.warp_distribute
 
@@ -92,7 +92,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
 //         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 128], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [128, 1, 1]}
-//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 128 : i64}
+//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 32 : i64}
 
 // -----
 
@@ -137,3 +137,57 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.structured.tile %{{.*}}[0, 4]
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
 //     CHECK-NOT:   transform.iree.vector.to_warp_execute_on_lane_0
+
+
+// -----
+
+hal.executable @group_reduction_12345 {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @group_reduction_12345 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @group_reduction_12345() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0 : i8
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<8x12345xi8>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<8x12345xi8>>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, 12345], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x12345xi8>> -> tensor<8x12345xi8>
+      %3 = tensor.empty() : tensor<8x12345xi8>
+      %4 = tensor.empty() : tensor<8xi8>
+      %5 = linalg.fill ins(%cst : i8) outs(%4 : tensor<8xi8>) -> tensor<8xi8>
+      %6 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], 
+                           iterator_types = ["parallel", "reduction"]} 
+        ins(%2 : tensor<8x12345xi8>)
+       outs(%5 : tensor<8xi8>) {
+      ^bb0(%in: i8, %out: i8):
+        %6 = arith.addi %in, %out : i8
+        linalg.yield %6 : i8
+      } -> tensor<8xi8>
+      %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>, affine_map<(d0, d1) -> (d0, d1)>], 
+                           iterator_types = ["parallel", "parallel"]}
+        ins(%2, %6 : tensor<8x12345xi8>, tensor<8xi8>)
+       outs(%3 : tensor<8x12345xi8>) {
+      ^bb0(%in: i8, %in_0: i8, %out: i8):
+        %8 = arith.divui %in, %in_0 : i8
+        linalg.yield %8 : i8
+      } -> tensor<8x12345xi8>
+      flow.dispatch.tensor.store %7, %1, offsets = [0, 0], sizes = [8, 12345], strides = [1, 1] : tensor<8x12345xi8> -> !flow.dispatch.tensor<writeonly:tensor<8x12345xi8>>
+      return
+    }
+  }
+}
+}
+
+//   CHECK-LABEL: func.func @group_reduction_12345
+//         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
+//         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region %{{.*}} num_threads [] tile_sizes [1](mapping = [#gpu.block<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [0, 1024] tile_sizes [](mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [0, 1024] tile_sizes [](mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [] tile_sizes [1](mapping = [#gpu.thread<y>])
+//         CHECK:   transform.structured.split %{{.*}} after 8192  {dimension = 1 : i64}
+//         CHECK:   transform.structured.tile %{{.*}}[0, 8192]
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [1024, 1, 1]}
+//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0{{.*}}{warp_size = 64 : i64}

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -77,6 +77,11 @@ struct CaptureRank : public CaptureStaticValue<int64_t> {
   using Base::Base;
 };
 
+/// Captures the bitwidth of an element type.
+struct CaptureElementTypeBitWidth : public CaptureStaticValue<int64_t> {
+  using Base::Base;
+};
+
 /// A tag indicating to look for any user of the operation's result that would
 /// satisfy the predicate.
 struct HasAnyUse {};
@@ -283,6 +288,14 @@ public:
   /// have a projected permutation indexing map.
   StructuredOpMatcher &input(AllOperands tag, IsProjectedPermutation);
 
+  /// Adds a predicate checking that the bit width of the elemental type of the
+  /// structured op input at the given position is equal to the given value.
+  StructuredOpMatcher &input(int64_t position, ElementTypeBitWidth width);
+
+  /// Capture the elemental type bitwidth of input operand `position`.
+  StructuredOpMatcher &input(int64_t position,
+                             CaptureElementTypeBitWidth width);
+
   /// Adds a predicate that recursively applies another predicate to the
   /// operation defining the `position`-th input operand, looking through any
   /// "subsetting" operation such as "tensor.extract_slice".
@@ -331,6 +344,10 @@ public:
   /// Adds a predicate checking that the bit width of the elemental type of the
   /// structured op output at the given position is equal to the given value.
   StructuredOpMatcher &output(int64_t position, ElementTypeBitWidth width);
+
+  /// Capture the elemental type bitwidth of output operand `position`.
+  StructuredOpMatcher &output(int64_t position,
+                              CaptureElementTypeBitWidth width);
 
   /// Adds a predicate checking that the output of the structured op is produced
   /// by a reduction with a single-operation combinator (such as addf or mulf,
@@ -543,11 +560,14 @@ private:
 
 struct MatchedReductionCaptures {
   int64_t reductionRank = 0;
+  int64_t maybeLeadingRank = 0;
+  int64_t maybeTrailingRank = 0;
   SmallVector<int64_t> leadingOpSizes = {};
   SmallVector<int64_t> reductionOpSizes = {};
   SmallVector<int64_t> trailingOpSizes = {};
-  int64_t maybeLeadingRank = 0;
-  int64_t maybeTrailingRank = 0;
+  int64_t reductionOutputElementalTypeBitWidth = 0;
+  int64_t maybeLeadingOutputElementalTypeBitWidth = 0;
+  int64_t maybeTrailingOutputElementalTypeBitWidth = 0;
 };
 
 /// Creates a group of matchers for:


### PR DESCRIPTION
Add support for elemental types with bitwidth other than 32.

Proper bitwidth support is piped through the reduction, leading and trailing elementwise ops.
The group shuffle part is adjusted to get as close as possible to 128b loads around the shuffles.

Some semi-random performance profiles show:
```
(TRANSFORM_DIALECT_NO_DEBUG=1 benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_elementwise_static i8 150000 10240)
With transform dialect: reduction_2d_elementwise_static --function_input="150000x10240xi8=1" P50: 6876100.0000 ns 247.03520178589607480984 GElements/s
Without transform dialect: reduction_2d_elementwise_static --function_input="150000x10240xi8=1" P50: 626660000.00 ns 2.71062258800625538569 GElements/s

(TRANSFORM_DIALECT_NO_DEBUG=1 benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_elementwise_static i8 1500 1024)
With transform dialect: reduction_2d_elementwise_static --function_input="1500x1024xi8=1" P50: 10433.000 ns 162.78769289753666251317 GElements/s
Without transform dialect: reduction_2d_elementwise_static --function_input="1500x1024xi8=1" P50: 9888.0000 ns 171.76011326860841423948 GElements/s

(TRANSFORM_DIALECT_NO_DEBUG=1 benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_elementwise_static i8 1500 2000)
With transform dialect: reduction_2d_elementwise_static --function_input="1500x2000xi8=1" P50: 22753.000 ns 140.18903001801960181075 GElements/s
Without transform dialect: reduction_2d_elementwise_static --function_input="1500x2000xi8=1" P50: 332020.00 ns 9.60701463767242937172 GElements/s

(TRANSFORM_DIALECT_NO_DEBUG=1 benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_elementwise_static i16 1500 2000)
With transform dialect: reduction_2d_elementwise_static --function_input="1500x2000xi16=1" P50: 38658.000 ns 82.51127838998396192249 GElements/s
Without transform dialect: reduction_2d_elementwise_static --function_input="1500x2000xi16=1" P50: 403830.00 ns 7.89867270881311442933 GElements/s

(TRANSFORM_DIALECT_NO_DEBUG=1 benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_elementwise_static i16 1500 4096)
With transform dialect: reduction_2d_elementwise_static --function_input="1500x4096xi16=1" P50: 95846.000 ns 66.14940633933601819585 GElements/s
Without transform dialect: reduction_2d_elementwise_static --function_input="1500x4096xi16=1" P50: 3825400.0000 ns 1.65738380300099336017 GElements/s

(TRANSFORM_DIALECT_NO_DEBUG=1 benchmark-transform-create -r  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_elementwise_static i16 1500 1024)
With transform dialect: reduction_2d_elementwise_static --function_input="1500x1024xi16=1" P50: 15585.000 ns 108.97427013153673403914 GElements/s
Without transform dialect: reduction_2d_elementwise_static --function_input="1500x1024xi16=1" P50: 1148700.0000 ns 1.47850961956994863759 GElements/s
```