### PR TITLE
[LLVMGPU] Support IR generated by aggressive fusion in group reduction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -19,6 +19,7 @@ iree_compiler_cc_library(
         "ConvertToNVVM.cpp",
         "ConvertToROCDL.cpp",
         "KernelConfig.cpp",
+        "LLVMGPUBreakupMultiResultReductions.cpp",
         "LLVMGPUDistribute.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
         "LLVMGPUTensorAlloc.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -23,6 +23,7 @@ iree_cc_library(
     "ConvertToNVVM.cpp"
     "ConvertToROCDL.cpp"
     "KernelConfig.cpp"
+    "LLVMGPUBreakupMultiResultReductions.cpp"
     "LLVMGPUDistribute.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
     "LLVMGPUTensorAlloc.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -553,12 +553,14 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
   if (!targetInfo.hasWarpShuffle) return failure();
   if (!isa<linalg::GenericOp>(op)) return failure();
   // TODO(thomasraoux): Enable dynamic shape.
-  if (op.hasDynamicShape()) return failure();
+  bool hasDynamicShape = false;
+  entryPoint.walk([&hasDynamicShape](linalg::LinalgOp op) {
+    if (op.hasDynamicShape()) hasDynamicShape = true;
+  });
+  if (hasDynamicShape) return failure();
   SmallVector<unsigned> reductionDims;
   op.getReductionDims(reductionDims);
-  if (reductionDims.size() != 1 || reductionDims[0] != op.getNumLoops() - 1)
-    return failure();
-  if (op.getRegionOutputArgs().size() != 1) return failure();
+  if (reductionDims.size() != 1) return failure();
 
   // Only support projected permutation, this could be extended to projected
   // permutated with broadcast.
@@ -567,11 +569,21 @@ static LogicalResult setWarpReductionConfig(func::FuncOp entryPoint,
       }))
     return failure();
 
-  // Only single combiner operations are supported for now.
-  SmallVector<Operation *, 4> combinerOps;
-  if (!matchReduction(op.getRegionOutputArgs(), 0, combinerOps) ||
-      combinerOps.size() != 1)
-    return failure();
+  bool foundSingleReductionOutput = false;
+  for (int64_t i = 0, e = op.getDpsInitOperands().size(); i < e; i++) {
+    // Only single combiner operations are supported for now.
+    SmallVector<Operation *, 4> combinerOps;
+    if (matchReduction(op.getRegionOutputArgs(), i, combinerOps) &&
+        combinerOps.size() == 1) {
+      if (foundSingleReductionOutput) return failure();
+      foundSingleReductionOutput = true;
+      continue;
+    }
+    if (!op.getMatchingIndexingMap(op.getDpsInitOperand(i)).isIdentity())
+      return failure();
+  }
+  if (!foundSingleReductionOutput) return failure();
+
   Optional<int64_t> dimSize = getLinalgDimSize(op, reductionDims[0]);
   if (!dimSize || *dimSize % cudaWarpSize != 0) return failure();
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUBreakupMultiResultReductions.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUBreakupMultiResultReductions.cpp
@@ -1,0 +1,183 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/LinalgOpInfo.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+#define DEBUG_TYPE "iree-llvmgpu-breakup-multi-result-reductions"
+
+namespace mlir {
+namespace iree_compiler {
+
+static FailureOr<std::array<Operation*, 2>> breakupReductionOp(
+    RewriterBase& b, linalg::GenericOp op) {
+  Operation* cloneOp = b.clone(*op.getOperation());
+  for (int64_t i = 0, e = op.getNumDpsInits(); i < e; i++) {
+    // Just replace the use of the reduction and let the dead code elimination
+    // handle the clean up.
+    SmallVector<Operation*, 4> combinerOps;
+    if (matchReduction(op.getRegionOutputArgs(), i, combinerOps) &&
+        combinerOps.size() == 1) {
+      op.getResult(i).replaceAllUsesWith(cloneOp->getResult(i));
+    }
+  }
+  return std::array<Operation*, 2>({op.getOperation(), cloneOp});
+}
+
+static bool containsDim(AffineMap map, unsigned dim) {
+  for (AffineExpr expr : map.getResults()) {
+    if (auto exprDim = expr.dyn_cast<AffineDimExpr>()) {
+      if (exprDim.getPosition() == dim) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+template <typename OpTy>
+static SmallVector<NamedAttribute> pruneAttributeList(OpTy op) {
+  auto opAttributes = op.getAttributeNames();
+  llvm::StringSet<> elidedAttrs;
+  elidedAttrs.insert(opAttributes.begin(), opAttributes.end());
+  SmallVector<NamedAttribute> preservedAttrs;
+  for (auto attr : op->getAttrs()) {
+    if (elidedAttrs.count(attr.getName())) continue;
+    preservedAttrs.push_back(attr);
+  }
+  return preservedAttrs;
+}
+
+namespace {
+
+/// Convert reduction dimensions to parallel if there are no loop carried
+/// dependencies.
+struct ConvertReductionDims : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp linalgOp,
+                                PatternRewriter& rewriter) const override {
+    SmallVector<unsigned> reductionDims;
+    linalgOp.getReductionDims(reductionDims);
+    SmallVector<unsigned> dimsToParallelize;
+    for (unsigned dim : reductionDims) {
+      if (llvm::all_of(linalgOp.getResults(), [&](OpResult result) {
+            return containsDim(linalgOp.getIndexingMapMatchingResult(result),
+                               dim);
+          })) {
+        dimsToParallelize.push_back(dim);
+      }
+    }
+    if (dimsToParallelize.empty()) return failure();
+    SmallVector<utils::IteratorType> newIteratorTypes =
+        linalgOp.getIteratorTypesArray();
+    for (unsigned dim : dimsToParallelize) {
+      newIteratorTypes[dim] = utils::IteratorType::parallel;
+    }
+    SmallVector<AffineMap> newMaps = linalgOp.getIndexingMapsArray();
+    auto genericOp = rewriter.create<linalg::GenericOp>(
+        linalgOp.getLoc(), linalgOp.getResultTypes(), linalgOp.getInputs(),
+        linalgOp.getOutputs(), linalgOp.getIndexingMapsArray(),
+        newIteratorTypes);
+    // Forward lowering config.
+    if (auto loweringAttr = getLoweringConfig(linalgOp)) {
+      setLoweringConfig(genericOp, loweringAttr);
+    }
+    BlockAndValueMapping mapping;
+    linalgOp->getRegion(0).cloneInto(&genericOp.getRegion(),
+                                     genericOp.getRegion().begin(), mapping);
+    rewriter.replaceOp(linalgOp, genericOp.getResults());
+    return success();
+  }
+};
+
+/// Merge elementwise operations into their consumers.
+struct MergeElementwiseOps : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp genericOp,
+                                PatternRewriter& rewriter) const override {
+    // Find the first operand that is defined by another generic op on tensors.
+    for (OpOperand& opOperand : genericOp->getOpOperands()) {
+      if (!linalg::areElementwiseOpsFusable(&opOperand)) continue;
+
+      FailureOr<Operation*> fusedOp =
+          linalg::fuseElementwiseOps(rewriter, &opOperand);
+      if (succeeded(fusedOp)) {
+        // Forward lowering config.
+        if (auto loweringAttr = getLoweringConfig(genericOp)) {
+          setLoweringConfig(fusedOp.value(), loweringAttr);
+        }
+        auto replacements =
+            fusedOp.value()->getResults().take_back(genericOp.getNumResults());
+        rewriter.replaceOp(genericOp, replacements);
+        return success();
+      }
+    }
+    return failure();
+  }
+};
+
+struct LLVMGPUBreakupMultiResultReductionsPass
+    : public LLVMGPUBreakupMultiResultReductionsBase<
+          LLVMGPUBreakupMultiResultReductionsPass> {
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    SmallVector<linalg::GenericOp> reductions;
+    funcOp.walk([&](linalg::GenericOp op) {
+      if (op.getNumReductionLoops() > 0 && op.getNumResults() > 1)
+        reductions.push_back(op);
+    });
+    for (linalg::GenericOp op : reductions) {
+      IRRewriter rewriter(funcOp.getContext());
+      rewriter.setInsertionPoint(op);
+      if (failed(breakupReductionOp(rewriter, op))) {
+        return signalPassFailure();
+      }
+    }
+
+    // Clean up dead code within linalg ops.
+    RewritePatternSet patterns(funcOp.getContext());
+    linalg::populateEraseUnusedOperandsAndResultsPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+
+    // Convert reduction dims.
+    RewritePatternSet patterns2(funcOp.getContext());
+    patterns2.insert<ConvertReductionDims>(funcOp.getContext());
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns2)))) {
+      return signalPassFailure();
+    }
+
+    // merge linalg.generic ops.
+    {
+      RewritePatternSet fusionPatterns(funcOp.getContext());
+      fusionPatterns.insert<MergeElementwiseOps>(funcOp.getContext());
+      if (failed(applyPatternsAndFoldGreedily(funcOp,
+                                              std::move(fusionPatterns)))) {
+        return signalPassFailure();
+      }
+    }
+  }
+};
+
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMGPUBreakupMultiResultReductionsPass() {
+  return std::make_unique<LLVMGPUBreakupMultiResultReductionsPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -308,7 +308,9 @@ void addGPUTransposePassPipeline(OpPassManager &pm) {
 void addGPUWarpReductionPassPipeline(OpPassManager &pm) {
   tileAndDistributeToWorkgroup(pm);
   auto &nestedModulePM = pm.nest<ModuleOp>();
-
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUBreakupMultiResultReductionsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(createCanonicalizerPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createRemoveSingleIterationLoopPass());
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUTileReductionPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "breakup_multiresult_reductions.mlir",
             "conv_pipeline_test.mlir",
             "convert_to_nvvm.mlir",
             "convert_to_rocdl.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "breakup_multiresult_reductions.mlir"
     "conv_pipeline_test.mlir"
     "convert_to_nvvm.mlir"
     "convert_to_rocdl.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/breakup_multiresult_reductions.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/breakup_multiresult_reductions.mlir
@@ -1,0 +1,54 @@
+// RUN: iree-opt -iree-llvmgpu-breakup-multi-result-reductions %s | FileCheck %s
+
+func.func @merged_reduction_parallel(
+    %0: tensor<1x40960xf32>,
+    %1: tensor<1xf32>,
+    %2: tensor<1x40960xf32>,
+    %3: tensor<1xf32>) -> tensor<1x40960xf32> {
+    %cst = arith.constant -3.40282347E+38 : f32
+    %8:2 = linalg.generic 
+    {indexing_maps = [
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0)>,
+        affine_map<(d0, d1) -> (d0, d1)>,
+        affine_map<(d0, d1) -> (d0)>],
+        iterator_types = ["parallel", "reduction"]}
+        ins(%0, %1 : tensor<1x40960xf32>, tensor<1xf32>)
+        outs(%2, %3 : tensor<1x40960xf32>, tensor<1xf32>) {
+      ^bb0(%in: f32, %in_2: f32, %out: f32, %out_3: f32):
+        %10 = arith.subf %in, %in_2 : f32
+        %11 = math.exp %10 : f32
+        %12 = arith.addf %11, %out_3 : f32
+        linalg.yield %11, %12 : f32, f32
+      } -> (tensor<1x40960xf32>, tensor<1xf32>)
+    %9 = linalg.generic {
+        indexing_maps = [
+            affine_map<(d0, d1) -> (d0, d1)>,
+            affine_map<(d0, d1) -> (d0)>,
+            affine_map<(d0, d1) -> (d0, d1)>],
+            iterator_types = ["parallel", "parallel"]}
+            ins(%8#0, %8#1 : tensor<1x40960xf32>, tensor<1xf32>)
+            outs(%2 : tensor<1x40960xf32>) {
+      ^bb0(%in: f32, %in_2: f32, %out: f32):
+        %10 = arith.divf %cst, %in_2 : f32
+        %11 = arith.mulf %in, %10 : f32
+        linalg.yield %11 : f32
+      } -> tensor<1x40960xf32>
+   return %9 : tensor<1x40960xf32>
+}
+
+
+//   CHECK-LABEL: func.func @merged_reduction_parallel
+//         CHECK:   %{{.+}} = linalg.generic 
+//         CHECK:     arith.subf
+//         CHECK:     math.exp
+//         CHECK:     arith.addf
+//         CHECK:     linalg.yield %{{.*}} : f32
+//         CHECK:   } -> tensor<1xf32>
+//         CHECK:   %{{.+}} = linalg.generic
+//         CHECK:     arith.subf
+//         CHECK:     math.exp
+//         CHECK:     arith.divf
+//         CHECK:     arith.mulf
+//         CHECK:     linalg.yield %{{.+}} : f32
+//         CHECK:   } -> tensor<1x40960xf32>

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline.mlir
@@ -187,3 +187,136 @@ hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
 //         CHECK:      vector.transfer_write {{.*}} : vector<4xf32>, memref<512x10240xf32>
 //         CHECK:    }
 //         CHECK:    return
+
+// -----
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+hal.executable @softmax {
+hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
+  hal.executable.export @softmax layout(#pipeline_layout) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+      hal.return %x, %y, %z : index, index, index
+    }
+  builtin.module {
+    func.func @softmax() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant -3.40282347E+38 : f32
+      %cst_0 = arith.constant 0.000000e+00 : f32
+      %cst_1 = arith.constant 1.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<12x128x40960xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<12x128x40960xf32>>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [12, 128, 40960], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<12x128x40960xf32>> -> tensor<12x128x40960xf32>
+      %3 = tensor.empty() : tensor<12x128xf32>
+      %4 = tensor.empty() : tensor<12x128x40960xf32>
+      %5 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1], [0, 0, 4096]]>} ins(%cst : f32) outs(%3 : tensor<12x128xf32>) -> tensor<12x128xf32>
+      %6 = linalg.fill {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1], [0, 0, 4096]]>} ins(%cst_0 : f32) outs(%3 : tensor<12x128xf32>) -> tensor<12x128xf32>
+      %7 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%2 : tensor<12x128x40960xf32>) outs(%5 : tensor<12x128xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1], [0, 0, 4096]]>} {
+      ^bb0(%in: f32, %out: f32):
+        %10 = arith.maxf %in, %out : f32
+        linalg.yield %10 : f32
+      } -> tensor<12x128xf32>
+      %8:2 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%2, %7 : tensor<12x128x40960xf32>, tensor<12x128xf32>) outs(%4, %6 : tensor<12x128x40960xf32>, tensor<12x128xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1], [0, 0, 4096]]>} {
+      ^bb0(%in: f32, %in_2: f32, %out: f32, %out_3: f32):
+        %10 = arith.subf %in, %in_2 : f32
+        %11 = math.exp %10 : f32
+        %12 = arith.addf %11, %out_3 : f32
+        linalg.yield %11, %12 : f32, f32
+      } -> (tensor<12x128x40960xf32>, tensor<12x128xf32>)
+      %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%8#0, %8#1 : tensor<12x128x40960xf32>, tensor<12x128xf32>) outs(%4 : tensor<12x128x40960xf32>) attrs =  {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[1, 1], [0, 0, 4096]]>} {
+      ^bb0(%in: f32, %in_2: f32, %out: f32):
+        %10 = arith.divf %cst_1, %in_2 : f32
+        %11 = arith.mulf %in, %10 : f32
+        linalg.yield %11 : f32
+      } -> tensor<12x128x40960xf32>
+      flow.dispatch.tensor.store %9, %1, offsets = [0, 0, 0], sizes = [12, 128, 40960], strides = [1, 1, 1] : tensor<12x128x40960xf32> -> !flow.dispatch.tensor<writeonly:tensor<12x128x40960xf32>>
+      return
+    }
+  }
+}
+}
+
+//   CHECK-LABEL:  func.func @softmax
+//         CHECK:    scf.for {{.*}} -> (vector<4xf32>) {
+//         CHECK:      vector.transfer_read {{.*}} : memref<12x128x40960xf32>, vector<4xf32>
+//         CHECK:      arith.maxf {{.*}} : vector<4xf32>
+//         CHECK:      scf.yield
+//         CHECK:    vector.reduction <maxf>, %{{.*}} : vector<4xf32> into f32
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    arith.remui
+//         CHECK:    scf.if
+//         CHECK:      memref.store {{.*}} : memref<32xf32, 3>
+//         CHECK:    }
+//         CHECK:    gpu.barrier
+//         CHECK:    arith.minui
+//         CHECK:    memref.load
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.maxf
+//         CHECK:    arith.maxf
+//         CHECK:    vector.broadcast %{{.*}} : f32 to vector<4xf32>
+//         CHECK:    scf.for {{.*}} -> (vector<4xf32>) {
+//         CHECK:      vector.transfer_read
+//         CHECK:      arith.subf
+//         CHECK:      math.exp
+//         CHECK:      arith.addf
+//         CHECK:      scf.yield
+//         CHECK:    vector.reduction <add>, %{{.*}} : vector<4xf32> into f32
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    scf.if
+//         CHECK:      memref.store {{.*}} : memref<32xf32, 3>
+//         CHECK:    }
+//         CHECK:    gpu.barrier
+//         CHECK:    memref.load
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    gpu.shuffle  xor
+//         CHECK:    arith.addf
+//         CHECK:    arith.addf
+//         CHECK:    vector.broadcast
+//         CHECK:    vector.broadcast
+//         CHECK:    arith.divf
+//         CHECK:    scf.for
+//         CHECK:      vector.transfer_read
+//         CHECK:      arith.subf
+//         CHECK:      math.exp
+//         CHECK:      arith.mulf
+//         CHECK:      vector.transfer_write
+//         CHECK:    }
+//         CHECK:    return

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -469,6 +469,10 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU();
 //. Pass to pad out tensors up to static dimensions.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorPadPass();
 
+/// Pass to breakup reduction ops with multiple results.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMGPUBreakupMultiResultReductionsPass();
+
 //------------------------------------------------------------------------------
 // SPIR-V Passes
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -480,6 +480,12 @@ def LLVMGPUTensorPad :
   let constructor = "mlir::iree_compiler::createLLVMGPUTensorPadPass()";
 }
 
+def LLVMGPUBreakupMultiResultReductions :
+    Pass<"iree-llvmgpu-breakup-multi-result-reductions", "func::FuncOp"> {
+  let summary = "Pass to break up reductions with multiple results.";
+  let constructor = "mlir::iree_compiler::createLLVMGPUBreakupMultiResultReductionsPass()";
+}
+
 //------------------------------------------------------------------------------
 // SPIR-V
 //------------------------------------------------------------------------------

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -56,6 +56,7 @@ iree_lit_test_suite(
             "layernorm.mlir",
             "linalg_quantized_matmul_vs_linalg_matmul.mlir",
             "lowering_config.mlir",
+            "softmax_large.mlir",
         ] + BACKEND_TESTS,
     ),
     cfg = "//tests:lit.cfg.py",
@@ -123,6 +124,27 @@ iree_check_single_backend_test_suite(
         "layernorm.mlir",
     ] + BACKEND_TESTS,
     compiler_flags = ["--iree-input-type=mhlo"],
+    driver = "cuda",
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backend = "cuda",
+)
+
+iree_check_single_backend_test_suite(
+    name = "aggressive_fusion_test_cuda",
+    srcs = [
+        "softmax.mlir",
+        "softmax_large.mlir",
+    ],
+    compiler_flags = [
+        "--iree-flow-enable-aggressive-fusion",
+    ],
     driver = "cuda",
     tags = [
         # CUDA cuInit fails with sanitizer on.

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -162,6 +162,26 @@ iree_check_single_backend_test_suite(
 
 iree_check_single_backend_test_suite(
   NAME
+    aggressive_fusion_test_cuda
+  SRCS
+    "softmax.mlir"
+    "softmax_large.mlir"
+  TARGET_BACKEND
+    "cuda"
+  DRIVER
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-flow-enable-aggressive-fusion"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
+iree_check_single_backend_test_suite(
+  NAME
     disable_demote_f64_to_f32
   SRCS
     "disable_demote_f64_to_f32.mlir"

--- a/tests/e2e/regression/softmax_large.mlir
+++ b/tests/e2e/regression/softmax_large.mlir
@@ -1,0 +1,58 @@
+// Generated from this TOSA input:
+//
+// func.func @softmax() {
+//   %0 = util.unfoldable_constant dense<5.0> : tensor<12x128x40960xf32>
+//   %red = "tosa.reduce_max"(%0) {axis = 2 : i64} : (tensor<12x128x40960xf32>) -> tensor<12x128x1xf32>
+//   %sub = "tosa.sub"(%0, %red) : (tensor<12x128x40960xf32>, tensor<12x128x1xf32>) -> tensor<12x128x40960xf32>
+//   %exp = "tosa.exp"(%sub) : (tensor<12x128x40960xf32>) -> tensor<12x128x40960xf32>
+//   %sum = "tosa.reduce_sum"(%exp) {axis = 2 : i64} : (tensor<12x128x40960xf32>) -> tensor<12x128x1xf32>
+//   %rec = "tosa.reciprocal"(%sum) : (tensor<12x128x1xf32>) -> tensor<12x128x1xf32>
+//   %mul = "tosa.mul"(%exp, %rec) {shift = 0 : i32} : (tensor<12x128x40960xf32>, tensor<12x128x1xf32>) -> tensor<12x128x40960xf32>
+//   check.expect_almost_eq_const(%mul, dense<0.0078125> : tensor<12x128x40960xf32>) : tensor<12x128x40960xf32>
+//   return
+// }
+
+func.func @softmax() {
+  %cst = arith.constant 1.000000e+00 : f32
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant -3.40282347E+38 : f32
+  %cst_2 = arith.constant dense<7.812500e-03> : tensor<12x128x40960xf32>
+  %cst_3 = arith.constant dense<5.000000e+00> : tensor<12x128x40960xf32>
+  %0 = util.optimization_barrier %cst_3 : tensor<12x128x40960xf32>
+  %1 = tensor.empty() : tensor<12x128xf32>
+  %2 = linalg.fill ins(%cst_1 : f32) outs(%1 : tensor<12x128xf32>) -> tensor<12x128xf32>
+  %3 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%0 : tensor<12x128x40960xf32>) outs(%2 : tensor<12x128xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32):
+    %11 = arith.maxf %arg0, %arg1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128xf32>
+  %4 = tensor.empty() : tensor<12x128x40960xf32>
+  %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%0, %3 : tensor<12x128x40960xf32>, tensor<12x128xf32>) outs(%4 : tensor<12x128x40960xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %11 = arith.subf %arg0, %arg1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128x40960xf32>
+  %6 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%5 : tensor<12x128x40960xf32>) outs(%4 : tensor<12x128x40960xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32):
+    %11 = math.exp %arg0 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128x40960xf32>
+  %7 = linalg.fill ins(%cst_0 : f32) outs(%1 : tensor<12x128xf32>) -> tensor<12x128xf32>
+  %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%6 : tensor<12x128x40960xf32>) outs(%7 : tensor<12x128xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32):
+    %11 = arith.addf %arg0, %arg1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128xf32>
+  %9 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%8 : tensor<12x128xf32>) outs(%1 : tensor<12x128xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32):
+    %11 = arith.divf %cst, %arg0 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128xf32>
+  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%6, %9 : tensor<12x128x40960xf32>, tensor<12x128xf32>) outs(%4 : tensor<12x128x40960xf32>) {
+  ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+    %11 = arith.mulf %arg0, %arg1 : f32
+    linalg.yield %11 : f32
+  } -> tensor<12x128x40960xf32>
+  check.expect_almost_eq(%10, %cst_2) : tensor<12x128x40960xf32>
+  return
+}


### PR DESCRIPTION
Add support for back to back reductions through the group reduction path. The fusion code merges parallel and reductions which prevents us from tiling the operation without creating large allocations. In order to support this case we break up those kind of linalg ops between reduction only and parallel only ops.

The extra pass can be removed if fusion IR changes in the future.