### PR TITLE
Exporting LLVM CPU functions when debug symbols are enabled.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMCPUTarget.cpp
@@ -327,11 +327,13 @@ class LLVMCPUTargetBackend final : public TargetBackend {
     auto *queryLibraryFunc = libraryBuilder.build(queryFunctionName);
 
     // The query function must be exported for dynamic libraries.
+    queryLibraryFunc->setDSOLocal(false);
     queryLibraryFunc->setVisibility(
         llvm::GlobalValue::VisibilityTypes::DefaultVisibility);
     queryLibraryFunc->setLinkage(
         llvm::GlobalValue::LinkageTypes::ExternalLinkage);
-    queryLibraryFunc->setDSOLocal(false);
+    queryLibraryFunc->setDLLStorageClass(
+        llvm::GlobalValue::DLLStorageClassTypes::DLLExportStorageClass);
 
     // If linking dynamically, find a suitable linker tool and configure the
     // module with any options that tool requires.

--- a/runtime/src/iree/base/internal/dynamic_library_win32.c
+++ b/runtime/src/iree/base/internal/dynamic_library_win32.c
@@ -388,7 +388,7 @@ iree_status_t iree_dynamic_library_attach_symbols_from_memory(
   // Extract the library to a temp file.
   char* temp_path = NULL;
   iree_status_t status = iree_dynamic_library_write_temp_file(
-      buffer, "mem_", "pdb", library->allocator, &temp_path);
+      buffer, "mem", "pdb", library->allocator, &temp_path);
   if (iree_status_is_ok(status)) {
     // Associate the temp path to the library; the temp_path string and the
     // backing file will be deleted when the library is closed.

--- a/runtime/src/iree/hal/local/elf/arch.h
+++ b/runtime/src/iree/hal/local/elf/arch.h
@@ -29,8 +29,12 @@ typedef struct iree_elf_relocation_state_t {
   uint8_t* vaddr_bias;
 
   // PT_DYNAMIC table.
-  iree_host_size_t dyn_table_count;
   const iree_elf_dyn_t* dyn_table;
+  iree_host_size_t dyn_table_count;
+
+  // Dynamic symbol table (.dynsym) loaded into virtual memory.
+  const iree_elf_sym_t* dynsym;   // DT_SYMTAB
+  iree_host_size_t dynsym_count;  // DT_SYMENT (bytes) / sizeof(iree_elf_sym_t)
 } iree_elf_relocation_state_t;
 
 // Applies architecture-specific relocations.

--- a/runtime/src/iree/hal/local/elf/arch/arm_32.c
+++ b/runtime/src/iree/hal/local/elf/arch/arm_32.c
@@ -47,11 +47,16 @@ static iree_status_t iree_elf_arch_arm_apply_rel(
     uint32_t type = IREE_ELF_R_TYPE(rel->r_info);
     if (type == 0) continue;
 
-    // TODO(benvanik): support imports by resolving from the import table.
     iree_elf_addr_t sym_addr = 0;
-    if (IREE_ELF_R_SYM(rel->r_info) != 0) {
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "symbol-relative relocations not implemented");
+    uint32_t sym_ordinal = (uint32_t)IREE_ELF_R_SYM(rel->r_info);
+    if (sym_ordinal != 0) {
+      if (sym_ordinal >= state->dynsym_count) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "invalid symbol in relocation: %u",
+                                sym_ordinal);
+      }
+      sym_addr = (iree_elf_addr_t)state->vaddr_bias +
+                 state->dynsym[sym_ordinal].st_value;
     }
 
     iree_elf_addr_t instr_ptr =

--- a/runtime/src/iree/hal/local/elf/arch/arm_64.c
+++ b/runtime/src/iree/hal/local/elf/arch/arm_64.c
@@ -46,11 +46,16 @@ static iree_status_t iree_elf_arch_aarch64_apply_rela(
     uint32_t type = IREE_ELF_R_TYPE(rela->r_info);
     if (type == 0) continue;
 
-    // TODO(benvanik): support imports by resolving from the import table.
     iree_elf_addr_t sym_addr = 0;
-    if (IREE_ELF_R_SYM(rela->r_info) != 0) {
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "symbol-relative relocations not implemented");
+    uint32_t sym_ordinal = (uint32_t)IREE_ELF_R_SYM(rela->r_info);
+    if (sym_ordinal != 0) {
+      if (sym_ordinal >= state->dynsym_count) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "invalid symbol in relocation: %u",
+                                sym_ordinal);
+      }
+      sym_addr = (iree_elf_addr_t)state->vaddr_bias +
+                 state->dynsym[sym_ordinal].st_value;
     }
 
     iree_elf_addr_t instr_ptr =

--- a/runtime/src/iree/hal/local/elf/arch/riscv.c
+++ b/runtime/src/iree/hal/local/elf/arch/riscv.c
@@ -48,11 +48,16 @@ static iree_status_t iree_elf_arch_riscv_apply_rela(
     uint32_t type = IREE_ELF_R_TYPE(rela->r_info);
     if (type == 0) continue;
 
-    // TODO(benvanik): support imports by resolving from the import table.
     iree_elf_addr_t sym_addr = 0;
-    if (IREE_ELF_R_SYM(rela->r_info) != 0) {
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "symbol-relative relocations not implemented");
+    uint32_t sym_ordinal = (uint32_t)IREE_ELF_R_SYM(rela->r_info);
+    if (sym_ordinal != 0) {
+      if (sym_ordinal >= state->dynsym_count) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "invalid symbol in relocation: %u",
+                                sym_ordinal);
+      }
+      sym_addr = (iree_elf_addr_t)state->vaddr_bias +
+                 state->dynsym[sym_ordinal].st_value;
     }
 
     iree_elf_addr_t instr_ptr =
@@ -86,11 +91,16 @@ static iree_status_t iree_elf_arch_riscv_apply_rela(
     uint32_t type = IREE_ELF_R_TYPE(rela->r_info);
     if (type == 0) continue;
 
-    // TODO(benvanik): support imports by resolving from the import table.
     iree_elf_addr_t sym_addr = 0;
-    if (IREE_ELF_R_SYM(rela->r_info) != 0) {
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "symbol-relative relocations not implemented");
+    uint32_t sym_ordinal = (uint32_t)IREE_ELF_R_SYM(rela->r_info);
+    if (sym_ordinal != 0) {
+      if (sym_ordinal >= state->dynsym_count) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "invalid symbol in relocation: %u",
+                                sym_ordinal);
+      }
+      sym_addr = (iree_elf_addr_t)state->vaddr_bias +
+                 state->dynsym[sym_ordinal].st_value;
     }
 
     iree_elf_addr_t instr_ptr =

--- a/runtime/src/iree/hal/local/elf/arch/x86_32.c
+++ b/runtime/src/iree/hal/local/elf/arch/x86_32.c
@@ -47,11 +47,16 @@ static iree_status_t iree_elf_arch_x86_32_apply_rel(
     uint32_t type = IREE_ELF_R_TYPE(rel->r_info);
     if (type == IREE_ELF_R_386_NONE) continue;
 
-    // TODO(benvanik): support imports by resolving from the import table.
     iree_elf_addr_t sym_addr = 0;
-    if (IREE_ELF_R_SYM(rel->r_info) != 0) {
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "symbol-relative relocations not implemented");
+    uint32_t sym_ordinal = (uint32_t)IREE_ELF_R_SYM(rel->r_info);
+    if (sym_ordinal != 0) {
+      if (sym_ordinal >= state->dynsym_count) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "invalid symbol in relocation: %u",
+                                sym_ordinal);
+      }
+      sym_addr = (iree_elf_addr_t)state->vaddr_bias +
+                 state->dynsym[sym_ordinal].st_value;
     }
 
     iree_elf_addr_t instr_ptr =

--- a/runtime/src/iree/hal/local/elf/arch/x86_64.c
+++ b/runtime/src/iree/hal/local/elf/arch/x86_64.c
@@ -58,11 +58,16 @@ static iree_status_t iree_elf_arch_x86_64_apply_rela(
     uint32_t type = IREE_ELF_R_TYPE(rela->r_info);
     if (type == IREE_ELF_R_X86_64_NONE) continue;
 
-    // TODO(benvanik): support imports by resolving from the import table.
     iree_elf_addr_t sym_addr = 0;
-    if (IREE_ELF_R_SYM(rela->r_info) != 0) {
-      return iree_make_status(IREE_STATUS_UNIMPLEMENTED,
-                              "symbol-relative relocations not implemented");
+    uint32_t sym_ordinal = (uint32_t)IREE_ELF_R_SYM(rela->r_info);
+    if (sym_ordinal != 0) {
+      if (sym_ordinal >= state->dynsym_count) {
+        return iree_make_status(IREE_STATUS_OUT_OF_RANGE,
+                                "invalid symbol in relocation: %u",
+                                sym_ordinal);
+      }
+      sym_addr = (iree_elf_addr_t)state->vaddr_bias +
+                 state->dynsym[sym_ordinal].st_value;
     }
 
     iree_elf_addr_t instr_ptr =

--- a/runtime/src/iree/hal/local/elf/elf_module.c
+++ b/runtime/src/iree/hal/local/elf/elf_module.c
@@ -499,6 +499,8 @@ static iree_status_t iree_elf_module_apply_relocations(
   reloc_state.vaddr_bias = module->vaddr_bias;
   reloc_state.dyn_table = load_state->dyn_table;
   reloc_state.dyn_table_count = load_state->dyn_table_count;
+  reloc_state.dynsym = module->dynsym;
+  reloc_state.dynsym_count = module->dynsym_count;
   return iree_elf_arch_apply_relocations(&reloc_state);
 }
 


### PR DESCRIPTION
The exports are not used and we normally omit them to reduce binary size. When disassembling/decompiling, though, having the exported symbols makes it much easier to find the dispatches and correlate them to the original program.

Example:
![image](https://user-images.githubusercontent.com/75337/214125500-c0f682ea-34b4-428f-a6a2-34331d2fad7f.png)
