### PR TITLE
Make stack allocations checks in generated code on LLVMCPU more stringent

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -34,8 +34,14 @@ struct LLVMCPUCheckIRBeforeLLVMConversionPass
 /// Returns success if the cummulative stack allocation size is less than the
 /// limit set by clMaxAllocationSizeInBytes.
 static LogicalResult checkStackAllocationSize(func::FuncOp funcOp) {
-  auto allocaOps = funcOp.getOps<memref::AllocaOp>();
   if (funcOp.getBody().empty()) return success();
+
+  SmallVector<memref::AllocaOp> allocaOps;
+  funcOp.walk(
+      [&](memref::AllocaOp allocaOp) { allocaOps.push_back(allocaOp); });
+  if (allocaOps.empty()) {
+    return success();
+  }
 
   int cumSize = 0;
   for (auto allocaOp : allocaOps) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -56,18 +56,20 @@ static LogicalResult checkStackAllocationSize(func::FuncOp funcOp) {
         allocaSize *= ub.value();
         continue;
       }
-      return allocaOp.emitOpError("expoected no unbounded stack allocations");
+      return allocaOp.emitOpError("expected no unbounded stack allocations");
     }
     allocaSize *= allocaType.getElementType().getIntOrFloatBitWidth();
     if (allocaOp.getAlignment()) {
       int64_t alignmentInBits = *allocaOp.getAlignment() * 8;
       allocaSize =
-          llvm::divideCeil(allocaSize, alignmentInBits) * alignmentInBits / 8;
+          (llvm::divideCeil(allocaSize, alignmentInBits) * alignmentInBits);
     }
-    cumSize += allocaSize;
+    cumSize += allocaSize / 8;
   }
   if (cumSize > clMaxAllocationSizeInBytes) {
-    return funcOp.emitOpError("exceeded static allocation limit for function");
+    return funcOp.emitOpError("exceeded stack allocation limit of ")
+           << clMaxAllocationSizeInBytes.getValue()
+           << " bytes for function. Got " << cumSize << " bytes";
   }
   return success();
 }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPUCheckIRBeforeLLVMConversion.cpp
@@ -31,44 +31,55 @@ struct LLVMCPUCheckIRBeforeLLVMConversionPass
 };
 }  // namespace
 
-void LLVMCPUCheckIRBeforeLLVMConversionPass::runOnOperation() {
-  auto moduleOp = getOperation();
-  int64_t totalBits = 0;
-  auto walkResult = moduleOp.walk([&](memref::AllocaOp allocaOp) -> WalkResult {
-    auto type = allocaOp.getType().cast<ShapedType>();
-    int64_t size = 1;
-    for (auto dimSize : type.getShape()) {
-      if (dimSize == ShapedType::kDynamic) continue;
-      size *= dimSize;
+/// Returns success if the cummulative stack allocation size is less than the
+/// limit set by clMaxAllocationSizeInBytes.
+static LogicalResult checkStackAllocationSize(func::FuncOp funcOp) {
+  auto allocaOps = funcOp.getOps<memref::AllocaOp>();
+  if (funcOp.getBody().empty()) return success();
+
+  int cumSize = 0;
+  for (auto allocaOp : allocaOps) {
+    if (allocaOp->getBlock() != &funcOp.getBody().front()) {
+      return allocaOp->emitOpError(
+          "all stack allocations need to be hoisted to the entry block of the "
+          "function");
+    }
+    int allocaSize = 1;
+    auto allocaType = allocaOp.getType().cast<ShapedType>();
+    for (auto dimSize : allocaType.getShape()) {
+      if (ShapedType::isDynamic(dimSize)) continue;
+      allocaSize *= dimSize;
     }
     for (auto operand : allocaOp.getDynamicSizes()) {
       auto ub = linalg::getConstantUpperBoundForIndex(operand);
       if (succeeded(ub)) {
-        size *= *ub;
-      } else if (clFailOnOutOfBoundsStackAllocation) {
-        return allocaOp.emitOpError(
-            "expected no stack allocations without upper bound shapes");
+        allocaSize *= ub.value();
+        continue;
       }
+      return allocaOp.emitOpError("expoected no unbounded stack allocations");
     }
-    size *= type.getElementType().getIntOrFloatBitWidth();
+    allocaSize *= allocaType.getElementType().getIntOrFloatBitWidth();
     if (allocaOp.getAlignment()) {
       int64_t alignmentInBits = *allocaOp.getAlignment() * 8;
-      size = llvm::divideCeil(size, alignmentInBits) * alignmentInBits;
+      allocaSize =
+          llvm::divideCeil(allocaSize, alignmentInBits) * alignmentInBits / 8;
     }
-    totalBits += size;
-    return WalkResult::advance();
-  });
-  if (walkResult.wasInterrupted()) {
-    return signalPassFailure();
+    cumSize += allocaSize;
   }
-  int maxAllocationSizeInBits = clMaxAllocationSizeInBytes * 8;
-  if (clFailOnOutOfBoundsStackAllocation &&
-      totalBits > maxAllocationSizeInBits) {
-    moduleOp.emitOpError(
-        "expected total size of stack allocation is not greater than ")
-        << clMaxAllocationSizeInBytes.getValue() << " bytes, but got "
-        << llvm::divideCeil(totalBits, 8) << " bytes";
-    return signalPassFailure();
+  if (cumSize > clMaxAllocationSizeInBytes) {
+    return funcOp.emitOpError("exceeded static allocation limit for function");
+  }
+  return success();
+}
+
+void LLVMCPUCheckIRBeforeLLVMConversionPass::runOnOperation() {
+  auto moduleOp = getOperation();
+
+  for (auto funcOp : moduleOp.getOps<func::FuncOp>()) {
+    if (clFailOnOutOfBoundsStackAllocation &&
+        failed(checkStackAllocationSize(funcOp))) {
+      return signalPassFailure();
+    }
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/check_ir_before_llvm_conversion.mlir
@@ -53,3 +53,19 @@ module {
     return
   }
 }
+
+// -----
+
+#map = affine_map<(d0) -> (d0, 16)>
+module {
+  func.func @nested_op_alloca(%arg0 : index) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    scf.for %iv = %c0 to %arg0 step %c1 {
+      %0 = affine.min #map(%iv)
+      // expected-error @+1 {{all stack allocations need to be hoisted to the entry block of the function}}
+      %1 = memref.alloca(%0) : memref<?xi32>
+    }
+    return
+  }
+}


### PR DESCRIPTION
Earlier checks were ensuring that the stack allocation sizes are bounded, but without enforcing that these are hoisted all the way to the top this could still lead to explosion of stack allocations. Add this check. This gives LLVM codegeneration a static stack frame. With that is guaranteed to be bounded.

Issue #11880