### PR TITLE
[cmake] Disable building cpuinfo binaries

### DIFF
--- a/build_tools/cmake/iree_external_cmake_options.cmake
+++ b/build_tools/cmake/iree_external_cmake_options.cmake
@@ -14,7 +14,7 @@ macro(iree_set_benchmark_cmake_options)
 endmacro()
 
 macro(iree_set_cpuinfo_cmake_options)
-  set(CPUINFO_BUILD_TOOLS ON CACHE BOOL "" FORCE)
+  set(CPUINFO_BUILD_TOOLS OFF CACHE BOOL "" FORCE)
 
   set(CPUINFO_BUILD_BENCHMARKS OFF CACHE BOOL "" FORCE)
   set(CPUINFO_BUILD_UNIT_TESTS OFF CACHE BOOL "" FORCE)


### PR DESCRIPTION
We are calling into libraries; we don't need these binaries. Building them causes issues for iOS cross compilation, as right now cpuinfo are missing BUNDLE DESTINATION for MACOSX_BUNDLE for `install(TARGETS ..)`.

Part of https://github.com/iree-org/iree/discussions/11716