### PR TITLE
[Transform] Fix perf regression in the dynamic case and add a test

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -97,6 +97,48 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 // -----
 
 
+hal.executable @group_reduction_D {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @group_reduction_D ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @group_reduction_D() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant -0.000000e+00 : f32
+      %d0i = hal.interface.constant.load[0] : i32
+      %d0 = arith.index_castui %d0i : i32 to index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<readonly:tensor<8x?xf32>>{%d0}
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) : !flow.dispatch.tensor<writeonly:tensor<8xf32>>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [8, %d0], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<8x?xf32>>{%d0} -> tensor<8x?xf32>
+      %3 = tensor.empty() : tensor<8xf32>
+      %4 = linalg.fill ins(%cst : f32) outs(%3 : tensor<8xf32>) -> tensor<8xf32>
+      %5 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0)>], iterator_types = ["parallel", "reduction"]} ins(%2 : tensor<8x?xf32>) outs(%4 : tensor<8xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %6 = arith.addf %in, %out : f32
+        linalg.yield %6 : f32
+      } -> tensor<8xf32>
+      flow.dispatch.tensor.store %5, %1, offsets = [0], sizes = [8], strides = [1] : tensor<8xf32> -> !flow.dispatch.tensor<writeonly:tensor<8xf32>>
+      return
+    }
+  }
+}
+}
+
+// Overall, the schedule is same as above, but with larger tile sizes.
+// Checking only the tile sizes.
+
+//   CHECK-LABEL: func.func @group_reduction_D
+//         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
+//         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 256], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
+//         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [256, 1, 1]}
+//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 64 : i64}
+
+// -----
+
+
 hal.executable @group_reduction_34 {
 hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
   hal.executable.export public @group_reduction_34 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -325,11 +325,11 @@ static ReductionConfig getReductionConfig(
   // Since this mode does not coalesce reads, perf will suffer
   // catastrophically on larger runtime reduction.
   // TODO: explicit hint from above that we really want to do that.
-  int64_t reductionDimensionSize = captures.reductionOpSizes.back();
-  bool isDynamicReduction = ShapedType::isDynamic(reductionDimensionSize);
+  int64_t redSize = captures.reductionOpSizes.back();
+  bool isDynamicReduction = ShapedType::isDynamic(redSize);
   // Otherwise, still only support the small cases for now and fall back to
   // other strategies otherwise.
-  bool isSmallReduction = (reductionDimensionSize < 2 * kCudaWarpSize);
+  bool isSmallReduction = (redSize < 2 * kCudaWarpSize);
   if (!isDynamicReduction && isSmallReduction) {
     int64_t maxNumThreads = 4 * kCudaWarpSize;
     return ReductionConfig{maxNumThreads, 0, ReductionStrategy::Small};
@@ -343,9 +343,9 @@ static ReductionConfig getReductionConfig(
   int64_t maxNumThreads = 8 * kCudaWarpSize;
   // No adjustments in the dynamic case, we need extra information to make a
   // good decision.
-  int64_t redSize = captures.reductionOpSizes.back();
   if (ShapedType::isDynamic(redSize))
-    return ReductionConfig{maxNumThreads, vectorSize};
+    return ReductionConfig{maxNumThreads, vectorSize,
+                           ReductionStrategy::Staged};
   // Scale down to smaller sizes (4, 8, 16)-warps.
   if (scaleUpByBitWidth(redSize, bitWidth) <= 4 * kCudaWarpSize) {
     vectorSize = scaleUpByBitWidth(1, bitWidth);


### PR DESCRIPTION
d782f54f56def442105656cace5643666acd9b89 introduced a regression while refactoring: the SmallStrategy would be selected by default for dynamic cases.

Fix and add a test.

Ideally we should also have some microbenchmarkings part of presubmit.

Repro:
```
(benchmark-transform-create -r -b cuda  ../iree-samples/transform_dialect/benchmark_linalg_reductions.stub.mlir   reduction_2d_dynamic  f32 128 4096)
```

Before:
```
403.76ms  202.76us              (2 1 1)        (64 1 1)        56        0B        0B  NVIDIA GeForce          1        13                     -                -  reduction_2d_dynamic_dispatch_0_generic_DxD [33]
With transform dialect: reduction_2d_dynamic --function_input="128x4096xf32=1" P50: 202800.00 ns 2.64836291913214990138 GElements/s
```

After:
```
449.43ms  4.8640us            (128 1 1)       (256 1 1)        22        0B  1.0078KB  NVIDIA GeForce          1        13                     -                -  reduction_2d_dynamic_dispatch_0_generic_DxD [33]
With transform dialect: reduction_2d_dynamic --function_input="128x4096xf32=1" P50: 4608.0000 ns 116.55555555555555555555 GElements/s
```