### PR TITLE
Supporting host memory registration in CUDA via external buffers.

### DIFF
--- a/runtime/src/iree/hal/command_buffer_validation.c
+++ b/runtime/src/iree/hal/command_buffer_validation.c
@@ -228,7 +228,7 @@ iree_status_t iree_hal_command_buffer_fill_buffer_validation(
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_buffer_compatibility(
       command_buffer, validation_state, target_buffer,
       IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER,
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET));
 
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_memory_type(
       iree_hal_buffer_memory_type(target_buffer),
@@ -238,7 +238,7 @@ iree_status_t iree_hal_command_buffer_fill_buffer_validation(
       IREE_HAL_MEMORY_ACCESS_WRITE));
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_usage(
       iree_hal_buffer_allowed_usage(target_buffer),
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET));
   IREE_RETURN_IF_ERROR(
       iree_hal_buffer_validate_range(target_buffer, target_offset, length));
 
@@ -274,7 +274,7 @@ iree_status_t iree_hal_command_buffer_update_buffer_validation(
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_buffer_compatibility(
       command_buffer, validation_state, target_buffer,
       IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER,
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET));
 
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_memory_type(
       iree_hal_buffer_memory_type(target_buffer),
@@ -284,7 +284,7 @@ iree_status_t iree_hal_command_buffer_update_buffer_validation(
       IREE_HAL_MEMORY_ACCESS_WRITE));
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_usage(
       iree_hal_buffer_allowed_usage(target_buffer),
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET));
   IREE_RETURN_IF_ERROR(
       iree_hal_buffer_validate_range(target_buffer, target_offset, length));
 
@@ -302,24 +302,24 @@ iree_status_t iree_hal_command_buffer_copy_buffer_validation(
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_buffer_compatibility(
       command_buffer, validation_state, source_buffer,
       IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER,
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_SOURCE));
   IREE_RETURN_IF_ERROR(iree_hal_command_buffer_validate_buffer_compatibility(
       command_buffer, validation_state, target_buffer,
       IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_TRANSFER,
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET));
 
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_access(
       iree_hal_buffer_allowed_access(source_buffer),
       IREE_HAL_MEMORY_ACCESS_READ));
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_usage(
       iree_hal_buffer_allowed_usage(source_buffer),
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_SOURCE));
   IREE_RETURN_IF_ERROR(
       iree_hal_buffer_validate_range(source_buffer, source_offset, length));
 
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_usage(
       iree_hal_buffer_allowed_usage(target_buffer),
-      IREE_HAL_BUFFER_USAGE_TRANSFER));
+      IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET));
   IREE_RETURN_IF_ERROR(iree_hal_buffer_validate_access(
       iree_hal_buffer_allowed_access(target_buffer),
       IREE_HAL_MEMORY_ACCESS_WRITE));

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -155,15 +155,22 @@ iree_hal_cuda_allocator_query_compatibility(
 }
 
 static void iree_hal_cuda_buffer_free(iree_hal_cuda_context_wrapper_t* context,
-                                      iree_hal_memory_type_t memory_type,
+                                      iree_hal_cuda_buffer_type_t buffer_type,
                                       CUdeviceptr device_ptr, void* host_ptr) {
   IREE_TRACE_ZONE_BEGIN(z0);
-  if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
-    // Device local.
-    CUDA_IGNORE_ERROR(context->syms, cuMemFree(device_ptr));
-  } else {
-    // Host local.
-    CUDA_IGNORE_ERROR(context->syms, cuMemFreeHost(host_ptr));
+  switch (buffer_type) {
+    case IREE_HAL_CUDA_BUFFER_TYPE_DEVICE: {
+      CUDA_IGNORE_ERROR(context->syms, cuMemFree(device_ptr));
+      break;
+    }
+    case IREE_HAL_CUDA_BUFFER_TYPE_HOST: {
+      CUDA_IGNORE_ERROR(context->syms, cuMemFreeHost(host_ptr));
+      break;
+    }
+    case IREE_HAL_CUDA_BUFFER_TYPE_HOST_REGISTERED: {
+      CUDA_IGNORE_ERROR(context->syms, cuMemHostUnregister(host_ptr));
+      break;
+    }
   }
   IREE_TRACE_ZONE_END(z0);
 }
@@ -196,6 +203,7 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
   }
 
   iree_status_t status = iree_ok_status();
+  iree_hal_cuda_buffer_type_t buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_DEVICE;
   void* host_ptr = NULL;
   CUdeviceptr device_ptr = 0;
   IREE_TRACE_ZONE_BEGIN_NAMED(z0, "iree_hal_cuda_buffer_allocate");
@@ -203,6 +211,7 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
   if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
     // Device local case.
     if (iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)) {
+      buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_DEVICE;
       status =
           CU_RESULT_TO_STATUS(allocator->context->syms,
                               cuMemAllocManaged(&device_ptr, allocation_size,
@@ -218,10 +227,12 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
       host_ptr = (void*)device_ptr;
     } else {
       // Device only.
+      buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_DEVICE;
       status = CU_RESULT_TO_STATUS(allocator->context->syms,
                                    cuMemAlloc(&device_ptr, allocation_size));
     }
   } else {
+    buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_HOST;
     unsigned int flags = CU_MEMHOSTALLOC_DEVICEMAP;
     if (!iree_all_bits_set(memory_type, IREE_HAL_MEMORY_TYPE_HOST_CACHED)) {
       flags |= CU_MEMHOSTALLOC_WRITECOMBINED;
@@ -243,7 +254,8 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
         base_allocator, memory_type, params->access, params->usage,
         allocation_size,
         /*byte_offset=*/0,
-        /*byte_length=*/allocation_size, device_ptr, host_ptr, &buffer);
+        /*byte_length=*/allocation_size, buffer_type, device_ptr, host_ptr,
+        iree_hal_buffer_release_callback_null(), &buffer);
   }
 
   // Copy the initial contents into the buffer. This may require staging.
@@ -267,7 +279,7 @@ static iree_status_t iree_hal_cuda_allocator_allocate_buffer(
     *out_buffer = buffer;
   } else {
     if (!buffer) {
-      iree_hal_cuda_buffer_free(allocator->context, memory_type, device_ptr,
+      iree_hal_cuda_buffer_free(allocator->context, buffer_type, device_ptr,
                                 host_ptr);
     } else {
       iree_hal_buffer_release(buffer);
@@ -281,19 +293,54 @@ static void iree_hal_cuda_allocator_deallocate_buffer(
     iree_hal_buffer_t* IREE_RESTRICT base_buffer) {
   iree_hal_cuda_allocator_t* allocator =
       iree_hal_cuda_allocator_cast(base_allocator);
-  iree_hal_memory_type_t memory_type = iree_hal_buffer_memory_type(base_buffer);
-  iree_hal_cuda_buffer_free(allocator->context, memory_type,
-                            iree_hal_cuda_buffer_device_pointer(base_buffer),
-                            iree_hal_cuda_buffer_host_pointer(base_buffer));
 
-  IREE_TRACE_FREE_NAMED(
-      IREE_HAL_CUDA_ALLOCATOR_ID,
-      (void*)iree_hal_cuda_buffer_device_pointer(base_buffer));
-  IREE_STATISTICS(iree_hal_allocator_statistics_record_free(
-      &allocator->statistics, memory_type,
-      iree_hal_buffer_allocation_size(base_buffer)));
+  const iree_hal_cuda_buffer_type_t buffer_type =
+      iree_hal_cuda_buffer_type(base_buffer);
+
+  // We may be called from a random thread and need to ensure that we have an
+  // active CUDA context.
+  //
+  // WARNING: with CUDA's lazy error propagation it's possible that by the time
+  // this code is running something else has triggered device loss and we can't
+  // actually use the context. In that case we can't perform the frees and want
+  // to silently ignore them: whatever the user tries to do next will fail in
+  // the same way and if we were deallocating this buffer as part of a tear-down
+  // on failure we don't want to end up dying during cleanup.
+  iree_status_t context_status =
+      CU_RESULT_TO_STATUS(allocator->context->syms,
+                          cuCtxPushCurrent(allocator->context->cu_context));
+  if (iree_status_is_ok(context_status)) {
+    iree_hal_cuda_buffer_free(allocator->context, buffer_type,
+                              iree_hal_cuda_buffer_device_pointer(base_buffer),
+                              iree_hal_cuda_buffer_host_pointer(base_buffer));
+  } else {
+    IREE_TRACE_MESSAGE(ERROR,
+                       "CUDA context lost/invalid during buffer deallocation; "
+                       "leaking the buffer");
+    iree_status_ignore(context_status);
+  }
+
+  switch (buffer_type) {
+    case IREE_HAL_CUDA_BUFFER_TYPE_DEVICE:
+    case IREE_HAL_CUDA_BUFFER_TYPE_HOST: {
+      IREE_TRACE_FREE_NAMED(
+          IREE_HAL_CUDA_ALLOCATOR_ID,
+          (void*)iree_hal_cuda_buffer_device_pointer(base_buffer));
+      IREE_STATISTICS(iree_hal_allocator_statistics_record_free(
+          &allocator->statistics, iree_hal_buffer_memory_type(base_buffer),
+          iree_hal_buffer_allocation_size(base_buffer)));
+      break;
+    }
+    default:
+      // Buffer type not tracked.
+      break;
+  }
 
   iree_hal_buffer_destroy(base_buffer);
+
+  // Restore the context back to whatever it was before.
+  CUcontext old_context = NULL;
+  CUDA_IGNORE_ERROR(allocator->context->syms, cuCtxPopCurrent(&old_context));
 }
 
 static iree_status_t iree_hal_cuda_allocator_import_buffer(
@@ -302,8 +349,71 @@ static iree_status_t iree_hal_cuda_allocator_import_buffer(
     iree_hal_external_buffer_t* IREE_RESTRICT external_buffer,
     iree_hal_buffer_release_callback_t release_callback,
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
-  return iree_make_status(IREE_STATUS_UNAVAILABLE,
-                          "importing from external buffers not supported");
+  iree_hal_cuda_allocator_t* allocator =
+      iree_hal_cuda_allocator_cast(base_allocator);
+
+  iree_status_t status = iree_ok_status();
+  iree_hal_cuda_buffer_type_t buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_DEVICE;
+  void* host_ptr = NULL;
+  CUdeviceptr device_ptr = 0;
+
+  switch (external_buffer->type) {
+    case IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION: {
+      buffer_type = IREE_HAL_CUDA_BUFFER_TYPE_HOST_REGISTERED;
+      host_ptr = external_buffer->handle.host_allocation.ptr;
+      uint32_t register_flags = 0;
+      if (params->access == IREE_HAL_MEMORY_ACCESS_READ) {
+        register_flags = CU_MEMHOSTREGISTER_READ_ONLY;
+      }
+      if (iree_any_bit_set(params->usage,
+                           IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                               IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ |
+                               IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                               IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE)) {
+        register_flags = CU_MEMHOSTREGISTER_DEVICEMAP;
+      }
+      status = CU_RESULT_TO_STATUS(
+          allocator->context->syms,
+          cuMemHostRegister(host_ptr, external_buffer->size, register_flags),
+          "cuMemHostRegister");
+      if (iree_status_is_ok(status)) {
+        status = CU_RESULT_TO_STATUS(
+            allocator->context->syms,
+            cuMemHostGetDevicePointer(&device_ptr, host_ptr, 0),
+            "cuMemHostGetDevicePointer");
+      }
+      break;
+    }
+    case IREE_HAL_EXTERNAL_BUFFER_TYPE_OPAQUE_FD:
+    case IREE_HAL_EXTERNAL_BUFFER_TYPE_OPAQUE_WIN32:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "handle-based imports not yet implemented");
+    default:
+      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
+                              "external buffer type not supported");
+  }
+
+  iree_hal_buffer_t* buffer = NULL;
+  if (iree_status_is_ok(status)) {
+    status = iree_hal_cuda_buffer_wrap(
+        base_allocator, params->type, params->access, params->usage,
+        external_buffer->size,
+        /*byte_offset=*/0,
+        /*byte_length=*/external_buffer->size, buffer_type, device_ptr,
+        host_ptr, release_callback, &buffer);
+  }
+
+  if (iree_status_is_ok(status)) {
+    *out_buffer = buffer;
+  } else {
+    if (!buffer) {
+      iree_hal_cuda_buffer_free(allocator->context, buffer_type, device_ptr,
+                                host_ptr);
+    } else {
+      iree_hal_buffer_release(buffer);
+    }
+  }
+  return status;
 }
 
 static iree_status_t iree_hal_cuda_allocator_export_buffer(

--- a/runtime/src/iree/hal/drivers/cuda/cuda_buffer.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_buffer.c
@@ -15,8 +15,10 @@
 
 typedef struct iree_hal_cuda_buffer_t {
   iree_hal_buffer_t base;
+  iree_hal_cuda_buffer_type_t type;
   void* host_ptr;
   CUdeviceptr device_ptr;
+  iree_hal_buffer_release_callback_t release_callback;
 } iree_hal_cuda_buffer_t;
 
 static const iree_hal_buffer_vtable_t iree_hal_cuda_buffer_vtable;
@@ -27,12 +29,20 @@ static iree_hal_cuda_buffer_t* iree_hal_cuda_buffer_cast(
   return (iree_hal_cuda_buffer_t*)base_value;
 }
 
+static const iree_hal_cuda_buffer_t* iree_hal_cuda_buffer_const_cast(
+    const iree_hal_buffer_t* base_value) {
+  IREE_HAL_ASSERT_TYPE(base_value, &iree_hal_cuda_buffer_vtable);
+  return (const iree_hal_cuda_buffer_t*)base_value;
+}
+
 iree_status_t iree_hal_cuda_buffer_wrap(
     iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
-    CUdeviceptr device_ptr, void* host_ptr, iree_hal_buffer_t** out_buffer) {
+    iree_hal_cuda_buffer_type_t buffer_type, CUdeviceptr device_ptr,
+    void* host_ptr, iree_hal_buffer_release_callback_t release_callback,
+    iree_hal_buffer_t** out_buffer) {
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(out_buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
@@ -47,8 +57,10 @@ iree_status_t iree_hal_cuda_buffer_wrap(
                                allocation_size, byte_offset, byte_length,
                                memory_type, allowed_access, allowed_usage,
                                &iree_hal_cuda_buffer_vtable, &buffer->base);
+    buffer->type = buffer_type;
     buffer->host_ptr = host_ptr;
     buffer->device_ptr = device_ptr;
+    buffer->release_callback = release_callback;
     *out_buffer = &buffer->base;
   }
 
@@ -60,6 +72,10 @@ static void iree_hal_cuda_buffer_destroy(iree_hal_buffer_t* base_buffer) {
   iree_hal_cuda_buffer_t* buffer = iree_hal_cuda_buffer_cast(base_buffer);
   iree_allocator_t host_allocator = base_buffer->host_allocator;
   IREE_TRACE_ZONE_BEGIN(z0);
+  if (buffer->release_callback.fn) {
+    buffer->release_callback.fn(buffer->release_callback.user_data,
+                                base_buffer);
+  }
   iree_allocator_free(host_allocator, buffer);
   IREE_TRACE_ZONE_END(z0);
 }
@@ -115,14 +131,23 @@ static iree_status_t iree_hal_cuda_buffer_flush_range(
   return iree_ok_status();
 }
 
+iree_hal_cuda_buffer_type_t iree_hal_cuda_buffer_type(
+    const iree_hal_buffer_t* base_buffer) {
+  const iree_hal_cuda_buffer_t* buffer =
+      iree_hal_cuda_buffer_const_cast(base_buffer);
+  return buffer->type;
+}
+
 CUdeviceptr iree_hal_cuda_buffer_device_pointer(
-    iree_hal_buffer_t* base_buffer) {
-  iree_hal_cuda_buffer_t* buffer = iree_hal_cuda_buffer_cast(base_buffer);
+    const iree_hal_buffer_t* base_buffer) {
+  const iree_hal_cuda_buffer_t* buffer =
+      iree_hal_cuda_buffer_const_cast(base_buffer);
   return buffer->device_ptr;
 }
 
-void* iree_hal_cuda_buffer_host_pointer(iree_hal_buffer_t* base_buffer) {
-  iree_hal_cuda_buffer_t* buffer = iree_hal_cuda_buffer_cast(base_buffer);
+void* iree_hal_cuda_buffer_host_pointer(const iree_hal_buffer_t* base_buffer) {
+  const iree_hal_cuda_buffer_t* buffer =
+      iree_hal_cuda_buffer_const_cast(base_buffer);
   return buffer->host_ptr;
 }
 

--- a/runtime/src/iree/hal/drivers/cuda/cuda_buffer.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_buffer.h
@@ -15,21 +15,37 @@
 extern "C" {
 #endif  // __cplusplus
 
+typedef enum iree_hal_cuda_buffer_type_e {
+  // cuMemAlloc/cuMemAllocManaged + cuMemFree
+  IREE_HAL_CUDA_BUFFER_TYPE_DEVICE = 1u << 0,
+  // cuMemHostAlloc + cuMemFreeHost
+  IREE_HAL_CUDA_BUFFER_TYPE_HOST = 1u << 1,
+  // cuMemHostRegister + cuMemHostUnregister
+  IREE_HAL_CUDA_BUFFER_TYPE_HOST_REGISTERED = 1u << 2,
+} iree_hal_cuda_buffer_type_t;
+
 // Wraps a CUDA allocation in an iree_hal_buffer_t.
 iree_status_t iree_hal_cuda_buffer_wrap(
     iree_hal_allocator_t* allocator, iree_hal_memory_type_t memory_type,
     iree_hal_memory_access_t allowed_access,
     iree_hal_buffer_usage_t allowed_usage, iree_device_size_t allocation_size,
     iree_device_size_t byte_offset, iree_device_size_t byte_length,
-    CUdeviceptr device_ptr, void* host_ptr, iree_hal_buffer_t** out_buffer);
+    iree_hal_cuda_buffer_type_t buffer_type, CUdeviceptr device_ptr,
+    void* host_ptr, iree_hal_buffer_release_callback_t release_callback,
+    iree_hal_buffer_t** out_buffer);
+
+// Returns the underlying CUDA buffer type.
+iree_hal_cuda_buffer_type_t iree_hal_cuda_buffer_type(
+    const iree_hal_buffer_t* buffer);
 
 // Returns the CUDA base pointer for the given |buffer|.
 // This is the entire allocated_buffer and must be offset by the buffer
 // byte_offset and byte_length when used.
-CUdeviceptr iree_hal_cuda_buffer_device_pointer(iree_hal_buffer_t* buffer);
+CUdeviceptr iree_hal_cuda_buffer_device_pointer(
+    const iree_hal_buffer_t* buffer);
 
 // Returns the CUDA host pointer for the given |buffer|, if available.
-void* iree_hal_cuda_buffer_host_pointer(iree_hal_buffer_t* buffer);
+void* iree_hal_cuda_buffer_host_pointer(const iree_hal_buffer_t* buffer);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbol_tables.h
@@ -9,6 +9,8 @@ CU_PFN_DECL(cuCtxDestroy, CUcontext)
 CU_PFN_DECL(cuDevicePrimaryCtxRetain, CUcontext*, CUdevice)
 CU_PFN_DECL(cuDevicePrimaryCtxRelease, CUdevice)
 CU_PFN_DECL(cuCtxSetCurrent, CUcontext)
+CU_PFN_DECL(cuCtxPushCurrent, CUcontext)
+CU_PFN_DECL(cuCtxPopCurrent, CUcontext*)
 CU_PFN_DECL(cuDeviceGet, CUdevice*, int)
 CU_PFN_DECL(cuDeviceGetCount, int*)
 CU_PFN_DECL(cuDeviceGetName, char*, int, CUdevice)
@@ -36,6 +38,8 @@ CU_PFN_DECL(cuMemAlloc, CUdeviceptr*, size_t)
 CU_PFN_DECL(cuMemFree, CUdeviceptr)
 CU_PFN_DECL(cuMemFreeHost, void*)
 CU_PFN_DECL(cuMemHostAlloc, void**, size_t, unsigned int)
+CU_PFN_DECL(cuMemHostRegister, void*, size_t, unsigned int)
+CU_PFN_DECL(cuMemHostUnregister, void*)
 CU_PFN_DECL(cuMemHostGetDevicePointer, CUdeviceptr*, void*, unsigned int)
 CU_PFN_DECL(cuModuleGetFunction, CUfunction*, CUmodule, const char*)
 CU_PFN_DECL(cuModuleLoadDataEx, CUmodule*, const void*, unsigned int,
@@ -60,39 +64,39 @@ CU_PFN_DECL(cuLaunchKernel, CUfunction, unsigned int, unsigned int,
 
 // NCCL
 
-NCCL_PFN_DECL(ncclGetVersion, int *)
-NCCL_PFN_DECL(ncclGetUniqueId, ncclUniqueId *)
-NCCL_PFN_DECL(ncclCommInitRankConfig, ncclComm_t *, int, ncclUniqueId, int,
-              ncclConfig_t *)
-NCCL_PFN_DECL(ncclCommInitRank, ncclComm_t *, int, ncclUniqueId, int)
-NCCL_PFN_DECL(ncclCommInitAll, ncclComm_t *, int, const int *)
+NCCL_PFN_DECL(ncclGetVersion, int*)
+NCCL_PFN_DECL(ncclGetUniqueId, ncclUniqueId*)
+NCCL_PFN_DECL(ncclCommInitRankConfig, ncclComm_t*, int, ncclUniqueId, int,
+              ncclConfig_t*)
+NCCL_PFN_DECL(ncclCommInitRank, ncclComm_t*, int, ncclUniqueId, int)
+NCCL_PFN_DECL(ncclCommInitAll, ncclComm_t*, int, const int*)
 NCCL_PFN_DECL(ncclCommFinalize, ncclComm_t)
 NCCL_PFN_DECL(ncclCommDestroy, ncclComm_t)
 NCCL_PFN_DECL(ncclCommAbort, ncclComm_t)
 NCCL_PFN_DECL_STR_RETURN(ncclGetErrorString, ncclResult_t)
 NCCL_PFN_DECL_STR_RETURN(ncclGetLastError, ncclComm_t)
-NCCL_PFN_DECL(ncclCommGetAsyncError, ncclComm_t, ncclResult_t *)
-NCCL_PFN_DECL(ncclCommCount, const ncclComm_t, int *)
-NCCL_PFN_DECL(ncclCommCuDevice, const ncclComm_t, int *)
-NCCL_PFN_DECL(ncclCommUserRank, const ncclComm_t, int *)
-NCCL_PFN_DECL(ncclRedOpCreatePreMulSum, ncclRedOp_t *, void *, ncclDataType_t,
+NCCL_PFN_DECL(ncclCommGetAsyncError, ncclComm_t, ncclResult_t*)
+NCCL_PFN_DECL(ncclCommCount, const ncclComm_t, int*)
+NCCL_PFN_DECL(ncclCommCuDevice, const ncclComm_t, int*)
+NCCL_PFN_DECL(ncclCommUserRank, const ncclComm_t, int*)
+NCCL_PFN_DECL(ncclRedOpCreatePreMulSum, ncclRedOp_t*, void*, ncclDataType_t,
               ncclScalarResidence_t, ncclComm_t)
 NCCL_PFN_DECL(ncclRedOpDestroy, ncclRedOp_t, ncclComm_t)
-NCCL_PFN_DECL(ncclReduce, const void *, void *, size_t, ncclDataType_t,
+NCCL_PFN_DECL(ncclReduce, const void*, void*, size_t, ncclDataType_t,
               ncclRedOp_t, int, ncclComm_t, cudaStream_t)
-NCCL_PFN_DECL(ncclBcast, void *, size_t, ncclDataType_t, int, ncclComm_t,
+NCCL_PFN_DECL(ncclBcast, void*, size_t, ncclDataType_t, int, ncclComm_t,
               cudaStream_t)
-NCCL_PFN_DECL(ncclBroadcast, const void *, void *, size_t, ncclDataType_t, int,
+NCCL_PFN_DECL(ncclBroadcast, const void*, void*, size_t, ncclDataType_t, int,
               ncclComm_t, cudaStream_t)
-NCCL_PFN_DECL(ncclAllReduce, const void *, void *, size_t, ncclDataType_t,
+NCCL_PFN_DECL(ncclAllReduce, const void*, void*, size_t, ncclDataType_t,
               ncclRedOp_t, ncclComm_t, cudaStream_t)
-NCCL_PFN_DECL(ncclReduceScatter, const void *, void *, size_t, ncclDataType_t,
+NCCL_PFN_DECL(ncclReduceScatter, const void*, void*, size_t, ncclDataType_t,
               ncclRedOp_t, ncclComm_t, cudaStream_t)
-NCCL_PFN_DECL(ncclAllGather, const void *, void *, size_t, ncclDataType_t,
+NCCL_PFN_DECL(ncclAllGather, const void*, void*, size_t, ncclDataType_t,
               ncclComm_t, cudaStream_t)
-NCCL_PFN_DECL(ncclSend, const void *, size_t, ncclDataType_t, int, ncclComm_t,
+NCCL_PFN_DECL(ncclSend, const void*, size_t, ncclDataType_t, int, ncclComm_t,
               cudaStream_t)
-NCCL_PFN_DECL(ncclRecv, void *, size_t, ncclDataType_t, int, ncclComm_t,
+NCCL_PFN_DECL(ncclRecv, void*, size_t, ncclDataType_t, int, ncclComm_t,
               cudaStream_t)
 NCCL_PFN_DECL(ncclGroupStart)
 NCCL_PFN_DECL(ncclGroupEnd)


### PR DESCRIPTION
Note that registering host memory is an expensive operation (likely synchronizes with the device just like alloc/free, can result in cache clears, etc).

Example:
```c
  static float heap_buffer[1 * 224 * 224 * 3] = {5};
  iree_hal_external_buffer_t external_buffer = {
      .type = IREE_HAL_EXTERNAL_BUFFER_TYPE_HOST_ALLOCATION,
      .flags = IREE_HAL_EXTERNAL_BUFFER_FLAG_NONE,
      .size = sizeof(heap_buffer),
      .handle.host_allocation.ptr = heap_buffer,
  };
  iree_hal_buffer_t* buffer = NULL;
  IREE_CHECK_OK(iree_hal_allocator_import_buffer(
      buffer_allocator, buffer_params, &external_buffer,
      iree_hal_buffer_release_callback_null(), &buffer));
```