### PR TITLE
Make sure the selected workgroup size divides the problem size.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -913,6 +913,12 @@ static LogicalResult setRootConfig(
 
   SmallVector<int64_t> workgroupTileSizes =
       getMatmulWorkgroupSizes(entryPointFn, linalgOp, vectorSize, isQuantized);
+  for (auto [index, shape] : llvm::enumerate(linalgOp.getStaticShape())) {
+    if (index >= workgroupTileSizes.size()) break;
+    if (shape == ShapedType::kDynamic) continue;
+    workgroupTileSizes[index] =
+        getMaxTileSize(0, shape, workgroupTileSizes[index], vectorSize);
+  }
 
   auto targetAttr = IREE::HAL::ExecutableTargetAttr::lookup(entryPointFn);
 


### PR DESCRIPTION
Without either pre-padding or masking not having the tile sizes divide the problem size for all tiling levels will result in un-vectorized code that has the side-effect of stack allocation. Even though this stack is bounded it is within the inner most loop and dynamic which will result in stack overflow. The matmul path is supposed to use pad + hoist, but that doesnt seem to kick in for non x86 or non f32 paths. 
This workaround addresses this in the short-term, avoid stack allocations. A proper fix will need to either deprecate this pipeline completely, use vector masking or use pre-padding/data tiling.

Issue #11880 