### PR TITLE
Adding debug information to LLVM CPU codegen outputs.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -16,6 +16,7 @@ iree_compiler_cc_library(
     name = "LLVMCPU",
     srcs = [
         "ConvertToLLVM.cpp",
+        "DispatchABI.cpp",
         "KernelDispatch.cpp",
         "LLVMCPUAssignConstantOrdinals.cpp",
         "LLVMCPUAssignImportOrdinals.cpp",
@@ -33,6 +34,7 @@ iree_compiler_cc_library(
         "VerifyLinalgTransformLegality.cpp",
     ],
     hdrs = [
+        "DispatchABI.h",
         "KernelDispatch.h",
         "TargetMLTransformInfo.h",
     ],
@@ -57,6 +59,7 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialectPasses",
+        "@llvm-project//llvm:BinaryFormat",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineToStandard",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -14,10 +14,12 @@ iree_cc_library(
   NAME
     LLVMCPU
   HDRS
+    "DispatchABI.h"
     "KernelDispatch.h"
     "TargetMLTransformInfo.h"
   SRCS
     "ConvertToLLVM.cpp"
+    "DispatchABI.cpp"
     "KernelDispatch.cpp"
     "LLVMCPUAssignConstantOrdinals.cpp"
     "LLVMCPUAssignImportOrdinals.cpp"
@@ -38,6 +40,7 @@ iree_cc_library(
     IREELinalgExtPasses
     IREELinalgTransformDialect
     IREELinalgTransformDialectPasses
+    LLVMBinaryFormat
     LLVMSupport
     MLIRAffineDialect
     MLIRAffineToStandard

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/ConvertToLLVM.cpp
@@ -4,6 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
@@ -55,725 +56,14 @@ namespace iree_compiler {
 
 namespace {
 
-// NOTE: HALDispatchABI and the associated conversion patterns should live under
-// iree/compiler/Dialect/HAL/Target/LLVM/ instead of here as they have nothing
-// to do with linalg. If we need to use the patterns in this conversion we can
-// expose a populate*Patterns() function to access them without needing them
-// defined here.
-
-// Utility for accessing the IREE HAL dispatch function ABI values.
-// All accesses should route through this vs directly manipulating LLVM function
-// arguments so that we can adjust the ABI over time and support multiple
-// versions in the same compiled output.
-class HALDispatchABI {
- public:
-  // Matches the field order in iree_hal_processor_v0_t.
-  enum class ProcessorField {
-    data = 0,
-  };
-
-  // Matches IREE_HAL_PROCESSOR_DATA_CAPACITY_V0.
-  static constexpr int ProcessorDataCapacity = 8;
-
-  // Returns a Type representing iree_hal_processor_v0_t.
-  static LLVM::LLVMStructType getProcessorType(
-      MLIRContext *context, LLVMTypeConverter *typeConverter) {
-    llvm::sys::ScopedLock lock(sMutex);
-    auto structType =
-        LLVM::LLVMStructType::getIdentified(context, "iree_hal_processor_v0_t");
-    if (structType.isInitialized()) return structType;
-
-    auto uint64Type = IntegerType::get(context, 64);
-    SmallVector<Type> fieldTypes;
-
-    // uint64_t data[IREE_HAL_PROCESSOR_DATA_CAPACITY_V0];
-    fieldTypes.push_back(
-        LLVM::LLVMArrayType::get(uint64Type, ProcessorDataCapacity));
-
-    LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
-    assert(succeeded(bodySet) &&
-           "could not set the body of an identified struct");
-    (void)bodySet;
-
-    return structType;
-  }
-
-  // Matches the field order in iree_hal_executable_environment_v0_t.
-  enum class EnvironmentField {
-    constants,
-    import_thunk,
-    import_funcs,
-    import_contexts,
-    processor,
-  };
-
-  // Returns a Type representing iree_hal_executable_environment_v0_t.
-  static LLVM::LLVMStructType getEnvironmentType(
-      MLIRContext *context, LLVMTypeConverter *typeConverter,
-      LLVM::LLVMStructType processorType) {
-    llvm::sys::ScopedLock lock(sMutex);
-    auto structType = LLVM::LLVMStructType::getIdentified(
-        context, "iree_hal_executable_environment_v0_t");
-    if (structType.isInitialized()) return structType;
-
-    auto int8Type = IntegerType::get(context, 8);
-    auto uint32Type = IntegerType::get(context, 32);
-    auto int8PtrType = LLVM::LLVMPointerType::get(int8Type);
-    auto uint32PtrType = LLVM::LLVMPointerType::get(uint32Type);
-    SmallVector<Type, 4> fieldTypes;
-
-    // const uint32_t* constants;
-    fieldTypes.push_back(uint32PtrType);
-
-    // iree_hal_executable_import_thunk_v0_t import_thunk;
-    // const iree_hal_executable_import_v0_t* import_funcs;
-    // const void** import_contexts;
-    auto importType = LLVM::LLVMFunctionType::get(
-        uint32Type, {int8PtrType, int8PtrType, int8PtrType});
-    auto importPtrType = LLVM::LLVMPointerType::get(importType);
-    auto importThunkType = LLVM::LLVMFunctionType::get(
-        uint32Type, {importPtrType, int8PtrType, int8PtrType, int8PtrType});
-    fieldTypes.push_back(LLVM::LLVMPointerType::get(importThunkType));
-    fieldTypes.push_back(LLVM::LLVMPointerType::get(importPtrType));
-    fieldTypes.push_back(LLVM::LLVMPointerType::get(int8PtrType));
-
-    // iree_hal_processor_v0_t processor;
-    fieldTypes.push_back(processorType);
-
-    LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
-    assert(succeeded(bodySet) &&
-           "could not set the body of an identified struct");
-    (void)bodySet;
-
-    return structType;
-  }
-
-  // Matches the field order in iree_hal_executable_dispatch_state_v0_t.
-  enum class DispatchStateField {
-    /*uint32_t*/ workgroup_size_x,
-    /*uint32_t*/ workgroup_size_y,
-    /*uint16_t*/ workgroup_size_z,
-    /*uint16_t*/ push_constant_count,
-    /*uint32_t*/ workgroup_count_x,
-    /*uint32_t*/ workgroup_count_y,
-    /*uint16_t*/ workgroup_count_z,
-    /*uint8_t*/ max_concurrency,
-    /*uint8_t*/ binding_count,
-    /*intptr_t*/ push_constants,
-    /*intptr_t*/ binding_ptrs,
-    /*intptr_t*/ binding_lengths,
-  };
-  friend DispatchStateField operator+(DispatchStateField lhs, int32_t rhs) {
-    return static_cast<DispatchStateField>(static_cast<int32_t>(lhs) + rhs);
-  }
-
-  // Returns a Type representing iree_hal_executable_dispatch_state_v0_t.
-  static LLVM::LLVMStructType getDispatchStateType(
-      MLIRContext *context, LLVMTypeConverter *typeConverter) {
-    llvm::sys::ScopedLock lock(sMutex);
-    auto structType = LLVM::LLVMStructType::getIdentified(
-        context, "iree_hal_executable_dispatch_state_v0_t");
-    if (structType.isInitialized()) return structType;
-
-    auto indexType = typeConverter->convertType(IndexType::get(context));
-    auto int8Type = IntegerType::get(context, 8);
-    auto uint8Type = IntegerType::get(context, 8);
-    auto uint16Type = IntegerType::get(context, 16);
-    auto uint32Type = IntegerType::get(context, 32);
-    auto int8PtrType = LLVM::LLVMPointerType::get(int8Type);
-    auto uint32PtrType = LLVM::LLVMPointerType::get(uint32Type);
-    SmallVector<Type, 4> fieldTypes;
-
-    // uint32_t workgroup_size_x;
-    // uint32_t workgroup_size_y;
-    // uint16_t workgroup_size_z;
-    fieldTypes.push_back(uint32Type);
-    fieldTypes.push_back(uint32Type);
-    fieldTypes.push_back(uint16Type);
-
-    // uint16_t push_constant_count;
-    fieldTypes.push_back(uint16Type);
-
-    // uint32_t workgroup_count_x;
-    // uint32_t workgroup_count_y;
-    // uint16_t workgroup_count_z;
-    fieldTypes.push_back(uint32Type);
-    fieldTypes.push_back(uint32Type);
-    fieldTypes.push_back(uint16Type);
-
-    // uint8_t max_concurrency;
-    fieldTypes.push_back(uint8Type);
-
-    // uint8_t binding_count;
-    fieldTypes.push_back(uint8Type);
-
-    // const uint32_t * push_constants;
-    fieldTypes.push_back(uint32PtrType);
-    // void *const * binding_ptrs;
-    // const size_t * binding_lengths;
-    fieldTypes.push_back(LLVM::LLVMPointerType::get(int8PtrType));
-    fieldTypes.push_back(LLVM::LLVMPointerType::get(indexType));
-
-    LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
-    assert(succeeded(bodySet) &&
-           "could not set the body of an identified struct");
-    (void)bodySet;
-
-    return structType;
-  }
-
-  enum class WorkgroupStateField {
-    /*uint32_t*/ workgroup_id_x = 0,
-    /*uint32_t*/ workgroup_id_y,
-    /*uint16_t*/ workgroup_id_z,
-    /*uint16_t*/ reserved,
-    /*uint32_t*/ processor_id,
-    /*intptr_t*/ local_memory,
-    /*uint32_t*/ local_memory_size,
-  };
-  friend WorkgroupStateField operator+(WorkgroupStateField lhs, int32_t rhs) {
-    return static_cast<WorkgroupStateField>(static_cast<int32_t>(lhs) + rhs);
-  }
-
-  // Returns a Type representing iree_hal_executable_workgroup_state_v0_t.
-  static LLVM::LLVMStructType getWorkgroupStateType(
-      MLIRContext *context, LLVMTypeConverter *typeConverter) {
-    llvm::sys::ScopedLock lock(sMutex);
-    auto structType = LLVM::LLVMStructType::getIdentified(
-        context, "iree_hal_executable_workgroup_state_v0_t");
-    if (structType.isInitialized()) return structType;
-
-    auto int8Type = IntegerType::get(context, 8);
-    auto uint16Type = IntegerType::get(context, 16);
-    auto uint32Type = IntegerType::get(context, 32);
-    auto int8PtrType = LLVM::LLVMPointerType::get(int8Type);
-    SmallVector<Type, 4> fieldTypes;
-
-    // uint32_t workgroup_id_x;
-    // uint32_t workgroup_id_y;
-    // uint16_t workgroup_id_z;
-    fieldTypes.push_back(uint32Type);
-    fieldTypes.push_back(uint32Type);
-    fieldTypes.push_back(uint16Type);
-
-    // uint16_t reserved;
-    fieldTypes.push_back(uint16Type);
-
-    // uint32_t processor_id;
-    fieldTypes.push_back(uint32Type);
-
-    // void* local_memory;
-    // uint32_t local_memory_size;
-    fieldTypes.push_back(LLVM::LLVMPointerType::get(int8PtrType));
-    fieldTypes.push_back(uint32Type);
-
-    LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
-    assert(succeeded(bodySet) &&
-           "could not set the body of an identified struct");
-    (void)bodySet;
-
-    return structType;
-  }
-
-  // Returns the types of the LLVM function inputs for the ABI.
-  // This matches the signature of `iree_hal_executable_dispatch_v0_t` in
-  // `iree/hal/local/executable_library.h`.
-  static SmallVector<Type, 5> getInputTypes(MLIRContext *context,
-                                            LLVMTypeConverter *typeConverter) {
-    auto environmentType = LLVM::LLVMStructType::getIdentified(
-        context, "iree_hal_executable_environment_v0_t");
-    assert(environmentType &&
-           "environment type must be defined by ConvertToLLVM");
-    auto dispatchStateType = LLVM::LLVMStructType::getIdentified(
-        context, "iree_hal_executable_dispatch_state_v0_t");
-    assert(dispatchStateType &&
-           "dispatch state type must be defined by ConvertToLLVM");
-    auto workgroupStateType = LLVM::LLVMStructType::getIdentified(
-        context, "iree_hal_executable_workgroup_state_v0_t");
-    assert(workgroupStateType &&
-           "workgroup state type must be defined by ConvertToLLVM");
-    return SmallVector<Type, 5>{
-        // const iree_hal_executable_environment_v0_t* IREE_RESTRICT
-        //   environment
-        LLVM::LLVMPointerType::get(environmentType),
-        // const iree_hal_executable_dispatch_state_v0_t* IREE_RESTRICT
-        //   dispatch_state
-        LLVM::LLVMPointerType::get(dispatchStateType),
-        // const iree_hal_executable_workgroup_state_v0_t* IREE_RESTRICT
-        //   workgroup_state
-        LLVM::LLVMPointerType::get(workgroupStateType),
-    };
-  }
-
-  explicit HALDispatchABI(LLVM::LLVMFuncOp &funcOp,
-                          LLVMTypeConverter *typeConverter)
-      : funcOp(funcOp),
-        typeConverter(typeConverter),
-        processorType(getProcessorType(funcOp.getContext(), typeConverter)),
-        environmentType(getEnvironmentType(funcOp.getContext(), typeConverter,
-                                           processorType)),
-        dispatchStateType(
-            getDispatchStateType(funcOp.getContext(), typeConverter)),
-        workgroupStateType(
-            getWorkgroupStateType(funcOp.getContext(), typeConverter)) {}
-
-  LLVM::LLVMFuncOp getFuncOp() { return funcOp; }
-
-  // Loads the workgroup_id[dim] value (XYZ) and casts it to |resultType|.
-  Value loadWorkgroupID(Location loc, int32_t dim, Type resultType,
-                        OpBuilder &builder) {
-    auto dimValue =
-        loadFieldValue(loc, WorkgroupStateField::workgroup_id_x + dim, builder);
-    return castValueToType(loc, dimValue, resultType, builder);
-  }
-
-  // Loads the workgroup_count[dim] value (XYZ) and casts it to |resultType|.
-  Value loadWorkgroupCount(Location loc, int32_t dim, Type resultType,
-                           OpBuilder &builder) {
-    auto dimValue = loadFieldValue(
-        loc, DispatchStateField::workgroup_count_x + dim, builder);
-    return castValueToType(loc, dimValue, resultType, builder);
-  }
-
-  // Loads the workgroup_size[dim] value (XYZ) and casts it to |resultType|.
-  Value loadWorkgroupSize(Location loc, int32_t dim, Type resultType,
-                          OpBuilder &builder) {
-    auto dimValue = loadFieldValue(
-        loc, DispatchStateField::workgroup_size_x + dim, builder);
-    return castValueToType(loc, dimValue, resultType, builder);
-  }
-
-  // Returns the estimated maximum concurrency as an index-converted type.
-  Value loadMaxConcurrency(Location loc, OpBuilder &builder) {
-    auto value =
-        loadFieldValue(loc, DispatchStateField::max_concurrency, builder);
-    return castValueToType(loc, value,
-                           typeConverter->convertType(builder.getIndexType()),
-                           builder);
-  }
-
-  // Returns the total number of bytes available in workgroup local memory.
-  // This may be larger than the requested size.
-  Value loadWorkgroupLocalMemorySize(Location loc, OpBuilder &builder) {
-    auto value =
-        loadFieldValue(loc, WorkgroupStateField::local_memory_size, builder);
-    return castValueToType(loc, value,
-                           typeConverter->convertType(builder.getIndexType()),
-                           builder);
-  }
-
-  // Loads the base pointer of the workgroup local memory.
-  // Note that this may be NULL if no workgroup local memory was requested.
-  Value loadWorkgroupLocalMemoryPtr(Location loc, OpBuilder &builder) {
-    return loadFieldValue(loc, WorkgroupStateField::local_memory, builder);
-  }
-
-  // Returns the total push constant count as an index-converted type.
-  Value loadPushConstantCount(Location loc, OpBuilder &builder) {
-    auto value =
-        loadFieldValue(loc, DispatchStateField::push_constant_count, builder);
-    return castValueToType(loc, value,
-                           typeConverter->convertType(builder.getIndexType()),
-                           builder);
-  }
-
-  // Loads a push constant at |offset| and casts it to |resultType|.
-  Value loadPushConstant(Location loc, int64_t offset, Type resultType,
-                         OpBuilder &builder) {
-    auto constantsPtrValue =
-        loadFieldValue(loc, DispatchStateField::push_constants, builder);
-    auto offsetValue = getIndexValue(loc, offset, builder);
-    Value constantPtrValue = builder.create<LLVM::GEPOp>(
-        loc, constantsPtrValue.getType(), constantsPtrValue, offsetValue);
-    Value constantValue = builder.create<LLVM::LoadOp>(loc, constantPtrValue);
-    return castValueToType(loc, constantValue, resultType, builder);
-  }
-
-  // Returns the total binding count as an index-converted type.
-  Value loadBindingCount(Location loc, OpBuilder &builder) {
-    auto value =
-        loadFieldValue(loc, DispatchStateField::binding_count, builder);
-    return castValueToType(loc, value,
-                           typeConverter->convertType(builder.getIndexType()),
-                           builder);
-  }
-
-  // Loads the base pointer of the binding |ordinal| as an `i8**`.
-  // Equivalent to:
-  //   int8_t** base_ptr = &state->binding_ptrs[ordinal];
-  Value loadBindingPtr(Location loc, int64_t ordinal, OpBuilder &builder) {
-    auto ptrsPtrValue =
-        loadFieldValue(loc, DispatchStateField::binding_ptrs, builder);
-    auto ordinalValue = getIndexValue(loc, ordinal, builder);
-    auto elementPtrValue = builder.createOrFold<LLVM::GEPOp>(
-        loc, ptrsPtrValue.getType(), ptrsPtrValue, ordinalValue);
-    return builder.createOrFold<LLVM::LoadOp>(loc, elementPtrValue);
-  }
-
-  // Loads the byte length of the binding |ordinal| as an index-converted type.
-  Value loadBindingLength(Location loc, int64_t ordinal, OpBuilder &builder) {
-    auto lengthsPtrValue =
-        loadFieldValue(loc, DispatchStateField::binding_lengths, builder);
-    auto ordinalValue = getIndexValue(loc, ordinal, builder);
-    auto elementPtrValue = builder.createOrFold<LLVM::GEPOp>(
-        loc, lengthsPtrValue.getType(), lengthsPtrValue, ordinalValue);
-    return builder.createOrFold<LLVM::LoadOp>(loc, elementPtrValue);
-  }
-
-  // Loads a binding as a constructed MemRefDescriptor.
-  // |baseOffset| can optionally adjust the base byte offset of the buffer.
-  MemRefDescriptor loadBinding(Location loc, int64_t ordinal,
-                               Value baseOffsetValue, MemRefType memRefType,
-                               ValueRange dynamicDims, OpBuilder &builder) {
-    // Load the base buffer pointer in the appropriate type (f32*, etc).
-    Value basePtrValue = loadBindingPtr(loc, ordinal, builder);
-
-    // Adjust by baseOffset (if needed).
-    if (baseOffsetValue) {
-      basePtrValue = builder.createOrFold<LLVM::GEPOp>(
-          loc, basePtrValue.getType(), basePtrValue, baseOffsetValue);
-    }
-
-    // NOTE: if we wanted to check the range was in bounds here would be the
-    // place to do it.
-
-    // Cast to the desired memref element type.
-    auto elementType = typeConverter->convertType(memRefType.getElementType());
-    Value typedPtrValue = builder.createOrFold<LLVM::BitcastOp>(
-        loc,
-        LLVM::LLVMPointerType::get(elementType,
-                                   memRefType.getMemorySpaceAsInt()),
-        basePtrValue);
-
-    // Construct the MemRefDescriptor type based on the information we have.
-    // NOTE: we could use the binding length to clamp this/check that the
-    // requested range is valid.
-    if (memRefType.hasStaticShape()) {
-      return MemRefDescriptor::fromStaticShape(builder, loc, *typeConverter,
-                                               memRefType, typedPtrValue);
-    } else {
-      assert(memRefType.getNumDynamicDims() == dynamicDims.size());
-      int64_t rank = memRefType.getRank();
-
-      // Build MemRef descriptor for this interface binding.
-      auto desc = MemRefDescriptor::undef(
-          builder, loc, typeConverter->convertType(memRefType));
-      desc.setAllocatedPtr(builder, loc, typedPtrValue);
-      desc.setAlignedPtr(builder, loc, typedPtrValue);
-      desc.setConstantOffset(builder, loc, 0);
-
-      // Update memref descriptor shape. Dynamic dimensions can be mixed with
-      // static dimensions, like [128, ?, 128].
-      int dynamicDimIndex = 0;
-      for (int i = 0; i < rank; ++i) {
-        if (memRefType.isDynamicDim(i)) {
-          desc.setSize(builder, loc, i, dynamicDims[dynamicDimIndex++]);
-        } else {
-          desc.setConstantSize(builder, loc, i, memRefType.getDimSize(i));
-        }
-      }
-
-      // Compute and update strides. Assume that MemRefs are row-major, that is,
-      // following index linearization:
-      //   x[i, j, k] = i * x.dim[1] * x.dim[2] + j * x.dim[2] + k
-      desc.setConstantStride(builder, loc, rank - 1, 1);
-      for (int i = rank - 2; i >= 0; --i) {
-        auto stride = desc.stride(builder, loc, i + 1);
-        auto dim = desc.size(builder, loc, i + 1);
-        Value strideVal = builder.create<LLVM::MulOp>(loc, stride, dim);
-        desc.setStride(builder, loc, i, strideVal);
-      }
-
-      return desc;
-    }
-  }
-
-  // Loads the processor ID the code is (most likely) being run on.
-  // Equivalent to:
-  //   uint32_t processor_id = state->processor_id;
-  Value loadProcessorID(Location loc, OpBuilder &builder) {
-    return loadFieldValue(loc, WorkgroupStateField::processor_id, builder);
-  }
-
-  // Loads a processor information data field at the given index.
-  // May be 0 if the field is not available.
-  Value loadProcessorData(Location loc, int64_t index, OpBuilder &builder) {
-    // Load the value; it should always be in bounds.
-    Value dataArrayValue = loadFieldValue(loc, ProcessorField::data, builder);
-    SmallVector<int64_t, 1> position = {index};
-    Value dataValue =
-        builder.create<LLVM::ExtractValueOp>(loc, dataArrayValue, position);
-    return dataValue;
-  }
-
-  // Loads an executable constant with |key| and casts it to |resultType|.
-  // A placeholder global will be added for the ordinal.
-  Value loadExecutableConstant(Location loc, StringRef key, Type resultType,
-                               OpBuilder &builder) {
-    // Create top-level global placeholder.
-    // The magic attribute is used by future assignment passes.
-    std::string globalName = ("__constant_ordinal_" + key).str();
-    auto moduleOp =
-        builder.getInsertionPoint()->getParentOfType<mlir::ModuleOp>();
-    LLVM::GlobalOp globalOp;
-    if (!(globalOp = moduleOp.lookupSymbol<LLVM::GlobalOp>(globalName))) {
-      auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
-      globalOp = moduleBuilder.create<LLVM::GlobalOp>(loc, builder.getI32Type(),
-                                                      /*isConstant=*/false,
-                                                      LLVM::Linkage::Internal,
-                                                      globalName, Attribute{});
-      globalOp->setAttr(IREE::HAL::ExecutableConstantBlockOp::getKeyAttrName(),
-                        builder.getStringAttr(key));
-    }
-
-    // Load the placeholder global ordinal.
-    Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, globalOp);
-    Value ordinalValue = builder.create<LLVM::LoadOp>(loc, globalPtr);
-
-    // Load constant from the executable constants struct.
-    auto constantsPtrValue =
-        loadFieldValue(loc, EnvironmentField::constants, builder);
-    Value constantPtrValue = builder.create<LLVM::GEPOp>(
-        loc, constantsPtrValue.getType(), constantsPtrValue, ordinalValue);
-    Value constantValue = builder.create<LLVM::LoadOp>(loc, constantPtrValue);
-    return castValueToType(loc, constantValue, resultType, builder);
-  }
-
-  // Loads the ordinal of the import with the given |importName|.
-  // A placeholder global will be inserted that will be updated with the
-  // assigned ordinal after linking.
-  Value loadImportOrdinal(Location loc, StringRef importName, bool weak,
-                          OpBuilder &builder) {
-    // Create top-level global placeholder.
-    // The magic attribute is used by future assignment passes.
-    std::string globalName = ("__import_ordinal_" + importName).str();
-    auto moduleOp =
-        builder.getInsertionPoint()->getParentOfType<mlir::ModuleOp>();
-    LLVM::GlobalOp globalOp;
-    if (!(globalOp = moduleOp.lookupSymbol<LLVM::GlobalOp>(globalName))) {
-      auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
-      globalOp = moduleBuilder.create<LLVM::GlobalOp>(loc, builder.getI32Type(),
-                                                      /*isConstant=*/false,
-                                                      LLVM::Linkage::Internal,
-                                                      globalName, Attribute{});
-      globalOp->setAttr("hal.executable.import.key",
-                        builder.getStringAttr(importName));
-      if (weak) {
-        globalOp->setAttr("hal.executable.import.weak", builder.getUnitAttr());
-      }
-    }
-
-    // Load the placeholder global ordinal.
-    Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, globalOp);
-    return builder.create<LLVM::LoadOp>(loc, globalPtr);
-  }
-
-  // Loads the import function pointer of the import |ordinal|.
-  // Equivalent to:
-  //   iree_hal_executable_import_v0_t fn_ptr = state->import_funcs[ordinal];
-  //   void* context = state->import_contexts[ordinal];
-  std::pair<Value, Value> loadImportFunc(Location loc, Value importOrdinal,
-                                         OpBuilder &builder) {
-    auto funcPtrsValue =
-        loadFieldValue(loc, EnvironmentField::import_funcs, builder);
-    auto funcPtrValue = builder.createOrFold<LLVM::GEPOp>(
-        loc, funcPtrsValue.getType(), funcPtrsValue, importOrdinal);
-    auto contextPtrsValue =
-        loadFieldValue(loc, EnvironmentField::import_contexts, builder);
-    auto contextPtrValue = builder.createOrFold<LLVM::GEPOp>(
-        loc, contextPtrsValue.getType(), contextPtrsValue, importOrdinal);
-    return std::make_pair(
-        builder.createOrFold<LLVM::LoadOp>(loc, funcPtrValue),
-        builder.createOrFold<LLVM::LoadOp>(loc, contextPtrValue));
-  }
-
-  // Returns an i1 indicating whether the optional import with |importName| is
-  // defined. Equivalent to:
-  //   state->import_funcs[ordinal] != NULL
-  Value isImportFuncAvailable(Location loc, StringRef importName,
-                              OpBuilder &builder) {
-    auto importOrdinal =
-        loadImportOrdinal(loc, importName, /*weak=*/true, builder);
-    auto importFunc = loadImportFunc(loc, importOrdinal, builder);
-    Value nullPtrValue =
-        builder.create<LLVM::NullOp>(loc, importFunc.first.getType());
-    return builder.create<LLVM::ICmpOp>(loc, builder.getI1Type(),
-                                        LLVM::ICmpPredicate::ne,
-                                        importFunc.first, nullPtrValue);
-  }
-
-  // Emits a call to the import with the given |importName|.
-  // The provided |params| struct containing the function-specific arguments
-  // is passed without modification.
-  // Returns 0 on success and non-zero otherwise.
-  Value callImport(Location loc, StringRef importName, bool weak, Value params,
-                   OpBuilder &builder) {
-    auto importOrdinal = loadImportOrdinal(loc, importName, weak, builder);
-    auto thunkPtrValue =
-        loadFieldValue(loc, EnvironmentField::import_thunk, builder);
-    auto importFunc = loadImportFunc(loc, importOrdinal, builder);
-
-    // TODO(benvanik): if weak is set then we should bail if the import is not
-    // found. Since we've loaded the import func here we can just compare for
-    // null as in isImportFuncAvailable but we'll need to make the control flow.
-    assert(!weak && "calls to weak imports not yet implemented");
-
-    Value nullPtrValue = builder.create<LLVM::NullOp>(
-        loc, LLVM::LLVMPointerType::get(builder.getI8Type()));
-    auto callOp =
-        builder.create<LLVM::CallOp>(loc, TypeRange{builder.getI32Type()},
-                                     ValueRange{
-                                         /*thunk_func_ptr=*/thunkPtrValue,
-                                         /*import_func_ptr=*/importFunc.first,
-                                         /*context=*/importFunc.second,
-                                         /*params=*/params,
-                                         /*reserved=*/nullPtrValue,
-                                     });
-    return callOp.getResult();
-  }
-
-  // Emits a call to a dynamically linked import using the given |importName|
-  // as a template.
-  // The provided |resultTypes| and |args| are packed in a struct and transit
-  // through memory so that we can expose a single void* argument.
-  // Returns 0 on success and non-zero otherwise.
-  SmallVector<Value> wrapAndCallImport(Location loc, StringRef importName,
-                                       bool weak, TypeRange resultTypes,
-                                       ValueRange args, OpBuilder &builder) {
-    // Struct types are ordered [results..., args...].
-    SmallVector<Type> types(resultTypes);
-    types.reserve(resultTypes.size() + args.size());
-    for (Value arg : args) {
-      types.push_back(typeConverter->convertType(arg.getType()));
-    }
-
-    // Pack parameter structure.
-    Type structType;
-    Value paramsPtr, voidPtr;
-    auto voidPtrTy = LLVM::LLVMPointerType::get(builder.getI8Type());
-    if (!types.empty()) {
-      // TODO(benvanik): set specific layout to match runtime.
-      structType =
-          LLVM::LLVMStructType::getLiteral(builder.getContext(), types);
-      auto ptrStructType = LLVM::LLVMPointerType::get(structType);
-      Value one = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
-                                                   builder.getIndexAttr(1));
-      paramsPtr = builder.create<LLVM::AllocaOp>(loc, ptrStructType, one,
-                                                 /*alignment=*/0);
-      Value structVal = builder.create<LLVM::UndefOp>(loc, structType);
-      for (int64_t i = 0, e = args.size(); i < e; ++i) {
-        structVal = builder.create<LLVM::InsertValueOp>(loc, structVal, args[i],
-                                                        i + resultTypes.size());
-      }
-      // Store into the alloca'ed descriptor.
-      builder.create<LLVM::StoreOp>(loc, structVal, paramsPtr);
-      voidPtr = builder.create<LLVM::BitcastOp>(loc, voidPtrTy, paramsPtr);
-    } else {
-      voidPtr = builder.create<LLVM::UndefOp>(loc, voidPtrTy);
-    }
-
-    // Calls return 0 (success) or non-zero (failure).
-    auto callResult = callImport(loc, importName, weak, voidPtr, builder);
-    Block *trueDest =
-        builder.getInsertionBlock()->splitBlock(++builder.getInsertionPoint());
-    Block *falseDest = builder.createBlock(trueDest);
-
-    // Check the call results and branch to exit if it failed.
-    // Note that we weight the true branch (call successful) higher.
-    builder.setInsertionPointAfterValue(callResult);
-    Value zeroI32 = builder.create<LLVM::ConstantOp>(
-        loc, builder.getI32Type(), builder.getI32IntegerAttr(0));
-    Value cmpZero = builder.create<LLVM::ICmpOp>(
-        loc, builder.getI1Type(), LLVM::ICmpPredicate::eq, callResult, zeroI32);
-    builder.create<LLVM::CondBrOp>(loc, cmpZero, trueDest, ValueRange{},
-                                   falseDest, ValueRange{callResult},
-                                   std::make_pair(1u, 0u));
-
-    // Failure return block.
-    // Return the call result to the runtime.
-    builder.setInsertionPointToStart(falseDest);
-    builder.create<LLVM::ReturnOp>(
-        loc, falseDest->addArgument(builder.getI32Type(), loc));
-
-    // Successful continuation block.
-    // Marshal results out of the params struct.
-    builder.setInsertionPointToStart(trueDest);
-    SmallVector<Value> results;
-    if (!resultTypes.empty()) {
-      results.reserve(resultTypes.size());
-      Value structVal =
-          builder.create<LLVM::LoadOp>(loc, structType, paramsPtr);
-      for (int64_t i = 0, e = resultTypes.size(); i < e; ++i) {
-        results.push_back(
-            builder.create<LLVM::ExtractValueOp>(loc, structVal, i));
-      }
-    }
-    return results;
-  }
-
- private:
-  Value getIndexValue(Location loc, int64_t value, OpBuilder &builder) {
-    return builder.createOrFold<LLVM::ConstantOp>(
-        loc, typeConverter->convertType(builder.getIndexType()),
-        builder.getI64IntegerAttr(value));
-  }
-
-  Value castValueToType(Location loc, Value value, Type resultType,
-                        OpBuilder &builder) {
-    // NOTE: we should handle more cases here (and proper sign extension).
-    if (value.getType() == resultType) return value;
-    return builder.createOrFold<LLVM::ZExtOp>(loc, resultType, value);
-  }
-
-  Value loadFieldValue(Location loc, EnvironmentField field,
-                       OpBuilder &builder) {
-    auto environmentPtrValue = funcOp.getArgument(0);
-    Value environmentValue =
-        builder.create<LLVM::LoadOp>(loc, environmentPtrValue);
-    SmallVector<int64_t, 1> position = {int64_t(field)};
-    return builder.createOrFold<LLVM::ExtractValueOp>(loc, environmentValue,
-                                                      position);
-  }
-
-  Value loadFieldValue(Location loc, ProcessorField field, OpBuilder &builder) {
-    Value processorValue =
-        loadFieldValue(loc, EnvironmentField::processor, builder);
-    SmallVector<int64_t, 1> position = {int64_t(field)};
-    return builder.createOrFold<LLVM::ExtractValueOp>(loc, processorValue,
-                                                      position);
-  }
-
-  Value loadFieldValue(Location loc, DispatchStateField field,
-                       OpBuilder &builder) {
-    Value statePtrValue = funcOp.getArgument(1);
-    Value stateValue = builder.createOrFold<LLVM::LoadOp>(loc, statePtrValue);
-    SmallVector<int64_t, 1> position = {int64_t(field)};
-    return builder.createOrFold<LLVM::ExtractValueOp>(loc, stateValue,
-                                                      position);
-  }
-
-  Value loadFieldValue(Location loc, WorkgroupStateField field,
-                       OpBuilder &builder) {
-    Value statePtrValue = funcOp.getArgument(2);
-    Value stateValue = builder.createOrFold<LLVM::LoadOp>(loc, statePtrValue);
-    SmallVector<int64_t, 1> position = {int64_t(field)};
-    return builder.createOrFold<LLVM::ExtractValueOp>(loc, stateValue,
-                                                      position);
-  }
-
-  LLVM::LLVMFuncOp funcOp;
-  LLVMTypeConverter *typeConverter;
-  LLVM::LLVMStructType processorType;
-  LLVM::LLVMStructType environmentType;
-  LLVM::LLVMStructType dispatchStateType;
-  LLVM::LLVMStructType workgroupStateType;
-
-  // Used to lock around mutations of shared LLVM type information, e.g.
-  // mlir::LLVM::LLVMStructType::getIdentified.
-  static llvm::sys::Mutex sMutex;
+template <typename OpT>
+struct ConvertOpToLLVMWithABIPattern : public ConvertOpToLLVMPattern<OpT> {
+  ConvertOpToLLVMWithABIPattern(HALDispatchABI &abi,
+                                LLVMTypeConverter &typeConverter,
+                                PatternBenefit benefit = 1)
+      : ConvertOpToLLVMPattern<OpT>(typeConverter, benefit), abi(abi) {}
+  HALDispatchABI &abi;
 };
-
-llvm::sys::Mutex HALDispatchABI::sMutex;
 
 /// Converts Standard MLIR FuncOps to LLVMFuncOps matching the IREE HAL ABI.
 /// This is an IREE-specific conversion that assumes the input function is
@@ -800,21 +90,20 @@ llvm::sys::Mutex HALDispatchABI::sMutex;
 ///
 /// NOTE: we bump the benefit of the pattern to 100 to pick this pattern instead
 /// of a competing pattern inserted by `populateFuncToLLVMConversionPatterns`.
-class ConvertHALEntryPointFuncOp : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALEntryPointFuncOp(MLIRContext *context,
-                                      LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(mlir::func::FuncOp::getOperationName(), context,
-                             converter, 100) {}
-
+struct ConvertHALEntryPointFuncOp
+    : public ConvertOpToLLVMWithABIPattern<func::FuncOp> {
+  ConvertHALEntryPointFuncOp(HALDispatchABI &abi,
+                             LLVMTypeConverter &typeConverter)
+      : ConvertOpToLLVMWithABIPattern(abi, typeConverter,
+                                      /*benefit=*/100) {}
   LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
+      func::FuncOp stdFuncOp, func::FuncOpAdaptor operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto stdFuncOp = cast<func::FuncOp>(op);
     if (!stdFuncOp.isPublic()) return failure();
     FunctionType fnType = stdFuncOp.getFunctionType();
     if (fnType.getNumInputs() != 0 || fnType.getNumResults() != 0) {
-      op->emitWarning() << "public functions on executables must be () -> ()";
+      stdFuncOp->emitWarning()
+          << "public functions on executables must be () -> ()";
       return failure();
     }
 
@@ -837,8 +126,8 @@ class ConvertHALEntryPointFuncOp : public ConvertToLLVMPattern {
     }
 
     // Clone the function as an LLVMFuncOp and convert all interior types.
-    auto llvmFuncType = LLVM::LLVMFunctionType::get(
-        IntegerType::get(rewriter.getContext(), 32), abiInputTypes);
+    auto int32Type = IntegerType::get(rewriter.getContext(), 32);
+    auto llvmFuncType = LLVM::LLVMFunctionType::get(int32Type, abiInputTypes);
     auto llvmFuncOp = rewriter.create<LLVM::LLVMFuncOp>(
         stdFuncOp.getLoc(), stdFuncOp.getName(), llvmFuncType,
         LLVM::Linkage::External, /*dso_local=*/false, /*cconv*/ LLVM::CConv::C,
@@ -873,6 +162,15 @@ class ConvertHALEntryPointFuncOp : public ConvertToLLVMPattern {
       rewriter.replaceOpWithNewOp<mlir::func::ReturnOp>(returnOp, returnValue);
     }
 
+    // Populate debug info for the subprogram signature. This is required in
+    // order to get any debug information (including just line tables) from MLIR
+    // into LLVM IR.
+    auto scopeAttr = HALDispatchABI::buildScopeAttr(
+        llvmFuncOp->getParentOfType<mlir::ModuleOp>(), llvmFuncOp.getName(),
+        getTypeConverter());
+    llvmFuncOp->setLoc(FusedLoc::get(llvmFuncOp.getContext(),
+                                     {llvmFuncOp->getLoc()}, scopeAttr));
+
     rewriter.eraseOp(stdFuncOp);
     return success();
   }
@@ -883,24 +181,19 @@ class ConvertHALEntryPointFuncOp : public ConvertToLLVMPattern {
 /// later gets updated with the value after linking.
 ///
 /// The parent LLVMFuncOp must be compatible with HALDispatchABI.
-class ConvertHALExecutableConstantLoadOp : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALExecutableConstantLoadOp(MLIRContext *context,
-                                              LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(
-            IREE::HAL::ExecutableConstantLoadOp::getOperationName(), context,
-            converter) {}
+struct ConvertHALExecutableConstantLoadOp
+    : public ConvertOpToLLVMWithABIPattern<
+          IREE::HAL::ExecutableConstantLoadOp> {
+  using ConvertOpToLLVMWithABIPattern::ConvertOpToLLVMWithABIPattern;
   LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
+      IREE::HAL::ExecutableConstantLoadOp loadOp,
+      IREE::HAL::ExecutableConstantLoadOpAdaptor operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
-    auto loadOp = cast<IREE::HAL::ExecutableConstantLoadOp>(op);
-    auto resultType = typeConverter->convertType(op->getResult(0).getType());
-    rewriter.replaceOp(op,
-                       abi.loadExecutableConstant(op->getLoc(), loadOp.getKey(),
-                                                  resultType, rewriter));
+    auto resultType =
+        typeConverter->convertType(loadOp->getResult(0).getType());
+    rewriter.replaceOp(
+        loadOp, abi.loadExecutableConstant(loadOp, loadOp.getKey(), resultType,
+                                           rewriter));
     return success();
   }
 };
@@ -908,26 +201,17 @@ class ConvertHALExecutableConstantLoadOp : public ConvertToLLVMPattern {
 /// Rewrites hal.interface.workgroup.id to ops loading from the ABI structs.
 ///
 /// The parent LLVMFuncOp must be compatible with HALDispatchABI.
-class ConvertHALInterfaceWorkgroupIDOp : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALInterfaceWorkgroupIDOp(MLIRContext *context,
-                                            LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(
-            IREE::HAL::InterfaceWorkgroupIDOp::getOperationName(), context,
-            converter) {}
-
+struct ConvertHALInterfaceWorkgroupIDOp
+    : public ConvertOpToLLVMWithABIPattern<IREE::HAL::InterfaceWorkgroupIDOp> {
+  using ConvertOpToLLVMWithABIPattern::ConvertOpToLLVMWithABIPattern;
   LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
+      IREE::HAL::InterfaceWorkgroupIDOp idOp,
+      IREE::HAL::InterfaceWorkgroupIDOpAdaptor operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
-    int32_t dim = (int32_t)cast<IREE::HAL::InterfaceWorkgroupIDOp>(op)
-                      .getDimension()
-                      .getZExtValue();
-    auto resultType = typeConverter->convertType(op->getResult(0).getType());
-    rewriter.replaceOp(
-        op, abi.loadWorkgroupID(op->getLoc(), dim, resultType, rewriter));
+    int32_t dim = (int32_t)idOp.getDimension().getZExtValue();
+    auto resultType = typeConverter->convertType(idOp->getResult(0).getType());
+    rewriter.replaceOp(idOp,
+                       abi.loadWorkgroupID(idOp, dim, resultType, rewriter));
     return success();
   }
 };
@@ -935,26 +219,19 @@ class ConvertHALInterfaceWorkgroupIDOp : public ConvertToLLVMPattern {
 /// Rewrites hal.interface.workgroup.size to ops loading from the ABI structs.
 ///
 /// The parent LLVMFuncOp must be compatible with HALDispatchABI.
-class ConvertHALInterfaceWorkgroupSizeOp : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALInterfaceWorkgroupSizeOp(MLIRContext *context,
-                                              LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(
-            IREE::HAL::InterfaceWorkgroupSizeOp::getOperationName(), context,
-            converter) {}
-
+struct ConvertHALInterfaceWorkgroupSizeOp
+    : public ConvertOpToLLVMWithABIPattern<
+          IREE::HAL::InterfaceWorkgroupSizeOp> {
+  using ConvertOpToLLVMWithABIPattern::ConvertOpToLLVMWithABIPattern;
   LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
+      IREE::HAL::InterfaceWorkgroupSizeOp sizeOp,
+      IREE::HAL::InterfaceWorkgroupSizeOpAdaptor operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
-    int32_t dim = (int32_t)cast<IREE::HAL::InterfaceWorkgroupSizeOp>(op)
-                      .getDimension()
-                      .getZExtValue();
-    auto resultType = typeConverter->convertType(op->getResult(0).getType());
+    int32_t dim = (int32_t)sizeOp.getDimension().getZExtValue();
+    auto resultType =
+        typeConverter->convertType(sizeOp->getResult(0).getType());
     rewriter.replaceOp(
-        op, abi.loadWorkgroupSize(op->getLoc(), dim, resultType, rewriter));
+        sizeOp, abi.loadWorkgroupSize(sizeOp, dim, resultType, rewriter));
     return success();
   }
 };
@@ -962,26 +239,19 @@ class ConvertHALInterfaceWorkgroupSizeOp : public ConvertToLLVMPattern {
 /// Rewrites hal.interface.workgroup.count to ops loading from the ABI structs.
 ///
 /// The parent LLVMFuncOp must be compatible with HALDispatchABI.
-class ConvertHALInterfaceWorkgroupCountOp : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALInterfaceWorkgroupCountOp(MLIRContext *context,
-                                               LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(
-            IREE::HAL::InterfaceWorkgroupCountOp::getOperationName(), context,
-            converter) {}
-
+struct ConvertHALInterfaceWorkgroupCountOp
+    : public ConvertOpToLLVMWithABIPattern<
+          IREE::HAL::InterfaceWorkgroupCountOp> {
+  using ConvertOpToLLVMWithABIPattern::ConvertOpToLLVMWithABIPattern;
   LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
+      IREE::HAL::InterfaceWorkgroupCountOp countOp,
+      IREE::HAL::InterfaceWorkgroupCountOpAdaptor operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
-    int32_t dim = (int32_t)cast<IREE::HAL::InterfaceWorkgroupCountOp>(op)
-                      .getDimension()
-                      .getZExtValue();
-    auto resultType = typeConverter->convertType(op->getResult(0).getType());
+    int32_t dim = (int32_t)countOp.getDimension().getZExtValue();
+    auto resultType =
+        typeConverter->convertType(countOp->getResult(0).getType());
     rewriter.replaceOp(
-        op, abi.loadWorkgroupCount(op->getLoc(), dim, resultType, rewriter));
+        countOp, abi.loadWorkgroupCount(countOp, dim, resultType, rewriter));
     return success();
   }
 };
@@ -989,25 +259,18 @@ class ConvertHALInterfaceWorkgroupCountOp : public ConvertToLLVMPattern {
 /// Rewrites hal.interface.constant.load to ops loading from the ABI structs.
 ///
 /// The parent LLVMFuncOp must be compatible with HALDispatchABI.
-class ConvertHALInterfaceConstantLoadOp : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALInterfaceConstantLoadOp(MLIRContext *context,
-                                             LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(
-            IREE::HAL::InterfaceConstantLoadOp::getOperationName(), context,
-            converter) {}
-
+struct ConvertHALInterfaceConstantLoadOp
+    : public ConvertOpToLLVMWithABIPattern<IREE::HAL::InterfaceConstantLoadOp> {
+  using ConvertOpToLLVMWithABIPattern::ConvertOpToLLVMWithABIPattern;
   LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
+      IREE::HAL::InterfaceConstantLoadOp loadOp,
+      IREE::HAL::InterfaceConstantLoadOpAdaptor operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
-    auto loadConstantOp = cast<IREE::HAL::InterfaceConstantLoadOp>(op);
-    int64_t index = loadConstantOp.getIndex().getZExtValue();
-    auto resultType = typeConverter->convertType(op->getResult(0).getType());
+    int64_t index = loadOp.getIndex().getZExtValue();
+    auto resultType =
+        typeConverter->convertType(loadOp->getResult(0).getType());
     rewriter.replaceOp(
-        op, abi.loadPushConstant(op->getLoc(), index, resultType, rewriter));
+        loadOp, abi.loadPushConstant(loadOp, index, resultType, rewriter));
     return success();
   }
 };
@@ -1015,33 +278,25 @@ class ConvertHALInterfaceConstantLoadOp : public ConvertToLLVMPattern {
 /// Rewrites hal.interface.binding.subspan to ops loading from the ABI structs.
 ///
 /// The parent LLVMFuncOp must be compatible with HALDispatchABI.
-class ConvertHALInterfaceBindingSubspanOp : public ConvertToLLVMPattern {
- public:
-  explicit ConvertHALInterfaceBindingSubspanOp(MLIRContext *context,
-                                               LLVMTypeConverter &converter)
-      : ConvertToLLVMPattern(
-            IREE::HAL::InterfaceBindingSubspanOp::getOperationName(), context,
-            converter) {}
-
+struct ConvertHALInterfaceBindingSubspanOp
+    : public ConvertOpToLLVMWithABIPattern<
+          IREE::HAL::InterfaceBindingSubspanOp> {
+  using ConvertOpToLLVMWithABIPattern::ConvertOpToLLVMWithABIPattern;
   LogicalResult matchAndRewrite(
-      Operation *op, ArrayRef<Value> operands,
+      IREE::HAL::InterfaceBindingSubspanOp subspanOp,
+      IREE::HAL::InterfaceBindingSubspanOpAdaptor operands,
       ConversionPatternRewriter &rewriter) const override {
-    auto llvmFuncOp = op->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-    HALDispatchABI abi(llvmFuncOp, getTypeConverter());
-    IREE::HAL::InterfaceBindingSubspanOpAdaptor newOperands(
-        operands, op->getAttrDictionary());
-    MemRefType memRefType = op->getResult(0).getType().dyn_cast<MemRefType>();
+    MemRefType memRefType =
+        subspanOp->getResult(0).getType().dyn_cast<MemRefType>();
     if (!memRefType) {
       return rewriter.notifyMatchFailure(
-          op,
+          subspanOp,
           "failed to convert interface.binding.subspan result to memref type");
     }
-    auto memRefDesc =
-        abi.loadBinding(op->getLoc(), newOperands.getBindingAttr().getInt(),
-                        newOperands.getByteOffset(), memRefType,
-                        newOperands.getDynamicDims(), rewriter);
-    rewriter.replaceOp(op, {memRefDesc});
+    auto memRefDesc = abi.loadBinding(
+        subspanOp, operands.getBindingAttr().getInt(), operands.getByteOffset(),
+        memRefType, operands.getDynamicDims(), rewriter);
+    rewriter.replaceOp(subspanOp, {memRefDesc});
     return success();
   }
 };
@@ -1052,19 +307,15 @@ class ConvertHALInterfaceBindingSubspanOp : public ConvertToLLVMPattern {
 /// Note: this is an LLVM::CallOp -> LLVM::CallOp rewrite that is introduced
 /// after all conversions are done. Importantly, this is not a conversion
 /// pattern.
-class RewriteExternCallOpToDynamicImportCallOp
+struct RewriteExternCallOpToDynamicImportCallOp
     : public OpRewritePattern<LLVM::CallOp> {
- public:
-  explicit RewriteExternCallOpToDynamicImportCallOp(
-      MLIRContext *context, LLVMTypeConverter &converter)
-      : OpRewritePattern<LLVM::CallOp>(context), typeConverter(converter) {}
-
+  RewriteExternCallOpToDynamicImportCallOp(HALDispatchABI &abi,
+                                           LLVMTypeConverter &typeConverter)
+      : OpRewritePattern(&typeConverter.getContext()),
+        abi(abi),
+        typeConverter(typeConverter) {}
   LogicalResult matchAndRewrite(LLVM::CallOp callOp,
                                 PatternRewriter &rewriter) const override {
-    auto llvmFuncOp = callOp->getParentOfType<LLVM::LLVMFuncOp>();
-    if (!llvmFuncOp) return failure();
-    HALDispatchABI abi(llvmFuncOp, &typeConverter);
-
     // Ignore indirect calls (they're probably already converted imports).
     auto symbol = callOp.getCallableForCallee().dyn_cast<SymbolRefAttr>();
     auto flatSymbol = symbol.dyn_cast_or_null<FlatSymbolRefAttr>();
@@ -1073,9 +324,14 @@ class RewriteExternCallOpToDynamicImportCallOp
     // Ensure the target function is extern.
     // To support conversion inserting calls in local patterns that can't add
     // global function symbols we assume any missing callee is extern.
-    auto calleeOp = SymbolTable::lookupNearestSymbolFrom<LLVM::LLVMFuncOp>(
-        llvmFuncOp, symbol);
-    if (calleeOp && !calleeOp.isExternal()) return failure();
+    auto calleeOp =
+        SymbolTable::lookupNearestSymbolFrom<LLVM::LLVMFuncOp>(callOp, symbol);
+    if (calleeOp && !calleeOp.isExternal()) {
+      return rewriter.notifyMatchFailure(
+          callOp,
+          "callee is not external; treating as a normal call and skipping "
+          "import logic");
+    }
 
     // If the function is marked as statically linked we don't touch it. That'll
     // let it fall through to the linker stage where it can be picked up either
@@ -1092,14 +348,13 @@ class RewriteExternCallOpToDynamicImportCallOp
 
     // Rewrite the call to a dynamic import call.
     SmallVector<Value> results = abi.wrapAndCallImport(
-        callOp->getLoc(), flatSymbol.getValue(), weak, callOp->getResultTypes(),
+        callOp, flatSymbol.getValue(), weak, callOp->getResultTypes(),
         callOp->getOperands(), rewriter);
 
     rewriter.replaceOp(callOp, results);
     return success();
   }
-
- private:
+  HALDispatchABI &abi;
   LLVMTypeConverter &typeConverter;
 };
 
@@ -1188,7 +443,7 @@ void ConvertToLLVMPass::runOnOperation() {
                              dataLayoutAnalysis.getAtOrAbove(module));
   options.dataLayout = llvm::DataLayout(dataLayoutStr);
   options.overrideIndexBitwidth(options.dataLayout.getPointerSizeInBits());
-  LLVMTypeConverter converter(&getContext(), options, &dataLayoutAnalysis);
+  LLVMTypeConverter typeConverter(&getContext(), options, &dataLayoutAnalysis);
 
   RewritePatternSet patterns(&getContext());
 
@@ -1212,22 +467,23 @@ void ConvertToLLVMPass::runOnOperation() {
 
   populateAffineToStdConversionPatterns(patterns);
   populateSCFToControlFlowConversionPatterns(patterns);
-  cf::populateControlFlowToLLVMConversionPatterns(converter, patterns);
+  cf::populateControlFlowToLLVMConversionPatterns(typeConverter, patterns);
   populateExpandTanhPattern(patterns);
 
-  populateComplexToLLVMConversionPatterns(converter, patterns);
-  populateMathToLLVMConversionPatterns(converter, patterns);
+  populateComplexToLLVMConversionPatterns(typeConverter, patterns);
+  populateMathToLLVMConversionPatterns(typeConverter, patterns);
   memref::populateExpandStridedMetadataPatterns(patterns);
-  populateMemRefToLLVMConversionPatterns(converter, patterns);
-  populateFuncToLLVMConversionPatterns(converter, patterns);
-  arith::populateArithToLLVMConversionPatterns(converter, patterns);
+  populateMemRefToLLVMConversionPatterns(typeConverter, patterns);
+  populateFuncToLLVMConversionPatterns(typeConverter, patterns);
+  arith::populateArithToLLVMConversionPatterns(typeConverter, patterns);
   populateVectorToSCFConversionPatterns(patterns);
-  populateVectorToLLVMMatrixConversionPatterns(converter, patterns);
+  populateVectorToLLVMMatrixConversionPatterns(typeConverter, patterns);
   populateVectorToLLVMConversionPatterns(
-      converter, patterns, targetReassociateFpReductions.getValue());
-  populateLinalgToLLVMConversionPatterns(converter, patterns);
+      typeConverter, patterns, targetReassociateFpReductions.getValue());
+  populateLinalgToLLVMConversionPatterns(typeConverter, patterns);
   populateReconcileUnrealizedCastsPatterns(patterns);
 
+  HALDispatchABI abi(&typeConverter);
   // clang-format off
   patterns.insert<
     ConvertHALEntryPointFuncOp,
@@ -1237,7 +493,7 @@ void ConvertToLLVMPass::runOnOperation() {
     ConvertHALInterfaceWorkgroupCountOp,
     ConvertHALInterfaceConstantLoadOp,
     ConvertHALInterfaceBindingSubspanOp
-  >(&getContext(), converter);
+  >(abi, typeConverter);
   // clang-format on
 
   LLVMConversionTarget target(getContext());
@@ -1255,8 +511,8 @@ void ConvertToLLVMPass::runOnOperation() {
   // Rewrite any extern calls emitted to dynamic library imports.
   {
     RewritePatternSet patterns(&getContext());
-    patterns.insert<RewriteExternCallOpToDynamicImportCallOp>(&getContext(),
-                                                              converter);
+    patterns.insert<RewriteExternCallOpToDynamicImportCallOp>(abi,
+                                                              typeConverter);
     if (failed(applyPatternsAndFoldGreedily(module, std::move(patterns))))
       return signalPassFailure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -1,0 +1,1082 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
+
+#include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/Path.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/Math/IR/Math.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+//------------------------------------------------------------------------------
+// ExecutableLibraryDI
+//------------------------------------------------------------------------------
+
+// NOTE: the debug information used here is only present as a compiler developer
+// aid. It may get out of sync with published versions of the executable ABI and
+// may not be very clean. For example, we size push constant and binding arrays
+// not based on the actual layout of the pipeline layout but with some
+// reasonable limit that allows for use in a debugger. If we wanted to improve
+// this we could customize per-scope the structures and look up the
+// IREE::HAL::PipelineLayoutAttr for each entry point to discover the real
+// limits.
+//
+// NOTE: MLIR and subsequent LLVM optimizations will often remove a lot of this
+// debug information (or at least make it less useful). This can happen even in
+// LLVM modes of -O0 as MLIR has no such configurability at this time.
+//
+// It'd be nice to have an automatic sync of the debug information and structs
+// in this file such that we'd get matching source file/line information with
+// the runtime headers and be able to delete most of this hand-authored code.
+// The current debug information and types were constructed by compiling
+// executable_library_demo.c to LLVM IR and then importing it into MLIR to see
+// what the attributes look like. We could automate this and embed the
+// attributes in the compiler binary but due to the differences in 32/64-bit
+// pointer widths some manual massaging may still be required (or we just embed
+// both).
+//
+// $ clang -emit-llvm -Iruntime/src/ \
+//     runtime/src/iree/hal/local/executable_library_demo.c -g -S \
+//     --target=x86_64-pc-windows-elf
+// $ mlir-translate --import-llvm executable_library_demo.ll
+
+// Returns the size, in bits, of |typeAttr|.
+static unsigned getDITypeSizeInBits(LLVM::DITypeAttr typeAttr) {
+  if (auto basicTypeAttr = typeAttr.dyn_cast<LLVM::DIBasicTypeAttr>()) {
+    return basicTypeAttr.getSizeInBits();
+  } else if (auto derivedTypeAttr =
+                 typeAttr.dyn_cast<LLVM::DIDerivedTypeAttr>()) {
+    if (unsigned derivedSize = derivedTypeAttr.getSizeInBits()) {
+      return derivedSize;
+    } else {
+      return getDITypeSizeInBits(derivedTypeAttr.getBaseType());
+    }
+  } else {
+    return 0;
+  }
+}
+
+ExecutableLibraryDI::ExecutableLibraryDI(LLVMTypeConverter *typeConverter)
+    : typeConverter(typeConverter), builder(&typeConverter->getContext()) {
+  auto *context = builder.getContext();
+  fileAttr = LLVM::DIFileAttr::get(
+      context, "runtime/src/iree/hal/local/executable_library.h", ".");
+  ptrBitwidth = typeConverter->getPointerBitwidth();
+
+  voidPtr = getPtrOf(LLVM::DIBasicTypeAttr::get(
+      context, llvm::dwarf::DW_TAG_base_type, "void",
+      /*sizeInBits=*/0, llvm::dwarf::DW_ATE_address));
+  int8T = getTypedefOf("int8_t",
+                       LLVM::DIBasicTypeAttr::get(
+                           context, llvm::dwarf::DW_TAG_base_type, "char",
+                           /*sizeInBits=*/8, llvm::dwarf::DW_ATE_signed_char));
+  uint8T = getTypedefOf(
+      "uint8_t", LLVM::DIBasicTypeAttr::get(
+                     context, llvm::dwarf::DW_TAG_base_type, "unsigned char",
+                     /*sizeInBits=*/8, llvm::dwarf::DW_ATE_unsigned_char));
+  int16T = getTypedefOf("int16_t",
+                        LLVM::DIBasicTypeAttr::get(
+                            context, llvm::dwarf::DW_TAG_base_type, "short",
+                            /*sizeInBits=*/16, llvm::dwarf::DW_ATE_signed));
+  uint16T = getTypedefOf(
+      "uint16_t", LLVM::DIBasicTypeAttr::get(
+                      context, llvm::dwarf::DW_TAG_base_type, "unsigned short",
+                      /*sizeInBits=*/16, llvm::dwarf::DW_ATE_unsigned));
+  int32T = getTypedefOf("int32_t",
+                        LLVM::DIBasicTypeAttr::get(
+                            context, llvm::dwarf::DW_TAG_base_type, "int",
+                            /*sizeInBits=*/32, llvm::dwarf::DW_ATE_signed));
+  uint32T = getTypedefOf(
+      "uint32_t", LLVM::DIBasicTypeAttr::get(
+                      context, llvm::dwarf::DW_TAG_base_type, "unsigned int",
+                      /*sizeInBits=*/32, llvm::dwarf::DW_ATE_unsigned));
+  int64T = getTypedefOf(
+      "int64_t", LLVM::DIBasicTypeAttr::get(
+                     context, llvm::dwarf::DW_TAG_base_type, "long long int",
+                     /*sizeInBits=*/64, llvm::dwarf::DW_ATE_signed));
+  uint64T = getTypedefOf(
+      "uint64_t",
+      LLVM::DIBasicTypeAttr::get(
+          context, llvm::dwarf::DW_TAG_base_type, "long long unsigned int",
+          /*sizeInBits=*/64, llvm::dwarf::DW_ATE_unsigned));
+  intptrT =
+      getTypedefOf("intptr_t", ptrBitwidth == 32 ? getInt32T() : getInt64T());
+  sizeT =
+      getTypedefOf("size_t", ptrBitwidth == 32 ? getUint32T() : getUint64T());
+}
+
+LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getConstOf(
+    LLVM::DITypeAttr typeAttr) {
+  return LLVM::DIDerivedTypeAttr::get(
+      builder.getContext(), llvm::dwarf::DW_TAG_const_type,
+      /*name=*/nullptr, typeAttr, /*sizeInBits=*/0, /*alignInBits=*/0,
+      /*offsetInBits=*/0);
+}
+
+LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getPtrOf(
+    LLVM::DITypeAttr typeAttr) {
+  return LLVM::DIDerivedTypeAttr::get(
+      builder.getContext(), llvm::dwarf::DW_TAG_pointer_type,
+      /*name=*/nullptr, typeAttr, /*sizeInBits=*/ptrBitwidth,
+      /*alignInBits=*/0,
+      /*offsetInBits=*/0);
+}
+
+LLVM::DICompositeTypeAttr ExecutableLibraryDI::getArrayOf(
+    LLVM::DITypeAttr typeAttr, int64_t count) {
+  return LLVM::DICompositeTypeAttr::get(
+      builder.getContext(), llvm::dwarf::DW_TAG_array_type,
+      /*name=*/builder.getStringAttr(""), fileAttr,
+      /*line=*/227, fileAttr,
+      /*baseType=*/typeAttr, LLVM::DIFlags::Zero,
+      /*sizeInBits=*/getDITypeSizeInBits(typeAttr) * count,
+      /*alignInBits=*/0,
+      {
+          LLVM::DISubrangeAttr::get(
+              builder.getContext(), builder.getI64IntegerAttr(count),
+              /*lowerBound=*/nullptr, /*upperBound=*/nullptr,
+              /*stride=*/nullptr),
+      });
+}
+
+LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getTypedefOf(
+    StringRef name, LLVM::DITypeAttr typeAttr) {
+  return LLVM::DIDerivedTypeAttr::get(
+      builder.getContext(), llvm::dwarf::DW_TAG_typedef,
+      builder.getStringAttr(name), typeAttr, /*sizeInBits=*/0,
+      /*alignInBits=*/0, /*offsetInBits=*/0);
+}
+
+LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getMemberOf(
+    StringRef name, LLVM::DITypeAttr typeAttr, unsigned *offsetInBits) {
+  unsigned memberOffsetInBits = *offsetInBits;
+  unsigned memberSizeInBits = getDITypeSizeInBits(typeAttr);
+  *offsetInBits += memberSizeInBits;
+  return LLVM::DIDerivedTypeAttr::get(
+      builder.getContext(), llvm::dwarf::DW_TAG_member,
+      builder.getStringAttr(name), typeAttr,
+      /*sizeInBits=*/memberSizeInBits, /*alignInBits=*/0,
+      /*offsetInBits=*/memberOffsetInBits);
+}
+
+LLVM::DITypeAttr ExecutableLibraryDI::getBasicType(Type type) {
+  return TypeSwitch<Type, LLVM::DITypeAttr>(type)
+      .Case([&](IndexType) { return getIntptrT(); })
+      .Case([&](IntegerType integerType) -> LLVM::DITypeAttr {
+        unsigned bitWidth = integerType.getIntOrFloatBitWidth();
+        switch (bitWidth) {
+          case 8:
+            return integerType.isUnsigned() ? getUint8T() : getInt8T();
+          case 16:
+            return integerType.isUnsigned() ? getUint16T() : getInt16T();
+          case 32:
+            return integerType.isUnsigned() ? getUint32T() : getInt32T();
+          case 64:
+            return integerType.isUnsigned() ? getUint64T() : getInt64T();
+          default:
+            return LLVM::DIBasicTypeAttr::get(
+                builder.getContext(), llvm::dwarf::DW_TAG_base_type,
+                StringRef("int") + std::to_string(bitWidth),
+                /*sizeInBits=*/bitWidth,
+                integerType.isUnsigned() ? llvm::dwarf::DW_ATE_unsigned
+                                         : llvm::dwarf::DW_ATE_signed);
+        }
+      })
+      .Case([&](FloatType floatType) -> LLVM::DITypeAttr {
+        unsigned bitWidth = floatType.getIntOrFloatBitWidth();
+        return LLVM::DIBasicTypeAttr::get(
+            builder.getContext(), llvm::dwarf::DW_TAG_base_type,
+            StringRef("float") + std::to_string(bitWidth),
+            /*sizeInBits=*/bitWidth, llvm::dwarf::DW_ATE_float);
+      })
+      .Default([](Type) {
+        assert(false && "unhandled basic type");
+        return nullptr;
+      });
+}
+
+LLVM::DICompositeTypeAttr ExecutableLibraryDI::getProcessorV0T() {
+  unsigned offsetInBits = 0;
+  return LLVM::DICompositeTypeAttr::get(
+      builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
+      builder.getStringAttr("iree_hal_processor_v0_t"), fileAttr,
+      /*line=*/227, fileAttr,
+      /*baseType=*/nullptr, LLVM::DIFlags::Zero, /*sizeInBits=*/512,
+      /*alignInBits=*/0,
+      {
+          getMemberOf("data", getArrayOf(getUint64T(), 8), &offsetInBits),
+      });
+}
+
+LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getEnvironmentV0T() {
+  unsigned offsetInBits = 0;
+  return getTypedefOf(
+      "iree_hal_executable_environment_v0_t",
+      LLVM::DICompositeTypeAttr::get(
+          builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
+          builder.getStringAttr("iree_hal_executable_environment_v0_t"),
+          fileAttr,
+          /*line=*/246, fileAttr,
+          /*baseType=*/nullptr, LLVM::DIFlags::Zero, /*sizeInBits=*/768,
+          /*alignInBits=*/0,
+          {
+              getMemberOf("constants",
+                          getPtrOf(getConstOf(getArrayOf(getUint32T(), 64))),
+                          &offsetInBits),
+              getMemberOf("import_thunk", getVoidPtr(), &offsetInBits),
+              getMemberOf("import_funcs", getPtrOf(getConstOf(getVoidPtr())),
+                          &offsetInBits),
+              getMemberOf("import_contexts",
+                          getPtrOf(getPtrOf(getConstOf(getVoidPtr()))),
+                          &offsetInBits),
+              getMemberOf("processor", getProcessorV0T(), &offsetInBits),
+          }));
+}
+
+LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getDispatchStateV0T() {
+  unsigned offsetInBits = 0;
+  return getTypedefOf(
+      "iree_hal_executable_dispatch_state_v0_t",
+      LLVM::DICompositeTypeAttr::get(
+          builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
+          builder.getStringAttr("iree_hal_executable_dispatch_state_v0_t"),
+          fileAttr, /*line=*/275, fileAttr,
+          /*baseType=*/nullptr, LLVM::DIFlags::Zero, /*sizeInBits=*/384,
+          /*alignInBits=*/0,
+          {
+              getMemberOf("workgroup_size_x", getUint32T(), &offsetInBits),
+              getMemberOf("workgroup_size_y", getUint32T(), &offsetInBits),
+              getMemberOf("workgroup_size_z", getUint16T(), &offsetInBits),
+              getMemberOf("push_constant_count", getUint16T(), &offsetInBits),
+              getMemberOf("workgroup_count_x", getUint32T(), &offsetInBits),
+              getMemberOf("workgroup_count_y", getUint32T(), &offsetInBits),
+              getMemberOf("workgroup_count_z", getUint16T(), &offsetInBits),
+              getMemberOf("max_concurrency", getUint8T(), &offsetInBits),
+              getMemberOf("binding_count", getUint8T(), &offsetInBits),
+              getMemberOf("push_constants",
+                          getPtrOf(getConstOf(getArrayOf(getUint32T(), 64))),
+                          &offsetInBits),
+              getMemberOf(
+                  "binding_ptrs",
+                  getPtrOf(getConstOf(getArrayOf(getPtrOf(getUint8T()), 64))),
+                  &offsetInBits),
+              getMemberOf("binding_lengths",
+                          getPtrOf(getConstOf(getArrayOf(getSizeT(), 64))),
+                          &offsetInBits),
+          }));
+}
+
+LLVM::DIDerivedTypeAttr ExecutableLibraryDI::getWorkgroupStateV0T() {
+  unsigned offsetInBits = 0;
+  return getTypedefOf(
+      "iree_hal_executable_workgroup_state_v0_t",
+      LLVM::DICompositeTypeAttr::get(
+          builder.getContext(), llvm::dwarf::DW_TAG_structure_type,
+          builder.getStringAttr("iree_hal_executable_workgroup_state_v0_t"),
+          fileAttr, /*line=*/321, fileAttr,
+          /*baseType=*/nullptr, LLVM::DIFlags::Zero, /*sizeInBits=*/256,
+          /*alignInBits=*/0,
+          {
+              getMemberOf("workgroup_id_x", getUint32T(), &offsetInBits),
+              getMemberOf("workgroup_id_y", getUint32T(), &offsetInBits),
+              getMemberOf("workgroup_id_z", getUint16T(), &offsetInBits),
+              getMemberOf("reserved", getUint16T(), &offsetInBits),
+              getMemberOf("processor_id", getUint32T(), &offsetInBits),
+              getMemberOf("local_memory", getVoidPtr(), &offsetInBits),
+              getMemberOf("local_memory_size", getUint32T(), &offsetInBits),
+          }));
+}
+
+//------------------------------------------------------------------------------
+// HALDispatchABI
+//------------------------------------------------------------------------------
+
+// static
+llvm::sys::Mutex HALDispatchABI::sMutex;
+
+// static
+LLVM::LLVMStructType HALDispatchABI::getProcessorType(
+    MLIRContext *context, LLVMTypeConverter *typeConverter) {
+  llvm::sys::ScopedLock lock(sMutex);
+  auto structType =
+      LLVM::LLVMStructType::getIdentified(context, "iree_hal_processor_v0_t");
+  if (structType.isInitialized()) return structType;
+
+  auto uint64Type = IntegerType::get(context, 64);
+  SmallVector<Type> fieldTypes;
+
+  // uint64_t data[IREE_HAL_PROCESSOR_DATA_CAPACITY_V0];
+  fieldTypes.push_back(
+      LLVM::LLVMArrayType::get(uint64Type, ProcessorDataCapacity));
+
+  LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
+  assert(succeeded(bodySet) &&
+         "could not set the body of an identified struct");
+  (void)bodySet;
+
+  return structType;
+}
+
+// static
+LLVM::LLVMStructType HALDispatchABI::getEnvironmentType(
+    MLIRContext *context, LLVMTypeConverter *typeConverter,
+    LLVM::LLVMStructType processorType) {
+  llvm::sys::ScopedLock lock(sMutex);
+  auto structType = LLVM::LLVMStructType::getIdentified(
+      context, "iree_hal_executable_environment_v0_t");
+  if (structType.isInitialized()) return structType;
+
+  auto int8Type = IntegerType::get(context, 8);
+  auto uint32Type = IntegerType::get(context, 32);
+  auto int8PtrType = LLVM::LLVMPointerType::get(int8Type);
+  auto uint32PtrType = LLVM::LLVMPointerType::get(uint32Type);
+  SmallVector<Type, 4> fieldTypes;
+
+  // const uint32_t* constants;
+  fieldTypes.push_back(uint32PtrType);
+
+  // iree_hal_executable_import_thunk_v0_t import_thunk;
+  // const iree_hal_executable_import_v0_t* import_funcs;
+  // const void** import_contexts;
+  auto importType = LLVM::LLVMFunctionType::get(
+      uint32Type, {int8PtrType, int8PtrType, int8PtrType});
+  auto importPtrType = LLVM::LLVMPointerType::get(importType);
+  auto importThunkType = LLVM::LLVMFunctionType::get(
+      uint32Type, {importPtrType, int8PtrType, int8PtrType, int8PtrType});
+  fieldTypes.push_back(LLVM::LLVMPointerType::get(importThunkType));
+  fieldTypes.push_back(LLVM::LLVMPointerType::get(importPtrType));
+  fieldTypes.push_back(LLVM::LLVMPointerType::get(int8PtrType));
+
+  // iree_hal_processor_v0_t processor;
+  fieldTypes.push_back(processorType);
+
+  LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
+  assert(succeeded(bodySet) &&
+         "could not set the body of an identified struct");
+  (void)bodySet;
+
+  return structType;
+}
+
+// static
+LLVM::LLVMStructType HALDispatchABI::getDispatchStateType(
+    MLIRContext *context, LLVMTypeConverter *typeConverter) {
+  llvm::sys::ScopedLock lock(sMutex);
+  auto structType = LLVM::LLVMStructType::getIdentified(
+      context, "iree_hal_executable_dispatch_state_v0_t");
+  if (structType.isInitialized()) return structType;
+
+  auto indexType = typeConverter->convertType(IndexType::get(context));
+  auto int8Type = IntegerType::get(context, 8);
+  auto uint8Type = IntegerType::get(context, 8);
+  auto uint16Type = IntegerType::get(context, 16);
+  auto uint32Type = IntegerType::get(context, 32);
+  auto int8PtrType = LLVM::LLVMPointerType::get(int8Type);
+  auto uint32PtrType = LLVM::LLVMPointerType::get(uint32Type);
+  SmallVector<Type, 4> fieldTypes;
+
+  // uint32_t workgroup_size_x;
+  // uint32_t workgroup_size_y;
+  // uint16_t workgroup_size_z;
+  fieldTypes.push_back(uint32Type);
+  fieldTypes.push_back(uint32Type);
+  fieldTypes.push_back(uint16Type);
+
+  // uint16_t push_constant_count;
+  fieldTypes.push_back(uint16Type);
+
+  // uint32_t workgroup_count_x;
+  // uint32_t workgroup_count_y;
+  // uint16_t workgroup_count_z;
+  fieldTypes.push_back(uint32Type);
+  fieldTypes.push_back(uint32Type);
+  fieldTypes.push_back(uint16Type);
+
+  // uint8_t max_concurrency;
+  fieldTypes.push_back(uint8Type);
+
+  // uint8_t binding_count;
+  fieldTypes.push_back(uint8Type);
+
+  // const uint32_t * push_constants;
+  fieldTypes.push_back(uint32PtrType);
+  // void *const * binding_ptrs;
+  // const size_t * binding_lengths;
+  fieldTypes.push_back(LLVM::LLVMPointerType::get(int8PtrType));
+  fieldTypes.push_back(LLVM::LLVMPointerType::get(indexType));
+
+  LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
+  assert(succeeded(bodySet) &&
+         "could not set the body of an identified struct");
+  (void)bodySet;
+
+  return structType;
+}
+
+// static
+LLVM::LLVMStructType HALDispatchABI::getWorkgroupStateType(
+    MLIRContext *context, LLVMTypeConverter *typeConverter) {
+  llvm::sys::ScopedLock lock(sMutex);
+  auto structType = LLVM::LLVMStructType::getIdentified(
+      context, "iree_hal_executable_workgroup_state_v0_t");
+  if (structType.isInitialized()) return structType;
+
+  auto int8Type = IntegerType::get(context, 8);
+  auto uint16Type = IntegerType::get(context, 16);
+  auto uint32Type = IntegerType::get(context, 32);
+  auto int8PtrType = LLVM::LLVMPointerType::get(int8Type);
+  SmallVector<Type, 4> fieldTypes;
+
+  // uint32_t workgroup_id_x;
+  // uint32_t workgroup_id_y;
+  // uint16_t workgroup_id_z;
+  fieldTypes.push_back(uint32Type);
+  fieldTypes.push_back(uint32Type);
+  fieldTypes.push_back(uint16Type);
+
+  // uint16_t reserved;
+  fieldTypes.push_back(uint16Type);
+
+  // uint32_t processor_id;
+  fieldTypes.push_back(uint32Type);
+
+  // void* local_memory;
+  // uint32_t local_memory_size;
+  fieldTypes.push_back(LLVM::LLVMPointerType::get(int8PtrType));
+  fieldTypes.push_back(uint32Type);
+
+  LogicalResult bodySet = structType.setBody(fieldTypes, /*isPacked=*/false);
+  assert(succeeded(bodySet) &&
+         "could not set the body of an identified struct");
+  (void)bodySet;
+
+  return structType;
+}
+
+// static
+SmallVector<Type, 5> HALDispatchABI::getInputTypes(
+    MLIRContext *context, LLVMTypeConverter *typeConverter) {
+  auto environmentType = LLVM::LLVMStructType::getIdentified(
+      context, "iree_hal_executable_environment_v0_t");
+  assert(environmentType &&
+         "environment type must be defined by ConvertToLLVM");
+  auto dispatchStateType = LLVM::LLVMStructType::getIdentified(
+      context, "iree_hal_executable_dispatch_state_v0_t");
+  assert(dispatchStateType &&
+         "dispatch state type must be defined by ConvertToLLVM");
+  auto workgroupStateType = LLVM::LLVMStructType::getIdentified(
+      context, "iree_hal_executable_workgroup_state_v0_t");
+  assert(workgroupStateType &&
+         "workgroup state type must be defined by ConvertToLLVM");
+  return SmallVector<Type, 5>{
+      // const iree_hal_executable_environment_v0_t* IREE_RESTRICT
+      //   environment
+      LLVM::LLVMPointerType::get(environmentType),
+      // const iree_hal_executable_dispatch_state_v0_t* IREE_RESTRICT
+      //   dispatch_state
+      LLVM::LLVMPointerType::get(dispatchStateType),
+      // const iree_hal_executable_workgroup_state_v0_t* IREE_RESTRICT
+      //   workgroup_state
+      LLVM::LLVMPointerType::get(workgroupStateType),
+  };
+}
+
+// static
+LLVM::DISubprogramAttr HALDispatchABI::buildScopeAttr(
+    mlir::ModuleOp moduleOp, StringRef funcName,
+    LLVMTypeConverter *typeConverter) {
+  auto *context = &typeConverter->getContext();
+  Builder builder(context);
+
+  std::string inputFilePath("-");
+  if (auto fileLoc = moduleOp.getLoc().dyn_cast<mlir::FileLineColLoc>()) {
+    inputFilePath = fileLoc.getFilename().getValue();
+  }
+
+  auto fileAttr =
+      LLVM::DIFileAttr::get(context, llvm::sys::path::filename(inputFilePath),
+                            llvm::sys::path::parent_path(inputFilePath));
+  auto compileUnitAttr = LLVM::DICompileUnitAttr::get(
+      context, llvm::dwarf::DW_LANG_C17, fileAttr,
+      builder.getStringAttr("IREE"), /*isOptimized=*/true,
+      LLVM::DIEmissionKind::Full);
+
+  auto int32TypeAttr =
+      LLVM::DIBasicTypeAttr::get(context, llvm::dwarf::DW_TAG_base_type, "int",
+                                 /*sizeInBits=*/32, llvm::dwarf::DW_ATE_signed);
+  ExecutableLibraryDI di(typeConverter);
+  auto subroutineTypeAttr = LLVM::DISubroutineTypeAttr::get(
+      context, llvm::dwarf::DW_CC_normal,
+      {
+          int32TypeAttr,
+          di.getPtrOf(di.getConstOf(di.getEnvironmentV0T())),
+          di.getPtrOf(di.getConstOf(di.getDispatchStateV0T())),
+          di.getPtrOf(di.getConstOf(di.getWorkgroupStateV0T())),
+      });
+
+  auto funcNameAttr = builder.getStringAttr(funcName);
+  return LLVM::DISubprogramAttr::get(
+      context, compileUnitAttr, fileAttr, funcNameAttr, funcNameAttr, fileAttr,
+      /*line=*/1,
+      /*scopeline=*/1,
+      LLVM::DISubprogramFlags::Definition | LLVM::DISubprogramFlags::Optimized,
+      subroutineTypeAttr);
+}
+
+// Returns the most local DISubprogramAttr starting from |forOp|.
+static LLVM::DISubprogramAttr getLocalScopeAttr(Operation *forOp) {
+  auto funcOp = forOp->getParentOfType<LLVM::LLVMFuncOp>();
+  assert(funcOp && "usage requires an enclosing LLVMFuncOp");
+  auto scopeLocAttr =
+      funcOp.getLoc()
+          ->findInstanceOf<mlir::FusedLocWith<LLVM::DISubprogramAttr>>();
+  assert(scopeLocAttr &&
+         "must have attached a DISubprogramAttr to the parent function");
+  return scopeLocAttr.getMetadata();
+}
+
+// Returns the argument at |argIndex| in the parent function of |forOp|.
+static Value getLocalArgument(Operation *forOp, unsigned argIndex) {
+  auto funcOp = forOp->getParentOfType<LLVM::LLVMFuncOp>();
+  assert(funcOp && "usage requires an enclosing LLVMFuncOp");
+  return funcOp.getArgument(argIndex);
+}
+
+// Returns "x" "y" or "z" based on |dim|.
+static StringRef getDimName(int32_t dim) {
+  assert(dim >= 0 && dim <= 2 && "must be x, y, z");
+  static const char *dims[3] = {"x", "y", "z"};
+  return StringRef(dims[dim]);
+}
+
+// Debug intrinsics require valid location information to pass LLVM's verifier.
+// Since nothing checks these cases in MLIR before converting we avoid creating
+// the ops if MLIR or LLVM is likely to reject them.
+static bool isLocationValidForDI(Location loc) {
+  // Unknown locations are passed as null and DI doesn't like that.
+  if (loc.isa<UnknownLoc>()) return false;
+  // MLIR currently can't handle name-only locations. We do this check to ensure
+  // there's at least one real location MLIR can pass along.
+  if (auto callLoc = loc.dyn_cast<CallSiteLoc>()) {
+    return isLocationValidForDI(callLoc.getCaller()) &&
+           isLocationValidForDI(callLoc.getCallee());
+  } else if (auto fileLoc = loc.dyn_cast<FileLineColLoc>()) {
+    return true;
+  } else if (auto fusedLoc = loc.dyn_cast<FusedLoc>()) {
+    return llvm::all_of(fusedLoc.getLocations(), isLocationValidForDI);
+  } else if (auto namedLoc = loc.dyn_cast<NameLoc>()) {
+    return isLocationValidForDI(namedLoc.getChildLoc());
+  } else if (auto opaqueLoc = loc.dyn_cast<OpaqueLoc>()) {
+    return isLocationValidForDI(opaqueLoc.getFallbackLocation());
+  }
+  return false;
+}
+
+static Value buildArgDI(Operation *forOp, int argNum, Value value, Twine name,
+                        LLVM::DITypeAttr type, OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  if (!isLocationValidForDI(loc)) return value;
+  auto scopeAttr = getLocalScopeAttr(forOp);
+  builder.create<LLVM::DbgValueOp>(
+      loc, value,
+      LLVM::DILocalVariableAttr::get(scopeAttr, builder.getStringAttr(name),
+                                     scopeAttr.getFile(),
+                                     /*line=*/1, /*arg=*/argNum + 1,
+                                     /*alignInBits=*/0, type));
+  return value;
+}
+
+static Value buildValueDI(Operation *forOp, Value value, Twine name,
+                          LLVM::DITypeAttr type, OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  if (!isLocationValidForDI(loc)) return value;
+  auto scopeAttr = getLocalScopeAttr(forOp);
+  builder.create<LLVM::DbgValueOp>(
+      loc, value,
+      LLVM::DILocalVariableAttr::get(scopeAttr, builder.getStringAttr(name),
+                                     scopeAttr.getFile(),
+                                     /*line=*/1, /*arg=*/0,
+                                     /*alignInBits=*/0, type));
+  return value;
+}
+
+Value HALDispatchABI::loadWorkgroupID(Operation *forOp, int32_t dim,
+                                      Type resultType, OpBuilder &builder) {
+  auto dimValue =
+      loadFieldValue(forOp, WorkgroupStateField::workgroup_id_x + dim, builder);
+  auto resultValue =
+      castValueToType(forOp->getLoc(), dimValue, resultType, builder);
+  return buildValueDI(forOp, resultValue,
+                      StringRef("workgroup_id_") + getDimName(dim),
+                      di.getBasicType(resultType), builder);
+}
+
+Value HALDispatchABI::loadWorkgroupCount(Operation *forOp, int32_t dim,
+                                         Type resultType, OpBuilder &builder) {
+  auto dimValue = loadFieldValue(
+      forOp, DispatchStateField::workgroup_count_x + dim, builder);
+  auto resultValue =
+      castValueToType(forOp->getLoc(), dimValue, resultType, builder);
+  return buildValueDI(forOp, resultValue,
+                      StringRef("workgroup_count_") + getDimName(dim),
+                      di.getBasicType(resultType), builder);
+}
+
+Value HALDispatchABI::loadWorkgroupSize(Operation *forOp, int32_t dim,
+                                        Type resultType, OpBuilder &builder) {
+  auto dimValue = loadFieldValue(
+      forOp, DispatchStateField::workgroup_size_x + dim, builder);
+  auto resultValue =
+      castValueToType(forOp->getLoc(), dimValue, resultType, builder);
+  return buildValueDI(forOp, resultValue,
+                      StringRef("workgroup_size_") + getDimName(dim),
+                      di.getBasicType(resultType), builder);
+}
+
+Value HALDispatchABI::loadMaxConcurrency(Operation *forOp, OpBuilder &builder) {
+  auto maxValue =
+      loadFieldValue(forOp, DispatchStateField::max_concurrency, builder);
+  auto resultValue = castValueToType(
+      forOp->getLoc(), maxValue,
+      typeConverter->convertType(builder.getIndexType()), builder);
+  return buildValueDI(forOp, resultValue, "max_concurrency", di.getIntptrT(),
+                      builder);
+}
+
+Value HALDispatchABI::loadWorkgroupLocalMemorySize(Operation *forOp,
+                                                   OpBuilder &builder) {
+  auto sizeValue =
+      loadFieldValue(forOp, WorkgroupStateField::local_memory_size, builder);
+  auto resultValue = castValueToType(
+      forOp->getLoc(), sizeValue,
+      typeConverter->convertType(builder.getIndexType()), builder);
+  return buildValueDI(forOp, resultValue, "local_memory_size", di.getSizeT(),
+                      builder);
+}
+
+Value HALDispatchABI::loadWorkgroupLocalMemoryPtr(Operation *forOp,
+                                                  OpBuilder &builder) {
+  auto resultValue =
+      loadFieldValue(forOp, WorkgroupStateField::local_memory, builder);
+  return buildValueDI(forOp, resultValue, "local_memory", di.getVoidPtr(),
+                      builder);
+}
+
+Value HALDispatchABI::loadPushConstantCount(Operation *forOp,
+                                            OpBuilder &builder) {
+  auto countValue =
+      loadFieldValue(forOp, DispatchStateField::push_constant_count, builder);
+  auto resultValue = castValueToType(
+      forOp->getLoc(), countValue,
+      typeConverter->convertType(builder.getIndexType()), builder);
+  return buildValueDI(forOp, resultValue, "push_constant_count", di.getSizeT(),
+                      builder);
+}
+
+Value HALDispatchABI::loadPushConstant(Operation *forOp, int64_t offset,
+                                       Type resultType, OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto constantsPtrValue =
+      loadFieldValue(forOp, DispatchStateField::push_constants, builder);
+  auto offsetValue = getIndexValue(loc, offset, builder);
+  Value constantPtrValue = builder.create<LLVM::GEPOp>(
+      loc, constantsPtrValue.getType(), constantsPtrValue, offsetValue);
+  Value constantValue = builder.create<LLVM::LoadOp>(loc, constantPtrValue);
+  auto resultValue = castValueToType(loc, constantValue, resultType, builder);
+  return buildValueDI(
+      forOp, resultValue,
+      StringRef("push_constant[") + std::to_string(offset) + "]",
+      di.getBasicType(resultType), builder);
+}
+
+Value HALDispatchABI::loadBindingCount(Operation *forOp, OpBuilder &builder) {
+  auto countValue =
+      loadFieldValue(forOp, DispatchStateField::binding_count, builder);
+  auto resultValue = castValueToType(
+      forOp->getLoc(), countValue,
+      typeConverter->convertType(builder.getIndexType()), builder);
+  return buildValueDI(forOp, resultValue, "binding_count", di.getSizeT(),
+                      builder);
+}
+
+Value HALDispatchABI::loadBindingPtr(Operation *forOp, int64_t ordinal,
+                                     OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto ptrsPtrValue =
+      loadFieldValue(forOp, DispatchStateField::binding_ptrs, builder);
+  auto ordinalValue = getIndexValue(loc, ordinal, builder);
+  auto elementPtrValue = builder.create<LLVM::GEPOp>(
+      loc, ptrsPtrValue.getType(), ptrsPtrValue, ordinalValue);
+  auto elementValue = builder.create<LLVM::LoadOp>(loc, elementPtrValue);
+  return buildValueDI(
+      forOp, elementValue,
+      StringRef("binding_ptrs[") + std::to_string(ordinal) + "]",
+      di.getPtrOf(di.getUint8T()), builder);
+}
+
+Value HALDispatchABI::loadBindingLength(Operation *forOp, int64_t ordinal,
+                                        OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto lengthsPtrValue =
+      loadFieldValue(forOp, DispatchStateField::binding_lengths, builder);
+  auto ordinalValue = getIndexValue(loc, ordinal, builder);
+  auto elementPtrValue = builder.create<LLVM::GEPOp>(
+      loc, lengthsPtrValue.getType(), lengthsPtrValue, ordinalValue);
+  auto elementValue = builder.create<LLVM::LoadOp>(loc, elementPtrValue);
+  return buildValueDI(
+      forOp, elementValue,
+      StringRef("binding_lengths[") + std::to_string(ordinal) + "]",
+      di.getSizeT(), builder);
+}
+
+MemRefDescriptor HALDispatchABI::loadBinding(Operation *forOp, int64_t ordinal,
+                                             Value baseOffsetValue,
+                                             MemRefType memRefType,
+                                             ValueRange dynamicDims,
+                                             OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+
+  // Load the base buffer pointer in the appropriate type (f32*, etc).
+  Value basePtrValue = loadBindingPtr(forOp, ordinal, builder);
+
+  // Adjust by baseOffset (if needed).
+  if (baseOffsetValue) {
+    basePtrValue = builder.create<LLVM::GEPOp>(loc, basePtrValue.getType(),
+                                               basePtrValue, baseOffsetValue);
+  }
+
+  // NOTE: if we wanted to check the range was in bounds here would be the
+  // place to do it.
+
+  // Cast to the desired memref element type.
+  auto elementType = typeConverter->convertType(memRefType.getElementType());
+  Value typedPtrValue = builder.create<LLVM::BitcastOp>(
+      loc,
+      LLVM::LLVMPointerType::get(elementType, memRefType.getMemorySpaceAsInt()),
+      basePtrValue);
+
+  // Construct the MemRefDescriptor type based on the information we have.
+  // NOTE: we could use the binding length to clamp this/check that the
+  // requested range is valid.
+  if (memRefType.hasStaticShape()) {
+    return MemRefDescriptor::fromStaticShape(builder, loc, *typeConverter,
+                                             memRefType, typedPtrValue);
+  } else {
+    assert(memRefType.getNumDynamicDims() == dynamicDims.size());
+    int64_t rank = memRefType.getRank();
+
+    // Build MemRef descriptor for this interface binding.
+    auto desc = MemRefDescriptor::undef(builder, loc,
+                                        typeConverter->convertType(memRefType));
+    desc.setAllocatedPtr(builder, loc, typedPtrValue);
+    desc.setAlignedPtr(builder, loc, typedPtrValue);
+    desc.setConstantOffset(builder, loc, 0);
+
+    // Update memref descriptor shape. Dynamic dimensions can be mixed with
+    // static dimensions, like [128, ?, 128].
+    int dynamicDimIndex = 0;
+    for (int i = 0; i < rank; ++i) {
+      if (memRefType.isDynamicDim(i)) {
+        desc.setSize(builder, loc, i, dynamicDims[dynamicDimIndex++]);
+      } else {
+        desc.setConstantSize(builder, loc, i, memRefType.getDimSize(i));
+      }
+    }
+
+    // Compute and update strides. Assume that MemRefs are row-major, that is,
+    // following index linearization:
+    //   x[i, j, k] = i * x.dim[1] * x.dim[2] + j * x.dim[2] + k
+    desc.setConstantStride(builder, loc, rank - 1, 1);
+    for (int i = rank - 2; i >= 0; --i) {
+      auto stride = desc.stride(builder, loc, i + 1);
+      auto dim = desc.size(builder, loc, i + 1);
+      Value strideVal = builder.create<LLVM::MulOp>(loc, stride, dim);
+      desc.setStride(builder, loc, i, strideVal);
+    }
+
+    return desc;
+  }
+}
+
+Value HALDispatchABI::loadProcessorID(Operation *forOp, OpBuilder &builder) {
+  auto resultValue =
+      loadFieldValue(forOp, WorkgroupStateField::processor_id, builder);
+  return buildValueDI(forOp, resultValue, "processor_id",
+                      di.getBasicType(resultValue.getType()), builder);
+}
+
+Value HALDispatchABI::loadProcessorData(Operation *forOp, int64_t index,
+                                        OpBuilder &builder) {
+  // Load the value; it should always be in bounds.
+  Value dataArrayValue = loadFieldValue(forOp, ProcessorField::data, builder);
+  SmallVector<int64_t, 1> position = {index};
+  Value dataValue = builder.create<LLVM::ExtractValueOp>(
+      forOp->getLoc(), dataArrayValue, position);
+  return buildValueDI(
+      forOp, dataValue,
+      StringRef("processor_data[") + std::to_string(index) + "]",
+      di.getBasicType(dataValue.getType()), builder);
+}
+
+Value HALDispatchABI::loadExecutableConstant(Operation *forOp, StringRef key,
+                                             Type resultType,
+                                             OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+
+  // Create top-level global placeholder.
+  // The magic attribute is used by future assignment passes.
+  std::string globalName = ("__constant_ordinal_" + key).str();
+  auto moduleOp =
+      builder.getInsertionPoint()->getParentOfType<mlir::ModuleOp>();
+  LLVM::GlobalOp globalOp;
+  if (!(globalOp = moduleOp.lookupSymbol<LLVM::GlobalOp>(globalName))) {
+    auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
+    globalOp = moduleBuilder.create<LLVM::GlobalOp>(
+        loc, builder.getI32Type(),
+        /*isConstant=*/false, LLVM::Linkage::Internal, globalName, Attribute{});
+    globalOp->setAttr(IREE::HAL::ExecutableConstantBlockOp::getKeyAttrName(),
+                      builder.getStringAttr(key));
+  }
+
+  // Load the placeholder global ordinal.
+  Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, globalOp);
+  Value ordinalValue = builder.create<LLVM::LoadOp>(loc, globalPtr);
+
+  // Load constant from the executable constants struct.
+  auto constantsPtrValue =
+      loadFieldValue(forOp, EnvironmentField::constants, builder);
+  Value constantPtrValue = builder.create<LLVM::GEPOp>(
+      loc, constantsPtrValue.getType(), constantsPtrValue, ordinalValue);
+  Value constantValue = builder.create<LLVM::LoadOp>(loc, constantPtrValue);
+  auto resultValue = castValueToType(loc, constantValue, resultType, builder);
+  return buildValueDI(forOp, resultValue,
+                      StringRef("executable_constant['") + key + "']",
+                      di.getBasicType(resultValue.getType()), builder);
+}
+
+Value HALDispatchABI::loadImportOrdinal(Operation *forOp, StringRef importName,
+                                        bool weak, OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+
+  // Create top-level global placeholder.
+  // The magic attribute is used by future assignment passes.
+  std::string globalName = ("__import_ordinal_" + importName).str();
+  auto moduleOp =
+      builder.getInsertionPoint()->getParentOfType<mlir::ModuleOp>();
+  LLVM::GlobalOp globalOp;
+  if (!(globalOp = moduleOp.lookupSymbol<LLVM::GlobalOp>(globalName))) {
+    auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
+    globalOp = moduleBuilder.create<LLVM::GlobalOp>(
+        loc, builder.getI32Type(),
+        /*isConstant=*/false, LLVM::Linkage::Internal, globalName, Attribute{});
+    globalOp->setAttr("hal.executable.import.key",
+                      builder.getStringAttr(importName));
+    if (weak) {
+      globalOp->setAttr("hal.executable.import.weak", builder.getUnitAttr());
+    }
+  }
+
+  // Load the placeholder global ordinal.
+  Value globalPtr = builder.create<LLVM::AddressOfOp>(loc, globalOp);
+  return builder.create<LLVM::LoadOp>(loc, globalPtr);
+}
+
+std::pair<Value, Value> HALDispatchABI::loadImportFunc(Operation *forOp,
+                                                       Value importOrdinal,
+                                                       OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto funcPtrsValue =
+      loadFieldValue(forOp, EnvironmentField::import_funcs, builder);
+  auto funcPtrValue = builder.create<LLVM::GEPOp>(loc, funcPtrsValue.getType(),
+                                                  funcPtrsValue, importOrdinal);
+  auto contextPtrsValue =
+      loadFieldValue(forOp, EnvironmentField::import_contexts, builder);
+  auto contextPtrValue = builder.create<LLVM::GEPOp>(
+      loc, contextPtrsValue.getType(), contextPtrsValue, importOrdinal);
+  return std::make_pair(builder.create<LLVM::LoadOp>(loc, funcPtrValue),
+                        builder.create<LLVM::LoadOp>(loc, contextPtrValue));
+}
+
+Value HALDispatchABI::isImportFuncAvailable(Operation *forOp,
+                                            StringRef importName,
+                                            OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto importOrdinal =
+      loadImportOrdinal(forOp, importName, /*weak=*/true, builder);
+  auto importFunc = loadImportFunc(forOp, importOrdinal, builder);
+  Value nullPtrValue =
+      builder.create<LLVM::NullOp>(loc, importFunc.first.getType());
+  return builder.create<LLVM::ICmpOp>(loc, builder.getI1Type(),
+                                      LLVM::ICmpPredicate::ne, importFunc.first,
+                                      nullPtrValue);
+}
+
+Value HALDispatchABI::callImport(Operation *forOp, StringRef importName,
+                                 bool weak, Value params, OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto importOrdinal = loadImportOrdinal(forOp, importName, weak, builder);
+  auto thunkPtrValue =
+      loadFieldValue(forOp, EnvironmentField::import_thunk, builder);
+  auto importFunc = loadImportFunc(forOp, importOrdinal, builder);
+
+  // TODO(benvanik): if weak is set then we should bail if the import is not
+  // found. Since we've loaded the import func here we can just compare for
+  // null as in isImportFuncAvailable but we'll need to make the control flow.
+  assert(!weak && "calls to weak imports not yet implemented");
+
+  Value nullPtrValue = builder.create<LLVM::NullOp>(
+      loc, LLVM::LLVMPointerType::get(builder.getI8Type()));
+  auto callOp =
+      builder.create<LLVM::CallOp>(loc, TypeRange{builder.getI32Type()},
+                                   ValueRange{
+                                       /*thunk_func_ptr=*/thunkPtrValue,
+                                       /*import_func_ptr=*/importFunc.first,
+                                       /*context=*/importFunc.second,
+                                       /*params=*/params,
+                                       /*reserved=*/nullPtrValue,
+                                   });
+  return callOp.getResult();
+}
+
+SmallVector<Value> HALDispatchABI::wrapAndCallImport(
+    Operation *forOp, StringRef importName, bool weak, TypeRange resultTypes,
+    ValueRange args, OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+
+  // Struct types are ordered [results..., args...].
+  SmallVector<Type> types(resultTypes);
+  types.reserve(resultTypes.size() + args.size());
+  for (Value arg : args) {
+    types.push_back(typeConverter->convertType(arg.getType()));
+  }
+
+  // Pack parameter structure.
+  Type structType;
+  Value paramsPtr, voidPtr;
+  auto voidPtrTy = LLVM::LLVMPointerType::get(builder.getI8Type());
+  if (!types.empty()) {
+    // TODO(benvanik): set specific layout to match runtime.
+    structType = LLVM::LLVMStructType::getLiteral(context, types);
+    auto ptrStructType = LLVM::LLVMPointerType::get(structType);
+    Value one = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
+                                                 builder.getIndexAttr(1));
+    paramsPtr = builder.create<LLVM::AllocaOp>(loc, ptrStructType, one,
+                                               /*alignment=*/0);
+    Value structVal = builder.create<LLVM::UndefOp>(loc, structType);
+    for (int64_t i = 0, e = args.size(); i < e; ++i) {
+      structVal = builder.create<LLVM::InsertValueOp>(loc, structVal, args[i],
+                                                      i + resultTypes.size());
+    }
+    // Store into the alloca'ed descriptor.
+    builder.create<LLVM::StoreOp>(loc, structVal, paramsPtr);
+    voidPtr = builder.create<LLVM::BitcastOp>(loc, voidPtrTy, paramsPtr);
+  } else {
+    voidPtr = builder.create<LLVM::UndefOp>(loc, voidPtrTy);
+  }
+
+  // Calls return 0 (success) or non-zero (failure).
+  auto callResult = callImport(forOp, importName, weak, voidPtr, builder);
+  Block *trueDest =
+      builder.getInsertionBlock()->splitBlock(++builder.getInsertionPoint());
+  Block *falseDest = builder.createBlock(trueDest);
+
+  // Check the call results and branch to exit if it failed.
+  // Note that we weight the true branch (call successful) higher.
+  builder.setInsertionPointAfterValue(callResult);
+  Value zeroI32 = builder.create<LLVM::ConstantOp>(
+      loc, builder.getI32Type(), builder.getI32IntegerAttr(0));
+  Value cmpZero = builder.create<LLVM::ICmpOp>(
+      loc, builder.getI1Type(), LLVM::ICmpPredicate::eq, callResult, zeroI32);
+  builder.create<LLVM::CondBrOp>(loc, cmpZero, trueDest, ValueRange{},
+                                 falseDest, ValueRange{callResult},
+                                 std::make_pair(1u, 0u));
+
+  // Failure return block.
+  // Return the call result to the runtime.
+  builder.setInsertionPointToStart(falseDest);
+  builder.create<LLVM::ReturnOp>(
+      loc, falseDest->addArgument(builder.getI32Type(), loc));
+
+  // Successful continuation block.
+  // Marshal results out of the params struct.
+  builder.setInsertionPointToStart(trueDest);
+  SmallVector<Value> results;
+  if (!resultTypes.empty()) {
+    results.reserve(resultTypes.size());
+    Value structVal = builder.create<LLVM::LoadOp>(loc, structType, paramsPtr);
+    for (int64_t i = 0, e = resultTypes.size(); i < e; ++i) {
+      results.push_back(
+          builder.create<LLVM::ExtractValueOp>(loc, structVal, i));
+    }
+  }
+  return results;
+}
+
+Value HALDispatchABI::getIndexValue(Location loc, int64_t value,
+                                    OpBuilder &builder) {
+  return builder.create<LLVM::ConstantOp>(
+      loc, typeConverter->convertType(builder.getIndexType()),
+      builder.getI64IntegerAttr(value));
+}
+
+Value HALDispatchABI::castValueToType(Location loc, Value value,
+                                      Type resultType, OpBuilder &builder) {
+  // NOTE: we should handle more cases here (and proper sign extension).
+  if (value.getType() == resultType) return value;
+  return builder.createOrFold<LLVM::ZExtOp>(loc, resultType, value);
+}
+
+Value HALDispatchABI::loadFieldValue(Operation *forOp, EnvironmentField field,
+                                     OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto environmentPtrValue =
+      buildArgDI(forOp, /*argNum=*/0, getLocalArgument(forOp, 0), "environment",
+                 di.getPtrOf(di.getConstOf(di.getEnvironmentV0T())), builder);
+  Value environmentValue =
+      builder.create<LLVM::LoadOp>(loc, environmentPtrValue);
+  SmallVector<int64_t, 1> position = {int64_t(field)};
+  return builder.create<LLVM::ExtractValueOp>(loc, environmentValue, position);
+}
+
+Value HALDispatchABI::loadFieldValue(Operation *forOp, ProcessorField field,
+                                     OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  Value processorValue =
+      loadFieldValue(forOp, EnvironmentField::processor, builder);
+  SmallVector<int64_t, 1> position = {int64_t(field)};
+  return builder.create<LLVM::ExtractValueOp>(loc, processorValue, position);
+}
+
+Value HALDispatchABI::loadFieldValue(Operation *forOp, DispatchStateField field,
+                                     OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto statePtrValue = buildArgDI(
+      forOp, /*argNum=*/1, getLocalArgument(forOp, 1), "dispatch_state",
+      di.getPtrOf(di.getConstOf(di.getDispatchStateV0T())), builder);
+  Value stateValue = builder.create<LLVM::LoadOp>(loc, statePtrValue);
+  SmallVector<int64_t, 1> position = {int64_t(field)};
+  return builder.create<LLVM::ExtractValueOp>(loc, stateValue, position);
+}
+
+Value HALDispatchABI::loadFieldValue(Operation *forOp,
+                                     WorkgroupStateField field,
+                                     OpBuilder &builder) {
+  auto loc = forOp->getLoc();
+  auto statePtrValue = buildArgDI(
+      forOp, /*argNum=*/2, getLocalArgument(forOp, 2), "workgroup_state",
+      di.getPtrOf(di.getConstOf(di.getWorkgroupStateV0T())), builder);
+  Value stateValue = builder.create<LLVM::LoadOp>(loc, statePtrValue);
+  SmallVector<int64_t, 1> position = {int64_t(field)};
+  return builder.create<LLVM::ExtractValueOp>(loc, stateValue, position);
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.h
@@ -1,0 +1,348 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_LLVMCPU_DISPATCHABI_H_
+#define IREE_COMPILER_CODEGEN_LLVMCPU_DISPATCHABI_H_
+
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/Support/Mutex.h"
+#include "llvm/Support/raw_ostream.h"
+#include "mlir/Conversion/LLVMCommon/MemRefBuilder.h"
+#include "mlir/Conversion/LLVMCommon/TypeConverter.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+// NOTE: HALDispatchABI and the associated conversion patterns should live under
+// iree/compiler/Dialect/HAL/Target/LLVM/ instead of here as they have nothing
+// to do with linalg. If we need to use the patterns in this conversion we can
+// expose a populate*Patterns() function to access them without needing them
+// defined here.
+
+//------------------------------------------------------------------------------
+// ExecutableLibraryDI
+//------------------------------------------------------------------------------
+
+// Debug information adapter for the executable_library.h types.
+// Manually synchronized with the runtime header as needed.
+class ExecutableLibraryDI {
+ public:
+  // Initializes a cached DI provider using |typeConverter| to determine
+  // variable-width types such as index/size_t.
+  explicit ExecutableLibraryDI(LLVMTypeConverter *typeConverter);
+
+  // Returns `void*`.
+  LLVM::DIDerivedTypeAttr getVoidPtr() { return voidPtr; }
+  // Returns `int8_t`.
+  LLVM::DIDerivedTypeAttr getInt8T() { return int8T; }
+  // Returns `uint8_t`.
+  LLVM::DIDerivedTypeAttr getUint8T() { return uint8T; }
+  // Returns `int16_t`.
+  LLVM::DIDerivedTypeAttr getInt16T() { return int16T; }
+  // Returns `uint16_t`.
+  LLVM::DIDerivedTypeAttr getUint16T() { return uint16T; }
+  // Returns `int32_t`.
+  LLVM::DIDerivedTypeAttr getInt32T() { return int32T; }
+  // Returns `uint32_t`.
+  LLVM::DIDerivedTypeAttr getUint32T() { return uint32T; }
+  // Returns `int64_t`.
+  LLVM::DIDerivedTypeAttr getInt64T() { return int64T; }
+  // Returns `uint64_t`.
+  LLVM::DIDerivedTypeAttr getUint64T() { return uint64T; }
+  // Returns `intptr_t`.
+  LLVM::DIDerivedTypeAttr getIntptrT() { return intptrT; }
+  // Returns `size_t`.
+  LLVM::DIDerivedTypeAttr getSizeT() { return sizeT; }
+
+  // Returns `const |typeAttr|`.
+  LLVM::DIDerivedTypeAttr getConstOf(LLVM::DITypeAttr typeAttr);
+
+  // Returns `|typeAttr|*`.
+  LLVM::DIDerivedTypeAttr getPtrOf(LLVM::DITypeAttr typeAttr);
+
+  // Returns `|typeAttr|[count]`.
+  LLVM::DICompositeTypeAttr getArrayOf(LLVM::DITypeAttr typeAttr,
+                                       int64_t count);
+
+  // Returns `using |name| = |typeAttr|`.
+  LLVM::DIDerivedTypeAttr getTypedefOf(StringRef name,
+                                       LLVM::DITypeAttr typeAttr);
+
+  // Returns a member |name| of |typeAttr| at bit offset |offsetInBits|.
+  // Upon return |offsetInBits| is updated to point after the member.
+  LLVM::DIDerivedTypeAttr getMemberOf(StringRef name, LLVM::DITypeAttr typeAttr,
+                                      unsigned *offsetInBits);
+
+  // Returns the DI type for the given LLVM type.
+  LLVM::DITypeAttr getBasicType(Type type);
+
+  // Returns `iree_hal_processor_v0_t`.
+  LLVM::DICompositeTypeAttr getProcessorV0T();
+  // Returns `iree_hal_executable_environment_v0_t`.
+  LLVM::DIDerivedTypeAttr getEnvironmentV0T();
+  // Returns `iree_hal_executable_dispatch_state_v0_t`.
+  LLVM::DIDerivedTypeAttr getDispatchStateV0T();
+  // Returns `iree_hal_executable_workgroup_state_v0_t`.
+  LLVM::DIDerivedTypeAttr getWorkgroupStateV0T();
+
+ private:
+  LLVMTypeConverter *typeConverter;
+  Builder builder;
+  LLVM::DIFileAttr fileAttr;
+  unsigned ptrBitwidth;
+
+  // Cached as they are commonly constructed with any usage of the DI info.
+  LLVM::DIDerivedTypeAttr voidPtr;
+  LLVM::DIDerivedTypeAttr int8T;
+  LLVM::DIDerivedTypeAttr uint8T;
+  LLVM::DIDerivedTypeAttr int16T;
+  LLVM::DIDerivedTypeAttr uint16T;
+  LLVM::DIDerivedTypeAttr int32T;
+  LLVM::DIDerivedTypeAttr uint32T;
+  LLVM::DIDerivedTypeAttr int64T;
+  LLVM::DIDerivedTypeAttr uint64T;
+  LLVM::DIDerivedTypeAttr intptrT;
+  LLVM::DIDerivedTypeAttr sizeT;
+};
+
+//------------------------------------------------------------------------------
+// HALDispatchABI
+//------------------------------------------------------------------------------
+
+// Utility for accessing the IREE HAL dispatch function ABI values.
+// All accesses should route through this vs directly manipulating LLVM function
+// arguments so that we can adjust the ABI over time and support multiple
+// versions in the same compiled output.
+class HALDispatchABI {
+ public:
+  // Matches the field order in iree_hal_processor_v0_t.
+  enum class ProcessorField {
+    data = 0,
+  };
+
+  // Matches IREE_HAL_PROCESSOR_DATA_CAPACITY_V0.
+  static constexpr int ProcessorDataCapacity = 8;
+
+  // Returns a Type representing iree_hal_processor_v0_t.
+  static LLVM::LLVMStructType getProcessorType(
+      MLIRContext *context, LLVMTypeConverter *typeConverter);
+
+  // Matches the field order in iree_hal_executable_environment_v0_t.
+  enum class EnvironmentField {
+    constants,
+    import_thunk,
+    import_funcs,
+    import_contexts,
+    processor,
+  };
+
+  // Returns a Type representing iree_hal_executable_environment_v0_t.
+  static LLVM::LLVMStructType getEnvironmentType(
+      MLIRContext *context, LLVMTypeConverter *typeConverter,
+      LLVM::LLVMStructType processorType);
+
+  // Matches the field order in iree_hal_executable_dispatch_state_v0_t.
+  enum class DispatchStateField {
+    /*uint32_t*/ workgroup_size_x,
+    /*uint32_t*/ workgroup_size_y,
+    /*uint16_t*/ workgroup_size_z,
+    /*uint16_t*/ push_constant_count,
+    /*uint32_t*/ workgroup_count_x,
+    /*uint32_t*/ workgroup_count_y,
+    /*uint16_t*/ workgroup_count_z,
+    /*uint8_t*/ max_concurrency,
+    /*uint8_t*/ binding_count,
+    /*intptr_t*/ push_constants,
+    /*intptr_t*/ binding_ptrs,
+    /*intptr_t*/ binding_lengths,
+  };
+  friend DispatchStateField operator+(DispatchStateField lhs, int32_t rhs) {
+    return static_cast<DispatchStateField>(static_cast<int32_t>(lhs) + rhs);
+  }
+
+  // Returns a Type representing iree_hal_executable_dispatch_state_v0_t.
+  static LLVM::LLVMStructType getDispatchStateType(
+      MLIRContext *context, LLVMTypeConverter *typeConverter);
+
+  enum class WorkgroupStateField {
+    /*uint32_t*/ workgroup_id_x = 0,
+    /*uint32_t*/ workgroup_id_y,
+    /*uint16_t*/ workgroup_id_z,
+    /*uint16_t*/ reserved,
+    /*uint32_t*/ processor_id,
+    /*intptr_t*/ local_memory,
+    /*uint32_t*/ local_memory_size,
+  };
+  friend WorkgroupStateField operator+(WorkgroupStateField lhs, int32_t rhs) {
+    return static_cast<WorkgroupStateField>(static_cast<int32_t>(lhs) + rhs);
+  }
+
+  // Returns a Type representing iree_hal_executable_workgroup_state_v0_t.
+  static LLVM::LLVMStructType getWorkgroupStateType(
+      MLIRContext *context, LLVMTypeConverter *typeConverter);
+
+  // Returns the types of the LLVM function inputs for the ABI.
+  // This matches the signature of `iree_hal_executable_dispatch_v0_t` in
+  // `iree/hal/local/executable_library.h`.
+  static SmallVector<Type, 5> getInputTypes(MLIRContext *context,
+                                            LLVMTypeConverter *typeConverter);
+
+  // Builds a DISubprogram for a function in |moduleOp| named |funcName|.
+  // This is required in order to get any debug information (including line
+  // tables) from MLIR into LLVM IR. It does not need to match the exact
+  // definition but the closer we can make it to the real thing the more useful
+  // downstream tools will be.
+  static LLVM::DISubprogramAttr buildScopeAttr(
+      mlir::ModuleOp moduleOp, StringRef funcName,
+      LLVMTypeConverter *typeConverter);
+
+  explicit HALDispatchABI(LLVMTypeConverter *typeConverter)
+      : context(&typeConverter->getContext()),
+        typeConverter(typeConverter),
+        processorType(getProcessorType(context, typeConverter)),
+        environmentType(
+            getEnvironmentType(context, typeConverter, processorType)),
+        dispatchStateType(getDispatchStateType(context, typeConverter)),
+        workgroupStateType(getWorkgroupStateType(context, typeConverter)),
+        di(typeConverter) {}
+
+  // Loads the workgroup_id[dim] value (XYZ) and casts it to |resultType|.
+  Value loadWorkgroupID(Operation *forOp, int32_t dim, Type resultType,
+                        OpBuilder &builder);
+
+  // Loads the workgroup_count[dim] value (XYZ) and casts it to |resultType|.
+  Value loadWorkgroupCount(Operation *forOp, int32_t dim, Type resultType,
+                           OpBuilder &builder);
+
+  // Loads the workgroup_size[dim] value (XYZ) and casts it to |resultType|.
+  Value loadWorkgroupSize(Operation *forOp, int32_t dim, Type resultType,
+                          OpBuilder &builder);
+
+  // Returns the estimated maximum concurrency as an index-converted type.
+  Value loadMaxConcurrency(Operation *forOp, OpBuilder &builder);
+
+  // Returns the total number of bytes available in workgroup local memory.
+  // This may be larger than the requested size.
+  Value loadWorkgroupLocalMemorySize(Operation *forOp, OpBuilder &builder);
+
+  // Loads the base pointer of the workgroup local memory.
+  // Note that this may be NULL if no workgroup local memory was requested.
+  Value loadWorkgroupLocalMemoryPtr(Operation *forOp, OpBuilder &builder);
+
+  // Returns the total push constant count as an index-converted type.
+  Value loadPushConstantCount(Operation *forOp, OpBuilder &builder);
+
+  // Loads a push constant at |offset| and casts it to |resultType|.
+  Value loadPushConstant(Operation *forOp, int64_t offset, Type resultType,
+                         OpBuilder &builder);
+
+  // Returns the total binding count as an index-converted type.
+  Value loadBindingCount(Operation *forOp, OpBuilder &builder);
+
+  // Loads the base pointer of the binding |ordinal| as an `i8**`.
+  // Equivalent to:
+  //   int8_t** base_ptr = &state->binding_ptrs[ordinal];
+  Value loadBindingPtr(Operation *forOp, int64_t ordinal, OpBuilder &builder);
+
+  // Loads the byte length of the binding |ordinal| as an index-converted type.
+  Value loadBindingLength(Operation *forOp, int64_t ordinal,
+                          OpBuilder &builder);
+
+  // Loads a binding as a constructed MemRefDescriptor.
+  // |baseOffset| can optionally adjust the base byte offset of the buffer.
+  MemRefDescriptor loadBinding(Operation *forOp, int64_t ordinal,
+                               Value baseOffsetValue, MemRefType memRefType,
+                               ValueRange dynamicDims, OpBuilder &builder);
+
+  // Loads the processor ID the code is (most likely) being run on.
+  // Equivalent to:
+  //   uint32_t processor_id = state->processor_id;
+  Value loadProcessorID(Operation *forOp, OpBuilder &builder);
+
+  // Loads a processor information data field at the given index.
+  // May be 0 if the field is not available.
+  Value loadProcessorData(Operation *forOp, int64_t index, OpBuilder &builder);
+
+  // Loads an executable constant with |key| and casts it to |resultType|.
+  // A placeholder global will be added for the ordinal.
+  Value loadExecutableConstant(Operation *forOp, StringRef key, Type resultType,
+                               OpBuilder &builder);
+
+  // Loads the ordinal of the import with the given |importName|.
+  // A placeholder global will be inserted that will be updated with the
+  // assigned ordinal after linking.
+  Value loadImportOrdinal(Operation *forOp, StringRef importName, bool weak,
+                          OpBuilder &builder);
+
+  // Loads the import function pointer of the import |ordinal|.
+  // Equivalent to:
+  //   iree_hal_executable_import_v0_t fn_ptr = state->import_funcs[ordinal];
+  //   void* context = state->import_contexts[ordinal];
+  std::pair<Value, Value> loadImportFunc(Operation *forOp, Value importOrdinal,
+                                         OpBuilder &builder);
+
+  // Returns an i1 indicating whether the optional import with |importName| is
+  // defined. Equivalent to:
+  //   state->import_funcs[ordinal] != NULL
+  Value isImportFuncAvailable(Operation *forOp, StringRef importName,
+                              OpBuilder &builder);
+
+  // Emits a call to the import with the given |importName|.
+  // The provided |params| struct containing the function-specific arguments
+  // is passed without modification.
+  // Returns 0 on success and non-zero otherwise.
+  Value callImport(Operation *forOp, StringRef importName, bool weak,
+                   Value params, OpBuilder &builder);
+
+  // Emits a call to a dynamically linked import using the given |importName|
+  // as a template.
+  // The provided |resultTypes| and |args| are packed in a struct and transit
+  // through memory so that we can expose a single void* argument.
+  // Returns 0 on success and non-zero otherwise.
+  SmallVector<Value> wrapAndCallImport(Operation *forOp, StringRef importName,
+                                       bool weak, TypeRange resultTypes,
+                                       ValueRange args, OpBuilder &builder);
+
+ private:
+  Value getIndexValue(Location loc, int64_t value, OpBuilder &builder);
+
+  Value castValueToType(Location loc, Value value, Type resultType,
+                        OpBuilder &builder);
+
+  Value loadFieldValue(Operation *forOp, EnvironmentField field,
+                       OpBuilder &builder);
+  Value loadFieldValue(Operation *forOp, ProcessorField field,
+                       OpBuilder &builder);
+  Value loadFieldValue(Operation *forOp, DispatchStateField field,
+                       OpBuilder &builder);
+  Value loadFieldValue(Operation *forOp, WorkgroupStateField field,
+                       OpBuilder &builder);
+
+  mlir::MLIRContext *context;
+  LLVMTypeConverter *typeConverter;
+  LLVM::LLVMStructType processorType;
+  LLVM::LLVMStructType environmentType;
+  LLVM::LLVMStructType dispatchStateType;
+  LLVM::LLVMStructType workgroupStateType;
+  LLVM::DISubprogramAttr scopeAttr;
+  ExecutableLibraryDI di;
+
+  // Used to lock around mutations of shared LLVM type information, e.g.
+  // mlir::LLVM::LLVMStructType::getIdentified.
+  static llvm::sys::Mutex sMutex;
+};
+
+}  // namespace iree_compiler
+}  // namespace mlir
+
+#endif  // IREE_COMPILER_CODEGEN_LLVMCPU_DISPATCHABI_H_

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/convert_to_llvm.mlir
@@ -8,8 +8,8 @@ builtin.module {
 }
 //      CHECK: llvm.func @extern_public()
 //      CHECK: llvm.func @entry_point(
-// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]:  !llvm.ptr<struct<"iree_hal_executable_environment_v0_t", opaque>> {llvm.align = 16 : i64, llvm.noalias}
-// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]:  !llvm.ptr<struct<"iree_hal_executable_dispatch_state_v0_t", opaque>> {llvm.align = 16 : i64, llvm.noalias}
-// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]:  !llvm.ptr<struct<"iree_hal_executable_workgroup_state_v0_t", opaque>> {llvm.align = 16 : i64, llvm.noalias}) -> i32
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: !llvm.ptr<struct<"iree_hal_executable_environment_v0_t", {{[^\{]+}}>> {llvm.align = 16 : i64, llvm.noalias},
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: !llvm.ptr<struct<"iree_hal_executable_dispatch_state_v0_t", {{[^\{]+}}>> {llvm.align = 16 : i64, llvm.noalias},
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: !llvm.ptr<struct<"iree_hal_executable_workgroup_state_v0_t", {{[^\{]+}}>> {llvm.align = 16 : i64, llvm.noalias}) -> i32
 //      CHECK:     llvm.return %{{.+}} : i32
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_workgroup_info.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/hal_interface_workgroup_info.mlir
@@ -6,7 +6,7 @@ func.func @workgroup_id() {
   // CHECK: %[[Z16:.+]] = llvm.extractvalue %[[STATE]][2]
   // CHECK: %[[Z64:.+]] = llvm.zext %[[Z16]] : i16 to i64
   %workgroup_id_z = hal.interface.workgroup.id[2] : index
-  // CHECK-NEXT: llvm.call @sink(%[[Z64]])
+  // CHECK: llvm.call @sink(%[[Z64]])
   %val = arith.index_cast %workgroup_id_z : index to i64
   llvm.call @sink(%val) : (i64) -> ()
   return
@@ -23,7 +23,7 @@ func.func @workgroup_size() {
   // CHECK: %[[Z16:.+]] = llvm.extractvalue %[[STATE]][2]
   // CHECK: %[[Z64:.+]] = llvm.zext %[[Z16]] : i16 to i64
   %workgroup_size_z = hal.interface.workgroup.size[2] : index
-  // CHECK-NEXT: llvm.call @sink(%[[Z64]])
+  // CHECK: llvm.call @sink(%[[Z64]])
   %val = arith.index_cast %workgroup_size_z : index to i64
   llvm.call @sink(%val) : (i64) -> ()
   return
@@ -40,7 +40,7 @@ func.func @workgroup_count() {
   // CHECK: %[[Z16:.+]] = llvm.extractvalue %[[STATE]][6]
   // CHECK: %[[Z64:.+]] = llvm.zext %[[Z16]] : i16 to i64
   %workgroup_count_z = hal.interface.workgroup.count[2] : index
-  // CHECK-NEXT: llvm.call @sink(%[[Z64]])
+  // CHECK: llvm.call @sink(%[[Z64]])
   %val = arith.index_cast %workgroup_count_z : index to i64
   llvm.call @sink(%val) : (i64) -> ()
   return

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -306,8 +306,7 @@ def EraseHALDescriptorTypeFromMemRef :
 
 def RematerializeParallelOps :
     Pass<"iree-codegen-rematerialize-parallel-ops", "func::FuncOp"> {
-  let summary = "Pass to rematerialize and merge parallel ops to avoid"
-                "creating temporary allocs.";
+  let summary = "Pass to rematerialize and merge parallel ops to avoid creating temporary allocs.";
   let constructor = "mlir::iree_compiler::createRematerializeParallelOpsPass()";
 }
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.h
@@ -43,7 +43,8 @@ struct LLVMTargetOptions {
   // Include debug information in output files (PDB, DWARF, etc).
   // Though this can be set independently from the optLevel (so -O3 with debug
   // information is valid) it may significantly change the output program
-  // and benchmarking
+  // contents and benchmarking of binary sizes and to some extent execution
+  // time should be avoided with symbols present.
   bool debugSymbols = true;
 
   // Sanitizer Kind for CPU Kernels


### PR DESCRIPTION
This restores line table information that had been dropped due to upstream MLIR changes by adding DISubprogramAttr to dispatch functions. In addition the arguments commonly used within dispatch functions are annotated with value information for use by debuggers. Additional debug information can be added in the future but hopefully with a way to more automatically keep it in sync with the runtime definitions. Since all of the debug information is strictly informational it's ok for them to get desynchronized (similar to our natvis file). Only ABI debug information is included here but others who may want to play with producing higher-level debug information can give that a try if they'd like though it's difficult to make anything at the higher-levels to make any sense by the time things reach codegen: there's no tensors, no ops, and after going through codegen even linalg-on-tensors or linalg-on-buffers doesn't make much sense.

Internal functions are not yet annotated but we don't generate any with the current pipeline anyway. Externs/imports are also not annotated but they are not usually needed by debuggers as the destination will usually contain this information or it'll be brought in via bitcode we merge.

Since this added quite a bit more code the debug info and type/accessors have been moved to their own file and cleaned up a bit. Previously we would recreate and cache the ABI accessors for every op converted leading to some expensive attribute interning - now we only cache the debug info and types once and reuse that for all ops.

Along with some other pending changes we can now step into dispatches as before as well as view dispatch parameters:
![image](https://user-images.githubusercontent.com/75337/213840105-52164cbf-53c2-43fb-bbce-dd876cde1f7c.png)

And tracy can now again show source/asm views when sampling:
![image](https://user-images.githubusercontent.com/75337/213840488-468b080d-0b17-4696-a272-e3e7880483d2.png)