### PR TITLE
Replace constant `outs` operands of Linalg ops as well.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DetachElementwiseFromNamedOps.cpp
@@ -125,26 +125,32 @@ struct DetachElementwisePattern
 /// with allocations. Using `fill` will allow for fusing with the op just like
 /// fill -> linalg ops are fused. If not as a fallback they would be converted
 /// to a splat, but both without stack allocations.
+template <typename InterfaceOp>
 struct DetachSplatConstantOutsOperands
-    : public OpInterfaceRewritePattern<IREE::LinalgExt::LinalgExtOp> {
-  using OpInterfaceRewritePattern<
-      IREE::LinalgExt::LinalgExtOp>::OpInterfaceRewritePattern;
+    : public OpInterfaceRewritePattern<InterfaceOp> {
+  using OpInterfaceRewritePattern<InterfaceOp>::OpInterfaceRewritePattern;
 
-  LogicalResult matchAndRewrite(IREE::LinalgExt::LinalgExtOp linalgExtOp,
+  LogicalResult matchAndRewrite(InterfaceOp interfaceOp,
                                 PatternRewriter &rewriter) const {
     SmallVector<Value> newOutsOperands;
+    auto dpsInterfaceOp =
+        dyn_cast<DestinationStyleOpInterface>(interfaceOp.getOperation());
+    if (!dpsInterfaceOp) {
+      return rewriter.notifyMatchFailure(
+          interfaceOp, "expected op to implement DPS interface");
+    }
     bool madeChanges = false;
-    for (auto outsOperandNum :
-         llvm::seq<unsigned>(0, linalgExtOp.getNumOutputs())) {
-      OpOperand *outOperand = linalgExtOp.getOutputOperand(outsOperandNum);
-      auto constOp = outOperand->get().getDefiningOp<arith::ConstantOp>();
+    for (auto outOperand :
+         llvm::enumerate(dpsInterfaceOp.getDpsInitOperands())) {
+      auto constOp =
+          outOperand.value()->get().template getDefiningOp<arith::ConstantOp>();
       if (!constOp) continue;
 
       auto resultType =
-          constOp.getResult().getType().dyn_cast<RankedTensorType>();
+          constOp.getResult().getType().template dyn_cast<RankedTensorType>();
       if (!resultType || !resultType.getElementType().isIntOrFloat()) continue;
 
-      auto attr = constOp.getValue().dyn_cast<DenseElementsAttr>();
+      auto attr = constOp.getValue().template dyn_cast<DenseElementsAttr>();
       if (!attr || !attr.isSplat()) continue;
 
       Location loc = constOp.getLoc();
@@ -153,11 +159,11 @@ struct DetachSplatConstantOutsOperands
           loc, resultType.getShape(), elementType);
       Attribute constValue;
       if (elementType.isa<IntegerType>()) {
-        constValue =
-            rewriter.getIntegerAttr(elementType, attr.getSplatValue<APInt>());
+        constValue = rewriter.getIntegerAttr(
+            elementType, attr.template getSplatValue<APInt>());
       } else {
-        constValue =
-            rewriter.getFloatAttr(elementType, attr.getSplatValue<APFloat>());
+        constValue = rewriter.getFloatAttr(
+            elementType, attr.template getSplatValue<APFloat>());
       }
       Value scalarConstantOp =
           rewriter.create<arith::ConstantOp>(loc, elementType, constValue);
@@ -166,8 +172,8 @@ struct DetachSplatConstantOutsOperands
                          .create<linalg::FillOp>(
                              loc, resultType, scalarConstantOp, emptyTensorOp)
                          .getResult(0);
-      rewriter.updateRootInPlace(linalgExtOp, [&]() {
-        linalgExtOp->setOperand(outOperand->getOperandNumber(), fillOp);
+      rewriter.updateRootInPlace(dpsInterfaceOp, [&]() {
+        dpsInterfaceOp.setDpsInitOperand(outOperand.index(), fillOp);
       });
       madeChanges = true;
     }
@@ -185,7 +191,9 @@ struct DetachElementwiseFromNamedOpsPass
 
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
-    patterns.add<DetachElementwisePattern, DetachSplatConstantOutsOperands>(
+    patterns.add<DetachElementwisePattern,
+                 DetachSplatConstantOutsOperands<IREE::LinalgExt::LinalgExtOp>,
+                 DetachSplatConstantOutsOperands<linalg::LinalgOp>>(
         &getContext());
     if (failed(applyPatternsAndFoldGreedily(getOperation(),
                                             std::move(patterns)))) {


### PR DESCRIPTION
This change replaces the `outs` operands of Linalg ops that are splat constants with `fill` of that value. Having constants operands for `outs` causes bufferization issues downstream (which are harder to fix, though in theory whether the outs is a constant or not it shouldnt matter. The general case fix looks very similar to what happens here anyway).

Fixes #11830