### PR TITLE
Fix compile flags of ARM padding fusion experiments

### DIFF
--- a/benchmarks/TFLite/android-arm64-v8a.cmake
+++ b/benchmarks/TFLite/android-arm64-v8a.cmake
@@ -254,6 +254,8 @@ iree_benchmark_suite(
     ${ANDROID_CPU_COMPILATION_FLAGS}
     "--iree-flow-enable-data-tiling"
     "--iree-llvm-target-cpu-features=+dotprod"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
   BENCHMARK_TOOL
     iree-benchmark-module
   CONFIG


### PR DESCRIPTION
According to https://github.com/iree-org/iree/pull/10458#issuecomment-1307621087, the padding fusion flags are missing for local-sync benchmark.