### PR TITLE
Search more CI jobs to check benchmark results

### DIFF
--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -57,7 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCHMARK_PROCESS_JOB: process_benchmark_results
         run: |
-          # Assume the workflow has less then 100 jobs.
+          # Assume the workflow has fewer than 100 jobs.
           export CONCLUSION=$(gh api \
             "/repos/${GITHUB_REPOSITORY}/actions/runs/${PR_CI_RUN_ID}/attempts/${PR_CI_RUN_ATTEMPT}/jobs?per_page=100" \
             | jq --raw-output --arg job "${BENCHMARK_PROCESS_JOB}" \

--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -58,7 +58,7 @@ jobs:
           BENCHMARK_PROCESS_JOB: process_benchmark_results
         run: |
           export CONCLUSION=$(gh api \
-            "/repos/${GITHUB_REPOSITORY}/actions/runs/${PR_CI_RUN_ID}/attempts/${PR_CI_RUN_ATTEMPT}/jobs" \
+            "/repos/${GITHUB_REPOSITORY}/actions/runs/${PR_CI_RUN_ID}/attempts/${PR_CI_RUN_ATTEMPT}/jobs?per_page=100" \
             | jq --raw-output --arg job "${BENCHMARK_PROCESS_JOB}" \
               '.jobs | map(select(.name==$job))[0] | .conclusion')
           echo "job-conclusion=${CONCLUSION}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -57,6 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BENCHMARK_PROCESS_JOB: process_benchmark_results
         run: |
+          # Assume the workflow has less then 100 jobs.
           export CONCLUSION=$(gh api \
             "/repos/${GITHUB_REPOSITORY}/actions/runs/${PR_CI_RUN_ID}/attempts/${PR_CI_RUN_ATTEMPT}/jobs?per_page=100" \
             | jq --raw-output --arg job "${BENCHMARK_PROCESS_JOB}" \


### PR DESCRIPTION
By default the job listing API only returns 30 jobs (while the workflow has 33 jobs in my sample), which might not contain `process_benchmark_results`.

Increases to 100 when searching the benchmark results for posting comments.