### PR TITLE
Define our own `_HOST_EXECUTABLE_SUFFIX` to fix Emscripten builds.

### DIFF
--- a/build_tools/cmake/iree_import_binary.cmake
+++ b/build_tools/cmake/iree_import_binary.cmake
@@ -49,7 +49,7 @@ function(iree_import_binary)
   # platforms like Emscripten that set the suffix (e.g. to .js.)
   # https://gitlab.kitware.com/cmake/cmake/-/issues/17553
   set(_HOST_EXECUTABLE_SUFFIX "")
-  if(${CMAKE_HOST_SYSTEM} MATCHES "Windows")
+  if(CMAKE_HOST_WIN32)
     set(_HOST_EXECUTABLE_SUFFIX ".exe")
   endif()
 

--- a/build_tools/cmake/iree_import_binary.cmake
+++ b/build_tools/cmake/iree_import_binary.cmake
@@ -46,7 +46,7 @@ function(iree_import_binary)
   endif()
 
   # We can't use CMAKE_EXECUTABLE_SUFFIX for host tools when cross-compiling for
-  # platforms like Emscripten that set the suffix (e.g. to .js.)
+  # platforms like Emscripten that set the suffix (e.g. to .js).
   # https://gitlab.kitware.com/cmake/cmake/-/issues/17553
   set(_HOST_EXECUTABLE_SUFFIX "")
   if(CMAKE_HOST_WIN32)

--- a/build_tools/cmake/iree_import_binary.cmake
+++ b/build_tools/cmake/iree_import_binary.cmake
@@ -45,7 +45,15 @@ function(iree_import_binary)
     message(FATAL_ERROR "IREE_HOST_BINARY_ROOT must be set to use iree_import_binary")
   endif()
 
-  set(_FULL_BINARY_NAME "${_RULE_NAME}${CMAKE_EXECUTABLE_SUFFIX}")
+  # We can't use CMAKE_EXECUTABLE_SUFFIX for host tools when cross-compiling for
+  # platforms like Emscripten that set the suffix (e.g. to .js.)
+  # https://gitlab.kitware.com/cmake/cmake/-/issues/17553
+  set(_HOST_EXECUTABLE_SUFFIX "")
+  if(${CMAKE_HOST_SYSTEM} MATCHES "Windows")
+    set(_HOST_EXECUTABLE_SUFFIX ".exe")
+  endif()
+
+  set(_FULL_BINARY_NAME "${_RULE_NAME}${_HOST_EXECUTABLE_SUFFIX}")
   set(_BINARY_PATH "${IREE_HOST_BINARY_ROOT}/bin/${_FULL_BINARY_NAME}")
   file(REAL_PATH "${_BINARY_PATH}" _BINARY_PATH
        BASE_DIRECTORY ${IREE_ROOT_DIR} EXPAND_TILDE)


### PR DESCRIPTION
Fixes https://github.com/iree-org/iree/actions/runs/3904444915/jobs/6670814128

```
CMake Error at build_tools/cmake/iree_import_binary.cmake:54 (message):
  Could not find 'iree-flatcc-cli.js' under
  '/work/full-build-dir/install/bin'

  (Expanded to '/work/full-build-dir/install/bin/iree-flatcc-cli.js').
```