### PR TITLE
Supporting pooling vectorization in IREE

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1475,50 +1475,61 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
                      is2DPoolingOp(op);
   (void)isSupported;
   assert(isSupported && "conv op is not supported");
+  llvm::errs() << "Murali started\n";
 
   SmallVector<int64_t> tileSizes;
   auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(entryPointFn);
 
   if (isX86(targetAttr)) {
     TypeSwitch<Operation *>(op.getOperation())
-        .Case<linalg::Conv2DNhwcHwcfOp, linalg::PoolingNhwcSumOp,
-              linalg::PoolingNhwcMaxOp, linalg::PoolingNhwcMaxUnsignedOp,
-              linalg::PoolingNhwcMinOp, linalg::PoolingNhwcMinUnsignedOp>(
+        .Case<linalg::Conv2DNhwcHwcfOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 1, 8}; })
+        .Case<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+              linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+              linalg::PoolingNhwcMinUnsignedOp>(
+            [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 8}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 3}; })
-        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) { llvm::errs() << "Murail bad1\n" ; llvm_unreachable("unsupported conv"); });
   } else if (isRISCV(targetAttr)) {
     TypeSwitch<Operation *>(op.getOperation())
-        .Case<linalg::Conv2DNhwcHwcfOp, linalg::PoolingNhwcSumOp,
-              linalg::PoolingNhwcMaxOp, linalg::PoolingNhwcMaxUnsignedOp,
-              linalg::PoolingNhwcMinOp, linalg::PoolingNhwcMinUnsignedOp>(
+        .Case<linalg::Conv2DNhwcHwcfOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 1, 8}; })
+        .Case<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+              linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+              linalg::PoolingNhwcMinUnsignedOp>(
+            [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 8}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize, 1, 3}; })
-        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) { llvm::errs() << "Murail bad2\n" ; llvm_unreachable("unsupported conv"); });
   } else if (isAArch64(targetAttr)) {
     TypeSwitch<Operation *>(op.getOperation())
-        .Case<linalg::Conv2DNhwcHwcfOp, linalg::PoolingNhwcSumOp,
-              linalg::PoolingNhwcMaxOp, linalg::PoolingNhwcMaxUnsignedOp,
-              linalg::PoolingNhwcMinOp, linalg::PoolingNhwcMinUnsignedOp>(
+        .Case<linalg::Conv2DNhwcHwcfOp>(
             [&](auto op) { tileSizes = {1, 1, 32, 64, 1, 1, 16}; })
+        .Case<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+              linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+              linalg::PoolingNhwcMinUnsignedOp>(
+            [&](auto op) { tileSizes = {1, 1, 32, 64, 1, 16}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 4, 4, 1, 4}; })
-        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) { llvm::errs() << "Murail bad3\n" ; llvm_unreachable("unsupported conv"); });
   } else {
     // Get default hard-coded tile sizes if we couldn't compute anything better.
     TypeSwitch<Operation *>(op.getOperation())
-        .Case<linalg::Conv2DNhwcHwcfOp, linalg::PoolingNhwcSumOp,
-              linalg::PoolingNhwcMaxOp, linalg::PoolingNhwcMaxUnsignedOp,
-              linalg::PoolingNhwcMinOp, linalg::PoolingNhwcMinUnsignedOp>(
+        .Case<linalg::Conv2DNhwcHwcfOp>(
             [&](auto op) {
               tileSizes = {1, 1, vectorSize, vectorSize, 1, 1, vectorSize};
+            })
+        .Case<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+              linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+              linalg::PoolingNhwcMinUnsignedOp>(
+            [&](auto op) {
+              tileSizes = {1, 1, vectorSize, vectorSize, 1, vectorSize};
             })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>([&](auto op) {
           tileSizes = {1, 1, vectorSize, vectorSize, 1, vectorSize};
         })
-        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) { llvm::errs() << "Murail bad4\n" ; llvm_unreachable("unsupported conv"); });
   }
 
   return tileSizes;
@@ -1677,7 +1688,10 @@ static LogicalResult setRootConfigImpl(
         .Case<IREE::LinalgExt::FftOp, IREE::LinalgExt::PackOp,
               IREE::LinalgExt::UnPackOp, linalg::Mmt4DOp,
               linalg::Conv2DNhwcHwcfOp, linalg::Conv2DNchwFchwOp,
-              linalg::DepthwiseConv2DNhwcHwcOp>(
+              linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+              linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+              linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
+              linalg::PoolingNchwMaxOp, linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { return setRootConfig(entryPointFn, op); })
         .Case<linalg::ContractionOpInterface>(
             [&](auto op) { return setRootConfig(entryPointFn, op); })

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1475,7 +1475,6 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
                      is2DPoolingOp(op);
   (void)isSupported;
   assert(isSupported && "conv op is not supported");
-  llvm::errs() << "Murali started\n";
 
   SmallVector<int64_t> tileSizes;
   auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(entryPointFn);
@@ -1491,7 +1490,6 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 3}; })
         .Default([&](Operation *op) {
-          llvm::errs() << "Murail bad1\n";
           llvm_unreachable("unsupported conv");
         });
   } else if (isRISCV(targetAttr)) {
@@ -1505,7 +1503,6 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize, 1, 3}; })
         .Default([&](Operation *op) {
-          llvm::errs() << "Murail bad2\n";
           llvm_unreachable("unsupported conv");
         });
   } else if (isAArch64(targetAttr)) {
@@ -1519,7 +1516,6 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 4, 4, 1, 4}; })
         .Default([&](Operation *op) {
-          llvm::errs() << "Murail bad3\n";
           llvm_unreachable("unsupported conv");
         });
   } else {
@@ -1537,7 +1533,6 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
           tileSizes = {1, 1, vectorSize, vectorSize, 1, vectorSize};
         })
         .Default([&](Operation *op) {
-          llvm::errs() << "Murail bad4\n";
           llvm_unreachable("unsupported conv");
         });
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1489,9 +1489,7 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 8}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 3}; })
-        .Default([&](Operation *op) {
-          llvm_unreachable("unsupported conv");
-        });
+        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
   } else if (isRISCV(targetAttr)) {
     TypeSwitch<Operation *>(op.getOperation())
         .Case<linalg::Conv2DNhwcHwcfOp>(
@@ -1502,9 +1500,7 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 8}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize, 1, 3}; })
-        .Default([&](Operation *op) {
-          llvm_unreachable("unsupported conv");
-        });
+        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
   } else if (isAArch64(targetAttr)) {
     TypeSwitch<Operation *>(op.getOperation())
         .Case<linalg::Conv2DNhwcHwcfOp>(
@@ -1515,9 +1511,7 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
             [&](auto op) { tileSizes = {1, 1, 32, 64, 1, 16}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 4, 4, 1, 4}; })
-        .Default([&](Operation *op) {
-          llvm_unreachable("unsupported conv");
-        });
+        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
   } else {
     // Get default hard-coded tile sizes if we couldn't compute anything better.
     TypeSwitch<Operation *>(op.getOperation())
@@ -1532,9 +1526,7 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>([&](auto op) {
           tileSizes = {1, 1, vectorSize, vectorSize, 1, vectorSize};
         })
-        .Default([&](Operation *op) {
-          llvm_unreachable("unsupported conv");
-        });
+        .Default([&](Operation *op) { llvm_unreachable("unsupported conv"); });
   }
 
   return tileSizes;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1490,7 +1490,10 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 8}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 3}; })
-        .Default([&](Operation *op) { llvm::errs() << "Murail bad1\n" ; llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) {
+          llvm::errs() << "Murail bad1\n";
+          llvm_unreachable("unsupported conv");
+        });
   } else if (isRISCV(targetAttr)) {
     TypeSwitch<Operation *>(op.getOperation())
         .Case<linalg::Conv2DNhwcHwcfOp>(
@@ -1501,7 +1504,10 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize * 2, 1, 8}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 8, vectorSize, 1, 3}; })
-        .Default([&](Operation *op) { llvm::errs() << "Murail bad2\n" ; llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) {
+          llvm::errs() << "Murail bad2\n";
+          llvm_unreachable("unsupported conv");
+        });
   } else if (isAArch64(targetAttr)) {
     TypeSwitch<Operation *>(op.getOperation())
         .Case<linalg::Conv2DNhwcHwcfOp>(
@@ -1512,24 +1518,28 @@ static SmallVector<int64_t> getConvWorkgroupSizes(func::FuncOp entryPointFn,
             [&](auto op) { tileSizes = {1, 1, 32, 64, 1, 16}; })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>(
             [&](auto op) { tileSizes = {1, 1, 4, 4, 1, 4}; })
-        .Default([&](Operation *op) { llvm::errs() << "Murail bad3\n" ; llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) {
+          llvm::errs() << "Murail bad3\n";
+          llvm_unreachable("unsupported conv");
+        });
   } else {
     // Get default hard-coded tile sizes if we couldn't compute anything better.
     TypeSwitch<Operation *>(op.getOperation())
-        .Case<linalg::Conv2DNhwcHwcfOp>(
-            [&](auto op) {
-              tileSizes = {1, 1, vectorSize, vectorSize, 1, 1, vectorSize};
-            })
+        .Case<linalg::Conv2DNhwcHwcfOp>([&](auto op) {
+          tileSizes = {1, 1, vectorSize, vectorSize, 1, 1, vectorSize};
+        })
         .Case<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
               linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
-              linalg::PoolingNhwcMinUnsignedOp>(
-            [&](auto op) {
-              tileSizes = {1, 1, vectorSize, vectorSize, 1, vectorSize};
-            })
+              linalg::PoolingNhwcMinUnsignedOp>([&](auto op) {
+          tileSizes = {1, 1, vectorSize, vectorSize, 1, vectorSize};
+        })
         .Case<linalg::DepthwiseConv2DNhwcHwcOp>([&](auto op) {
           tileSizes = {1, 1, vectorSize, vectorSize, 1, vectorSize};
         })
-        .Default([&](Operation *op) { llvm::errs() << "Murail bad4\n" ; llvm_unreachable("unsupported conv"); });
+        .Default([&](Operation *op) {
+          llvm::errs() << "Murail bad4\n";
+          llvm_unreachable("unsupported conv");
+        });
   }
 
   return tileSizes;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -289,24 +289,22 @@ LogicalResult verifyConvTileAndDecomposeExpertConfig(
           .Case<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
                 linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
                 linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
-                linalg::PoolingNchwMaxOp>(
-              [&](auto) {
-                // Shape: N, OH, OW, OC, KH, KW
-                khSize = shape[4];
-                kwSize = shape[5];
-                ohSize = shape[1];
-                owSize = shape[2];
-                return success();
-              })
-          .Case<linalg::PoolingNchwSumOp, linalg::PoolingNchwMaxOp>(
-              [&](auto) {
-                // Shape: N, OC, OH, OW, KH, KW
-                khSize = shape[4];
-                kwSize = shape[5];
-                ohSize = shape[2];
-                owSize = shape[3];
-                return success();
-              })
+                linalg::PoolingNchwMaxOp>([&](auto) {
+            // Shape: N, OH, OW, OC, KH, KW
+            khSize = shape[4];
+            kwSize = shape[5];
+            ohSize = shape[1];
+            owSize = shape[2];
+            return success();
+          })
+          .Case<linalg::PoolingNchwSumOp, linalg::PoolingNchwMaxOp>([&](auto) {
+            // Shape: N, OC, OH, OW, KH, KW
+            khSize = shape[4];
+            kwSize = shape[5];
+            ohSize = shape[2];
+            owSize = shape[3];
+            return success();
+          })
           .Default([&](auto) { return failure(); });
   if (failed(isSizeExtracted)) {
     llvm::errs() << "Murali worst\n";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -273,15 +273,14 @@ LogicalResult verifyConvTileAndDecomposeExpertConfig(
                 linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
                 linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
                 linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
-                linalg::PoolingNchwMaxOp>(
-              [&](auto) {
-                // Shape: N, OH, OW, OC, KH, KW, (IC)
-                khSize = shape[4];
-                kwSize = shape[5];
-                ohSize = shape[1];
-                owSize = shape[2];
-                return success();
-              })
+                linalg::PoolingNchwMaxOp>([&](auto) {
+            // Shape: N, OH, OW, OC, KH, KW, (IC)
+            khSize = shape[4];
+            kwSize = shape[5];
+            ohSize = shape[1];
+            owSize = shape[2];
+            return success();
+          })
           .Case<linalg::Conv2DNchwFchwOp>([&](auto) {
             // Shape: N, OC, OH, OW, (IC), KH, KW
             khSize = shape[5];

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -286,8 +286,30 @@ LogicalResult verifyConvTileAndDecomposeExpertConfig(
             owSize = shape[3];
             return success();
           })
+          .Case<linalg::PoolingNhwcSumOp, linalg::PoolingNhwcMaxOp,
+                linalg::PoolingNhwcMaxUnsignedOp, linalg::PoolingNhwcMinOp,
+                linalg::PoolingNhwcMinUnsignedOp, linalg::PoolingNchwSumOp,
+                linalg::PoolingNchwMaxOp>(
+              [&](auto) {
+                // Shape: N, OH, OW, OC, KH, KW
+                khSize = shape[4];
+                kwSize = shape[5];
+                ohSize = shape[1];
+                owSize = shape[2];
+                return success();
+              })
+          .Case<linalg::PoolingNchwSumOp, linalg::PoolingNchwMaxOp>(
+              [&](auto) {
+                // Shape: N, OC, OH, OW, KH, KW
+                khSize = shape[4];
+                kwSize = shape[5];
+                ohSize = shape[2];
+                owSize = shape[3];
+                return success();
+              })
           .Default([&](auto) { return failure(); });
   if (failed(isSizeExtracted)) {
+    llvm::errs() << "Murali worst\n";
     return op->emitOpError("unsupported conv types");
   }
 

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -454,28 +454,6 @@ struct LinalgStrategyDecomposePass
       return;
     RewritePatternSet decompositionPattern(funcOp.getContext());
     linalg::populateDecomposeConvolutionPatterns(decompositionPattern);
-    /*
-    decompositionPattern.add<
-        DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNhwcHwcfOp,
-                                              linalg::Conv1DNwcWcfOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNchwFchwOp,
-                                              linalg::Conv1DNcwFcwOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcSumOp,
-                                              linalg::PoolingNwcSumOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwSumOp,
-                                              linalg::PoolingNcwSumOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMaxOp,
-                                              linalg::PoolingNwcMaxOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMaxUnsignedOp,
-                                              linalg::PoolingNwcMaxUnsignedOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMinOp,
-                                              linalg::PoolingNwcMinOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMinUnsignedOp,
-                                              linalg::PoolingNwcMinUnsignedOp>,
-        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwMaxOp,
-                                              linalg::PoolingNcwMaxOp>,
-        DownscaleDepthwiseConv2DNhwcHwcOp>(funcOp.getContext(), filter);
-    */
     if (failed(applyPatternsAndFoldGreedily(funcOp,
                                             std::move(decompositionPattern))))
       signalPassFailure();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -453,28 +453,26 @@ struct LinalgStrategyDecomposePass
     if (!anchorFuncName.empty() && funcOp.getName() != anchorFuncName)
       return;
     RewritePatternSet decompositionPattern(funcOp.getContext());
-    decompositionPattern
-        .add<DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNhwcHwcfOp,
-                                                   linalg::Conv1DNwcWcfOp>,
-             DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNchwFchwOp,
-                                                   linalg::Conv1DNcwFcwOp>,
-             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcSumOp,
-                                                   linalg::PoolingNwcSumOp>,
-             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwSumOp,
-                                                   linalg::PoolingNcwSumOp>,
-             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMaxOp,
-                                                   linalg::PoolingNwcMaxOp>,
-             DownscaleSizeOneWindowed2DConvolution<
-                 linalg::PoolingNhwcMaxUnsignedOp,
-                 linalg::PoolingNwcMaxUnsignedOp>,
-             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMinOp,
-                                                   linalg::PoolingNwcMinOp>,
-             DownscaleSizeOneWindowed2DConvolution<
-                 linalg::PoolingNhwcMinUnsignedOp,
-                 linalg::PoolingNwcMinUnsignedOp>,
-             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwMaxOp,
-                                                   linalg::PoolingNcwMaxOp>,
-             DownscaleDepthwiseConv2DNhwcHwcOp>(funcOp.getContext(), filter);
+    decompositionPattern.add<
+        DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNhwcHwcfOp,
+                                              linalg::Conv1DNwcWcfOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNchwFchwOp,
+                                              linalg::Conv1DNcwFcwOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcSumOp,
+                                              linalg::PoolingNwcSumOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwSumOp,
+                                              linalg::PoolingNcwSumOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMaxOp,
+                                              linalg::PoolingNwcMaxOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMaxUnsignedOp,
+                                              linalg::PoolingNwcMaxUnsignedOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMinOp,
+                                              linalg::PoolingNwcMinOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMinUnsignedOp,
+                                              linalg::PoolingNwcMinUnsignedOp>,
+        DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwMaxOp,
+                                              linalg::PoolingNcwMaxOp>,
+        DownscaleDepthwiseConv2DNhwcHwcOp>(funcOp.getContext(), filter);
     if (failed(applyPatternsAndFoldGreedily(funcOp,
                                             std::move(decompositionPattern))))
       signalPassFailure();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -453,6 +453,8 @@ struct LinalgStrategyDecomposePass
     if (!anchorFuncName.empty() && funcOp.getName() != anchorFuncName)
       return;
     RewritePatternSet decompositionPattern(funcOp.getContext());
+    // TODO(muralivi): Use
+    // linalg::populateDecomposeConvolutionPatterns(decompositionPattern).
     decompositionPattern.add<
         DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNhwcHwcfOp,
                                               linalg::Conv1DNwcWcfOp>,

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -453,8 +453,8 @@ struct LinalgStrategyDecomposePass
     if (!anchorFuncName.empty() && funcOp.getName() != anchorFuncName)
       return;
     RewritePatternSet decompositionPattern(funcOp.getContext());
-    // TODO(muralivi): Use
-    // linalg::populateDecomposeConvolutionPatterns(decompositionPattern).
+    linalg::populateDecomposeConvolutionPatterns(decompositionPattern);
+    /*
     decompositionPattern.add<
         DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNhwcHwcfOp,
                                               linalg::Conv1DNwcWcfOp>,
@@ -475,6 +475,7 @@ struct LinalgStrategyDecomposePass
         DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwMaxOp,
                                               linalg::PoolingNcwMaxOp>,
         DownscaleDepthwiseConv2DNhwcHwcOp>(funcOp.getContext(), filter);
+    */
     if (failed(applyPatternsAndFoldGreedily(funcOp,
                                             std::move(decompositionPattern))))
       signalPassFailure();

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -458,6 +458,22 @@ struct LinalgStrategyDecomposePass
                                                    linalg::Conv1DNwcWcfOp>,
              DownscaleSizeOneWindowed2DConvolution<linalg::Conv2DNchwFchwOp,
                                                    linalg::Conv1DNcwFcwOp>,
+             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcSumOp,
+                                                   linalg::PoolingNwcSumOp>,
+             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwSumOp,
+                                                   linalg::PoolingNcwSumOp>,
+             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMaxOp,
+                                                   linalg::PoolingNwcMaxOp>,
+             DownscaleSizeOneWindowed2DConvolution<
+                 linalg::PoolingNhwcMaxUnsignedOp,
+                 linalg::PoolingNwcMaxUnsignedOp>,
+             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNhwcMinOp,
+                                                   linalg::PoolingNwcMinOp>,
+             DownscaleSizeOneWindowed2DConvolution<
+                 linalg::PoolingNhwcMinUnsignedOp,
+                 linalg::PoolingNwcMinUnsignedOp>,
+             DownscaleSizeOneWindowed2DConvolution<linalg::PoolingNchwMaxOp,
+                                                   linalg::PoolingNcwMaxOp>,
              DownscaleDepthwiseConv2DNhwcHwcOp>(funcOp.getContext(), filter);
     if (failed(applyPatternsAndFoldGreedily(funcOp,
                                             std::move(decompositionPattern))))


### PR DESCRIPTION
This PR fixes the lowering_config and calls to transform higher-dimensional pooling ops to single dimensional ones.