### PR TITLE
[stream] Don't group timepoint awaits in different blocks

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -2584,6 +2584,7 @@ struct GroupAwaitsByTimepoint : public OpRewritePattern<TimepointAwaitOp> {
       // there. We rely on other canonicalizers to sink things such that
       // (hopefully) we get them directly accessible here.
       if (use.getOwner() == op) continue;
+      if (op->getBlock() != use.getOwner()->getBlock()) continue;
       if (dominanceInfo.dominates(use.getOwner(), op)) continue;
       auto awaitOp = dyn_cast<TimepointAwaitOp>(use.getOwner());
       if (!awaitOp ||


### PR DESCRIPTION
We sort various await ops over the same timepoint according to their order in the same block, but the list was pulling in await ops in other blocks too. This caused crash.

In general, unifying ops across the blocks is triky given we need to consider dominance and referened values in each op. Prefer to be conservative for now.