### PR TITLE
[cmake] Disable debug print with generator expression for Xcode

### DIFF
--- a/build_tools/cmake/iree_cc_library.cmake
+++ b/build_tools/cmake/iree_cc_library.cmake
@@ -330,8 +330,12 @@ function(iree_cc_unified_library)
   set(_LIBS "$<REMOVE_DUPLICATES:$<GENEX_EVAL:$<TARGET_PROPERTY:${_RULE_ROOT},INTERFACE_IREE_TRANSITIVE_OBJECT_LIBS>>>")
 
   # For debugging, write out evaluated objects to a file.
-  file(GENERATE OUTPUT "${_RULE_NAME}.$<CONFIG>.contents.txt" CONTENT
-    "OBJECTS:\n${_OBJECTS}\n\nLIBS:\n${_LIBS}\n")
+  # This cannot be enabled for Xcode given that Xcode does not support
+  # per-configuration sources.
+  if (NOT "${CMAKE_GENERATOR}" STREQUAL "Xcode")
+    file(GENERATE OUTPUT "${_RULE_NAME}.$<CONFIG>.contents.txt" CONTENT
+      "OBJECTS:\n${_OBJECTS}\n\nLIBS:\n${_LIBS}\n")
+  endif()
   if(_RULE_SHARED)
     add_library(${_NAME} SHARED ${_OBJECTS})
   else()


### PR DESCRIPTION
This fixes the following error when configuring CMake with `-G Xcode`

```
CMake Error at build_tools/cmake/iree_cc_library.cmake:333 (file):
  Error evaluating generator expression:

    $<TARGET_OBJECTS:iree_runtime_impl.objects>

  The evaluation of the TARGET_OBJECTS generator expression is only suitable
  for consumption by CMake (limited under Xcode with multiple architectures).
  It is not suitable for writing out elsewhere.
```

With it, now we can use the `Xcode` generator for CMake.