### PR TITLE
[cmake] Add BUNDLE DESTINATION for runtime binaries

### DIFF
--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -146,12 +146,14 @@ function(iree_cc_binary)
             RENAME ${_RULE_NAME}
             COMPONENT ${_RULE_NAME}
             RUNTIME DESTINATION bin
+            BUNDLE DESTINATION bin
             EXCLUDE_FROM_ALL)
   else()
     install(TARGETS ${_NAME}
       RENAME ${_RULE_NAME}
       COMPONENT ${_RULE_NAME}
-      RUNTIME DESTINATION bin)
+      RUNTIME DESTINATION bin
+      BUNDLE DESTINATION bin)
   endif()
 
   # Setup RPATH if on a Unix-like system. We have two use cases that we are

--- a/build_tools/embed_data/CMakeLists.txt
+++ b/build_tools/embed_data/CMakeLists.txt
@@ -11,7 +11,8 @@ if(NOT CMAKE_CROSSCOMPILING)
 
   install(TARGETS generate_embed_data
           COMPONENT generate_embed_data
-          RUNTIME DESTINATION bin)
+          RUNTIME DESTINATION bin
+          BUNDLE DESTINATION bin)
 
   iree_c_embed_data(
     NAME


### PR DESCRIPTION
These are needed for cross compiling to iOS, which requires building app bundles.

Part of https://github.com/iree-org/iree/discussions/11716