### PR TITLE
Allows non-privileged users to access perf counters in CI

### DIFF
--- a/build_tools/github_actions/runner/gcp/image_setup.sh
+++ b/build_tools/github_actions/runner/gcp/image_setup.sh
@@ -260,6 +260,11 @@ EOF
   # Make sure the runner user can use docker
   runuser --user runner -- docker ps
 
+  #################################### Benchmarks ##############################
+
+  # Allow non-privileged users (runner) to access the perf counters.
+  echo "kernel.perf_event_paranoid=-1" > /etc/sysctl.d/99-unpriv-perf.conf
+
   #################################### GPU #####################################
 
   if [[ "${RUNNER_TYPE^^}" == GPU ]]; then


### PR DESCRIPTION
Tracy needs to access performance counters (`perf_event_open`) when recording the traces.

Right now our CI jobs are running under non-root user `runner` and by default it can't access performance counters (due to information leak issues). This change removes all restrictions.

I think this is acceptable since we rely on VM to do isolation between jobs.