### PR TITLE
Add structured-bindings-friendly utility to enumerate and zip

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/BUILD
@@ -67,6 +67,7 @@ iree_compiler_cc_library(
         ":FlowOpsGen",
         ":FlowTypesGen",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
+        "//compiler/src/iree/compiler/Utils",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/CMakeLists.txt
@@ -57,6 +57,7 @@ iree_cc_library(
     MLIRTransformUtils
     MLIRViewLikeInterface
     iree::compiler::Dialect::Util::IR
+    iree::compiler::Utils
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/Dialect/Util/IR/ClosureOpUtils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Utils/ADTExtras.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/SmallBitVector.h"
 #include "llvm/ADT/StringExtras.h"

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Util/IR/ClosureOpUtils.h"
 #include "iree/compiler/Dialect/Util/IR/UtilOps.h"
 #include "iree/compiler/Dialect/Util/IR/UtilTypes.h"
+#include "iree/compiler/Utils/ADTExtras.h"
 #include "iree/compiler/Utils/ModuleUtils.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/StringExtras.h"
@@ -64,14 +65,12 @@ static LogicalResult verifyDispatchWorkload(
              << workgroupCount.getNumArguments()
              << " arguments but dispatch provides " << workload.size();
     }
-    for (auto it : llvm::enumerate(llvm::zip_equal(
-             workgroupCount.getArgumentTypes(), workload.getTypes()))) {
-      auto expectedType = std::get<0>(it.value());
-      auto actualType = std::get<1>(it.value());
+    for (auto [idx, expectedType, actualType] : enumerate_zip_equal(
+             workgroupCount.getArgumentTypes(), workload.getTypes())) {
       if (expectedType != actualType) {
-        return op->emitOpError() << "workload operand " << it.index()
-                                 << " type mismatch; expected " << expectedType
-                                 << " but passed " << actualType;
+        return op->emitOpError()
+               << "workload operand " << idx << " type mismatch; expected "
+               << expectedType << " but passed " << actualType;
       }
     }
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FuseDispatchBindings.cpp
@@ -10,6 +10,7 @@
 #include "iree/compiler/Dialect/Stream/IR/StreamOps.h"
 #include "iree/compiler/Dialect/Stream/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Stream/Transforms/Passes.h"
+#include "iree/compiler/Utils/ADTExtras.h"
 #include "llvm/ADT/BitVector.h"
 #include "llvm/ADT/EquivalenceClasses.h"
 #include "llvm/Support/Debug.h"
@@ -86,20 +87,17 @@ static SmallVector<Binding> findCorrelatedBindings(
   for (auto dispatchOp : dispatchOps) {
     llvm::EquivalenceClasses<unsigned> ec;
     DenseMap<Value, unsigned> leaders;
-    for (auto it : llvm::enumerate(llvm::zip_equal(
-             dispatchOp.getResources(), dispatchOp.getResourceAccesses()))) {
-      auto resource = std::get<0>(it.value());
-
+    for (auto [idx, resource, resourceAccessAttr] : enumerate_zip_equal(
+             dispatchOp.getResources(), dispatchOp.getResourceAccesses())) {
       // If the resource is mutable and we were told not to alias mutable
       // bindings we always put the resource into its own class.
       auto resourceAccess =
-          std::get<1>(it.value())
-              .cast<IREE::Stream::ResourceAccessBitfieldAttr>();
+          resourceAccessAttr.cast<IREE::Stream::ResourceAccessBitfieldAttr>();
       if (!aliasMutableBindings &&
           bitEnumContainsAll(resourceAccess.getValue(),
                              IREE::Stream::ResourceAccessBitfield::Write)) {
-        ec.insert(it.index());
-        leaders.insert(std::make_pair(resource, it.index()));
+        ec.insert(idx);
+        leaders.insert(std::make_pair(resource, idx));
         continue;
       }
 
@@ -107,11 +105,11 @@ static SmallVector<Binding> findCorrelatedBindings(
       auto ecIt = leaders.find(resource);
       if (ecIt == leaders.end()) {
         // New unique value.
-        ec.insert(it.index());
-        leaders.insert(std::make_pair(resource, it.index()));
+        ec.insert(idx);
+        leaders.insert(std::make_pair(resource, idx));
       } else {
         // Found existing; union with leader.
-        ec.unionSets(ecIt->second, it.index());
+        ec.unionSets(ecIt->second, idx);
       }
     }
     ecs.push_back(std::move(ec));

--- a/compiler/src/iree/compiler/Utils/ADTExtras.h
+++ b/compiler/src/iree/compiler/Utils/ADTExtras.h
@@ -1,0 +1,28 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_UTILS_ADTEXTRAS_H_
+#define IREE_COMPILER_UTILS_ADTEXTRAS_H_
+
+#include <utility>
+
+#include "llvm/ADT/STLExtras.h"
+#include "llvm/ADT/Sequence.h"
+
+namespace mlir::iree_compiler {
+
+template <typename FirstIteratee, typename... RestIteratees>
+auto enumerate_zip_equal(FirstIteratee&& first, RestIteratees&&... rest) {
+  size_t numElements =
+      std::distance(llvm::adl_begin(first), llvm::adl_end(first));
+  return llvm::zip_equal(llvm::seq(static_cast<size_t>(0), numElements),
+                         std::forward<FirstIteratee>(first),
+                         std::forward<RestIteratees>(rest)...);
+}
+
+}  // namespace mlir::iree_compiler
+
+#endif  // IREE_COMPILER_UTILS_ADT_EXTRAS_H_

--- a/compiler/src/iree/compiler/Utils/ADTExtrasTest.cpp
+++ b/compiler/src/iree/compiler/Utils/ADTExtrasTest.cpp
@@ -1,0 +1,77 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cstddef>
+#include <list>
+#include <string>
+#include <tuple>
+#include <vector>
+
+#include "iree/compiler/Utils/ADTExtras.h"
+#include "iree/testing/gtest.h"
+
+using ::testing::ElementsAre;
+
+using mlir::iree_compiler::enumerate_zip_equal;
+
+namespace {
+
+TEST(ADTExtras, EnumerateZipEqualVector) {
+  llvm::SmallVector<int> ints = {0, 1, 2};
+  std::vector<char> chars = {'a', 'b', 'c'};
+
+  using Values = std::tuple<size_t, int, char>;
+  EXPECT_THAT(
+      enumerate_zip_equal(ints, chars),
+      ElementsAre(Values(0, 0, 'a'), Values(1, 1, 'b'), Values(2, 2, 'c')));
+
+  for (auto [i, a, b] : enumerate_zip_equal(ints, chars)) {
+    EXPECT_LT(i, size_t{3});
+    EXPECT_LT(a, 3);
+    EXPECT_LT(b, 'd');
+    a = -1;
+    b = 'x';
+  }
+
+  EXPECT_THAT(
+      enumerate_zip_equal(ints, chars),
+      ElementsAre(Values(0, -1, 'x'), Values(1, -1, 'x'), Values(2, -1, 'x')));
+}
+
+TEST(ADTExtras, EnumerateZipEqualVectorBool) {
+  // `std::vector<bool>` is interesting because exposes elements via a custom
+  // reference wrapper type.
+  std::vector<bool> bools1 = {true, false, true};
+  std::vector<bool> bools2 = bools1;
+
+  using Values = std::tuple<size_t, bool, bool>;
+  EXPECT_THAT(enumerate_zip_equal(bools1, bools2),
+              ElementsAre(Values(0, true, true), Values(1, false, false),
+                          Values(2, true, true)));
+
+  for (auto [i, a, b] : enumerate_zip_equal(bools1, bools2)) {
+    EXPECT_LT(i, size_t{3});
+    EXPECT_EQ(a, b);
+    // Check that we can modify the elements behind the reference wrapper type.
+    a = true;
+    b = false;
+  }
+
+  EXPECT_THAT(enumerate_zip_equal(bools1, bools2),
+              ElementsAre(Values(0, true, false), Values(1, true, false),
+                          Values(2, true, false)));
+}
+
+TEST(ADTExtras, EnumerateZipEqualEmpty) {
+  std::list<int> a;
+  EXPECT_THAT(enumerate_zip_equal(a, a, a), ElementsAre());
+
+  for (auto it : enumerate_zip_equal(a, a, a)) {
+    (void)it;
+    FAIL() << "This loop body should not execute";
+  }
+}
+}  // namespace

--- a/compiler/src/iree/compiler/Utils/BUILD
+++ b/compiler/src/iree/compiler/Utils/BUILD
@@ -6,7 +6,7 @@
 
 # Utilities for working with IREE MLIR types.
 
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library", "iree_runtime_cc_test")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -27,6 +27,7 @@ iree_compiler_cc_library(
         "TracingUtils.cpp",
     ],
     hdrs = [
+        "ADTExtras.h",
         "ConversionUtils.h",
         "CustomKernelsTargetInfo.h",
         "FlatbufferUtils.h",
@@ -53,5 +54,15 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "UtilsTest",
+    srcs = ["ADTExtrasTest.cpp"],
+    deps = [
+        ":Utils",
+        "//runtime/src/iree/testing:gtest",
+        "//runtime/src/iree/testing:gtest_main",
     ],
 )

--- a/compiler/src/iree/compiler/Utils/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Utils/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_cc_library(
   NAME
     Utils
   HDRS
+    "ADTExtras.h"
     "ConversionUtils.h"
     "CustomKernelsTargetInfo.h"
     "FlatbufferUtils.h"
@@ -49,6 +50,17 @@ iree_cc_library(
     iree::base::tracing
     iree::compiler::Dialect::Util::IR
   PUBLIC
+)
+
+iree_cc_test(
+  NAME
+    UtilsTest
+  SRCS
+    "ADTExtrasTest.cpp"
+  DEPS
+    ::Utils
+    iree::testing::gtest
+    iree::testing::gtest_main
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
This is not possible with the combination of
`llvm::enumerate(llvm::zip_equal(...))` because C++17 does not support nesting in structured bindings.

Add tests and replace existing uses of `enumerate(zip(...))` in the codebase.