### PR TITLE
Add a few links to the new iOS documentation page.

### DIFF
--- a/docs/website/docs/building-from-source/index.md
+++ b/docs/website/docs/building-from-source/index.md
@@ -11,4 +11,5 @@ compiler or import tools themselves.
 * [Getting started](./getting-started.md)
 * [Bindings and importers](./python-bindings-and-importers.md)
 * [Android cross-compilation](./android.md)
+* [iOS cross-compilation](./ios.md)
 * [RISC-V cross-compilation](./riscv.md)

--- a/docs/website/docs/deployment-configurations/cpu.md
+++ b/docs/website/docs/deployment-configurations/cpu.md
@@ -54,9 +54,9 @@ python -m pip install iree-compiler
 
 Please make sure you have followed the [Getting started][get-started] page
 to build IREE for your host platform and the
-[Android cross-compilation][android-cc] page if you are cross compiling for
-Android. The LLVM (CPU) compiler backend is compiled in by default on all
-platforms.
+[Android cross-compilation][android-cc] or [iOS cross-compilation][ios-cc] page
+if you are cross compiling for a mobile device. The LLVM (CPU) compiler backend
+is compiled in by default on all platforms.
 
 Ensure that the `IREE_TARGET_BACKEND_LLVM_CPU` CMake option is `ON` when
 configuring for the host.
@@ -147,6 +147,7 @@ concrete values.
 <!-- TODO(??): troubleshooting -->
 
 [android-cc]: ../building-from-source/android.md
+[ios-cc]: ../building-from-source/ios.md
 [get-started]: ../building-from-source/getting-started.md
 [llvm]: https://llvm.org/
 [mlir]: https://mlir.llvm.org/


### PR DESCRIPTION
Follow-up to https://github.com/iree-org/iree/pull/11758

Edits are to these pages:
* https://iree-org.github.io/iree/building-from-source/#reference-pages
* https://iree-org.github.io/iree/deployment-configurations/cpu/#build-compiler-from-source