### PR TITLE
Run `build_test_all_windows` CI job on presubmit.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    if: needs.setup.outputs.should-run == 'true'
     runs-on: managed-windows-cpu
     defaults:
       run:


### PR DESCRIPTION
Now that this job is using caches, it might be fast enough to run on presubmit. We should keep an eye on how long the job is taking and if we are approaching any resource quotas.

Fixes https://github.com/iree-org/iree/issues/11009