### PR TITLE
[tracy] Add support for `csvexport` tool.

### DIFF
--- a/build_tools/third_party/tracy/CMakeLists.txt
+++ b/build_tools/third_party/tracy/CMakeLists.txt
@@ -154,6 +154,24 @@ target_link_libraries(IREETracyCaptureServer
 )
 
 #-------------------------------------------------------------------------------
+# CSV Export Tool
+#-------------------------------------------------------------------------------
+
+add_executable(IREETracyCSVExport
+  ${TRACY_SOURCE_DIR}/csvexport/src/csvexport.cpp
+)
+set_target_properties(IREETracyCSVExport
+  PROPERTIES
+    OUTPUT_NAME "iree-tracy-csvexport"
+)
+setup_cxx_options(IREETracyCSVExport)
+target_link_libraries(IREETracyCSVExport
+  PRIVATE
+    IREETracyCommon
+    IREETracyServer
+)
+
+#-------------------------------------------------------------------------------
 # Graphical frontends
 #-------------------------------------------------------------------------------
 

--- a/docs/developers/developing_iree/profiling_with_tracy.md
+++ b/docs/developers/developing_iree/profiling_with_tracy.md
@@ -85,7 +85,7 @@ Install other dependencies:
 brew install glfw freetype
 ```
 
-## Build the Tracy tools ("servers")
+## Build the Tracy tools
 
 A CMake-based build system for Tracy is maintained as part of IREE. In your IREE
 desktop build directory, set the following CMake option:
@@ -95,7 +95,9 @@ $ cmake -DIREE_BUILD_TRACY=ON .
 ```
 
 That enables building the Tracy server tools, `iree-tracy-profiler` and
-`iree-tracy-capture`, introduced above.
+`iree-tracy-capture`, introduced above. It also enables building the tool
+`iree-tracy-csvexport` which can be used to export a captured trace as a
+CSV file (see Section 6 "Exporting zone statistics to CSV" in the Tracy manual).
 
 If profiling on Android/ARM, you might need the patch discussed in the next
 paragraph.
@@ -105,19 +107,20 @@ At least `iree-tracy-profiler` has some
 [faulty assertions](https://github.com/wolfpld/tracy/pull/382) that can cause
 the profiler UI to crash during normal usage.
 
-Rebuild, either everything or just these one or two targets:
+Rebuild, either everything or just these specific targets:
 
 ```shell
-cmake --build . --target iree-tracy-profiler iree-tracy-capture
+cmake --build . --target iree-tracy-profiler iree-tracy-capture iree-tracy-csvexport
 ```
 
-This should have created the `iree-tracy-profiler` and `iree-tracy-capture`
-binaries:
+This should have created the `iree-tracy-profiler`, `iree-tracy-capture`, and
+`iree-tracy-csvexport` binaries:
 
 ```shell
 $ find . -name iree-tracy-*
 ./tracy/iree-tracy-profiler
 ./tracy/iree-tracy-capture
+./tracy/iree-tracy-csvexport
 ```
 
 ## Build IREE binaries with Tracy instrumentation ("clients")


### PR DESCRIPTION
This tool provides information about the trace in machine-readable form. This tool loses a lot of context from the trace, so it is recommended to only use this tool in reference to a particular trace that has been already examined manually or otherwise controlled so that the extracted numbers are known to be meaningful.