### PR TITLE
Support transform dialect matchers in dispatch region formation

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
@@ -118,22 +118,6 @@ void mlir::iree_compiler::buildPrint(ImplicitLocOpBuilder &b,
   for (auto h : handles) b.create<PrintOp>(h);
 }
 
-/// Dynamically selects the first non-empty handle; i.e. if (h1, h2) is:
-///   - (non-empty, non-empty), returns (h1, h2)
-///   - (empty, non-empty), returns (h2, empty)
-///   - (non-empty, empty), returns (h1, empty)
-///   - (empty, empty), returns (empty, empty)
-/// This is used as a normalization operation that replaces conditionals, either
-/// in C++ or in transform IR.
-/// This can be thought of as a control-flow -> data-dependent conversion.
-std::pair<Value, Value> mlir::iree_compiler::buildSelectFirstNonEmpty(
-    ImplicitLocOpBuilder &b, Value handle1, Value handle2) {
-  auto pdlOperation = pdl::OperationType::get(b.getContext());
-  auto selector = b.create<TakeFirstOp>(pdlOperation, pdlOperation,
-                                        ArrayRef<Value>{handle1, handle2});
-  return std::make_pair(selector.getFirst(), selector.getRest());
-}
-
 mlir::iree_compiler::TileToScfForAndFuseResult
 mlir::iree_compiler::buildTileFuseToScfFor(ImplicitLocOpBuilder &b, Value rootH,
                                            ValueRange opsHToFuse,

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
@@ -56,18 +56,6 @@ void createTransformRegion(func::FuncOp entryPoint,
 /// `handles` is empty.
 void buildPrint(ImplicitLocOpBuilder &b, ValueRange handles = {});
 
-/// Build transform IR to dynamically selects the first non-empty handle; i.e.
-/// if (h1, h2) is:
-///   - (non-empty, non-empty), returns (h1, h2)
-///   - (empty, non-empty), returns (h2, empty)
-///   - (non-empty, empty), returns (h1, empty)
-///   - (empty, empty), returns (empty, empty)
-/// This is used as a normalization operation that replaces conditionals, either
-/// in C++ or in transform IR.
-/// This can be thought of as a control-flow -> data-dependent conversion.
-std::pair<Value, Value> buildSelectFirstNonEmpty(ImplicitLocOpBuilder &b,
-                                                 Value handle1, Value handle2);
-
 /// Result of the combined transform performing tiling, fusion and
 /// distribution to parallel constructs.
 struct TileToScfForAndFuseResult {

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
@@ -100,7 +100,7 @@ static void buildSmallReductionStrategyThreadDistribution(
     ImplicitLocOpBuilder &b, Value maybeLeadingH, Value fillH, Value reductionH,
     Value maybeTrailingH, const AbstractReductionStrategy &strategy) {
   auto [fusionTargetH, fusionGroupH] =
-      iree_compiler::buildSelectFirstNonEmpty(b, maybeTrailingH, reductionH);
+      buildSelectFirstNonEmpty(b, maybeTrailingH, reductionH);
   ArrayRef<Attribute> allThreadsRef(strategy.allThreadAttrs);
   iree_compiler::TileToForeachThreadAndFuseAndDistributeResult tileResult =
       iree_compiler::buildTileFuseDistToForeachThreadWithNumThreads(
@@ -124,7 +124,7 @@ static void buildSmallReductionStrategyThreadDistribution(
   Value fusedH = b.create<ScalarizeOp>(
       pdlOperation, tileResult.resultingFusedOpsHandles.front());
   auto [blockReductionH, maybeBlockTrailingH] =
-      iree_compiler::buildSelectFirstNonEmpty(b, fusedH, tiledH);
+      buildSelectFirstNonEmpty(b, fusedH, tiledH);
 
   // 2. Apply the 1d splitting strategy to the reduction part while specifying
   // a single thread. This triggers the splitting but not the thread mapping

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.cpp
@@ -589,6 +589,12 @@ transform_dialect::MovePrecedingOpIntoDispatchRegionOp::apply(
   return DiagnosedSilenceableFailure::success();
 }
 
+void transform_dialect::MovePrecedingOpIntoDispatchRegionOp::build(
+    OpBuilder &builder, OperationState &state, Value target,
+    Value dispatchRegion) {
+  build(builder, state, dispatchRegion.getType(), target, dispatchRegion);
+}
+
 void transform_dialect::MovePrecedingOpIntoDispatchRegionOp::getEffects(
     SmallVectorImpl<MemoryEffects::EffectInstance> &effects) {
   transform::onlyReadsHandle(getTarget(), effects);

--- a/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensionsOps.td
@@ -172,6 +172,9 @@ def MovePrecedingOpIntoDispatchRegionOp : Op<
   let results = (outs PDL_Operation:$transformed);
   let assemblyFormat = "$target `into` $dispatch_region attr-dict";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+  let builders = [
+    OpBuilder<(ins "Value":$target, "Value":$dispatchRegion)>
+  ];
   let extraClassDeclaration = [{
     ::mlir::DiagnosedSilenceableFailure apply(
         ::mlir::transform::TransformResults &transformResults,
@@ -222,7 +225,7 @@ def MoveSucceedingOpIntoDispatchRegionOp : Op<
 
     All operands of the target are replaced with values that are defined inside
     of the dispatch region when possible. All uses of the target op are
-    replaced with a newly ammended results of the dispatch region op.
+    replaced with a newly amended results of the dispatch region op.
 
     #### Return modes
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -43,6 +43,7 @@ iree_compiler_cc_library(
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",
         "@llvm-project//mlir:PDLDialect",
         "@llvm-project//mlir:PDLInterpDialect",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD
@@ -29,6 +29,61 @@ iree_gentbl_cc_library(
 )
 
 iree_compiler_cc_library(
+    name = "DispatchWithTransformDialect",
+    srcs = [
+        "DispatchWithTransformDialect.cpp",
+    ],
+    deps = [
+        ":PassesIncGen",
+        ":Transforms",
+        "//compiler/src/iree/compiler/Dialect/Flow/IR",
+        "//compiler/src/iree/compiler/Dialect/Flow/TransformExtensions:FlowExtensions",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:AffineDialect",
+        "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:LinalgDialect",
+        "@llvm-project//mlir:PDLDialect",
+        "@llvm-project//mlir:PDLInterpDialect",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:TensorDialect",
+        "@llvm-project//mlir:TransformDialect",
+    ],
+)
+
+# Separate pass registration from pass definition. This is necessary to a avoid
+# a circular dependency between Flow TransformExtensions and Flow Transforms.
+#
+# TODO: better layering requires separating Flow Transforms from Flow Passes so
+# that TransformExtensions can depend on Transforms and Passes can depend on
+# both Transforms and TransformExtensions in order to run the Flow-specific
+# Transform dialect interpreter pass.
+iree_compiler_cc_library(
+    name = "Passes",
+    srcs = [
+        "Passes.cpp",
+    ],
+    deps = [
+        ":DispatchWithTransformDialect",
+        ":PassesIncGen",
+        ":Transforms",
+        "//compiler/src/iree/compiler/Dialect/Util/Transforms",
+        "//compiler/src/iree/compiler/Utils",
+        "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
+        "@llvm-project//llvm:Support",
+        "@llvm-project//mlir:FuncDialect",
+        "@llvm-project//mlir:LinalgTransforms",
+        "@llvm-project//mlir:MemRefTransforms",
+        "@llvm-project//mlir:Pass",
+        "@llvm-project//mlir:Support",
+        "@llvm-project//mlir:Transforms",
+    ],
+)
+
+iree_compiler_cc_library(
     name = "Transforms",
     srcs = [
         "CaptureDispatchDynamicDims.cpp",
@@ -43,7 +98,6 @@ iree_compiler_cc_library(
         "ConvertToFlow.cpp",
         "DeduplicateExecutables.cpp",
         "DetachElementwiseFromNamedOps.cpp",
-        "DispatchWithTransformDialect.cpp",
         "DumpDispatchGraph.cpp",
         "ExpandTensorShapes.cpp",
         "ExportBenchmarkFuncs.cpp",
@@ -58,8 +112,6 @@ iree_compiler_cc_library(
         "OptimizeNumerics.cpp",
         "OutlineDispatchRegions.cpp",
         "PadLinalgOps.cpp",
-        "PassDetail.h",
-        "Passes.cpp",
         "RegionOpUtils.cpp",
         "SetEncoding.cpp",
         "SplitReduction.cpp",
@@ -71,6 +123,7 @@ iree_compiler_cc_library(
     hdrs = [
         "ConvertRegionToWorkgroups.h",
         "FormDispatchRegions.h",
+        "PassDetail.h",
         "Passes.h",
         "Passes.h.inc",
         "RegionOpUtils.h",
@@ -108,8 +161,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:MemRefTransforms",
-        "@llvm-project//mlir:PDLDialect",
-        "@llvm-project//mlir:PDLInterpDialect",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Pass",
         "@llvm-project//mlir:SCFDialect",
@@ -119,7 +170,6 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorUtils",
         "@llvm-project//mlir:TilingInterface",
         "@llvm-project//mlir:TosaDialect",
-        "@llvm-project//mlir:TransformDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
     ],

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_cc_library(
     LLVMSupport
     MLIRAffineDialect
     MLIRArithDialect
+    MLIRIR
     MLIRLinalgDialect
     MLIRPDLDialect
     MLIRPDLInterpDialect

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -21,10 +21,59 @@ iree_tablegen_library(
 
 iree_cc_library(
   NAME
+    DispatchWithTransformDialect
+  SRCS
+    "DispatchWithTransformDialect.cpp"
+  DEPS
+    ::PassesIncGen
+    ::Transforms
+    IREELinalgExtDialect
+    IREELinalgTransformDialect
+    LLVMSupport
+    MLIRAffineDialect
+    MLIRArithDialect
+    MLIRLinalgDialect
+    MLIRPDLDialect
+    MLIRPDLInterpDialect
+    MLIRPass
+    MLIRSCFDialect
+    MLIRSupport
+    MLIRTensorDialect
+    MLIRTransformDialect
+    iree::compiler::Dialect::Flow::IR
+    iree::compiler::Dialect::Flow::TransformExtensions::FlowExtensions
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    Passes
+  SRCS
+    "Passes.cpp"
+  DEPS
+    ::DispatchWithTransformDialect
+    ::PassesIncGen
+    ::Transforms
+    IREELinalgExtPasses
+    LLVMSupport
+    MLIRFuncDialect
+    MLIRLinalgTransforms
+    MLIRMemRefTransforms
+    MLIRPass
+    MLIRSupport
+    MLIRTransforms
+    iree::compiler::Dialect::Util::Transforms
+    iree::compiler::Utils
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     Transforms
   HDRS
     "ConvertRegionToWorkgroups.h"
     "FormDispatchRegions.h"
+    "PassDetail.h"
     "Passes.h"
     "Passes.h.inc"
     "RegionOpUtils.h"
@@ -41,7 +90,6 @@ iree_cc_library(
     "ConvertToFlow.cpp"
     "DeduplicateExecutables.cpp"
     "DetachElementwiseFromNamedOps.cpp"
-    "DispatchWithTransformDialect.cpp"
     "DumpDispatchGraph.cpp"
     "ExpandTensorShapes.cpp"
     "ExportBenchmarkFuncs.cpp"
@@ -56,8 +104,6 @@ iree_cc_library(
     "OptimizeNumerics.cpp"
     "OutlineDispatchRegions.cpp"
     "PadLinalgOps.cpp"
-    "PassDetail.h"
-    "Passes.cpp"
     "RegionOpUtils.cpp"
     "SetEncoding.cpp"
     "SplitReduction.cpp"
@@ -88,8 +134,6 @@ iree_cc_library(
     MLIRMathDialect
     MLIRMemRefDialect
     MLIRMemRefTransforms
-    MLIRPDLDialect
-    MLIRPDLInterpDialect
     MLIRParser
     MLIRPass
     MLIRSCFDialect
@@ -99,7 +143,6 @@ iree_cc_library(
     MLIRTensorUtils
     MLIRTilingInterface
     MLIRTosaDialect
-    MLIRTransformDialect
     MLIRTransformUtils
     MLIRTransforms
     iree::compiler::Dialect::Flow::Conversion::TensorToFlow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
@@ -5,19 +5,24 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h"
 #include "iree-dialects/Dialect/LinalgTransform/TransformInterpreterPassBase.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowDialect.h"
+#include "iree/compiler/Dialect/Flow/TransformExtensions/FlowExtensions.h"
 #include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
 #include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "llvm/ADT/STLExtras.h"
 #include "llvm/Support/CommandLine.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/PDL/IR/PDL.h"
+#include "mlir/Dialect/PDL/IR/PDLTypes.h"
 #include "mlir/Dialect/PDLInterp/IR/PDLInterp.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Support/LLVM.h"
 
@@ -25,6 +30,39 @@ namespace mlir {
 namespace iree_compiler {
 namespace IREE {
 namespace Flow {
+
+namespace {
+
+/// Builds transform IR forming dispatch regions for reductions.
+void buildReductionDispatch(ImplicitLocOpBuilder &builder, Value scopeH,
+                            bool emitRemarkOnMatch = false) {
+  auto pdlOperation = pdl::OperationType::get(builder.getContext());
+  SmallVector<Type> matchedTypes(4, pdlOperation);
+  auto matched = builder.create<transform_ext::MatchCallbackOp>(
+      matchedTypes, "reduction_partial",
+      transform::FailurePropagationMode::Suppress, scopeH);
+
+  if (emitRemarkOnMatch) {
+    builder.create<transform_ext::EmitRemarkOp>(
+        matched->getResults().drop_back().back(), "dispatch matched reduction");
+  }
+
+  auto [firstH, restH] =
+      buildSelectFirstNonEmpty(builder, matched->getResults().back(),
+                               matched->getResults().drop_back().back());
+  Value regionH = builder.create<transform_dialect::WrapInDispatchRegionOp>(
+      pdlOperation, firstH);
+  SmallVector<Value> handlesToMerge(matched->getResults().begin(),
+                                    std::prev(matched->getResults().end(), 2));
+  handlesToMerge.push_back(restH);
+  Value mergedHandlesH = builder.create<transform::MergeHandlesOp>(
+      handlesToMerge, /*deduplicate=*/false);
+  regionH =
+      builder.create<transform_dialect::MovePrecedingOpIntoDispatchRegionOp>(
+          mergedHandlesH, regionH);
+  builder.create<transform_dialect::RegionToWorkgroupsOp>(pdlOperation,
+                                                          regionH);
+}
 
 /// Pass declaration.
 /// Interpreter pass that applies transform dialect ops for dispatch region
@@ -49,31 +87,64 @@ struct DispatchWithTransformDialect
     // clang-format on
   }
 
-  DispatchWithTransformDialect(StringRef transformFileName,
+  DispatchWithTransformDialect(StringRef transformFileName = StringRef(),
                                StringRef debugPayloadRootTag = StringRef(),
-                               StringRef debugTransformRootTag = StringRef()) {
+                               StringRef debugTransformRootTag = StringRef(),
+                               bool debugEmitRemarkOnMatch = false) {
     this->transformFileName = transformFileName.str();
     this->debugPayloadRootTag = debugPayloadRootTag.str();
     this->debugTransformRootTag = debugTransformRootTag.str();
+    this->debugEmitRemarkOnMatch = debugEmitRemarkOnMatch;
   }
   DispatchWithTransformDialect(const DispatchWithTransformDialect &pass)
       : TransformInterpreterPassBase(pass) {
     this->transformFileName = pass.transformFileName;
     this->debugPayloadRootTag = pass.debugPayloadRootTag;
     this->debugTransformRootTag = pass.debugTransformRootTag;
+    this->debugEmitRemarkOnMatch = pass.debugEmitRemarkOnMatch;
+  }
+
+  void getPayloadRoots(SmallVectorImpl<Operation *> &targets) {
+    getOperation()->walk<WalkOrder::PreOrder>([&](linalg::LinalgOp linalgOp) {
+      targets.push_back(linalgOp);
+      return WalkResult::skip();
+    });
+  }
+
+  OwningOpRef<ModuleOp> constructTransformModule(Location initialLoc) {
+    auto m = ModuleOp::create(initialLoc);
+    OpBuilder b(initialLoc->getContext());
+    b.setInsertionPointToEnd(m.getBody());
+    b.create<transform::SequenceOp>(
+        initialLoc, TypeRange(), transform::FailurePropagationMode::Propagate,
+        b.getType<transform::AnyOpType>(),
+        [&](OpBuilder &b, Location loc, Value rootH) {
+          ImplicitLocOpBuilder ib(loc, b);
+          ib.create<transform_ext::RegisterMatchCallbacksOp>();
+
+          // Matchers+dispatch builders for each case, ordered by priority.
+          buildReductionDispatch(ib, rootH, debugEmitRemarkOnMatch);
+
+          b.create<transform::YieldOp>(loc);
+        });
+
+    return m;
   }
 
  private:
   Statistic numDispatches{this, "number of dispatches",
                           "Number of Flow dispatches created"};
 };
+}  // namespace
 
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createDispatchWithTransformDialect(StringRef transformFileName,
                                    StringRef debugPayloadRootTag,
-                                   StringRef debugTransformRootTag) {
+                                   StringRef debugTransformRootTag,
+                                   bool debugEmitRemarkOnMatch) {
   return std::make_unique<DispatchWithTransformDialect>(
-      transformFileName, debugPayloadRootTag, debugTransformRootTag);
+      transformFileName, debugPayloadRootTag, debugTransformRootTag,
+      debugEmitRemarkOnMatch);
 }
 
 }  // namespace Flow

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -165,12 +165,13 @@ createFormDispatchWorkgroupsPass(bool generateWorkloadRegion = true);
 
 // Pass to perform dispatch of Linalg on tensor ops by using the transform
 // dialect. Dispatch regions are created as specified by the transform module
-// that is parsed from `transformFileName`.
+// that is parsed from `transformFileName` or on-the-fly by the pass otherwise.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createDispatchWithTransformDialect(
     llvm::StringRef transformFileName = llvm::StringRef(),
     llvm::StringRef debugPayloadRootTag = llvm::StringRef(),
-    llvm::StringRef debugTransformRootTag = llvm::StringRef());
+    llvm::StringRef debugTransformRootTag = llvm::StringRef(),
+    bool debugEmitRemarkOnMatch = false);
 
 // Captures dynamic shape dimensions required by dispatch operands.
 std::unique_ptr<Pass> createCaptureDispatchDynamicDimsPass();

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -123,7 +123,11 @@ def DispatchWithTransformDialect :
             "mode, without requiring intimate knowledge of the IREE nested "
             "pass pipeline.\\n"
             "If empty (normal operation mode), select the container of the "
-            "top-level transform op.">
+            "top-level transform op.">,
+    Option<"debugEmitRemarkOnMatch", "debug-emit-remark-on-match", "bool",
+            /*default=*/"false",
+            "Emit remarks when on the root operation of a successful match "
+            "when running matchers in the transform dialect.">
   ];
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD
@@ -46,6 +46,7 @@ iree_lit_test_suite(
             "strip_and_splat_constant_variables.mlir",
             "strip_signedness.mlir",
             "tensor_pad_to_tensor_insert_slice.mlir",
+            "transform_dialect_reduction_dispatch.mlir",
             "transform_dispatch_region_formation.mlir",
             "transformation_pipeline.mlir",
             "verify_input_ir.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -44,6 +44,7 @@ iree_lit_test_suite(
     "strip_and_splat_constant_variables.mlir"
     "strip_signedness.mlir"
     "tensor_pad_to_tensor_insert_slice.mlir"
+    "transform_dialect_reduction_dispatch.mlir"
     "transform_dispatch_region_formation.mlir"
     "transformation_pipeline.mlir"
     "verify_input_ir.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_transform_dialect.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-flow-dispatch-with-transform-dialect{transform-file-name=%p/transform_dialect_dispatch_spec.mlir}))" %s | \
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-flow-dispatch-with-transform-dialect{transform-file-name=%p/transform_dialect_dispatch_spec.mlir}),canonicalize,cse)" %s | \
 // RUN: FileCheck %s
 
 func.func @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_dispatch_spec.mlir
@@ -1,4 +1,4 @@
-transform.structured.canonicalized_sequence failures(propagate) {
+transform.sequence failures(propagate) {
 ^bb1(%arg1: !pdl.operation):
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
   %foreach_op, %tiled_op = transform.structured.tile_to_foreach_thread_op %0 num_threads [42, 67]

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_reduction_dispatch.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/transform_dialect_reduction_dispatch.mlir
@@ -1,0 +1,210 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(func.func(iree-flow-dispatch-with-transform-dialect),canonicalize,cse)" %s | \
+// RUN: FileCheck %s
+
+// CHECK-LABEL: @reduction
+func.func @reduction(%arg: tensor<8x479xf32>) -> tensor<8xf32> {
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+  // CHECK:   flow.return
+  // CHECK: count
+
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%arg : tensor<8x479xf32>)
+    outs(%fill : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<8xf32>
+  return %result : tensor<8xf32>
+}
+
+// CHECK-LABEL: @multiple_reductions
+func.func @multiple_reductions(%arg0: tensor<8x479xf32>, %arg1: tensor<32x32xf32>) -> (tensor<8xf32>, tensor<32xf32>) {
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+  // CHECK:   flow.return
+  // CHECK: count
+
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%arg0 : tensor<8x479xf32>)
+    outs(%fill : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<8xf32>
+
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+  // CHECK:   flow.return
+  // CHECK: count
+
+  %empty2 = tensor.empty() : tensor<32xf32>
+  %fill2 = linalg.fill ins(%cst : f32) outs(%empty2 : tensor<32xf32>) -> tensor<32xf32>
+  %result2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%arg1 : tensor<32x32xf32>)
+    outs(%fill2 : tensor<32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<32xf32>
+
+  return %result, %result2 : tensor<8xf32>, tensor<32xf32>
+}
+
+// CHECK-LABEL: @eltwise_reduction
+func.func @eltwise_reduction(%arg: tensor<8x479xf32>) -> tensor<8xf32> {
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.generic
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+  // CHECK:   flow.return
+  // CHECK: count
+
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  %eltwise_output = tensor.empty() : tensor<8x479xf32>
+  %eltwise = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : tensor<8x479xf32>)
+    outs(%eltwise_output : tensor<8x479xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %0 = arith.mulf %in, %in : f32
+    linalg.yield %0 : f32
+  } -> tensor<8x479xf32>
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%eltwise : tensor<8x479xf32>)
+    outs(%fill : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<8xf32>
+  return %result : tensor<8xf32>
+}
+
+func.func @reduction_eltwise(%arg: tensor<8x479xf32>) -> tensor<8xf32> {
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+  // CHECK:   flow.return
+  // CHECK: count
+
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  %reduction = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%arg : tensor<8x479xf32>)
+    outs(%fill : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<8xf32>
+  %eltwise_output = tensor.empty() : tensor<8xf32>
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%reduction : tensor<8xf32>)
+    outs(%eltwise_output : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %0 = math.sqrt %in : f32
+    linalg.yield %0 : f32
+  } -> tensor<8xf32>
+  return %result : tensor<8xf32>
+}
+
+func.func @eltwise_reduction_eltwise(%arg: tensor<8x479xf32>) -> tensor<8xf32> {
+  // CHECK: flow.dispatch.workgroups
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.generic
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+  // CHECK:   flow.return
+  // CHECK: count
+
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  %eltwise_output = tensor.empty() : tensor<8x479xf32>
+  %eltwise = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0, d1)>],
+    iterator_types = ["parallel", "parallel"]}
+    ins(%arg : tensor<8x479xf32>)
+    outs(%eltwise_output : tensor<8x479xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %0 = arith.mulf %in, %in : f32
+    linalg.yield %0 : f32
+  } -> tensor<8x479xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  %reduction = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%eltwise : tensor<8x479xf32>)
+    outs(%fill : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<8xf32>
+  %eltwise_output2 = tensor.empty() : tensor<8xf32>
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0) -> (d0)>,
+                     affine_map<(d0) -> (d0)>],
+    iterator_types = ["parallel"]}
+    ins(%reduction : tensor<8xf32>)
+    outs(%eltwise_output2 : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %0 = math.sqrt %in : f32
+    linalg.yield %0 : f32
+  } -> tensor<8xf32>
+  return %result : tensor<8xf32>
+}

--- a/compiler/src/iree/compiler/Pipelines/BUILD
+++ b/compiler/src/iree/compiler/Pipelines/BUILD
@@ -37,6 +37,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Bindings/Native/Transforms",
         "//compiler/src/iree/compiler/Bindings/TFLite/Transforms",
         "//compiler/src/iree/compiler/Dialect/Flow/Transforms",
+        "//compiler/src/iree/compiler/Dialect/Flow/Transforms:Passes",
         "//compiler/src/iree/compiler/Dialect/HAL/Conversion/HALToVM",
         "//compiler/src/iree/compiler/Dialect/HAL/Target",
         "//compiler/src/iree/compiler/Dialect/HAL/Transforms",

--- a/compiler/src/iree/compiler/Pipelines/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Pipelines/CMakeLists.txt
@@ -46,6 +46,7 @@ iree_cc_library(
     iree::compiler::Bindings::Native::Transforms
     iree::compiler::Bindings::TFLite::Transforms
     iree::compiler::Dialect::Flow::Transforms
+    iree::compiler::Dialect::Flow::Transforms::Passes
     iree::compiler::Dialect::HAL::Conversion::HALToVM
     iree::compiler::Dialect::HAL::Transforms
     iree::compiler::Dialect::Stream::Transforms

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/StructuredTransformOpsExt.h
@@ -46,6 +46,18 @@ auto unpackRegisteredMatchCallback(ImplicitLocOpBuilder &b,
   return std::tuple_cat(a);
 }
 
+/// Build transform IR to dynamically selects the first non-empty handle; i.e.
+/// if (h1, h2) is:
+///   - (non-empty, non-empty), returns (h1, h2)
+///   - (empty, non-empty), returns (h2, empty)
+///   - (non-empty, empty), returns (h1, empty)
+///   - (empty, empty), returns (empty, empty)
+/// This is used as a normalization operation that replaces conditionals, either
+/// in C++ or in transform IR.
+/// This can be thought of as a control-flow -> data-dependent conversion.
+std::pair<Value, Value> buildSelectFirstNonEmpty(ImplicitLocOpBuilder &b,
+                                                 Value handle1, Value handle2);
+
 class TrackingListener : public RewriteListener,
                          public transform::TransformState::Extension {
 public:

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -7,10 +7,7 @@
 #include "iree-dialects/Transforms/TransformMatchers.h"
 
 #include "mlir/Analysis/SliceAnalysis.h"
-#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
@@ -646,6 +643,5 @@ void transform_ext::makeReductionMatcher(
           // Capture output elemental type.
           .output(0, CaptureElementTypeBitWidth(
                          captures.maybeTrailingOutputElementalTypeBitWidth));
-  reduction = reduction.result(0, HasAnyUse(), trailing, OptionalMatch())
-                  .allTilableOpsCaptured<func::FuncOp>();
+  reduction = reduction.result(0, HasAnyUse(), trailing, OptionalMatch());
 }

--- a/tests/e2e/linalg_transform/BUILD
+++ b/tests/e2e/linalg_transform/BUILD
@@ -13,7 +13,10 @@ package(
 
 iree_lit_test_suite(
     name = "check_linalg_transform",
-    srcs = ["linalg_transform.mlir"],
+    srcs = [
+        "dispatch_formation_flow.mlir",
+        "linalg_transform.mlir",
+    ],
     cfg = "//tests:lit.cfg.py",
     # transform_dialect_xxx_spec are MLIR files that specify a transformation,
     # they need to be included as data.

--- a/tests/e2e/linalg_transform/CMakeLists.txt
+++ b/tests/e2e/linalg_transform/CMakeLists.txt
@@ -14,6 +14,7 @@ iree_lit_test_suite(
   NAME
     check_linalg_transform
   SRCS
+    "dispatch_formation_flow.mlir"
     "linalg_transform.mlir"
   TOOLS
     ${IREE_LLD_TARGET}

--- a/tests/e2e/linalg_transform/dispatch_formation_flow.mlir
+++ b/tests/e2e/linalg_transform/dispatch_formation_flow.mlir
@@ -1,0 +1,78 @@
+// RUN: iree-opt --iree-abi-transformation-pipeline \
+// RUN:          --iree-flow-transformation-pipeline \
+// RUN:          --iree-flow-dispatch-use-transform-dialect-jit \
+// RUN:          --iree-flow-dispatch-use-transform-dialect-debug-emit-remarks \
+// RUN:          --verify-diagnostics --split-input-file %s | FileCheck %s
+
+// Check that the transform dialect-based dispatch region formation successfully
+// kicks in. We request it to emit remarks when a match happens. Only do the
+// basic matching of the actual region here, it is tested more extensively in
+// Flow transforms.
+
+// CHECK: flow.executable private @[[EXEC_1_NAME:.+]] {
+// CHECK: builtin.module
+// CHECK: func.func @[[FUNC_1_NAME:.+]](
+func.func @multiple_reductions(%arg0: tensor<8x479xf32>, %arg1: tensor<32x32xf32>) -> (tensor<8xf32>, tensor<32xf32>) {
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  // expected-remark @below {{dispatch matched reduction}}
+  %result = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%arg0 : tensor<8x479xf32>)
+    outs(%fill : tensor<8xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<8xf32>
+
+// CHECK: flow.executable private @[[EXEC_2_NAME:.+]] {
+// CHECK: builtin.module
+// CHECK: func.func @[[FUNC_2_NAME:.+]](
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   flow.dispatch.tensor.load
+  // CHECK:   linalg.fill
+  // CHECK:   linalg.generic
+  // CHECK:   flow.dispatch.tensor.store
+
+  %empty2 = tensor.empty() : tensor<32xf32>
+  %fill2 = linalg.fill ins(%cst : f32) outs(%empty2 : tensor<32xf32>) -> tensor<32xf32>
+  // expected-remark @below {{dispatch matched reduction}}
+  %result2 = linalg.generic {
+    indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>,
+                     affine_map<(d0, d1) -> (d0)>],
+    iterator_types = ["parallel", "reduction"]} 
+    ins(%arg1 : tensor<32x32xf32>)
+    outs(%fill2 : tensor<32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %6 = arith.addf %in, %out : f32
+    linalg.yield %6 : f32
+  } -> tensor<32xf32>
+
+  return %result, %result2 : tensor<8xf32>, tensor<32xf32>
+}
+// CHECK: @multiple_reductions(
+// CHECK: flow.dispatch @[[EXEC_1_NAME]]::@[[FUNC_1_NAME]]
+// CHECK: flow.dispatch @[[EXEC_2_NAME]]::@[[FUNC_2_NAME]]
+
+// -----
+
+// Transform dialect-based dispatch region formation is not expected to handle
+// this, but we need to check that the fallback happens.
+
+// CHECK: @foo(
+// CHECK: flow.tensor.splat
+func.func @foo() -> tensor<8xf32> {
+  %cst = arith.constant 0.0 : f32
+  %empty = tensor.empty() : tensor<8xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<8xf32>) -> tensor<8xf32>
+  return %fill : tensor<8xf32>
+}

--- a/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
+++ b/tests/e2e/linalg_transform/transform_dialect_dispatch_spec.mlir
@@ -1,4 +1,4 @@
-transform.structured.canonicalized_sequence failures(propagate) {
+transform.sequence failures(propagate) {
 ^bb1(%arg1: !pdl.operation):
   %0 = transform.structured.match ops{["linalg.matmul"]} in %arg1
   %foreach_op, %tiled_op = transform.structured.tile_to_foreach_thread_op %0 num_threads [13, 33]

--- a/tests/transform_dialect/cuda/softmax_dispatch_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_dispatch_spec.mlir
@@ -1,26 +1,49 @@
 // RUN: iree-opt %s
 
 // Dispatch softmax.
-transform.structured.canonicalized_sequence failures(propagate){
-^bb1(%variant_op: !pdl.operation):
-  %ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]}
-    in %variant_op
+//
+// This is quite hacky because it uses the obsolete approach with matching a
+// fixed number of Linalg operations in a function.
+// TODO: use the proper matcher (callback) for softmax.
+//
+// In order to work at a function level instead of the individual op level,
+// this gets the closest isolated parent, which is a function, and checks
+// whether it already has "flow.dispatch.tensor.store" as an indication that
+// dispatch region formation has already happened. It then attempts to
+// split that into 0 handles to trigger a silenceable error when a store
+// was matched. The inner sequence propagates silenceable errors to stop
+// further transformation. The additional outer sequence suppressed them
+// so this intended failure-to-split doesn't get reported to the user and
+// stop the pass.
+transform.sequence failures(suppress) {
+^bb0(%root: !pdl.operation):
+  transform.sequence  %root : !pdl.operation failures(propagate) {
+  ^bb1(%op: !pdl.operation):
+    %variant_op = transform.get_closest_isolated_parent %op : (!pdl.operation) -> !pdl.operation
 
-  %input_max_fill, %input_max, %exps_sum_fill, %exps, %exps_sum, %div =
+    %flow = transform.structured.match ops{["flow.dispatch.tensor.store"]} in %variant_op
+    transform.split_handles %flow in [0] : (!pdl.operation) -> ()
+    // transform.print %flow : !pdl.operation
+
+    %ops = transform.structured.match ops{["linalg.fill", "linalg.generic"]}
+      in %variant_op
+
+    %input_max_fill, %input_max, %exps_sum_fill, %exps, %exps_sum, %div =
     transform.split_handles %ops in [6]
       : (!pdl.operation) -> (!pdl.operation, !pdl.operation, !pdl.operation,
-                             !pdl.operation, !pdl.operation, !pdl.operation)
+                              !pdl.operation, !pdl.operation, !pdl.operation)
 
-  /// This must be used with the custom dispatch region formation
-  /// because IREE's does not fuse the 6 ops softmax version even with
-  /// --iree-flow-enable-aggressive-fusion.
-  %region_op = transform.iree.wrap_in_dispatch_region %div { generateWorkload = false }
+    /// This must be used with the custom dispatch region formation
+    /// because IREE's does not fuse the 6 ops softmax version even with
+    /// --iree-flow-enable-aggressive-fusion.
+    %region_op = transform.iree.wrap_in_dispatch_region %div { generateWorkload = false }
 
-  %non_div = transform.merge_handles %input_max_fill, %input_max, %exps_sum_fill, %exps, %exps_sum
-    : !pdl.operation
-  %region_op_2 = transform.iree.move_preceding_op_into_dispatch_region %non_div into %region_op
+    %non_div = transform.merge_handles %input_max_fill, %input_max, %exps_sum_fill, %exps, %exps_sum
+      : !pdl.operation
+    %region_op_2 = transform.iree.move_preceding_op_into_dispatch_region %non_div into %region_op
 
-  %empty = transform.structured.match ops{["tensor.empty"]} in %variant_op
-  %region_op_3 = transform.iree.move_preceding_op_into_dispatch_region %empty into %region_op_2
-  transform.iree.region_to_workgroups %region_op_3
+    %empty = transform.structured.match ops{["tensor.empty"]} in %variant_op
+    %region_op_3 = transform.iree.move_preceding_op_into_dispatch_region %empty into %region_op_2
+    transform.iree.region_to_workgroups %region_op_3
+  }
 }


### PR DESCRIPTION
This requires some changes to the base logic of the transform dialect interpreter pass. The transform IR is constructed on the fly in a separate module, the ownership of which is shared by all copies of the dispatch-with-interpreter pass, similarly to the externally supplied transform IR file. The interpreter currently is currently run multiple times with Linalg ops as potential roots to control the matching from C++ instead of deferring it to the transform dialect.