### PR TITLE
[NFC] Register tiling implementation for tensor dialect in IREE.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -380,6 +380,9 @@ void addDoubleTilingPadExpertPassPipeline(OpPassManager &passManager) {
 
   {
     LinalgSingleTilingExpertPassOptions options;
+    // Explicitly set anchor op to matmul because only the op contains the
+    // reduction loops. Otherwise, it could try to tile tensor.pad ops.
+    options.anchorOpName = "linalg.matmul";
     options.tilingLevel =
         static_cast<int64_t>(StrategyTilingLevel::ReductionTiles);
     nestedModulePM.addNestedPass<func::FuncOp>(

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -196,7 +196,9 @@ static bool isRootOp(Operation *op) {
     }
     return !isa<linalg::FillOp>(op);
   }
-  return isa<TilingInterface>(op) ||
+  // tensor::PadOp fusion is not ready. Explicitly marking it not a root op for
+  // now.
+  return (isa<TilingInterface>(op) && !isa<tensor::PadOp>(op)) ||
          isa<LinalgExt::SetEncodingOp, LinalgExt::UnsetEncodingOp>(op);
 }
 

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -32,6 +32,7 @@
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
+#include "mlir/Dialect/Tensor/IR/TensorTilingInterfaceImpl.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Dialect.h"
@@ -69,6 +70,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   shape::ShapeDialect>();
   // clang-format on
   tensor::registerInferTypeOpInterfaceExternalModels(registry);
+  tensor::registerTilingInterfaceExternalModels(registry);
 
 #ifdef IREE_HAVE_C_OUTPUT_FORMAT
   registry.insert<emitc::EmitCDialect>();


### PR DESCRIPTION
It forces the CPUDoubleTilingPadExpert pipeline explicitly set anchor op. Otherwise, the CodgenStrategy could tile on pad op, which is not expected. In the past, it would not tile pad op because the tiling implementation was not registered. This is an NFC to the CPU pipeline.