### PR TITLE
[cuda] Remove `-iree-hal-cuda-dump-ptx`

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/CUDATarget.cpp
@@ -38,10 +38,6 @@
 #include "mlir/Target/LLVMIR/Dialect/NVVM/NVVMToLLVMIRTranslation.h"
 #include "mlir/Target/LLVMIR/Export.h"
 
-static llvm::cl::opt<bool> dumpPtx(
-    "iree-hal-cuda-dump-ptx", llvm::cl::init(false),
-    llvm::cl::desc("Dump ptx to the debug stream."));
-
 // TODO: remove this workaround altogether once we decide not to support
 // CUDA 11.3
 static llvm::cl::opt<bool> clDisableLoopNounrollWa(
@@ -355,9 +351,6 @@ class CUDATargetBackend final : public TargetBackend {
       ptxImage = translateModuleToISA(*llvmModule, *targetMachine);
     }
 
-    if (dumpPtx) {
-      llvm::dbgs() << ptxImage;
-    }
     if (!options.dumpBinariesPath.empty()) {
       dumpDataToPath(options.dumpBinariesPath, options.dumpBaseName,
                      variantOp.getName(), ".ptx", ptxImage);

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/CUDA/test/smoketest.mlir
@@ -1,5 +1,4 @@
 // RUN: iree-opt --split-input-file --iree-hal-transformation-pipeline %s | FileCheck %s
-// RUN: iree-opt --split-input-file --iree-hal-transformation-pipeline --iree-hal-cuda-dump-ptx %s 2>&1 | FileCheck %s --check-prefix=PTX
 
 #map = affine_map<(d0) -> (d0)>
 
@@ -39,10 +38,6 @@ stream.executable public @add_dispatch_0 {
 }
 
 }
-
-// PTX: .entry add_dispatch_0
-// PTX: .maxntid 64, 1, 1
-// PTX:   add.rn.f32
 
 //      CHECK:   hal.executable.binary public @cuda_nvptx_fb attributes {
 // CHECK-SAME:     data = dense


### PR DESCRIPTION
We can use `-iree-hal-dump-executable-binaries-to=` instead, which is consistent across all compiler backends.