### PR TITLE
Use task_topology_max_group_count in x86_64 benchmarks

### DIFF
--- a/benchmarks/TF/linux-x86_64.cmake
+++ b/benchmarks/TF/linux-x86_64.cmake
@@ -77,7 +77,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=1"
+    "--task_topology_max_group_count=1"
 )
 
 # CPU, LLVM, local-task, 4 threads, x86_64, full-inference
@@ -107,7 +107,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=4"
+    "--task_topology_max_group_count=4"
 )
 
 # CPU, LLVM, local-task, 8 threads, x86_64, full-inference
@@ -137,5 +137,5 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=8"
+    "--task_topology_max_group_count=8"
 )

--- a/benchmarks/TFLite/android-arm64-v8a.cmake
+++ b/benchmarks/TFLite/android-arm64-v8a.cmake
@@ -81,7 +81,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=1"
+    "--task_topology_max_group_count=1"
 )
 
 # TODO(#7792): Re-enable these when we are able to run different benchmarks
@@ -114,7 +114,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_group_count=2"
+#     "--task_topology_max_group_count=2"
 # )
 
 # iree_benchmark_suite(
@@ -145,7 +145,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_group_count=3"
+#     "--task_topology_max_group_count=3"
 # )
 
 iree_benchmark_suite(
@@ -177,7 +177,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=4"
+    "--task_topology_max_group_count=4"
 )
 
 ################################################################################
@@ -302,7 +302,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=1"
+    "--task_topology_max_group_count=1"
 )
 
 # CPU, LLVM, local-task, 1 through 4 threads, big/little-core, full-inference, +dotprod
@@ -336,7 +336,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=1"
+    "--task_topology_max_group_count=1"
 )
 
 # TODO(#7792): Re-enable these when we are able to run different benchmarks
@@ -370,7 +370,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_group_count=2"
+#     "--task_topology_max_group_count=2"
 # )
 
 # iree_benchmark_suite(
@@ -402,7 +402,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_group_count=3"
+#     "--task_topology_max_group_count=3"
 # )
 
 # CPU, LLVM, local-task, 1 through 4 threads, big/little-core, full-inference.
@@ -441,7 +441,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=4"
+    "--task_topology_max_group_count=4"
 )
 
 # CPU, LLVM, local-sync, big/little-core, full-inference, +dotprod
@@ -476,7 +476,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=4"
+    "--task_topology_max_group_count=4"
 )
 
 # CPU, VMVX, 4-thread, big-core, full-inference
@@ -507,7 +507,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=4"
+    "--task_topology_max_group_count=4"
 )
 
 ################################################################################

--- a/benchmarks/TFLite/android-arm64-v8a.cmake
+++ b/benchmarks/TFLite/android-arm64-v8a.cmake
@@ -81,7 +81,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_max_group_count=1"
+    "--task_topology_group_count=1"
 )
 
 # TODO(#7792): Re-enable these when we are able to run different benchmarks
@@ -114,7 +114,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_max_group_count=2"
+#     "--task_topology_group_count=2"
 # )
 
 # iree_benchmark_suite(
@@ -145,7 +145,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_max_group_count=3"
+#     "--task_topology_group_count=3"
 # )
 
 iree_benchmark_suite(
@@ -177,7 +177,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_max_group_count=4"
+    "--task_topology_group_count=4"
 )
 
 ################################################################################
@@ -302,7 +302,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_max_group_count=1"
+    "--task_topology_group_count=1"
 )
 
 # CPU, LLVM, local-task, 1 through 4 threads, big/little-core, full-inference, +dotprod
@@ -336,7 +336,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_max_group_count=1"
+    "--task_topology_group_count=1"
 )
 
 # TODO(#7792): Re-enable these when we are able to run different benchmarks
@@ -370,7 +370,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_max_group_count=2"
+#     "--task_topology_group_count=2"
 # )
 
 # iree_benchmark_suite(
@@ -402,7 +402,7 @@ iree_benchmark_suite(
 #   DRIVER
 #     "local-task"
 #   RUNTIME_FLAGS
-#     "--task_topology_max_group_count=3"
+#     "--task_topology_group_count=3"
 # )
 
 # CPU, LLVM, local-task, 1 through 4 threads, big/little-core, full-inference.
@@ -441,7 +441,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_max_group_count=4"
+    "--task_topology_group_count=4"
 )
 
 # CPU, LLVM, local-sync, big/little-core, full-inference, +dotprod
@@ -476,7 +476,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_max_group_count=4"
+    "--task_topology_group_count=4"
 )
 
 # CPU, VMVX, 4-thread, big-core, full-inference
@@ -507,7 +507,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_max_group_count=4"
+    "--task_topology_group_count=4"
 )
 
 ################################################################################

--- a/benchmarks/TFLite/linux-x86_64.cmake
+++ b/benchmarks/TFLite/linux-x86_64.cmake
@@ -87,7 +87,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=1"
+    "--task_topology_max_group_count=1"
 )
 
 # CPU, LLVM, local-task, 4 threads, x86_64, full-inference
@@ -121,7 +121,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=4"
+    "--task_topology_max_group_count=4"
 )
 
 # CPU, LLVM, local-task, 8 threads, x86_64, full-inference
@@ -155,7 +155,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=8"
+    "--task_topology_max_group_count=8"
 )
 
 ################################################################################
@@ -231,7 +231,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=1"
+    "--task_topology_max_group_count=1"
 )
 
 # CPU, LLVM, local-task, 4 threads, x86_64, full-inference
@@ -267,7 +267,7 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=4"
+    "--task_topology_max_group_count=4"
 )
 
 # CPU, LLVM, local-task, 8 threads, x86_64, full-inference
@@ -303,5 +303,5 @@ iree_benchmark_suite(
   DRIVER
     "local-task"
   RUNTIME_FLAGS
-    "--task_topology_group_count=8"
+    "--task_topology_max_group_count=8"
 )

--- a/build_tools/benchmarks/comparisons/common/benchmark_command.py
+++ b/build_tools/benchmarks/comparisons/common/benchmark_command.py
@@ -130,6 +130,6 @@ class IreeBenchmarkCommand(BenchmarkCommand):
   def generate_benchmark_command(self) -> list[str]:
     command = super().generate_benchmark_command()
     command.append("--device=" + self.driver)
-    command.append("--task_topology_group_count=" + str(self.num_threads))
+    command.append("--task_topology_max_group_count=" + str(self.num_threads))
     command.append("--benchmark_repetitions=" + str(self.num_runs))
     return command

--- a/build_tools/python/benchmark_suites/iree/module_execution_configs.py
+++ b/build_tools/python/benchmark_suites/iree/module_execution_configs.py
@@ -67,7 +67,7 @@ def get_elf_local_task_config(thread_num: int):
       tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
       driver=iree_definitions.RuntimeDriver.LOCAL_TASK,
-      extra_flags=[f"--task_topology_group_count={thread_num}"])
+      extra_flags=[f"--task_topology_max_group_count={thread_num}"])
 
 
 def get_vmvx_local_task_config(thread_num: int):
@@ -77,4 +77,4 @@ def get_vmvx_local_task_config(thread_num: int):
       tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.VMVX_MODULE,
       driver=iree_definitions.RuntimeDriver.LOCAL_TASK,
-      extra_flags=[f"--task_topology_group_count={thread_num}"])
+      extra_flags=[f"--task_topology_max_group_count={thread_num}"])

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -17,9 +17,7 @@ def build_linux_wrapper_cmds_for_device_spec(
 
   affinity_mask = None
   for param in device_spec.device_parameters:
-    if param == device_parameters.OCTA_CORES:
-      affinity_mask = "0xFF"
-    else:
+    if param != device_parameters.ALL_CORES:
       raise ValueError(f"Unsupported device parameter: {param}.")
 
   cmds = []

--- a/build_tools/python/e2e_model_tests/run_module_utils_test.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils_test.py
@@ -19,13 +19,13 @@ class RunModuleUtilsTest(unittest.TestCase):
         device_name="test-device",
         architecture=common_definitions.DeviceArchitecture.VMVX_GENERIC,
         host_environment=common_definitions.HostEnvironment.LINUX_X86_64,
-        device_parameters=[device_parameters.OCTA_CORES],
+        device_parameters=[device_parameters.ALL_CORES],
         tags=[])
 
     flags = run_module_utils.build_linux_wrapper_cmds_for_device_spec(
         device_spec)
 
-    self.assertEqual(flags, ["taskset", "0xFF"])
+    self.assertEqual(flags, [])
 
 
 if __name__ == "__main__":

--- a/build_tools/python/e2e_test_framework/device_specs/device_parameters.py
+++ b/build_tools/python/e2e_test_framework/device_specs/device_parameters.py
@@ -7,4 +7,4 @@
 
 ARM_LITTLE_CORES = "little-cores"
 ARM_BIG_CORES = "big-cores"
-OCTA_CORES = "octa-cores"
+ALL_CORES = "all-cores"

--- a/build_tools/python/e2e_test_framework/device_specs/gcp_specs.py
+++ b/build_tools/python/e2e_test_framework/device_specs/gcp_specs.py
@@ -14,7 +14,7 @@ GCP_C2_STANDARD_16 = common_definitions.DeviceSpec.build(
     device_name="c2-standard-16",
     host_environment=common_definitions.HostEnvironment.LINUX_X86_64,
     architecture=common_definitions.DeviceArchitecture.X86_64_CASCADELAKE,
-    device_parameters=[device_parameters.OCTA_CORES],
+    device_parameters=[device_parameters.ALL_CORES],
     tags=["cpu"])
 
 GCP_A2_HIGHGPU_1G = common_definitions.DeviceSpec.build(


### PR DESCRIPTION
For x86_64 CPU benchmarks, instead of manually running with `taskset`, use `--task_topology_max_group_count` to let IREE runtime figure out the best way to allocate threads on the benchmark machines.

Although this changes the way we run benchmarks, if there is no significant performance change on the current x86_64 benchmarks, I think it's fine to not create new benchmark series for this change.