### PR TITLE
Add placeholder JAX integration documentation.

### DIFF
--- a/docs/website/docs/getting-started/jax.md
+++ b/docs/website/docs/getting-started/jax.md
@@ -1,12 +1,21 @@
 # JAX Integration
 
-!!! todo
-    [Issue#5454](https://github.com/iree-org/iree/issues/5454): write this documentation
+!!! note
+    IREE's JAX support is under active development. This page is still under
+    construction.
 
-<!-- TODO(??): overview (mention XLA? numpy?) -->
+IREE offers two ways to interface with [JAX](https://github.com/google/jax)
+programs:
 
-<!-- TODO(??): pip install vs build from source -->
+* An API for extracting and compiling full models ahead of time (AOT) for
+  execution apart from JAX. This API is being developed in the
+  [iree-org/iree-jax repository](https://github.com/iree-org/iree-jax).
+* A PJRT plugin that adapts IREE as a native JAX backend for online / just in
+  time (JIT) use. This plugin is being developed in the
+  [pjrt-plugin/](https://github.com/iree-org/iree-samples/tree/main/pjrt-plugin)
+  folder within the iree-samples repository for now, though it will likely move
+  elsewhere as it matures.
 
-<!-- TODO(??): python model code vs intermediate/serialization format(s), if any -->
-
-<!-- TODO(??): Colab notebooks, code samples -->
+<!-- TODO: Expand on interface differences -->
+<!-- TODO: Add quickstart instructions -->
+<!-- TODO: Link to samples -->


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/5454.

This updates https://iree-org.github.io/iree/getting-started/jax/