### PR TITLE
Allow partial subsets of correlated globals to fuse.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fuse_globals.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Transforms/test/fuse_globals.mlir
@@ -24,7 +24,7 @@ func.func @foo(%arg0: index) -> (index, index) {
 util.global private mutable @unfusable0 : index
 // CHECK: util.global private mutable @unfusable1 : index
 util.global private mutable @unfusable1 : index
-func.func @foo(%arg0: index) -> (index, index) {
+func.func @nonuniform_a(%arg0: index) -> (index, index) {
   // CHECK: util.global.store %arg0, @unfusable0 : index
   util.global.store %arg0, @unfusable0 : index
   // CHECK: util.global.store %arg0, @unfusable1 : index
@@ -36,7 +36,7 @@ func.func @foo(%arg0: index) -> (index, index) {
   // CHECK: return %[[VALUE0]], %[[VALUE1]]
   return %0, %1 : index, index
 }
-func.func @bar(%arg0: index) {
+func.func @nonuniform_b(%arg0: index) {
   util.global.store %arg0, @unfusable0 : index
   return
 }
@@ -54,7 +54,7 @@ util.initializer {
 util.global private mutable @unfusableInit0 = 5 : index
 // CHECK: util.global private mutable @unfusableInit1 = 6 : index
 util.global private mutable @unfusableInit1 = 6 : index
-func.func @foo(%arg0: index) -> (index, index) {
+func.func @initializer_mix(%arg0: index) -> (index, index) {
   // CHECK: util.global.store %arg0, @unfusableInit0
   util.global.store %arg0, @unfusableInit0 : index
   // CHECK: util.global.store %arg0, @unfusableInit1
@@ -80,5 +80,32 @@ func.func @fn_a(%arg0: index) {
 }
 func.func @fn_b(%arg0: index) {
   util.global.store %arg0, @unfusableDivergent0 : index
+  return
+}
+
+// -----
+
+// Tests globals that have some subset fusable and some not.
+
+// CHECK: util.global private mutable @fusableSubset0 : index
+util.global private mutable @fusableSubset0 : index
+util.global private mutable @fusableSubset1 : index
+// CHECK: util.global private mutable @unfusableSubset2 : index
+util.global private mutable @unfusableSubset2 : index
+// CHECK: util.initializer
+util.initializer {
+  // CHECK: %[[V:.+]] = arith.constant 4
+  %v = arith.constant 4 : index
+  // CHECK-NEXT: util.global.store %[[V]], @fusableSubset0
+  util.global.store %v, @fusableSubset0 : index
+  util.global.store %v, @fusableSubset1 : index
+  // CHECK-NEXT: util.global.store %[[V]], @unfusableSubset2
+  util.global.store %v, @unfusableSubset2 : index
+  util.initializer.return
+}
+// CHECK: func.func @mutate_unfusable(%[[ARG0:.+]]: index)
+func.func @mutate_unfusable(%arg0: index) {
+  // CHECK: util.global.store %[[ARG0]], @unfusableSubset2
+  util.global.store %arg0, @unfusableSubset2 : index
   return
 }


### PR DESCRIPTION
Previously the fusion pass was being conservative when there was divergence but that can cause issues with downstream IR that requires at least some level of global fusion.

Fixes #11652.