### PR TITLE
[LLVMGPU] Remove allocations in reduction codegen using shared memory.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -1180,6 +1180,7 @@ void transform_dialect::ApplyBufferOptimizationsOp::getEffects(
 void transform_dialect::ApplyBufferOptimizationsOp::build(
     OpBuilder &builder, OperationState &result, Value target) {
   result.addOperands(target);
+  result.addTypes({pdl::OperationType::get(target.getContext())});
 }
 
 #define GET_OP_CLASSES

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -38,6 +38,8 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   tile_reduction_using_foreach_thread {{.*}} by num_threads = [0, 64], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
 //         CHECK:   transform.structured.fuse_into_containing_op
 //         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}} tile_sizes [1](mapping = [#gpu.thread<y>])
+//         CHECK:   cast %{{.*}} : !pdl.operation to !transform.op<"scf.foreach_thread">
+//         CHECK:   transform.iree.share_foreach_thread_operands %{{.*}} share_operands = [0] : (!transform.op<"scf.foreach_thread">) -> !transform.op<"scf.foreach_thread">
 //         CHECK:   transform.structured.match ops{["func.func"]} in %arg0
 //         CHECK:   transform.structured.vectorize
 //         CHECK:   transform.iree.bufferize {target_gpu}
@@ -46,10 +48,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.structured.match ops{["func.func"]} in %{{.*}}
 //         CHECK:   transform.iree.foreach_thread_to_workgroup
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [64, 1, 1]}
-//         CHECK:   transform.iree.apply_patterns %{{.*}} {fold_memref_aliases, rank_reducing_linalg, rank_reducing_vector}
+//         CHECK:   transform.iree.apply_patterns %{{.*}} {fold_memref_aliases, rank_reducing_vector}
 //         CHECK:   transform.structured.match ops{["scf.if"]} in %{{.*}}
 //         CHECK:   sequence {{.*}} failures(suppress) {
-//         CHECK:     transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 32 : i64}
+//         CHECK:     transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 64 : i64}
 //         CHECK:   }
 //         CHECK:   transform.iree.vector.warp_distribute
 
@@ -134,7 +136,7 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
 //         CHECK:   transform.structured.tile_reduction_using_foreach_thread %{{.*}} by num_threads = [0, 256], tile_sizes = [0, 1], mapping = [#gpu.thread<x>]
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [256, 1, 1]}
-//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 64 : i64}
+//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0 %{{.*}} {warp_size = 256 : i64}
 
 // -----
 
@@ -232,4 +234,4 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   transform.structured.split %{{.*}} after 8192  {dimension = 1 : i64}
 //         CHECK:   transform.structured.tile %{{.*}}[0, 8192]
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [1024, 1, 1]}
-//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0{{.*}}{warp_size = 64 : i64}
+//         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0{{.*}}{warp_size = 1024 : i64}

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
@@ -61,8 +61,8 @@ void mlir::iree_compiler::cpu::buildReductionStrategy(
     ImplicitLocOpBuilder &b, Value variantH,
     const ReductionStrategy &strategy) {
   // Step 1. Tiling to the block/workgroup level. Keep everything fused.
-  auto [maybeLeadingHBlock, gridFillH, gridReductionH,
-        maybeTiledTrailingHBlock] =
+  auto [maybeLeadingHBlock, gridFillH, gridReductionH, maybeTiledTrailingHBlock,
+        foreachThread] =
       buildReductionStrategyBlockDistribution(b, variantH, strategy);
 
   // Step 2. Naive first strategy to tile the most minor dimension by

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
@@ -207,7 +207,7 @@ buildReductionStrategyBlockDistribution(
     ImplicitLocOpBuilder &b, Value variantH,
     const AbstractReductionStrategy &strategy);
 
-/// Build transform IR  that applies memory optimizations.
+/// Build transform IR that applies memory optimizations.
 Value buildMemoryOptimizations(ImplicitLocOpBuilder &b, Value funcH);
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.h
@@ -187,7 +187,8 @@ std::tuple<Value, Value, Value> buildTileReductionUsingScfForeach(
 /// The matched `maybeLeadingH`, `fillH`, `reductionH` and `maybeTrailingH` are
 /// fused into the top-level `scf.foreach_thread` and handles are returned to
 /// the fused versions of these ops, in order, that are all tiled and
-/// distributed accordingly.
+/// distributed accordingly. The scf.foreach_thread is returned as the last
+/// value.
 /// The mapping of the `scf.foreach_thread` dimensions is tied the first
 /// dimensions of `strategy.allBlockAttrs`.
 ///
@@ -201,9 +202,13 @@ std::tuple<Value, Value, Value> buildTileReductionUsingScfForeach(
 ///
 /// Note: A future version of this op will be able to directly apply on the DAG
 /// and form the dispatch region.
-std::tuple<Value, Value, Value, Value> buildReductionStrategyBlockDistribution(
+std::tuple<Value, Value, Value, Value, Value>
+buildReductionStrategyBlockDistribution(
     ImplicitLocOpBuilder &b, Value variantH,
     const AbstractReductionStrategy &strategy);
+
+/// Build transform IR  that applies memory optimizations.
+Value buildMemoryOptimizations(ImplicitLocOpBuilder &b, Value funcH);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -153,7 +153,6 @@ Value mlir::iree_compiler::gpu::buildDistributeVectors(ImplicitLocOpBuilder &b,
   ApplyPatternsOpPatterns patterns;
   patterns.foldMemrefAliases = true;
   patterns.rankReducingVector = true;
-  patterns.rankReducingLinalg = true;
   funcH = b.create<ApplyPatternsOp>(funcH, patterns);
   Value ifH = b.create<MatchOp>(funcH, scf::IfOp::getOperationName());
   // Locally suppress failures for this op only because it doesn't cover the
@@ -261,6 +260,7 @@ std::pair<Value, Value> mlir::iree_compiler::gpu::buildCommonTrailingStrategy(
     const AbstractReductionStrategy &strategy) {
   // Step N-1. Bufferize and drop HAL descriptor from memref ops.
   Value funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
+
   funcH = iree_compiler::buildVectorize(b, funcH);
   variantH = iree_compiler::buildBufferize(b, variantH, /*targetGpu=*/true);
 

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/SmallReductionStrategy.cpp
@@ -154,8 +154,8 @@ void mlir::iree_compiler::gpu::buildSmallReductionStrategy(
     ImplicitLocOpBuilder &b, Value variantH,
     const SmallReductionStrategy &strategy) {
   // Step 1. Apply block-level part of the strategy, keeps everything fused.
-  auto [maybeLeadingHBlock, gridFillH, gridReductionH,
-        maybeTiledTrailingHBlock] =
+  auto [maybeLeadingHBlock, gridFillH, gridReductionH, maybeTiledTrailingHBlock,
+        foreachThread] =
       buildReductionStrategyBlockDistribution(b, variantH, strategy);
 
   // Step 2. Apply thread-level part of the strategy, keeps everything fused.


### PR DESCRIPTION
Add transformation to do store to load forwarding and remove extra alloc to store the partial reduction data.
This removes rank reduction for tensor/memref as those are currently creating extra copies that would prevent removing the allocations. This also changes how we distribute the merge reduction to be done across all threads of the group and fuse the fill op coming from reduction tiling with the reduction merge.