### PR TITLE
Add flash attention forward op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -458,6 +458,8 @@ void registerBufferizationInterfaces(DialectRegistry &registry) {
         LinalgExtOpInterface<IREE::LinalgExt::WinogradInputTransformOp>>(*ctx);
     IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
         LinalgExtOpInterface<IREE::LinalgExt::WinogradOutputTransformOp>>(*ctx);
+    IREE::LinalgExt::FlashAttentionFwdOp::attachInterface<
+        LinalgExtOpInterface<IREE::LinalgExt::FlashAttentionFwdOp>>(*ctx);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -236,6 +236,9 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
     IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
         AllParallelAsPartitionableLoops<
             IREE::LinalgExt::WinogradOutputTransformOp>>(*ctx);
+    IREE::LinalgExt::FlashAttentionFwdOp::attachInterface<
+        AllParallelAsPartitionableLoops<IREE::LinalgExt::FlashAttentionFwdOp>>(
+        *ctx);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -128,6 +128,8 @@ static void addTileAndDistributePasses(
     OpPassManager &pm, bool useFuseTensorPadWithConsumerPass = true) {
   pm.addPass(createTileAndDistributeToWorkgroupsPass());
   auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createTileAndDecomposeFlashAttentionTransformPass());
   if (clEnablePadConsumerFusion && useFuseTensorPadWithConsumerPass) {
     nestedModulePM.addNestedPass<func::FuncOp>(
         createFuseTensorPadWithConsumerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -96,6 +96,9 @@ static void tileAndDistributeToWorkgroup(
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createTileAndDecomposeFlashAttentionTransformPass());
+
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass(
           useWARForCooperativeMatrixCodegen));
   nestedModulePM.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
@@ -144,6 +144,8 @@ void registerUtilExternalModels(DialectRegistry &registry) {
         LinalgExt::WinogradOutputTransformOp::attachInterface<
             LinalgOpTiedOpInterface<LinalgExt::WinogradOutputTransformOp>>(
             *ctx);
+        LinalgExt::FlashAttentionFwdOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::FlashAttentionFwdOp>>(*ctx);
       });
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1106,6 +1106,99 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
 }
 
 //===----------------------------------------------------------------------===//
+// Flash Attention ops
+//===----------------------------------------------------------------------===//
+
+def IREELinalgExt_FlashAttentionFwdOp : IREELinalgExt_Op<"flash_attention.fwd",
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+     DeclareOpInterfaceMethods<TilingInterface,
+      ["getIterationDomain",
+       "getLoopIteratorTypes",
+       "getResultTilePosition",
+       "getTiledImplementation"]>]> {
+  let summary = "Flash Attention Forward operator";
+  let description = [{
+    This is an implementation of the forward pass of the flash attention operator.
+    The operator takes 3 inputs: the query tensor (Q), the key tensor (K) and the value tensor (V).
+    All 3 inputs have dimensions BxNxd where B is the product of the batch dimension and the
+    number of heads, N is the sequence length and d is the head dimension (often N>>>d).
+    The standard attention operator computes matmul(softmax(matmul(Q, transpose(K))), V).
+    This operator computes the same quantity above but does so in a way that requires much fewer
+    HBM accesses (in the context of a CUDA GPU device). Specifically, it uses tiling and fusion
+    to compute the two matmuls and softmax in one kernel. This operator usually also performs
+    scaling, masking and dropout, but we ignore these transformations for now.
+  }];
+
+  let arguments = (ins Variadic<AnyShaped>:$inputs,
+                       Variadic<AnyShaped>:$outputs
+  );
+
+  let builders = [
+    OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs)>
+  ];
+
+  let results = (outs Variadic<AnyRankedTensor>:$result);
+  let hasFolder = 1;
+  let assemblyFormat = [{
+    attr-dict
+    `ins` `(` $inputs `:` type($inputs) `)`
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`->` type($result)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    Value query() {
+      return getInputOperand(0)->get();
+    }
+    Value key() {
+      return getInputOperand(1)->get();
+    }
+    Value value() {
+      return getInputOperand(2)->get();
+    }
+    Value output() {
+      return getOutputOperand(0)->get();
+    }
+    ShapedType getQueryType() {
+      return query().getType().cast<ShapedType>();
+    }
+    ShapedType getKeyType() {
+      return key().getType().cast<ShapedType>();
+    }
+    ShapedType getValueType() {
+      return value().getType().cast<ShapedType>();
+    }
+    ShapedType getOutputType() {
+      return output().getType().cast<ShapedType>();
+    }
+    int64_t getQueryRank() {
+      return getQueryType().getRank();
+    }
+    int64_t getKeyRank() {
+      return getKeyType().getRank();
+    }
+    int64_t getValueRank() {
+      return getValueType().getRank();
+    }
+    int64_t getOutputRank() {
+      return getOutputType().getRank();
+    }
+    int64_t getIterationDomainRank() {
+      return 2;
+    }
+    // Method to implement for specifying output range for
+    // DestinationStyleOpInterface
+    std::pair<int64_t, int64_t> getDpsInitsPositionRange() {
+      std::pair<unsigned, unsigned> outputsIndexAndLength =
+        getODSOperandIndexAndLength(1);
+      return std::make_pair<int64_t, int64_t>(
+          outputsIndexAndLength.first,
+          outputsIndexAndLength.first + outputsIndexAndLength.second);
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Pure ops
 //===----------------------------------------------------------------------===//
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -167,6 +167,11 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLinalgExtVectorizationPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createTileAndDecomposeWinogradTransformPass();
 
+/// Tile and decompose the flash attention ops into a sequence
+/// of linalg ops.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createTileAndDecomposeFlashAttentionTransformPass();
+
 // Creates a pass to convert linalg convolution ops into a sequence of
 // linalg_ext.winograd.* ops and linalg.batch_matmul ops using the winograd
 // tranformation.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -90,6 +90,14 @@ def TileAndDecomposeWinogradTransform :
                     "createTileAndDecomposeWinogradTransformPass()";
 }
 
+def TileAndDecomposeFlashAttentionTransform :
+    Pass<"iree-linalg-ext-tile-and-decompose-flash-attention", "func::FuncOp"> {
+  let summary =
+      "Tiles and decomposes flash attention ops into linalg ops";
+  let constructor = "mlir::iree_compiler::IREE::LinalgExt::"
+                    "createTileAndDecomposeFlashAttentionTransformPass()";
+}
+
 def ConvertConv2DToWinograd :
     Pass<"iree-linalg-ext-convert-conv2d-to-winograd", ""> {
   let summary = "Convert linalg convolution ops to winograd based implementation";

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2878,8 +2878,8 @@ LogicalResult FlashAttentionFwdOp::getResultTilePosition(
     resultOffsets =
         SmallVector<OpFoldResult>(getOutputRank(), builder.getIndexAttr(0));
     for (auto info : llvm::enumerate(llvm::zip(offsets, sizes))) {
-      resultSizes[info.index()] = std::get<0>(info.value());
-      resultOffsets[info.index()] = std::get<1>(info.value());
+      resultOffsets[info.index()] = std::get<0>(info.value());
+      resultSizes[info.index()] = std::get<1>(info.value());
     }
     return success();
   }

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2768,13 +2768,13 @@ LogicalResult FlashAttentionFwdOp::verify() {
   if (getNumOutputs() != 1) {
     return op->emitOpError("expected one output operand");
   }
-  const int64_t keyRank = getKeyRank();
+  int64_t keyRank = getKeyRank();
   if (keyRank != 3) {
     return op->emitError("expected key tensor to have rank 3");
   }
-  const ShapedType queryType = getQueryType();
-  const ShapedType keyType = getKeyType();
-  const ShapedType valueType = getValueType();
+  ShapedType queryType = getQueryType();
+  ShapedType keyType = getKeyType();
+  ShapedType valueType = getValueType();
   // Check that the head dimension of the query and key are the same
   ArrayRef<int64_t> queryShape = queryType.getShape();
   ArrayRef<int64_t> keyShape = keyType.getShape();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
@@ -6,6 +6,7 @@ add_mlir_library(IREELinalgExtPasses
   PadContractionToBlockSize.cpp
   Passes.cpp
   SplitReduction.cpp
+  TileAndDecomposeFlashAttentionPass.cpp
   TileAndDecomposeWinogradPass.cpp
   Tiling.cpp
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeFlashAttentionPass.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/TileAndDecomposeFlashAttentionPass.cpp
@@ -1,0 +1,428 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/PassDetail.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/SCF/Transforms/Transforms.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/Pass/Pass.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/Support/Debug.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace LinalgExt {
+
+namespace {
+
+// Computes a reduction along the rows of a 2d tensor of shape MxN
+// to produce a tensor of shape M
+template <typename T>
+static Value computeRowwiseReduction(Value a, Value output, Location loc,
+                                     OpBuilder &builder) {
+  SmallVector<utils::IteratorType> iteratorTypes{utils::IteratorType::reduction,
+                                                 utils::IteratorType::parallel};
+  AffineMap id = AffineMap::getMultiDimIdentityMap(2, builder.getContext());
+  AffineExpr d0, d1;
+  bindDims(builder.getContext(), d0, d1);
+  // (d0, d1) -> (d0)
+  auto rowMap = AffineMap::get(2, 0, {d0}, builder.getContext());
+  SmallVector<AffineMap> indexingMaps{id, rowMap};
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, output.getType(), a, output, indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value result = b.create<T>(loc, args[0], args[1]);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+static Value computeNewMax(Value oldMax, Value currentMax, Value output,
+                           Location loc, OpBuilder &builder) {
+  SmallVector<utils::IteratorType> iteratorTypes{utils::IteratorType::parallel};
+  auto identityMap = AffineMap::getMultiDimIdentityMap(1, builder.getContext());
+  SmallVector<AffineMap> indexingMaps(3, identityMap);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, currentMax.getType(), ValueRange{oldMax, currentMax}, output,
+      indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value result = b.create<arith::MaxFOp>(loc, args[0], args[1]);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+// Computes alpha * oldSum + beta * currentSum
+static Value computeNewSum(Value oldSum, Value currentSum, Value alpha,
+                           Value beta, Value output, Location loc,
+                           OpBuilder &builder) {
+  SmallVector<utils::IteratorType> iteratorTypes{utils::IteratorType::parallel};
+  auto identityMap = AffineMap::getMultiDimIdentityMap(1, builder.getContext());
+  SmallVector<AffineMap> indexingMaps(5, identityMap);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, currentSum.getType(), ValueRange{oldSum, currentSum, alpha, beta},
+      output, indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value first = b.create<arith::MulFOp>(loc, args[2], args[0]);
+        Value second = b.create<arith::MulFOp>(loc, args[3], args[1]);
+        Value result = b.create<arith::AddFOp>(loc, first, second);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+// Computes c = exp(a - b) where a, b, c are 1D
+static Value subtractAndExponentiate1D(Value a, Value b, Value output,
+                                       Location loc, OpBuilder &builder) {
+  SmallVector<utils::IteratorType> iteratorTypes{utils::IteratorType::parallel};
+  auto identityMap = AffineMap::getMultiDimIdentityMap(1, builder.getContext());
+  SmallVector<AffineMap> indexingMaps(3, identityMap);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, a.getType(), ValueRange{a, b}, output, indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value diff = b.create<arith::SubFOp>(loc, args[0], args[1]);
+        Value result = b.create<math::ExpOp>(loc, diff);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+static Value computeSoftmax(Value qkTranspose, Value currentMax,
+                            Value currentWeight, Value newSum, Value output,
+                            Location loc, OpBuilder &builder) {
+  AffineMap identityMap =
+      AffineMap::getMultiDimIdentityMap(2, builder.getContext());
+  AffineExpr d0, d1;
+  bindDims(builder.getContext(), d0, d1);
+  // (d0, d1) -> (d0)
+  auto rowMap = AffineMap::get(2, 0, {d0}, builder.getContext());
+  SmallVector<AffineMap> indexingMaps{identityMap, rowMap, rowMap, rowMap,
+                                      identityMap};
+  SmallVector<utils::IteratorType> iteratorTypes(2,
+                                                 utils::IteratorType::parallel);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, qkTranspose.getType(),
+      ValueRange{qkTranspose, currentMax, currentWeight, newSum}, output,
+      indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value diff = b.create<arith::SubFOp>(loc, args[0], args[1]);
+        Value result = b.create<math::ExpOp>(loc, diff);
+        Value scaledResult = b.create<arith::MulFOp>(loc, result, args[2]);
+        Value finalResult = b.create<arith::DivFOp>(loc, scaledResult, args[3]);
+        b.create<linalg::YieldOp>(loc, finalResult);
+      });
+  return genericOp.getResult(0);
+}
+
+static Value scaleAccumulator(Value accumulator, Value oldSum, Value newSum,
+                              Value oldWeight, Value output, Location loc,
+                              OpBuilder &builder) {
+  AffineMap identityMap =
+      AffineMap::getMultiDimIdentityMap(2, builder.getContext());
+  AffineExpr d0, d1;
+  bindDims(builder.getContext(), d0, d1);
+  // (d0, d1) -> (d0)
+  auto rowMap = AffineMap::get(2, 0, {d0}, builder.getContext());
+  SmallVector<AffineMap> indexingMaps{identityMap, rowMap, rowMap, rowMap,
+                                      identityMap};
+  SmallVector<utils::IteratorType> iteratorTypes(2,
+                                                 utils::IteratorType::parallel);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, accumulator.getType(),
+      ValueRange{accumulator, oldSum, newSum, oldWeight}, output, indexingMaps,
+      iteratorTypes, [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value prod = b.create<arith::MulFOp>(loc, args[1], args[3]);
+        Value scaled = b.create<arith::MulFOp>(loc, args[0], prod);
+        Value result = b.create<arith::DivFOp>(loc, scaled, args[2]);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+static Value computeQKTranspose(Value query, Value key, Value transposedOutput,
+                                Value output, Value zero,
+                                RankedTensorType tensorType, Location loc,
+                                OpBuilder &builder) {
+  SmallVector<int64_t> perm{1, 0};
+  auto transposeOp =
+      builder.create<linalg::TransposeOp>(loc, key, transposedOutput, perm);
+  Value acc =
+      builder.create<linalg::FillOp>(loc, ValueRange{zero}, output).result();
+  auto matmulOp = builder.create<linalg::MatmulOp>(
+      loc, tensorType, ValueRange{query, transposeOp.getResult()[0]}, acc);
+  return matmulOp.getResult(0);
+}
+
+static std::tuple<Value, Value, Value, Value>
+extractSlices(Value key, Value value, Value query, Value output,
+              ArrayRef<int64_t> queryShape, ArrayRef<Value> ivs,
+              Value sequenceTileLength, Type elementType, Location loc,
+              OpBuilder &builder) {
+  auto one = builder.getIndexAttr(1);
+  auto zero = builder.getIndexAttr(0);
+  auto headDimension = builder.getIndexAttr(queryShape.back());
+  SmallVector<OpFoldResult> strides(queryShape.size(), one);
+  SmallVector<OpFoldResult> sizes(queryShape.size(), one);
+  SmallVector<OpFoldResult> offsets(queryShape.size(), zero);
+  sizes[1] = sequenceTileLength;
+  sizes[2] = headDimension;
+  offsets[0] = ivs[0];
+  offsets[1] = ivs[1];
+  SmallVector<int64_t> tensorShape;
+  for (int i = 1; i < queryShape.size(); i++)
+    tensorShape.push_back(queryShape[i]);
+  auto tensorType = RankedTensorType::get(tensorShape, elementType);
+  Value keySlice = builder.create<tensor::ExtractSliceOp>(
+      loc, tensorType, key, offsets, sizes, strides);
+  Value valueSlice = builder.create<tensor::ExtractSliceOp>(
+      loc, tensorType, value, offsets, sizes, strides);
+
+  offsets = SmallVector<OpFoldResult>(queryShape.size(), zero);
+  offsets[0] = ivs[0];
+  Value querySlice = builder.create<tensor::ExtractSliceOp>(
+      loc, tensorType, query, offsets, sizes, strides);
+  Value outputSlice = builder.create<tensor::ExtractSliceOp>(
+      loc, tensorType, output, offsets, sizes, strides);
+
+  return std::make_tuple(keySlice, valueSlice, querySlice, outputSlice);
+}
+
+static std::tuple<Value, Value, Value>
+insertSlices(Value newResult, Value result, Value newMax, Value max,
+             Value newSum, Value sum, ArrayRef<int64_t> queryShape,
+             ArrayRef<Value> ivs, Value sequenceTileLength, Location loc,
+             OpBuilder &builder) {
+  auto one = builder.getIndexAttr(1);
+  auto zero = builder.getIndexAttr(0);
+  auto headDimension = builder.getIndexAttr(queryShape.back());
+  SmallVector<OpFoldResult> strides(queryShape.size(), one);
+  SmallVector<OpFoldResult> sizes(queryShape.size(), one);
+  SmallVector<OpFoldResult> offsets(queryShape.size(), zero);
+  sizes[1] = sequenceTileLength;
+  sizes[2] = headDimension;
+  offsets[0] = ivs[0];
+  Value updatedAcc = builder.create<tensor::InsertSliceOp>(
+      loc, newResult, result, offsets, sizes, strides);
+  offsets = SmallVector<OpFoldResult>{zero};
+  sizes = SmallVector<OpFoldResult>{sequenceTileLength};
+  strides = SmallVector<OpFoldResult>{one};
+  Value updatedMax = builder.create<tensor::InsertSliceOp>(
+      loc, newMax, max, offsets, sizes, strides);
+  Value updatedSum = builder.create<tensor::InsertSliceOp>(
+      loc, newSum, sum, offsets, sizes, strides);
+  return std::make_tuple(updatedAcc, updatedMax, updatedSum);
+}
+
+static scf::LoopNest createLoopNest(SmallVectorImpl<Value> &ivs, Value lb,
+                                    Value step, Value ub, ValueRange args,
+                                    Location loc, OpBuilder &builder) {
+  SmallVector<Value> lbs{lb};
+  SmallVector<Value> steps{step};
+  SmallVector<Value> ubs{ub};
+  scf::LoopNest loopNest = scf::buildLoopNest(
+      builder, loc, lbs, ubs, steps, args,
+      [&](OpBuilder &nestedBuilder, Location loc, ValueRange outputIvs,
+          ValueRange iterArgs) -> scf::ValueVector { return iterArgs; });
+  for (scf::ForOp loop : loopNest.loops) {
+    ivs.push_back(loop.getInductionVar());
+  }
+  return loopNest;
+}
+
+class ReifyFlashAttentionFwdTransform final
+    : public OpRewritePattern<FlashAttentionFwdOp> {
+public:
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(FlashAttentionFwdOp attnOp,
+                                PatternRewriter &rewriter) const override {
+    Location loc = attnOp.getLoc();
+    auto funcOp = attnOp->getParentOfType<func::FuncOp>();
+    if (!funcOp) {
+      return rewriter.notifyMatchFailure(attnOp,
+                                         "Could not find parent of type ");
+    }
+
+    rewriter.setInsertionPoint(attnOp);
+
+    Value query = attnOp.query();
+    ShapedType queryType = attnOp.getQueryType();
+    Type elementType = queryType.getElementType();
+    ArrayRef<int64_t> queryShape = queryType.getShape();
+    SmallVector<OpFoldResult> queryDimValues =
+        tensor::createDimValues(rewriter, loc, query);
+    Value sequenceTileLength =
+        getValueOrCreateConstantIndexOp(rewriter, loc, queryDimValues[1]);
+    Value batchTileLength =
+        getValueOrCreateConstantIndexOp(rewriter, loc, queryDimValues[0]);
+
+    Value key = attnOp.key();
+    Value value = attnOp.value();
+    SmallVector<OpFoldResult> keyDimValues =
+        tensor::createDimValues(rewriter, loc, key);
+    Value sequenceLength =
+        getValueOrCreateConstantIndexOp(rewriter, loc, keyDimValues[1]);
+
+    // Construct first loop
+    Value zeroValue = rewriter.create<arith::ConstantIndexOp>(loc, 0);
+    Value oneValue = rewriter.create<arith::ConstantIndexOp>(loc, 1);
+    SmallVector<Value> ivs;
+    Value output = attnOp.output();
+    scf::LoopNest firstLoopNest =
+        createLoopNest(ivs, zeroValue, oneValue, batchTileLength,
+                       ValueRange({output}), loc, rewriter);
+    Value iterArg = firstLoopNest.loops.back().getRegionIterArg(0);
+
+    rewriter.setInsertionPointToStart(firstLoopNest.loops.back().getBody());
+
+    // Create max and sum statistics
+    SmallVector<OpFoldResult> dims{sequenceTileLength};
+    Value zeroF32 = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(elementType));
+    Value largeNegativeF32 = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getFloatAttr(elementType, -100.0));
+    Value max = rewriter.create<tensor::EmptyOp>(loc, dims, elementType);
+    Value negativeMax =
+        rewriter.create<linalg::FillOp>(loc, ValueRange{largeNegativeF32}, max)
+            .result();
+    Value sum = rewriter.create<tensor::EmptyOp>(loc, dims, elementType);
+    Value zeroSum =
+        rewriter.create<linalg::FillOp>(loc, ValueRange{zeroF32}, sum).result();
+
+    // Construct second loop
+    scf::LoopNest secondLoopNest = createLoopNest(
+        ivs, zeroValue, sequenceTileLength, sequenceLength,
+        ValueRange({iterArg, negativeMax, zeroSum}), loc, rewriter);
+
+    Value iterArgResult = secondLoopNest.loops.back().getRegionIterArg(0);
+    Value iterArgMax = secondLoopNest.loops.back().getRegionIterArg(1);
+    Value iterArgSum = secondLoopNest.loops.back().getRegionIterArg(2);
+
+    rewriter.setInsertionPointToStart(secondLoopNest.loops.back().getBody());
+
+    auto [keySlice, valueSlice, querySlice, outputSlice] =
+        extractSlices(key, value, query, iterArgResult, queryShape, ivs,
+                      sequenceTileLength, elementType, loc, rewriter);
+
+    // Compute matmul(q, transpose(k))
+    auto headDimension = rewriter.getIndexAttr(queryShape.back());
+    SmallVector<OpFoldResult> transposedShape{headDimension,
+                                              sequenceTileLength};
+    Value empty =
+        rewriter.create<tensor::EmptyOp>(loc, transposedShape, elementType);
+    SmallVector<OpFoldResult> resultShape{sequenceTileLength,
+                                          sequenceTileLength};
+    Value emptySquare =
+        rewriter.create<tensor::EmptyOp>(loc, resultShape, elementType);
+    auto tensorType = RankedTensorType::get(
+        SmallVector<int64_t>(2, queryShape[1]), elementType);
+    Value qkTranspose =
+        computeQKTranspose(querySlice, keySlice, empty, emptySquare, zeroF32,
+                           tensorType, loc, rewriter);
+
+    empty = rewriter.create<tensor::EmptyOp>(
+        loc, SmallVector<OpFoldResult>{sequenceTileLength}, elementType);
+
+    // Compute current statistics
+    Value currentMax = computeRowwiseReduction<arith::MaxFOp>(
+        qkTranspose, empty, loc, rewriter);
+    Value currentSum = computeRowwiseReduction<arith::AddFOp>(
+        qkTranspose, empty, loc, rewriter);
+
+    // Update global statistics
+    Value newMax = computeNewMax(iterArgMax, currentMax, empty, loc, rewriter);
+    Value oldWeight =
+        subtractAndExponentiate1D(iterArgMax, newMax, empty, loc, rewriter);
+    Value currentWeight =
+        subtractAndExponentiate1D(currentMax, newMax, empty, loc, rewriter);
+    Value newSum = computeNewSum(iterArgSum, currentSum, oldWeight,
+                                 currentWeight, empty, loc, rewriter);
+
+    // Compute softmax
+    Value softmax = computeSoftmax(qkTranspose, currentMax, currentWeight,
+                                   newSum, emptySquare, loc, rewriter);
+
+    // Update accumulator
+    empty = rewriter.create<tensor::EmptyOp>(
+        loc, SmallVector<OpFoldResult>{sequenceLength, headDimension},
+        elementType);
+    Value scaledAcc = scaleAccumulator(outputSlice, iterArgSum, newSum,
+                                       oldWeight, empty, loc, rewriter);
+
+    // Compute matmul(softmax, v)
+    Value result = rewriter
+                       .create<linalg::MatmulOp>(
+                           loc, outputSlice.getType(),
+                           ValueRange{softmax, valueSlice}, scaledAcc)
+                       .getResult(0);
+
+    // Insert slices
+    auto [updatedAcc, updatedMax, updatedSum] =
+        insertSlices(result, iterArgResult, newMax, max, newSum, sum,
+                     queryShape, ivs, sequenceTileLength, loc, rewriter);
+
+    if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
+            secondLoopNest.loops.back().getBody()->getTerminator())) {
+      rewriter.replaceOpWithNewOp<scf::YieldOp>(
+          yieldOp, ValueRange{updatedAcc, updatedMax, updatedSum});
+    }
+
+    if (scf::YieldOp yieldOp = dyn_cast<scf::YieldOp>(
+            firstLoopNest.loops.back().getBody()->getTerminator())) {
+      rewriter.setInsertionPoint(yieldOp);
+      rewriter.replaceOpWithNewOp<scf::YieldOp>(
+          yieldOp, ValueRange{secondLoopNest.results[0]});
+    }
+
+    attnOp.getResults()[0].replaceAllUsesWith(firstLoopNest.results[0]);
+    return success();
+  }
+};
+
+} // namespace
+
+namespace {
+struct TileAndDecomposeFlashAttentionTransformPass
+    : public TileAndDecomposeFlashAttentionTransformBase<
+          TileAndDecomposeFlashAttentionTransformPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<AffineDialect, IREE::LinalgExt::IREELinalgExtDialect,
+                    linalg::LinalgDialect, scf::SCFDialect,
+                    tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override;
+};
+} // namespace
+
+void TileAndDecomposeFlashAttentionTransformPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(&getContext());
+  patterns.insert<ReifyFlashAttentionFwdTransform>(context);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createTileAndDecomposeFlashAttentionTransformPass() {
+  return std::make_unique<TileAndDecomposeFlashAttentionTransformPass>();
+}
+
+} // namespace LinalgExt
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -722,3 +722,12 @@ func.func @illegal_winograd_output_image_dimensions(%arg0: tensor<8x8x1x2x2x32xf
 }
 
 // -----
+
+func.func @illegal_flash_attention_inputs(%query: tensor<6x12x20x8xf32>, %key: tensor<6x12x20x8xf32>, %value: tensor<6x12x20x8xf32>) {
+  %0 = tensor.empty() : tensor<6x12x20x8xf32>
+  // expected-error @+1 {{expected key tensor to have rank 3}}
+  %1 = iree_linalg_ext.flash_attention.fwd ins(%query, %key, %value : tensor<6x12x20x8xf32>, tensor<6x12x20x8xf32>, tensor<6x12x20x8xf32>) outs(%0 : tensor<6x12x20x8xf32>) -> tensor<6x12x20x8xf32>
+  return %1 : tensor<6x12x20x8xf32>
+}
+
+// -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -1034,3 +1034,20 @@ func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x2x2x1280xf32>) -> 
 // CHECK:    }
 
 // -----
+
+func.func @flash_attention_fwd(%query: tensor<192x1024x64xf32>, %key: tensor<192x1024x64xf32>, %value: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32> {
+  %0 = tensor.empty() : tensor<192x1024x64xf32>
+  %1 = iree_linalg_ext.flash_attention.fwd ins(%query, %key, %value : tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>) outs(%0 : tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
+  return %1 : tensor<192x1024x64xf32>
+}
+// CHECK:      func.func @flash_attention_fwd(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
+// CHECK-SAME:   tensor<192x1024x64xf32>, %[[ARG2:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
+// CHECK-SAME:   {
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<192x1024x64xf32>
+// CHECK:        %[[D1:.+]] = iree_linalg_ext.flash_attention.fwd ins(%[[ARG0]], %[[ARG1]], %[[ARG2]] :
+// CHECK-SAME:     tensor<192x1024x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>) outs(%[[D0]] :
+// CHECK-SAME:     tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
+// CHECK:        return %[[D1]] : tensor<192x1024x64xf32>
+// CHECK:      }
+
+// -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_flash_attention.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_flash_attention.mlir
@@ -1,0 +1,173 @@
+// RUN: iree-dialects-opt --iree-linalg-ext-tile-and-decompose-flash-attention --split-input-file %s | FileCheck %s
+
+#map = affine_map<(d0)[s0, s1] -> (2, -d0 + s1)>
+#map1 = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+module {
+  func.func @flash_attention_fwd(%arg0: tensor<192x1024x64xf32>, %arg1: tensor<192x1024x64xf32>, %arg2: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32> {
+    %c0 = arith.constant 0 : index
+    %c192 = arith.constant 192 : index
+    %c1024 = arith.constant 1024 : index
+    %c2 = arith.constant 2 : index
+    %c32 = arith.constant 32 : index
+    %0 = tensor.empty() : tensor<192x1024x64xf32>
+    %1 = scf.for %arg3 = %c0 to %c192 step %c2 iter_args(%arg4 = %0) -> (tensor<192x1024x64xf32>) {
+      %2 = affine.min #map(%arg3)[%c2, %c192]
+      %3 = scf.for %arg5 = %c0 to %c1024 step %c32 iter_args(%arg6 = %arg4) -> (tensor<192x1024x64xf32>) {
+        %4 = affine.min #map1(%arg5)[%c32, %c1024]
+        %extracted_slice = tensor.extract_slice %arg0[%arg3, %arg5, 0] [%2, %4, 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
+        %extracted_slice_0 = tensor.extract_slice %arg1[%arg3, 0, 0] [%2, 1024, 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
+        %extracted_slice_1 = tensor.extract_slice %arg2[%arg3, 0, 0] [%2, 1024, 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
+        %extracted_slice_2 = tensor.extract_slice %0[%arg3, %arg5, 0] [%2, %4, 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
+        %5 = iree_linalg_ext.flash_attention.fwd ins(%extracted_slice, %extracted_slice_0, %extracted_slice_1 : tensor<?x?x64xf32>, tensor<?x1024x64xf32>, tensor<?x1024x64xf32>) outs(%extracted_slice_2 : tensor<?x?x64xf32>) -> tensor<?x?x64xf32>
+        %inserted_slice = tensor.insert_slice %5 into %arg6[%2, %4, 0] [%arg3, %arg5, 64] [1, 1, 1] : tensor<?x?x64xf32> into tensor<192x1024x64xf32>
+        scf.yield %inserted_slice : tensor<192x1024x64xf32>
+      }
+      scf.yield %3 : tensor<192x1024x64xf32>
+    }
+    return %1 : tensor<192x1024x64xf32>
+  }
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (2, -d0 + s1)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0, d1)>
+// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0, d1) -> (d0)>
+// CHECK-DAG:  #[[MAP4:.+]] = affine_map<(d0) -> (d0)>
+// CHECK:      func.func @flash_attention_fwd(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
+// CHECK-SAME:   tensor<192x1024x64xf32>, %[[ARG2:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
+// CHECK-SAME:   {
+// CHECK:        %[[C1:.+]] = arith.constant 1 : index
+// CHECK:        %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[CST_0:.+]] = arith.constant -1.000000e+02 : f32
+// CHECK:        %[[C0:.+]] = arith.constant 0 : index
+// CHECK:        %[[C192:.+]] = arith.constant 192 : index
+// CHECK:        %[[C1024:.+]] = arith.constant 1024 : index
+// CHECK:        %[[C2:.+]] = arith.constant 2 : index
+// CHECK:        %[[C32:.+]] = arith.constant 32 : index
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<192x1024x64xf32>
+// CHECK:        %[[D1:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C192]] step %[[C2]]
+// CHECK-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D0]]) -> (tensor<192x1024x64xf32>) {
+// CHECK-DAG:        %[[D2:.+]] = affine.min #[[MAP]](%[[ARG3]])[%[[C2]], %[[C192]]]
+// CHECK:          %[[D3:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C32]]
+// CHECK-SAME:       iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[ARG4]]) -> (tensor<192x1024x64xf32>) {
+// CHECK-DAG:          %[[D4:.+]] = affine.min #[[MAP1]](%[[ARG5]])[%[[C32]], %[[C1024]]]
+// CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
+// CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
+// CHECK:            %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
+// CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
+// CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[ARG2]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
+// CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
+// CHECK:            %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[D0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
+// CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
+// CHECK:            %[[D5:.+]] = scf.for %[[ARG7:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D2]] step %[[C1]]
+// CHECK-SAME:         iter_args(%[[ARG8:[a-zA-Z0-9_]+]] = %[[EXTRACTED_SLICE_3]]) -> (tensor<?x?x64xf32>) {
+// CHECK:              %[[D6:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
+// CHECK:              %[[D7:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D6]] : tensor<?xf32>) -> tensor<?xf32>
+// CHECK:              %[[D8:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
+// CHECK:              %[[D9:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D8]] : tensor<?xf32>) -> tensor<?xf32>
+// CHECK:              %[[D10:.+]]:3 = scf.for %[[ARG9:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[D4]]
+// CHECK-SAME:           iter_args(%[[ARG10:[a-zA-Z0-9_]+]] = %[[ARG8]], %[[ARG11:[a-zA-Z0-9_]+]] = %[[D7]],
+// CHECK-SAME:           %[[ARG12:[a-zA-Z0-9_]+]] = %[[D9]]) -> (tensor<?x?x64xf32>, tensor<?xf32>, tensor<?xf32>) {
+// CHECK:                %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE_1]][%[[ARG7]], %[[ARG9]],
+// CHECK-SAME:             0] [1, %[[D4]], 64] [1, 1, 1] : tensor<?x1024x64xf32> to tensor<?x64xf32>
+// CHECK:                %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE_2]][%[[ARG7]], %[[ARG9]],
+// CHECK-SAME:             0] [1, %[[D4]], 64] [1, 1, 1] : tensor<?x1024x64xf32> to tensor<?x64xf32>
+// CHECK:                %[[EXTRACTED_SLICE_6:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG7]], 0, 0] [1,
+// CHECK-SAME:             %[[D4]], 64] [1, 1, 1] : tensor<?x?x64xf32> to tensor<?x64xf32>
+// CHECK:                %[[EXTRACTED_SLICE_7:.+]] = tensor.extract_slice %[[ARG10]][%[[ARG7]], 0, 0] [1, %[[D4]], 64]
+// CHECK-SAME:             [1, 1, 1] : tensor<?x?x64xf32> to tensor<?x64xf32>
+// CHECK:                %[[D11:.+]] = tensor.empty(%[[D4]]) : tensor<64x?xf32>
+// CHECK:                %[[D12:.+]] = tensor.empty(%[[D4]], %[[D4]]) : tensor<?x?xf32>
+// CHECK:                %[[TRANSPOSED:.+]] = linalg.transpose ins(%[[EXTRACTED_SLICE_4]] : tensor<?x64xf32>)
+// CHECK-SAME:             outs(%[[D11]] : tensor<64x?xf32>) permutation = [1, 0]
+// CHECK:                %[[D13:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D12]] : tensor<?x?xf32>) ->
+// CHECK-SAME:             tensor<?x?xf32>
+// CHECK:                %[[D14:.+]] = linalg.matmul ins(%[[EXTRACTED_SLICE_6]], %[[TRANSPOSED]] : tensor<?x64xf32>,
+// CHECK-SAME:             tensor<64x?xf32>) outs(%[[D13]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:                %[[D15:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
+// CHECK:                %[[D16:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]]], iterator_types =
+// CHECK-SAME:             ["reduction", "parallel"]} ins(%[[D14]] : tensor<?x?xf32>) outs(%[[D15]] : tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
+// CHECK:                  linalg.yield %[[D26]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D17:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]]], iterator_types =
+// CHECK-SAME:             ["reduction", "parallel"]} ins(%[[D14]] : tensor<?x?xf32>) outs(%[[D15]] : tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26]] = arith.addf %[[IN]], %[[OUT]] : f32
+// CHECK:                  linalg.yield %[[D26]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D18:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]]], iterator_types
+// CHECK-SAME:             = ["parallel"]} ins(%[[ARG11]], %[[D16]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] :
+// CHECK-SAME:             tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26]] = arith.maxf %[[IN]], %[[IN_11]] : f32
+// CHECK:                  linalg.yield %[[D26]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D19:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]]], iterator_types
+// CHECK-SAME:             = ["parallel"]} ins(%[[ARG11]], %[[D18]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] :
+// CHECK-SAME:             tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26]] = arith.subf %[[IN]], %[[IN_11]] : f32
+// CHECK:                  %[[D27:.+]] = math.exp %[[D26]] : f32
+// CHECK:                  linalg.yield %[[D27]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D20:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]]], iterator_types
+// CHECK-SAME:             = ["parallel"]} ins(%[[D16]], %[[D18]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] :
+// CHECK-SAME:             tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26]] = arith.subf %[[IN]], %[[IN_11]] : f32
+// CHECK:                  %[[D27]] = math.exp %[[D26]] : f32
+// CHECK:                  linalg.yield %[[D27]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D21:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]], #[[MAP4]],
+// CHECK-SAME:             #[[MAP4]]], iterator_types = ["parallel"]} ins(%[[ARG12]], %[[D17]], %[[D19]], %[[D20]] :
+// CHECK-SAME:             tensor<?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] : tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[IN_12:.+]]: f32, %[[IN_13:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26]] = arith.mulf %[[IN_12]], %[[IN]] : f32
+// CHECK:                  %[[D27]] = arith.mulf %[[IN_13]], %[[IN_11]] : f32
+// CHECK:                  %[[D28:.+]] = arith.addf %[[D26]], %[[D27]] : f32
+// CHECK:                  linalg.yield %[[D28]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D22:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP3]], #[[MAP3]],
+// CHECK-SAME:             #[[MAP2]]], iterator_types = ["parallel", "parallel"]} ins(%[[D14]], %[[D16]], %[[D20]],
+// CHECK-SAME:             %[[D21]] : tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) outs(%[[D12]] :
+// CHECK-SAME:             tensor<?x?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[IN_12:.+]]: f32, %[[IN_13:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26]] = arith.subf %[[IN]], %[[IN_11]] : f32
+// CHECK:                  %[[D27]] = math.exp %[[D26]] : f32
+// CHECK:                  %[[D28]] = arith.mulf %[[D27]], %[[IN_12]] : f32
+// CHECK:                  %[[D29:.+]] = arith.divf %[[D28]], %[[IN_13]] : f32
+// CHECK:                  linalg.yield %[[D29]] : f32
+// CHECK:                } -> tensor<?x?xf32>
+// CHECK:                %[[D23:.+]] = tensor.empty(%[[C1024]]) : tensor<?x64xf32>
+// CHECK:                %[[D24:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP3]], #[[MAP3]],
+// CHECK-SAME:             #[[MAP2]]], iterator_types = ["parallel", "parallel"]} ins(%[[EXTRACTED_SLICE_7]],
+// CHECK-SAME:             %[[ARG12]], %[[D21]], %[[D19]] : tensor<?x64xf32>, tensor<?xf32>, tensor<?xf32>,
+// CHECK-SAME:             tensor<?xf32>) outs(%[[D23]] : tensor<?x64xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[IN_12:.+]]: f32, %[[IN_13:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D26]] = arith.mulf %[[IN_11]], %[[IN_13]] : f32
+// CHECK:                  %[[D27]] = arith.mulf %[[IN]], %[[D26]] : f32
+// CHECK:                  %[[D28]] = arith.divf %[[D27]], %[[IN_12]] : f32
+// CHECK:                  linalg.yield %[[D28]] : f32
+// CHECK:                } -> tensor<?x64xf32>
+// CHECK:                %[[D25:.+]] = linalg.matmul ins(%[[D22]], %[[EXTRACTED_SLICE_5]] : tensor<?x?xf32>,
+// CHECK-SAME:             tensor<?x64xf32>) outs(%[[D24]] : tensor<?x64xf32>) -> tensor<?x64xf32>
+// CHECK:                %[[INSERTED_SLICE_8:.+]] = tensor.insert_slice %[[D25]] into %[[ARG10]][%[[ARG7]], 0, 0] [1,
+// CHECK-SAME:             %[[D4]], 64] [1, 1, 1] : tensor<?x64xf32> into tensor<?x?x64xf32>
+// CHECK:                %[[INSERTED_SLICE_9:.+]] = tensor.insert_slice %[[D18]] into %[[D6]][0] [%[[D4]]] [1] :
+// CHECK-SAME:             tensor<?xf32> into tensor<?xf32>
+// CHECK:                %[[INSERTED_SLICE_10:.+]] = tensor.insert_slice %[[D21]] into %[[D8]][0] [%[[D4]]] [1] :
+// CHECK-SAME:             tensor<?xf32> into tensor<?xf32>
+// CHECK:                scf.yield %[[INSERTED_SLICE_8]], %[[INSERTED_SLICE_9]], %[[INSERTED_SLICE_10]] :
+// CHECK-SAME:             tensor<?x?x64xf32>, tensor<?xf32>, tensor<?xf32>
+// CHECK:              }
+// CHECK:              scf.yield %[[D10]]#[[D0:.+]] : tensor<?x?x64xf32>
+// CHECK:            }
+// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D5]] into %[[ARG6]][%[[D2]], %[[D4]], 0]
+// CHECK-SAME:         [%[[ARG3]], %[[ARG5]], 64] [1, 1, 1] : tensor<?x?x64xf32> into tensor<192x1024x64xf32>
+// CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<192x1024x64xf32>
+// CHECK:          }
+// CHECK:          scf.yield %[[D3]] : tensor<192x1024x64xf32>
+// CHECK:        }
+// CHECK:        return %[[D1]] : tensor<192x1024x64xf32>
+// CHECK:      }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_flash_attention.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tile_and_decompose_flash_attention.mlir
@@ -27,6 +27,7 @@ module {
     return %1 : tensor<192x1024x64xf32>
   }
 }
+
 // CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0)[s0, s1] -> (2, -d0 + s1)>
 // CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (32, -d0 + s1)>
 // CHECK-DAG:  #[[MAP2:.+]] = affine_map<(d0, d1) -> (d0, d1)>
@@ -35,9 +36,6 @@ module {
 // CHECK:      func.func @flash_attention_fwd(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
 // CHECK-SAME:   tensor<192x1024x64xf32>, %[[ARG2:[a-zA-Z0-9_]+]]: tensor<192x1024x64xf32>) -> tensor<192x1024x64xf32>
 // CHECK-SAME:   {
-// CHECK:        %[[C1:.+]] = arith.constant 1 : index
-// CHECK:        %[[CST:.+]] = arith.constant 0.000000e+00 : f32
-// CHECK:        %[[CST_0:.+]] = arith.constant -1.000000e+02 : f32
 // CHECK:        %[[C0:.+]] = arith.constant 0 : index
 // CHECK:        %[[C192:.+]] = arith.constant 192 : index
 // CHECK:        %[[C1024:.+]] = arith.constant 1024 : index
@@ -52,117 +50,128 @@ module {
 // CHECK-DAG:          %[[D4:.+]] = affine.min #[[MAP1]](%[[ARG5]])[%[[C32]], %[[C1024]]]
 // CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
 // CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
-// CHECK:            %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
+// CHECK:            %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
 // CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
-// CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[ARG2]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
+// CHECK:            %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[ARG2]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
 // CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
-// CHECK:            %[[EXTRACTED_SLICE_3:.+]] = tensor.extract_slice %[[D0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
+// CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
 // CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
-// CHECK:            %[[D5:.+]] = scf.for %[[ARG7:[a-zA-Z0-9_]+]] = %[[C0]] to %[[D2]] step %[[C1]]
-// CHECK-SAME:         iter_args(%[[ARG8:[a-zA-Z0-9_]+]] = %[[EXTRACTED_SLICE_3]]) -> (tensor<?x?x64xf32>) {
-// CHECK:              %[[D6:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
-// CHECK:              %[[D7:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D6]] : tensor<?xf32>) -> tensor<?xf32>
-// CHECK:              %[[D8:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
-// CHECK:              %[[D9:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D8]] : tensor<?xf32>) -> tensor<?xf32>
-// CHECK:              %[[D10:.+]]:3 = scf.for %[[ARG9:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[D4]]
-// CHECK-SAME:           iter_args(%[[ARG10:[a-zA-Z0-9_]+]] = %[[ARG8]], %[[ARG11:[a-zA-Z0-9_]+]] = %[[D7]],
-// CHECK-SAME:           %[[ARG12:[a-zA-Z0-9_]+]] = %[[D9]]) -> (tensor<?x?x64xf32>, tensor<?xf32>, tensor<?xf32>) {
-// CHECK:                %[[EXTRACTED_SLICE_4:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE_1]][%[[ARG7]], %[[ARG9]],
+// CHECK:            %[[C0]]_3 = arith.constant 0 : index
+// CHECK:            %[[C1:.+]] = arith.constant 1 : index
+// CHECK:            %[[C0]]_4 = arith.constant 0 : index
+// CHECK:            %[[C1024]]_5 = arith.constant 1024 : index
+// CHECK:            %[[C0]]_6 = arith.constant 0 : index
+// CHECK:            %[[C1]]_7 = arith.constant 1 : index
+// CHECK:            %[[D5:.+]] = scf.for %[[ARG7:[a-zA-Z0-9_]+]] = %[[C0]]_6 to %[[D2]] step %[[C1]]_7
+// CHECK-SAME:         iter_args(%[[ARG8:[a-zA-Z0-9_]+]] = %[[EXTRACTED_SLICE_2]]) -> (tensor<?x?x64xf32>) {
+// CHECK:              %[[CST:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:              %[[CST_8:.+]] = arith.constant -1.000000e+02 : f32
+// CHECK:              %[[D7:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
+// CHECK:              %[[D8:.+]] = linalg.fill ins(%[[CST_8]] : f32) outs(%[[D7]] : tensor<?xf32>) -> tensor<?xf32>
+// CHECK:              %[[D9:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
+// CHECK:              %[[D10:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D9]] : tensor<?xf32>) -> tensor<?xf32>
+// CHECK:              %[[D11:.+]]:3 = scf.for %[[ARG9:[a-zA-Z0-9_]+]] = %[[C0]]_6 to %[[C1024]]_5 step %[[D4]]
+// CHECK-SAME:           iter_args(%[[ARG10:[a-zA-Z0-9_]+]] = %[[ARG8]], %[[ARG11:[a-zA-Z0-9_]+]] = %[[D8]],
+// CHECK-SAME:           %[[ARG12:[a-zA-Z0-9_]+]] = %[[D10]]) -> (tensor<?x?x64xf32>, tensor<?xf32>, tensor<?xf32>) {
+// CHECK:                %[[EXTRACTED_SLICE_9:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE_0]][%[[ARG7]], %[[ARG9]],
 // CHECK-SAME:             0] [1, %[[D4]], 64] [1, 1, 1] : tensor<?x1024x64xf32> to tensor<?x64xf32>
-// CHECK:                %[[EXTRACTED_SLICE_5:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE_2]][%[[ARG7]], %[[ARG9]],
+// CHECK:                %[[EXTRACTED_SLICE_10:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE_1]][%[[ARG7]], %[[ARG9]],
 // CHECK-SAME:             0] [1, %[[D4]], 64] [1, 1, 1] : tensor<?x1024x64xf32> to tensor<?x64xf32>
-// CHECK:                %[[EXTRACTED_SLICE_6:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG7]], 0, 0] [1,
+// CHECK:                %[[EXTRACTED_SLICE_11:.+]] = tensor.extract_slice %[[EXTRACTED_SLICE]][%[[ARG7]], 0, 0] [1,
 // CHECK-SAME:             %[[D4]], 64] [1, 1, 1] : tensor<?x?x64xf32> to tensor<?x64xf32>
-// CHECK:                %[[EXTRACTED_SLICE_7:.+]] = tensor.extract_slice %[[ARG10]][%[[ARG7]], 0, 0] [1, %[[D4]], 64]
+// CHECK:                %[[EXTRACTED_SLICE_12:.+]] = tensor.extract_slice %[[ARG10]][%[[ARG7]], 0, 0] [1, %[[D4]], 64]
 // CHECK-SAME:             [1, 1, 1] : tensor<?x?x64xf32> to tensor<?x64xf32>
-// CHECK:                %[[D11:.+]] = tensor.empty(%[[D4]]) : tensor<64x?xf32>
-// CHECK:                %[[D12:.+]] = tensor.empty(%[[D4]], %[[D4]]) : tensor<?x?xf32>
-// CHECK:                %[[TRANSPOSED:.+]] = linalg.transpose ins(%[[EXTRACTED_SLICE_4]] : tensor<?x64xf32>)
-// CHECK-SAME:             outs(%[[D11]] : tensor<64x?xf32>) permutation = [1, 0]
-// CHECK:                %[[D13:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D12]] : tensor<?x?xf32>) ->
+// CHECK:                %[[D12:.+]] = tensor.empty(%[[D4]]) : tensor<64x?xf32>
+// CHECK:                %[[D13:.+]] = tensor.empty(%[[D4]], %[[D4]]) : tensor<?x?xf32>
+// CHECK:                %[[TRANSPOSED:.+]] = linalg.transpose ins(%[[EXTRACTED_SLICE_9]] : tensor<?x64xf32>)
+// CHECK-SAME:             outs(%[[D12]] : tensor<64x?xf32>) permutation = [1, 0]
+// CHECK:                %[[D14:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D13]] : tensor<?x?xf32>) ->
 // CHECK-SAME:             tensor<?x?xf32>
-// CHECK:                %[[D14:.+]] = linalg.matmul ins(%[[EXTRACTED_SLICE_6]], %[[TRANSPOSED]] : tensor<?x64xf32>,
-// CHECK-SAME:             tensor<64x?xf32>) outs(%[[D13]] : tensor<?x?xf32>) -> tensor<?x?xf32>
-// CHECK:                %[[D15:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
-// CHECK:                %[[D16:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]]], iterator_types =
-// CHECK-SAME:             ["reduction", "parallel"]} ins(%[[D14]] : tensor<?x?xf32>) outs(%[[D15]] : tensor<?xf32>) {
-// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
-// CHECK:                  linalg.yield %[[D26]] : f32
-// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D15:.+]] = linalg.matmul ins(%[[EXTRACTED_SLICE_11]], %[[TRANSPOSED]] : tensor<?x64xf32>,
+// CHECK-SAME:             tensor<64x?xf32>) outs(%[[D14]] : tensor<?x?xf32>) -> tensor<?x?xf32>
+// CHECK:                %[[D16:.+]] = tensor.empty(%[[D4]]) : tensor<?xf32>
 // CHECK:                %[[D17:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]]], iterator_types =
-// CHECK-SAME:             ["reduction", "parallel"]} ins(%[[D14]] : tensor<?x?xf32>) outs(%[[D15]] : tensor<?xf32>) {
+// CHECK-SAME:             ["reduction", "parallel"]} ins(%[[D15]] : tensor<?x?xf32>) outs(%[[D16]] : tensor<?xf32>) {
 // CHECK:                ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26]] = arith.addf %[[IN]], %[[OUT]] : f32
-// CHECK:                  linalg.yield %[[D26]] : f32
+// CHECK:                  %[[D27:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
+// CHECK:                  linalg.yield %[[D27]] : f32
 // CHECK:                } -> tensor<?xf32>
-// CHECK:                %[[D18:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]]], iterator_types
-// CHECK-SAME:             = ["parallel"]} ins(%[[ARG11]], %[[D16]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] :
-// CHECK-SAME:             tensor<?xf32>) {
-// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26]] = arith.maxf %[[IN]], %[[IN_11]] : f32
-// CHECK:                  linalg.yield %[[D26]] : f32
+// CHECK:                %[[D18:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]]], iterator_types =
+// CHECK-SAME:             ["reduction", "parallel"]} ins(%[[D15]] : tensor<?x?xf32>) outs(%[[D16]] : tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D27]] = arith.addf %[[IN]], %[[OUT]] : f32
+// CHECK:                  linalg.yield %[[D27]] : f32
 // CHECK:                } -> tensor<?xf32>
 // CHECK:                %[[D19:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]]], iterator_types
-// CHECK-SAME:             = ["parallel"]} ins(%[[ARG11]], %[[D18]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] :
+// CHECK-SAME:             = ["parallel"]} ins(%[[ARG11]], %[[D17]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D16]] :
 // CHECK-SAME:             tensor<?xf32>) {
-// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26]] = arith.subf %[[IN]], %[[IN_11]] : f32
-// CHECK:                  %[[D27:.+]] = math.exp %[[D26]] : f32
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_16:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D27]] = arith.maxf %[[IN]], %[[IN_16]] : f32
 // CHECK:                  linalg.yield %[[D27]] : f32
 // CHECK:                } -> tensor<?xf32>
 // CHECK:                %[[D20:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]]], iterator_types
-// CHECK-SAME:             = ["parallel"]} ins(%[[D16]], %[[D18]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] :
+// CHECK-SAME:             = ["parallel"]} ins(%[[ARG11]], %[[D19]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D16]] :
 // CHECK-SAME:             tensor<?xf32>) {
-// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26]] = arith.subf %[[IN]], %[[IN_11]] : f32
-// CHECK:                  %[[D27]] = math.exp %[[D26]] : f32
-// CHECK:                  linalg.yield %[[D27]] : f32
-// CHECK:                } -> tensor<?xf32>
-// CHECK:                %[[D21:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]], #[[MAP4]],
-// CHECK-SAME:             #[[MAP4]]], iterator_types = ["parallel"]} ins(%[[ARG12]], %[[D17]], %[[D19]], %[[D20]] :
-// CHECK-SAME:             tensor<?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) outs(%[[D15]] : tensor<?xf32>) {
-// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[IN_12:.+]]: f32, %[[IN_13:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26]] = arith.mulf %[[IN_12]], %[[IN]] : f32
-// CHECK:                  %[[D27]] = arith.mulf %[[IN_13]], %[[IN_11]] : f32
-// CHECK:                  %[[D28:.+]] = arith.addf %[[D26]], %[[D27]] : f32
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_16:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D27]] = arith.subf %[[IN]], %[[IN_16]] : f32
+// CHECK:                  %[[D28:.+]] = math.exp %[[D27]] : f32
 // CHECK:                  linalg.yield %[[D28]] : f32
 // CHECK:                } -> tensor<?xf32>
-// CHECK:                %[[D22:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP3]], #[[MAP3]],
-// CHECK-SAME:             #[[MAP2]]], iterator_types = ["parallel", "parallel"]} ins(%[[D14]], %[[D16]], %[[D20]],
-// CHECK-SAME:             %[[D21]] : tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) outs(%[[D12]] :
-// CHECK-SAME:             tensor<?x?xf32>) {
-// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[IN_12:.+]]: f32, %[[IN_13:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26]] = arith.subf %[[IN]], %[[IN_11]] : f32
-// CHECK:                  %[[D27]] = math.exp %[[D26]] : f32
-// CHECK:                  %[[D28]] = arith.mulf %[[D27]], %[[IN_12]] : f32
-// CHECK:                  %[[D29:.+]] = arith.divf %[[D28]], %[[IN_13]] : f32
+// CHECK:                %[[D21:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]]], iterator_types
+// CHECK-SAME:             = ["parallel"]} ins(%[[D17]], %[[D19]] : tensor<?xf32>, tensor<?xf32>) outs(%[[D16]] :
+// CHECK-SAME:             tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_16:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D27]] = arith.subf %[[IN]], %[[IN_16]] : f32
+// CHECK:                  %[[D28]] = math.exp %[[D27]] : f32
+// CHECK:                  linalg.yield %[[D28]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D22:.+]] = linalg.generic {indexing_maps = [#[[MAP4]], #[[MAP4]], #[[MAP4]], #[[MAP4]],
+// CHECK-SAME:             #[[MAP4]]], iterator_types = ["parallel"]} ins(%[[ARG12]], %[[D18]], %[[D20]], %[[D21]] :
+// CHECK-SAME:             tensor<?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) outs(%[[D16]] : tensor<?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_16:.+]]: f32, %[[IN_17:.+]]: f32, %[[IN_18:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D27]] = arith.mulf %[[IN_17]], %[[IN]] : f32
+// CHECK:                  %[[D28]] = arith.mulf %[[IN_18]], %[[IN_16]] : f32
+// CHECK:                  %[[D29:.+]] = arith.addf %[[D27]], %[[D28]] : f32
 // CHECK:                  linalg.yield %[[D29]] : f32
+// CHECK:                } -> tensor<?xf32>
+// CHECK:                %[[D23:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP3]], #[[MAP3]],
+// CHECK-SAME:             #[[MAP2]]], iterator_types = ["parallel", "parallel"]} ins(%[[D15]], %[[D17]], %[[D21]],
+// CHECK-SAME:             %[[D22]] : tensor<?x?xf32>, tensor<?xf32>, tensor<?xf32>, tensor<?xf32>) outs(%[[D13]] :
+// CHECK-SAME:             tensor<?x?xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_16:.+]]: f32, %[[IN_17:.+]]: f32, %[[IN_18:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D27]] = arith.subf %[[IN]], %[[IN_16]] : f32
+// CHECK:                  %[[D28]] = math.exp %[[D27]] : f32
+// CHECK:                  %[[D29]] = arith.mulf %[[D28]], %[[IN_17]] : f32
+// CHECK:                  %[[D30:.+]] = arith.divf %[[D29]], %[[IN_18]] : f32
+// CHECK:                  linalg.yield %[[D30]] : f32
 // CHECK:                } -> tensor<?x?xf32>
-// CHECK:                %[[D23:.+]] = tensor.empty(%[[C1024]]) : tensor<?x64xf32>
-// CHECK:                %[[D24:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP3]], #[[MAP3]],
-// CHECK-SAME:             #[[MAP2]]], iterator_types = ["parallel", "parallel"]} ins(%[[EXTRACTED_SLICE_7]],
-// CHECK-SAME:             %[[ARG12]], %[[D21]], %[[D19]] : tensor<?x64xf32>, tensor<?xf32>, tensor<?xf32>,
-// CHECK-SAME:             tensor<?xf32>) outs(%[[D23]] : tensor<?x64xf32>) {
-// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_11:.+]]: f32, %[[IN_12:.+]]: f32, %[[IN_13:.+]]: f32, %[[OUT:.+]]: f32):
-// CHECK:                  %[[D26]] = arith.mulf %[[IN_11]], %[[IN_13]] : f32
-// CHECK:                  %[[D27]] = arith.mulf %[[IN]], %[[D26]] : f32
-// CHECK:                  %[[D28]] = arith.divf %[[D27]], %[[IN_12]] : f32
-// CHECK:                  linalg.yield %[[D28]] : f32
+// CHECK:                %[[D24:.+]] = tensor.empty(%[[C1024]]_5) : tensor<?x64xf32>
+// CHECK:                %[[D25:.+]] = linalg.generic {indexing_maps = [#[[MAP2]], #[[MAP3]], #[[MAP3]], #[[MAP3]],
+// CHECK-SAME:             #[[MAP2]]], iterator_types = ["parallel", "parallel"]} ins(%[[EXTRACTED_SLICE_12]],
+// CHECK-SAME:             %[[ARG12]], %[[D22]], %[[D20]] : tensor<?x64xf32>, tensor<?xf32>, tensor<?xf32>,
+// CHECK-SAME:             tensor<?xf32>) outs(%[[D24]] : tensor<?x64xf32>) {
+// CHECK:                ^bb0(%[[IN:.+]]: f32, %[[IN_16:.+]]: f32, %[[IN_17:.+]]: f32, %[[IN_18:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:                  %[[D27]] = arith.mulf %[[IN_16]], %[[IN_18]] : f32
+// CHECK:                  %[[D28]] = arith.mulf %[[IN]], %[[D27]] : f32
+// CHECK:                  %[[D29]] = arith.divf %[[D28]], %[[IN_17]] : f32
+// CHECK:                  linalg.yield %[[D29]] : f32
 // CHECK:                } -> tensor<?x64xf32>
-// CHECK:                %[[D25:.+]] = linalg.matmul ins(%[[D22]], %[[EXTRACTED_SLICE_5]] : tensor<?x?xf32>,
-// CHECK-SAME:             tensor<?x64xf32>) outs(%[[D24]] : tensor<?x64xf32>) -> tensor<?x64xf32>
-// CHECK:                %[[INSERTED_SLICE_8:.+]] = tensor.insert_slice %[[D25]] into %[[ARG10]][%[[ARG7]], 0, 0] [1,
+// CHECK:                %[[D26:.+]] = linalg.matmul ins(%[[D23]], %[[EXTRACTED_SLICE_10]] : tensor<?x?xf32>,
+// CHECK-SAME:             tensor<?x64xf32>) outs(%[[D25]] : tensor<?x64xf32>) -> tensor<?x64xf32>
+// CHECK:                %[[INSERTED_SLICE_13:.+]] = tensor.insert_slice %[[D26]] into %[[ARG10]][%[[ARG7]], 0, 0] [1,
 // CHECK-SAME:             %[[D4]], 64] [1, 1, 1] : tensor<?x64xf32> into tensor<?x?x64xf32>
-// CHECK:                %[[INSERTED_SLICE_9:.+]] = tensor.insert_slice %[[D18]] into %[[D6]][0] [%[[D4]]] [1] :
+// CHECK:                %[[INSERTED_SLICE_14:.+]] = tensor.insert_slice %[[D19]] into %[[ARG11]][0] [%[[D4]]] [1] :
 // CHECK-SAME:             tensor<?xf32> into tensor<?xf32>
-// CHECK:                %[[INSERTED_SLICE_10:.+]] = tensor.insert_slice %[[D21]] into %[[D8]][0] [%[[D4]]] [1] :
+// CHECK:                %[[INSERTED_SLICE_15:.+]] = tensor.insert_slice %[[D22]] into %[[ARG12]][0] [%[[D4]]] [1] :
 // CHECK-SAME:             tensor<?xf32> into tensor<?xf32>
-// CHECK:                scf.yield %[[INSERTED_SLICE_8]], %[[INSERTED_SLICE_9]], %[[INSERTED_SLICE_10]] :
+// CHECK:                scf.yield %[[INSERTED_SLICE_13]], %[[INSERTED_SLICE_14]], %[[INSERTED_SLICE_15]] :
 // CHECK-SAME:             tensor<?x?x64xf32>, tensor<?xf32>, tensor<?xf32>
 // CHECK:              }
-// CHECK:              scf.yield %[[D10]]#[[D0:.+]] : tensor<?x?x64xf32>
+// CHECK:              scf.yield %[[D11]]#[[D0:.+]] : tensor<?x?x64xf32>
 // CHECK:            }
+// CHECK:            %[[D6:.+]] = iree_linalg_ext.flash_attention.fwd ins(%[[EXTRACTED_SLICE]], %[[EXTRACTED_SLICE_0]],
+// CHECK-SAME:         %[[EXTRACTED_SLICE_1]] : tensor<?x?x64xf32>, tensor<?x1024x64xf32>, tensor<?x1024x64xf32>)
+// CHECK-SAME:         outs(%[[EXTRACTED_SLICE_2]] : tensor<?x?x64xf32>) -> tensor<?x?x64xf32>
 // CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D5]] into %[[ARG6]][%[[D2]], %[[D4]], 0]
 // CHECK-SAME:         [%[[ARG3]], %[[ARG5]], 64] [1, 1, 1] : tensor<?x?x64xf32> into tensor<192x1024x64xf32>
 // CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<192x1024x64xf32>

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
@@ -1524,7 +1524,7 @@ func.func @flash_attention_fwd(%query: tensor<192x1024x64xf32>, %key: tensor<192
 // CHECK:        %[[D0:.+]] = tensor.empty() : tensor<192x1024x64xf32>
 // CHECK:        %[[D1:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C192]] step %[[C1]]
 // CHECK-SAME:     iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[D0]]) -> (tensor<192x1024x64xf32>) {
-// CHECK-DAG:        %[[D2:.+]] = affine.min #[[MAP]](%[[ARG3]])[%[[C1]], %[[C1]]92]
+// CHECK-DAG:        %[[D2:.+]] = affine.min #[[MAP]](%[[ARG3]])[%[[C1]], %[[C192]]]
 // CHECK:          %[[D3:.+]] = scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C32]]
 // CHECK-SAME:       iter_args(%[[ARG6:[a-zA-Z0-9_]+]] = %[[ARG4]]) -> (tensor<192x1024x64xf32>) {
 // CHECK-DAG:          %[[D4:.+]] = affine.min #[[MAP1]](%[[ARG5]])[%[[C32]], %[[C1024]]]
@@ -1536,11 +1536,11 @@ func.func @flash_attention_fwd(%query: tensor<192x1024x64xf32>, %key: tensor<192
 // CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
 // CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
 // CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
-// CHECK:            %[[D5:.+]] = iree_linalg_ext.flash_attention.fwd ins(%[[EXTRACTED_SLICE]], %[[EXTRACTED_SLICE]]_0,
-// CHECK-SAME:         %[[EXTRACTED_SLICE]]_1 : tensor<?x?x64xf32>, tensor<?x1024x64xf32>, tensor<?x1024x64xf32>)
-// CHECK-SAME:         outs(%[[EXTRACTED_SLICE]]_2 : tensor<?x?x64xf32>) -> tensor<?x?x64xf32>
-// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D5]] into %[[ARG6]][%[[D2]], %[[D4]], 0]
-// CHECK-SAME:         [%[[ARG3]], %[[ARG5]], 64] [1, 1, 1] : tensor<?x?x64xf32> into tensor<192x1024x64xf32>
+// CHECK:            %[[D5:.+]] = iree_linalg_ext.flash_attention.fwd ins(%[[EXTRACTED_SLICE]], %[[EXTRACTED_SLICE_0]],
+// CHECK-SAME:         %[[EXTRACTED_SLICE_1]] : tensor<?x?x64xf32>, tensor<?x1024x64xf32>, tensor<?x1024x64xf32>)
+// CHECK-SAME:         outs(%[[EXTRACTED_SLICE_2]] : tensor<?x?x64xf32>) -> tensor<?x?x64xf32>
+// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D5]] into %[[ARG6]][%[[ARG3]], %[[ARG5]], 0]
+// CHECK-SAME:         [%[[D2]], %[[D4]], 64] [1, 1, 1] : tensor<?x?x64xf32> into tensor<192x1024x64xf32>
 // CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<192x1024x64xf32>
 // CHECK:          }
 // CHECK:          scf.yield %[[D3]] : tensor<192x1024x64xf32>
@@ -1565,7 +1565,7 @@ func.func @flash_attention_fwd_memref(%query: memref<192x1024x64xf32>, %key: mem
 // CHECK:        %[[C1:.+]] = arith.constant 1 : index
 // CHECK:        %[[C32:.+]] = arith.constant 32 : index
 // CHECK:        scf.for %[[ARG4:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C192]] step %[[C1]] {
-// CHECK-DAG:        %[[D0:.+]] = affine.min #[[MAP]](%[[ARG4]])[%[[C1]], %[[C1]]92]
+// CHECK-DAG:        %[[D0:.+]] = affine.min #[[MAP]](%[[ARG4]])[%[[C1]], %[[C192]]]
 // CHECK:          scf.for %[[ARG5:[a-zA-Z0-9_]+]] = %[[C0]] to %[[C1024]] step %[[C32]] {
 // CHECK-DAG:          %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG5]])[%[[C32]], %[[C1024]]]
 // CHECK:            %[[SUBVIEW:.+]] = memref.subview %[[ARG0]][%[[ARG4]], %[[ARG5]], 0] [%[[D0]], %[[D1]], 64] [1, 1,
@@ -1576,9 +1576,9 @@ func.func @flash_attention_fwd_memref(%query: memref<192x1024x64xf32>, %key: mem
 // CHECK-SAME:         memref<192x1024x64xf32> to memref<?x1024x64xf32, strided<[65536, 64, 1], offset: ?>>
 // CHECK:            %[[SUBVIEW_2:.+]] = memref.subview %[[ARG3]][%[[ARG4]], %[[ARG5]], 0] [%[[D0]], %[[D1]], 64] [1, 1,
 // CHECK-SAME:         1] : memref<192x1024x64xf32> to memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>
-// CHECK:            iree_linalg_ext.flash_attention.fwd ins(%[[SUBVIEW]], %[[SUBVIEW]]_0, %[[SUBVIEW]]_1 :
+// CHECK:            iree_linalg_ext.flash_attention.fwd ins(%[[SUBVIEW]], %[[SUBVIEW_0]], %[[SUBVIEW_1]] :
 // CHECK-SAME:         memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>, memref<?x1024x64xf32, strided<[65536, 64,
-// CHECK-SAME:         1], offset: ?>>, memref<?x1024x64xf32, strided<[65536, 64, 1], offset: ?>>) outs(%[[SUBVIEW]]_2 :
+// CHECK-SAME:         1], offset: ?>>, memref<?x1024x64xf32, strided<[65536, 64, 1], offset: ?>>) outs(%[[SUBVIEW_2]] :
 // CHECK-SAME:         memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>)
 // CHECK:          }
 // CHECK:        }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
@@ -1530,11 +1530,15 @@ func.func @flash_attention_fwd(%query: tensor<192x1024x64xf32>, %key: tensor<192
 // CHECK-DAG:          %[[D4:.+]] = affine.min #[[MAP1]](%[[ARG5]])[%[[C32]], %[[C1024]]]
 // CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
 // CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
-// CHECK:            %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[D0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
+// CHECK:            %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[ARG1]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
+// CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
+// CHECK:            %[[EXTRACTED_SLICE_1:.+]] = tensor.extract_slice %[[ARG2]][%[[ARG3]], 0, 0] [%[[D2]], 1024, 64] [1,
+// CHECK-SAME:         1, 1] : tensor<192x1024x64xf32> to tensor<?x1024x64xf32>
+// CHECK:            %[[EXTRACTED_SLICE_2:.+]] = tensor.extract_slice %[[D0]][%[[ARG3]], %[[ARG5]], 0] [%[[D2]],
 // CHECK-SAME:         %[[D4]], 64] [1, 1, 1] : tensor<192x1024x64xf32> to tensor<?x?x64xf32>
-// CHECK:            %[[D5:.+]] = iree_linalg_ext.flash_attention.fwd ins(%[[EXTRACTED_SLICE]], %[[ARG1]], %[[ARG2]] :
-// CHECK-SAME:         tensor<?x?x64xf32>, tensor<192x1024x64xf32>, tensor<192x1024x64xf32>) outs(%[[EXTRACTED_SLICE]]_0
-// CHECK-SAME:         : tensor<?x?x64xf32>) -> tensor<?x?x64xf32>
+// CHECK:            %[[D5:.+]] = iree_linalg_ext.flash_attention.fwd ins(%[[EXTRACTED_SLICE]], %[[EXTRACTED_SLICE]]_0,
+// CHECK-SAME:         %[[EXTRACTED_SLICE]]_1 : tensor<?x?x64xf32>, tensor<?x1024x64xf32>, tensor<?x1024x64xf32>)
+// CHECK-SAME:         outs(%[[EXTRACTED_SLICE]]_2 : tensor<?x?x64xf32>) -> tensor<?x?x64xf32>
 // CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D5]] into %[[ARG6]][%[[D2]], %[[D4]], 0]
 // CHECK-SAME:         [%[[ARG3]], %[[ARG5]], 64] [1, 1, 1] : tensor<?x?x64xf32> into tensor<192x1024x64xf32>
 // CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<192x1024x64xf32>
@@ -1566,11 +1570,16 @@ func.func @flash_attention_fwd_memref(%query: memref<192x1024x64xf32>, %key: mem
 // CHECK-DAG:          %[[D1:.+]] = affine.min #[[MAP1]](%[[ARG5]])[%[[C32]], %[[C1024]]]
 // CHECK:            %[[SUBVIEW:.+]] = memref.subview %[[ARG0]][%[[ARG4]], %[[ARG5]], 0] [%[[D0]], %[[D1]], 64] [1, 1,
 // CHECK-SAME:         1] : memref<192x1024x64xf32> to memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>
-// CHECK:            %[[SUBVIEW_0:.+]] = memref.subview %[[ARG3]][%[[ARG4]], %[[ARG5]], 0] [%[[D0]], %[[D1]], 64] [1, 1,
+// CHECK:            %[[SUBVIEW_0:.+]] = memref.subview %[[ARG1]][%[[ARG4]], 0, 0] [%[[D0]], 1024, 64] [1, 1, 1] :
+// CHECK-SAME:         memref<192x1024x64xf32> to memref<?x1024x64xf32, strided<[65536, 64, 1], offset: ?>>
+// CHECK:            %[[SUBVIEW_1:.+]] = memref.subview %[[ARG2]][%[[ARG4]], 0, 0] [%[[D0]], 1024, 64] [1, 1, 1] :
+// CHECK-SAME:         memref<192x1024x64xf32> to memref<?x1024x64xf32, strided<[65536, 64, 1], offset: ?>>
+// CHECK:            %[[SUBVIEW_2:.+]] = memref.subview %[[ARG3]][%[[ARG4]], %[[ARG5]], 0] [%[[D0]], %[[D1]], 64] [1, 1,
 // CHECK-SAME:         1] : memref<192x1024x64xf32> to memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>
-// CHECK:            iree_linalg_ext.flash_attention.fwd ins(%[[SUBVIEW]], %[[ARG1]], %[[ARG2]] : memref<?x?x64xf32,
-// CHECK-SAME:         strided<[65536, 64, 1], offset: ?>>, memref<192x1024x64xf32>, memref<192x1024x64xf32>)
-// CHECK-SAME:         outs(%[[SUBVIEW]]_0 : memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>)
+// CHECK:            iree_linalg_ext.flash_attention.fwd ins(%[[SUBVIEW]], %[[SUBVIEW]]_0, %[[SUBVIEW]]_1 :
+// CHECK-SAME:         memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>, memref<?x1024x64xf32, strided<[65536, 64,
+// CHECK-SAME:         1], offset: ?>>, memref<?x1024x64xf32, strided<[65536, 64, 1], offset: ?>>) outs(%[[SUBVIEW]]_2 :
+// CHECK-SAME:         memref<?x?x64xf32, strided<[65536, 64, 1], offset: ?>>)
 // CHECK:          }
 // CHECK:        }
 // CHECK:        return


### PR DESCRIPTION
This patch adds the flash attention forward op
to LinalgExt. For tiling, we expose the two
outer dimensions corresponding to batch and sequence length.