### PR TITLE
Populate CPU features from CPU (on X86)

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/BUILD
@@ -107,6 +107,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Passes",
         "@llvm-project//llvm:Support",
         "@llvm-project//llvm:Target",
+        "@llvm-project//llvm:TargetParser",
     ],
 )
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -88,6 +88,7 @@ iree_cc_library(
     LLVMPasses
     LLVMSupport
     LLVMTarget
+    LLVMTargetParser
   PUBLIC
 )
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -15,13 +15,14 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Target/TargetOptions.h"
+#include "llvm/TargetParser/X86TargetParser.h"
 
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {
 namespace HAL {
 
-LLVMTargetOptions getDefaultLLVMTargetOptions() {
+static LLVMTargetOptions getDefaultLLVMTargetOptions() {
   static LLVMTargetOptions targetOptions;
   static std::once_flag onceFlag;
   std::call_once(onceFlag, [&]() {
@@ -61,6 +62,20 @@ LLVMTargetOptions getDefaultLLVMTargetOptions() {
   return targetOptions;
 }
 
+static void addTargetCPUFeaturesForCPU(LLVMTarget &target) {
+  if (!llvm::Triple(target.triple).isX86()) {
+    // Currently only implemented on x86.
+    return;
+  }
+  llvm::SubtargetFeatures targetCpuFeatures(target.cpuFeatures);
+  llvm::SmallVector<llvm::StringRef> cpuFeatures;
+  llvm::X86::getFeaturesForCPU(target.cpu, cpuFeatures);
+  for (auto &feature : cpuFeatures) {
+    targetCpuFeatures.AddFeature(feature);
+  }
+  target.cpuFeatures = targetCpuFeatures.getString();
+}
+
 LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
   auto targetOptions = getDefaultLLVMTargetOptions();
 
@@ -98,6 +113,9 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
   }
   if (clTargetCPUFeatures != "host") {
     targetOptions.target.cpuFeatures = clTargetCPUFeatures;
+  }
+  if (clTargetCPU != "host" && clTargetCPU != "generic") {
+    addTargetCPUFeaturesForCPU(targetOptions.target);
   }
 
   // LLVM opt options.


### PR DESCRIPTION
There are 2 ways to pass sub-target features: by specifying a target CPU as in `--iree-llvm-target-cpu=cascadelake` (that's what our benchmarks do) or by specifying an explicit list of CPU features as in  `--iree-llvm-target-cpu-features=avx512vnni`.

The 2 are so far merged only when we go into the LLVM back-end here: https://github.com/iree-org/iree/blob/d91712bf4d32c44f6075620293e638418a47d78f/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMIRPasses.cpp#L36-L38

This means that any IREE compiler code trying to act on CPU features is so far sensitive to which way CPU features are passed. Current code is reading the list of individual CPU features, not the specified CPU, e.g.: https://github.com/iree-org/iree/blob/d91712bf4d32c44f6075620293e638418a47d78f/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp#L167-L169

So currently, when benchmarks are built with just  `--iree-llvm-target-cpu=cascadelake` , that is the same as generic baseline x86-64 from the point of view of all such IREE compiler code.

(I ran into this debugging why #11849 wasn't having the intended effect).

Clearly we need to resolve the specified CPU into a CPU features list early. We were already doing this in the specific case of targeting `host`: https://github.com/iree-org/iree/blob/d91712bf4d32c44f6075620293e638418a47d78f/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp#L24-L40

This PR adds similar logic but to get the list of CPU features from the specified CPU. It merges with any specified CPU features (so one can still have control), see how `target.cpuFeatures` is passed to the `llvm::SubtargetFeatures` constructor.

This is implemented only on X86 as I couldn't find a more generic way (or the equivalent on other archs).  This doesn't concern builds targeting `host` - the above-linked host-querying code already has non-x86 code paths.

I'm not worried about having this unimplemented outside of x86 because I expect `--iree-llvm-target-cpu` to be used mostly on x86.  On ARM, it feels more natural to use `--iree-llvm-target-cpu-features`.

Together with #11849, this has the intended effect of getting data-tiling to generate a decent-looking AVX-512 kernel in the benchmarks build command line specifying just `--iree-llvm-target-cpu=cascadelake`:

```
    3440:       62 c1 7c 48 28 04 39    vmovaps (%r9,%rdi,1),%zmm16
    3447:       62 d2 7d 50 b8 04 3e    vfmadd231ps (%r14,%rdi,1){1to16},%zmm16,%zmm0
    344e:       62 d2 7d 50 b8 4c 3e    vfmadd231ps 0x4(%r14,%rdi,1){1to16},%zmm16,%zmm1
    3455:       01 
    3456:       62 d2 7d 50 b8 54 3e    vfmadd231ps 0x8(%r14,%rdi,1){1to16},%zmm16,%zmm2
    345d:       02 
    345e:       62 d2 7d 50 b8 5c 3e    vfmadd231ps 0xc(%r14,%rdi,1){1to16},%zmm16,%zmm3
    3465:       03 
    3466:       62 d2 7d 50 b8 64 3e    vfmadd231ps 0x10(%r14,%rdi,1){1to16},%zmm16,%zmm4
    346d:       04 
    346e:       62 d2 7d 50 b8 6c 3e    vfmadd231ps 0x14(%r14,%rdi,1){1to16},%zmm16,%zmm5
    3475:       05 
    3476:       62 d2 7d 50 b8 74 3e    vfmadd231ps 0x18(%r14,%rdi,1){1to16},%zmm16,%zmm6
    347d:       06 
    347e:       62 d2 7d 50 b8 7c 3e    vfmadd231ps 0x1c(%r14,%rdi,1){1to16},%zmm16,%zmm7
    3485:       07 
    3486:       62 52 7d 50 b8 44 3e    vfmadd231ps 0x20(%r14,%rdi,1){1to16},%zmm16,%zmm8
    348d:       08 
    348e:       62 52 7d 50 b8 4c 3e    vfmadd231ps 0x24(%r14,%rdi,1){1to16},%zmm16,%zmm9
    3495:       09 
    3496:       62 52 7d 50 b8 54 3e    vfmadd231ps 0x28(%r14,%rdi,1){1to16},%zmm16,%zmm10
    349d:       0a 
    349e:       62 52 7d 50 b8 5c 3e    vfmadd231ps 0x2c(%r14,%rdi,1){1to16},%zmm16,%zmm11
    34a5:       0b 
    34a6:       62 52 7d 50 b8 64 3e    vfmadd231ps 0x30(%r14,%rdi,1){1to16},%zmm16,%zmm12
    34ad:       0c 
    34ae:       62 52 7d 50 b8 6c 3e    vfmadd231ps 0x34(%r14,%rdi,1){1to16},%zmm16,%zmm13
    34b5:       0d 
    34b6:       62 52 7d 50 b8 74 3e    vfmadd231ps 0x38(%r14,%rdi,1){1to16},%zmm16,%zmm14
    34bd:       0e 
    34be:       62 52 7d 50 b8 7c 3e    vfmadd231ps 0x3c(%r14,%rdi,1){1to16},%zmm16,%zmm15
    34c5:       0f 
    34c6:       48 83 c7 40             add    $0x40,%rdi
    34ca:       49 39 fb                cmp    %rdi,%r11
    34cd:       0f 85 6d ff ff ff       jne    3440 <iree_hal_executable_library_query-0x710>
```

