### PR TITLE
Enables visibility controls on IREE exported functions.

### DIFF
--- a/compiler/src/iree/compiler/API2/Embed.h
+++ b/compiler/src/iree/compiler/API2/Embed.h
@@ -19,10 +19,7 @@
 
 #include <stddef.h>
 
-#if (defined(_WIN32) || defined(__CYGWIN__))
-// Visibility annotations disabled.
-#define IREE_EMBED_EXPORTED
-#elif defined(_WIN32) || defined(__CYGWIN__)
+#if defined(_WIN32) || defined(__CYGWIN__)
 // Windows visibility declarations.
 #if IREE_EMBED_BUILDING_LIBRARY
 #define IREE_EMBED_EXPORTED __declspec(dllexport)
@@ -31,7 +28,7 @@
 #endif
 #else
 // Non-windows: use visibility attributes.
-#define IREE_EMBED_EXPORTED __attribute__((visibility("default")))
+#define IREE_EMBED_EXPORTED [[gnu::visibility("default")]]
 #endif
 
 #ifdef __cplusplus

--- a/runtime/src/iree/base/attributes.h
+++ b/runtime/src/iree/base/attributes.h
@@ -13,14 +13,37 @@
 // API/ABI interop
 //===----------------------------------------------------------------------===//
 
+// Visibility controls for exported functions.
+// By default, no visibility controls are defined, but if built with
+// |IREE_API_ENABLE_VISIBILITY|, then any functions marked with IREE_API_EXPORT
+// will have their visibility set such that they will be made visible across
+// a DSO boundary. Further, on Windows, if |IREE_API_BUILDING_LIBRARY| is set,
+// then the symbols will be marked with dllexport. Otherwise, they will be
+// marked dllimport.
+#if IREE_API_ENABLE_VISIBILITY
+#if defined(_WIN32) || defined(__CYGWIN__)
+#if IREE_API_BUILDING_LIBRARY
+#define IREE_API_VISIBILITY_ATTR __declspec(dllexport)
+#else
+#define IREE_API_VISIBILITY_ATTR __declspec(dllimport)
+#endif
+#else
+// Non-windows: use visibility attributes.
+#define IREE_API_VISIBILITY_ATTR [[gnu::visibility("default")]]
+#endif
+#else
+// Visibility controls disabled.
+#define IREE_API_VISIBILITY_ATTR
+#endif
+
 // Denotes a method exported by the IREE API.
 // Any call annotated with this will be relatively stable.
 // Calls without this are considered private to the IREE implementation and
 // should not be relied upon.
 #ifdef __cplusplus
-#define IREE_API_EXPORT extern "C"
+#define IREE_API_EXPORT extern "C" IREE_API_VISIBILITY_ATTR
 #else
-#define IREE_API_EXPORT
+#define IREE_API_EXPORT IREE_API_VISIBILITY_ATTR
 #endif  // __cplusplus
 
 // Denotes a function pointer that is exposed as part of the IREE API.


### PR DESCRIPTION
This is not used by the core project but allows external integrators to build the runtime library with hidden visibility and explicit control on when to override that.