### PR TITLE
Introduce Collapse Pass

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -34,6 +34,7 @@ iree_compiler_cc_library(
         "CaptureDispatchDynamicDims.cpp",
         "CleanupNumericNarrowing.cpp",
         "CleanupTensorShapes.cpp",
+        "CollapseDimensions.cpp",
         "CollapseReductionDims.cpp",
         "Convert1X1FilterConv2DToMatmul.cpp",
         "ConvertConv2DToImg2Col.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
     "CaptureDispatchDynamicDims.cpp"
     "CleanupNumericNarrowing.cpp"
     "CleanupTensorShapes.cpp"
+    "CollapseDimensions.cpp"
     "CollapseReductionDims.cpp"
     "Convert1X1FilterConv2DToMatmul.cpp"
     "ConvertConv2DToImg2Col.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CollapseDimensions.cpp
@@ -1,0 +1,234 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowTypes.h"
+#include "iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/Flow/Transforms/RegionOpUtils.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/IR/Block.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/FunctionInterfaces.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Support/LogicalResult.h"
+
+#define DEBUG_TYPE "iree-flow-collapse-dimensions"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+namespace {
+/// Pass declaration.
+struct CollapseDimensionsPass
+    : public CollapseDimensionsBase<CollapseDimensionsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {}
+  CollapseDimensionsPass() {}
+  CollapseDimensionsPass(const CollapseDimensionsPass &pass)
+      : CollapseDimensionsPass() {}
+  void runOnOperation() override;
+};
+}  // namespace
+
+/// Searches the same sequence in all the affine maps and collapses these
+/// dimensions. It only applies these to "parallel" loops without mixing them
+/// with "reduction" types.
+static SmallVector<ReassociationIndices> getCollapsibleLoops(
+    linalg::GenericOp genericOp) {
+  SmallVector<ReassociationIndices> contiguousLoops;
+
+  SmallVector<unsigned> pDims;
+  genericOp.getParallelDims(pDims);
+  if (pDims.size() < 2) return contiguousLoops;
+
+  llvm::SmallDenseSet<unsigned> pLoops(pDims.begin(), pDims.end());
+
+  auto hasAllMapsSameSequence = [&](AffineExpr preExpr, AffineExpr nextExpr) {
+    for (AffineMap map : genericOp.getIndexingMapsArray()) {
+      bool foundSeq = false;
+      for (auto [index, resultExpr] : llvm::enumerate(map.getResults())) {
+        if (resultExpr == nextExpr) {
+          foundSeq = (index > 0 && preExpr == map.getResult(index - 1));
+          break;
+        }
+      }
+      if (!foundSeq) return false;
+    }
+    return true;
+  };
+
+  ReassociationIndices range;
+  AffineExpr preExpr;
+  for (auto nextExpr : genericOp.getIndexingMapsArray().front().getResults()) {
+    unsigned pos = nextExpr.cast<AffineDimExpr>().getPosition();
+    if (!range.empty()) {
+      if (!hasAllMapsSameSequence(preExpr, nextExpr) || !pLoops.count(pos)) {
+        if (range.size() > 1)
+          contiguousLoops.push_back({range.begin(), range.end()});
+        range.clear();
+      }
+    }
+    preExpr = nextExpr;
+    if (pLoops.count(pos)) range.push_back(pos);
+  }
+  if (range.size() > 1) contiguousLoops.push_back(range);
+
+  LLVM_DEBUG({
+    llvm::dbgs() << "Collapsing dimensions if possible: ";
+    for (auto indices : contiguousLoops) {
+      llvm::dbgs() << "[";
+      for (auto idx : indices) llvm::dbgs() << idx << ",";
+      llvm::dbgs() << "]\t";
+    }
+    llvm::dbgs() << "\n";
+  });
+
+  return contiguousLoops;
+}
+
+/// Collapse possible dimension of the given linalg.generic
+static FailureOr<SmallVector<Value>> collapseLinalgGeneric(
+    IRRewriter &rewriter, linalg::GenericOp genericOp,
+    SmallVector<ReassociationIndices> &collapseIndices) {
+  rewriter.setInsertionPoint(genericOp->getParentOp());
+  FailureOr<SmallVector<Value>> replacements =
+      mlir::linalg::collapseGenericOpIterationDims(genericOp, collapseIndices,
+                                                   rewriter);
+  if (failed(replacements) || replacements->empty()) {
+    return rewriter.notifyMatchFailure(genericOp,
+                                       "failed to collapse dimensions");
+  }
+
+  return replacements;
+}
+
+/// Returns true if the given op is collapsable.
+static bool isEligibleForCollapse(linalg::GenericOp genericOp) {
+  // TODO(guray) There is no mechanism to tell the collapsed indexes to
+  // `tensor.expand_shape`. Once we have this support in MLIR, we can enable
+  // dynamic tensor shapes.
+  if (genericOp.hasDynamicShape()) return false;
+
+  // TODO(guray) Currently we can only collapse when result of all the
+  // AffineMaps are dimensions. Possible to collapse cases like
+  // affine_map<d0, d1+d2> with affine_map<d0, d1+d2>, however, this is not
+  // supported in collapsing mechanism in MLIR. Once we have this support,
+  // we can remove this if statement.
+  if (llvm::any_of(genericOp.getIndexingMapsArray(), [](AffineMap map) {
+        return !map.isProjectedPermutation();
+      })) {
+    return false;
+  }
+
+  // TODO(guray) Collapsing caused performance regression in a cpu
+  // benchmark, so we disable it.
+  if (genericOp.hasIndexSemantics()) return false;
+
+  return true;
+}
+
+/// Traverses all the the Ops in DispatchRegionOps and finds linalg.generic Op
+/// without any producers.
+static FailureOr<linalg::GenericOp> findRootGenericOp(
+    DispatchRegionOp regionOp) {
+  SmallVector<Operation *> computeOps;
+  auto &ops = regionOp.getBody().front().getOperations();
+  for (Operation &op : ops) {
+    if (isa<TilingInterface>(op)) computeOps.push_back(&op);
+  }
+  // Looking for root without producer
+  if (computeOps.size() != 1 || ops.size() != 2) return failure();
+  auto genericOp = llvm::dyn_cast<linalg::GenericOp>(computeOps.front());
+  if (!genericOp) return failure();
+  return genericOp;
+}
+
+/// Generate a new dispatch.region and workload according with the collapsed
+/// linalg Generic Op
+static LogicalResult generateNewDispatchRegion(
+    IRRewriter &rewriter, DispatchRegionOp regionOp,
+    SmallVector<Value> collapseResults, linalg::GenericOp newGenericOp) {
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(regionOp->getParentOp());
+
+  auto maybeBuilder =
+      iree_compiler::IREE::Flow::getWorkloadBuilder(rewriter,
+                                                    /*rootOp=*/newGenericOp);
+  if (failed(maybeBuilder)) return failure();
+
+  auto maybeRegionOp =
+      Flow::wrapOpInDispatchRegion(rewriter, newGenericOp, *maybeBuilder);
+  if (failed(maybeRegionOp)) return failure();
+
+  // Replace old regionOp with the result of collapse
+  rewriter.replaceOp(regionOp, collapseResults);
+
+  return success();
+}
+
+/// Traverses DispatchRegionOps to find linalg genericOps that has no
+/// producers and tries to collapse its dimensions.
+static LogicalResult collapseDimensions(IRRewriter &rewriter,
+                                        DispatchRegionOp &regionOp) {
+  // Step 1. Find the root linalg.generic Op with no producer
+  std::optional<linalg::GenericOp> genericOp = findRootGenericOp(regionOp);
+  if (!genericOp.has_value()) return success();
+
+  // Step 2. Check whether it is possible to collapse
+  if (!isEligibleForCollapse(genericOp.value())) return success();
+  SmallVector<ReassociationIndices> collapseIndices;
+  collapseIndices = getCollapsibleLoops(genericOp.value());
+  if (collapseIndices.empty()) return success();
+
+  // Step 3. Collapse dimensions
+  auto maybeReplacements =
+      collapseLinalgGeneric(rewriter, genericOp.value(), collapseIndices);
+  if (failed(maybeReplacements)) return failure();
+  auto expandshapeOp =
+      maybeReplacements->front().getDefiningOp<tensor::ExpandShapeOp>();
+  if (!expandshapeOp) return failure();
+  auto newGenericOp =
+      expandshapeOp.getOperand().getDefiningOp<linalg::GenericOp>();
+  if (!newGenericOp) return failure();
+
+  // Step 4. Generate new dispatch region and replace old one users
+  if (failed(generateNewDispatchRegion(rewriter, regionOp, *maybeReplacements,
+                                       newGenericOp)))
+    return failure();
+
+  return success();
+}
+
+void CollapseDimensionsPass::runOnOperation() {
+  mlir::FunctionOpInterface funcOp = getOperation();
+  IRRewriter rewriter(funcOp->getContext());
+
+  funcOp->walk([&](DispatchRegionOp regionOp) {
+    if (failed(collapseDimensions(rewriter, regionOp)))
+      return signalPassFailure();
+  });
+}
+
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createCollapseDimensionsPass() {
+  return std::make_unique<CollapseDimensionsPass>();
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -101,10 +101,6 @@ static llvm::cl::opt<bool> clDispatchGenerateWorkloadRegion(
     "iree-flow-dispatch-generate-workload-region",
     llvm::cl::desc("Generate the workload region"), llvm::cl::init(true));
 
-static llvm::cl::opt<bool> clCollapseDimensions(
-    "iree-flow-form-dispatch-regions-collapse",
-    llvm::cl::desc("Collapse dimensions"), llvm::cl::init(true));
-
 static llvm::cl::opt<bool> clEnableDataTiling(
     "iree-flow-enable-data-tiling", llvm::cl::desc("Enable data tiling path"),
     llvm::cl::init(false));
@@ -296,9 +292,10 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       // the FormDispatchRegions handle the rest.
       .addPass([&]() {
         return createFormDispatchRegionsPass(clEnableAggressiveFusion,
-                                             clDispatchGenerateWorkloadRegion,
-                                             clCollapseDimensions);
+                                             clDispatchGenerateWorkloadRegion);
       })
+      // Collapse dimensions of linalg Ops.
+      .addPass(createCollapseDimensionsPass)
       // Form dispatch region into dispatch workgroups
       .addPass([&]() {
         return createFormDispatchWorkgroupsPass(

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -147,8 +147,11 @@ std::unique_ptr<Pass> createVerifyInputLegalityPass();
 // is created for each tiled loop nest.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createFormDispatchRegionsPass(bool aggressiveFusion = false,
-                              bool generateWorkloadRegion = true,
-                              bool collapse = true);
+                              bool generateWorkloadRegion = true);
+
+// Pass to collapse dimensions of Linalg Ops on tensor ops.
+std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
+createCollapseDimensionsPass();
 
 //===----------------------------------------------------------------------===//
 // Dispatches (flow.dispatch.workgroups)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -77,8 +77,6 @@ def FormDispatchRegions :
            /*default=*/"false", "Fuse with aggressive heuristics">,
     Option<"generateWorkloadRegion", "genereate-workload-region", "bool",
            /*default=*/"true", "Generate workload regions of WorkgroupOps">,
-    Option<"collapse", "collapse", "bool",
-           /*default=*/"true", "Collapse Op and tensors that are used">,
   ];
 }
 
@@ -90,6 +88,12 @@ def FormDispatchWorkgroups :
     Option<"generateWorkloadRegion", "genereate-workload-region", "bool",
            /*default=*/"true", "Generate workload regions of WorkgroupOps">,
   ];
+}
+
+def CollapseDimensions :
+    InterfacePass<"iree-flow-collapse-dimensions", "mlir::FunctionOpInterface"> {
+  let summary = "Collapse dimensions of Linalg Ops on tensor ops.";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createCollapseDimensionsPass()";  
 }
 
 def DispatchWithTransformDialect :

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-flow-form-dispatch-regions{aggressive-fusion=true}))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-collapse-dimensions))" %s | FileCheck %s
 !type = tensor<2x4x8x16x32x64xf32>
 util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
 

--- a/tests/transform_dialect/cuda/vecadd2d.mlir
+++ b/tests/transform_dialect/cuda/vecadd2d.mlir
@@ -1,40 +1,38 @@
-!type = tensor<512x9xf32>
+!type = tensor<9x512xf32>
+!type2 = tensor<512x9xf32>
+
 #trait = { indexing_maps  = [affine_map<(d0, d1) -> (d0, d1)>],
            iterator_types = ["parallel", "parallel"] }
 
 #trait2 = { indexing_maps  = [affine_map<(d0, d1) -> (d0, d1)>,
-                              affine_map<(d0, d1) -> (d0, d1)>],
+                              affine_map<(d0, d1) -> (d1, d0)>],
            iterator_types = ["parallel", "parallel"] }
 
-func.func @vecadd2d() -> (!type) {
+util.global private @"lhs" {noinline} = dense<0.0> : !type2
+util.global private @"rhs" {noinline} = dense<2.0> : !type
+
+func.func @vecadd2d() -> (!type2) {
   %cst0 = arith.constant 0.000000e+00 : f32
   %cst1 = arith.constant 2.000000e+00 : f32
-  %0 = tensor.empty() : !type
-  %1 = tensor.empty() : !type
-  %x = linalg.generic #trait outs(%0 : !type) {
-  ^bb0(%arg: f32):
-    linalg.yield %cst1 : f32
-  } -> !type
-  %y = linalg.generic #trait outs(%0 : !type) {
-  ^bb0(%arg: f32):
-    linalg.yield %cst0 : f32
-  } -> !type
+  
+  %x_ptr = util.global.address @"rhs" : !util.ptr<!type>  
+  %x = util.global.load.indirect %x_ptr : !util.ptr<!type> -> !type  
+  %y_ptr = util.global.address @"lhs" : !util.ptr<!type2>  
+  %y = util.global.load.indirect %y_ptr : !util.ptr<!type2> -> !type2
+
   // Note: Two linalg.generics to fill the tensors will make IREE generate two
   // separate kernels for the above and the below. It is important to validate
   // the results.
-  %2 = linalg.generic #trait2 ins(%x : !type) outs(%y : !type) {
+  %2 = linalg.generic #trait2 ins(%x : !type) outs(%y : !type2) {
   ^bb0(%arg3: f32, %arg4: f32):
     %3 = arith.addf %arg3, %arg4 : f32
     linalg.yield %3 : f32
-  } -> !type
+  } -> !type2
 
-  return %2 : !type
+  return %2 : !type2
 }
 
 // RUN: iree-opt %s --iree-hal-target-backends=cuda \
-/// We must disable collapsing linalg.generic, because transform dialect maps 
-/// dimensions explicitly and is not aware of collapsing
-// RUN:     --iree-flow-form-dispatch-regions-collapse=false \
 // RUN:     --iree-abi-transformation-pipeline \
 // RUN:     --iree-flow-transformation-pipeline  \
 // RUN:     --iree-stream-transformation-pipeline \
@@ -44,7 +42,6 @@ func.func @vecadd2d() -> (!type) {
 // RUN: FileCheck %s --check-prefix=CHECK
 
 // RUN: iree-opt %s --iree-hal-target-backends=cuda \
-// RUN:     --iree-flow-form-dispatch-regions-collapse=false \
 // RUN:     --iree-abi-transformation-pipeline \
 // RUN:     --iree-flow-transformation-pipeline  \
 // RUN:     --iree-stream-transformation-pipeline \
@@ -54,7 +51,6 @@ func.func @vecadd2d() -> (!type) {
 // RUN: FileCheck %s --check-prefix=CHECK-PARTIAL-TILE
 
 // RUN: iree-compile %s --iree-hal-target-backends=cuda \
-// RUN:     --iree-flow-form-dispatch-regions-collapse=false \
 // RUN:     --iree-opt-const-expr-hoisting=false --iree-opt-const-eval=false \
 /// Constant JIT'ing must be disabled because the transform-dialect debug
 /// flags leak to the JIT session, which doesn't know what to do with them.


### PR DESCRIPTION
This is a follow-up PR. #11295 had already implemented the collapsing logic for `linalg.generic` operations in `dispatch.region`. This PR extracts that logic in a new Collapse Pass.

The new pass performs the following steps. The first and third steps here are new compared to the previous one as we are creating the Pass.
1. Finds `linalg.generic` that has no producer in `dispatch.region`, which means there will only be one `linalg.generic` in the region.
2. Collapse dimensions of the tensors in `linalg.generic` if possible
3. Generates new workload region for the collapsed Op and new `dispatch.region`

PR also removes collapse flag and changes a test that was using accordingly.