### PR TITLE
Rework null-terminator handling in ireeCompilerSourceWrapBuffer.

### DIFF
--- a/compiler/src/iree/compiler/API2/Embed.h
+++ b/compiler/src/iree/compiler/API2/Embed.h
@@ -240,12 +240,15 @@ IREE_EMBED_EXPORTED iree_compiler_error_t *ireeCompilerSourceOpenFile(
     iree_compiler_session_t *session, const char *filePath,
     iree_compiler_source_t **out_source);
 
-// Wraps an existing buffer in memory. The |buffer| must be null terminated, and
-// the null must be accounted for in the |length|.
+// Wraps an existing buffer in memory.
+// If |isNullTerminated| is true, then the null must be accounted for in the
+// length. This is required for text buffers and it is permitted for binary
+// buffers.
 // Must be destroyed with ireeCompilerSourceDestroy().
 IREE_EMBED_EXPORTED iree_compiler_error_t *ireeCompilerSourceWrapBuffer(
     iree_compiler_session_t *session, const char *bufferName,
-    const char *buffer, size_t length, iree_compiler_source_t **out_source);
+    const char *buffer, size_t length, bool isNullTerminated,
+    iree_compiler_source_t **out_source);
 
 // Splits the current source buffer, invoking a callback for each "split"
 // within it. This is per the usual MLIR split rules (see

--- a/compiler/src/iree/compiler/API2/Stub/Loader.cpp
+++ b/compiler/src/iree/compiler/API2/Stub/Loader.cpp
@@ -241,9 +241,10 @@ iree_compiler_error_t *ireeCompilerSourceOpenFile(
 
 iree_compiler_error_t *ireeCompilerSourceWrapBuffer(
     iree_compiler_session_t *session, const char *bufferName,
-    const char *buffer, size_t length, iree_compiler_source_t **out_source) {
+    const char *buffer, size_t length, bool isNullTerminated,
+    iree_compiler_source_t **out_source) {
   return __ireeCompilerSourceWrapBuffer(session, bufferName, buffer, length,
-                                        out_source);
+                                        isNullTerminated, out_source);
 }
 
 iree_compiler_error_t *ireeCompilerSourceSplit(

--- a/compiler/src/iree/compiler/API2/Stub/LoaderTest.c
+++ b/compiler/src/iree/compiler/API2/Stub/LoaderTest.c
@@ -143,7 +143,7 @@ int main(int argc, char **argv) {
   const char sourceWithErrorsStr[] = "}}}}FOOBAR\0";
   error = ireeCompilerSourceWrapBuffer(
       session, "foobar.mlir", sourceWithErrorsStr, sizeof(sourceWithErrorsStr),
-      &sourceWithErrors);
+      /*isNullTerminated=*/true, &sourceWithErrors);
   if (error) {
     printf("ERROR: ireeCompilerSourceWrapBuffer failed: %s\n",
            ireeCompilerErrorGetMessage(error));


### PR DESCRIPTION
What was there was not able to take a known-binary buffer that we do not know whether it is null terminated or not (nor do we care). This is a more explicit API which at least has the benefit or letting us represent known-null-terminated buffers or known-binary buffers without having LLVM try to probe one past what may be owned memory.

This is a breaking API change, but we are not yet stable so just making it vs versioning the entrypoint.