### PR TITLE
Collect tracy in new benchmark CI

### DIFF
--- a/.github/workflows/benchmark_execution.yml
+++ b/.github/workflows/benchmark_execution.yml
@@ -162,25 +162,20 @@ jobs:
           tar -xf ${BENCHMARK_TOOLS_ARCHIVE}
           echo "normal-benchmark-tools-dir=${BENCHMARK_TOOLS_DIR}/build/tools" >> "${GITHUB_OUTPUT}"
           echo "traced-benchmark-tools-dir=${BENCHMARK_TOOLS_DIR}/build-traced/tools" >> "${GITHUB_OUTPUT}"
+          echo "tracy-capture-tool=${BENCHMARK_TOOLS_DIR}/build-traced/tracy-capture" >> "${GITHUB_OUTPUT}"
       - name: "Running benchmarks"
-        id: run
         env:
           IREE_EXECUTION_BENCHMARK_CONFIG: ${{ steps.download-assets.outputs.benchmark-config }}
           IREE_DOCKER_WRAPPER: ./build_tools/github_actions/docker_run.sh
           IREE_NORMAL_BENCHMARK_TOOLS_DIR: ${{ steps.unpack-tools.outputs.normal-benchmark-tools-dir }}
           IREE_TRACED_BENCHMARK_TOOLS_DIR: ${{ steps.unpack-tools.outputs.traced-benchmark-tools-dir }}
+          IREE_TRACY_CAPTURE_TOOL: ${{ steps.unpack-tools.outputs.tracy-capture-tool }}
           IREE_TARGET_DEVICE_NAME: ${{ env.DEVICE_NAME }}
           IREE_E2E_TEST_ARTIFACTS_DIR: ${{ env.E2E_TEST_ARTIFACTS_DIR }}
           IREE_BENCHMARK_RESULTS: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-results-${{ matrix.benchmark.device_name }}.json
+          IREE_BENCHMARK_TRACES: ${{ env.BENCHMARK_RESULTS_DIR }}/benchmark-traces-${{ matrix.benchmark.device_name }}.tar.gz
         run: |
           mkdir -p ${BENCHMARK_RESULTS_DIR}
           ./build_tools/benchmarks/run_benchmarks.sh
-          echo "benchmark-results=${IREE_BENCHMARK_RESULTS}" >> "${GITHUB_OUTPUT}"
       - name: "Uploading benchmark results"
-        id: upload
-        env:
-          BENCHMARK_RESULTS: ${{ steps.run.outputs.benchmark-results }}
-        run: |
-          gcloud storage cp \
-            "${BENCHMARK_RESULTS}" \
-            "${GCS_DIR}/${BENCHMARK_RESULTS}"
+        run: gcloud storage cp -r "${BENCHMARK_RESULTS_DIR}" "${GCS_DIR}/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,13 +923,15 @@ jobs:
         target:
           - platform: "linux"
             arch: "x86_64"
-            docker_image: "gcr.io/iree-oss/base@sha256:dcae1cb774c62680ffb9ed870a255181a428aacf5eb2387676146e055bc3b9e8"
+            docker_image: "gcr.io/iree-oss/base-bleeding-edge@sha256:3ea6d37221a452058a7f5a5c25b4f8a82625e4b98c9e638ebdf19bb21917e6fd"
             # Builds tools on the host and assumes the builder is Linux x86_64.
             build_script: "./build_tools/cmake/build_runtime.sh"
+            tracy_capture: "gs://iree-shared-files/tracy-capture-linux-x86_64-52b6af88.tgz"
           - platform: "linux"
             arch: "riscv_64"
             docker_image: "gcr.io/iree-oss/riscv@sha256:000cc1bfe46666f2f42f82fb487c744cf3b1edb05d3c9810b049652428f38bb5"
             build_script: "./build_tools/cmake/build_riscv.sh"
+            tracy_capture: "gs://iree-shared-files/tracy-capture-linux-x86_64-52b6af88.tgz"
     env:
       PLATFORM: ${{ matrix.target.platform }}
       ARCH: ${{ matrix.target.arch }}
@@ -948,6 +950,13 @@ jobs:
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting host binaries"
         run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
+      - name: "Downloading pre-built tracy capture tool"
+        id: download-tracy-capture
+        env:
+          TRACY_CAPTURE_GCS_ARTIFACT: ${{ matrix.target.tracy_capture }}
+        run: |
+          gcloud storage cp "${TRACY_CAPTURE_GCS_ARTIFACT}" "tracy-capture.tgz"
+          echo "tracy-capture-archive=tracy-capture.tgz" >> "${GITHUB_OUTPUT}"
       - name: "Compiling the benchmark tools"
         id: build
         run: |
@@ -966,14 +975,21 @@ jobs:
             --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BIN_DIR=${BUILD_DIR}/install/bin" \
             "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build-traced"
+      - name: "Unpacking tracy capture"
+        env:
+          TRACY_CAPTURE_ARCHIVE: ${{ steps.download-tracy-capture.outputs.tracy-capture-archive }}
+        run: |
+          tar -C "${BUILD_TOOLS_DIR}/build-traced" \
+            -xvf "${TRACY_CAPTURE_ARCHIVE}"
       - name: "Creating the benchmark tools archive"
         id: archive
         env:
-          BENCHMARK_TOOLS_ARCHIVE: ${{ matrix.target.platform }}-${{ matrix.target.arch }}-benchmark-tools.tar
+          BENCHMARK_TOOLS_ARCHIVE: ${{ env.PLATFORM }}-${{ env.ARCH }}-benchmark-tools.tar
         run: |
           tar -cf "${BENCHMARK_TOOLS_ARCHIVE}" \
             "${BUILD_TOOLS_DIR}"/*/tools/iree-benchmark-module \
-            "${BUILD_TOOLS_DIR}"/*/tools/build_config.txt
+            "${BUILD_TOOLS_DIR}"/*/tools/build_config.txt \
+            "${BUILD_TOOLS_DIR}/build-traced/tracy-capture"
           echo "benchmark-tools-archive=${BENCHMARK_TOOLS_ARCHIVE}" >> "${GITHUB_OUTPUT}"
       - name: "Uploading the benchmark tools archive"
         id: upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -975,6 +975,7 @@ jobs:
           TRACY_CAPTURE: ${{ env.BUILD_TOOLS_DIR }}/build-traced/tracy-capture
         run: |
           gcloud storage cp "${TRACY_CAPTURE_GCS_ARTIFACT}" "${TRACY_CAPTURE}"
+          chmod +x "${TRACY_CAPTURE}"
           echo "tracy-capture=${TRACY_CAPTURE}" >> "${GITHUB_OUTPUT}"
       - name: "Creating the benchmark tools archive"
         # Here we pack a tracy-capture binary into each benchmark tools archive.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -978,11 +978,11 @@ jobs:
           chmod +x "${TRACY_CAPTURE}"
           echo "tracy-capture=${TRACY_CAPTURE}" >> "${GITHUB_OUTPUT}"
       - name: "Creating the benchmark tools archive"
-        # Here we pack a tracy-capture binary into each benchmark tools archive.
-        # This could be wasteful because multiple benchmark tools archives might
-        # pack the same tracy-capture binary. But it simplifies the process to
-        # fetch required tools to run benchmarks and we only have a few versions
-        # of the benchmark tools archives.
+        # Here we pack a tracy-capture binary (~7MB) into each benchmark tools
+        # archive. This could be wasteful because multiple benchmark tools
+        # archives might pack the same tracy-capture binary. But it simplifies
+        # the process to fetch required tools to run benchmarks and we only have
+        # a few versions of the benchmark tools archives.
         # Detailed reason: The generated benchmark matrix fetches the benchmark
         # tools archive based on the target device. However, there is a scenario
         # that the tracy-capture is running on a different host. E.g. Mobile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -926,12 +926,12 @@ jobs:
             docker_image: "gcr.io/iree-oss/base-bleeding-edge@sha256:3ea6d37221a452058a7f5a5c25b4f8a82625e4b98c9e638ebdf19bb21917e6fd"
             # Builds tools on the host and assumes the builder is Linux x86_64.
             build_script: "./build_tools/cmake/build_runtime.sh"
-            tracy_capture: "gs://iree-shared-files/tracy-capture-linux-x86_64-52b6af88.tgz"
+            tracy_capture: "gs://iree-shared-files/tracy-capture-linux-x86_64-52b6af88"
           - platform: "linux"
             arch: "riscv_64"
             docker_image: "gcr.io/iree-oss/riscv@sha256:000cc1bfe46666f2f42f82fb487c744cf3b1edb05d3c9810b049652428f38bb5"
             build_script: "./build_tools/cmake/build_riscv.sh"
-            tracy_capture: "gs://iree-shared-files/tracy-capture-linux-x86_64-52b6af88.tgz"
+            tracy_capture: "gs://iree-shared-files/tracy-capture-linux-x86_64-52b6af88"
     env:
       PLATFORM: ${{ matrix.target.platform }}
       ARCH: ${{ matrix.target.arch }}
@@ -950,13 +950,6 @@ jobs:
         run: gcloud storage cp "${BUILD_DIR_GCS_ARTIFACT}" "${BUILD_DIR_ARCHIVE}"
       - name: "Extracting host binaries"
         run: tar -xf "${BUILD_DIR_ARCHIVE}" "${BUILD_DIR}/install"
-      - name: "Downloading pre-built tracy capture tool"
-        id: download-tracy-capture
-        env:
-          TRACY_CAPTURE_GCS_ARTIFACT: ${{ matrix.target.tracy_capture }}
-        run: |
-          gcloud storage cp "${TRACY_CAPTURE_GCS_ARTIFACT}" "tracy-capture.tgz"
-          echo "tracy-capture-archive=tracy-capture.tgz" >> "${GITHUB_OUTPUT}"
       - name: "Compiling the benchmark tools"
         id: build
         run: |
@@ -975,12 +968,14 @@ jobs:
             --env "BUILD_PRESET=benchmark-with-tracing" \
             --env "IREE_HOST_BIN_DIR=${BUILD_DIR}/install/bin" \
             "${DOCKER_IMAGE}" "${BUILD_SCRIPT}" "${BUILD_TOOLS_DIR}/build-traced"
-      - name: "Unpacking tracy capture"
+      - name: "Downloading pre-built tracy capture tool"
+        id: download-tracy-capture
         env:
-          TRACY_CAPTURE_ARCHIVE: ${{ steps.download-tracy-capture.outputs.tracy-capture-archive }}
+          TRACY_CAPTURE_GCS_ARTIFACT: ${{ matrix.target.tracy_capture }}
+          TRACY_CAPTURE: ${{ env.BUILD_TOOLS_DIR }}/build-traced/tracy-capture
         run: |
-          tar -C "${BUILD_TOOLS_DIR}/build-traced" \
-            -xvf "${TRACY_CAPTURE_ARCHIVE}"
+          gcloud storage cp "${TRACY_CAPTURE_GCS_ARTIFACT}" "${TRACY_CAPTURE}"
+          echo "tracy-capture=${TRACY_CAPTURE}" >> "${GITHUB_OUTPUT}"
       - name: "Creating the benchmark tools archive"
         # Here we pack a tracy-capture binary into each benchmark tools archive.
         # This could be wasteful because multiple benchmark tools archives might
@@ -997,12 +992,13 @@ jobs:
         # into each benchmark tools archive.
         id: archive
         env:
+          TRACY_CAPTURE: ${{ steps.download-tracy-capture.outputs.tracy-capture }}
           BENCHMARK_TOOLS_ARCHIVE: ${{ env.PLATFORM }}-${{ env.ARCH }}-benchmark-tools.tar
         run: |
           tar -cf "${BENCHMARK_TOOLS_ARCHIVE}" \
             "${BUILD_TOOLS_DIR}"/*/tools/iree-benchmark-module \
             "${BUILD_TOOLS_DIR}"/*/tools/build_config.txt \
-            "${BUILD_TOOLS_DIR}/build-traced/tracy-capture"
+            "${TRACY_CAPTURE}"
           echo "benchmark-tools-archive=${BENCHMARK_TOOLS_ARCHIVE}" >> "${GITHUB_OUTPUT}"
       - name: "Uploading the benchmark tools archive"
         id: upload

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -982,6 +982,19 @@ jobs:
           tar -C "${BUILD_TOOLS_DIR}/build-traced" \
             -xvf "${TRACY_CAPTURE_ARCHIVE}"
       - name: "Creating the benchmark tools archive"
+        # Here we pack a tracy-capture binary into each benchmark tools archive.
+        # This could be wasteful because multiple benchmark tools archives might
+        # pack the same tracy-capture binary. But it simplifies the process to
+        # fetch required tools to run benchmarks and we only have a few versions
+        # of the benchmark tools archives.
+        # Detailed reason: The generated benchmark matrix fetches the benchmark
+        # tools archive based on the target device. However, there is a scenario
+        # that the tracy-capture is running on a different host. E.g. Mobile
+        # benchmarks have the benchmark tool forwarding the data from the phones
+        # to the tracy-capture running on Linux host. Embedding the host of
+        # tracy-capture will overloads the benchmark matrix and puts too much
+        # unrelated machine setup in it. So we simply pack everything needed
+        # into each benchmark tools archive.
         id: archive
         env:
           BENCHMARK_TOOLS_ARCHIVE: ${{ env.PLATFORM }}-${{ env.ARCH }}-benchmark-tools.tar

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -21,18 +21,28 @@ set -euo pipefail
 
 DOCKER_WRAPPER="${IREE_DOCKER_WRAPPER:-./build_tools/docker/docker_run.sh}"
 NORMAL_BENCHMARK_TOOLS_DIR="${IREE_NORMAL_BENCHMARK_TOOLS_DIR}"
+TRACED_BENCHMARK_TOOLS_DIR="${IREE_TRACED_BENCHMARK_TOOLS_DIR}"
+TRACY_CAPTURE_TOOL="${IREE_TRACY_CAPTURE_TOOL}"
 E2E_TEST_ARTIFACTS_DIR="${1:-${IREE_E2E_TEST_ARTIFACTS_DIR}}"
 EXECUTION_BENCHMARK_CONFIG="${2:-${IREE_EXECUTION_BENCHMARK_CONFIG}}"
 TARGET_DEVICE_NAME="${3:-${IREE_TARGET_DEVICE_NAME}}"
 BENCHMARK_RESULTS="${4:-${IREE_BENCHMARK_RESULTS}}"
+BENCHMARK_TRACES="${5:-${IREE_BENCHMARK_TRACES}}"
+
+# Give access to performance counters and kernel information.
+sudo sh -c "echo -1 > /proc/sys/kernel/perf_event_paranoid"
+sudo sh -c "echo 0 > /proc/sys/kernel/kptr_restrict"
 
 if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
   ${DOCKER_WRAPPER} \
     --gpus all \
     --env NVIDIA_DRIVER_CAPABILITIES=all \
-    gcr.io/iree-oss/nvidia@sha256:0088a9efa980de8c699dc75eb89a5d758e38c9f825181d8d5e679ac5a09a7da6 \
+    gcr.io/iree-oss/nvidia-bleeding-edge@sha256:5651a746a052990af1acb5190f526b5160a72dd645e81b50e76a7cc074d60970 \
       ./build_tools/benchmarks/run_benchmarks_on_linux.py \
         --normal_benchmark_tool_dir="${NORMAL_BENCHMARK_TOOLS_DIR}" \
+        --traced_benchmark_tool_dir="${TRACED_BENCHMARK_TOOLS_DIR}" \
+        --trace_capture_tool="${TRACY_CAPTURE_TOOL}" \
+        --capture_tarball="${BENCHMARK_TRACES}" \
         --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
         --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
         --target_device_name="${TARGET_DEVICE_NAME}" \
@@ -43,6 +53,9 @@ elif [[ "${TARGET_DEVICE_NAME}" == "c2-standard-16" ]]; then
     gcr.io/iree-oss/base-bleeding-edge@sha256:3ea6d37221a452058a7f5a5c25b4f8a82625e4b98c9e638ebdf19bb21917e6fd \
       ./build_tools/benchmarks/run_benchmarks_on_linux.py \
         --normal_benchmark_tool_dir="${NORMAL_BENCHMARK_TOOLS_DIR}" \
+        --traced_benchmark_tool_dir="${TRACED_BENCHMARK_TOOLS_DIR}" \
+        --trace_capture_tool="${TRACY_CAPTURE_TOOL}" \
+        --capture_tarball="${BENCHMARK_TRACES}" \
         --e2e_test_artifacts_dir="${E2E_TEST_ARTIFACTS_DIR}" \
         --execution_benchmark_config="${EXECUTION_BENCHMARK_CONFIG}" \
         --target_device_name="${TARGET_DEVICE_NAME}" \

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -29,9 +29,11 @@ TARGET_DEVICE_NAME="${3:-${IREE_TARGET_DEVICE_NAME}}"
 BENCHMARK_RESULTS="${4:-${IREE_BENCHMARK_RESULTS}}"
 BENCHMARK_TRACES="${5:-${IREE_BENCHMARK_TRACES}}"
 
-# Give access to performance counters and kernel information.
-sudo sh -c "echo -1 > /proc/sys/kernel/perf_event_paranoid"
-sudo sh -c "echo 0 > /proc/sys/kernel/kptr_restrict"
+if [[ "$(uname)" == "Linux" ]]; then
+  # Give access to performance counters and kernel information on Linux.
+  sudo sh -c "echo -1 > /proc/sys/kernel/perf_event_paranoid"
+  sudo sh -c "echo 0 > /proc/sys/kernel/kptr_restrict"
+fi
 
 if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
   ${DOCKER_WRAPPER} \

--- a/build_tools/benchmarks/run_benchmarks.sh
+++ b/build_tools/benchmarks/run_benchmarks.sh
@@ -29,12 +29,6 @@ TARGET_DEVICE_NAME="${3:-${IREE_TARGET_DEVICE_NAME}}"
 BENCHMARK_RESULTS="${4:-${IREE_BENCHMARK_RESULTS}}"
 BENCHMARK_TRACES="${5:-${IREE_BENCHMARK_TRACES}}"
 
-if [[ "$(uname)" == "Linux" ]]; then
-  # Give access to performance counters and kernel information on Linux.
-  sudo sh -c "echo -1 > /proc/sys/kernel/perf_event_paranoid"
-  sudo sh -c "echo 0 > /proc/sys/kernel/kptr_restrict"
-fi
-
 if [[ "${TARGET_DEVICE_NAME}" == "a2-highgpu-1g" ]]; then
   ${DOCKER_WRAPPER} \
     --gpus all \

--- a/docs/developers/developing_iree/benchmark_suites.md
+++ b/docs/developers/developing_iree/benchmark_suites.md
@@ -151,7 +151,7 @@ If you don't have aritfacts locally, see
 find the GCS directory of the CI artifacts. Then fetch the needed files:
 
 ```sh
-export GCS_URL="gs://iree-github-actions-...-artifacts/.../..."
+export GCS_URL="gs://iree-github-actions-<presubmit|postsubmit>-artifacts/<run_id>/<run_attempt>"
 export E2E_TEST_ARTIFACTS_DIR="e2e_test_artifacts"
 
 # Download all artifacts
@@ -189,8 +189,8 @@ by clicking the green check mark. Click the `Details` of job
 
 On the job detail page, expand the step `Uploading e2 test artifacts`, you will
 see a bunch of lines like below. The
-URL`gs://iree-github-actions-...-artifacts/.../.../` is the directory of
-artifacts:
+URL`gs://iree-github-actions-<presubmit|postsubmit>-artifacts/<run_id>/<run_attempt>/`
+is the directory of artifacts:
 
 ```
 Copying file://build-e2e-test-artifacts/e2e_test_artifacts/iree_MobileBertSquad_fp32_module_fdff4caa105318036534bd28b76a6fe34e6e2412752c1a000f50fafe7f01ef07/module.vmfb to gs://iree-github-actions-postsubmit-artifacts/4360950546/1/e2e-test-artifacts/iree_MobileBertSquad_fp32_module_fdff4caa105318036534bd28b76a6fe34e6e2412752c1a000f50fafe7f01ef07/module.vmfb
@@ -206,28 +206,39 @@ more usages). If you want to use CI artifacts to reproduce benchmarks locally,
 see
 [Find Compile and Run Commands to Reproduce Benchmarks](#find-compile-and-run-commands-to-reproduce-benchmarks).
 
+Set the GCS directory URL from the step
+[2. Get the GCS directory of the built artifacts](#2-get-the-gcs-directory-of-the-built-artifacts):
+
+```sh
+export GCS_URL="gs://iree-github-actions-<presubmit|postsubmit>-artifacts/<run_id>/<run_attempt>"
+```
+
+Download artifacts:
+
 ```sh
 # The GCS directory has the same structure as your local ${IREE_BUILD_DIR}/e2e_test_artifacts.
-gcloud storage ls gs://iree-github-actions-...-artifacts/.../.../e2e-test-artifacts
+gcloud storage ls "${GCS_URL}/e2e-test-artifacts"
 
 # Download all source and imported MLIR files:
-gcloud storage cp "gs://iree-github-actions-...-artifacts/.../.../e2e-test-artifacts/*.mlir" "<target_dir>"
+gcloud storage cp "${GCS_URL}/e2e-test-artifacts/*.mlir" "<target_dir>"
 ```
 
 Execution and compilation benchmark configs can be downloaded at:
 
 ```sh
 # Execution benchmark config:
-gcloud storage cp gs://iree-github-actions-...-artifacts/.../.../benchmark-config.json .
+gcloud storage cp "${GCS_URL}/benchmark-config.json" exec_config.json
+
 # Compilation benchmark config:
-gcloud storage cp gs://iree-github-actions-...-artifacts/.../.../compilation-config.json .
+gcloud storage cp "${GCS_URL}/compilation-config.json" comp_config.json
 ```
 
 Benchmark raw results and traces can be downloaded at:
 
 ```sh
 # Benchmark raw results
-gcloud storage cp "gs://iree-github-actions-...-artifacts/.../.../benchmark-results/benchmark-results-*.json" .
+gcloud storage cp "${GCS_URL}/benchmark-results/benchmark-results-*.json" .
+
 # Benchmark traces
-gcloud storage cp "gs://iree-github-actions-...-artifacts/.../.../benchmark-results/benchmark-traces-*.tar.gz" .
+gcloud storage cp "${GCS_URL}/benchmark-results/benchmark-traces-*.tar.gz" .
 ```

--- a/docs/developers/developing_iree/benchmark_suites.md
+++ b/docs/developers/developing_iree/benchmark_suites.md
@@ -208,17 +208,26 @@ see
 
 ```sh
 # The GCS directory has the same structure as your local ${IREE_BUILD_DIR}/e2e_test_artifacts.
-gcloud storage ls gs://iree-github-actions-postsubmit-artifacts/.../.../e2e-test-artifacts
+gcloud storage ls gs://iree-github-actions-...-artifacts/.../.../e2e-test-artifacts
 
 # Download all source and imported MLIR files:
-gcloud storage cp "gs://iree-github-actions-postsubmit-artifacts/.../.../e2e-test-artifacts/*.mlir" "<target_dir>"
+gcloud storage cp "gs://iree-github-actions-...-artifacts/.../.../e2e-test-artifacts/*.mlir" "<target_dir>"
 ```
 
 Execution and compilation benchmark configs can be downloaded at:
 
 ```sh
 # Execution benchmark config:
-gcloud storage cp gs://iree-github-actions-postsubmit-artifacts/.../.../benchmark-config.json .
+gcloud storage cp gs://iree-github-actions-...-artifacts/.../.../benchmark-config.json .
 # Compilation benchmark config:
-gcloud storage cp gs://iree-github-actions-postsubmit-artifacts/.../.../compilation-config.json .
+gcloud storage cp gs://iree-github-actions-...-artifacts/.../.../compilation-config.json .
+```
+
+Benchmark raw results and traces can be downloaded at:
+
+```sh
+# Benchmark raw results
+gcloud storage cp "gs://iree-github-actions-...-artifacts/.../.../benchmark-results/benchmark-results-*.json" .
+# Benchmark traces
+gcloud storage cp "gs://iree-github-actions-...-artifacts/.../.../benchmark-results/benchmark-traces-*.tar.gz" .
 ```


### PR DESCRIPTION
Captures the tracy traces in benchmark jobs (for both x86_64 and CUDA benchmarks). Currently these traces only include instrumentation data, no sampling data, because the GCP doesn't expose hardware PMU.

Tracy tool needs bleeding edge environment (>= Ubuntu 20.04), so benchmark environments are also upgraded to bleeding edge (x86_64 and cuda).

benchmarks: x86_64, cuda