### PR TITLE
Pull in the rematerialization pass into CPU lowering pipeline.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/RematerializeParallelOps.cpp
@@ -51,6 +51,7 @@ struct RematerializeParallelOpsPass
     func::FuncOp funcOp = getOperation();
     RewritePatternSet fusionPatterns(funcOp.getContext());
     fusionPatterns.insert<MergeElementwiseOps>(funcOp.getContext());
+    linalg::populateEraseUnusedOperandsAndResultsPatterns(fusionPatterns);
     if (failed(
             applyPatternsAndFoldGreedily(funcOp, std::move(fusionPatterns)))) {
       return signalPassFailure();

--- a/compiler/src/iree/compiler/Codegen/Common/test/rematerialize_parallel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/rematerialize_parallel_ops.mlir
@@ -42,3 +42,54 @@ func.func @merged_reduction_parallel(%0: tensor<1x40960xf32>, %1: tensor<1xf32>,
 //    CHECK-NEXT:     arith.mulf
 //    CHECK-NEXT:     linalg.yield %{{.+}} : f32
 //         CHECK:   } -> tensor<1x40960xf32>
+
+// -----
+
+func.func @softmax(%7 : tensor<16x32x4096xf32>) -> tensor<16x32x4096xf32> {
+  %cst = arith.constant -3.40282347E+38 : f32
+  %cst_0 = arith.constant 0.000000e+00 : f32
+  %cst_1 = arith.constant 1.000000e+00 : f32
+  %8 = tensor.empty() : tensor<16x32xf32>
+  %6 = tensor.empty() : tensor<16x32x4096xf32>
+  %9 = linalg.fill ins(%cst : f32) outs(%8 : tensor<16x32xf32>) -> tensor<16x32xf32>
+  %10 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%7 : tensor<16x32x4096xf32>) outs(%9 : tensor<16x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %16 = arith.maxf %in, %out : f32
+    linalg.yield %16 : f32
+  } -> tensor<16x32xf32>
+  %11 = tensor.empty() : tensor<16x32x4096xf32>
+  %12 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%7, %10 : tensor<16x32x4096xf32>, tensor<16x32xf32>) outs(%11 : tensor<16x32x4096xf32>) {
+  ^bb0(%in: f32, %in_2: f32, %out: f32):
+    %16 = arith.subf %in, %in_2 : f32
+    %17 = math.exp %16 : f32
+    linalg.yield %17 : f32
+  } -> tensor<16x32x4096xf32>
+  %13 = linalg.fill ins(%cst_0 : f32) outs(%8 : tensor<16x32xf32>) -> tensor<16x32xf32>
+  %14 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"]} ins(%12 : tensor<16x32x4096xf32>) outs(%13 : tensor<16x32xf32>) {
+  ^bb0(%in: f32, %out: f32):
+    %16 = arith.addf %in, %out : f32
+    linalg.yield %16 : f32
+  } -> tensor<16x32xf32>
+  %15 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d1, d2)>, affine_map<(d0, d1, d2) -> (d0, d1)>, affine_map<(d0, d1, d2) -> (d0, d1, d2)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%12, %14 : tensor<16x32x4096xf32>, tensor<16x32xf32>) outs(%6 : tensor<16x32x4096xf32>) {
+  ^bb0(%in: f32, %in_2: f32, %out: f32):
+    %16 = arith.divf %cst_1, %in_2 : f32
+    %17 = arith.mulf %in, %16 : f32
+    linalg.yield %17 : f32
+  } -> tensor<16x32x4096xf32>
+  return %15 : tensor<16x32x4096xf32>
+}
+//      CHECK: func @softmax(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<16x32x4096xf32>)
+//  CHECK-DAG:   %[[CST0:.+]] = arith.constant 0.0
+//      CHECK:   %[[MAXF:.+]] = linalg.generic
+// CHECK-SAME:       ["parallel", "parallel", "reduction"]
+// CHECK-SAME:       ins(%[[ARG0]] :
+//      CHECK:   %[[FILL0:.+]] = linalg.fill 
+// CHECK-SAME:       ins(%[[CST0]] :
+//      CHECK:   %[[EXPF:.+]] = linalg.generic
+// CHECK-SAME:       ["parallel", "parallel", "reduction"]
+// CHECK-SAME:       ins(%[[ARG0]], %[[MAXF]] :
+//      CHECK:   %[[RESULT:.+]] = linalg.generic
+// CHECK-SAME:       ["parallel", "parallel", "parallel"]
+// CHECK-SAME:       ins(%[[ARG0]], %[[MAXF]], %[[EXPF]] :
+//      CHECK:   return %[[RESULT]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -475,6 +475,13 @@ void addMultiTilingExpertPassPipeline(OpPassManager &passManager,
   addTileAndDistributePasses(passManager);
 
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
+
+  // This is a temporary solution for handling aggressive fusion heuristics.
+  // This rematerializes parallel ops into the consumers to avoid stack
+  // allocation.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createRematerializeParallelOpsPass());
+
   {
     LinalgFusePassOptions options;
     // Run SplitReductionPass before the final reduction Fuse pass, because

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -174,7 +174,6 @@ iree_check_single_backend_test_suite(
     ],
     compiler_flags = [
         "--iree-flow-enable-aggressive-fusion",
-        "--iree-llvmcpu-fail-on-out-of-bounds-stack-allocation=false",
     ],
     driver = "local-task",
     target_backend = "llvm-cpu",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -204,7 +204,6 @@ iree_check_single_backend_test_suite(
     "local-task"
   COMPILER_FLAGS
     "--iree-flow-enable-aggressive-fusion"
-    "--iree-llvmcpu-fail-on-out-of-bounds-stack-allocation=false"
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###


### PR DESCRIPTION
The rematerialization avoids use of stack allocations, instead of using a temporary buffer for one of the intermediate. This allows aggressive fusion herusitcs to be used without requirement of a intermediate stack buffer.