### PR TITLE
Fix GitHub Actions Runners for new image

### DIFF
--- a/build_tools/github_actions/runner/config/systemd/system/gh-runner-deregister.service
+++ b/build_tools/github_actions/runner/config/systemd/system/gh-runner-deregister.service
@@ -7,6 +7,7 @@ Before=halt.target shutdown.target reboot.target
 User=runner
 Group=runner
 Type=oneshot
+EnvironmentFile=/etc/environment
 ExecStart=/runner-root/config/systemd/scripts/deregister.sh
 RemainAfterExit=yes
 

--- a/build_tools/github_actions/runner/config/systemd/system/gh-runner.service
+++ b/build_tools/github_actions/runner/config/systemd/system/gh-runner.service
@@ -5,6 +5,7 @@ After=network.target
 [Service]
 User=runner
 Group=runner
+EnvironmentFile=/etc/environment
 ExecStart=/runner-root/config/systemd/scripts/start_runner.sh
 Restart=no
 KillMode=process

--- a/build_tools/github_actions/runner/config/systemd/system/health-check.service
+++ b/build_tools/github_actions/runner/config/systemd/system/health-check.service
@@ -5,6 +5,7 @@ After=gh-runner.target network.target
 [Service]
 User=root
 Group=root
+EnvironmentFile=/etc/environment
 ExecStart=/runner-root/config/health_server/health_server.py
 Restart=no
 KillMode=process

--- a/build_tools/github_actions/runner/config/systemd/system/stop-idle-runner.service
+++ b/build_tools/github_actions/runner/config/systemd/system/stop-idle-runner.service
@@ -7,6 +7,7 @@ RefuseManualStart=true
 User=root
 Group=root
 Type=oneshot
+EnvironmentFile=/etc/environment
 ExecStart=/runner-root/config/systemd/scripts/stop_idle_runner.sh
 KillMode=process
 KillSignal=SIGTERM

--- a/build_tools/github_actions/runner/gcp/create_image.sh
+++ b/build_tools/github_actions/runner/gcp/create_image.sh
@@ -31,6 +31,7 @@ CPU_MACHINE_TYPE="e2-medium"
 CPU_IMAGE_SIZE_GB=10
 # We need enough space to fetch Docker images that we test with
 # TODO(gcmn): See if we can make the image smaller, e.g. by resizing after setup
+# or using a local ssd for scratch space during setup.
 GPU_IMAGE_SIZE_GB=50
 
 # It takes a little bit to bring up ssh on the instance. I haven't found a

--- a/build_tools/github_actions/runner/gcp/image_setup.sh
+++ b/build_tools/github_actions/runner/gcp/image_setup.sh
@@ -292,7 +292,7 @@ EOF
         | gpg --dearmor -o "${nvidia_gpg_file}"
     nice_curl \
         "https://nvidia.github.io/libnvidia-container/${distribution}/libnvidia-container.list" | \
-        sed 's#deb https://#deb [signed-by=${nvidia_gpg_file}] https://#g' \
+        sed "s#deb https://#deb [signed-by=${nvidia_gpg_file}] https://#g" \
         > "${nvidia_apt_file}"
 
     apt-get update


### PR DESCRIPTION
It turns out that systemd doesn't use /etc/environment because that's a
pam login thing (I think I have discovered this before). We use
/etc/environment to add things to the PATH for all users. This just
sets /etc/environment as the environment file for all our services.

Also fixed quoting of a sed command for the GPU image so that it does
variable expansion.

Tested: Created new images and templates and deployed them to the
testing cluster then ran presubmit against it:
https://github.com/iree-org/iree/actions/runs/3955202440/jobs/6792181962