### PR TITLE
Bump website copyright year to 2023.

### DIFF
--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -65,7 +65,7 @@ extra:
 extra_css:
   - assets/stylesheets/extra.css
 
-copyright: Copyright &copy; 2022 The IREE Authors
+copyright: Copyright &copy; 2023 The IREE Authors
 
 markdown_extensions:
   - abbr


### PR DESCRIPTION
We don't bump the copyright year for source code files, but this is useful to keep current and show that the project is under active development.

See also: https://github.com/iree-org/iree/commit/6f4112eb79c8b1a730da333200638ac09611f1f5 for 2022, and the discussion about that [here on Discord](https://discord.com/channels/689900678990135345/692052262494797835/1026729012095107082).