### PR TITLE
[TransformDialectStrategies] Expose options for lower_vectors

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
@@ -19,7 +19,6 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
-#include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 
@@ -52,7 +51,8 @@ using transform_ext::StructuredOpMatcher;
 /// Return the handles to the updated variant and the func::FuncOp ops under
 /// the variant op.
 std::pair<Value, Value> mlir::iree_compiler::cpu::buildCommonTrailingStrategy(
-    ImplicitLocOpBuilder &b, Value variantH) {
+    ImplicitLocOpBuilder &b, Value variantH,
+    const vector::LowerVectorsOptions &lowerVectorsOpts) {
   // Step N-2. Bufferize and drop HAL descriptor from memref ops.
   Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
   funcH = iree_compiler::buildVectorize(b, funcH);
@@ -67,7 +67,7 @@ std::pair<Value, Value> mlir::iree_compiler::cpu::buildCommonTrailingStrategy(
 
   // Step N. Lower vectors.
   // TODO: Control the lowering to vectors.
-  funcH = b.create<LowerVectorsOp>(pdlOperation, funcH);
+  funcH = b.create<LowerVectorsOp>(pdlOperation, funcH, lowerVectorsOpts);
   return std::make_pair(variantH, funcH);
 }
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.h
@@ -9,6 +9,7 @@
 
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
 #include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
@@ -23,8 +24,9 @@ namespace cpu {
 /// Return the handles to the updated variant and the func::FuncOp ops under
 /// the variant op.
 // TODO: pass control to LowerVectorsOp once the builder allows it.
-std::pair<Value, Value> buildCommonTrailingStrategy(ImplicitLocOpBuilder& b,
-                                                    Value variantH);
+std::pair<Value, Value> buildCommonTrailingStrategy(
+    ImplicitLocOpBuilder& b, Value variantH,
+    const vector::LowerVectorsOptions& lowerVectorsOpts);
 
 //===----------------------------------------------------------------------===//
 // Higher-level problem-specific strategy creation APIs, these should favor

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Transform/IR/TransformOps.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
+#include "mlir/Dialect/Vector/Transforms/VectorRewritePatterns.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/ImplicitLocOpBuilder.h"
 
@@ -78,5 +79,14 @@ void mlir::iree_compiler::cpu::buildReductionStrategy(
   }
 
   // Step 3-5. Common trailing steps.
-  buildCommonTrailingStrategy(b, variantH);
+  vector::LowerVectorsOptions lowerVectorsOptions;
+  lowerVectorsOptions
+      .setVectorTransformsOptions(vector::VectorContractLowering::OuterProduct)
+      .setVectorMultiReductionLowering(
+          vector::VectorMultiReductionLowering::InnerParallel)
+      .setVectorTransferSplit(vector::VectorTransferSplit::LinalgCopy)
+      .setVectorTransposeLowering(vector::VectorTransposeLowering::EltWise)
+      .setTransposeAVX2Lowering(false)
+      .setUnrollVectorTransfers(true);
+  buildCommonTrailingStrategy(b, variantH, lowerVectorsOptions);
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/roundtrip.mlir
@@ -20,9 +20,9 @@ transform.structured.canonicalized_sequence failures(propagate) {
   // CHECK: bufferize
   bufferize
   // CHECK: %[[FUNC:.*]] = transform.structured.match ops{["func.func"]} in %arg0
-  // CHECK: lower_vectors %[[FUNC]] {multireduction_lowering = "innerreduce"}
+  // CHECK: lower_vectors %[[FUNC]] {{.*}} multireduction_lowering = innerreduction
   %6 = transform.structured.match ops{["func.func"]} in %arg0
-  transform.vector.lower_vectors %6 { multireduction_lowering = "innerreduce"}
+  transform.vector.lower_vectors %6 multireduction_lowering = "innerreduction"
   // CHECK: lower_to_llvm
   lower_to_llvm
 }

--- a/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/linalg_transform/single-tiling-full-script.mlir
@@ -21,6 +21,6 @@ transform.structured.canonicalized_sequence failures(propagate) {
   transform.structured.vectorize %2 { vectorize_padding }
   bufferize
   %3 = transform.structured.match ops{["func.func"]} in %module_op
-  transform.vector.lower_vectors %3 { multireduction_lowering = "innerreduce"}
+  transform.vector.lower_vectors %3 multireduction_lowering = "innerreduction"
   lower_to_llvm
 }


### PR DESCRIPTION
Augment the C++ API of the TransformDialectStrategies to expose the options for tweaking the lower_vectors behavior.

NFC

Note: This comes with two commits cherry-picked from open source LLVM, hence adding @hanhanW as a reviewer.