### PR TITLE
Default instance group updates to 'opportunistic replace'

### DIFF
--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -268,6 +268,7 @@ def parse_args():
   )
   subparser_base.add_argument(
       "--mode",
+      default="opportunistic",
       choices=["opportunistic", "proactive"],
       help=(
           "The mode in which to update instances. See README and"
@@ -275,7 +276,6 @@ def parse_args():
       ))
   subparser_base.add_argument(
       "--action",
-      default="refresh",
       choices=["refresh", "restart", "replace"],
       help=(
           "What action to take when updating an instance. See README and"
@@ -345,8 +345,8 @@ def parse_args():
   for sp in [canary_sp, direct_sp]:
     sp.add_argument(
         "--version",
-        help=("The new instance template version. Usually git hash + ISO date +"
-              " timestamp, e.g. b213037174-2022-09-06-1662502818"))
+        help=("The new instance template version. Usually git hash +"
+              " 3-character uid, e.g. 56e40f6505-9lp"))
 
   # TODO: Add this argument with a custom parser
   # canary_sp.add_argument("--canary-size", type=int, default=1)
@@ -356,11 +356,11 @@ def parse_args():
   if args.skip_confirmation is None:
     args.skip_confirmation = args.env == TESTING_ENV_NAME
 
-  if args.mode is None:
-    if args.action == "refresh":
-      args.mode = "proactive"
+  if args.action is None:
+    if args.mode == "proactive":
+      args.action = "refresh"
     else:
-      args.mode = "opportunistic"
+      args.action = "replace"
 
   return args
 

--- a/build_tools/github_actions/runner/instance_deleter/main.py
+++ b/build_tools/github_actions/runner/instance_deleter/main.py
@@ -42,6 +42,7 @@ you'll get an error:
     > /tmp/token.txt
 
 To deploy:
+  # Note timeout should be greater than STABILIZE_TIMEOUT_SECONDS
   gcloud functions deploy instance-self-deleter \
     --gen2 \
     --runtime=python310 \
@@ -52,7 +53,7 @@ To deploy:
     --run-service-account=managed-instance-deleter@iree-oss.iam.gserviceaccount.com \
     --service-account=managed-instance-deleter@iree-oss.iam.gserviceaccount.com \
     --ingress-settings=internal-only \
-    --timeout=30s \
+    --timeout=120s \
     --set-env-vars ALLOWED_MIG_PATTERN='github-runner-.*'
 
 
@@ -79,6 +80,7 @@ AUTH_HEADER_PREFIX = "Bearer "
 ALLOWED_HTTP_METHODS = ["DELETE", "GET"]
 MIG_METADATA_KEY = "created-by"
 ALLOWED_MIG_PATTERN_ENV_VARIABLE = "ALLOWED_MIG_PATTERN"
+# Must be less than timeout configuration for deployment
 STABILIZE_TIMEOUT_SECONDS = 100
 
 instances_client = compute.InstancesClient()


### PR DESCRIPTION
This used 'proactive refresh' previously to get around the bug/feature
in MIGs that recreation of VMs because they are unhealthy doesn't apply
any pending updates. Now that we have our workaround to have the VMs get
deleted through the MIG API, updates actually will get applied.
Replacing the VM is necessary for several update operations (e.g. stuff
with disks and policies). Our most common changes are just metadata
changes so they can be applied with refresh, but they actually don't take
effect until the VM restarts, so it's misleading to show the update as
having been applied.

Also fixed some comments and help text in this and the instance_deleter.
