### PR TITLE
Rename away from `AArch`-everything

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -21,8 +21,8 @@ def CPU_DoubleTilingPeelingExpert
     : I32EnumAttrCase<"CPUDoubleTilingPeelingExpert", 3>;
 def CPU_ConvTileAndDecomposeExpert
     : I32EnumAttrCase<"CPUConvTileAndDecomposeExpert", 4>;
-def CPU_CPUAArchDoubleTilingExpert
-    : I32EnumAttrCase<"CPUAArchDoubleTilingExpert", 5>;
+def CPU_Mmt4dTilingExpert
+    : I32EnumAttrCase<"Mmt4dTilingExpert", 5>;
 def CPU_BufferOpsTileAndVectorize
     : I32EnumAttrCase<"CPUBufferOpsTileAndVectorize", 6>;
 def CPU_TripleTilingExpert : I32EnumAttrCase<"CPUTripleTilingExpert", 7>;
@@ -65,7 +65,7 @@ def DispatchLoweringPassPipelineEnum
                   "identifier for pass pipeline use to lower dispatch region", [
                     CPU_Default, CPU_DoubleTilingExpert,
                     CPU_DoubleTilingPadExpert, CPU_DoubleTilingPeelingExpert,
-                    CPU_ConvTileAndDecomposeExpert, CPU_CPUAArchDoubleTilingExpert,
+                    CPU_ConvTileAndDecomposeExpert, CPU_Mmt4dTilingExpert,
                     CPU_BufferOpsTileAndVectorize, CPU_TripleTilingExpert,
                     CPU_DataTiling, LLVMGPU_SimpleDistribute,
                     LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -17,7 +17,6 @@ iree_compiler_cc_library(
     srcs = [
         "ConvertToLLVM.cpp",
         "KernelDispatch.cpp",
-        "LLVMCPUMmt4dVectorLowering.cpp",
         "LLVMCPUAssignConstantOrdinals.cpp",
         "LLVMCPUAssignImportOrdinals.cpp",
         "LLVMCPUCheckIRBeforeLLVMConversion.cpp",
@@ -25,6 +24,7 @@ iree_compiler_cc_library(
         "LLVMCPULinkExecutables.cpp",
         "LLVMCPULowerExecutableTarget.cpp",
         "LLVMCPUMaterializeEncodingPass.cpp",
+        "LLVMCPUMmt4dVectorLowering.cpp",
         "LLVMCPUSynchronizeSymbolVisibility.cpp",
         "LLVMCPUUnfuseFMAOps.cpp",
         "Passes.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -17,7 +17,7 @@ iree_compiler_cc_library(
     srcs = [
         "ConvertToLLVM.cpp",
         "KernelDispatch.cpp",
-        "LLVMCPUAArch64VectorLowering.cpp",
+        "LLVMCPUMmt4dVectorLowering.cpp",
         "LLVMCPUAssignConstantOrdinals.cpp",
         "LLVMCPUAssignImportOrdinals.cpp",
         "LLVMCPUCheckIRBeforeLLVMConversion.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -19,7 +19,6 @@ iree_cc_library(
   SRCS
     "ConvertToLLVM.cpp"
     "KernelDispatch.cpp"
-    "LLVMCPUMmt4dVectorLowering.cpp"
     "LLVMCPUAssignConstantOrdinals.cpp"
     "LLVMCPUAssignImportOrdinals.cpp"
     "LLVMCPUCheckIRBeforeLLVMConversion.cpp"
@@ -27,6 +26,7 @@ iree_cc_library(
     "LLVMCPULinkExecutables.cpp"
     "LLVMCPULowerExecutableTarget.cpp"
     "LLVMCPUMaterializeEncodingPass.cpp"
+    "LLVMCPUMmt4dVectorLowering.cpp"
     "LLVMCPUSynchronizeSymbolVisibility.cpp"
     "LLVMCPUUnfuseFMAOps.cpp"
     "Passes.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -19,7 +19,7 @@ iree_cc_library(
   SRCS
     "ConvertToLLVM.cpp"
     "KernelDispatch.cpp"
-    "LLVMCPUAArch64VectorLowering.cpp"
+    "LLVMCPUMmt4dVectorLowering.cpp"
     "LLVMCPUAssignConstantOrdinals.cpp"
     "LLVMCPUAssignImportOrdinals.cpp"
     "LLVMCPUCheckIRBeforeLLVMConversion.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -816,7 +816,7 @@ static LogicalResult setAArch64RootConfig(func::FuncOp entryPointFn,
 
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, op, tileSizes,
-      DispatchLoweringPassPipeline::CPUAArchDoubleTilingExpert);
+      DispatchLoweringPassPipeline::Mmt4dTilingExpert);
 }
 
 /// Returns default hard-coded workgroup sizes for a give target. No smartness
@@ -1034,7 +1034,7 @@ static LogicalResult setRootConfig(func::FuncOp entryPointFn,
 
   return setOpConfigAndEntryPointFnTranslation(
       entryPointFn, mmt4dOp, tileSizes,
-      DispatchLoweringPassPipeline::CPUAArchDoubleTilingExpert);
+      DispatchLoweringPassPipeline::Mmt4dTilingExpert);
 }
 
 static SmallVector<int64_t> getLinalgExtDefaultWorkgroupTileSizes(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerExecutableTarget.cpp
@@ -227,10 +227,8 @@ void LLVMCPULowerExecutableTargetPass::runOnOperation() {
             addConvTileAndDecomposeExpertPassPipeline(
                 executableLoweringPipeline);
             break;
-          case IREE::Codegen::DispatchLoweringPassPipeline::
-              CPUAArchDoubleTilingExpert:
-            addCPUAArchDoubleTilingExpertPassPipeline(
-                executableLoweringPipeline);
+          case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert:
+            addMmt4dTilingExpertPassPipeline(executableLoweringPipeline);
             break;
           case IREE::Codegen::DispatchLoweringPassPipeline::CPUDataTiling:
             addCPUDataTilingPipeline(executableLoweringPipeline);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUMmt4dVectorLowering.cpp
@@ -14,7 +14,7 @@
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
-#define DEBUG_TYPE "iree-llvmcpu-aarch64-vector-lowering"
+#define DEBUG_TYPE "iree-llvmcpu-mmt4d-vector-lowering"
 
 // A flag to switch between inline asm and intrinsics while we develop these two
 // parallel paths.
@@ -29,9 +29,8 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
-struct LLVMCPUAArch64VectorLoweringPass
-    : public LLVMCPUAArch64VectorLoweringBase<
-          LLVMCPUAArch64VectorLoweringPass> {
+struct LLVMCPUMmt4dVectorLoweringPass
+    : public LLVMCPUMmt4dVectorLoweringBase<LLVMCPUMmt4dVectorLoweringPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<vector::VectorDialect>();
   }
@@ -39,7 +38,7 @@ struct LLVMCPUAArch64VectorLoweringPass
 };
 }  // namespace
 
-void LLVMCPUAArch64VectorLoweringPass::runOnOperation() {
+void LLVMCPUMmt4dVectorLoweringPass::runOnOperation() {
   MLIRContext *context = &getContext();
   auto funcOp = getOperation();
 
@@ -155,8 +154,8 @@ void LLVMCPUAArch64VectorLoweringPass::runOnOperation() {
 }
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMCPUAArch64VectorLoweringPass() {
-  return std::make_unique<LLVMCPUAArch64VectorLoweringPass>();
+createLLVMCPUMmt4dVectorLoweringPass() {
+  return std::make_unique<LLVMCPUMmt4dVectorLoweringPass>();
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -594,7 +594,7 @@ void addConvTileAndDecomposeExpertPassPipeline(OpPassManager &passManager) {
   }
 }
 
-void addCPUAArchDoubleTilingExpertPassPipeline(OpPassManager &passManager) {
+void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager) {
   addTileAndDistributePasses(passManager);
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
@@ -635,7 +635,7 @@ void addCPUAArchDoubleTilingExpertPassPipeline(OpPassManager &passManager) {
   addBufferizePasses(nestedModulePM);
 
   nestedModulePM.addNestedPass<func::FuncOp>(
-      createLLVMCPUAArch64VectorLoweringPass());
+      createLLVMCPUMmt4dVectorLoweringPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createOptimizeVectorTransferPass(/*flatten=*/true));
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_dotprod_vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_dotprod_vector_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmcpu-aarch64-vector-lowering,iree-codegen-optimize-vector-transfer{flatten=true})))))' --split-input-file %s | FileCheck %s
+// RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(builtin.module(func.func(iree-llvmcpu-mmt4d-vector-lowering,iree-codegen-optimize-vector-transfer{flatten=true})))))' --split-input-file %s | FileCheck %s
 
 // -----
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_vector_lowering.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/aarch64_vector_lowering.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt %s --iree-llvmcpu-aarch64-vector-lowering --split-input-file | FileCheck %s
+// RUN: iree-opt %s --iree-llvmcpu-mmt4d-vector-lowering --split-input-file | FileCheck %s
 
 #map0 = affine_map<()[s0] -> (s0 * 64)>
 #map1 = affine_map<(d0, d1, d2) -> (d0, d2)>

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -45,7 +45,7 @@ hal.executable private @matmul_tensors  {
   }
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64, 0], [16, 4, 0], [0, 0, 64]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUAArchDoubleTilingExpert>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<Mmt4dTilingExpert>
 //      CHECK: hal.executable.export public @matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK: linalg.matmul
@@ -96,7 +96,7 @@ hal.executable private @batch_matmul_tensors {
   }
 }
 //  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64, 0], [1, 16, 4, 0], [0, 0, 0, 64]{{\]}}>
-//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUAArchDoubleTilingExpert>
+//  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<Mmt4dTilingExpert>
 //      CHECK: hal.executable.export public @batch_matmul_tensors
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //      CHECK:  linalg.batch_matmul
@@ -144,7 +144,7 @@ hal.executable private @matmul_static {
 }
 
 //   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[49, 8, 0], [7, 4, 0], [0, 0, 60]{{\]}}>
-//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUAArchDoubleTilingExpert>
+//   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<Mmt4dTilingExpert>
 //       CHECK: hal.executable.export public @matmul_static
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]
 //       CHECK: linalg.matmul

--- a/compiler/src/iree/compiler/Codegen/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/Passes.cpp
@@ -72,8 +72,7 @@ LogicalResult verifyLoweringConfiguration(
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize) {
   switch (translationInfo.getDispatchLoweringPassPipeline()) {
-    case IREE::Codegen::DispatchLoweringPassPipeline::
-        CPUAArchDoubleTilingExpert:
+    case IREE::Codegen::DispatchLoweringPassPipeline::Mmt4dTilingExpert:
       return verifyDoubleTilingExpertPassPipelineConfig(op, loweringConfig,
                                                         translationInfo);
     case IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUMatmulSimt:

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -275,7 +275,7 @@ std::unique_ptr<OperationPass<ModuleOp>>
 createLLVMCPUSynchronizeSymbolVisibilityPass();
 
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMCPUAArch64VectorLoweringPass();
+createLLVMCPUMmt4dVectorLoweringPass();
 
 /// Replaces llvm.intr.fma with its unfused mul and add ops.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMCPUUnfuseFMAOpsPass();
@@ -351,7 +351,7 @@ void addTransformDialectPasses(OpPassManager &passManager);
 
 /// Populates the passes needed to multi level tile, fuse and vectorize
 /// lowering of linalg ops on tensors to vectors operations.
-void addCPUAArchDoubleTilingExpertPassPipeline(OpPassManager &passManager);
+void addMmt4dTilingExpertPassPipeline(OpPassManager &passManager);
 
 //----------------------------------------------------------------------------//
 // LLVMCPU Pass Pipelines for lowering to LLVM dialect.

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -367,11 +367,11 @@ def LLVMCPUSynchronizeSymbolVisibility :
   let constructor = "mlir::iree_compiler::createLLVMCPUSynchronizeSymbolVisibilityPass()";
 }
 
-def LLVMCPUAArch64VectorLowering
-    : Pass<"iree-llvmcpu-aarch64-vector-lowering", "func::FuncOp"> {
+def LLVMCPUMmt4dVectorLowering
+    : Pass<"iree-llvmcpu-mmt4d-vector-lowering", "func::FuncOp"> {
   let summary = "Apply vector lowering logic to vector ops";
   let constructor =
-      "mlir::iree_compiler::createLLVMCPUAArch64VectorLoweringPass()";
+      "mlir::iree_compiler::createLLVMCPUMmt4dVectorLoweringPass()";
 }
 
 def LLVMCPUUnfuseFMAOps :


### PR DESCRIPTION
A number of things in LLVMCPU/ unnecessarily have references to AArch64 in their names.

It's most obvious in the `setRootConfig` overload taking a `Mmt4dOp`: this function is called regardless of architecture for any `Mmt4dOp`, and yet it ends up selecting `CPUAArchDoubleTilingExpert`: https://github.com/iree-org/iree/blob/a9227685614999b4de7ee53b3843ef1c7b409489/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp#L993-L1038

So the chain of renamings in this PR starts here. There are multiple problems in the name `CPUAArchDoubleTilingExpert`:
1. It's suggesting something specific to ARM architectures ("AArch") even though it's used everywhere.
2. Just `AArch` alone without a 64 or 32 suffix is not a common term.
3. The `Double` part is out of sync with what the code actually does (it uses a `SingleTilingExpert`).

So, in line with other experts in the same file, we rename `CPUAArchDoubleTilingExpert` to `Mmt4dTilingExpert`. This is consistent with the above described call site; there is only one other place that creates that expert, that was `setAArch64RootConfig` in the same file. That one was actually specific to `AArch64` but not Mmt4d,  so the new name looks out of place here, but I think that's OK because this should only be used in non-data-tiling on AArch64 and I think we already know that this is going away soon.

The rest of this PR follows by similar renamings to be consistent.

This results in over-using the term `Mmt4d` a bit, since for instance the vector lowerings only see `vector` ops such as the `vector.contract` that result from vectorization of `mmt4d`, not the `mmt4d` themselves. But I think that's less bad than overusing `AArch64` in code that runs on all CPU architectures.

Very much open to better names --- don't want to blindly jump from aarch-everything to mmt4d-everything.  Maybe a follow-up would reduce the number of separate experts, and the new name would arise for the more unified expert?