### PR TITLE
discard-root-before-leaf-tasks

### DIFF
--- a/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
+++ b/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c
@@ -171,8 +171,8 @@ static void iree_hal_task_command_buffer_destroy(
   IREE_TRACE_ZONE_BEGIN(z0);
 
   memset(&command_buffer->state, 0, sizeof(command_buffer->state));
-  iree_task_list_discard(&command_buffer->leaf_tasks);
   iree_task_list_discard(&command_buffer->root_tasks);
+  iree_task_list_discard(&command_buffer->leaf_tasks);
   iree_arena_deinitialize(&command_buffer->arena);
   iree_hal_resource_set_free(command_buffer->resource_set);
   iree_allocator_free(host_allocator, command_buffer);


### PR DESCRIPTION
Fixes #11843.   The assertion there is saying that we should not be discarding a task before its dependencies. From the comments at https://github.com/iree-org/iree/blob/d91712bf4d32c44f6075620293e638418a47d78f/runtime/src/iree/hal/drivers/local_task/task_command_buffer.c#L51-L61  I understand that root tasks may be dependencies of leaf tasks, so it makes sense to order the `iree_task_list_discard` calls accordingly? This fixes the assertion observed in #11843, anyway.