### PR TITLE
Rename CPU benchmark MIG

### DIFF
--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -149,7 +149,7 @@ function create_template() {
       --maintenance-policy=MIGRATE
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
     )
-  elif [[ "${type}" == cpu-c2-16 ]]; then
+  elif [[ "${type}" == cpuc2s16 ]]; then
     cmd+=(
       --machine-type=c2-standard-16
       --maintenance-policy=MIGRATE
@@ -169,7 +169,7 @@ function create_template() {
 }
 
 for group in presubmit postsubmit; do
-  for type in gpu cpu cpu-c2-16; do
+  for type in gpu cpu cpuc2s16; do
     create_template "${group}" "${type}"
   done
 done

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -149,7 +149,7 @@ function create_template() {
       --maintenance-policy=MIGRATE
       --create-disk="auto-delete=yes,boot=yes,image=projects/iree-oss/global/images/${CPU_IMAGE},mode=rw,size=${CPU_DISK_SIZE_GB},type=pd-balanced"
     )
-  elif [[ "${type}" == cpuc2s16 ]]; then
+  elif [[ "${type}" == c2s16 ]]; then
     cmd+=(
       --machine-type=c2-standard-16
       --maintenance-policy=MIGRATE
@@ -169,7 +169,7 @@ function create_template() {
 }
 
 for group in presubmit postsubmit; do
-  for type in gpu cpu cpuc2s16; do
+  for type in gpu cpu c2s16; do
     create_template "${group}" "${type}"
   done
 done


### PR DESCRIPTION
The `-` in the MIG type name is ambiguous since it's used to split parts in the full name.

Rename `cpu-c2-16` to `c2s16` (the abbreviation of `cpu-c2-standard-16`).