### PR TITLE
FuseProducersOp: emit a definite failure with a message

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.cpp
@@ -55,7 +55,7 @@ LinalgExt::FuseProducersOp::apply(transform::TransformResults &transformResults,
     FailureOr<LinalgExt::FusionResult> result =
         pattern.returningMatchAndRewrite(target, rewriter);
     if (failed(result))
-      return DiagnosedSilenceableFailure::definiteFailure();
+      return emitDefaultDefiniteFailure(target);
 
     // Update the fused operations.
     transformedOps.push_back(result->consumerOp);


### PR DESCRIPTION
Previously, the failed application of the internal pattern would return a definite failure without printing any message, stopping the pass without user-visible feedback.