### PR TITLE
Report outstanding `scope->permanent_status` at destruction time

### DIFF
--- a/runtime/src/iree/task/scope.c
+++ b/runtime/src/iree/task/scope.c
@@ -48,7 +48,13 @@ void iree_task_scope_deinitialize(iree_task_scope_t* scope) {
   // In most cases the status will have been consumed by the scope owner.
   iree_status_t status = (iree_status_t)iree_atomic_exchange_intptr(
       &scope->permanent_status, (intptr_t)NULL, iree_memory_order_acquire);
-  IREE_IGNORE_ERROR(status);
+  if (!iree_status_is_ok(status)) {
+    fprintf(
+        stderr,
+        "%s:%d: %s: warning: a task scope had the following non-OK status:\n",
+        __FILE__, __LINE__, __func__);
+    iree_status_fprint(stderr, status);
+  }
 
   while (iree_atomic_load_int32(&scope->pending_idle_notification_posts,
                                 iree_memory_order_acquire)) {


### PR DESCRIPTION
The code was silentely eating outstanding statuses with this comment:

```c
// In most cases the status will have been consumed by the scope owner.
```

But as I'm debugging why ukernel statuses aren't reported in e2e matmul tests, after having fixed Issue #11843, I still don't see error statuses. Debugging, I found that I was landing exactly in this case (actually this had been hinted by @benvanik [on Discord the last time I had brought up the topic](https://discord.com/channels/689900678990135345/689900680009482386/1014203985911087104)).

I have not succeeded finding the more proper place, closer to the root cause, where to catch and report the `scope->permanent_status`. In `iree_vm_invoke`, the main thread goes through the `vmvx` module call for the ukernel, then it goes into a `hal` module call to `fence.await` where it waits for worker threads to finish work. Somewhere around this might be the place to see if the scope has an error status?

Anyway, the present PR might be good to have anyway: it seems generally worth echoing un-consumed error statuses to `stderr`?

Question - do I need to do something more than just `iree_status_fprint` to mark the status as having been consumed?