### PR TITLE
Pin version of Torch in SHARK

### DIFF
--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     - cron: '0 10 * * *'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   setup:
@@ -71,7 +72,6 @@ jobs:
         with:
           submodules: true
       - name: "Benchmarking SHARK tank on CPU"
-        # Only Tensorflow is working at the moment so limit benchmarking to TF models.
         run: |
           ./build_tools/github_actions/docker_run.sh \
             gcr.io/iree-oss/shark@sha256:1fa2d51110c47ac12826754b66d95e3d68336a8ecf141db8be1eec74f39c42e2 \
@@ -99,7 +99,6 @@ jobs:
         with:
           submodules: true
       - name: "Benchmarking SHARK tank on CUDA"
-        # Only Tensorflow is working at the moment so limit benchmarking to TF models.
         run: |
           ./build_tools/github_actions/docker_run.sh \
             --gpus all \

--- a/build_tools/benchmarks/shark/run_shark.sh
+++ b/build_tools/benchmarks/shark/run_shark.sh
@@ -47,6 +47,11 @@ fi
 # Run with SHARK-Runtime.
 PYTHON=python3.10 VENV_DIR=shark.venv BENCHMARK=1 IMPORTER=1 ./setup_venv.sh
 source shark.venv/bin/activate
+
+# Revert Torch version due to https://github.com/nod-ai/SHARK/issues/824.
+pip uninstall -y torch torchvision
+pip install --no-deps https://download.pytorch.org/whl/nightly/cu117/torch-2.0.0.dev20230113%2Bcu117-cp310-cp310-linux_x86_64.whl https://download.pytorch.org/whl/nightly/cu117/torchvision-0.15.0.dev20230114%2Bcu117-cp310-cp310-linux_x86_64.whl
+
 export SHARK_VERSION=`pip show iree-compiler | grep Version | sed -e "s/^Version: \(.*\)$/\1/g"`
 pytest "${args[@]}" tank/test_models.py || true
 
@@ -64,6 +69,11 @@ rm -rf ~/.local/shark_tank
 # Run with IREE.
 PYTHON=python3.10 VENV_DIR=iree.venv BENCHMARK=1 IMPORTER=1 USE_IREE=1 ./setup_venv.sh
 source iree.venv/bin/activate
+
+# Revert Torch version due to https://github.com/nod-ai/SHARK/issues/824.
+pip uninstall -y torch torchvision
+pip install --no-deps https://download.pytorch.org/whl/nightly/cu117/torch-2.0.0.dev20230113%2Bcu117-cp310-cp310-linux_x86_64.whl https://download.pytorch.org/whl/nightly/cu117/torchvision-0.15.0.dev20230114%2Bcu117-cp310-cp310-linux_x86_64.whl
+
 export IREE_VERSION=`pip show iree-compiler | grep Version | sed -e "s/^Version: \(.*\)$/\1/g"`
 pytest "${args[@]}" tank/test_models.py || true
 


### PR DESCRIPTION
AlexNet is seg faulting on CUDA: https://github.com/nod-ai/SHARK/issues/824

And CPU benchmarks hang upon shut down.

Reverting to a previous Torch version to unblock.