### PR TITLE
Adapt IREE ConvertToDPS pass to support DPS interface generally.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -195,12 +195,9 @@ static LogicalResult analysePadTensorOp(tensor::PadOp padTensorOp,
 
 /// For every result of the LinalgOp, gets the operands (`ins` or `outs`) whose
 /// buffer can be reused for the result.
-template <typename OpType>
-static SmallVector<Value> getTiedOperandsForLinalgOps(
-    OpType linalgOp, const BufferizationPlan &plan) {
-  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(linalgOp.getOperation());
-  if (!dpsOp) return {};
-  SmallVector<Value> tiedOperands(linalgOp.getOperation()->getNumResults());
+static SmallVector<Value> getTiedOperandsForDPSOps(
+    DestinationStyleOpInterface dpsOp, const BufferizationPlan &plan) {
+  SmallVector<Value> tiedOperands(dpsOp.getOperation()->getNumResults());
   auto outputOperands = dpsOp.getDpsInitOperands();
   for (auto [index, outTensor] : llvm::enumerate(outputOperands)) {
     // If the `outs` tensor has a single use (this op) and is not from a
@@ -215,14 +212,11 @@ static SmallVector<Value> getTiedOperandsForLinalgOps(
 
 /// Adds the corresponding `outs` and result tensors of the linalg op into the
 /// same equivalence class.
-template <typename OpType>
-static LogicalResult analyseLinalgOps(OpType linalgOp,
-                                      BufferizationPlan &plan) {
-  auto dpsOp = dyn_cast<DestinationStyleOpInterface>(linalgOp.getOperation());
-  if (!dpsOp) return failure();
+static LogicalResult analyseDPSOps(DestinationStyleOpInterface dpsOp,
+                                   BufferizationPlan &plan) {
   if (!dpsOp.hasTensorSemantics()) return success();
-  auto results = linalgOp->getResults();
-  auto tiedOperands = getTiedOperandsForLinalgOps(linalgOp, plan);
+  auto results = dpsOp->getResults();
+  auto tiedOperands = getTiedOperandsForDPSOps(dpsOp, plan);
   if (tiedOperands.empty()) return failure();
   for (auto [index, resultTensor, tiedOperand] : llvm::zip_equal(
            llvm::seq<int64_t>(0, results.size()), results, tiedOperands)) {
@@ -507,12 +501,9 @@ LogicalResult createTensorEquivalenceClasses(func::FuncOp funcOp,
         .Case<tensor::PadOp>([&](tensor::PadOp padTensorOp) {
           return analysePadTensorOp(padTensorOp, plan);
         })
-        .Case<linalg::LinalgOp>([&](linalg::LinalgOp linalgOp) {
-          return analyseLinalgOps(linalgOp, plan);
-        })
-        .Case<IREE::LinalgExt::LinalgExtOp>(
-            [&](IREE::LinalgExt::LinalgExtOp linalgExtOp) {
-              return analyseLinalgOps(linalgExtOp, plan);
+        .Case<DestinationStyleOpInterface>(
+            [&](DestinationStyleOpInterface dpsOp) {
+              return analyseDPSOps(dpsOp, plan);
             })
         .Case<tensor::CollapseShapeOp, tensor::ExpandShapeOp>(
             [&](auto reshapeOp) {

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -158,10 +158,8 @@ static LogicalResult replaceDestinationBuffer(OpResult resultValue,
                                               Value destinationValue) {
   Operation *op = resultValue.getOwner();
   return TypeSwitch<Operation *, LogicalResult>(op)
-      .Case<linalg::LinalgOp, IREE::LinalgExt::LinalgExtOp>([&](auto linalgOp) {
-        unsigned resultNumber = resultValue.getResultNumber();
-        cast<DestinationStyleOpInterface>(linalgOp.getOperation())
-            .setDpsInitOperand(resultNumber, destinationValue);
+      .Case<DestinationStyleOpInterface>([&](auto op) {
+        op.setDpsInitOperand(resultValue.getResultNumber(), destinationValue);
         return success();
       })
       .Case<tensor::EmptyOp>([&](auto emptyTensorOp) {
@@ -206,10 +204,10 @@ static LogicalResult modifyResultToUseStoreBuffer(
     Operation *op = it->getOwner();
     resultBuffer =
         TypeSwitch<Operation *, Value>(op)
-            .Case<scf::IfOp, scf::ForOp, linalg::LinalgOp,
-                  IREE::LinalgExt::LinalgExtOp, tensor::InsertSliceOp,
-                  vector::TransferWriteOp>(
-                [&](auto caseOp) { return resultBuffer; })
+            .Case<DestinationStyleOpInterface>(
+                [&](auto) { return resultBuffer; })
+            .Case<scf::IfOp, scf::ForOp, tensor::InsertSliceOp,
+                  vector::TransferWriteOp>([&](auto) { return resultBuffer; })
             .Case<tensor::InsertSliceOp>([&](auto insertSliceOp) -> Value {
               if (it->get() == insertSliceOp.getDest()) {
                 return resultBuffer;


### PR DESCRIPTION
This refactors bufferization analysis of Linalg ops and LinalgExt ops. The implementation can be reused if DestinationStyleOpInterface is implemented.

Also adds tests for tensor.pack and tensor.unpack ops.