### PR TITLE
Add softmax op to linalg_ext

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BufferizationInterfaces.cpp
@@ -458,6 +458,8 @@ void registerBufferizationInterfaces(DialectRegistry &registry) {
         LinalgExtOpInterface<IREE::LinalgExt::WinogradInputTransformOp>>(*ctx);
     IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
         LinalgExtOpInterface<IREE::LinalgExt::WinogradOutputTransformOp>>(*ctx);
+    IREE::LinalgExt::SoftmaxOp::attachInterface<
+        LinalgExtOpInterface<IREE::LinalgExt::SoftmaxOp>>(*ctx);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -236,6 +236,8 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
     IREE::LinalgExt::WinogradOutputTransformOp::attachInterface<
         AllParallelAsPartitionableLoops<
             IREE::LinalgExt::WinogradOutputTransformOp>>(*ctx);
+    IREE::LinalgExt::SoftmaxOp::attachInterface<
+        AllParallelAsPartitionableLoops<IREE::LinalgExt::SoftmaxOp>>(*ctx);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -128,6 +128,8 @@ static void addTileAndDistributePasses(
     OpPassManager &pm, bool useFuseTensorPadWithConsumerPass = true) {
   pm.addPass(createTileAndDistributeToWorkgroupsPass());
   auto &nestedModulePM = pm.nest<ModuleOp>();
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createDecomposeSoftmaxPass());
   if (clEnablePadConsumerFusion && useFuseTensorPadWithConsumerPass) {
     nestedModulePM.addNestedPass<func::FuncOp>(
         createFuseTensorPadWithConsumerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -96,6 +96,8 @@ static void tileAndDistributeToWorkgroup(
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createDecomposeSoftmaxPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass(
           useWARForCooperativeMatrixCodegen));
   nestedModulePM.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilExternalModels.cpp
@@ -144,6 +144,8 @@ void registerUtilExternalModels(DialectRegistry &registry) {
         LinalgExt::WinogradOutputTransformOp::attachInterface<
             LinalgOpTiedOpInterface<LinalgExt::WinogradOutputTransformOp>>(
             *ctx);
+        LinalgExt::SoftmaxOp::attachInterface<
+            LinalgOpTiedOpInterface<LinalgExt::SoftmaxOp>>(*ctx);
       });
 }
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1106,6 +1106,77 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
 }
 
 //===----------------------------------------------------------------------===//
+// Softmax
+//===----------------------------------------------------------------------===//
+
+def IREELinalgExt_SoftmaxOp : IREELinalgExt_Op<"softmax",
+    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+     DeclareOpInterfaceMethods<TilingInterface,
+      ["getIterationDomain",
+       "getLoopIteratorTypes",
+       "getResultTilePosition",
+       "getTiledImplementation"]>]> {
+  let summary = "Softmax operator";
+  let description = [{
+    This op computes a numerically stable version of softmax for a given tensor.
+    For a given input tensor x and specified dimension d,
+    we first compute the max along that dimension (m). We then compute
+    f(x) = exp(x - m). Then, we sum f(x) along dimension d to get l(x). Finally,
+    we compute the softmax as f(x) / l(x).
+  }];
+
+  let arguments = (ins Variadic<AnyShaped>:$inputs,
+                       Variadic<AnyShaped>:$outputs,
+                       I64Attr:$dimension
+  );
+
+  let builders = [
+    OpBuilder<(ins "ValueRange":$inputs, "ValueRange":$outputs,
+      CArg<"int64_t", "0">:$dimension)>
+  ];
+
+  let results = (outs Variadic<AnyRankedTensor>:$result);
+  let hasFolder = 1;
+  let assemblyFormat = [{
+    attr-dict
+    `dimension` `(` $dimension `)`
+    `ins` `(` $inputs `:` type($inputs) `)`
+    `outs` `(` $outputs `:` type($outputs) `)`
+    (`->` type($result)^)?
+  }];
+
+  let extraClassDeclaration = extraLinalgExtOpClassDeclaration # [{
+    Value input() {
+      return getInputOperand(0)->get();
+    }
+    Value output() {
+      return getOutputOperand(0)->get();
+    }
+    ShapedType getInputOperandType() {
+      return input().getType().cast<ShapedType>();
+    }
+    ShapedType getOutputOperandType() {
+      return output().getType().cast<ShapedType>();
+    }
+    int64_t getInputOperandRank() {
+      return getInputOperandType().getRank();
+    }
+    int64_t getOutputOperandRank() {
+      return getOutputOperandType().getRank();
+    }
+    // Method to implement for specifying output range for
+    // DestinationStyleOpInterface
+    std::pair<int64_t, int64_t> getDpsInitsPositionRange() {
+      std::pair<unsigned, unsigned> outputsIndexAndLength =
+        getODSOperandIndexAndLength(1);
+      return std::make_pair<int64_t, int64_t>(
+          outputsIndexAndLength.first,
+          outputsIndexAndLength.first + outputsIndexAndLength.second);
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Pure ops
 //===----------------------------------------------------------------------===//
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.td
@@ -1109,8 +1109,12 @@ def IREELinalgExt_WinogradOutputTransformOp : IREELinalgExt_Op<"winograd.output_
 // Softmax
 //===----------------------------------------------------------------------===//
 
+class CheckNumOperands<int i> : CPred<"$_op.getNumOperands() == " # i>;
+
 def IREELinalgExt_SoftmaxOp : IREELinalgExt_Op<"softmax",
-    [DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
+    [PredOpTrait<"only one input and one output",  CheckNumOperands<2>>,
+     PredOpTrait<"input and output have same element type", TCopVTEtIsSameAs<0, 1>>,
+     DeclareOpInterfaceMethods<ReifyRankedShapedTypeOpInterface>,
      DeclareOpInterfaceMethods<TilingInterface,
       ["getIterationDomain",
        "getLoopIteratorTypes",

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -172,6 +172,10 @@ createTileAndDecomposeWinogradTransformPass();
 // tranformation.
 std::unique_ptr<Pass> createConvertConv2DToWinogradPass();
 
+// Creates a pass to convert the softmax op into a sequence of
+// linalg generic ops.
+std::unique_ptr<Pass> createDecomposeSoftmaxPass();
+
 // Marker used as attribute the depth of the split reduction transformations.
 const StringLiteral kSplitReductionDepthMarker = "__split_reduction_depth__";
 

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -96,6 +96,13 @@ def ConvertConv2DToWinograd :
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::createConvertConv2DToWinogradPass()";
 }
 
+def DecomposeSoftmax :
+    Pass<"iree-linalg-ext-decompose-softmax", "func::FuncOp"> {
+  let summary =
+      "Decomposes softmax op into a sequence of linalg ops";
+  let constructor = "mlir::iree_compiler::IREE::LinalgExt::"
+                    "createDecomposeSoftmaxPass()";
+}
 
 //===---------------------------------------------------------------------====//
 // Codegen Strategy passes moved into IREE

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2762,19 +2762,9 @@ LogicalResult WinogradOutputTransformOp::reifyResultShapes(
 
 LogicalResult SoftmaxOp::verify() {
   Operation *op = getOperation();
-  if (getNumInputs() != 1) {
-    return op->emitOpError("expected one input operand");
-  }
-  if (getNumOutputs() != 1) {
-    return op->emitOpError("expected one output operand");
-  }
   auto inputType = input().getType().cast<ShapedType>();
   auto outputType = output().getType().cast<ShapedType>();
-  if (outputType.getElementType() != inputType.getElementType()) {
-    return op->emitOpError(
-        "expected input/output element types to be identical");
-  }
-  SmallVector<int64_t> inputShape(inputType.getShape());
+  ArrayRef<int64_t> inputShape = inputType.getShape();
   ArrayRef<int64_t> outputShape = outputType.getShape();
   if (!areShapesCompatible(inputShape, outputShape)) {
     return op->emitOpError("incompatible output shape");

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -2756,6 +2756,106 @@ LogicalResult WinogradOutputTransformOp::reifyResultShapes(
       .reifyResultShapes(b, reifiedReturnShapes);
 }
 
+//===----------------------------------------------------------------------===//
+// SoftmaxOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult SoftmaxOp::verify() {
+  Operation *op = getOperation();
+  if (getNumInputs() != 1) {
+    return op->emitOpError("expected one input operand");
+  }
+  if (getNumOutputs() != 1) {
+    return op->emitOpError("expected one output operand");
+  }
+  auto inputType = input().getType().cast<ShapedType>();
+  auto outputType = output().getType().cast<ShapedType>();
+  if (outputType.getElementType() != inputType.getElementType()) {
+    return op->emitOpError(
+        "expected input/output element types to be identical");
+  }
+  SmallVector<int64_t> inputShape(inputType.getShape());
+  ArrayRef<int64_t> outputShape = outputType.getShape();
+  if (!areShapesCompatible(inputShape, outputShape)) {
+    return op->emitOpError("incompatible output shape");
+  }
+  int64_t inputRank = getInputOperandRank();
+  int64_t dimension = getDimension();
+  if ((dimension < 0) || (dimension >= inputRank)) {
+    return op->emitOpError("incorrect dimension specified");
+  }
+  return success();
+}
+
+SmallVector<Range> SoftmaxOp::getIterationDomain(OpBuilder &builder) {
+  int64_t operandRank = getInputOperandRank();
+  SmallVector<Range> loopBounds(operandRank);
+  Location loc = getLoc();
+  Value zero = builder.create<arith::ConstantIndexOp>(loc, 0);
+  Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
+  Value source = input();
+  for (auto dim : llvm::seq<int64_t>(0, operandRank)) {
+    loopBounds[dim].offset = zero;
+    loopBounds[dim].size = getDimValue(builder, loc, source, dim);
+    loopBounds[dim].stride = one;
+  }
+  return loopBounds;
+}
+
+SmallVector<utils::IteratorType> SoftmaxOp::getLoopIteratorTypes() {
+  SmallVector<utils::IteratorType> iteratorTypes(getInputOperandRank(),
+                                                 utils::IteratorType::parallel);
+  iteratorTypes[getDimension()] = utils::IteratorType::reduction;
+  return iteratorTypes;
+}
+
+SmallVector<Operation *>
+SoftmaxOp::getTiledImplementation(OpBuilder &builder,
+                                  ArrayRef<OpFoldResult> offsets,
+                                  ArrayRef<OpFoldResult> sizes) {
+  int64_t rank = getInputOperandRank();
+  auto oneAttr = builder.getI64IntegerAttr(1);
+  SmallVector<OpFoldResult> strides(rank, oneAttr);
+  SmallVector<Value> tiledOperands;
+  tiledOperands.emplace_back(
+      getSlice(builder, getLoc(), input(), offsets, sizes, strides));
+  tiledOperands.emplace_back(
+      getSlice(builder, getLoc(), getOutputs()[0], offsets, sizes, strides));
+
+  SmallVector<Type, 4> resultTypes;
+  if (hasTensorSemantics()) {
+    resultTypes.push_back(tiledOperands[1].getType());
+  }
+  Operation *tiledOp =
+      mlir::clone(builder, getOperation(), resultTypes, tiledOperands);
+
+  return {tiledOp};
+}
+
+LogicalResult SoftmaxOp::getResultTilePosition(
+    OpBuilder &builder, unsigned resultNumber, ArrayRef<OpFoldResult> offsets,
+    ArrayRef<OpFoldResult> sizes, SmallVector<OpFoldResult> &resultOffsets,
+    SmallVector<OpFoldResult> &resultSizes) {
+  if (resultNumber == 0) {
+    resultOffsets.assign(offsets.begin(), offsets.end());
+    resultSizes.assign(sizes.begin(), sizes.end());
+    return success();
+  }
+  return failure();
+}
+
+LogicalResult SoftmaxOp::fold(ArrayRef<Attribute>,
+                              SmallVectorImpl<OpFoldResult> &) {
+  return memref::foldMemRefCast(*this);
+}
+
+LogicalResult
+SoftmaxOp::reifyResultShapes(OpBuilder &b,
+                             ReifiedRankedShapedTypeDims &reifiedReturnShapes) {
+  return cast<LinalgExtOp>(getOperation())
+      .reifyResultShapes(b, reifiedReturnShapes);
+}
+
 #define DEFINE_OP_GET_EFFECTS(OP_NAME)                                         \
   void OP_NAME::getEffects(                                                    \
       SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>      \
@@ -2776,6 +2876,7 @@ DEFINE_OP_GET_EFFECTS(PackOp)
 DEFINE_OP_GET_EFFECTS(UnPackOp)
 DEFINE_OP_GET_EFFECTS(WinogradInputTransformOp)
 DEFINE_OP_GET_EFFECTS(WinogradOutputTransformOp)
+DEFINE_OP_GET_EFFECTS(SoftmaxOp)
 
 //===----------------------------------------------------------------------===//
 // iree_linalg_ext.set_encoding

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_library(IREELinalgExtPasses
   ConvertConv2DToWinograd.cpp
   ConvertToLoops.cpp
+  DecomposeSoftmax.cpp
   FoldIntoPackAndUnpackOps.cpp
   MaterializeEncoding.cpp
   PadContractionToBlockSize.cpp

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/DecomposeSoftmax.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/DecomposeSoftmax.cpp
@@ -1,0 +1,183 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtDialect.h"
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/PassDetail.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
+#include "iree-dialects/Dialect/LinalgExt/Utils/Utils.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace LinalgExt {
+
+namespace {
+
+std::tuple<SmallVector<utils::IteratorType>, SmallVector<AffineMap>>
+computeIteratorTypesAndIndexingMaps(int64_t inputRank, int64_t dim,
+                                    OpBuilder &builder,
+                                    bool allParallel = false) {
+  SmallVector<utils::IteratorType> iteratorTypes(inputRank,
+                                                 utils::IteratorType::parallel);
+  if (!allParallel)
+    iteratorTypes[dim] = utils::IteratorType::reduction;
+  auto identityMap =
+      AffineMap::getMultiDimIdentityMap(inputRank, builder.getContext());
+  SmallVector<AffineExpr, 2> affineExprs;
+  for (int i = 0; i < inputRank; i++) {
+    if (i != dim)
+      affineExprs.push_back(mlir::getAffineDimExpr(i, builder.getContext()));
+  }
+  auto reductionMap =
+      AffineMap::get(inputRank, 0, affineExprs, builder.getContext());
+  SmallVector<AffineMap> indexingMaps{identityMap, reductionMap};
+  return std::make_tuple(iteratorTypes, indexingMaps);
+}
+
+template <typename T>
+static Value reduce(Value input, Value output, int64_t dim, Location loc,
+                    OpBuilder &builder) {
+  auto inputType = input.getType().cast<ShapedType>();
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  int64_t inputRank = inputShape.size();
+  auto [iteratorTypes, indexingMaps] =
+      computeIteratorTypesAndIndexingMaps(inputRank, dim, builder);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, output.getType(), input, output, indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value result = b.create<T>(loc, args[0], args[1]);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+static Value subtractAndExp(Value input, Value max, Value output, int64_t dim,
+                            Location loc, OpBuilder &builder) {
+  auto inputType = input.getType().cast<ShapedType>();
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  int64_t inputRank = inputShape.size();
+  auto [iteratorTypes, indexingMaps] =
+      computeIteratorTypesAndIndexingMaps(inputRank, dim, builder, true);
+  indexingMaps.push_back(indexingMaps[0]);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, input.getType(), ValueRange{input, max}, output, indexingMaps,
+      iteratorTypes, [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value diff = b.create<arith::SubFOp>(loc, args[0], args[1]);
+        Value result = b.create<math::ExpOp>(loc, diff);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+static Value computeSoftmax(Value numerator, Value denominator, Value output,
+                            int64_t dim, Location loc, OpBuilder &builder) {
+  auto inputType = numerator.getType().cast<ShapedType>();
+  ArrayRef<int64_t> inputShape = inputType.getShape();
+  int64_t inputRank = inputShape.size();
+  auto [iteratorTypes, indexingMaps] =
+      computeIteratorTypesAndIndexingMaps(inputRank, dim, builder, true);
+  indexingMaps.push_back(indexingMaps[0]);
+  auto genericOp = builder.create<linalg::GenericOp>(
+      loc, numerator.getType(), ValueRange{numerator, denominator}, output,
+      indexingMaps, iteratorTypes,
+      [&](OpBuilder &b, Location loc, ValueRange args) {
+        Value result = b.create<arith::DivFOp>(loc, args[0], args[1]);
+        b.create<linalg::YieldOp>(loc, result);
+      });
+  return genericOp.getResult(0);
+}
+
+/// Given an N-dimensional tensor x, this op converts
+/// softmax(x) to the following sequence of operations:
+///
+/// 1. Compute the max of x along dimension d. This results
+///    in a N-1 dimensional tensor m.
+///    m = max(x, dim = d)
+///
+/// 2. Subtract m from x and exponentiate. This results in
+///    a N dimensional tensor z.
+///    z = exp(x - m)
+///
+/// 3. Compute the sum of z along dimension d. This results in
+///    a N-1 dimensional tensor l.
+///    l = sum(z, dim = d)
+///
+/// 4. Divide z and l. This gives the N-dimensional softmax.
+///    softmax = z / l
+///
+LogicalResult convertSoftmaxToGenerics(func::FuncOp funcOp) {
+  IRRewriter rewriter(funcOp.getContext());
+  funcOp.walk([&](IREE::LinalgExt::SoftmaxOp softmaxOp) {
+    OpBuilder::InsertionGuard guard(rewriter);
+    rewriter.setInsertionPoint(softmaxOp);
+    Location loc = softmaxOp.getLoc();
+    Value input = softmaxOp.input();
+    ShapedType inputType = input.getType().cast<ShapedType>();
+    Type elementType = inputType.getElementType();
+    int64_t reductionDim = softmaxOp.getDimension();
+    SmallVector<OpFoldResult> dims =
+        tensor::createDimValues(rewriter, loc, input);
+    Value outputNd = rewriter.create<tensor::EmptyOp>(loc, dims, elementType);
+    dims.erase(dims.begin() + reductionDim);
+    // Compute max along dim
+    Value output = rewriter.create<tensor::EmptyOp>(loc, dims, elementType);
+    Value largeNegative = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getFloatAttr(elementType, -1.0e30));
+    Value negativeInit =
+        rewriter.create<linalg::FillOp>(loc, Value{largeNegative}, output)
+            .result();
+    Value max =
+        reduce<arith::MaxFOp>(input, negativeInit, reductionDim, loc, rewriter);
+    // Subtract max from input and exponentiate
+    Value numerator =
+        subtractAndExp(input, max, outputNd, reductionDim, loc, rewriter);
+    // Compute sum along dim
+    Value zero = rewriter.create<arith::ConstantOp>(
+        loc, rewriter.getZeroAttr(elementType));
+    Value zeroInit =
+        rewriter.create<linalg::FillOp>(loc, Value{zero}, output).result();
+    Value denominator =
+        reduce<arith::AddFOp>(numerator, zeroInit, reductionDim, loc, rewriter);
+    // Compute softmax
+    Value result = computeSoftmax(numerator, denominator, outputNd,
+                                  reductionDim, loc, rewriter);
+    softmaxOp.getResult()[0].replaceAllUsesWith(result);
+    return WalkResult::advance();
+  });
+  return success();
+}
+
+struct DecomposeSoftmaxPass : DecomposeSoftmaxBase<DecomposeSoftmaxPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry
+        .insert<linalg::LinalgDialect, IREE::LinalgExt::IREELinalgExtDialect>();
+  }
+  void runOnOperation() override {
+    MLIRContext *context = &getContext();
+    IRRewriter rewriter(context);
+    if (failed(convertSoftmaxToGenerics(getOperation())))
+      return signalPassFailure();
+  }
+};
+
+} // namespace
+
+std::unique_ptr<Pass> createDecomposeSoftmaxPass() {
+  return std::make_unique<DecomposeSoftmaxPass>();
+}
+
+} // namespace LinalgExt
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/decompose_softmax.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/decompose_softmax.mlir
@@ -1,0 +1,46 @@
+// RUN: iree-dialects-opt --split-input-file -iree-linalg-ext-decompose-softmax -cse %s | FileCheck %s
+
+func.func @softmax(%arg0: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
+  %0 = tensor.empty() : tensor<2x16x32xf32>
+  %1 = iree_linalg_ext.softmax dimension(2) ins(%arg0 : tensor<2x16x32xf32>) outs(%0: tensor<2x16x32xf32>) -> tensor<2x16x32xf32>
+  return %1 : tensor<2x16x32xf32>
+}
+
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0, d1, d2) -> (d0, d1)>
+// CHECK:      func.func @softmax(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<2x16x32xf32>
+// CHECK:        %[[D1:.+]] = tensor.empty() : tensor<2x16xf32>
+// CHECK:        %[[CST:.+]] = arith.constant -1.000000e+30 : f32
+// CHECK:        %[[D2:.+]] = linalg.fill ins(%[[CST]] : f32) outs(%[[D1]] : tensor<2x16xf32>) -> tensor<2x16xf32>
+// CHECK:        %[[D3:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:     "parallel", "reduction"]} ins(%[[ARG0]] : tensor<2x16x32xf32>) outs(%[[D2]] : tensor<2x16xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8:.+]] = arith.maxf %[[IN]], %[[OUT]] : f32
+// CHECK:          linalg.yield %[[D8]] : f32
+// CHECK:        } -> tensor<2x16xf32>
+// CHECK:        %[[D4:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP]]], iterator_types =
+// CHECK-SAME:     ["parallel", "parallel", "parallel"]} ins(%[[ARG0]], %[[D3]] : tensor<2x16x32xf32>, tensor<2x16xf32>)
+// CHECK-SAME:     outs(%[[D0]] : tensor<2x16x32xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[IN_1:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8]] = arith.subf %[[IN]], %[[IN_1]] : f32
+// CHECK:          %[[D9:.+]] = math.exp %[[D8]] : f32
+// CHECK:          linalg.yield %[[D9]] : f32
+// CHECK:        } -> tensor<2x16x32xf32>
+// CHECK:        %[[CST_0:.+]] = arith.constant 0.000000e+00 : f32
+// CHECK:        %[[D5:.+]] = linalg.fill ins(%[[CST_0]] : f32) outs(%[[D1]] : tensor<2x16xf32>) -> tensor<2x16xf32>
+// CHECK:        %[[D6:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]]], iterator_types = ["parallel",
+// CHECK-SAME:     "parallel", "reduction"]} ins(%[[D4]] : tensor<2x16x32xf32>) outs(%[[D5]] : tensor<2x16xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8]] = arith.addf %[[IN]], %[[OUT]] : f32
+// CHECK:          linalg.yield %[[D8]] : f32
+// CHECK:        } -> tensor<2x16xf32>
+// CHECK:        %[[D7:.+]] = linalg.generic {indexing_maps = [#[[MAP]], #[[MAP1]], #[[MAP]]], iterator_types =
+// CHECK-SAME:     ["parallel", "parallel", "parallel"]} ins(%[[D4]], %[[D6]] : tensor<2x16x32xf32>, tensor<2x16xf32>)
+// CHECK-SAME:     outs(%[[D0]] : tensor<2x16x32xf32>) {
+// CHECK:        ^bb0(%[[IN:.+]]: f32, %[[IN_1:.+]]: f32, %[[OUT:.+]]: f32):
+// CHECK:          %[[D8]] = arith.divf %[[IN]], %[[IN_1]] : f32
+// CHECK:          linalg.yield %[[D8]] : f32
+// CHECK:        } -> tensor<2x16x32xf32>
+// CHECK:        return %[[D7]] : tensor<2x16x32xf32>
+// CHECK:      }

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/invalid.mlir
@@ -722,3 +722,12 @@ func.func @illegal_winograd_output_image_dimensions(%arg0: tensor<8x8x1x2x2x32xf
 }
 
 // -----
+
+func.func @illegal_softmax_output_shape(%arg0: tensor<2x16x32xf32>) -> tensor<2x16xf32> {
+  %0 = tensor.empty() : tensor<2x16xf32>
+  // expected-error @+1 {{incompatible output shape}}
+  %1 = iree_linalg_ext.softmax dimension(2) ins(%arg0 : tensor<2x16x32xf32>) outs(%0: tensor<2x16xf32>) -> tensor<2x16xf32>
+  return %1 : tensor<2x16xf32>
+}
+
+// -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/roundtrip.mlir
@@ -1034,3 +1034,17 @@ func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x2x2x1280xf32>) -> 
 // CHECK:    }
 
 // -----
+
+func.func @softmax(%arg0: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
+  %0 = tensor.empty() : tensor<2x16x32xf32>
+  %1 = iree_linalg_ext.softmax dimension(2) ins(%arg0 : tensor<2x16x32xf32>) outs(%0: tensor<2x16x32xf32>) -> tensor<2x16x32xf32>
+  return %1 : tensor<2x16x32xf32>
+}
+// CHECK:      func.func @softmax(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<2x16x32xf32>) -> tensor<2x16x32xf32> {
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<2x16x32xf32>
+// CHECK:        %[[D1:.+]] = iree_linalg_ext.softmax dimension(2) ins(%[[ARG0]] : tensor<2x16x32xf32>) outs(%[[D0]] :
+// CHECK-SAME:     tensor<2x16x32xf32>) -> tensor<2x16x32xf32>
+// CHECK:        return %[[D1]] : tensor<2x16x32xf32>
+// CHECK:      }
+
+// -----

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/tiling.mlir
@@ -1505,3 +1505,94 @@ func.func @winograd_output_transform_nchw(%arg0: tensor<8x8x1x2x2x32xf32>) -> te
 // CHECK:    }
 
 // -----
+
+func.func @softmax(%arg0: tensor<16x64x256xf32>) -> tensor<16x64x256xf32> {
+  %0 = tensor.empty() : tensor<16x64x256xf32>
+  %1 = iree_linalg_ext.softmax {__internal_linalg_transform__ = "distribute_input"}
+         dimension(1) ins(%arg0 : tensor<16x64x256xf32>) outs(%0 : tensor<16x64x256xf32>) -> tensor<16x64x256xf32>
+  return %1 : tensor<16x64x256xf32>
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<()[s0] -> (s0 * 10)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (10, -d0 + s1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 30)>
+// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0)[s0, s1] -> (30, -d0 + s1)>
+// CHECK:      func.func @softmax(%[[ARG0:[a-zA-Z0-9_]+]]: tensor<16x64x256xf32>) -> tensor<16x64x256xf32> {
+// CHECK:        %[[C16:.+]] = arith.constant 16 : index
+// CHECK:        %[[C64:.+]] = arith.constant 64 : index
+// CHECK:        %[[C256:.+]] = arith.constant 256 : index
+// CHECK:        %[[C10:.+]] = arith.constant 10 : index
+// CHECK:        %[[C30:.+]] = arith.constant 30 : index
+// CHECK:        %[[D0:.+]] = tensor.empty() : tensor<16x64x256xf32>
+// CHECK:        %[[D1:.+]] = iree_input.dispatch.workgroup.id[0] : index
+// CHECK:        %[[D2:.+]] = iree_input.dispatch.workgroup.count[0] : index
+// CHECK:        %[[D3:.+]] = iree_input.dispatch.workgroup.id[1] : index
+// CHECK:        %[[D4:.+]] = iree_input.dispatch.workgroup.count[1] : index
+// CHECK-DAG:      %[[D5:.+]] = affine.apply #[[MAP]]()[%[[D3]]]
+// CHECK-DAG:      %[[D6:.+]] = affine.apply #[[MAP]]()[%[[D4]]]
+// CHECK:        %[[D7:.+]] = scf.for %[[ARG1:[a-zA-Z0-9_]+]] = %[[D5]] to %[[C16]] step %[[D6]]
+// CHECK-SAME:     iter_args(%[[ARG2:[a-zA-Z0-9_]+]] = %[[D0]]) -> (tensor<16x64x256xf32>) {
+// CHECK-DAG:        %[[D8:.+]] = affine.min #[[MAP1]](%[[ARG1]])[%[[C10]], %[[C16]]]
+// CHECK-DAG:        %[[D9:.+]] = affine.apply #[[MAP2]]()[%[[D1]]]
+// CHECK-DAG:        %[[D10:.+]] = affine.apply #[[MAP2]]()[%[[D2]]]
+// CHECK:          %[[D11:.+]] = scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[D9]] to %[[C256]] step %[[D10]]
+// CHECK-SAME:       iter_args(%[[ARG4:[a-zA-Z0-9_]+]] = %[[ARG2]]) -> (tensor<16x64x256xf32>) {
+// CHECK-DAG:          %[[D12:.+]] = affine.min #[[MAP3]](%[[ARG3]])[%[[C30]], %[[C256]]]
+// CHECK:            %[[EXTRACTED_SLICE:.+]] = tensor.extract_slice %[[ARG0]][%[[ARG1]], 0, %[[ARG3]]] [%[[D8]],
+// CHECK-SAME:         %[[C64]], %[[D12]]] [1, 1, 1] : tensor<16x64x256xf32> to tensor<?x?x?xf32>
+// CHECK:            %[[EXTRACTED_SLICE_0:.+]] = tensor.extract_slice %[[D0]][%[[ARG1]], 0, %[[ARG3]]] [%[[D8]],
+// CHECK-SAME:         %[[C64]], %[[D12]]] [1, 1, 1] : tensor<16x64x256xf32> to tensor<?x?x?xf32>
+// CHECK:            %[[D13:.+]] = iree_linalg_ext.softmax {__internal_linalg_transform__ = "distribute_output"}
+// CHECK-SAME:         dimension(1) ins(%[[EXTRACTED_SLICE]] : tensor<?x?x?xf32>) outs(%[[EXTRACTED_SLICE_0]] :
+// CHECK-SAME:         tensor<?x?x?xf32>) -> tensor<?x?x?xf32>
+// CHECK:            %[[INSERTED_SLICE:.+]] = tensor.insert_slice %[[D13]] into %[[ARG4]][%[[ARG1]], 0, %[[ARG3]]]
+// CHECK-SAME:         [%[[D8]], %[[C64]], %[[D12]]] [1, 1, 1] : tensor<?x?x?xf32> into tensor<16x64x256xf32>
+// CHECK:            scf.yield %[[INSERTED_SLICE]] : tensor<16x64x256xf32>
+// CHECK:          }
+// CHECK:          scf.yield %[[D11]] : tensor<16x64x256xf32>
+// CHECK:        }
+// CHECK:        return %[[D7]] : tensor<16x64x256xf32>
+// CHECK:      }
+
+// -----
+
+func.func @softmax_memref(%arg0: memref<16x64x256xf32>, %arg1: memref<16x64x256xf32>) {
+  iree_linalg_ext.softmax {__internal_linalg_transform__ = "distribute_input"}
+    dimension(1) ins(%arg0 : memref<16x64x256xf32>) outs(%arg1 : memref<16x64x256xf32>)
+  return
+}
+// CHECK-DAG:  #[[MAP:.+]] = affine_map<()[s0] -> (s0 * 10)>
+// CHECK-DAG:  #[[MAP1:.+]] = affine_map<(d0)[s0, s1] -> (10, -d0 + s1)>
+// CHECK-DAG:  #[[MAP2:.+]] = affine_map<()[s0] -> (s0 * 30)>
+// CHECK-DAG:  #[[MAP3:.+]] = affine_map<(d0)[s0, s1] -> (30, -d0 + s1)>
+// CHECK:      func.func @softmax_memref(%[[ARG0:[a-zA-Z0-9_]+]]: memref<16x64x256xf32>, %[[ARG1:[a-zA-Z0-9_]+]]:
+// CHECK-SAME:   memref<16x64x256xf32>) {
+// CHECK:        %[[C16:.+]] = arith.constant 16 : index
+// CHECK:        %[[C64:.+]] = arith.constant 64 : index
+// CHECK:        %[[C256:.+]] = arith.constant 256 : index
+// CHECK:        %[[C10:.+]] = arith.constant 10 : index
+// CHECK:        %[[C30:.+]] = arith.constant 30 : index
+// CHECK:        %[[D0:.+]] = iree_input.dispatch.workgroup.id[0] : index
+// CHECK:        %[[D1:.+]] = iree_input.dispatch.workgroup.count[0] : index
+// CHECK:        %[[D2:.+]] = iree_input.dispatch.workgroup.id[1] : index
+// CHECK:        %[[D3:.+]] = iree_input.dispatch.workgroup.count[1] : index
+// CHECK-DAG:      %[[D4:.+]] = affine.apply #[[MAP]]()[%[[D2]]]
+// CHECK-DAG:      %[[D5:.+]] = affine.apply #[[MAP]]()[%[[D3]]]
+// CHECK:        scf.for %[[ARG2:[a-zA-Z0-9_]+]] = %[[D4]] to %[[C16]] step %[[D5]] {
+// CHECK-DAG:        %[[D6:.+]] = affine.min #[[MAP1]](%[[ARG2]])[%[[C10]], %[[C16]]]
+// CHECK-DAG:        %[[D7:.+]] = affine.apply #[[MAP2]]()[%[[D0]]]
+// CHECK-DAG:        %[[D8:.+]] = affine.apply #[[MAP2]]()[%[[D1]]]
+// CHECK:          scf.for %[[ARG3:[a-zA-Z0-9_]+]] = %[[D7]] to %[[C256]] step %[[D8]] {
+// CHECK-DAG:          %[[D9:.+]] = affine.min #[[MAP3]](%[[ARG3]])[%[[C30]], %[[C256]]]
+// CHECK:            %[[SUBVIEW:.+]] = memref.subview %[[ARG0]][%[[ARG2]], 0, %[[ARG3]]] [%[[D6]], %[[C64]], %[[D9]]]
+// CHECK-SAME:         [1, 1, 1] : memref<16x64x256xf32> to memref<?x?x?xf32, strided<[16384, 256, 1], offset: ?>>
+// CHECK:            %[[SUBVIEW_0:.+]] = memref.subview %[[ARG1]][%[[ARG2]], 0, %[[ARG3]]] [%[[D6]], %[[C64]], %[[D9]]]
+// CHECK-SAME:         [1, 1, 1] : memref<16x64x256xf32> to memref<?x?x?xf32, strided<[16384, 256, 1], offset: ?>>
+// CHECK:            iree_linalg_ext.softmax {__internal_linalg_transform__ = "distribute_output"} dimension(1)
+// CHECK-SAME:         ins(%[[SUBVIEW]] : memref<?x?x?xf32, strided<[16384, 256, 1], offset: ?>>) outs(%[[SUBVIEW_0]] :
+// CHECK-SAME:         memref<?x?x?xf32, strided<[16384, 256, 1], offset: ?>>)
+// CHECK:          }
+// CHECK:        }
+// CHECK:        return
+// CHECK:      }
+
+// -----

--- a/tests/e2e/linalg_ext_ops/BUILD
+++ b/tests/e2e/linalg_ext_ops/BUILD
@@ -20,6 +20,7 @@ iree_check_single_backend_test_suite(
             "reverse.mlir",
             "scan.mlir",
             "scatter.mlir",
+            "softmax.mlir",
             "sort.mlir",
             "top-k.mlir",
         ],
@@ -88,6 +89,7 @@ iree_check_single_backend_test_suite(
             "reverse.mlir",
             "scan.mlir",
             "scatter.mlir",
+            "softmax.mlir",
             "sort.mlir",
             "top-k.mlir",
             "unpack.mlir",
@@ -135,6 +137,7 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
+            "softmax.mlir",
             "winograd_input.mlir",
             "winograd_output.mlir",
         ],
@@ -164,6 +167,7 @@ iree_check_single_backend_test_suite(
             # Re-enable this once we have new devices with up-to-date drivers.
             "top-k.mlir",
             "scan.mlir",
+            "softmax.mlir",
         ],
     ),
     driver = "vulkan",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -17,6 +17,7 @@ iree_check_single_backend_test_suite(
     "reverse.mlir"
     "scan.mlir"
     "scatter.mlir"
+    "softmax.mlir"
     "sort.mlir"
     "top-k.mlir"
   TARGET_BACKEND
@@ -77,6 +78,7 @@ iree_check_single_backend_test_suite(
     "reverse.mlir"
     "scan.mlir"
     "scatter.mlir"
+    "softmax.mlir"
     "sort.mlir"
     "top-k.mlir"
     "unpack.mlir"

--- a/tests/e2e/linalg_ext_ops/softmax.mlir
+++ b/tests/e2e/linalg_ext_ops/softmax.mlir
@@ -1,0 +1,14 @@
+func.func @softmax() {
+  %input = util.unfoldable_constant dense<1.0> : tensor<2x8x4xf32>
+
+  %init = tensor.empty() : tensor<2x8x4xf32>
+  %1 = iree_linalg_ext.softmax dimension(2)
+       ins(%input : tensor<2x8x4xf32>)
+       outs(%init : tensor<2x8x4xf32>) -> tensor<2x8x4xf32>
+  %2 = flow.tensor.reshape %1 : tensor<2x8x4xf32> -> tensor<2x8x4xf32>
+  check.expect_almost_eq_const(
+      %2,
+      dense<0.25> : tensor<2x8x4xf32>
+  ) : tensor<2x8x4xf32>
+  return
+}

--- a/tests/e2e/linalg_ext_ops/softmax.mlir
+++ b/tests/e2e/linalg_ext_ops/softmax.mlir
@@ -5,9 +5,8 @@ func.func @softmax() {
   %1 = iree_linalg_ext.softmax dimension(2)
        ins(%input : tensor<2x8x4xf32>)
        outs(%init : tensor<2x8x4xf32>) -> tensor<2x8x4xf32>
-  %2 = flow.tensor.reshape %1 : tensor<2x8x4xf32> -> tensor<2x8x4xf32>
   check.expect_almost_eq_const(
-      %2,
+      %1,
       dense<0.25> : tensor<2x8x4xf32>
   ) : tensor<2x8x4xf32>
   return


### PR DESCRIPTION
This patch adds the softmax op to the linalg ext dialect. It also adds a lowering that decomposes the softmax into a sequence of linalg generic ops. Finally, we add the pass into the CPU and CUDA pipeline along with an e2e test to validate functional accuracy.