### PR TITLE
[LLVMGPU] Fix shared memory allocation when packing

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -55,10 +55,13 @@ void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
       offset = globalMemoryOffsetMap[globalOp];
     } else {
       offset = numberOfBytes;
+      if (std::optional<uint64_t> alignment = globalOp.getAlignment()) {
+        offset = llvm::alignTo(offset, *alignment);
+      }
       globalMemoryOffsetMap[globalOp] = offset;
       auto thisarray = globalOp.getType();
       DataLayout dataLayout = DataLayout::closest(addressOfOp);
-      numberOfBytes += dataLayout.getTypeSizeInBits(thisarray) / 8;
+      numberOfBytes = offset + dataLayout.getTypeSizeInBits(thisarray) / 8;
     }
     auto loc = addressOfOp.getLoc();
     builder.setInsertionPoint(addressOfOp);
@@ -138,6 +141,18 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
                      [](int64_t dim) { return dim == ShapedType::kDynamic; })) {
       return failure();
     }
+
+    uint64_t alignement;
+    if (llvm::Optional<uint64_t> alignementInfo = allocOp.getAlignment()) {
+      alignement = alignementInfo.value();
+    } else {
+      // If no alignment specified align at least to the size of an element.
+      Type elType = allocOp.getType().getElementType();
+      if (auto shapeType = elType.dyn_cast<ShapedType>())
+        alignement = shapeType.getSizeInBits() / 8;
+      else
+        alignement = elType.getIntOrFloatBitWidth() / 8;
+    }
     // In CUDA workgroup memory is represented by a global variable.
     MemRefType allocType = allocOp.getType();
     auto funcOp = allocOp->getParentOfType<func::FuncOp>();
@@ -150,7 +165,8 @@ struct ConvertSharedMemAllocOp : public OpRewritePattern<memref::AllocOp> {
         /*sym_visibility=*/rewriter.getStringAttr("private"),
         /*type=*/allocType,
         /*initial_value=*/ElementsAttr(),
-        /*constant=*/false, /*alignment=*/IntegerAttr());
+        /*constant=*/false,
+        /*alignment=*/rewriter.getI64IntegerAttr(alignement));
     symbolTable.insert(global);
 
     rewriter.setInsertionPointToStart(&(*funcOp.getFunctionBody().begin()));


### PR DESCRIPTION
We pack all the allocations into 1 to be able to use dynamic shared memory, we need to respect the alignment of each allocation.