### PR TITLE
Compute workgroup count based on `pack` op input shape, not result shape.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/tile_and_distribute_to_workgroups.mlir
@@ -1851,15 +1851,14 @@ hal.executable private @pack_lowering {
     }
   }
 }
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> ((s0 ceildiv 8) ceildiv 64)
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> ((s0 ceildiv 4) ceildiv 64)
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.export public @gemm_lhs_pack
 // CHECK-NEXT:   %[[ARG0:.+]]: !hal.device
 // CHECK-SAME:   %[[ARG1:.+]]: index,
 // CHECK-SAME:   %[[ARG2:.+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
 //  CHECK-DAG:   %[[W0:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
-//  CHECK-DAG:   %[[W1:.+]] = affine.apply #[[MAP1]]()[%[[ARG2]]]
+//  CHECK-DAG:   %[[W1:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
 //      CHECK:   hal.return %[[W1]], %[[W0]], %[[C1]]
 
 // -----
@@ -1896,15 +1895,14 @@ hal.executable private @pack_lowering {
     }
   }
 }
-//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> ((s0 ceildiv 8) ceildiv 64)
-//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> ((s0 ceildiv 4) ceildiv 64)
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 64)>
 //      CHECK: hal.executable.export public @gemm_rhs_transpose_pack
 // CHECK-NEXT:   %[[ARG0:.+]]: !hal.device
 // CHECK-SAME:   %[[ARG1:.+]]: index,
 // CHECK-SAME:   %[[ARG2:.+]]: index
 //  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
-//  CHECK-DAG:   %[[W0:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
-//  CHECK-DAG:   %[[W1:.+]] = affine.apply #[[MAP1]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[W0:.+]] = affine.apply #[[MAP0]]()[%[[ARG1]]]
+//  CHECK-DAG:   %[[W1:.+]] = affine.apply #[[MAP0]]()[%[[ARG2]]]
 //      CHECK:   hal.return %[[W1]], %[[W0]], %[[C1]]
 
 // -----


### PR DESCRIPTION
This is part 4/9 of https://github.com/iree-org/iree/issues/11755: Finish the transition to --iree-flow-enable-data-tiling.

The workgroup count computation should not care about the inner (register-level) tile sizes. But the result shape outer dims of a pack op depend on tile sizes (they are the quotient of the input shape by tile shape).

With the newly added possibility of dynamic tile sizes, this code had gotten complicated as the workgroup count computation had to call the `query_tile_sizes` ukernel.

Finally the last straw was that we realized that since that is host-side not device-side work, that was the one place introducing a host-side dependency on the VMVX module providing the `query_tile_size` ukernel, so that was why we suddenly needed either #11643 or #11644.

So this PR not only removes the need for #11643 and #11644, it removes an unnessary tangling of device details into host code and removes > 50 lines of nontrivial code from TileAndDistributeToWorkgroupsPass.

The only downside is that since the input shape is larger than the outer dims of result shape that were being used, this is increasing the number of workgroups, so we may want to adjust that in a follow-up?  But was the current workgroup count determination any optimized anyway?