### PR TITLE
Roll forward stateful loop_emscripten changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1048,7 +1048,7 @@ jobs:
 
   emscripten:
     needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    if: needs.setup.outputs.should-run == 'true'
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1048,7 +1048,7 @@ jobs:
 
   emscripten:
     needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
+    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}

--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -358,6 +358,16 @@ iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
     "-natvis:${IREE_ROOT_DIR}/runtime/iree.natvis"
 )
 
+# Our Emscripten library code uses dynCall, which needs these link flags.
+# TODO(scotttodd): Find a way to refactor this, this is nasty to always set :(
+if(EMSCRIPTEN)
+  iree_select_compiler_opts(IREE_DEFAULT_LINKOPTS
+    ALL
+      "-sDYNCALLS=1"
+      "-sEXPORTED_RUNTIME_METHODS=['dynCall']"
+  )
+endif()
+
 #-------------------------------------------------------------------------------
 # Size-optimized build flags
 #-------------------------------------------------------------------------------

--- a/experimental/web/testing/build_tests.sh
+++ b/experimental/web/testing/build_tests.sh
@@ -59,6 +59,7 @@ emcmake "${CMAKE_BIN?}" -G Ninja .. \
     -DIREE_HAL_EXECUTABLE_LOADER_VMVX_MODULE=ON \
     -DIREE_BUILD_SAMPLES=OFF \
     -DIREE_ENABLE_CPUINFO=OFF \
+    -DIREE_ENABLE_ASAN=OFF \
     -DIREE_BUILD_TESTS=ON
 
 echo "=== Building default targets ==="

--- a/runtime/src/iree/base/loop_emscripten.h
+++ b/runtime/src/iree/base/loop_emscripten.h
@@ -35,7 +35,6 @@ iree_loop_emscripten_ctl(void* self, iree_loop_command_t command,
                          const void* params, void** inout_ptr);
 
 // Returns a loop that uses |data|.
-// TODO(scotttodd): rework structs with "scope" so 2+ loops can exist at once
 static inline iree_loop_t iree_loop_emscripten(iree_loop_emscripten_t* data) {
   iree_loop_t loop = {
       data,

--- a/runtime/src/iree/base/loop_emscripten.js
+++ b/runtime/src/iree/base/loop_emscripten.js
@@ -11,33 +11,112 @@
 //   * https://github.com/evanw/emscripten-library-generator
 //   * https://github.com/emscripten-core/emscripten/tree/main/src
 
-const LibraryLoopEmscripten = {
-  $loop_emscripten_support__postset: 'loop_emscripten_support();',
-  $loop_emscripten_support: function() {
-    class LoopEmscripten {
-      constructor() {
-        // TODO(scotttodd): store state here
+const IreeLibraryLoopEmscripten = {
+  $iree_loop_emscripten_support__postset: 'iree_loop_emscripten_support();',
+  $iree_loop_emscripten_support: function() {
+    const IREE_STATUS_OK = 0;
+    const IREE_STATUS_CODE_MASK = 0x1F;
+    const IREE_STATUS_ABORTED = 10 & IREE_STATUS_CODE_MASK;
+    const IREE_STATUS_OUT_OF_RANGE = 11 & IREE_STATUS_CODE_MASK;
+
+    class LoopCommand {
+      abort() {}
+    }
+
+    // IREE_LOOP_COMMAND_CALL
+    class LoopCommandCall extends LoopCommand {
+      constructor(scope, operationId, callback, user_data, loop) {
+        super();
+
+        this.callback = callback;
+        this.user_data = user_data;
+        this.loop = loop;
+
+        this.timeoutId = setTimeout(() => {
+          Module['dynCall'](
+              'iiii', this.callback, this.user_data, this.loop, IREE_STATUS_OK);
+          // TODO(scotttodd): handle the returned status (sticky failure state?)
+          //     at least free the status so it doesn't leak
+          delete scope.pendingOperations[operationId];
+        }, 0);
       }
 
-      loop_command_call(callback, user_data, loop) {
-        const IREE_STATUS_OK = 0;
+      abort() {
+        clearTimeout(this.timeoutId);
+        Module['dynCall'](
+            'iiii', this.callback, this.user_data, this.loop,
+            IREE_STATUS_ABORTED);
+      }
+    }
 
-        setTimeout(() => {
-          const ret =
-              Module['dynCall_iiii'](callback, user_data, loop, IREE_STATUS_OK);
-          // TODO(scotttodd): handle the returned status (sticky failure state?)
-        }, 0);
+    class LoopEmscriptenScope {
+      constructor() {
+        this.nextOperationId = 0;
 
+        // Dictionary of operationIds -> LoopCommands.
+        this.pendingOperations = {};
+      }
+
+      destroy() {
+        for (const [id, operation] of Object.entries(this.pendingOperations)) {
+          operation.abort();
+          delete this.pendingOperations[id];
+        }
+      }
+
+      command_call(callback, user_data, loop) {
+        // TODO(scotttodd): assert not destroyed to avoid reentrant queueing?
+        const operationId = this.nextOperationId++;
+        this.pendingOperations[operationId] =
+            new LoopCommandCall(this, operationId, callback, user_data, loop);
         return IREE_STATUS_OK;
       }
     }
 
-    const instance = new LoopEmscripten();
-    _loop_command_call = instance.loop_command_call.bind(instance);
-  },
+    class LoopEmscripten {
+      constructor() {
+        this.nextScopeHandle = 0;
 
-  loop_command_call: function() {},
-  loop_command_call__deps: ['$loop_emscripten_support'],
+        // Dictionary of scopeHandles -> LoopEmscriptenScopes.
+        this.scopes = {};
+      }
+
+      iree_loop_allocate_scope() {
+        const scopeHandle = this.nextScopeHandle++;
+        this.scopes[scopeHandle] = new LoopEmscriptenScope();
+        return scopeHandle;
+      }
+
+      iree_loop_free_scope(scope_handle) {
+        if (!(scope_handle in this.scopes)) return;
+
+        const scope = this.scopes[scope_handle];
+        scope.destroy();
+        delete this.scopes[scope_handle];
+      }
+
+      iree_loop_command_call(scope_handle, callback, user_data, loop) {
+        if (!(scope_handle in this.scopes)) return IREE_STATUS_OUT_OF_RANGE;
+
+        const scope = this.scopes[scope_handle];
+        return scope.command_call(callback, user_data, loop);
+      }
+    }
+
+    const instance = new LoopEmscripten();
+    _iree_loop_allocate_scope =
+        instance.iree_loop_allocate_scope.bind(instance);
+    _iree_loop_free_scope = instance.iree_loop_free_scope.bind(instance);
+    _iree_loop_command_call = instance.iree_loop_command_call.bind(instance);
+  },
+  $iree_loop_emscripten_support__deps: ['$dynCall'],
+
+  iree_loop_allocate_scope: function() {},
+  iree_loop_allocate_scope__deps: ['$iree_loop_emscripten_support'],
+  iree_loop_free_scope: function() {},
+  iree_loop_free_scope__deps: ['$iree_loop_emscripten_support'],
+  iree_loop_command_call: function() {},
+  iree_loop_command_call__deps: ['$iree_loop_emscripten_support'],
 }
 
-mergeInto(LibraryManager.library, LibraryLoopEmscripten);
+mergeInto(LibraryManager.library, IreeLibraryLoopEmscripten);

--- a/runtime/src/iree/base/loop_emscripten.js
+++ b/runtime/src/iree/base/loop_emscripten.js
@@ -58,7 +58,8 @@ const IreeLibraryLoopEmscripten = {
       }
 
       destroy() {
-        for (const [id, operation] of Object.entries(this.pendingOperations)) {
+        for (const id in this.pendingOperations) {
+          const operation = this.pendingOperations[id];
           operation.abort();
           delete this.pendingOperations[id];
         }


### PR DESCRIPTION
This is a roll forward of https://github.com/iree-org/iree/pull/11507

Successful CI run: https://github.com/iree-org/iree/actions/runs/3897710708/jobs/6655737094

---

I had been testing locally with [`experimental/web/testing/build_tests.sh`](https://github.com/iree-org/iree/blob/main/experimental/web/testing/build_tests.sh), which sets `-DCMAKE_BUILD_TYPE=RelWithDebInfo`. The CI uses [`build_tools/cmake/build_runtime_emscripten.sh`](https://github.com/iree-org/iree/blob/main/build_tools/cmake/build_runtime_emscripten.sh), which leaves the build type unset and defaults to `Release`. 

Release builds were failing with `SyntaxError: Unexpected token (1:72626)` in `/emsdk/upstream/emscripten/tools/acorn-optimizer.js:1852` with this code: 
![image](https://user-images.githubusercontent.com/4010439/211941096-c2041567-08e7-44bf-b770-ed64b4e76b60.png)

While `for (const [key, value] of Object.entries(object1))` is the recommended way to iterate through an object's enumerable string-keyed property key-value pairs ([source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)), Emscripten does not appear to support that newer syntax out of the box.