### PR TITLE
Adding iree_hal_device_replace_allocator API.

### DIFF
--- a/experimental/rocm/rocm_device.c
+++ b/experimental/rocm/rocm_device.c
@@ -153,6 +153,14 @@ static iree_hal_allocator_t* iree_hal_rocm_device_allocator(
   return device->device_allocator;
 }
 
+static void iree_hal_rocm_replace_device_allocator(
+    iree_hal_device_t* base_device, iree_hal_allocator_t* new_allocator) {
+  iree_hal_rocm_device_t* device = iree_hal_rocm_device_cast(base_device);
+  iree_hal_allocator_retain(new_allocator);
+  iree_hal_allocator_release(device->device_allocator);
+  device->device_allocator = new_allocator;
+}
+
 static iree_status_t iree_hal_rocm_device_query_i64(
     iree_hal_device_t* base_device, iree_string_view_t category,
     iree_string_view_t key, int64_t* out_value) {
@@ -327,6 +335,7 @@ static const iree_hal_device_vtable_t iree_hal_rocm_device_vtable = {
     .id = iree_hal_rocm_device_id,
     .host_allocator = iree_hal_rocm_device_host_allocator,
     .device_allocator = iree_hal_rocm_device_allocator,
+    .replace_device_allocator = iree_hal_rocm_replace_device_allocator,
     .trim = iree_hal_rocm_device_trim,
     .query_i64 = iree_hal_rocm_device_query_i64,
     .create_channel = iree_hal_rocm_device_create_channel,

--- a/runtime/src/iree/hal/device.c
+++ b/runtime/src/iree/hal/device.c
@@ -36,6 +36,13 @@ IREE_API_EXPORT iree_hal_allocator_t* iree_hal_device_allocator(
   return _VTABLE_DISPATCH(device, device_allocator)(device);
 }
 
+IREE_API_EXPORT void iree_hal_device_replace_allocator(
+    iree_hal_device_t* device, iree_hal_allocator_t* new_allocator) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_ASSERT_ARGUMENT(new_allocator);
+  _VTABLE_DISPATCH(device, replace_device_allocator)(device, new_allocator);
+}
+
 IREE_API_EXPORT
 iree_status_t iree_hal_device_trim(iree_hal_device_t* device) {
   IREE_ASSERT_ARGUMENT(device);

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -210,6 +210,14 @@ static iree_hal_allocator_t* iree_hal_cuda_device_allocator(
   return device->device_allocator;
 }
 
+static void iree_hal_cuda_replace_device_allocator(
+    iree_hal_device_t* base_device, iree_hal_allocator_t* new_allocator) {
+  iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
+  iree_hal_allocator_retain(new_allocator);
+  iree_hal_allocator_release(device->device_allocator);
+  device->device_allocator = new_allocator;
+}
+
 static iree_status_t iree_hal_cuda_device_trim(iree_hal_device_t* base_device) {
   iree_hal_cuda_device_t* device = iree_hal_cuda_device_cast(base_device);
   iree_arena_block_pool_trim(&device->block_pool);
@@ -492,6 +500,7 @@ static const iree_hal_device_vtable_t iree_hal_cuda_device_vtable = {
     .id = iree_hal_cuda_device_id,
     .host_allocator = iree_hal_cuda_device_host_allocator,
     .device_allocator = iree_hal_cuda_device_allocator,
+    .replace_device_allocator = iree_hal_cuda_replace_device_allocator,
     .trim = iree_hal_cuda_device_trim,
     .query_i64 = iree_hal_cuda_device_query_i64,
     .create_channel = iree_hal_cuda_device_create_channel,

--- a/runtime/src/iree/hal/drivers/local_sync/sync_device.c
+++ b/runtime/src/iree/hal/drivers/local_sync/sync_device.c
@@ -151,6 +151,14 @@ static iree_hal_allocator_t* iree_hal_sync_device_allocator(
   return device->device_allocator;
 }
 
+static void iree_hal_sync_replace_device_allocator(
+    iree_hal_device_t* base_device, iree_hal_allocator_t* new_allocator) {
+  iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
+  iree_hal_allocator_retain(new_allocator);
+  iree_hal_allocator_release(device->device_allocator);
+  device->device_allocator = new_allocator;
+}
+
 static iree_status_t iree_hal_sync_device_trim(iree_hal_device_t* base_device) {
   iree_hal_sync_device_t* device = iree_hal_sync_device_cast(base_device);
   return iree_hal_allocator_trim(device->device_allocator);
@@ -405,6 +413,7 @@ static const iree_hal_device_vtable_t iree_hal_sync_device_vtable = {
     .id = iree_hal_sync_device_id,
     .host_allocator = iree_hal_sync_device_host_allocator,
     .device_allocator = iree_hal_sync_device_allocator,
+    .replace_device_allocator = iree_hal_sync_replace_device_allocator,
     .trim = iree_hal_sync_device_trim,
     .query_i64 = iree_hal_sync_device_query_i64,
     .create_channel = iree_hal_sync_device_create_channel,

--- a/runtime/src/iree/hal/drivers/local_task/task_device.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_device.c
@@ -180,6 +180,14 @@ static iree_hal_allocator_t* iree_hal_task_device_allocator(
   return device->device_allocator;
 }
 
+static void iree_hal_task_replace_device_allocator(
+    iree_hal_device_t* base_device, iree_hal_allocator_t* new_allocator) {
+  iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
+  iree_hal_allocator_retain(new_allocator);
+  iree_hal_allocator_release(device->device_allocator);
+  device->device_allocator = new_allocator;
+}
+
 static iree_status_t iree_hal_task_device_trim(iree_hal_device_t* base_device) {
   iree_hal_task_device_t* device = iree_hal_task_device_cast(base_device);
 
@@ -424,6 +432,7 @@ static const iree_hal_device_vtable_t iree_hal_task_device_vtable = {
     .id = iree_hal_task_device_id,
     .host_allocator = iree_hal_task_device_host_allocator,
     .device_allocator = iree_hal_task_device_allocator,
+    .replace_device_allocator = iree_hal_task_replace_device_allocator,
     .trim = iree_hal_task_device_trim,
     .query_i64 = iree_hal_task_device_query_i64,
     .create_channel = iree_hal_task_device_create_channel,

--- a/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vulkan_device.cc
@@ -1039,6 +1039,14 @@ static iree_hal_allocator_t* iree_hal_vulkan_device_allocator(
   return device->device_allocator;
 }
 
+static void iree_hal_vulkan_replace_device_allocator(
+    iree_hal_device_t* base_device, iree_hal_allocator_t* new_allocator) {
+  iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
+  iree_hal_allocator_retain(new_allocator);
+  iree_hal_allocator_release(device->device_allocator);
+  device->device_allocator = new_allocator;
+}
+
 static iree_status_t iree_hal_vulkan_device_trim(
     iree_hal_device_t* base_device) {
   iree_hal_vulkan_device_t* device = iree_hal_vulkan_device_cast(base_device);
@@ -1332,6 +1340,7 @@ const iree_hal_device_vtable_t iree_hal_vulkan_device_vtable = {
     /*.id=*/iree_hal_vulkan_device_id,
     /*.host_allocator=*/iree_hal_vulkan_device_host_allocator,
     /*.device_allocator=*/iree_hal_vulkan_device_allocator,
+    /*.replace_device_allocator=*/iree_hal_vulkan_replace_device_allocator,
     /*.trim=*/iree_hal_vulkan_device_trim,
     /*.query_i64=*/iree_hal_vulkan_device_query_i64,
     /*.create_channel=*/iree_hal_vulkan_device_create_channel,

--- a/runtime/src/iree/hal/utils/deferred_command_buffer.c
+++ b/runtime/src/iree/hal/utils/deferred_command_buffer.c
@@ -33,7 +33,9 @@ typedef enum iree_hal_command_type_e {
 
 // Header prefixed to all commands, forming a linked-list.
 //
-// Each command is allocated from the arena and does *not* retain any resources.
+// Each command is allocated from the arena and does *not* retain any resources;
+// the command buffer has a resource set that does lifetime tracking.
+//
 // We could elide some of these commands by keeping local state however that
 // requires knowing more about the target device (pipeline layouts, etc) and
 // prevents using this as a way to debug or benchmark command buffers. The

--- a/runtime/src/iree/hal/utils/deferred_command_buffer.h
+++ b/runtime/src/iree/hal/utils/deferred_command_buffer.h
@@ -25,9 +25,8 @@ typedef struct iree_arena_block_pool_t iree_arena_block_pool_t;
 //
 // Argument arrays (like push constants) and host buffers (like the source
 // buffer in iree_hal_command_buffer_update_buffer) that usually live on the
-// stack will be cloned. As with all command buffers the resources (buffers,
-// events, etc) referenced will not be retained and the caller must ensure that
-// all resource lifetimes outlive the command buffer.
+// stack will be cloned. All resources used will be referenced until the command
+// buffer is reset or released.
 //
 // |block_pool| will be used to allocate the underlying storage and the blocks
 // will be retained until the command buffer is reset or released, or if


### PR DESCRIPTION
This allows for wrapping base device allocators in shims that can specialize allocation logic. It's a dangerous method but for drivers that have specific requirements on their base allocators such as internal dependencies on device handles (Vulkan/CUDA/etc) it's difficult to allow for pure allocator injection on device creation.

Users can now inject their own custom device allocators when managing devices themselves and as we add supported upstream ones we can use them in tools based on the new `--device_allocator=` flag.