### PR TITLE
Modify aggressive fusion heuristics to not create ops where reduction ops also return intermediate results.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fusion_of_tensor_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/fusion_of_tensor_ops.mlir
@@ -46,18 +46,24 @@ func.func @softmax(%arg0 : tensor<12x128x128xf32>) -> tensor<12x128x128xf32> {
 //       CHECK:   %[[FILL0:.+]] = linalg.fill
 //  CHECK-SAME:       outs(%[[INIT0]] :
 //       CHECK:   %[[GENERIC0:.+]] = linalg.generic
+//  CHECK-SAME:       ["parallel", "parallel", "reduction"]
 //  CHECK-SAME:       ins(%[[ARG0]] :
 //  CHECK-SAME:       outs(%[[FILL0]] :
 //       CHECK:   %[[INIT1:.+]] = tensor.empty()
+//       CHECK:   %[[GENERIC1:.+]] = linalg.generic
+//  CHECK-SAME:       ["parallel", "parallel", "parallel"]
+//  CHECK-SAME:       ins(%[[ARG0]], %[[GENERIC0]] :
+//  CHECK-SAME:       outs(%[[INIT1]] :
 //       CHECK:   %[[FILL1:.+]] = linalg.fill
 //  CHECK-SAME:       outs(%[[INIT0]] :
-//       CHECK:   %[[GENERIC1:.+]]:2 = linalg.generic
-//  CHECK-SAME:       ins(%[[ARG0]], %[[GENERIC0]] :
-//  CHECK-SAME:       outs(%[[INIT1]], %[[FILL1]] :
 //       CHECK:   %[[GENERIC2:.+]] = linalg.generic
-//  CHECK-SAME:       ins(%[[GENERIC1]]#0, %[[GENERIC1]]#1 :
+//  CHECK-SAME:       ["parallel", "parallel", "reduction"]
+//  CHECK-SAME:       ins(%[[GENERIC1]] :
+//  CHECK-SAME:       outs(%[[FILL1]] :
+//       CHECK:   %[[GENERIC3:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[GENERIC1]], %[[GENERIC2]] :
 //  CHECK-SAME:       outs(%[[INIT1]] :
-//       CHECK:   return %[[GENERIC2]]
+//       CHECK:   return %[[GENERIC3]]
 
 // -----
 


### PR DESCRIPTION
Currently under aggressive fusion, elementwise parallel ops are fused with consumer that are reductions. When the parallel op has other uses the fused op also returns the reduced and non-reduced values. This results in operations that are reductions returning results that have shape similar to the entire iteration space of the op. Such ops are hard to handle in the backend.  This patch avoids creating such ops, but adapts the fusion heuristics to still pull these ops into the same dispatch.