### PR TITLE
Adding --task_worker_stack_size= flag and defaulting to 128KB.

### DIFF
--- a/runtime/src/iree/task/api.c
+++ b/runtime/src/iree/task/api.c
@@ -25,6 +25,16 @@ IREE_FLAG(
     "when latency is the #1 priority (vs. thermals, system-wide scheduling,\n"
     "etc).");
 
+IREE_FLAG(
+    int32_t, task_worker_stack_size, 128 * 1024,
+    "Minimum size in bytes of each worker thread stack.\n"
+    "The underlying platform may allocate more stack space but _should_\n"
+    "guarantee that the available stack space is near this amount. Note that\n"
+    "the task system will take some stack space and not all bytes should be\n"
+    "assumed usable. Note that as much as possible users should not rely on\n"
+    "the stack for storage over ~16-32KB and instead use local workgroup\n"
+    "memory.");
+
 // TODO(benvanik): enable this when we use it - though hopefully we don't!
 IREE_FLAG(
     int32_t, task_worker_local_memory, 0,  // 64 * 1024,
@@ -39,13 +49,12 @@ iree_status_t iree_task_executor_options_initialize_from_flags(
     iree_task_executor_options_t* out_options) {
   IREE_ASSERT_ARGUMENT(out_options);
   iree_task_executor_options_initialize(out_options);
-
   out_options->worker_spin_ns =
       (iree_duration_t)FLAG_task_worker_spin_us * 1000;
-
+  out_options->worker_stack_size =
+      (iree_host_size_t)FLAG_task_worker_stack_size;
   out_options->worker_local_memory_size =
       (iree_host_size_t)FLAG_task_worker_local_memory;
-
   return iree_ok_status();
 }
 

--- a/runtime/src/iree/task/executor.c
+++ b/runtime/src/iree/task/executor.c
@@ -145,6 +145,7 @@ iree_status_t iree_task_executor_create(iree_task_executor_options_t options,
       iree_task_worker_t* worker = &executor->workers[i];
       status = iree_task_worker_initialize(
           executor, i, iree_task_topology_get_group(topology, i),
+          options.worker_stack_size,
           iree_make_byte_span(worker_local_memory,
                               options.worker_local_memory_size),
           &seed_prng, worker);

--- a/runtime/src/iree/task/executor.h
+++ b/runtime/src/iree/task/executor.h
@@ -288,6 +288,14 @@ typedef struct iree_task_executor_options_t {
   // scheduling, and the environment).
   iree_duration_t worker_spin_ns;
 
+  // Minimum size in bytes of each worker thread stack.
+  // The underlying platform may allocate more stack space but _should_
+  // guarantee that the available stack space is near this amount. Note that the
+  // task system will take some stack space and not all bytes should be assumed
+  // usable. Note that as much as possible users should not rely on the stack
+  // for storage over ~16-32KB and instead use local workgroup memory.
+  iree_host_size_t worker_stack_size;
+
   // Defines the bytes to be allocated and reserved by each worker to use for
   // local memory operations. Will be rounded up to the next power of two.
   // Dispatches performed will be able to request up to this amount of memory

--- a/runtime/src/iree/task/worker.h
+++ b/runtime/src/iree/task/worker.h
@@ -160,8 +160,8 @@ static_assert(offsetof(iree_task_worker_t, local_task_queue) >=
 iree_status_t iree_task_worker_initialize(
     iree_task_executor_t* executor, iree_host_size_t worker_index,
     const iree_task_topology_group_t* topology_group,
-    iree_byte_span_t local_memory, iree_prng_splitmix64_state_t* seed_prng,
-    iree_task_worker_t* out_worker);
+    iree_host_size_t stack_size, iree_byte_span_t local_memory,
+    iree_prng_splitmix64_state_t* seed_prng, iree_task_worker_t* out_worker);
 
 // Requests that the worker begin exiting (if it hasn't already).
 // If the worker is actively processing tasks it will wait until it has


### PR DESCRIPTION
This explicitly requests (and on Windows commits) the per-worker stack memory such that we can assume it is valid when executing dispatch work. Prior to this we were using the executable default which will vary across platforms and compiler/linker configurations and make it difficult to reproduce stack issues.

The 128KB number is chosen as a conservative value based on what we currently produce in the compiler (<=32KB), what the VM+VMVX may require, and how much stack the task system itself may require on the workers (today ~8KB in x64 debug builds). The option/flag is exposed for users wanting to increase the limit along with larger compiler settings but the default is kept to something reasonable for smallish systems. For specific platforms that are looking to minimize fixed memory consumption setting it lower is also possible with most programs I tried being ok with as little as 32KB (though at least on Windows this gets rounded up to 64KB by the system in order to make room for guard pages).