### PR TITLE
Tiling all the higher dimensions to 1

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -510,10 +510,10 @@ static SmallVector<int64_t> getDefaultDistributedLevelTileSizes(
                        allowIncompleteTile);
   }
   // All higher dimensions should be tiled at the workgroup level
-  // (distributedTileSizes), except after encountering an already specified workgroup
-  // tile - because at that point, parallel and reduction tiling would handle
-  // the required tiling. If the dimensions is less than 3, again parallel and
-  // reduction tiling would handle it.
+  // (distributedTileSizes), except after encountering an already specified
+  // workgroup tile - because at that point, parallel and reduction tiling would
+  // handle the required tiling. If the dimensions is less than 3, again
+  // parallel and reduction tiling would handle it.
   SmallVector<int64_t> updatedDistributedTileSizes;
   updatedDistributedTileSizes.reserve(distributedTileSizes.size());
   bool foundNonZero = false;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1233,11 +1233,12 @@ static LogicalResult setDefaultGenericOpRootConfig(
   // the required tiling. If the dimensions is less than 3, again parallel and
   // reduction tiling would handle it.
   SmallVector<int64_t> updatedFlowTileSizes;
+  updatedFlowTileSizes.reserve(flowTileSizes.size());
   bool foundNonZero = false;
   for (auto val : flowTileSizes) {
     if (val == 0) {
-      updatedFlowTileSizes.push_back(foundNonZero || tileSizes.size() <= 3 ? 0
-                                                                           : 1);
+      updatedFlowTileSizes.push_back((foundNonZero || 
+                                      flowTileSizes.size() <= 3) ? 0 : 1);
       continue;
     }
     updatedFlowTileSizes.push_back(val);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -512,7 +512,7 @@ static SmallVector<int64_t> getDefaultDistributedLevelTileSizes(
   // All higher dimensions should be tiled at the workgroup level
   // (distributedTileSizes), except after encountering an already specified
   // workgroup tile - because at that point, parallel and reduction tiling would
-  // handle the required tiling. If the dimensions is less than 3, again
+  // handle the required tiling. If the dimensions is less than 4, again
   // parallel and reduction tiling would handle it.
   SmallVector<int64_t> updatedDistributedTileSizes;
   updatedDistributedTileSizes.reserve(distributedTileSizes.size());

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1227,6 +1227,11 @@ static LogicalResult setDefaultGenericOpRootConfig(
                                  parallelTileSizes, reductionTileSizes);
 
   TileSizesListType tileSizes;
+  // All higher dimensions should be tiled at the workgroup level
+  // (flowTileSizes), except after encountering an already specified workgroup
+  // tile - because at that point, parallel and reduction tiling would handle
+  // the required tiling. If the dimensions is less than 3, again parallel and
+  // reduction tiling would handle it.
   SmallVector<int64_t> updatedFlowTileSizes;
   bool foundNonZero = false;
   for (auto val : flowTileSizes) {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -520,7 +520,7 @@ static SmallVector<int64_t> getDefaultDistributedLevelTileSizes(
   for (auto val : distributedTileSizes) {
     if (val == 0) {
       updatedDistributedTileSizes.push_back(
-          (foundNonZero || distributedTileSizes.size() <= 3) ? 0 : 1);
+          (foundNonZero || distributedTileSizes.size() <= 4) ? 0 : 1);
       continue;
     }
     updatedDistributedTileSizes.push_back(val);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1227,7 +1227,18 @@ static LogicalResult setDefaultGenericOpRootConfig(
                                  parallelTileSizes, reductionTileSizes);
 
   TileSizesListType tileSizes;
-  tileSizes.push_back(flowTileSizes);
+  SmallVector<int64_t> updatedFlowTileSizes;
+  bool foundNonZero = false;
+  for (auto val: flowTileSizes) {
+    if (val == 0) {
+      updatedFlowTileSizes.push_back(
+          foundNonZero || tileSizes.size() <= 3? 0 : 1);
+      continue;
+    }
+    updatedFlowTileSizes.push_back(val);
+    foundNonZero = true;
+  }
+  tileSizes.push_back(updatedFlowTileSizes);
   tileSizes.push_back(parallelTileSizes);
   tileSizes.push_back(reductionTileSizes);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1229,10 +1229,10 @@ static LogicalResult setDefaultGenericOpRootConfig(
   TileSizesListType tileSizes;
   SmallVector<int64_t> updatedFlowTileSizes;
   bool foundNonZero = false;
-  for (auto val: flowTileSizes) {
+  for (auto val : flowTileSizes) {
     if (val == 0) {
-      updatedFlowTileSizes.push_back(
-          foundNonZero || tileSizes.size() <= 3? 0 : 1);
+      updatedFlowTileSizes.push_back(foundNonZero || tileSizes.size() <= 3 ? 0
+                                                                           : 1);
       continue;
     }
     updatedFlowTileSizes.push_back(val);

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -509,24 +509,7 @@ static SmallVector<int64_t> getDefaultDistributedLevelTileSizes(
         getMaxTileSize(lbs[i], ubs[i], distributedTileSizes[i], minTileSizes[i],
                        allowIncompleteTile);
   }
-  // All higher dimensions should be tiled at the workgroup level
-  // (distributedTileSizes), except after encountering an already specified workgroup
-  // tile - because at that point, parallel and reduction tiling would handle
-  // the required tiling. If the dimensions is less than 3, again parallel and
-  // reduction tiling would handle it.
-  SmallVector<int64_t> updatedDistributedTileSizes;
-  updatedDistributedTileSizes.reserve(distributedTileSizes.size());
-  bool foundNonZero = false;
-  for (auto val : distributedTileSizes) {
-    if (val == 0) {
-      updatedDistributedTileSizes.push_back(
-          (foundNonZero || distributedTileSizes.size() <= 3) ? 0 : 1);
-      continue;
-    }
-    updatedDistributedTileSizes.push_back(val);
-    foundNonZero = true;
-  }
-  return updatedDistributedTileSizes;
+  return distributedTileSizes;
 }
 
 static SmallVector<int64_t> getDefaultDistributedLevelTileSizes(
@@ -1244,7 +1227,24 @@ static LogicalResult setDefaultGenericOpRootConfig(
                                  parallelTileSizes, reductionTileSizes);
 
   TileSizesListType tileSizes;
-  tileSizes.push_back(flowTileSizes);
+  // All higher dimensions should be tiled at the workgroup level
+  // (flowTileSizes), except after encountering an already specified workgroup
+  // tile - because at that point, parallel and reduction tiling would handle
+  // the required tiling. If the dimensions is less than 3, again parallel and
+  // reduction tiling would handle it.
+  SmallVector<int64_t> updatedFlowTileSizes;
+  updatedFlowTileSizes.reserve(flowTileSizes.size());
+  bool foundNonZero = false;
+  for (auto val : flowTileSizes) {
+    if (val == 0) {
+      updatedFlowTileSizes.push_back((foundNonZero || 
+                                      flowTileSizes.size() <= 3) ? 0 : 1);
+      continue;
+    }
+    updatedFlowTileSizes.push_back(val);
+    foundNonZero = true;
+  }
+  tileSizes.push_back(updatedFlowTileSizes);
   tileSizes.push_back(parallelTileSizes);
   tileSizes.push_back(reductionTileSizes);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_aarch64_launch_configuration.mlir
@@ -185,7 +185,7 @@ hal.executable private @conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 5, 20, 64, 0, 0, 0], [1, 1, 20, 64, 0, 0, 0], [0, 0, 0, 0, 1, 1, 16]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 5, 20, 64, 0, 0, 0], [1, 1, 20, 64, 0, 0, 0], [0, 0, 0, 0, 1, 1, 16]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.export public @conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -232,7 +232,7 @@ hal.executable private @restrict_num_workgroups {
     }
   }
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 1, 7, 64, 0, 0], [1, 1, 1, 4, 0, 0], [0, 0, 0, 0, 1, 1]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 7, 64, 0, 0], [1, 1, 1, 4, 0, 0], [0, 0, 0, 0, 1, 1]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //       CHECK: hal.executable.export public @restrict_num_workgroups
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_riscv_launch_configuration.mlir
@@ -91,7 +91,7 @@ hal.executable private @thin_depthwise_conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 7, 7, 72, 0, 0], [1, 1, 7, 4, 0, 0], [0, 0, 0, 0, 1, 3]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 7, 7, 72, 0, 0], [1, 1, 7, 4, 0, 0], [0, 0, 0, 0, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.export public @thin_depthwise_conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_x86_64_launch_configuration.mlir
@@ -275,7 +275,7 @@ hal.executable private @add4D  {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 64, 64, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
 //      CHECK: hal.executable.export public @add4D
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -316,7 +316,7 @@ hal.executable private @add_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 8, 16, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 8, 16, 64], [1, 1, 1, 4], [0, 0, 0, 0]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
 //      CHECK: hal.executable.export public @add_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -604,7 +604,7 @@ hal.executable private @conv_dynamic {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 64, 64, 64, 0, 0, 0], [1, 1, 1, 1, 0, 0, 0], [0, 0, 0, 0, 1, 1, 1]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 64, 64, 0, 0, 0], [1, 1, 1, 1, 0, 0, 0], [0, 0, 0, 0, 1, 1, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.export public @conv_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -646,7 +646,7 @@ hal.executable private @conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 28, 28, 16, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 28, 28, 16, 0, 0, 0], [1, 1, 4, 8, 0, 0, 0], [0, 0, 0, 0, 1, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.export public @conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -685,7 +685,7 @@ hal.executable private @conv_nchw_static {
   }
 }
 
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 64, 28, 4, 0, 0, 0], [1, 8, 1, 4, 0, 0, 0], [0, 0, 0, 0, 8, 1, 1]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 64, 28, 4, 0, 0, 0], [1, 8, 1, 4, 0, 0, 0], [0, 0, 0, 0, 8, 1, 1]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.export public @conv_nchw_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -731,7 +731,7 @@ hal.executable private @depthwise_conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 40, 40, 48, 0, 0], [1, 1, 8, 16, 0, 0], [0, 0, 0, 0, 1, 3]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 40, 40, 48, 0, 0], [1, 1, 8, 16, 0, 0], [0, 0, 0, 0, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.export public @depthwise_conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -780,7 +780,7 @@ hal.executable private @thin_depthwise_conv_static {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 7, 14, 36, 0, 0], [1, 1, 7, 18, 0, 0], [0, 0, 0, 0, 1, 3]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 7, 14, 36, 0, 0], [1, 1, 7, 18, 0, 0], [0, 0, 0, 0, 1, 3]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUConvTileAndDecomposeExpert>
 //      CHECK: hal.executable.export public @thin_depthwise_conv_static
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -1175,7 +1175,7 @@ hal.executable private @generic_unit_dims_dynamic {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[0, 0, 0, 0, 64, 64, 0, 64], [1, 1, 1, 1, 1, 1, 1, 4], [0, 0, 0, 0, 0, 0, 0, 0]{{\]}}>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1, 1, 1, 64, 64, 0, 64], [1, 1, 1, 1, 1, 1, 1, 4], [0, 0, 0, 0, 0, 0, 0, 0]{{\]}}>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<CPUDoubleTilingPeelingExpert>
 //      CHECK: hal.executable.export public @generic_unit_dims_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/integrations/tensorflow/test/iree_tf_tests/math/llvmcpu__dynamic_dim_lbeta.run
+++ b/integrations/tensorflow/test/iree_tf_tests/math/llvmcpu__dynamic_dim_lbeta.run
@@ -1,5 +1,4 @@
 # TODO(#11923): Enable after fixing.
-# XFAIL: *
 
 # REQUIRES: llvmcpu
 # RUN: %PYTHON -m iree_tf_tests.math.math_test --target_backends=iree_llvmcpu --dynamic_dims=true --functions=lbeta --artifacts_dir=%t


### PR DESCRIPTION
The idea is to force `memref.alloca` generated after tiling to have a static size. This with https://github.com/iree-org/iree/pull/11944 and https://github.com/iree-org/iree/pull/11938 (hoisting inner loop's`memref.alloca` and check that stack size constraint is met) should fix https://github.com/iree-org/iree/issues/11923