### PR TITLE
Cherry-pick upstream transform dialect

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -216,7 +216,7 @@ static void addConverToDPSPatterns(RewritePatternSet &patterns) {
 }
 
 DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
-    Operation *target, SmallVectorImpl<Operation *> &results,
+    Operation *target, transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   if (!target->hasTrait<OpTrait::IsIsolatedFromAbove>()) {
     return mlir::emitDefiniteFailure(
@@ -256,7 +256,7 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
   if (failed(listenerResult))
     return mlir::emitDefiniteFailure(target, "listener tracking failed");
 
-  results.assign({target});
+  results.push_back(target);
   return DiagnosedSilenceableFailure::success();
 }
 
@@ -442,7 +442,7 @@ LogicalResult rewriteForeachThreadToWorkgroup(
 
 DiagnosedSilenceableFailure
 transform_dialect::ForeachThreadToWorkgroupOp::applyToOne(
-    func::FuncOp target, SmallVectorImpl<Operation *> &results,
+    func::FuncOp target, transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   if (!isa<HAL::ExecutableOp, HAL::ExecutableVariantOp>(state.getTopLevel())) {
     return mlir::emitDefiniteFailure(
@@ -484,7 +484,7 @@ transform_dialect::ForeachThreadToWorkgroupOp::applyToOne(
                                      "rewriteForeachThreadToWorkgroup failed");
   }
 
-  results.assign({target});
+  results.push_back(target);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -103,7 +103,7 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::Operation *target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -266,7 +266,7 @@ def ForeachThreadToWorkgroupOp : Op<Transform_Dialect,
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::func::FuncOp target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -98,7 +98,7 @@ def MapNestedForeachThreadToGpuThreadsOp :
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::func::FuncOp target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -203,7 +203,7 @@ def VectorToWarpExecuteOnLane0Op : Op<Transform_Dialect, "iree.vector.to_warp_ex
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::scf::IfOp target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -311,7 +311,7 @@ def VectorWarpDistributionOp : Op<Transform_Dialect, "iree.vector.warp_distribut
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::Operation *target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -460,7 +460,7 @@ rewriteForeachThreadToFlowDispatchWorkgroups(
 
 DiagnosedSilenceableFailure
 transform_dialect::ForeachThreadToFlowDispatchWorkgroupsOp::applyToOne(
-    scf::ForeachThreadOp target, SmallVectorImpl<Operation *> &results,
+    scf::ForeachThreadOp target, transform::ApplyToEachResultList &results,
     transform::TransformState &) {
   SimplePatternRewriter rewriter(target->getContext());
   FailureOr<Flow::DispatchWorkgroupsOp> result =
@@ -478,7 +478,7 @@ void transform_dialect::ForeachThreadToFlowDispatchWorkgroupsOp::getEffects(
 }
 
 DiagnosedSilenceableFailure transform_dialect::RegionToWorkgroupsOp::applyToOne(
-    Flow::DispatchRegionOp target, SmallVectorImpl<Operation *> &results,
+    Flow::DispatchRegionOp target, transform::ApplyToEachResultList &results,
     transform::TransformState &) {
   IRRewriter rewriter(target->getContext());
   FailureOr<Flow::DispatchWorkgroupsOp> result =
@@ -827,7 +827,7 @@ void transform_dialect::MoveSucceedingOpIntoDispatchRegionOp::getEffects(
 
 DiagnosedSilenceableFailure
 transform_dialect::WrapInDispatchRegionOp::applyToOne(
-    Operation *target, SmallVectorImpl<Operation *> &results,
+    Operation *target, transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   IRRewriter rewriter(target->getContext());
   Optional<Flow::WorkloadBuilder> workloadBuilder = std::nullopt;

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -47,7 +47,7 @@ def ForeachThreadToFlowDispatchWorkgroupsOp : Op<Transform_Dialect, "iree.foreac
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::scf::ForeachThreadOp target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -78,7 +78,7 @@ def RegionToWorkgroupsOp : Op<Transform_Dialect, "iree.region_to_workgroups",
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::iree_compiler::IREE::Flow::DispatchRegionOp target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -111,7 +111,7 @@ def WrapInDispatchRegionOp : Op<
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::Operation *target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.td
@@ -60,7 +60,7 @@ def RewriteForeachThreadToAsyncOp :
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::scf::ForeachThreadOp target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }
@@ -96,7 +96,7 @@ def RewriteForeachThreadToScfForOp :
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
         ::mlir::scf::ForeachThreadOp target,
-        ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+        ::mlir::transform::ApplyToEachResultList &results,
         ::mlir::transform::TransformState &state);
   }];
 }

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.td
@@ -166,8 +166,8 @@ def MatchCallbackOp :
 
   let arguments = (ins StrAttr:$callback_name,
                        FailurePropagationMode:$failure_propagation_mode,
-                       Variadic<TransformTypeInterface>:$inputs);
-  let results = (outs Variadic<TransformTypeInterface>:$outputs);
+                       Variadic<TransformHandleTypeInterface>:$inputs);
+  let results = (outs Variadic<TransformHandleTypeInterface>:$outputs);
   let assemblyFormat = "`failures` `(` $failure_propagation_mode `)` "
                        "$callback_name `(` $inputs `)` attr-dict "
                        "`:` functional-type($inputs, $outputs)";
@@ -193,9 +193,9 @@ def TakeFirstOp :
     unsuccessful matches.
   }];
 
-  let arguments = (ins Variadic<TransformTypeInterface>:$inputs);
-  let results = (outs TransformTypeInterface:$first,
-                      TransformTypeInterface:$rest);
+  let arguments = (ins Variadic<TransformHandleTypeInterface>:$inputs);
+  let results = (outs TransformHandleTypeInterface:$first,
+                      TransformHandleTypeInterface:$rest);
   let assemblyFormat =
       "$inputs attr-dict `:` functional-type($inputs, results)";
   let cppNamespace = "mlir::transform_ext";
@@ -210,7 +210,7 @@ def EmitRemarkOp :
     associated with the given handle. This can be used, e.g., for debugging.
   }];
 
-  let arguments = (ins TransformTypeInterface:$handle,
+  let arguments = (ins TransformHandleTypeInterface:$handle,
                        StrAttr:$message);
   let assemblyFormat = "$message `at` $handle attr-dict `:` type($handle)";
   let cppNamespace = "mlir::transform_ext";
@@ -218,7 +218,7 @@ def EmitRemarkOp :
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure applyToOne(
       ::mlir::Operation *target,
-      ::llvm::SmallVectorImpl<::mlir::Operation *> &results,
+      ::mlir::transform::ApplyToEachResultList &results,
       ::mlir::transform::TransformState &state);
   }];
 }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.cpp
@@ -124,7 +124,7 @@ void LinalgExt::FuseProducersOp::print(OpAsmPrinter &p) {
 
 DiagnosedSilenceableFailure
 LinalgExt::RewriteForeachThreadToAsyncOp::applyToOne(
-    scf::ForeachThreadOp target, SmallVectorImpl<Operation *> &results,
+    scf::ForeachThreadOp target, transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   LinalgExt::ForeachThreadOpToAsyncRewriter pattern(this->getContext());
   SimplePatternRewriter rewriter(target);
@@ -132,13 +132,13 @@ LinalgExt::RewriteForeachThreadToAsyncOp::applyToOne(
       pattern.returningMatchAndRewrite(target, rewriter);
   if (failed(result))
     return emitDefaultDefiniteFailure(target);
-  results.assign({*result});
+  results.push_back(*result);
   return DiagnosedSilenceableFailure::success();
 }
 
 DiagnosedSilenceableFailure
 LinalgExt::RewriteForeachThreadToScfForOp::applyToOne(
-    scf::ForeachThreadOp target, SmallVectorImpl<Operation *> &results,
+    scf::ForeachThreadOp target, transform::ApplyToEachResultList &results,
     transform::TransformState &state) {
   LinalgExt::ForeachThreadOpToScfForRewriter pattern(this->getContext());
   SimplePatternRewriter rewriter(target);
@@ -146,7 +146,7 @@ LinalgExt::RewriteForeachThreadToScfForOp::applyToOne(
       pattern.returningMatchAndRewrite(target, rewriter);
   if (failed(result))
     return emitDefaultDefiniteFailure(target);
-  results.assign({*result});
+  results.push_back(*result);
   return DiagnosedSilenceableFailure::success();
 }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/IR/StructuredTransformOpsExt.cpp
@@ -1393,7 +1393,7 @@ void transform_ext::TakeFirstOp::getEffects(
 //===---------------------------------------------------------------------===//
 
 DiagnosedSilenceableFailure transform_ext::EmitRemarkOp::applyToOne(
-    Operation *target, SmallVectorImpl<::mlir::Operation *> &results,
+    Operation *target, mlir::transform::ApplyToEachResultList &results,
     mlir::transform::TransformState &state) {
   for (Operation *payload : state.getPayloadOps(getHandle())) {
     payload->emitRemark(getMessage());


### PR DESCRIPTION
This cherry-picks a group of upstream commits improving the usability and hardening the transform dialect:

* [mlir] verify against nullptr payload in transform dialect
* [mlir] improve error handling in Linalg op splitting
* [mlir] fix use-after-free on error path in transform dialect
* [mlir] adapt TransformEachOpTrait to parameter values
* [mlir] NFC: move DiagnosedSilenceableFailure to Utils in Transform dialect
* [mlir] NFC: rename TransformTypeInterface to TransformHandleTypeInterface
* [mlir] introduce parameters into the transofrm dialect