### PR TITLE
[spirv] Allow single tile configurations for cooperative matrix

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Verifiers.cpp
@@ -229,13 +229,6 @@ LogicalResult verifySPIRVCooperativeMatrixVectorizePassPipeline(
            << *subgroupSize;
   }
 
-  // Verify the total workgroup size should be equal or larger than 2 *
-  // subgroupSize.
-  if (totalWorkgroupSize / *subgroupSize < 2) {
-    return op->emitOpError("expected total workgroup size to be >= ")
-           << 2 * *subgroupSize;
-  }
-
   // Verify that there are four level of tile sizes.
   if (loweringConfig.getTileSizes().size() != 4) {
     return op->emitOpError("expected 4 levels of tiling sizes, got ")


### PR DESCRIPTION
Removes a check in the verifier that required at least two tiles per workgroup as the motivating case has since been fixed.