### PR TITLE
Remove build_tf_integrations dep from build_benchmark_tools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -718,7 +718,7 @@ jobs:
   ##############################################################################
 
   build_benchmark_tools:
-    needs: [setup, build_all, build_tf_integrations]
+    needs: [setup, build_all]
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first


### PR DESCRIPTION
`build_benchmark_tools` doesn't need to depend on `build_tf_integrations`.