### PR TITLE
Exclude failing test from Windows CI.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -76,6 +76,8 @@ if [[ "$OSTYPE" =~ ^msys ]]; then
     # TODO(#11077): Fix assert on task->pending_dependency_count atomic
     "iree/tests/e2e/matmul/e2e_matmul_direct_i8_small_ukernel_vmvx_local-task"
     "iree/tests/e2e/matmul/e2e_matmul_direct_f32_small_ukernel_vmvx_local-task"
+    # TODO: fix segfault
+    "iree/tests/e2e/models/check_llvm-cpu_local-task_mobilenetv3_fake_weights.mlir"
     # TODO(#11068): Fix compilation segfault
     "iree/tests/e2e/regression/check_regression_llvm-cpu_lowering_config.mlir"
     # TODO: Fix equality mismatch


### PR DESCRIPTION
This test has been failing consistently on the recently re-enabled Windows CI. I can reproduce the segfault on my local Windows machine, but I haven't yet triaged/debugged it. Rather than disable the entire workflow/job, this just disables the one test that appears to have regressed, so we can continue to evaluate how stable the Windows CI is.