### PR TITLE
Disable timer to stop idle runner

### DIFF
--- a/build_tools/github_actions/runner/config/systemd/system/stop-idle-runner.timer
+++ b/build_tools/github_actions/runner/config/systemd/system/stop-idle-runner.timer
@@ -10,4 +10,6 @@ OnActiveSec=30m
 OnUnitInactiveSec=15m
 
 [Install]
-WantedBy=timers.target runner-setup.target
+WantedBy=timers.target
+# TODO(gcmn): Re-enable once we've debugged this causing actions failures.
+# runner-setup.target

--- a/build_tools/github_actions/runner/config/systemd/system/stop-idle-runner.timer
+++ b/build_tools/github_actions/runner/config/systemd/system/stop-idle-runner.timer
@@ -10,6 +10,8 @@ OnActiveSec=30m
 OnUnitInactiveSec=15m
 
 [Install]
-WantedBy=timers.target
 # TODO(gcmn): Re-enable once we've debugged this causing actions failures.
-# runner-setup.target
+# WantedBy=timers.target runner-setup.target
+# This install command just exists to make it possible to call enable on this
+# without an error (effectively a noop)
+Also=stop-idle-runner.service


### PR DESCRIPTION
I suspect this is implicated in unhelpful GitHub actions server errors
that we saw when it was canaried. I didn't do a complete rollback of
https://github.com/iree-org/iree/pull/11688 because that does some
nice cleanup of systemd services and enables cloud logging for the VM
systemd, which helps a lot with debugging these sorts of issues. I have
not identified the precise cause of the issue, but my best guess is
that a race causes a runner to pick up a job and then get killed.

We need to do a rollout of the latest actions runner version in the
next couple days (https://github.com/iree-org/iree/issues/11554), so
need to push a version without this potential bug.