### PR TITLE
[cmake] Set macOS/iOS app bundle properties

### DIFF
--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -197,7 +197,9 @@ function(iree_cc_binary)
   get_target_property(APPLE_BUNDLE ${_NAME} MACOSX_BUNDLE)
   if (APPLE_BUNDLE)
     set_target_properties(${_NAME} PROPERTIES
+      MACOSX_BUNDLE_BUNDLE_NAME "${_RULE_NAME}"
       MACOSX_BUNDLE_GUI_IDENTIFIER "com.google.iree.${_RULE_NAME}"
+      MACOSX_BUNDLE_COPYRIGHT "Copyright © 2023 The IREE Authors"
       # These are just placeholder version numbers until we define proper
       # version scheme and support.
       MACOSX_BUNDLE_BUNDLE_VERSION 0.1

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -192,4 +192,16 @@ function(iree_cc_binary)
       )
     endif()
   endif()
+
+  # Set up Info.plist properties when building macOS/iOS app bundles.
+  get_target_property(APPLE_BUNDLE ${_NAME} MACOSX_BUNDLE)
+  if (APPLE_BUNDLE)
+    set_target_properties(${_NAME} PROPERTIES
+      MACOSX_BUNDLE_GUI_IDENTIFIER "com.google.iree.${_RULE_NAME}"
+      # These are just placeholder version numbers until we define proper
+      # version scheme and support.
+      MACOSX_BUNDLE_BUNDLE_VERSION 0.1
+      MACOSX_BUNDLE_SHORT_VERSION_STRING 0.1
+      MACOSX_BUNDLE_LONG_VERSION_STRING 0.1)
+  endif()
 endfunction()


### PR DESCRIPTION
These properties are needed to generate `Info.plist` associated with macOS/iOS apps.

Fixes https://github.com/iree-org/iree/issues/11733