### PR TITLE
Improve CUDA warp-level reduction with `redux` instruction

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -118,6 +118,7 @@ struct ConvertToNVVMPass : public ConvertToNVVMBase<ConvertToNVVMPass> {
       arith::populateArithToLLVMConversionPatterns(converter, llvmPatterns);
       populateVectorToLLVMConversionPatterns(converter, llvmPatterns);
       populateGpuToNVVMConversionPatterns(converter, llvmPatterns);
+      populateGpuSubgroupReduceOpLoweringPattern(converter, llvmPatterns);
       populateNVGPUToNVVMConversionPatterns(converter, llvmPatterns);
       populateGpuWMMAToNVVMConversionPatterns(converter, llvmPatterns);
       LLVMConversionTarget target(getContext());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -7,10 +7,25 @@
 #ifndef IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
 #define IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
 namespace iree_compiler {
+//===----------------------------------------------------------------------===//
+// Target architecture utils
+//===----------------------------------------------------------------------===//
+
+/// Structure to represent target features.
+struct TargetInfo {
+  // TODO: add finer grain control for other tensorcore types.
+  bool hasTF32TensorCore = false;
+  bool hasWarpShuffle = false;
+  bool hasRedux = false;
+  int warpSize;
+};
+
+TargetInfo getTargetInfo(func::FuncOp entryPoint);
 
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -190,7 +190,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createGPUTileReductionPass();
 // If nullptr, warp size 32 will be used.
 std::unique_ptr<OperationPass<func::FuncOp>>
 createConvertVectorReductionToGPUPass(
-    std::function<int(func::FuncOp)> getWarpSize = nullptr);
+    std::function<int(func::FuncOp)> getWarpSize = nullptr,
+    std::function<bool(func::FuncOp)> hasRedux = nullptr);
 
 /// Fuses tensor.pad ops into their consumer ops' tiled loop nests.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/tests/transform_dialect/cuda/CMakeLists.txt
+++ b/tests/transform_dialect/cuda/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "reduction.mlir"
+    "reductioni32.mlir"
     "reduction_eltwise.mlir"
     "reduction_v2.mlir"
     "reduction_v2_uneven.mlir"


### PR DESCRIPTION
sm80+ GPUs introduced `redux`[1] instruction to do warp-level reduction. Currently iree implements this by generating 4 `gpu.shuffle` Ops and 4 arithmetic Ops. The code below shows the SASS code of this pattern. Here each instruction waits the output of previous instruction, so instruction level parallelism is low in this chain of 8 instructions.

```
SHFL.BFLY PT, R5, R6, 0x1, 0x1f
IMAD.IADD R5, R6, 0x1, R5               --> waits R5
SHFL.BFLY PT, R4, R5, 0x2, 0x1f         --> waits R5
IMAD.IADD R4, R5, 0x1, R4               --> waits R4
SHFL.BFLY PT, R7, R4, 0x4, 0x1f         --> waits R4
IADD3 R7, R4, R7, RZ                    .....
SHFL.BFLY PT, R8, R7, 0x8, 0x1f
IMAD.IADD R8, R7, 0x1, R8
SHFL.BFLY PT, R9, R8, 0x10, 0x1f
LOP3.LUT P0, RZ, R12, 0x1f, RZ, 0xc0, !PT
IMAD.MOV.U32 R7, RZ, RZ, 0x4
WARPSYNC 0xffffffff
```

This PR does warp-level reduction with a single `REDUX.SUM.S32` instruction.
```
REDUX.SUM.S32 UR6, R4
MOV R5, UR6
LOP3.LUT P0, RZ, R12, 0x1f, RZ, 0xc0, !PT
IMAD.MOV.U32 R7, RZ, RZ, 0x4
WARPSYNC 0xffffffff
```

Unfortunately the instruction only supports 32 bit integers, no floating point.

While PR is a performance improvement, it accelerates ONLY warp level reduction. Therefore, it is difficult to find performance gain in small codes. However, I was able to achieve up to 3-4% improvement when I had 4 reductions in a single kernel in handwritten CUDA code.

[1] https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-redux-sync