### PR TITLE
[LLVMGPU] Fuse trailing op if it doesn't broadcast

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/reduction_pipeline_transform.mlir
@@ -172,12 +172,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //         CHECK:   %[[PARTIAL:.*]] = arith.addf %{{.*}}
 //         CHECK:   %[[BROADCAST:.*]], %{{.*}} = gpu.shuffle  idx %[[PARTIAL]]
 //         CHECK:   %[[RES_VEC:.*]] = vector.broadcast %[[BROADCAST]] : f32 to vector<1xf32>
+//         CHECK:   %[[SQRT_VEC:.*]] = math.sqrt %[[RES_VEC]] : vector<1xf32>
 //         CHECK:   %[[CONDXIS0:.*]] = arith.cmpi eq, %[[TIDX]], %[[C0]] : index
 //         CHECK:   scf.if %[[CONDXIS0]]
-//         CHECK:     vector.transfer_write %[[RES_VEC]]
-
-//         CHECK:   gpu.barrier
-//         CHECK:   math.sqrt
+//         CHECK:     vector.transfer_write %[[SQRT_VEC]], {{.*}} : vector<1xf32>, memref<8xf32>
 //         CHECK:   gpu.barrier
 
 // -----

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
@@ -164,7 +164,7 @@ static void buildStagedReductionStrategyThreadLevel(
   Value root = blockCombinerOpH;
   SmallVector<Value> opsToFuse = {gridFillH};
   // If we have a unit dim after the reduction that doesn't broadcast fuse it
-  // wuth the reduction.
+  // with the reduction.
   if (strategy.captures.maybeTrailingRank ==
       strategy.captures.reductionRank - 1) {
     root = maybeTiledTrailingH;

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/StagedReductionStrategy.cpp
@@ -163,8 +163,19 @@ static void buildStagedReductionStrategyThreadLevel(
   // This predicate allows further vector distribution to kick in.
   Value root = blockCombinerOpH;
   SmallVector<Value> opsToFuse = {gridFillH};
-  // If we have a unit dim after the reduction that doesn't broadcast fuse it
-  // with the reduction.
+
+  // By the properties matching, we know the optional trailing op takes the
+  // result of the reduction as an input argument.
+  // It necessarily follows that maybeTrailingRank >= reductionRank - 1.
+  // When maybeTrailingRank == reductionRank - 1, by the properties of the
+  // transformations we have applied until now, we know that the elementwise is
+  // a simple scalar operation and it can be fused in the producing reduction
+  // without creating recomputations.
+  // TODO: Some `transform.assert` op that the shape of the op is indeed 1s only
+  // as a safety measure.
+  // TODO: More composable transform strategy parts require more matching after
+  // part of the strategy has been applied. See the discussion in #11951 for
+  // more context.
   if (strategy.captures.maybeTrailingRank ==
       strategy.captures.reductionRank - 1) {
     root = maybeTiledTrailingH;


### PR DESCRIPTION
If the op following the reduction doesn't broadcast it can be fused with the reduction to avoid having to go through memory.