### PR TITLE
[WIP] Use MaskedVectorOp in the transform script

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
@@ -77,8 +77,6 @@ void mlir::iree_compiler::cpu::buildReductionStrategy(
     auto tileRes = buildTileFuseToScfFor(
         b, val, {}, getAsOpFoldResult(b.getI64ArrayAttr(tileSizes)));
 
-    // Don't know how to mask vectorize reductions yet.
-    if (val == gridReductionH) continue;
     auto vectorTileSizes = strategy.workgroupTileSizes;
     int64_t e = std::min(
         static_cast<int64_t>(strategy.workgroupTileSizes.size()), rank - 1);

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/Debug.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/TransformOps/LinalgTransformOps.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/BuiltinAttributes.h"
@@ -53,7 +54,7 @@ void mlir::iree_compiler::cpu::ReductionStrategy::configure(
   vectorSize = config.vectorSize;
 }
 
-/// Builds the transform IR tiling reductions for CUDA targets. Supports
+/// Builds the transform IR tiling reductions for CPU targets. Supports
 /// reductions in the last dimension, with optional leading and trailing
 /// elementwise operations.
 void mlir::iree_compiler::cpu::buildReductionStrategy(
@@ -73,8 +74,18 @@ void mlir::iree_compiler::cpu::buildReductionStrategy(
     if (rank == 0) continue;
     SmallVector<int64_t> tileSizes(rank - 1, 0);
     tileSizes.push_back(strategy.getVectorSize());
-    buildTileFuseToScfFor(b, val, {},
-                          getAsOpFoldResult(b.getI64ArrayAttr(tileSizes)));
+    auto tileRes = buildTileFuseToScfFor(
+        b, val, {}, getAsOpFoldResult(b.getI64ArrayAttr(tileSizes)));
+
+    // Don't know how to mask vectorize reductions yet.
+    if (val == gridReductionH) continue;
+    auto vectorTileSizes = strategy.workgroupTileSizes;
+    int64_t e = std::min(
+        static_cast<int64_t>(strategy.workgroupTileSizes.size()), rank - 1);
+    for (int64_t i = 0; i < e; ++i)
+      tileSizes[i] = strategy.workgroupTileSizes[i];
+    b.create<transform::MaskedVectorizeOp>(tileRes.tiledOpH, ValueRange{},
+                                           b.getDenseI64ArrayAttr({tileSizes}));
   }
 
   // Step 3-5. Common trailing steps.


### PR DESCRIPTION

At the moment this fails on bufferization of a masked vector.transfer:

```
        %36 = "vector.mask"(%32) ({
          "vector.transfer_write"(%35, %30, %3, %3) {in_bounds = [true, true], operand_segment_sizes = array<i32: 1, 1, 2, 0>, permutation_map = affine_map<(d0, d1) -> (d0, d1)>} : (vector<8x16xf32>, memref<?x?xf32, strided<[4567, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>, index, index) -> ()
          %38 = "bufferization.to_tensor"(%30) : (memref<?x?xf32, strided<[4567, 1], offset: ?>, #hal.descriptor_type<storage_buffer>>) -> tensor<?x?xf32>
          "vector.yield"(%38) : (tensor<?x?xf32>) -> ()
        }) : (vector<8x16xi1>) -> tensor<?x?xf32>
```

Repro using the iree-samples script:
```
(benchmark-transform-create -r -b llvm-cpu  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_elementwise_static f32 123 4567)
```