### PR TITLE
Disable `/Zi` when using ccache on Windows/MSVC.

### DIFF
--- a/build_tools/cmake/iree_copts.cmake
+++ b/build_tools/cmake/iree_copts.cmake
@@ -427,7 +427,20 @@ endif()
 # Compiler: MSVC
 #-------------------------------------------------------------------------------
 
-# TODO(benvanik): MSVC options.
+if(MSVC)
+  if("${CMAKE_C_COMPILER_LAUNCHER}" MATCHES "ccache" OR
+     "${CMAKE_CXX_COMPILER_LAUNCHER}" MATCHES "ccache")
+    # Disable separate PDB file generation (for debug info) when using ccache.
+    # ccache silently falls back to the real compiler when an unsupported flag
+    # like /Zi is encountered.
+    message(STATUS "Replacing /Zi with /Z7 since ccache is in use and does not support /Zi")
+    # https://learn.microsoft.com/en-us/cpp/build/reference/z7-zi-zi-debug-information-format
+    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")
+    string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")
+  endif()
+endif()
 
 #-------------------------------------------------------------------------------
 # Third party: llvm-project


### PR DESCRIPTION
One step towards enabling [ccache](https://ccache.dev/) on our Windows CI, but there are a few details to still work through: https://github.com/iree-org/iree/issues/11009#issuecomment-1382597509.

On my machine, I see these results (sample size 1):

> clean build (no cache): 528 seconds
> ```
> λ ccache --show-stats
> Cacheable calls:   3942 / 3943 (99.97%)
>   Hits:               2 / 3942 ( 0.05%)
>     Direct:           0 /    2 ( 0.00%)
>     Preprocessed:     2 /    2 (100.0%)
>   Misses:          3940 / 3942 (99.95%)
> Uncacheable calls:    1 / 3943 ( 0.03%)
> Local storage:
>   Cache size (GB): 2.21 / 5.00 (44.21%)
>   Cleanups:          16
> ```
> clean build (with cache): 96 seconds
> ```
> λ ccache --show-stats
> Cacheable calls:   3942 / 3943 (99.97%)
>   Hits:            3939 / 3942 (99.92%)
>     Direct:        3939 / 3939 (100.0%)
>     Preprocessed:     0 / 3939 ( 0.00%)
>   Misses:             3 / 3942 ( 0.08%)
> Uncacheable calls:    1 / 3943 ( 0.03%)
> Local storage:
>   Cache size (GB): 2.21 / 5.00 (44.23%)
> ```

My only changes to enable ccache were:
* Download ccache.exe and put it on my `PATH`
* Configure CMake with `-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache` (added to `"cmake.configureArgs": [ ... ]` in VSCode settings)