### PR TITLE
Switching IREE dialects to useFoldAPI = kEmitFoldAdaptorFolder.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowBase.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowBase.td
@@ -64,6 +64,7 @@ def Flow_Dialect : Dialect {
 
   let useDefaultTypePrinterParser = 0;
   let useDefaultAttributePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALDialect.td
@@ -38,6 +38,7 @@ def HAL_Dialect : Dialect {
   }];
 
   let useDefaultAttributePrinterParser = 0;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 #endif // IREE_DIALECT_HAL_DIALECT

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALOpFolders.cpp
@@ -32,7 +32,7 @@ namespace HAL {
 // hal.tensor.import/export
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TensorImportOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TensorImportOp::fold(FoldAdaptor operands) {
   if (auto exportOp = getSource().getDefiningOp<TensorExportOp>()) {
     if (exportOp.getSource().getType() == getTarget().getType() &&
         exportOp.getSourceEncoding() == getTargetEncoding()) {
@@ -42,7 +42,7 @@ OpFoldResult TensorImportOp::fold(ArrayRef<Attribute> operands) {
   return {};
 }
 
-OpFoldResult TensorExportOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TensorExportOp::fold(FoldAdaptor operands) {
   if (auto importOp = getSource().getDefiningOp<TensorImportOp>()) {
     if (importOp.getSource().getType() == getTarget().getType() &&
         importOp.getTargetEncoding() == getSourceEncoding()) {

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamBase.td
@@ -108,6 +108,7 @@ def Stream_Dialect : Dialect {
 
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOpFolders.cpp
@@ -391,7 +391,7 @@ void ResourceDeallocaOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.resource.size
 //===----------------------------------------------------------------------===//
 
-OpFoldResult ResourceSizeOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ResourceSizeOp::fold(FoldAdaptor operands) {
   auto sizeAwareType =
       getOperand().getType().cast<IREE::Util::SizeAwareTypeInterface>();
   Operation *op = this->getOperation();
@@ -545,7 +545,7 @@ void ResourceStoreOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.resource.pack
 //===----------------------------------------------------------------------===//
 
-LogicalResult ResourcePackOp::fold(ArrayRef<Attribute> operands,
+LogicalResult ResourcePackOp::fold(FoldAdaptor operands,
                                    SmallVectorImpl<OpFoldResult> &results) {
   Builder builder(getContext());
 
@@ -687,7 +687,7 @@ void ResourcePackOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.resource.pack
 //===----------------------------------------------------------------------===//
 
-OpFoldResult ResourceSubviewOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ResourceSubviewOp::fold(FoldAdaptor operands) {
   if (getSourceSize() == getResultSize()) {
     // Entire range is covered; return it all.
     return getSource();
@@ -764,7 +764,7 @@ void ResourceSubviewOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.tensor.import
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TensorImportOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TensorImportOp::fold(FoldAdaptor operands) {
   // If operand comes from an export with the same affinity and size then fold.
   // Different affinities may indicate exporting from one device or queue and
   // importing to a different device or queue.
@@ -786,7 +786,7 @@ void TensorImportOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.tensor.export
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TensorExportOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TensorExportOp::fold(FoldAdaptor operands) {
   // If operand comes from import with the same properties then fold.
   // These checks are conservative, since encoding changes may be meaningful.
   auto importOp = getSource().getDefiningOp<TensorImportOp>();
@@ -1048,7 +1048,7 @@ void TensorSplatOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.tensor.clone
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TensorCloneOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TensorCloneOp::fold(FoldAdaptor operands) {
   auto users = getResult().getUsers();
   if (!users.empty() && std::next(users.begin()) == users.end()) {
     // If the second user is the end it means there's one user.
@@ -1088,7 +1088,7 @@ void TensorCloneOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.tensor.slice
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TensorSliceOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TensorSliceOp::fold(FoldAdaptor operands) {
   // TODO(benvanik): fold if source_size == result_size and affinity/lifetime.
   return {};
 }
@@ -1141,7 +1141,7 @@ void TensorFillOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.tensor.update
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TensorUpdateOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TensorUpdateOp::fold(FoldAdaptor operands) {
   // TODO(benvanik): fold if target_size == update_size and affinity/lifetime.
   return {};
 }
@@ -1301,7 +1301,7 @@ void AsyncSplatOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.async.clone
 //===----------------------------------------------------------------------===//
 
-OpFoldResult AsyncCloneOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult AsyncCloneOp::fold(FoldAdaptor operands) {
   // TODO(benvanik): trivial elides when there are no tied users/one user.
   return {};
 }
@@ -1351,7 +1351,7 @@ void AsyncCloneOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.async.slice
 //===----------------------------------------------------------------------===//
 
-OpFoldResult AsyncSliceOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult AsyncSliceOp::fold(FoldAdaptor operands) {
   if (getSourceSize() == getResultSize()) {
     // Slicing entire source - just reroute to source.
     // Note that this breaks copy-on-write semantics but will be fixed up during
@@ -1434,7 +1434,7 @@ void AsyncFillOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.async.update
 //===----------------------------------------------------------------------===//
 
-OpFoldResult AsyncUpdateOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult AsyncUpdateOp::fold(FoldAdaptor operands) {
   if (getUpdateSize() == getTargetSize()) {
     // If updating the entire target then just replace with the update.
     // Note that this breaks copy-on-write semantics but will be fixed up during
@@ -1573,7 +1573,7 @@ void AsyncCollectiveOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.async.transfer
 //===----------------------------------------------------------------------===//
 
-OpFoldResult AsyncTransferOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult AsyncTransferOp::fold(FoldAdaptor operands) {
   if (auto sourceTransferOp = getSource().getDefiningOp<AsyncTransferOp>()) {
     if (sourceTransferOp.getSource().getType() == getResult().getType() &&
         sourceTransferOp.getSourceAffinity() == getResultAffinity()) {
@@ -2237,7 +2237,7 @@ void CmdConcurrentOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.timepoint.immediate
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TimepointImmediateOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TimepointImmediateOp::fold(FoldAdaptor operands) {
   return IREE::Stream::TimepointAttr::get(getContext(), getResult().getType());
 }
 
@@ -2245,7 +2245,7 @@ OpFoldResult TimepointImmediateOp::fold(ArrayRef<Attribute> operands) {
 // stream.timepoint.export
 //===----------------------------------------------------------------------===//
 
-LogicalResult TimepointExportOp::fold(ArrayRef<Attribute> operands,
+LogicalResult TimepointExportOp::fold(FoldAdaptor operands,
                                       SmallVectorImpl<OpFoldResult> &results) {
   // If the source timepoint comes from an import op we can fold - but only if
   // the types match.
@@ -2263,8 +2263,9 @@ LogicalResult TimepointExportOp::fold(ArrayRef<Attribute> operands,
 // stream.timepoint.join
 //===----------------------------------------------------------------------===//
 
-OpFoldResult TimepointJoinOp::fold(ArrayRef<Attribute> operands) {
-  if (llvm::all_of(operands, [](auto operand) { return operand != nullptr; })) {
+OpFoldResult TimepointJoinOp::fold(FoldAdaptor operands) {
+  if (llvm::all_of(operands.getAwaitTimepoints(),
+                   [](auto operand) { return operand != nullptr; })) {
     // Immediate wait; fold into immediate.
     return IREE::Stream::TimepointAttr::get(getContext(),
                                             getResult().getType());
@@ -2434,9 +2435,9 @@ void TimepointBarrierOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // stream.timepoint.await
 //===----------------------------------------------------------------------===//
 
-LogicalResult TimepointAwaitOp::fold(ArrayRef<Attribute> foldOperands,
+LogicalResult TimepointAwaitOp::fold(FoldAdaptor operands,
                                      SmallVectorImpl<OpFoldResult> &results) {
-  if (foldOperands[0]) {
+  if (operands.getAwaitTimepoint()) {
     // Immediate wait; fold to all captured operands.
     results.append(getResourceOperands().begin(), getResourceOperands().end());
     return success();

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilBase.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilBase.td
@@ -24,6 +24,7 @@ def Util_Dialect : Dialect {
 
   let useDefaultTypePrinterParser = 1;
   let useDefaultAttributePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOpFolders.cpp
@@ -31,14 +31,15 @@ namespace Util {
 // util.cmp.eq
 //===----------------------------------------------------------------------===//
 
-OpFoldResult CmpEQOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpEQOp::fold(FoldAdaptor operands) {
   auto makeBool = [&](bool value) {
     return IntegerAttr::get(IntegerType::get(getContext(), 1), value ? 1 : 0);
   };
   if (getLhs() == getRhs()) {
     // SSA values are exactly the same.
     return makeBool(true);
-  } else if (operands[0] && operands[1] && operands[0] == operands[1]) {
+  } else if (operands.getLhs() && operands.getRhs() &&
+             operands.getLhs() == operands.getRhs()) {
     // Folded attributes are equal but may come from separate ops.
     return makeBool(true);
   }
@@ -72,12 +73,14 @@ static OpFoldResult foldRangeOp(Type type, ValueRange operands,
   return IntegerAttr::get(type, value);
 }
 
-OpFoldResult RangeMinOp::fold(ArrayRef<Attribute> operands) {
-  return foldRangeOp<INT64_MAX, xmin>(getType(), this->getOperands(), operands);
+OpFoldResult RangeMinOp::fold(FoldAdaptor operands) {
+  return foldRangeOp<INT64_MAX, xmin>(getType(), this->getOperands(),
+                                      operands.getOperands());
 }
 
-OpFoldResult RangeMaxOp::fold(ArrayRef<Attribute> operands) {
-  return foldRangeOp<INT64_MIN, xmax>(getType(), this->getOperands(), operands);
+OpFoldResult RangeMaxOp::fold(FoldAdaptor operands) {
+  return foldRangeOp<INT64_MIN, xmax>(getType(), this->getOperands(),
+                                      operands.getOperands());
 }
 
 namespace {
@@ -382,7 +385,7 @@ static bool isAlignedTo(Value value, Value alignment) {
   return false;
 }
 
-OpFoldResult AlignOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult AlignOp::fold(FoldAdaptor operands) {
   // If aligning an already-aligned value then fold if this is provably a
   // no-op. We can check this for equality even with dynamic alignments.
   if (isAlignedTo(getValue(), getAlignment())) return getValue();
@@ -393,7 +396,7 @@ OpFoldResult AlignOp::fold(ArrayRef<Attribute> operands) {
 // util.sizeof
 //===----------------------------------------------------------------------===//
 
-OpFoldResult SizeOfOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SizeOfOp::fold(FoldAdaptor operands) {
   Type t = getSizedType();
   if (t.isa<IntegerType>() || t.isa<FloatType>()) {
     return IntegerAttr::get(IndexType::get(getContext()),
@@ -587,7 +590,7 @@ void BufferAllocOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // util.buffer.subspan
 //===----------------------------------------------------------------------===//
 
-OpFoldResult BufferSubspanOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult BufferSubspanOp::fold(FoldAdaptor operands) {
   if (getSourceSize() == getResultSize()) {
     // Entire range is covered; return it all.
     return getSource();
@@ -701,7 +704,7 @@ void BufferSubspanOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // util.buffer.size
 //===----------------------------------------------------------------------===//
 
-OpFoldResult BufferSizeOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult BufferSizeOp::fold(FoldAdaptor operands) {
   // Try to find the size in the use-def chain.
   // If it's out of the local scope we'll need IPO to help out.
   // During A->B->C dialect conversion, the type may not be legal so be
@@ -815,7 +818,7 @@ void BufferStorageOp::getCanonicalizationPatterns(RewritePatternSet &results,
 // util.buffer.load
 //===----------------------------------------------------------------------===//
 
-OpFoldResult BufferLoadOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult BufferLoadOp::fold(FoldAdaptor operands) {
   // TODO(benvanik): if source is a constant then perform the load.
   return {};
 }

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/VMToEmitC/EmitCBuilders.cpp
@@ -24,6 +24,9 @@ std::string mapUnaryOperator(UnaryOperator op) {
       return "~";
     case UnaryOperator::LOGICAL_NOT:
       return "!";
+    default:
+      llvm_unreachable("unsupported unary operator");
+      return "XXX";
   }
 }
 
@@ -65,6 +68,9 @@ std::string mapBinaryOperator(BinaryOperator op) {
       return "<=";
     case BinaryOperator::GREATER_THAN_OR_EQUAL:
       return ">=";
+    default:
+      llvm_unreachable("unsupported binary operator");
+      return "XXX";
   }
 }
 }  // namespace

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMBase.td
@@ -45,6 +45,8 @@ def VM_Dialect : Dialect {
     The types in the VM dialect correspond to the storage rather than value
     type, with the interpretation of the type encoded on the op.
   }];
+
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/IR/VMOpFolders.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <algorithm>
+#include <type_traits>
 
 #include "iree/compiler/Dialect/VM/IR/VMDialect.h"
 #include "iree/compiler/Dialect/VM/IR/VMOps.h"
@@ -192,7 +193,6 @@ namespace {
 template <typename INDIRECT, typename DIRECT>
 struct PropagateGlobalLoadAddress : public OpRewritePattern<INDIRECT> {
   using OpRewritePattern<INDIRECT>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(INDIRECT op,
                                 PatternRewriter &rewriter) const override {
     if (auto addressOp = dyn_cast_or_null<IREE::Util::GlobalAddressOpInterface>(
@@ -247,7 +247,6 @@ namespace {
 template <typename INDIRECT, typename DIRECT>
 struct PropagateGlobalStoreAddress : public OpRewritePattern<INDIRECT> {
   using OpRewritePattern<INDIRECT>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(INDIRECT op,
                                 PatternRewriter &rewriter) const override {
     if (auto addressOp = dyn_cast_or_null<IREE::Util::GlobalAddressOpInterface>(
@@ -303,13 +302,15 @@ void GlobalStoreIndirectRefOp::getCanonicalizationPatterns(
 
 namespace {
 
-template <typename GeneralOp, typename ZeroOp>
+template <typename AttrT, typename GeneralOp, typename ZeroOp>
 struct FoldZeroConstPrimitive final : public OpRewritePattern<GeneralOp> {
   using OpRewritePattern<GeneralOp>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(GeneralOp constOp,
                                 PatternRewriter &rewriter) const override {
-    if (matchPattern(constOp.getResult(), m_Zero())) {
+    if ((std::is_same<AttrT, IntegerAttr>::value &&
+         matchPattern(constOp.getResult(), m_Zero())) ||
+        (std::is_same<AttrT, FloatAttr>::value &&
+         matchPattern(constOp.getResult(), m_AnyZeroFloat()))) {
       rewriter.replaceOpWithNewOp<ZeroOp>(constOp);
       return success();
     }
@@ -319,59 +320,57 @@ struct FoldZeroConstPrimitive final : public OpRewritePattern<GeneralOp> {
 
 }  // namespace
 
-OpFoldResult ConstI32Op::fold(ArrayRef<Attribute> operands) {
-  return getValue();
-}
+OpFoldResult ConstI32Op::fold(FoldAdaptor operands) { return getValue(); }
 
 void ConstI32Op::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<FoldZeroConstPrimitive<ConstI32Op, ConstI32ZeroOp>>(context);
+  results
+      .insert<FoldZeroConstPrimitive<IntegerAttr, ConstI32Op, ConstI32ZeroOp>>(
+          context);
 }
 
-OpFoldResult ConstI64Op::fold(ArrayRef<Attribute> operands) {
-  return getValue();
-}
+OpFoldResult ConstI64Op::fold(FoldAdaptor operands) { return getValue(); }
 
 void ConstI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<FoldZeroConstPrimitive<ConstI64Op, ConstI64ZeroOp>>(context);
+  results
+      .insert<FoldZeroConstPrimitive<IntegerAttr, ConstI64Op, ConstI64ZeroOp>>(
+          context);
 }
 
-OpFoldResult ConstF32Op::fold(ArrayRef<Attribute> operands) {
-  return getValue();
-}
+OpFoldResult ConstF32Op::fold(FoldAdaptor operands) { return getValue(); }
 
 void ConstF32Op::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<FoldZeroConstPrimitive<ConstF32Op, ConstF32ZeroOp>>(context);
+  results.insert<FoldZeroConstPrimitive<FloatAttr, ConstF32Op, ConstF32ZeroOp>>(
+      context);
 }
 
-OpFoldResult ConstF64Op::fold(ArrayRef<Attribute> operands) {
-  return getValue();
-}
+OpFoldResult ConstF64Op::fold(FoldAdaptor operands) { return getValue(); }
 
 void ConstF64Op::getCanonicalizationPatterns(RewritePatternSet &results,
                                              MLIRContext *context) {
-  results.insert<FoldZeroConstPrimitive<ConstF64Op, ConstF64ZeroOp>>(context);
+  results.insert<FoldZeroConstPrimitive<FloatAttr, ConstF64Op, ConstF64ZeroOp>>(
+      context);
 }
 
-OpFoldResult ConstI32ZeroOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ConstI32ZeroOp::fold(FoldAdaptor operands) {
   return IntegerAttr::get(getResult().getType(), 0);
 }
 
-OpFoldResult ConstI64ZeroOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ConstI64ZeroOp::fold(FoldAdaptor operands) {
   return IntegerAttr::get(getResult().getType(), 0);
 }
 
-OpFoldResult ConstF32ZeroOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ConstF32ZeroOp::fold(FoldAdaptor operands) {
   return FloatAttr::get(getResult().getType(), 0.0f);
 }
 
-OpFoldResult ConstF64ZeroOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ConstF64ZeroOp::fold(FoldAdaptor operands) {
   return FloatAttr::get(getResult().getType(), 0.0);
 }
 
-OpFoldResult ConstRefZeroOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ConstRefZeroOp::fold(FoldAdaptor operands) {
   // TODO(benvanik): relace unit attr with a proper null ref attr.
   return UnitAttr::get(getContext());
 }
@@ -399,23 +398,23 @@ static OpFoldResult foldSelectOp(T op) {
   return {};
 }
 
-OpFoldResult SelectI32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SelectI32Op::fold(FoldAdaptor operands) {
   return foldSelectOp(*this);
 }
 
-OpFoldResult SelectI64Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SelectI64Op::fold(FoldAdaptor operands) {
   return foldSelectOp(*this);
 }
 
-OpFoldResult SelectF32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SelectF32Op::fold(FoldAdaptor operands) {
   return foldSelectOp(*this);
 }
 
-OpFoldResult SelectF64Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SelectF64Op::fold(FoldAdaptor operands) {
   return foldSelectOp(*this);
 }
 
-OpFoldResult SelectRefOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SelectRefOp::fold(FoldAdaptor operands) {
   return foldSelectOp(*this);
 }
 
@@ -447,23 +446,23 @@ static OpFoldResult foldSwitchOp(T op) {
   return {};
 }
 
-OpFoldResult SwitchI32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SwitchI32Op::fold(FoldAdaptor operands) {
   return foldSwitchOp(*this);
 }
 
-OpFoldResult SwitchI64Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SwitchI64Op::fold(FoldAdaptor operands) {
   return foldSwitchOp(*this);
 }
 
-OpFoldResult SwitchF32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SwitchF32Op::fold(FoldAdaptor operands) {
   return foldSwitchOp(*this);
 }
 
-OpFoldResult SwitchF64Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SwitchF64Op::fold(FoldAdaptor operands) {
   return foldSwitchOp(*this);
 }
 
-OpFoldResult SwitchRefOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult SwitchRefOp::fold(FoldAdaptor operands) {
   return foldSwitchOp(*this);
 }
 
@@ -476,17 +475,16 @@ OpFoldResult SwitchRefOp::fold(ArrayRef<Attribute> operands) {
 template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,
           class CalculationT = std::function<APInt(ElementValueT)>>
-static Attribute constFoldUnaryOp(ArrayRef<Attribute> operands,
+static Attribute constFoldUnaryOp(Attribute rawOperand,
                                   const CalculationT &calculate) {
-  assert(operands.size() == 1 && "unary op takes one operand");
-  if (auto operand = operands[0].dyn_cast_or_null<AttrElementT>()) {
+  if (auto operand = rawOperand.dyn_cast_or_null<AttrElementT>()) {
     return AttrElementT::get(operand.getType(), calculate(operand.getValue()));
-  } else if (auto operand = operands[0].dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto operand = rawOperand.dyn_cast_or_null<SplatElementsAttr>()) {
     auto elementResult = constFoldUnaryOp<AttrElementT>(
         {operand.getSplatValue<Attribute>()}, calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(operand.getType(), elementResult);
-  } else if (auto operand = operands[0].dyn_cast_or_null<ElementsAttr>()) {
+  } else if (auto operand = rawOperand.dyn_cast_or_null<ElementsAttr>()) {
     return operand.cast<DenseIntOrFPElementsAttr>().mapValues(
         operand.getType().getElementType(),
         llvm::function_ref<ElementValueT(const ElementValueT &)>(
@@ -498,17 +496,15 @@ static Attribute constFoldUnaryOp(ArrayRef<Attribute> operands,
 /// Performs const folding `calculate` with element-wise behavior on the given
 /// attribute in `operands` and returns the result if possible.
 static Attribute constFoldFloatUnaryOp(
-    ArrayRef<Attribute> operands,
-    const std::function<APFloat(APFloat)> &calculate) {
-  assert(operands.size() == 1 && "unary op takes one operand");
-  if (auto operand = operands[0].dyn_cast_or_null<FloatAttr>()) {
+    Attribute rawOperand, const std::function<APFloat(APFloat)> &calculate) {
+  if (auto operand = rawOperand.dyn_cast_or_null<FloatAttr>()) {
     return FloatAttr::get(operand.getType(), calculate(operand.getValue()));
-  } else if (auto operand = operands[0].dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto operand = rawOperand.dyn_cast_or_null<SplatElementsAttr>()) {
     auto elementResult =
         constFoldFloatUnaryOp({operand.getSplatValue<Attribute>()}, calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(operand.getType(), elementResult);
-  } else if (auto operand = operands[0].dyn_cast_or_null<ElementsAttr>()) {
+  } else if (auto operand = rawOperand.dyn_cast_or_null<ElementsAttr>()) {
     return operand.cast<DenseIntOrFPElementsAttr>().mapValues(
         operand.getType().getElementType(),
         llvm::function_ref<APInt(const APFloat &)>([&](const APFloat &value) {
@@ -525,32 +521,31 @@ template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,
           class CalculationT =
               std::function<ElementValueT(ElementValueT, ElementValueT)>>
-static Attribute constFoldBinaryOp(ArrayRef<Attribute> operands,
+static Attribute constFoldBinaryOp(Attribute rawLhs, Attribute rawRhs,
                                    const CalculationT &calculate) {
-  assert(operands.size() == 2 && "binary op takes two operands");
-  if (auto lhs = operands[0].dyn_cast_or_null<AttrElementT>()) {
-    auto rhs = operands[1].dyn_cast_or_null<AttrElementT>();
+  if (auto lhs = rawLhs.dyn_cast_or_null<AttrElementT>()) {
+    auto rhs = rawRhs.dyn_cast_or_null<AttrElementT>();
     if (!rhs) return {};
     return AttrElementT::get(lhs.getType(),
                              calculate(lhs.getValue(), rhs.getValue()));
-  } else if (auto lhs = operands[0].dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto lhs = rawLhs.dyn_cast_or_null<SplatElementsAttr>()) {
     // TODO(benvanik): handle splat/otherwise.
-    auto rhs = operands[1].dyn_cast_or_null<SplatElementsAttr>();
+    auto rhs = rawRhs.dyn_cast_or_null<SplatElementsAttr>();
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto elementResult = constFoldBinaryOp<AttrElementT>(
-        {lhs.getSplatValue<Attribute>(), rhs.getSplatValue<Attribute>()},
+        lhs.getSplatValue<Attribute>(), rhs.getSplatValue<Attribute>(),
         calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(lhs.getType(), elementResult);
-  } else if (auto lhs = operands[0].dyn_cast_or_null<ElementsAttr>()) {
-    auto rhs = operands[1].dyn_cast_or_null<ElementsAttr>();
+  } else if (auto lhs = rawLhs.dyn_cast_or_null<ElementsAttr>()) {
+    auto rhs = rawRhs.dyn_cast_or_null<ElementsAttr>();
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto lhsIt = lhs.getValues<AttrElementT>().begin();
     auto rhsIt = rhs.getValues<AttrElementT>().begin();
     SmallVector<Attribute, 4> resultAttrs(lhs.getNumElements());
     for (int64_t i = 0; i < lhs.getNumElements(); ++i) {
       resultAttrs[i] =
-          constFoldBinaryOp<AttrElementT>({*lhsIt, *rhsIt}, calculate);
+          constFoldBinaryOp<AttrElementT>(*lhsIt, *rhsIt, calculate);
       if (!resultAttrs[i]) return {};
       ++lhsIt;
       ++rhsIt;
@@ -566,33 +561,32 @@ template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,
           class CalculationT =
               std::function<ElementValueT(ElementValueT, ElementValueT)>>
-static Attribute constFoldTernaryOp(ArrayRef<Attribute> operands,
+static Attribute constFoldTernaryOp(Attribute rawA, Attribute rawB,
+                                    Attribute rawC,
                                     const CalculationT &calculate) {
-  assert(operands.size() == 3 && "ternary op takes two operands");
-  if (auto a = operands[0].dyn_cast_or_null<AttrElementT>()) {
-    auto b = operands[1].dyn_cast_or_null<AttrElementT>();
-    auto c = operands[2].dyn_cast_or_null<AttrElementT>();
+  if (auto a = rawA.dyn_cast_or_null<AttrElementT>()) {
+    auto b = rawB.dyn_cast_or_null<AttrElementT>();
+    auto c = rawC.dyn_cast_or_null<AttrElementT>();
     if (!b || !c || a.getType() != b.getType() || a.getType() != c.getType()) {
       return {};
     }
     return AttrElementT::get(
         a.getType(), calculate(a.getValue(), b.getValue(), c.getValue()));
-  } else if (auto a = operands[0].dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto a = rawA.dyn_cast_or_null<SplatElementsAttr>()) {
     // TODO(benvanik): handle splat/otherwise.
-    auto b = operands[1].dyn_cast_or_null<SplatElementsAttr>();
-    auto c = operands[2].dyn_cast_or_null<SplatElementsAttr>();
+    auto b = rawB.dyn_cast_or_null<SplatElementsAttr>();
+    auto c = rawC.dyn_cast_or_null<SplatElementsAttr>();
     if (!b || !c || a.getType() != b.getType() || a.getType() != c.getType()) {
       return {};
     }
     auto elementResult = constFoldTernaryOp<AttrElementT>(
-        {a.getSplatValue<Attribute>(), b.getSplatValue<Attribute>(),
-         c.getSplatValue<Attribute>()},
-        calculate);
+        a.getSplatValue<Attribute>(), b.getSplatValue<Attribute>(),
+        c.getSplatValue<Attribute>(), calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(a.getType(), elementResult);
-  } else if (auto a = operands[0].dyn_cast_or_null<ElementsAttr>()) {
-    auto b = operands[1].dyn_cast_or_null<ElementsAttr>();
-    auto c = operands[2].dyn_cast_or_null<ElementsAttr>();
+  } else if (auto a = rawA.dyn_cast_or_null<ElementsAttr>()) {
+    auto b = rawB.dyn_cast_or_null<ElementsAttr>();
+    auto c = rawC.dyn_cast_or_null<ElementsAttr>();
     if (!b || !c || a.getType() != b.getType() || a.getType() != c.getType()) {
       return {};
     }
@@ -602,7 +596,7 @@ static Attribute constFoldTernaryOp(ArrayRef<Attribute> operands,
     SmallVector<Attribute, 4> resultAttrs(a.getNumElements());
     for (int64_t i = 0; i < a.getNumElements(); ++i) {
       resultAttrs[i] =
-          constFoldTernaryOp<AttrElementT>({*aIt, *bIt, *cIt}, calculate);
+          constFoldTernaryOp<AttrElementT>(*aIt, *bIt, *cIt, calculate);
       if (!resultAttrs[i]) return {};
       ++aIt;
       ++bIt;
@@ -615,8 +609,11 @@ static Attribute constFoldTernaryOp(ArrayRef<Attribute> operands,
 
 template <class AttrElementT, typename ADD, typename SUB,
           class ElementValueT = typename AttrElementT::ValueType>
-static OpFoldResult foldAddOp(ADD op, ArrayRef<Attribute> operands) {
-  if (matchPattern(op.getRhs(), m_Zero())) {
+static OpFoldResult foldAddOp(ADD op, Attribute lhs, Attribute rhs) {
+  if ((std::is_same<AttrElementT, IntegerAttr>::value &&
+       matchPattern(op.getRhs(), m_Zero())) ||
+      (std::is_same<AttrElementT, FloatAttr>::value &&
+       matchPattern(op.getRhs(), m_AnyZeroFloat()))) {
     // x + 0 = x or 0 + y = y (commutative)
     return op.getLhs();
   }
@@ -628,22 +625,27 @@ static OpFoldResult foldAddOp(ADD op, ArrayRef<Attribute> operands) {
     if (subOp.getRhs() == op.getLhs()) return subOp.getLhs();
   }
   return constFoldBinaryOp<AttrElementT>(
-      operands,
+      lhs, rhs,
       [](const ElementValueT &a, const ElementValueT &b) { return a + b; });
 }
 
-OpFoldResult AddI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldAddOp<IntegerAttr, AddI32Op, SubI32Op>(*this, operands);
+OpFoldResult AddI32Op::fold(FoldAdaptor operands) {
+  return foldAddOp<IntegerAttr, AddI32Op, SubI32Op>(*this, operands.getLhs(),
+                                                    operands.getRhs());
 }
 
-OpFoldResult AddI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldAddOp<IntegerAttr, AddI64Op, SubI64Op>(*this, operands);
+OpFoldResult AddI64Op::fold(FoldAdaptor operands) {
+  return foldAddOp<IntegerAttr, AddI64Op, SubI64Op>(*this, operands.getLhs(),
+                                                    operands.getRhs());
 }
 
 template <class AttrElementT, typename SUB, typename ADD,
           class ElementValueT = typename AttrElementT::ValueType>
-static OpFoldResult foldSubOp(SUB op, ArrayRef<Attribute> operands) {
-  if (matchPattern(op.getRhs(), m_Zero())) {
+static OpFoldResult foldSubOp(SUB op, Attribute lhs, Attribute rhs) {
+  if ((std::is_same<AttrElementT, IntegerAttr>::value &&
+       matchPattern(op.getRhs(), m_Zero())) ||
+      (std::is_same<AttrElementT, FloatAttr>::value &&
+       matchPattern(op.getRhs(), m_AnyZeroFloat()))) {
     // x - 0 = x
     return op.getLhs();
   }
@@ -655,30 +657,38 @@ static OpFoldResult foldSubOp(SUB op, ArrayRef<Attribute> operands) {
     if (addOp.getRhs() == op.getLhs()) return addOp.getLhs();
   }
   return constFoldBinaryOp<AttrElementT>(
-      operands,
+      lhs, rhs,
       [](const ElementValueT &a, const ElementValueT &b) { return a - b; });
 }
 
-OpFoldResult SubI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldSubOp<IntegerAttr, SubI32Op, AddI32Op>(*this, operands);
+OpFoldResult SubI32Op::fold(FoldAdaptor operands) {
+  return foldSubOp<IntegerAttr, SubI32Op, AddI32Op>(*this, operands.getLhs(),
+                                                    operands.getRhs());
 }
 
-OpFoldResult SubI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldSubOp<IntegerAttr, SubI64Op, AddI64Op>(*this, operands);
+OpFoldResult SubI64Op::fold(FoldAdaptor operands) {
+  return foldSubOp<IntegerAttr, SubI64Op, AddI64Op>(*this, operands.getLhs(),
+                                                    operands.getRhs());
 }
 
 template <class AttrElementT, typename T,
           class ElementValueT = typename AttrElementT::ValueType>
-static OpFoldResult foldMulOp(T op, ArrayRef<Attribute> operands) {
-  if (matchPattern(op.getRhs(), m_Zero())) {
+static OpFoldResult foldMulOp(T op, Attribute lhs, Attribute rhs) {
+  if ((std::is_same<AttrElementT, IntegerAttr>::value &&
+       matchPattern(op.getRhs(), m_Zero())) ||
+      (std::is_same<AttrElementT, FloatAttr>::value &&
+       matchPattern(op.getRhs(), m_AnyZeroFloat()))) {
     // x * 0 = 0 or 0 * y = 0 (commutative)
     return zeroOfType(op.getType());
-  } else if (matchPattern(op.getRhs(), m_One())) {
+  } else if ((std::is_same<AttrElementT, IntegerAttr>::value &&
+              matchPattern(op.getRhs(), m_One())) ||
+             (std::is_same<AttrElementT, FloatAttr>::value &&
+              matchPattern(op.getRhs(), m_OneFloat()))) {
     // x * 1 = x or 1 * y = y (commutative)
     return op.getLhs();
   }
   return constFoldBinaryOp<AttrElementT>(
-      operands,
+      lhs, rhs,
       [](const ElementValueT &a, const ElementValueT &b) { return a * b; });
 }
 
@@ -686,7 +696,6 @@ template <class AttrElementT, typename T, typename CONST_OP,
           class ElementValueT = typename AttrElementT::ValueType>
 struct FoldConstantMulOperand : public OpRewritePattern<T> {
   using OpRewritePattern<T>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(T op,
                                 PatternRewriter &rewriter) const override {
     AttrElementT c1, c2;
@@ -696,7 +705,7 @@ struct FoldConstantMulOperand : public OpRewritePattern<T> {
         auto c = rewriter.createOrFold<CONST_OP>(
             rewriter.getFusedLoc({mulOp.getLoc(), op.getLoc()}),
             constFoldBinaryOp<AttrElementT>(
-                {c1, c2}, [](const ElementValueT &a, const ElementValueT &b) {
+                c1, c2, [](const ElementValueT &a, const ElementValueT &b) {
                   return a * b;
                 }));
         rewriter.replaceOpWithNewOp<T>(op, op.getType(), mulOp.getLhs(), c);
@@ -707,8 +716,8 @@ struct FoldConstantMulOperand : public OpRewritePattern<T> {
   }
 };
 
-OpFoldResult MulI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldMulOp<IntegerAttr>(*this, operands);
+OpFoldResult MulI32Op::fold(FoldAdaptor operands) {
+  return foldMulOp<IntegerAttr>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void MulI32Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -717,8 +726,8 @@ void MulI32Op::getCanonicalizationPatterns(RewritePatternSet &results,
       context);
 }
 
-OpFoldResult MulI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldMulOp<IntegerAttr>(*this, operands);
+OpFoldResult MulI64Op::fold(FoldAdaptor operands) {
+  return foldMulOp<IntegerAttr>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void MulI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -728,7 +737,7 @@ void MulI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <typename DivOpT, typename MulOpT>
-static OpFoldResult foldDivSOp(DivOpT op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldDivSOp(DivOpT op, Attribute lhs, Attribute rhs) {
   if (matchPattern(op.getRhs(), m_Zero())) {
     // x / 0 = death
     op.emitOpError() << "is a divide by constant zero";
@@ -751,19 +760,21 @@ static OpFoldResult foldDivSOp(DivOpT op, ArrayRef<Attribute> operands) {
     }
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b) { return a.sdiv(b); });
+      lhs, rhs, [](const APInt &a, const APInt &b) { return a.sdiv(b); });
 }
 
-OpFoldResult DivI32SOp::fold(ArrayRef<Attribute> operands) {
-  return foldDivSOp<DivI32SOp, MulI32Op>(*this, operands);
+OpFoldResult DivI32SOp::fold(FoldAdaptor operands) {
+  return foldDivSOp<DivI32SOp, MulI32Op>(*this, operands.getLhs(),
+                                         operands.getRhs());
 }
 
-OpFoldResult DivI64SOp::fold(ArrayRef<Attribute> operands) {
-  return foldDivSOp<DivI64SOp, MulI64Op>(*this, operands);
+OpFoldResult DivI64SOp::fold(FoldAdaptor operands) {
+  return foldDivSOp<DivI64SOp, MulI64Op>(*this, operands.getLhs(),
+                                         operands.getRhs());
 }
 
 template <typename DivOpT>
-static OpFoldResult foldDivUOp(DivOpT op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldDivUOp(DivOpT op, Attribute lhs, Attribute rhs) {
   if (matchPattern(op.getRhs(), m_Zero())) {
     // x / 0 = death
     op.emitOpError() << "is a divide by constant zero";
@@ -776,19 +787,19 @@ static OpFoldResult foldDivUOp(DivOpT op, ArrayRef<Attribute> operands) {
     return op.getLhs();
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b) { return a.udiv(b); });
+      lhs, rhs, [](const APInt &a, const APInt &b) { return a.udiv(b); });
 }
 
-OpFoldResult DivI32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldDivUOp(*this, operands);
+OpFoldResult DivI32UOp::fold(FoldAdaptor operands) {
+  return foldDivUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult DivI64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldDivUOp(*this, operands);
+OpFoldResult DivI64UOp::fold(FoldAdaptor operands) {
+  return foldDivUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldRemSOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldRemSOp(T op, Attribute lhs, Attribute rhs) {
   if (matchPattern(op.getRhs(), m_Zero())) {
     // x % 0 = death
     op.emitOpError() << "is a remainder by constant zero";
@@ -800,19 +811,19 @@ static OpFoldResult foldRemSOp(T op, ArrayRef<Attribute> operands) {
     return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b) { return a.srem(b); });
+      lhs, rhs, [](const APInt &a, const APInt &b) { return a.srem(b); });
 }
 
-OpFoldResult RemI32SOp::fold(ArrayRef<Attribute> operands) {
-  return foldRemSOp(*this, operands);
+OpFoldResult RemI32SOp::fold(FoldAdaptor operands) {
+  return foldRemSOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult RemI64SOp::fold(ArrayRef<Attribute> operands) {
-  return foldRemSOp(*this, operands);
+OpFoldResult RemI64SOp::fold(FoldAdaptor operands) {
+  return foldRemSOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldRemUOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldRemUOp(T op, Attribute lhs, Attribute rhs) {
   if (matchPattern(op.getRhs(), m_Zero())) {
     // x % 0 = death
     op.emitOpError() << "is a remainder by constant zero";
@@ -824,25 +835,25 @@ static OpFoldResult foldRemUOp(T op, ArrayRef<Attribute> operands) {
     return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b) { return a.urem(b); });
+      lhs, rhs, [](const APInt &a, const APInt &b) { return a.urem(b); });
 }
 
-OpFoldResult RemI32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldRemUOp(*this, operands);
+OpFoldResult RemI32UOp::fold(FoldAdaptor operands) {
+  return foldRemUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult RemI64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldRemUOp(*this, operands);
+OpFoldResult RemI64UOp::fold(FoldAdaptor operands) {
+  return foldRemUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldFMAOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldFMAOp(T op, Attribute a, Attribute b, Attribute c) {
   // a * b + c
   if (matchPattern(op.getA(), m_Zero()) || matchPattern(op.getB(), m_Zero())) {
     return op.getC();
   }
   return constFoldTernaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b, const APInt &c) {
+      a, b, c, [](const APInt &a, const APInt &b, const APInt &c) {
         return APInt(a.getBitWidth(),
                      a.getSExtValue() * b.getSExtValue() + c.getSExtValue());
       });
@@ -851,7 +862,6 @@ static OpFoldResult foldFMAOp(T op, ArrayRef<Attribute> operands) {
 template <typename FMAOp, typename MulOp, typename AddOp>
 struct CanonicalizeFMA final : public OpRewritePattern<FMAOp> {
   using OpRewritePattern<FMAOp>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(FMAOp fmaOp,
                                 PatternRewriter &rewriter) const override {
     // a * b + c
@@ -875,12 +885,12 @@ struct CanonicalizeFMA final : public OpRewritePattern<FMAOp> {
   }
 };
 
-OpFoldResult FMAI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldFMAOp(*this, operands);
+OpFoldResult FMAI32Op::fold(FoldAdaptor operands) {
+  return foldFMAOp(*this, operands.getA(), operands.getB(), operands.getC());
 }
 
-OpFoldResult FMAI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldFMAOp(*this, operands);
+OpFoldResult FMAI64Op::fold(FoldAdaptor operands) {
+  return foldFMAOp(*this, operands.getA(), operands.getB(), operands.getC());
 }
 
 void FMAI32Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -893,13 +903,13 @@ void FMAI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<CanonicalizeFMA<FMAI64Op, MulI64Op, AddI64Op>>(context);
 }
 
-OpFoldResult AbsI32Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(operands,
+OpFoldResult AbsI32Op::fold(FoldAdaptor operands) {
+  return constFoldUnaryOp<IntegerAttr>(operands.getOperand(),
                                        [](const APInt &a) { return a.abs(); });
 }
 
-OpFoldResult AbsI64Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(operands,
+OpFoldResult AbsI64Op::fold(FoldAdaptor operands) {
+  return constFoldUnaryOp<IntegerAttr>(operands.getOperand(),
                                        [](const APInt &a) { return a.abs(); });
 }
 
@@ -907,24 +917,28 @@ OpFoldResult AbsI64Op::fold(ArrayRef<Attribute> operands) {
 // Floating-point arithmetic
 //===----------------------------------------------------------------------===//
 
-OpFoldResult AddF32Op::fold(ArrayRef<Attribute> operands) {
-  return foldAddOp<FloatAttr, AddF32Op, SubF32Op>(*this, operands);
+OpFoldResult AddF32Op::fold(FoldAdaptor operands) {
+  return foldAddOp<FloatAttr, AddF32Op, SubF32Op>(*this, operands.getLhs(),
+                                                  operands.getRhs());
 }
 
-OpFoldResult AddF64Op::fold(ArrayRef<Attribute> operands) {
-  return foldAddOp<FloatAttr, AddF64Op, SubF64Op>(*this, operands);
+OpFoldResult AddF64Op::fold(FoldAdaptor operands) {
+  return foldAddOp<FloatAttr, AddF64Op, SubF64Op>(*this, operands.getLhs(),
+                                                  operands.getRhs());
 }
 
-OpFoldResult SubF32Op::fold(ArrayRef<Attribute> operands) {
-  return foldSubOp<FloatAttr, SubF32Op, AddF32Op>(*this, operands);
+OpFoldResult SubF32Op::fold(FoldAdaptor operands) {
+  return foldSubOp<FloatAttr, SubF32Op, AddF32Op>(*this, operands.getLhs(),
+                                                  operands.getRhs());
 }
 
-OpFoldResult SubF64Op::fold(ArrayRef<Attribute> operands) {
-  return foldSubOp<FloatAttr, SubF64Op, AddF64Op>(*this, operands);
+OpFoldResult SubF64Op::fold(FoldAdaptor operands) {
+  return foldSubOp<FloatAttr, SubF64Op, AddF64Op>(*this, operands.getLhs(),
+                                                  operands.getRhs());
 }
 
-OpFoldResult MulF32Op::fold(ArrayRef<Attribute> operands) {
-  return foldMulOp<FloatAttr>(*this, operands);
+OpFoldResult MulF32Op::fold(FoldAdaptor operands) {
+  return foldMulOp<FloatAttr>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void MulF32Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -933,8 +947,8 @@ void MulF32Op::getCanonicalizationPatterns(RewritePatternSet &results,
       context);
 }
 
-OpFoldResult MulF64Op::fold(ArrayRef<Attribute> operands) {
-  return foldMulOp<FloatAttr>(*this, operands);
+OpFoldResult MulF64Op::fold(FoldAdaptor operands) {
+  return foldMulOp<FloatAttr>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void MulF64Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -944,47 +958,47 @@ void MulF64Op::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <typename T>
-static OpFoldResult foldDivFOp(T op, ArrayRef<Attribute> operands) {
-  if (matchPattern(op.getRhs(), m_Zero())) {
+static OpFoldResult foldDivFOp(T op, Attribute lhs, Attribute rhs) {
+  if (matchPattern(op.getRhs(), m_AnyZeroFloat())) {
     // x / 0 = death
     op.emitOpError() << "is a divide by constant zero";
     return {};
-  } else if (matchPattern(op.getLhs(), m_Zero())) {
+  } else if (matchPattern(op.getLhs(), m_AnyZeroFloat())) {
     // 0 / y = 0
     return zeroOfType(op.getType());
-  } else if (matchPattern(op.getRhs(), m_One())) {
+  } else if (matchPattern(op.getRhs(), m_OneFloat())) {
     // x / 1 = x
     return op.getLhs();
   }
   return constFoldBinaryOp<FloatAttr>(
-      operands, [](const APFloat &a, const APFloat &b) {
+      lhs, rhs, [](const APFloat &a, const APFloat &b) {
         APFloat c = a;
         c.divide(b, APFloat::rmNearestTiesToAway);
         return c;
       });
 }
 
-OpFoldResult DivF32Op::fold(ArrayRef<Attribute> operands) {
-  return foldDivFOp(*this, operands);
+OpFoldResult DivF32Op::fold(FoldAdaptor operands) {
+  return foldDivFOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult DivF64Op::fold(ArrayRef<Attribute> operands) {
-  return foldDivFOp(*this, operands);
+OpFoldResult DivF64Op::fold(FoldAdaptor operands) {
+  return foldDivFOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldRemFOp(T op, ArrayRef<Attribute> operands) {
-  if (matchPattern(op.getRhs(), m_Zero())) {
+static OpFoldResult foldRemFOp(T op, Attribute lhs, Attribute rhs) {
+  if (matchPattern(op.getRhs(), m_AnyZeroFloat())) {
     // x % 0 = death
     op.emitOpError() << "is a remainder by constant zero";
     return {};
-  } else if (matchPattern(op.getLhs(), m_Zero()) ||
-             matchPattern(op.getRhs(), m_One())) {
+  } else if (matchPattern(op.getLhs(), m_AnyZeroFloat()) ||
+             matchPattern(op.getRhs(), m_OneFloat())) {
     // x % 1 = 0
     // 0 % y = 0
     return zeroOfType(op.getType());
   }
-  return constFoldBinaryOp<FloatAttr>(operands,
+  return constFoldBinaryOp<FloatAttr>(lhs, rhs,
                                       [](const APFloat &a, const APFloat &b) {
                                         APFloat c = a;
                                         c.remainder(b);
@@ -992,34 +1006,35 @@ static OpFoldResult foldRemFOp(T op, ArrayRef<Attribute> operands) {
                                       });
 }
 
-OpFoldResult RemF32Op::fold(ArrayRef<Attribute> operands) {
-  return foldRemFOp(*this, operands);
+OpFoldResult RemF32Op::fold(FoldAdaptor operands) {
+  return foldRemFOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult RemF64Op::fold(ArrayRef<Attribute> operands) {
-  return foldRemFOp(*this, operands);
+OpFoldResult RemF64Op::fold(FoldAdaptor operands) {
+  return foldRemFOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldFMAFOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldFMAFOp(T op, Attribute a, Attribute b, Attribute c) {
   // a * b + c
-  if (matchPattern(op.getA(), m_Zero()) || matchPattern(op.getB(), m_Zero())) {
+  if (matchPattern(op.getA(), m_AnyZeroFloat()) ||
+      matchPattern(op.getB(), m_AnyZeroFloat())) {
     return op.getC();
   }
   return constFoldTernaryOp<FloatAttr>(
-      operands, [](const APFloat &a, const APFloat &b, const APFloat &c) {
+      a, b, c, [](const APFloat &a, const APFloat &b, const APFloat &c) {
         APFloat d = a;
         d.fusedMultiplyAdd(b, c, APFloat::rmNearestTiesToAway);
         return d;
       });
 }
 
-OpFoldResult FMAF32Op::fold(ArrayRef<Attribute> operands) {
-  return foldFMAFOp(*this, operands);
+OpFoldResult FMAF32Op::fold(FoldAdaptor operands) {
+  return foldFMAFOp(*this, operands.getA(), operands.getB(), operands.getC());
 }
 
-OpFoldResult FMAF64Op::fold(ArrayRef<Attribute> operands) {
-  return foldFMAFOp(*this, operands);
+OpFoldResult FMAF64Op::fold(FoldAdaptor operands) {
+  return foldFMAFOp(*this, operands.getA(), operands.getB(), operands.getC());
 }
 
 void FMAF32Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1032,64 +1047,64 @@ void FMAF64Op::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<CanonicalizeFMA<FMAF64Op, MulF64Op, AddF64Op>>(context);
 }
 
-OpFoldResult AbsF32Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult AbsF32Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.clearSign();
     return b;
   });
 }
 
-OpFoldResult AbsF64Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult AbsF64Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.clearSign();
     return b;
   });
 }
 
-OpFoldResult NegF32Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult NegF32Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.changeSign();
     return b;
   });
 }
 
-OpFoldResult NegF64Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult NegF64Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.changeSign();
     return b;
   });
 }
 
-OpFoldResult CeilF32Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult CeilF32Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.roundToIntegral(APFloat::rmTowardPositive);
     return b;
   });
 }
 
-OpFoldResult CeilF64Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult CeilF64Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.roundToIntegral(APFloat::rmTowardPositive);
     return b;
   });
 }
 
-OpFoldResult FloorF32Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult FloorF32Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.roundToIntegral(APFloat::rmTowardNegative);
     return b;
   });
 }
 
-OpFoldResult FloorF64Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult FloorF64Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     auto b = a;
     b.roundToIntegral(APFloat::rmTowardNegative);
     return b;
@@ -1100,14 +1115,14 @@ OpFoldResult FloorF64Op::fold(ArrayRef<Attribute> operands) {
 // Floating-point math
 //===----------------------------------------------------------------------===//
 
-OpFoldResult SqrtF32Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult SqrtF32Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     return APFloat(sqrtf(a.convertToFloat()));
   });
 }
 
-OpFoldResult SqrtF64Op::fold(ArrayRef<Attribute> operands) {
-  return constFoldFloatUnaryOp(operands, [](const APFloat &a) {
+OpFoldResult SqrtF64Op::fold(FoldAdaptor operands) {
+  return constFoldFloatUnaryOp(operands.getOperand(), [](const APFloat &a) {
     return APFloat(sqrt(a.convertToDouble()));
   });
 }
@@ -1117,23 +1132,23 @@ OpFoldResult SqrtF64Op::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 
 template <typename T>
-static OpFoldResult foldNotOp(T op, ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(operands, [](APInt a) {
+static OpFoldResult foldNotOp(T op, Attribute operand) {
+  return constFoldUnaryOp<IntegerAttr>(operand, [](APInt a) {
     a.flipAllBits();
     return a;
   });
 }
 
-OpFoldResult NotI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldNotOp(*this, operands);
+OpFoldResult NotI32Op::fold(FoldAdaptor operands) {
+  return foldNotOp(*this, operands.getOperand());
 }
 
-OpFoldResult NotI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldNotOp(*this, operands);
+OpFoldResult NotI64Op::fold(FoldAdaptor operands) {
+  return foldNotOp(*this, operands.getOperand());
 }
 
 template <typename T>
-static OpFoldResult foldAndOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldAndOp(T op, Attribute lhs, Attribute rhs) {
   if (matchPattern(op.getRhs(), m_Zero())) {
     // x & 0 = 0 or 0 & y = 0 (commutative)
     return zeroOfType(op.getType());
@@ -1142,19 +1157,19 @@ static OpFoldResult foldAndOp(T op, ArrayRef<Attribute> operands) {
     return op.getLhs();
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b) { return a & b; });
+      lhs, rhs, [](const APInt &a, const APInt &b) { return a & b; });
 }
 
-OpFoldResult AndI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldAndOp(*this, operands);
+OpFoldResult AndI32Op::fold(FoldAdaptor operands) {
+  return foldAndOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult AndI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldAndOp(*this, operands);
+OpFoldResult AndI64Op::fold(FoldAdaptor operands) {
+  return foldAndOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldOrOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldOrOp(T op, Attribute lhs, Attribute rhs) {
   if (matchPattern(op.getRhs(), m_Zero())) {
     // x | 0 = x or 0 | y = y (commutative)
     return op.getLhs();
@@ -1163,19 +1178,19 @@ static OpFoldResult foldOrOp(T op, ArrayRef<Attribute> operands) {
     return op.getLhs();
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b) { return a | b; });
+      lhs, rhs, [](const APInt &a, const APInt &b) { return a | b; });
 }
 
-OpFoldResult OrI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldOrOp(*this, operands);
+OpFoldResult OrI32Op::fold(FoldAdaptor operands) {
+  return foldOrOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult OrI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldOrOp(*this, operands);
+OpFoldResult OrI64Op::fold(FoldAdaptor operands) {
+  return foldOrOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldXorOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldXorOp(T op, Attribute lhs, Attribute rhs) {
   if (matchPattern(op.getRhs(), m_Zero())) {
     // x ^ 0 = x or 0 ^ y = y (commutative)
     return op.getLhs();
@@ -1184,30 +1199,30 @@ static OpFoldResult foldXorOp(T op, ArrayRef<Attribute> operands) {
     return zeroOfType(op.getType());
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [](const APInt &a, const APInt &b) { return a ^ b; });
+      lhs, rhs, [](const APInt &a, const APInt &b) { return a ^ b; });
 }
 
-OpFoldResult XorI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldXorOp(*this, operands);
+OpFoldResult XorI32Op::fold(FoldAdaptor operands) {
+  return foldXorOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult XorI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldXorOp(*this, operands);
+OpFoldResult XorI64Op::fold(FoldAdaptor operands) {
+  return foldXorOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <typename T>
-static OpFoldResult foldCtlzOp(T op, ArrayRef<Attribute> operands) {
-  return constFoldUnaryOp<IntegerAttr>(operands, [](APInt a) {
+static OpFoldResult foldCtlzOp(T op, Attribute operand) {
+  return constFoldUnaryOp<IntegerAttr>(operand, [](APInt a) {
     return APInt(a.getBitWidth(), a.countLeadingZeros());
   });
 }
 
-OpFoldResult CtlzI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldCtlzOp(*this, operands);
+OpFoldResult CtlzI32Op::fold(FoldAdaptor operands) {
+  return foldCtlzOp(*this, operands.getOperand());
 }
 
-OpFoldResult CtlzI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldCtlzOp(*this, operands);
+OpFoldResult CtlzI64Op::fold(FoldAdaptor operands) {
+  return foldCtlzOp(*this, operands.getOperand());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1215,7 +1230,7 @@ OpFoldResult CtlzI64Op::fold(ArrayRef<Attribute> operands) {
 //===----------------------------------------------------------------------===//
 
 template <typename T>
-static OpFoldResult foldShlOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldShlOp(T op, Attribute operand, Attribute amount) {
   if (matchPattern(op.getOperand(), m_Zero())) {
     // 0 << y = 0
     return zeroOfType(op.getType());
@@ -1224,19 +1239,20 @@ static OpFoldResult foldShlOp(T op, ArrayRef<Attribute> operands) {
     return op.getOperand();
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.shl(b); });
+      operand, amount,
+      [&](const APInt &a, const APInt &b) { return a.shl(b); });
 }
 
-OpFoldResult ShlI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldShlOp(*this, operands);
+OpFoldResult ShlI32Op::fold(FoldAdaptor operands) {
+  return foldShlOp(*this, operands.getOperand(), operands.getAmount());
 }
 
-OpFoldResult ShlI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldShlOp(*this, operands);
+OpFoldResult ShlI64Op::fold(FoldAdaptor operands) {
+  return foldShlOp(*this, operands.getOperand(), operands.getAmount());
 }
 
 template <typename T>
-static OpFoldResult foldShrSOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldShrSOp(T op, Attribute operand, Attribute amount) {
   if (matchPattern(op.getOperand(), m_Zero())) {
     // 0 >> y = 0
     return zeroOfType(op.getType());
@@ -1245,19 +1261,20 @@ static OpFoldResult foldShrSOp(T op, ArrayRef<Attribute> operands) {
     return op.getOperand();
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.ashr(b); });
+      operand, amount,
+      [&](const APInt &a, const APInt &b) { return a.ashr(b); });
 }
 
-OpFoldResult ShrI32SOp::fold(ArrayRef<Attribute> operands) {
-  return foldShrSOp(*this, operands);
+OpFoldResult ShrI32SOp::fold(FoldAdaptor operands) {
+  return foldShrSOp(*this, operands.getOperand(), operands.getAmount());
 }
 
-OpFoldResult ShrI64SOp::fold(ArrayRef<Attribute> operands) {
-  return foldShrSOp(*this, operands);
+OpFoldResult ShrI64SOp::fold(FoldAdaptor operands) {
+  return foldShrSOp(*this, operands.getOperand(), operands.getAmount());
 }
 
 template <typename T>
-static OpFoldResult foldShrUOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldShrUOp(T op, Attribute operand, Attribute amount) {
   if (matchPattern(op.getOperand(), m_Zero())) {
     // 0 >> y = 0
     return zeroOfType(op.getType());
@@ -1266,15 +1283,16 @@ static OpFoldResult foldShrUOp(T op, ArrayRef<Attribute> operands) {
     return op.getOperand();
   }
   return constFoldBinaryOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.lshr(b); });
+      operand, amount,
+      [&](const APInt &a, const APInt &b) { return a.lshr(b); });
 }
 
-OpFoldResult ShrI32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldShrUOp(*this, operands);
+OpFoldResult ShrI32UOp::fold(FoldAdaptor operands) {
+  return foldShrUOp(*this, operands.getOperand(), operands.getAmount());
 }
 
-OpFoldResult ShrI64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldShrUOp(*this, operands);
+OpFoldResult ShrI64UOp::fold(FoldAdaptor operands) {
+  return foldShrUOp(*this, operands.getOperand(), operands.getAmount());
 }
 
 //===----------------------------------------------------------------------===//
@@ -1286,115 +1304,113 @@ OpFoldResult ShrI64UOp::fold(ArrayRef<Attribute> operands) {
 template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,
           class CalculationT = std::function<ElementValueT(ElementValueT)>>
-static Attribute constFoldConversionOp(Type resultType,
-                                       ArrayRef<Attribute> operands,
+static Attribute constFoldConversionOp(Type resultType, Attribute rawOperand,
                                        const CalculationT &calculate) {
-  assert(operands.size() == 1 && "unary op takes one operand");
-  if (auto operand = operands[0].dyn_cast_or_null<AttrElementT>()) {
+  if (auto operand = rawOperand.dyn_cast_or_null<AttrElementT>()) {
     return AttrElementT::get(resultType, calculate(operand.getValue()));
   }
   return {};
 }
 
-OpFoldResult TruncI32I8Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TruncI32I8Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(8).zext(32); });
 }
 
-OpFoldResult TruncI32I16Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TruncI32I16Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(16).zext(32); });
 }
 
-OpFoldResult TruncI64I8Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TruncI64I8Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(8).zext(32); });
 }
 
-OpFoldResult TruncI64I16Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TruncI64I16Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(16).zext(32); });
 }
 
-OpFoldResult TruncI64I32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TruncI64I32Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(32); });
 }
 
-OpFoldResult TruncF64F32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult TruncF64F32Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<FloatAttr>(
-      FloatType::getF32(getContext()), operands,
+      FloatType::getF32(getContext()), operands.getOperand(),
       [&](const APFloat &a) { return APFloat(a.convertToFloat()); });
 }
 
-OpFoldResult ExtI8I32SOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI8I32SOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(8).sext(32); });
 }
 
-OpFoldResult ExtI8I32UOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI8I32UOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(8).zext(32); });
 }
 
-OpFoldResult ExtI16I32SOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI16I32SOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(16).sext(32); });
 }
 
-OpFoldResult ExtI16I32UOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI16I32UOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands,
+      IntegerType::get(getContext(), 32), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(16).zext(32); });
 }
 
-OpFoldResult ExtI8I64SOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI8I64SOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 64), operands,
+      IntegerType::get(getContext(), 64), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(8).sext(64); });
 }
 
-OpFoldResult ExtI8I64UOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI8I64UOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 64), operands,
+      IntegerType::get(getContext(), 64), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(8).zext(64); });
 }
 
-OpFoldResult ExtI16I64SOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI16I64SOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 64), operands,
+      IntegerType::get(getContext(), 64), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(16).sext(64); });
 }
 
-OpFoldResult ExtI16I64UOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI16I64UOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 64), operands,
+      IntegerType::get(getContext(), 64), operands.getOperand(),
       [&](const APInt &a) { return a.trunc(16).zext(64); });
 }
 
-OpFoldResult ExtI32I64SOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI32I64SOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 64), operands,
+      IntegerType::get(getContext(), 64), operands.getOperand(),
       [&](const APInt &a) { return a.sext(64); });
 }
 
-OpFoldResult ExtI32I64UOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtI32I64UOp::fold(FoldAdaptor operands) {
   return constFoldConversionOp<IntegerAttr>(
-      IntegerType::get(getContext(), 64), operands,
+      IntegerType::get(getContext(), 64), operands.getOperand(),
       [&](const APInt &a) { return a.zext(64); });
 }
 
-OpFoldResult ExtF32F64Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult ExtF32F64Op::fold(FoldAdaptor operands) {
   return constFoldConversionOp<FloatAttr>(
-      FloatType::getF64(getContext()), operands,
+      FloatType::getF64(getContext()), operands.getOperand(),
       [&](const APFloat &a) { return APFloat(a.convertToDouble()); });
 }
 
@@ -1404,7 +1420,6 @@ template <typename SRC_OP, typename OP_A, int SZ_T, typename OP_B>
 struct PseudoIntegerConversionToSplitConversionOp
     : public OpRewritePattern<SRC_OP> {
   using OpRewritePattern<SRC_OP>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(SRC_OP op,
                                 PatternRewriter &rewriter) const override {
     auto tmp = rewriter.createOrFold<OP_A>(
@@ -1457,36 +1472,38 @@ template <
     class SrcElementValueT = typename SrcAttrElementT::ValueType,
     class DstElementValueT = typename DstAttrElementT::ValueType,
     class CalculationT = std::function<DstElementValueT(SrcElementValueT)>>
-static Attribute constFoldCastOp(Type resultType, ArrayRef<Attribute> operands,
+static Attribute constFoldCastOp(Type resultType, Attribute rawOperand,
                                  const CalculationT &calculate) {
-  assert(operands.size() == 1 && "unary op takes one operand");
-  if (auto operand = operands[0].dyn_cast_or_null<SrcAttrElementT>()) {
+  if (auto operand = rawOperand.dyn_cast_or_null<SrcAttrElementT>()) {
     return DstAttrElementT::get(resultType, calculate(operand.getValue()));
   }
   return {};
 }
 
-OpFoldResult CastSI32F32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CastSI32F32Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<IntegerAttr, FloatAttr>(
-      Float32Type::get(getContext()), operands, [&](const APInt &a) {
+      Float32Type::get(getContext()), operands.getOperand(),
+      [&](const APInt &a) {
         APFloat b = APFloat(0.0f);
         b.convertFromAPInt(a, /*IsSigned=*/true, APFloat::rmNearestTiesToAway);
         return b;
       });
 }
 
-OpFoldResult CastUI32F32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CastUI32F32Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<IntegerAttr, FloatAttr>(
-      Float32Type::get(getContext()), operands, [&](const APInt &a) {
+      Float32Type::get(getContext()), operands.getOperand(),
+      [&](const APInt &a) {
         APFloat b = APFloat(0.0f);
         b.convertFromAPInt(a, /*IsSigned=*/false, APFloat::rmNearestTiesToAway);
         return b;
       });
 }
 
-OpFoldResult CastF32SI32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CastF32SI32Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<FloatAttr, IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands, [&](const APFloat &a) {
+      IntegerType::get(getContext(), 32), operands.getOperand(),
+      [&](const APFloat &a) {
         bool isExact = false;
         llvm::APSInt b(/*BitWidth=*/32, /*isUnsigned=*/false);
         a.convertToInteger(b, APFloat::rmNearestTiesToAway, &isExact);
@@ -1494,9 +1511,10 @@ OpFoldResult CastF32SI32Op::fold(ArrayRef<Attribute> operands) {
       });
 }
 
-OpFoldResult CastF32UI32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CastF32UI32Op::fold(FoldAdaptor operands) {
   return constFoldCastOp<FloatAttr, IntegerAttr>(
-      IntegerType::get(getContext(), 32), operands, [&](const APFloat &a) {
+      IntegerType::get(getContext(), 32), operands.getOperand(),
+      [&](const APFloat &a) {
         bool isExact = false;
         llvm::APSInt b(/*BitWidth=*/32, /*isUnsigned=*/false);
         a.convertToInteger(b, APFloat::rmNearestTiesToAway, &isExact);
@@ -1520,13 +1538,12 @@ namespace {
 template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,
           class CalculationT = std::function<APInt(ElementValueT)>>
-static Attribute constFoldUnaryCmpOp(ArrayRef<Attribute> operands,
+static Attribute constFoldUnaryCmpOp(Attribute rawOperand,
                                      const CalculationT &calculate) {
-  assert(operands.size() == 1 && "unary cmp op takes one operand");
-  if (auto operand = operands[0].dyn_cast_or_null<AttrElementT>()) {
+  if (auto operand = rawOperand.dyn_cast_or_null<AttrElementT>()) {
     auto boolType = IntegerType::get(operand.getContext(), 32);
     return IntegerAttr::get(boolType, calculate(operand.getValue()));
-  } else if (auto operand = operands[0].dyn_cast_or_null<ElementsAttr>()) {
+  } else if (auto operand = rawOperand.dyn_cast_or_null<ElementsAttr>()) {
     auto boolType = IntegerType::get(operand.getContext(), 32);
     return operand.cast<DenseIntOrFPElementsAttr>().mapValues(
         boolType,
@@ -1542,11 +1559,10 @@ template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,
           class CalculationT =
               std::function<ElementValueT(ElementValueT, ElementValueT)>>
-static Attribute constFoldBinaryCmpOp(ArrayRef<Attribute> operands,
+static Attribute constFoldBinaryCmpOp(Attribute rawLhs, Attribute rawRhs,
                                       const CalculationT &calculate) {
-  assert(operands.size() == 2 && "binary op takes two operands");
-  if (auto lhs = operands[0].dyn_cast_or_null<AttrElementT>()) {
-    auto rhs = operands[1].dyn_cast_or_null<AttrElementT>();
+  if (auto lhs = rawLhs.dyn_cast_or_null<AttrElementT>()) {
+    auto rhs = rawRhs.dyn_cast_or_null<AttrElementT>();
     if (!rhs) return {};
     auto boolType = IntegerType::get(lhs.getContext(), 32);
     return AttrElementT::get(boolType,
@@ -1586,17 +1602,17 @@ struct SwapInvertedCmpOps : public OpRewritePattern<OP> {
 }  // namespace
 
 template <typename T>
-static OpFoldResult foldCmpEQOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpEQOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x == x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.eq(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.eq(b); });
 }
 
-OpFoldResult CmpEQI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQOp(*this, operands);
+OpFoldResult CmpEQI32Op::fold(FoldAdaptor operands) {
+  return foldCmpEQOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpEQI32Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1604,8 +1620,8 @@ void CmpEQI32Op::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<SwapInvertedCmpOps<CmpEQI32Op, CmpNEI32Op>>(context);
 }
 
-OpFoldResult CmpEQI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQOp(*this, operands);
+OpFoldResult CmpEQI64Op::fold(FoldAdaptor operands) {
+  return foldCmpEQOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpEQI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1614,21 +1630,21 @@ void CmpEQI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <typename T>
-static OpFoldResult foldCmpNEOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpNEOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x != x = false
     return zeroOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.ne(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.ne(b); });
 }
 
-OpFoldResult CmpNEI32Op::fold(ArrayRef<Attribute> operands) {
-  return foldCmpNEOp(*this, operands);
+OpFoldResult CmpNEI32Op::fold(FoldAdaptor operands) {
+  return foldCmpNEOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpNEI64Op::fold(ArrayRef<Attribute> operands) {
-  return foldCmpNEOp(*this, operands);
+OpFoldResult CmpNEI64Op::fold(FoldAdaptor operands) {
+  return foldCmpNEOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 namespace {
@@ -1662,21 +1678,21 @@ void CmpNEI64Op::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <typename T>
-static OpFoldResult foldCmpLTSOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpLTSOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x < x = false
     return zeroOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.slt(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.slt(b); });
 }
 
-OpFoldResult CmpLTI32SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTSOp(*this, operands);
+OpFoldResult CmpLTI32SOp::fold(FoldAdaptor operands) {
+  return foldCmpLTSOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTI64SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTSOp(*this, operands);
+OpFoldResult CmpLTI64SOp::fold(FoldAdaptor operands) {
+  return foldCmpLTSOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpLTI32SOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1686,21 +1702,21 @@ void CmpLTI64SOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                               MLIRContext *context) {}
 
 template <typename T>
-static OpFoldResult foldCmpLTUOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpLTUOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x < x = false
     return zeroOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.ult(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.ult(b); });
 }
 
-OpFoldResult CmpLTI32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTUOp(*this, operands);
+OpFoldResult CmpLTI32UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTI64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTUOp(*this, operands);
+OpFoldResult CmpLTI64UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpLTI32UOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1730,21 +1746,21 @@ struct RewritePseudoCmpLTEToLT : public OpRewritePattern<T> {
 }  // namespace
 
 template <typename T>
-static OpFoldResult foldCmpLTESOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpLTESOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x <= x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.sle(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.sle(b); });
 }
 
-OpFoldResult CmpLTEI32SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTESOp(*this, operands);
+OpFoldResult CmpLTEI32SOp::fold(FoldAdaptor operands) {
+  return foldCmpLTESOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTEI64SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTESOp(*this, operands);
+OpFoldResult CmpLTEI64SOp::fold(FoldAdaptor operands) {
+  return foldCmpLTESOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpLTEI32SOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1760,21 +1776,21 @@ void CmpLTEI64SOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <typename T>
-static OpFoldResult foldCmpLTEUOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpLTEUOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x <= x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.ule(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.ule(b); });
 }
 
-OpFoldResult CmpLTEI32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTEUOp(*this, operands);
+OpFoldResult CmpLTEI32UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTEUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTEI64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTEUOp(*this, operands);
+OpFoldResult CmpLTEI64UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTEUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpLTEI32UOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1806,21 +1822,21 @@ struct RewritePseudoCmpGTToLT : public OpRewritePattern<T> {
 }  // namespace
 
 template <typename T>
-static OpFoldResult foldCmpGTSOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpGTSOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x > x = false
     return zeroOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.sgt(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.sgt(b); });
 }
 
-OpFoldResult CmpGTI32SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTSOp(*this, operands);
+OpFoldResult CmpGTI32SOp::fold(FoldAdaptor operands) {
+  return foldCmpGTSOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTI64SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTSOp(*this, operands);
+OpFoldResult CmpGTI64SOp::fold(FoldAdaptor operands) {
+  return foldCmpGTSOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpGTI32SOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1836,21 +1852,21 @@ void CmpGTI64SOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <typename T>
-static OpFoldResult foldCmpGTUOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpGTUOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x > x = false
     return zeroOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.ugt(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.ugt(b); });
 }
 
-OpFoldResult CmpGTI32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTUOp(*this, operands);
+OpFoldResult CmpGTI32UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTI64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTUOp(*this, operands);
+OpFoldResult CmpGTI64UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpGTI32UOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1886,21 +1902,21 @@ struct RewritePseudoCmpGTEToLT : public OpRewritePattern<T> {
 }  // namespace
 
 template <typename T>
-static OpFoldResult foldCmpGTESOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpGTESOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x >= x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.sge(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.sge(b); });
 }
 
-OpFoldResult CmpGTEI32SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTESOp(*this, operands);
+OpFoldResult CmpGTEI32SOp::fold(FoldAdaptor operands) {
+  return foldCmpGTESOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTEI64SOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTESOp(*this, operands);
+OpFoldResult CmpGTEI64SOp::fold(FoldAdaptor operands) {
+  return foldCmpGTESOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpGTEI32SOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1916,21 +1932,21 @@ void CmpGTEI64SOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <typename T>
-static OpFoldResult foldCmpGTEUOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpGTEUOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x >= x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpOp<IntegerAttr>(
-      operands, [&](const APInt &a, const APInt &b) { return a.uge(b); });
+      lhs, rhs, [&](const APInt &a, const APInt &b) { return a.uge(b); });
 }
 
-OpFoldResult CmpGTEI32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTEUOp(*this, operands);
+OpFoldResult CmpGTEI32UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTEUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTEI64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTEUOp(*this, operands);
+OpFoldResult CmpGTEI64UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTEUOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpGTEI32UOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -1945,14 +1961,16 @@ void CmpGTEI64UOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<RewritePseudoCmpGTEToLT<CmpGTEI64UOp, CmpLTI64UOp>>(context);
 }
 
-OpFoldResult CmpNZI32Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpNZI32Op::fold(FoldAdaptor operands) {
   return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](const APInt &a) { return APInt(32, a.getBoolValue()); });
+      operands.getOperand(),
+      [&](const APInt &a) { return APInt(32, a.getBoolValue()); });
 }
 
-OpFoldResult CmpNZI64Op::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpNZI64Op::fold(FoldAdaptor operands) {
   return constFoldUnaryOp<IntegerAttr>(
-      operands, [&](const APInt &a) { return APInt(64, a.getBoolValue()); });
+      operands.getOperand(),
+      [&](const APInt &a) { return APInt(64, a.getBoolValue()); });
 }
 
 //===----------------------------------------------------------------------===//
@@ -1966,34 +1984,32 @@ template <class AttrElementT,
           class ElementValueT = typename AttrElementT::ValueType,
           class CalculationT =
               std::function<ElementValueT(ElementValueT, ElementValueT)>>
-static Attribute constFoldBinaryCmpFOp(ArrayRef<Attribute> operands,
+static Attribute constFoldBinaryCmpFOp(Attribute rawLhs, Attribute rawRhs,
                                        const CalculationT &calculate) {
-  assert(operands.size() == 2 && "binary op takes two operands");
-
-  if (auto lhs = operands[0].dyn_cast_or_null<AttrElementT>()) {
-    auto rhs = operands[1].dyn_cast_or_null<AttrElementT>();
+  if (auto lhs = rawLhs.dyn_cast_or_null<AttrElementT>()) {
+    auto rhs = rawRhs.dyn_cast_or_null<AttrElementT>();
     if (!rhs) return {};
     return IntegerAttr::get(IntegerType::get(lhs.getContext(), 32),
                             calculate(lhs.getValue(), rhs.getValue()));
-  } else if (auto lhs = operands[0].dyn_cast_or_null<SplatElementsAttr>()) {
+  } else if (auto lhs = rawLhs.dyn_cast_or_null<SplatElementsAttr>()) {
     // TODO(benvanik): handle splat/otherwise.
-    auto rhs = operands[1].dyn_cast_or_null<SplatElementsAttr>();
+    auto rhs = rawRhs.dyn_cast_or_null<SplatElementsAttr>();
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto elementResult = constFoldBinaryCmpFOp<AttrElementT>(
-        {lhs.getSplatValue<Attribute>(), rhs.getSplatValue<Attribute>()},
+        lhs.getSplatValue<Attribute>(), rhs.getSplatValue<Attribute>(),
         calculate);
     if (!elementResult) return {};
     return DenseElementsAttr::get(IntegerType::get(lhs.getContext(), 32),
                                   elementResult);
-  } else if (auto lhs = operands[0].dyn_cast_or_null<ElementsAttr>()) {
-    auto rhs = operands[1].dyn_cast_or_null<ElementsAttr>();
+  } else if (auto lhs = rawLhs.dyn_cast_or_null<ElementsAttr>()) {
+    auto rhs = rawRhs.dyn_cast_or_null<ElementsAttr>();
     if (!rhs || lhs.getType() != rhs.getType()) return {};
     auto lhsIt = lhs.getValues<AttrElementT>().begin();
     auto rhsIt = rhs.getValues<AttrElementT>().begin();
     SmallVector<Attribute, 4> resultAttrs(lhs.getNumElements());
     for (int64_t i = 0; i < lhs.getNumElements(); ++i) {
       resultAttrs[i] =
-          constFoldBinaryCmpFOp<AttrElementT>({*lhsIt, *rhsIt}, calculate);
+          constFoldBinaryCmpFOp<AttrElementT>(*lhsIt, *rhsIt, calculate);
       if (!resultAttrs[i]) return {};
       ++lhsIt;
       ++rhsIt;
@@ -2010,13 +2026,13 @@ enum CmpFOrdering {
 };
 
 template <CmpFOrdering ordering, typename T>
-static OpFoldResult foldCmpEQFOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpEQFOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x == x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpFOp<FloatAttr>(
-      operands, [&](const APFloat &a, const APFloat &b) {
+      lhs, rhs, [&](const APFloat &a, const APFloat &b) {
         auto result = a.compare(b);
         if (ordering == ORDERED) {
           return result == APFloat::cmpEqual;
@@ -2026,20 +2042,20 @@ static OpFoldResult foldCmpEQFOp(T op, ArrayRef<Attribute> operands) {
       });
 }
 
-OpFoldResult CmpEQF32OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQFOp<ORDERED>(*this, operands);
+OpFoldResult CmpEQF32OOp::fold(FoldAdaptor operands) {
+  return foldCmpEQFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpEQF64OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQFOp<ORDERED>(*this, operands);
+OpFoldResult CmpEQF64OOp::fold(FoldAdaptor operands) {
+  return foldCmpEQFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpEQF32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpEQF32UOp::fold(FoldAdaptor operands) {
+  return foldCmpEQFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpEQF64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpEQF64UOp::fold(FoldAdaptor operands) {
+  return foldCmpEQFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpEQF32OOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2134,13 +2150,13 @@ struct RewritePseudoCmpNear : public OpRewritePattern<T> {
 }  // namespace
 
 template <typename T>
-static OpFoldResult foldCmpEQNearOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpEQNearOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x ~ x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpFOp<FloatAttr>(
-      operands, [&](const APFloat &a, const APFloat &b) {
+      lhs, rhs, [&](const APFloat &a, const APFloat &b) {
         // See the corresponding rewrite pattern above for references used here.
         if (a.isNegative() != b.isNegative()) {
           return a.compare(b) == APFloat::cmpEqual;
@@ -2154,12 +2170,12 @@ static OpFoldResult foldCmpEQNearOp(T op, ArrayRef<Attribute> operands) {
       });
 }
 
-OpFoldResult CmpEQF32NearOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQNearOp(*this, operands);
+OpFoldResult CmpEQF32NearOp::fold(FoldAdaptor operands) {
+  return foldCmpEQNearOp(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpEQF64NearOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpEQNearOp(*this, operands);
+OpFoldResult CmpEQF64NearOp::fold(FoldAdaptor operands) {
+  return foldCmpEQNearOp(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpEQF32NearOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2179,13 +2195,13 @@ void CmpEQF64NearOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <CmpFOrdering ordering, typename T>
-static OpFoldResult foldCmpNEFOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpNEFOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x != x = false
     return zeroOfType(op.getType());
   }
   return constFoldBinaryCmpFOp<FloatAttr>(
-      operands, [&](const APFloat &a, const APFloat &b) {
+      lhs, rhs, [&](const APFloat &a, const APFloat &b) {
         auto result = a.compare(b);
         if (ordering == ORDERED) {
           return result != APFloat::cmpEqual;
@@ -2195,20 +2211,20 @@ static OpFoldResult foldCmpNEFOp(T op, ArrayRef<Attribute> operands) {
       });
 }
 
-OpFoldResult CmpNEF32OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpNEFOp<ORDERED>(*this, operands);
+OpFoldResult CmpNEF32OOp::fold(FoldAdaptor operands) {
+  return foldCmpNEFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpNEF64OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpNEFOp<ORDERED>(*this, operands);
+OpFoldResult CmpNEF64OOp::fold(FoldAdaptor operands) {
+  return foldCmpNEFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpNEF32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpNEFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpNEF32UOp::fold(FoldAdaptor operands) {
+  return foldCmpNEFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpNEF64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpNEFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpNEF64UOp::fold(FoldAdaptor operands) {
+  return foldCmpNEFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpNEF32OOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2232,36 +2248,37 @@ void CmpNEF64UOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <CmpFOrdering ordering, typename T>
-static OpFoldResult foldCmpLTFOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpLTFOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x < x = false
     return zeroOfType(op.getType());
   }
-  return constFoldBinaryCmpFOp<FloatAttr>(operands, [&](const APFloat &a,
-                                                        const APFloat &b) {
-    auto result = a.compare(b);
-    if (ordering == ORDERED) {
-      return result == APFloat::cmpLessThan;
-    } else {
-      return result == APFloat::cmpLessThan || result == APFloat::cmpUnordered;
-    }
-  });
+  return constFoldBinaryCmpFOp<FloatAttr>(
+      lhs, rhs, [&](const APFloat &a, const APFloat &b) {
+        auto result = a.compare(b);
+        if (ordering == ORDERED) {
+          return result == APFloat::cmpLessThan;
+        } else {
+          return result == APFloat::cmpLessThan ||
+                 result == APFloat::cmpUnordered;
+        }
+      });
 }
 
-OpFoldResult CmpLTF32OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTFOp<ORDERED>(*this, operands);
+OpFoldResult CmpLTF32OOp::fold(FoldAdaptor operands) {
+  return foldCmpLTFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTF64OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTFOp<ORDERED>(*this, operands);
+OpFoldResult CmpLTF64OOp::fold(FoldAdaptor operands) {
+  return foldCmpLTFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTF32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpLTF32UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTF64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpLTF64UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpLTF32OOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2277,13 +2294,13 @@ void CmpLTF64UOp::getCanonicalizationPatterns(RewritePatternSet &results,
                                               MLIRContext *context) {}
 
 template <CmpFOrdering ordering, typename T>
-static OpFoldResult foldCmpLTEFOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpLTEFOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x <= x = true
     return oneOfType(op.getType());
   }
   return constFoldBinaryCmpFOp<FloatAttr>(
-      operands, [&](const APFloat &a, const APFloat &b) {
+      lhs, rhs, [&](const APFloat &a, const APFloat &b) {
         auto result = a.compare(b);
         if (ordering == ORDERED) {
           return result == APFloat::cmpLessThan || result == APFloat::cmpEqual;
@@ -2294,30 +2311,30 @@ static OpFoldResult foldCmpLTEFOp(T op, ArrayRef<Attribute> operands) {
       });
 }
 
-OpFoldResult CmpLTEF32OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTEFOp<ORDERED>(*this, operands);
+OpFoldResult CmpLTEF32OOp::fold(FoldAdaptor operands) {
+  return foldCmpLTEFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTEF64OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTEFOp<ORDERED>(*this, operands);
+OpFoldResult CmpLTEF64OOp::fold(FoldAdaptor operands) {
+  return foldCmpLTEFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTEF32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTEFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpLTEF32UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTEFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpLTEF64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpLTEFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpLTEF64UOp::fold(FoldAdaptor operands) {
+  return foldCmpLTEFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
 template <CmpFOrdering ordering, typename T>
-static OpFoldResult foldCmpGTFOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpGTFOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x > x = false
     return zeroOfType(op.getType());
   }
   return constFoldBinaryCmpFOp<FloatAttr>(
-      operands, [&](const APFloat &a, const APFloat &b) {
+      lhs, rhs, [&](const APFloat &a, const APFloat &b) {
         auto result = a.compare(b);
         if (ordering == ORDERED) {
           return result == APFloat::cmpGreaterThan;
@@ -2328,20 +2345,20 @@ static OpFoldResult foldCmpGTFOp(T op, ArrayRef<Attribute> operands) {
       });
 }
 
-OpFoldResult CmpGTF32OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTFOp<ORDERED>(*this, operands);
+OpFoldResult CmpGTF32OOp::fold(FoldAdaptor operands) {
+  return foldCmpGTFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTF64OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTFOp<ORDERED>(*this, operands);
+OpFoldResult CmpGTF64OOp::fold(FoldAdaptor operands) {
+  return foldCmpGTFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTF32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpGTF32UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTF64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpGTF64UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpGTF32OOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2369,37 +2386,38 @@ void CmpGTF64UOp::getCanonicalizationPatterns(RewritePatternSet &results,
 }
 
 template <CmpFOrdering ordering, typename T>
-static OpFoldResult foldCmpGTEFOp(T op, ArrayRef<Attribute> operands) {
+static OpFoldResult foldCmpGTEFOp(T op, Attribute lhs, Attribute rhs) {
   if (op.getLhs() == op.getRhs()) {
     // x >= x = true
     return oneOfType(op.getType());
   }
-  return constFoldBinaryCmpFOp<FloatAttr>(operands, [&](const APFloat &a,
-                                                        const APFloat &b) {
-    auto result = a.compare(b);
-    if (ordering == ORDERED) {
-      return result == APFloat::cmpGreaterThan || result == APFloat::cmpEqual;
-    } else {
-      return result == APFloat::cmpGreaterThan || result == APFloat::cmpEqual ||
-             result == APFloat::cmpUnordered;
-    }
-  });
+  return constFoldBinaryCmpFOp<FloatAttr>(
+      lhs, rhs, [&](const APFloat &a, const APFloat &b) {
+        auto result = a.compare(b);
+        if (ordering == ORDERED) {
+          return result == APFloat::cmpGreaterThan ||
+                 result == APFloat::cmpEqual;
+        } else {
+          return result == APFloat::cmpGreaterThan ||
+                 result == APFloat::cmpEqual || result == APFloat::cmpUnordered;
+        }
+      });
 }
 
-OpFoldResult CmpGTEF32OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTEFOp<ORDERED>(*this, operands);
+OpFoldResult CmpGTEF32OOp::fold(FoldAdaptor operands) {
+  return foldCmpGTEFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTEF64OOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTEFOp<ORDERED>(*this, operands);
+OpFoldResult CmpGTEF64OOp::fold(FoldAdaptor operands) {
+  return foldCmpGTEFOp<ORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTEF32UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTEFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpGTEF32UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTEFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
-OpFoldResult CmpGTEF64UOp::fold(ArrayRef<Attribute> operands) {
-  return foldCmpGTEFOp<UNORDERED>(*this, operands);
+OpFoldResult CmpGTEF64UOp::fold(FoldAdaptor operands) {
+  return foldCmpGTEFOp<UNORDERED>(*this, operands.getLhs(), operands.getRhs());
 }
 
 void CmpGTEF32OOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2442,26 +2460,28 @@ struct RewritePseudoCmpNZToNE : public OpRewritePattern<T> {
 
 }  // namespace
 
-OpFoldResult CmpNZF32OOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpNZF32OOp::fold(FoldAdaptor operands) {
   return constFoldUnaryCmpOp<FloatAttr>(
-      operands, [&](const APFloat &a) { return APInt(32, a.isNonZero()); });
+      operands.getOperand(),
+      [&](const APFloat &a) { return APInt(32, a.isNonZero()); });
 }
 
-OpFoldResult CmpNZF64OOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpNZF64OOp::fold(FoldAdaptor operands) {
   return constFoldUnaryCmpOp<FloatAttr>(
-      operands, [&](const APFloat &a) { return APInt(32, a.isNonZero()); });
+      operands.getOperand(),
+      [&](const APFloat &a) { return APInt(32, a.isNonZero()); });
 }
 
-OpFoldResult CmpNZF32UOp::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryCmpOp<FloatAttr>(operands, [&](const APFloat &a) {
-    return APInt(32, a.isNonZero() || a.isNaN());
-  });
+OpFoldResult CmpNZF32UOp::fold(FoldAdaptor operands) {
+  return constFoldUnaryCmpOp<FloatAttr>(
+      operands.getOperand(),
+      [&](const APFloat &a) { return APInt(32, a.isNonZero() || a.isNaN()); });
 }
 
-OpFoldResult CmpNZF64UOp::fold(ArrayRef<Attribute> operands) {
-  return constFoldUnaryCmpOp<FloatAttr>(operands, [&](const APFloat &a) {
-    return APInt(32, a.isNonZero() || a.isNaN());
-  });
+OpFoldResult CmpNZF64UOp::fold(FoldAdaptor operands) {
+  return constFoldUnaryCmpOp<FloatAttr>(
+      operands.getOperand(),
+      [&](const APFloat &a) { return APInt(32, a.isNonZero() || a.isNaN()); });
 }
 
 void CmpNZF32OOp::getCanonicalizationPatterns(RewritePatternSet &results,
@@ -2492,16 +2512,16 @@ void CmpNZF64UOp::getCanonicalizationPatterns(RewritePatternSet &results,
           context);
 }
 
-OpFoldResult CmpNaNF32Op::fold(ArrayRef<Attribute> operands) {
-  if (auto operand = operands[0].dyn_cast_or_null<FloatAttr>()) {
+OpFoldResult CmpNaNF32Op::fold(FoldAdaptor operands) {
+  if (auto operand = operands.getOperand().dyn_cast_or_null<FloatAttr>()) {
     return operand.getValue().isNaN() ? oneOfType(getType())
                                       : zeroOfType(getType());
   }
   return {};
 }
 
-OpFoldResult CmpNaNF64Op::fold(ArrayRef<Attribute> operands) {
-  if (auto operand = operands[0].dyn_cast_or_null<FloatAttr>()) {
+OpFoldResult CmpNaNF64Op::fold(FoldAdaptor operands) {
+  if (auto operand = operands.getOperand().dyn_cast_or_null<FloatAttr>()) {
     return operand.getValue().isNaN() ? oneOfType(getType())
                                       : zeroOfType(getType());
   }
@@ -2512,11 +2532,12 @@ OpFoldResult CmpNaNF64Op::fold(ArrayRef<Attribute> operands) {
 // vm.ref comparison
 //===----------------------------------------------------------------------===//
 
-OpFoldResult CmpEQRefOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpEQRefOp::fold(FoldAdaptor operands) {
   if (getLhs() == getRhs()) {
     // x == x = true
     return oneOfType(getType());
-  } else if (operands[0] && operands[1]) {
+  } else if (operands.getLhs() && operands.getRhs() &&
+             operands.getLhs() == operands.getRhs()) {
     // Constant null == null = true
     return oneOfType(getType());
   }
@@ -2550,7 +2571,7 @@ void CmpEQRefOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<NullCheckCmpEQRefToCmpNZRef>(context);
 }
 
-OpFoldResult CmpNERefOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpNERefOp::fold(FoldAdaptor operands) {
   if (getLhs() == getRhs()) {
     // x != x = false
     return zeroOfType(getType());
@@ -2581,7 +2602,7 @@ void CmpNERefOp::getCanonicalizationPatterns(RewritePatternSet &results,
   results.insert<NullCheckCmpNERefToCmpNZRef>(context);
 }
 
-OpFoldResult CmpNZRefOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult CmpNZRefOp::fold(FoldAdaptor operands) {
   Attribute operandValue;
   if (matchPattern(getOperand(), m_Constant(&operandValue))) {
     // x == null
@@ -2654,7 +2675,6 @@ namespace {
 /// (same logic as for std.br)
 struct SimplifyBrToBlockWithSinglePred : public OpRewritePattern<BranchOp> {
   using OpRewritePattern<BranchOp>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(BranchOp op,
                                 PatternRewriter &rewriter) const override {
     // Check that the successor block has a single predecessor.
@@ -2680,7 +2700,6 @@ struct SimplifyBrToBlockWithSinglePred : public OpRewritePattern<BranchOp> {
 /// (same logic as for std.br)
 struct SimplifyPassThroughBr : public OpRewritePattern<BranchOp> {
   using OpRewritePattern<BranchOp>::OpRewritePattern;
-
   LogicalResult matchAndRewrite(BranchOp op,
                                 PatternRewriter &rewriter) const override {
     Block *dest = op.getDest();

--- a/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXBase.td
+++ b/compiler/src/iree/compiler/Dialect/VMVX/IR/VMVXBase.td
@@ -28,6 +28,8 @@ def VMVX_Dialect : Dialect {
 
     See `vmvx.imports.mlir` for the full list of exported functions.
   }];
+
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.td
+++ b/compiler/src/iree/compiler/Modules/Check/IR/CheckOps.td
@@ -16,6 +16,8 @@ def CHECK_Dialect : Dialect {
   let summary = [{
     A dialect implementing test assertions for IREE modules.
   }];
+
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 def CHECK_ExpectTrueOp : Op<CHECK_Dialect, "expect_true"> {

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineBase.td
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineBase.td
@@ -31,6 +31,8 @@ def HALInline_Dialect : Dialect {
 
     See `hal_inline.imports.mlir` for the full list of exported functions.
   }];
+
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
+++ b/compiler/src/iree/compiler/Modules/HAL/Inline/IR/HALInlineOps.cpp
@@ -90,7 +90,7 @@ void BufferLengthOp::getAsmResultNames(
   setNameFn(getResult(), "length");
 }
 
-OpFoldResult BufferLengthOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult BufferLengthOp::fold(FoldAdaptor operands) {
   Operation *op = this->getOperation();
   return IREE::Util::SizeAwareTypeInterface::findSizeValue(
       getBuffer(), op->getBlock(), Block::iterator(op));
@@ -105,7 +105,7 @@ void BufferStorageOp::getAsmResultNames(
   setNameFn(getResult(), "storage");
 }
 
-OpFoldResult BufferStorageOp::fold(ArrayRef<Attribute> operands) {
+OpFoldResult BufferStorageOp::fold(FoldAdaptor operands) {
   auto *definingOp = getBuffer().getDefiningOp();
   if (!definingOp) return {};
   if (auto sourceOp =

--- a/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderBase.td
+++ b/compiler/src/iree/compiler/Modules/HAL/Loader/IR/HALLoaderBase.td
@@ -31,6 +31,8 @@ def HALLoader_Dialect : Dialect {
 
     See `hal_loader.imports.mlir` for the full list of exported functions.
   }];
+
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
The latest integrate pulled in the deprecation of the default and this fixes the warnings generated by the IREE dialects.