### PR TITLE
Commonolize implementation of transform interpreters

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -73,7 +73,6 @@ iree_compiler_cc_library(
         # IR
         "@llvm-project//mlir:Analysis",
         "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:Rewrite",
         # Interfaces
@@ -85,6 +84,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:VectorTransforms",
         # Other Stuff
         "//compiler/src/iree/compiler/Codegen:PassHeaders",
+        "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:DialectUtils",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -51,7 +51,6 @@ iree_cc_library(
     MLIRMemRefTransformOps
     MLIRPDLDialect
     MLIRPDLInterpDialect
-    MLIRParser
     MLIRPass
     MLIRRewrite
     MLIRSCFDialect
@@ -72,6 +71,7 @@ iree_cc_library(
     iree::compiler::Codegen::TransformDialectStrategies::Common::TransformDialectStrategies
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::Flow::TransformExtensions::FlowExtensions
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -8,7 +8,7 @@
 #include "iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
-#include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h"
+#include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterPassBase.h"
 #include "iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h"
 #include "iree/compiler/Codegen/LLVMCPU/TransformExtensions/LLVMCPUExtensions.h"
 #include "iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensions.h"

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -16,16 +16,6 @@
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/ADT/ScopeExit.h"
-#include "llvm/Support/Debug.h"
-#include "llvm/Support/Error.h"
-#include "llvm/Support/ErrorHandling.h"
-#include "llvm/Support/FileSystem.h"
-#include "llvm/Support/FormatVariadic.h"
-#include "llvm/Support/Path.h"
-#include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/raw_ostream.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Affine/TransformOps/AffineTransformOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
@@ -48,74 +38,12 @@
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/Transforms/BufferizableOpInterfaceImpl.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
-#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
 #include "mlir/Dialect/Vector/Transforms/BufferizableOpInterfaceImpl.h"
-#include "mlir/Parser/Parser.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassRegistry.h"
-#include "mlir/Support/FileUtilities.h"
-
-#define DEBUG_TYPE "iree-transform-dialect-interpreter"
-#define DEBUG_TYPE_DUMP_STDERR "iree-transform-dialect-dump-repro"
-#define DEBUG_TYPE_DUMP_FILE "iree-transform-dialect-save-repro"
-#define DBGS() (llvm::dbgs() << "[" DEBUG_TYPE "]: ")
 
 using namespace mlir;
-
-/// Finds the single top-level transform operation with `root` as ancestor.
-/// Reports an error if there is more than one such operation and returns the
-/// first one found. Reports an error returns nullptr if no such operation
-/// found.
-static Operation *findTopLevelTransform(Operation *root, StringRef debugStr) {
-  transform::TransformOpInterface topLevelTransform = nullptr;
-  WalkResult walkResult = root->walk<WalkOrder::PreOrder>(
-      [&](transform::TransformOpInterface transformOp) {
-        if (!topLevelTransform) {
-          topLevelTransform = transformOp;
-          return WalkResult::skip();
-        }
-        auto diag = transformOp.emitError()
-                    << "more than one top-level transform op";
-        diag.attachNote(topLevelTransform.getLoc())
-            << "previous top-level transform op";
-        return WalkResult::interrupt();
-      });
-  if (walkResult.wasInterrupted()) return nullptr;
-  if (!topLevelTransform) {
-    auto diag = root->emitError()
-                << "could not find a nested top-level transform op";
-    diag.attachNote() << "use the '" << debugStr
-                      << "' option to provide transform as external file";
-    return nullptr;
-  }
-  return topLevelTransform;
-}
-
-/// Finds an operation nested in `root` that has the transform dialect tag
-/// attribute with the value specified as `tag`. Assumes only one operation
-/// may have the tag. Returns nullptr if there is no such operation.
-static Operation *findOpWithTag(Operation *root, StringRef tagKey,
-                                StringRef tagValue) {
-  Operation *found = nullptr;
-  root->walk<WalkOrder::PreOrder>([tagKey, tagValue, &found](Operation *op) {
-    auto attr = op->getAttrOfType<StringAttr>(tagKey);
-    if (!attr || attr.getValue() != tagValue) return WalkResult::advance();
-
-    assert(found == nullptr && "more than one op with the same tag");
-    found = op;
-
-    // In debug mode, continue the traversal to see if the tag is not
-    // duplicated.
-#ifndef NDEBUG
-    return WalkResult::advance();
-#else
-    return WalkResult::interrupt();
-#endif  // NDEBUG
-  });
-  return found;
-}
 
 namespace {
 
@@ -124,8 +52,9 @@ namespace {
 /// This needs to be its own pass because the registration mechanism and ops
 /// available are different than for other interpreters.
 class TransformDialectInterpreterPass
-    : public iree_compiler::TransformDialectInterpreterBase<
-          TransformDialectInterpreterPass> {
+    : public transform::TransformInterpreterPassBase<
+          TransformDialectInterpreterPass,
+          iree_compiler::TransformDialectInterpreterBase> {
  public:
   void getDependentDialects(DialectRegistry &registry) const override {
     // TODO: this is only necessary to make registry subset happy when running
@@ -185,281 +114,10 @@ class TransformDialectInterpreterPass
     this->debugPayloadRootTag = debugPayloadRootTag.str();
     this->debugTransformRootTag = debugTransformRootTag.str();
   }
-  TransformDialectInterpreterPass(const TransformDialectInterpreterPass &pass) {
-    this->transformFileName = pass.transformFileName;
-    this->debugPayloadRootTag = pass.debugPayloadRootTag;
-    this->debugTransformRootTag = pass.debugTransformRootTag;
-    // TODO: if we really don't like shared_ptr, we could also clone the
-    // transformModule here.
-    sharedTransformModule = pass.sharedTransformModule;
-  }
-
-  LogicalResult initialize(MLIRContext *context) override {
-    OwningOpRef<ModuleOp> module;
-    if (failed(transform::parseTransformModuleFromFile(
-            context, transformFileName, module)))
-      return failure();
-
-    sharedTransformModule =
-        std::make_shared<OwningOpRef<ModuleOp>>(std::move(module));
-    return success();
-  }
-
-  void runOnOperation() override;
-
- private:
-  // Optionally perform debug actions requested by the user to dump IR and a
-  // repro to stderr and/or a fie.
-  void performOptionalDebugActions(Operation *target, Region *transformRegion);
-
-  /// Name of the attribute used for targeting the transform dialect interpreter
-  /// at specific operations.
-  constexpr static llvm::StringLiteral kTransformIreeTagAttrName =
-      "transform.iree_tag";
-  /// Value of the attribute indicating the root payload operation.
-  constexpr static llvm::StringLiteral kTransformIreeTagPayloadRootValue =
-      "iree_payload_root";
-  /// Value of the attribute indicating the container of transform operations
-  /// (containing the top-level transform operation).
-  constexpr static llvm::StringLiteral
-      kTransformIreeTagTransformContainerValue = "iree_transform_container";
-
-  /// Returns the ancestor of `target` that doesn't have a parent.
-  Operation *getRootOperation(Operation *target) {
-    Operation *root = target;
-    while (root->getParentOp()) root = root->getParentOp();
-    return root;
-  }
-
-  /// Prints the CLI command running the repro with the current path.
-  llvm::raw_ostream &printIreeOptReproCall(llvm::raw_ostream &os,
-                                           StringRef rootOpName);
-
-  /// Prints the module rooted at `root` to `os` and appends
-  /// `transformContainer` if it is not nested in `root`.
-  llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os, Operation *root,
-                                         Operation *transformContainer);
-
-  /// Saves the payload and the transform IR into a temporary file and reports
-  /// the file name to `os`.
-  void saveReproToTempFile(llvm::raw_ostream &os, Operation *target,
-                           Operation *transformContainer);
-
-  // The parsed transform module to be used for transformations.
-  // TODO: Figure a better way to build a transform module and transport it in
-  // the proper places in the IR as it is transformed by IREE so that it is
-  // available with better ownership semantics.
-  // Note: we wrap the OwningOpRef to get the desired destruction mechanism.
-  // Note: shared_ptr is not great but we know the sharedTransformModule is
-  // readonly.
-  // Alternatives comprise:
-  //   1. no shared_ptr but copying the module with every pass clone that the
-  //      OpPassManager decides to perform.
-  //   2. lifting ownership of the parsed transform module higher up in the
-  //      IREE stack. This may be only shift the problem as we have passes
-  //      building pass managers in IREE.
-  //   3. build better support to embed the transformation module in the
-  //      input IR and transport it to the place of use in IREE. This is deemed
-  //      too intrusive atm.
-  //   4. (future) config/resources mechanism that is being proposed in core?
-  std::shared_ptr<OwningOpRef<ModuleOp>> sharedTransformModule;
+  TransformDialectInterpreterPass(const TransformDialectInterpreterPass &pass) =
+      default;
 };
 }  // namespace
-
-/// Prints the CLI command running the repro with the current path.
-llvm::raw_ostream &TransformDialectInterpreterPass::printIreeOptReproCall(
-    llvm::raw_ostream &os, StringRef rootOpName) {
-  os << llvm::formatv(
-      "iree-opt "
-      "--pass-pipeline=\"{0}(iree-transform-dialect-interpreter{{{1}={2} "
-      "{3}={4}})\"",
-      rootOpName, debugPayloadRootTag.getArgStr(),
-      debugPayloadRootTag.empty() ? StringRef(kTransformIreeTagPayloadRootValue)
-                                  : debugPayloadRootTag,
-      debugTransformRootTag.getArgStr(),
-      debugTransformRootTag.empty()
-          ? StringRef(kTransformIreeTagTransformContainerValue)
-          : debugTransformRootTag);
-  return os;
-}
-
-/// Prints the module rooted at `root` to `os` and appends
-/// `transformContainer` if it is not nested in `root`.
-llvm::raw_ostream &TransformDialectInterpreterPass::printModuleForRepro(
-    llvm::raw_ostream &os, Operation *root, Operation *transformContainer) {
-  root->print(os);
-  if (!root->isAncestor(transformContainer)) {
-    transformContainer->print(os);
-  }
-  return os;
-}
-
-/// Saves the payload and the transform IR into a temporary file and reports
-/// the file name to `os`.
-void TransformDialectInterpreterPass::saveReproToTempFile(
-    llvm::raw_ostream &os, Operation *target, Operation *transformContainer) {
-  using llvm::sys::fs::TempFile;
-  Operation *root = getRootOperation(target);
-
-  SmallVector<char, 128> tmpPath;
-  llvm::sys::path::system_temp_directory(/*erasedOnReboot=*/true, tmpPath);
-  llvm::sys::path::append(tmpPath, "iree_transform_dialect_%%%%%%.mlir");
-  llvm::Expected<TempFile> tempFile = TempFile::create(tmpPath);
-  if (!tempFile) {
-    os << "could not open temporary file to save the repro\n";
-    return;
-  }
-
-  llvm::raw_fd_ostream fout(tempFile->FD, /*shouldClose=*/false);
-  printModuleForRepro(fout, root, transformContainer);
-  fout.flush();
-  std::string filename = tempFile->TmpName;
-
-  if (tempFile->keep()) {
-    os << "could not preserve the temporary file with the repro\n";
-    return;
-  }
-
-  os << "=== Transform Interpreter Repro ===\n";
-  printIreeOptReproCall(os, root->getName().getStringRef())
-      << " " << filename << "\n";
-  os << "===================================\n";
-}
-
-// Optionally perform debug actions requested by the user to dump IR and a
-// repro to stderr and/or a fie.
-void TransformDialectInterpreterPass::performOptionalDebugActions(
-    Operation *target, Region *transformRegion) {
-  // Add temporary debug / repro attributes, these must never leak out.
-  if (debugPayloadRootTag.empty()) {
-    target->setAttr(
-        kTransformIreeTagAttrName,
-        StringAttr::get(&getContext(), kTransformIreeTagPayloadRootValue));
-  }
-  if (debugTransformRootTag.empty()) {
-    transformRegion->getParentOp()->setAttr(
-        kTransformIreeTagAttrName,
-        StringAttr::get(&getContext(),
-                        kTransformIreeTagTransformContainerValue));
-  }
-
-  DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_STDERR, {
-    Operation *root = getRootOperation(target);
-    llvm::dbgs() << "=== Transform Interpreter Repro ===\n";
-    printIreeOptReproCall(llvm::dbgs() << "cat <<EOF | ",
-                          root->getName().getStringRef());
-    printModuleForRepro(llvm::dbgs(), root, transformRegion->getParentOp());
-    llvm::dbgs() << "\nEOF\n";
-    llvm::dbgs() << "===================================\n";
-  });
-  DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_FILE, {
-    saveReproToTempFile(llvm::dbgs(), target, transformRegion->getParentOp());
-  });
-
-  // Drop the temporary debug / repro attributes, these must never leak out.
-  if (debugTransformRootTag.empty()) {
-    transformRegion->getParentOp()->removeAttr(
-        kTransformIreeTagTransformContainerValue);
-  }
-  if (debugPayloadRootTag.empty()) {
-    target->removeAttr(kTransformIreeTagAttrName);
-  }
-}
-
-void TransformDialectInterpreterPass::runOnOperation() {
-  Operation *target = getOperation();
-  bool parsedTransform = (sharedTransformModule && *sharedTransformModule);
-
-  // Step 1
-  // ------
-  // Get the default payloadRoot and transformRegion that one expects
-  // when running the IREE nested pass pipeline or the interpreter.
-  Operation *payloadRoot = target;
-  Region *transformRegion = nullptr;
-  // If a parsed transform was specified separately, use it immediately.
-  // Otherwise, the transform is embedded in the IR: go inspect the IR and
-  // get the first top-level transform we find.
-  if (parsedTransform) {
-    transformRegion = &(*sharedTransformModule)->getRegion();
-  } else {
-    // TODO: In large IR we will likely want more control in selecting a
-    // particular transform to focus on, this may warrant a user-specified
-    // attribute that one would manually injected in the IR when operating in
-    // interpreted mode.
-    Operation *topLevelTransform =
-        findTopLevelTransform(target, transformFileName.getArgStr());
-    if (!topLevelTransform) return signalPassFailure();
-    transformRegion = topLevelTransform->getParentRegion();
-  }
-  assert(transformRegion && "unexpected detached root transform op");
-
-  // Step 2
-  // ------
-  // Optionally override payloadRoot if the debugPayloadRootTag was passed.
-  //
-  // If debugPayloadRootTag was passed, then we are in user-specified selection
-  // of the transformed IR. This corresponds to REPL debug mode.
-  // Otherwise, just apply to `target`, which is what the IREE nested
-  // pipeline wants to operate on.
-  if (!debugPayloadRootTag.empty()) {
-    payloadRoot =
-        findOpWithTag(target, kTransformIreeTagAttrName, debugPayloadRootTag);
-    if (!payloadRoot) {
-      target->emitError() << "couldn't find the root payload op with "
-                          << kTransformIreeTagAttrName << "=\""
-                          << kTransformIreeTagPayloadRootValue
-                          << "\" attribute";
-      return signalPassFailure();
-    }
-  }
-
-  // Step 3
-  // ------
-  // Optionally override transformRegion if the debugTransformRootTag was
-  // passed.
-  //
-  // If debugTransformRootTag was passed, then we are in user-specified
-  // selection of the transforming IR. This corresponds to REPL debug mode.
-  // Otherwise, just apply to the existing `transformRegion`, which is what
-  // the IREE nested pipeline wants to operate on.
-  if (!debugTransformRootTag.empty()) {
-    Operation *transformRoot =
-        findOpWithTag(transformRegion->getParentOp(), kTransformIreeTagAttrName,
-                      kTransformIreeTagTransformContainerValue);
-    if (!transformRoot) {
-      transformRegion->getParentOp()->emitError()
-          << "couldn't find the transform container op with "
-          << kTransformIreeTagAttrName << "=\""
-          << kTransformIreeTagTransformContainerValue << "\" attribute";
-      return signalPassFailure();
-    }
-    if (transformRoot->getNumRegions() != 1 ||
-        !transformRoot->getRegion(0).hasOneBlock()) {
-      transformRoot->emitError() << "expected transform container op to have "
-                                    "one single-block region";
-      return signalPassFailure();
-    }
-    transformRegion = &transformRoot->getRegion(0);
-  }
-
-  // Step 4
-  // ------
-  // Optionally perform debug actions requested by the user to dump IR and a
-  // repro to stderr and/or a fie.
-  performOptionalDebugActions(target, transformRegion);
-
-  // Step 5
-  // ------
-  // Apply the transform to the IR
-  // TODO: lift this assertion.
-  assert(transformRegion->getBlocks().size() == 1 &&
-         "expected single-region block");
-  if (failed(
-          transform::applyTransformsInRegion(*transformRegion, payloadRoot))) {
-    payloadRoot->emitOpError() << "transform dialect interpreter failed";
-    return signalPassFailure();
-  }
-}
 
 namespace mlir {
 namespace iree_compiler {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
@@ -5,13 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
-#include "iree-dialects/Dialect/LinalgExt/TransformOps/LinalgExtTransformOps.h"
 #include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
 #include "llvm/Support/CommandLine.h"
-#include "llvm/Support/SourceMgr.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
@@ -20,11 +18,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
-#include "mlir/Dialect/Transform/IR/TransformOps.h"
-#include "mlir/Parser/Parser.h"
 #include "mlir/Pass/Pass.h"
-#include "mlir/Pass/PassManager.h"
-#include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LLVM.h"
 
 namespace mlir {
@@ -37,7 +31,8 @@ namespace Flow {
 /// formation. This needs to be its own pass because the registration mechanism
 /// and ops available are different than for other interpreters.
 struct DispatchWithTransformDialect
-    : public DispatchWithTransformDialectBase<DispatchWithTransformDialect> {
+    : public transform::TransformInterpreterPassBase<
+          DispatchWithTransformDialect, DispatchWithTransformDialectBase> {
   void getDependentDialects(DialectRegistry &registry) const override {
     // clang-format off
     registry.insert<mlir::iree_compiler::IREE::LinalgExt::IREELinalgExtDialect,
@@ -54,68 +49,31 @@ struct DispatchWithTransformDialect
     // clang-format on
   }
 
-  DispatchWithTransformDialect(StringRef transformFileName) {
+  DispatchWithTransformDialect(StringRef transformFileName,
+                               StringRef debugPayloadRootTag = StringRef(),
+                               StringRef debugTransformRootTag = StringRef()) {
     this->transformFileName = transformFileName.str();
+    this->debugPayloadRootTag = debugPayloadRootTag.str();
+    this->debugTransformRootTag = debugTransformRootTag.str();
   }
-  DispatchWithTransformDialect(const DispatchWithTransformDialect &pass) {
+  DispatchWithTransformDialect(const DispatchWithTransformDialect &pass)
+      : TransformInterpreterPassBase(pass) {
     this->transformFileName = pass.transformFileName;
-    // TODO: if we really don't like shared_ptr, we could also clone the
-    // transformModule here.
-    sharedTransformModule = pass.sharedTransformModule;
+    this->debugPayloadRootTag = pass.debugPayloadRootTag;
+    this->debugTransformRootTag = pass.debugTransformRootTag;
   }
-  LogicalResult initialize(MLIRContext *context) override;
-  void runOnOperation() override;
 
  private:
   Statistic numDispatches{this, "number of dispatches",
                           "Number of Flow dispatches created"};
-
-  // The parsed transform module to be used for creating dispatches.
-  // TODO: Figure a better way to build a transform module and transport it in
-  // the proper places in the IR as it is transformed by IREE so that it is
-  // available with better ownership semantics.
-  // Note: we wrap the OwningOpRef to get the desired destruction mechanism.
-  // Note: shared_ptr is not great but we know the sharedTransformModule is
-  // readonly.
-  // Alternatives comprise:
-  //   1. no shared_ptr but copying the module with every pass clone that the
-  //      OpPassManager decides to perform.
-  //   2. lifting ownership of the parsed transform module higher up in the
-  //      IREE stack. This may be only shift the problem as we have passes
-  //      building pass managers in IREE.
-  //   3. build better support to embed the transformation module in the
-  //      input IR and transport it to the place of use in IREE. This is deemed
-  //      too intrusive atm.
-  //   4. (future) config/resources mechanism that is being proposed in core?
-  std::shared_ptr<OwningOpRef<ModuleOp>> sharedTransformModule;
 };
 
-LogicalResult DispatchWithTransformDialect::initialize(MLIRContext *context) {
-  OwningOpRef<ModuleOp> module;
-  if (failed(transform::parseTransformModuleFromFile(context, transformFileName,
-                                                     module)))
-    return failure();
-  sharedTransformModule =
-      std::make_shared<OwningOpRef<ModuleOp>>(std::move(module));
-  return success();
-}
-
-void DispatchWithTransformDialect::runOnOperation() {
-  Operation *target = getOperation();
-  bool parsedTransform = (sharedTransformModule && *sharedTransformModule);
-  assert(parsedTransform || (target->getNumRegions() == 1 &&
-                             target->getRegion(0).getBlocks().size() == 1) &&
-                                "Cannot extract transform from op");
-  Region &transformRegion = parsedTransform
-                                ? (*sharedTransformModule)->getRegion()
-                                : target->getRegion(0);
-  if (failed(transform::applyTransformsInRegion(transformRegion, target)))
-    return signalPassFailure();
-}
-
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createDispatchWithTransformDialect(StringRef transformFileName) {
-  return std::make_unique<DispatchWithTransformDialect>(transformFileName);
+createDispatchWithTransformDialect(StringRef transformFileName,
+                                   StringRef debugPayloadRootTag,
+                                   StringRef debugTransformRootTag) {
+  return std::make_unique<DispatchWithTransformDialect>(
+      transformFileName, debugPayloadRootTag, debugTransformRootTag);
 }
 
 }  // namespace Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
-#include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h"
+#include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterPassBase.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -168,7 +168,9 @@ createFormDispatchWorkgroupsPass(bool generateWorkloadRegion = true);
 // that is parsed from `transformFileName`.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createDispatchWithTransformDialect(
-    llvm::StringRef transformFileName = llvm::StringRef());
+    llvm::StringRef transformFileName = llvm::StringRef(),
+    llvm::StringRef debugPayloadRootTag = llvm::StringRef(),
+    llvm::StringRef debugTransformRootTag = llvm::StringRef());
 
 // Captures dynamic shape dimensions required by dispatch operands.
 std::unique_ptr<Pass> createCaptureDispatchDynamicDimsPass();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -102,8 +102,28 @@ def DispatchWithTransformDialect :
   let constructor = "mlir::iree_compiler::IREE::Flow::createDispatchWithTransformDialect()";
 
   let options = [
-    Option<"transformFileName", "transform-file-name", "std::string", /*default=*/"",
-           "File name containing a transform dialect specification to apply.">
+    Option<"transformFileName", "transform-file-name", "std::string",
+            /*default=*/"\"\"",
+            "Optional filename containing a transform dialect specification to "
+            "apply. If left empty, the IR is assumed to contain one top-level "
+            "transform dialect operation somewhere in the module.">,
+    Option<"debugPayloadRootTag", "debug-payload-root-tag", "std::string",
+            /*default=*/"\"\"",
+            "Select the operation with 'transform.iree_tag' attribute having "
+            "the given value as payload IR root. This allows user control on "
+            "what operation to transform in debug mode, without requiring "
+            "intimate knowledge of the IREE nested pass pipeline.\\n"
+            "If empty (normal operation mode), select the pass anchor "
+            "operation in the IREE pipeline, as the payload IR root.">,
+    Option<"debugTransformRootTag", "debug-transform-root-tag", "std::string",
+            /*default=*/"\"\"",
+            "Select the operation with 'transform.iree_tag' attribute having "
+            "the given value as container IR for top-level transform ops. This "
+            "allows user control on what transformation to apply in debug "
+            "mode, without requiring intimate knowledge of the IREE nested "
+            "pass pipeline.\\n"
+            "If empty (normal operation mode), select the container of the "
+            "top-level transform op.">
   ];
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h
@@ -7,19 +7,26 @@
 #ifndef IREE_DIALECTS_LINALG_TRANSFORM_TRANSFORM_INTERPRETER_UTILS_H
 #define IREE_DIALECTS_LINALG_TRANSFORM_TRANSFORM_INTERPRETER_UTILS_H
 
+#include "mlir/Pass/Pass.h"
+#include "mlir/Support/LLVM.h"
 #include <memory>
 
 namespace mlir {
-class Operation;
 class LogicalResult;
+class MLIRContext;
+class ModuleOp;
+class Operation;
+template <typename>
+class OwningOpRef;
+class Region;
+
 namespace transform {
 class TransformOpInterface;
 
 /// Utility to parse the content of a `transformFileName` mlir file containing
 /// a transform dialect specification.
 LogicalResult
-parseTransformModuleFromFile(MLIRContext *context,
-                             llvm::StringRef transformFileName,
+parseTransformModuleFromFile(MLIRContext *context, StringRef transformFileName,
                              OwningOpRef<ModuleOp> &transformModule);
 
 /// Utility to extract the `TransformOpInterface` ops that have the trait
@@ -35,6 +42,114 @@ extractTopLevelTransformOps(Region &r,
 /// applying them.
 LogicalResult applyTransformsInRegion(Region &transformRegion,
                                       Operation *target);
+
+namespace detail {
+/// Template-free implementation of TransformInterpreterPassBase::initialize.
+LogicalResult
+interpreterBaseInitializeImpl(MLIRContext *context, StringRef transformFileName,
+                              std::shared_ptr<OwningOpRef<ModuleOp>> &module);
+
+/// Template-free implementation of
+/// TransformInterpreterPassBase::runOnOperation.
+LogicalResult interpreterBaseRunOnOperationImpl(
+    Operation *target, StringRef passName,
+    const std::shared_ptr<OwningOpRef<ModuleOp>> &sharedTransformModule,
+    const Pass::Option<std::string> &transformFileName,
+    const Pass::Option<std::string> &debugPayloadRootTag,
+    const Pass::Option<std::string> &debugTransformRootTag);
+} // namespace detail
+
+/// Base class for transform dialect interpreter passes that can consume and
+/// dump transform dialect scripts in separate files. The pass is controlled by
+/// three string options:
+///
+///   - transformFileName: if non-empty, the name of the file containing the
+///     transform script. If empty, `debugTransformRootTag` is considered or the
+///     pass root operation must contain a single top-level transform op that
+///     will be interpreted.
+///   - debugPayloadRootTag: if non-empty, the value of the attribute named
+///     `kTransformIreeTagAttrName` indicating the single op that is considered
+///     the payload root of the transform interpreter; otherwise, the root
+///     operation of the pass is used.
+///   - debugTransformRootTag: if non-empty, the value of the attribute named
+///     `kTransformIreeTagAttrName` indicating the single top-level transform
+///     op contained in the payload root to be used as the entry point by the
+///     transform interpreter; mutually exclusive with `transformFileName`.
+///
+/// The pass runs the transform dialect interpreter as directed by the options.
+/// It also provides the mechanism to dump reproducers into stderr
+/// (-debug-only=iree-transform-dialect-dump-repro) or into a temporary file
+/// (-debug-only=iree-transform-dialect-save-repro) that can be used with this
+/// pass in a standalone mode.
+///
+/// Concrete passes must derive from this class instead of their generated base
+/// class (or PassWrapper), and supply themselves and the generated base class
+/// as template arguments. They are *not* expected to to implement `initialize`
+/// or `runOnOperation`. They *are* expected to call the copy constructor of
+/// this class in their copy constructors, short of which the file-based
+/// transform dialect script injection facility will become nonoperational.
+template <typename Concrete, template <typename> typename GeneratedBase>
+class TransformInterpreterPassBase : public GeneratedBase<Concrete> {
+public:
+  TransformInterpreterPassBase() = default;
+
+  TransformInterpreterPassBase(const TransformInterpreterPassBase &pass) {
+    // TODO: if we really don't like shared_ptr, we could also clone the
+    // transformModule here.
+    sharedTransformModule = pass.sharedTransformModule;
+  }
+
+  LogicalResult initialize(MLIRContext *context) final {
+
+#define REQUIRE_PASS_OPTION(NAME)                                              \
+  static_assert(                                                               \
+      std::is_same_v<                                                          \
+          std::remove_reference_t<decltype(std::declval<Concrete &>().NAME)>,  \
+          Pass::Option<std::string>>,                                          \
+      "required " #NAME " string pass option is missing")
+
+    REQUIRE_PASS_OPTION(transformFileName);
+    REQUIRE_PASS_OPTION(debugPayloadRootTag);
+    REQUIRE_PASS_OPTION(debugTransformRootTag);
+
+#undef REQUIRE_PASS_OPTION
+
+    StringRef transformFileName =
+        static_cast<Concrete *>(this)->transformFileName;
+    return detail::interpreterBaseInitializeImpl(context, transformFileName,
+                                  sharedTransformModule);
+  }
+
+  void runOnOperation() final {
+    auto *pass = static_cast<Concrete *>(this);
+    if (failed(detail::interpreterBaseRunOnOperationImpl(
+            pass->getOperation(), pass->getArgument(), sharedTransformModule,
+            pass->transformFileName, pass->debugPayloadRootTag,
+            pass->debugTransformRootTag)))
+      return pass->signalPassFailure();
+  }
+
+private:
+  // The parsed transform module to be used for transformations.
+  // TODO: Figure a better way to build a transform module and transport it in
+  // the proper places in the IR as it is transformed by IREE so that it is
+  // available with better ownership semantics.
+  // Note: we wrap the OwningOpRef to get the desired destruction mechanism.
+  // Note: shared_ptr is not great but we know the sharedTransformModule is
+  // readonly.
+  // Alternatives comprise:
+  //   1. no shared_ptr but copying the module with every pass clone that the
+  //      OpPassManager decides to perform.
+  //   2. lifting ownership of the parsed transform module higher up in the
+  //      IREE stack. This may be only shift the problem as we have passes
+  //      building pass managers in IREE.
+  //   3. build better support to embed the transformation module in the
+  //      input IR and transport it to the place of use in IREE. This is deemed
+  //      too intrusive atm.
+  //   4. (future) config/resources mechanism that is being proposed in core?
+  std::shared_ptr<OwningOpRef<ModuleOp>> sharedTransformModule = nullptr;
+};
+
 } // namespace transform
 } // namespace mlir
 #endif // IREE_DIALECTS_LINALG_TRANSFORM_TRANSFORM_INTERPRETER_UTILS_H

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(IREELinalgTransformDialectPasses
   ExpertExpansion.cpp
   TransformInterpreter.cpp
+  TransformInterpreterPassBase.cpp
 
   DEPENDS
   mlir-headers

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreterPassBase.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreterPassBase.cpp
@@ -1,0 +1,321 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterUtils.h"
+#include "mlir/Dialect/Transform/IR/TransformInterfaces.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/Support/FileSystem.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "llvm/Support/Path.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+#define DEBUG_TYPE_DUMP_STDERR "iree-transform-dialect-dump-repro"
+#define DEBUG_TYPE_DUMP_FILE "iree-transform-dialect-save-repro"
+
+/// Name of the attribute used for targeting the transform dialect interpreter
+/// at specific operations.
+constexpr static llvm::StringLiteral kTransformIreeTagAttrName =
+    "transform.iree_tag";
+/// Value of the attribute indicating the root payload operation.
+constexpr static llvm::StringLiteral kTransformIreeTagPayloadRootValue =
+    "iree_payload_root";
+/// Value of the attribute indicating the container of transform operations
+/// (containing the top-level transform operation).
+constexpr static llvm::StringLiteral kTransformIreeTagTransformContainerValue =
+    "iree_transform_container";
+
+/// Finds the single top-level transform operation with `root` as ancestor.
+/// Reports an error if there is more than one such operation and returns the
+/// first one found. Reports an error returns nullptr if no such operation
+/// found.
+static Operation *findTopLevelTransform(Operation *root, StringRef debugStr) {
+  ::mlir::transform::TransformOpInterface topLevelTransform = nullptr;
+  WalkResult walkResult = root->walk<WalkOrder::PreOrder>(
+      [&](::mlir::transform::TransformOpInterface transformOp) {
+        if (!topLevelTransform) {
+          topLevelTransform = transformOp;
+          return WalkResult::skip();
+        }
+        auto diag = transformOp.emitError()
+                    << "more than one top-level transform op";
+        diag.attachNote(topLevelTransform.getLoc())
+            << "previous top-level transform op";
+        return WalkResult::interrupt();
+      });
+  if (walkResult.wasInterrupted())
+    return nullptr;
+  if (!topLevelTransform) {
+    auto diag = root->emitError()
+                << "could not find a nested top-level transform op";
+    diag.attachNote() << "use the '" << debugStr
+                      << "' option to provide transform as external file";
+    return nullptr;
+  }
+  return topLevelTransform;
+}
+
+/// Finds an operation nested in `root` that has the transform dialect tag
+/// attribute with the value specified as `tag`. Assumes only one operation
+/// may have the tag. Returns nullptr if there is no such operation.
+static Operation *findOpWithTag(Operation *root, StringRef tagKey,
+                                StringRef tagValue) {
+  Operation *found = nullptr;
+  root->walk<WalkOrder::PreOrder>([tagKey, tagValue, &found](Operation *op) {
+    auto attr = op->getAttrOfType<StringAttr>(tagKey);
+    if (!attr || attr.getValue() != tagValue)
+      return WalkResult::advance();
+
+    assert(found == nullptr && "more than one op with the same tag");
+    found = op;
+
+    // In debug mode, continue the traversal to see if the tag is not
+    // duplicated. This is only necessary to ensure that the assert above is
+    // triggered. In the non-debug mode, assert is not performed and we can
+    // sparse some cycles by not iterating further.
+#ifndef NDEBUG
+    return WalkResult::advance();
+#else
+    return WalkResult::interrupt();
+#endif // NDEBUG
+  });
+  return found;
+}
+
+/// Returns the ancestor of `target` that doesn't have a parent.
+static Operation *getRootOperation(Operation *target) {
+  Operation *root = target;
+  while (root->getParentOp())
+    root = root->getParentOp();
+  return root;
+}
+
+/// Prints the CLI command running the repro with the current path.
+static llvm::raw_ostream &
+printIreeOptReproCall(llvm::raw_ostream &os, StringRef rootOpName,
+                      StringRef passName,
+                      const Pass::Option<std::string> &debugPayloadRootTag,
+                      const Pass::Option<std::string> &debugTransformRootTag) {
+  os << llvm::formatv("iree-opt --pass-pipeline=\"{0}({1}{{{2}={3} {4}={5}})\"",
+                      rootOpName, passName, debugPayloadRootTag.getArgStr(),
+                      debugPayloadRootTag.empty()
+                          ? StringRef(kTransformIreeTagPayloadRootValue)
+                          : debugPayloadRootTag,
+                      debugTransformRootTag.getArgStr(),
+                      debugTransformRootTag.empty()
+                          ? StringRef(kTransformIreeTagTransformContainerValue)
+                          : debugTransformRootTag);
+  return os;
+}
+
+/// Prints the module rooted at `root` to `os` and appends
+/// `transformContainer` if it is not nested in `root`.
+llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os, Operation *root,
+                                       Operation *transformContainer) {
+  root->print(os);
+  if (!root->isAncestor(transformContainer)) {
+    transformContainer->print(os);
+  }
+  return os;
+}
+
+/// Saves the payload and the transform IR into a temporary file and reports
+/// the file name to `os`.
+void saveReproToTempFile(
+    llvm::raw_ostream &os, Operation *target, Operation *transformContainer,
+    StringRef passName, const Pass::Option<std::string> &debugPayloadRootTag,
+    const Pass::Option<std::string> &debugTransformRootTag) {
+  using llvm::sys::fs::TempFile;
+  Operation *root = getRootOperation(target);
+
+  SmallVector<char, 128> tmpPath;
+  llvm::sys::path::system_temp_directory(/*erasedOnReboot=*/true, tmpPath);
+  llvm::sys::path::append(tmpPath, "iree_transform_dialect_%%%%%%.mlir");
+  llvm::Expected<TempFile> tempFile = TempFile::create(tmpPath);
+  if (!tempFile) {
+    os << "could not open temporary file to save the repro\n";
+    return;
+  }
+
+  llvm::raw_fd_ostream fout(tempFile->FD, /*shouldClose=*/false);
+  printModuleForRepro(fout, root, transformContainer);
+  fout.flush();
+  std::string filename = tempFile->TmpName;
+
+  if (tempFile->keep()) {
+    os << "could not preserve the temporary file with the repro\n";
+    return;
+  }
+
+  os << "=== Transform Interpreter Repro ===\n";
+  printIreeOptReproCall(os, root->getName().getStringRef(), passName,
+                        debugPayloadRootTag, debugTransformRootTag)
+      << " " << filename << "\n";
+  os << "===================================\n";
+}
+
+// Optionally perform debug actions requested by the user to dump IR and a
+// repro to stderr and/or a file.
+static void performOptionalDebugActions(
+    Operation *target, Region *transformRegion, StringRef passName,
+    const Pass::Option<std::string> &debugPayloadRootTag,
+    const Pass::Option<std::string> &debugTransformRootTag) {
+  MLIRContext *context = target->getContext();
+
+  // Add temporary debug / repro attributes, these must never leak out.
+  if (debugPayloadRootTag.empty()) {
+    target->setAttr(
+        kTransformIreeTagAttrName,
+        StringAttr::get(context, kTransformIreeTagPayloadRootValue));
+  }
+  if (debugTransformRootTag.empty()) {
+    transformRegion->getParentOp()->setAttr(
+        kTransformIreeTagAttrName,
+        StringAttr::get(context, kTransformIreeTagTransformContainerValue));
+  }
+
+  DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_STDERR, {
+    Operation *root = getRootOperation(target);
+    llvm::dbgs() << "=== Transform Interpreter Repro ===\n";
+    printIreeOptReproCall(llvm::dbgs() << "cat <<EOF | ",
+                          root->getName().getStringRef(), passName,
+                          debugPayloadRootTag, debugTransformRootTag);
+    printModuleForRepro(llvm::dbgs(), root, transformRegion->getParentOp());
+    llvm::dbgs() << "\nEOF\n";
+    llvm::dbgs() << "===================================\n";
+  });
+  DEBUG_WITH_TYPE(DEBUG_TYPE_DUMP_FILE, {
+    saveReproToTempFile(llvm::dbgs(), target, transformRegion->getParentOp(),
+                        passName, debugPayloadRootTag, debugTransformRootTag);
+  });
+
+  // Drop the temporary debug / repro attributes, these must never leak out.
+  if (debugTransformRootTag.empty()) {
+    transformRegion->getParentOp()->removeAttr(
+        kTransformIreeTagTransformContainerValue);
+  }
+  if (debugPayloadRootTag.empty()) {
+    target->removeAttr(kTransformIreeTagAttrName);
+  }
+}
+
+LogicalResult transform::detail::interpreterBaseRunOnOperationImpl(
+    Operation *target, StringRef passName,
+    const std::shared_ptr<OwningOpRef<ModuleOp>> &sharedTransformModule,
+    const Pass::Option<std::string> &transformFileName,
+    const Pass::Option<std::string> &debugPayloadRootTag,
+    const Pass::Option<std::string> &debugTransformRootTag) {
+  bool parsedTransform = (sharedTransformModule && *sharedTransformModule);
+
+  // Step 1
+  // ------
+  // Get the default payloadRoot and transformRegion that one expects
+  // when running the IREE nested pass pipeline or the interpreter.
+  Operation *payloadRoot = target;
+  Region *transformRegion = nullptr;
+  // If a parsed transform was specified separately, use it immediately.
+  // Otherwise, the transform is embedded in the IR: go inspect the IR and
+  // get the first top-level transform we find.
+  if (parsedTransform) {
+    transformRegion = &(*sharedTransformModule)->getRegion();
+  } else {
+    // TODO: In large IR we will likely want more control in selecting a
+    // particular transform to focus on, this may warrant a user-specified
+    // attribute that one would manually injected in the IR when operating in
+    // interpreted mode.
+    Operation *topLevelTransform =
+        findTopLevelTransform(target, transformFileName.getArgStr());
+    if (!topLevelTransform)
+      return failure();
+    transformRegion = topLevelTransform->getParentRegion();
+  }
+  assert(transformRegion && "unexpected detached root transform op");
+
+  // Step 2
+  // ------
+  // Optionally override payloadRoot if the debugPayloadRootTag was passed.
+  //
+  // If debugPayloadRootTag was passed, then we are in user-specified selection
+  // of the transformed IR. This corresponds to REPL debug mode.
+  // Otherwise, just apply to `target`, which is what the IREE nested
+  // pipeline wants to operate on.
+  if (!debugPayloadRootTag.empty()) {
+    payloadRoot =
+        findOpWithTag(target, kTransformIreeTagAttrName, debugPayloadRootTag);
+    if (!payloadRoot) {
+      target->emitError() << "couldn't find the root payload op with "
+                          << kTransformIreeTagAttrName << "=\""
+                          << kTransformIreeTagPayloadRootValue
+                          << "\" attribute";
+      return failure();
+    }
+  }
+
+  // Step 3
+  // ------
+  // Optionally override transformRegion if the debugTransformRootTag was
+  // passed.
+  //
+  // If debugTransformRootTag was passed, then we are in user-specified
+  // selection of the transforming IR. This corresponds to REPL debug mode.
+  // Otherwise, just apply to the existing `transformRegion`, which is what
+  // the IREE nested pipeline wants to operate on.
+  if (!debugTransformRootTag.empty()) {
+    Operation *transformRoot =
+        findOpWithTag(transformRegion->getParentOp(), kTransformIreeTagAttrName,
+                      kTransformIreeTagTransformContainerValue);
+    if (!transformRoot) {
+      transformRegion->getParentOp()->emitError()
+          << "couldn't find the transform container op with "
+          << kTransformIreeTagAttrName << "=\""
+          << kTransformIreeTagTransformContainerValue << "\" attribute";
+      return failure();
+    }
+    if (transformRoot->getNumRegions() != 1 ||
+        !transformRoot->getRegion(0).hasOneBlock()) {
+      transformRoot->emitError() << "expected transform container op to have "
+                                    "one single-block region";
+      return failure();
+    }
+    transformRegion = &transformRoot->getRegion(0);
+  }
+
+  // Step 4
+  // ------
+  // Optionally perform debug actions requested by the user to dump IR and a
+  // repro to stderr and/or a fie.
+  performOptionalDebugActions(target, transformRegion, passName,
+                              debugPayloadRootTag, debugTransformRootTag);
+
+  // Step 5
+  // ------
+  // Apply the transform to the IR
+  // TODO: lift this assertion.
+  assert(transformRegion->getBlocks().size() == 1 &&
+         "expected single-region block");
+  if (failed(
+          transform::applyTransformsInRegion(*transformRegion, payloadRoot))) {
+    payloadRoot->emitOpError() << "transform dialect interpreter failed";
+    return failure();
+  }
+
+  return success();
+}
+
+LogicalResult transform::detail::interpreterBaseInitializeImpl(
+    MLIRContext *context, StringRef transformFileName,
+    std::shared_ptr<OwningOpRef<ModuleOp>> &module) {
+  OwningOpRef<ModuleOp> parsed;
+  if (failed(transform::parseTransformModuleFromFile(context, transformFileName,
+                                                     parsed)))
+    return failure();
+
+  module = std::make_shared<OwningOpRef<ModuleOp>>(std::move(parsed));
+  return success();
+}

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/failure.mlir
@@ -1,23 +1,26 @@
 // RUN: iree-dialects-opt --transform-dialect-interpreter --split-input-file --verify-diagnostics --allow-unregistered-dialect %s
 
-func.func public @no_outlining() {
-  // expected-note @below {{target op}}
-  "some.operation"() ({}, {}) : () -> ()
-  return
-}
-
-transform.with_pdl_patterns {
-^bb0(%arg0: !pdl.operation):
-  pdl.pattern @some_operation : benefit(1) {
-    %0 = operation "some.operation"
-    rewrite %0 with "transform.dialect"
+// expected-error @below {{transform dialect interpreter failed}}
+module {
+  func.func public @no_outlining() {
+    // expected-note @below {{target op}}
+    "some.operation"() ({}, {}) : () -> ()
+    return
   }
 
-  transform.structured.canonicalized_sequence %arg0 failures(propagate) {
-  ^bb1(%arg1: !pdl.operation):
-    %0 = pdl_match @some_operation in %arg1 : (!pdl.operation) -> !pdl.operation
-    // Make sure we don't crash on wrong operation type.
-    // expected-error@below {{failed to outline}}
-    transform.loop.outline %0 {func_name = "outlined"} : (!pdl.operation) -> !pdl.operation
+  transform.with_pdl_patterns {
+  ^bb0(%arg0: !pdl.operation):
+    pdl.pattern @some_operation : benefit(1) {
+      %0 = operation "some.operation"
+      rewrite %0 with "transform.dialect"
+    }
+
+    transform.structured.canonicalized_sequence %arg0 failures(propagate) {
+    ^bb1(%arg1: !pdl.operation):
+      %0 = pdl_match @some_operation in %arg1 : (!pdl.operation) -> !pdl.operation
+      // Make sure we don't crash on wrong operation type.
+      // expected-error@below {{failed to outline}}
+      transform.loop.outline %0 {func_name = "outlined"} : (!pdl.operation) -> !pdl.operation
+    }
   }
 }


### PR DESCRIPTION
Factor out the common components of TransformDialectInterpreterPass in Codegen, in iree-dialects, and of DispatchWithTransformDialect into a base class template that lives in iree-dialects. This includes the logic necessary for injecting transforms from a file, maintaining those alive in a separate module, debug targeting via attributes, and transform module identification in the IR. It is currently used for IREE codegen, and will be reused for Flow and standalone interpreter.