### PR TITLE
Adding a greedy packing transform dialect op.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/BUILD
@@ -80,6 +80,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:ArithUtils",
         "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:BufferizationTransforms",
+        "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:GPUDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -763,9 +763,9 @@ void transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::build(
   SmallVector<int64_t> staticTileSizes;
   SmallVector<Value> dynamicTileSizes;
   dispatchIndexOpFoldResults(mixedTileSizes, dynamicTileSizes, staticTileSizes);
-  // Call the default builder which sets up the proper operands segment
-  // sizes attributes for multiple variadic operands. In the absence of
-  // this, horrible bugs ensue.
+  // Call the default builder which sets up the proper operands segment sizes
+  // attributes for multiple variadic operands. In the absence of this, horrible
+  // bugs ensue.
   MLIRContext *ctx = builder.getContext();
   auto operationType = pdl::OperationType::get(ctx);
 
@@ -800,9 +800,9 @@ void transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::build(
   SmallVector<Value> dynamicNumThreads;
   dispatchIndexOpFoldResults(mixedNumThreads, dynamicNumThreads,
                              staticNumThreads);
-  // Call the default builder which sets up the proper operands segment
-  // sizes attributes for multiple variadic operands. In the absence of
-  // this, horrible bugs ensue.
+  // Call the default builder which sets up the proper operands segment sizes
+  // attributes for multiple variadic operands. In the absence of this, horrible
+  // bugs ensue.
   MLIRContext *ctx = builder.getContext();
   auto operationType = pdl::OperationType::get(ctx);
   build(builder, result,
@@ -816,12 +816,11 @@ void transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::build(
 }
 
 /// Lower the ops within the workgroup count region of `exportOp` that
-/// represents the workgroup count calculation, to the actual
-/// computation that returns the number of workgroups. For now
-/// this lowers the `flow.dispatch.workgroup_count_from_dag_root` op
-/// to `ceilDiv(workload, tileSizes)`.
-/// Note: transform::TransformState &state is passed to allow  unpacking
-/// pdl::OperationType handles on the fly.
+/// represents the workgroup count calculation, to the actual computation that
+/// returns the number of workgroups. For now this lowers the
+/// `flow.dispatch.workgroup_count_from_dag_root` op to `ceilDiv(workload,
+/// tileSizes)`. Note: transform::TransformState &state is passed to allow
+/// unpacking pdl::OperationType handles on the fly.
 static LogicalResult lowerWorkgroupCountComputingRegion(
     transform::TransformState &state, RewriterBase &rewriter, Location loc,
     HAL::ExecutableExportOp exportOp, ArrayRef<OpFoldResult> tileSizes,
@@ -951,8 +950,8 @@ transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::apply(
                                      "couldn't find export op for func");
   }
 
-  /// Lower the workgroup count region in keeping with the way dispatch
-  /// regions are created by default in IREEs compilation flow.
+  /// Lower the workgroup count region in keeping with the way dispatch regions
+  /// are created by default in IREEs compilation flow.
   IRRewriter rewriter(getContext());
   if (failed(lowerWorkgroupCountComputingRegion(
           state, rewriter, getLoc(), exportOp.value(), getMixedTileSizes(),
@@ -985,17 +984,17 @@ transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::apply(
   return DiagnosedSilenceableFailure::success();
 }
 
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 // IREEBufferizeOp
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 // Important note: this transform is load-bearing and is the glue between
 // different dialects that want to operate on tensors.
 // Originaly, it used to just call `addIREEComprehensiveBufferizePasses` but
-// this introduces a lot of complexity in the registration process due to
-// the use of nested pass pipelines, to a point that it is a major endeavor
-// to connect a new dialect. Instead, avoid calling the passes and only take
-// what we need from them.
+// this introduces a lot of complexity in the registration process due to the
+// use of nested pass pipelines, to a point that it is a major endeavor to
+// connect a new dialect.
+// Instead, avoid calling the passes and only take what we need from them.
 //
 // TODO: Maybe we need both a transform.iree.cpu.bufferize and a
 // transform.iree.gpu.bufferize rather than a single common bufferize op?
@@ -1029,12 +1028,12 @@ void transform_dialect::IREEBufferizeOp::build(OpBuilder &builder,
   result.addTypes(pdl::OperationType::get(ctx));
 }
 
-//===---------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 // Default allocation functions for CPU backend
 // TODO: register the bufferization behavior in a target-specific way.
-// TODO: Maybe bufferize should have a separate cpu and a gpu version. This
-// is unclear though: what happens on heterogeneous HW ?
-//===---------------------------------------------------------------------===//
+// TODO: Maybe bufferize should have a separate cpu and a gpu version. This is
+// unclear though: what happens on heterogeneous HW ?
+//===----------------------------------------------------------------------===//
 
 // Allocation callbacks to use with upstream comprehensive bufferization
 static FailureOr<Value> cpuComprehensiveBufferizeAllocationFn(
@@ -1056,9 +1055,9 @@ static LogicalResult cpuComprehensiveBufferizeCopyFn(OpBuilder &builder,
                                                      Location loc, Value from,
                                                      Value to) {
   // TODO: ideally we should use linalg.copy which was recently reintroduced
-  // as an OpDSL named op. However, IREE-specific patterns to cleanup
-  // spurious post-bufferization copies do not trigger properly. So we keep
-  // using `createLinalgCopyOp` which builds a GenericOp.
+  // as an OpDSL named op. However, IREE-specific patterns to cleanup spurious
+  // post-bufferization copies do not trigger properly. So we keep using
+  // `createLinalgCopyOp` which builds a GenericOp.
   // builder.create<linalg::CopyOp>(loc, from, to);
   mlir::iree_compiler::createLinalgCopyOp(builder, loc, from, to);
   return success();
@@ -1089,9 +1088,9 @@ static LogicalResult gpuComprehensiveBufferizeCopyFn(OpBuilder &builder,
                                                      Location loc, Value from,
                                                      Value to) {
   // TODO: ideally we should use linalg.copy which was recently reintroduced
-  // as an OpDSL named op. However, IREE-specific patterns to cleanup
-  // spurious post-bufferization copies do not trigger properly. So we keep
-  // using `createLinalgCopyOp` which builds a GenericOp.
+  // as an OpDSL named op. However, IREE-specific patterns to cleanup spurious
+  // post-bufferization copies do not trigger properly. So we keep using
+  // `createLinalgCopyOp` which builds a GenericOp.
   // builder.create<linalg::CopyOp>(loc, from, to);
   mlir::iree_compiler::createLinalgCopyOp(builder, loc, from, to);
   return success();
@@ -1102,10 +1101,9 @@ static OneShotBufferizationOptions getBufferizationOptions() {
   // options.testAnalysisOnly = testAnalysisOnly;
   // options.printConflicts = printConflicts;
 
-  // bufferization.to_memref is used to bufferize constants in IREE. IREE
-  // has it's own logic to handle constants. We'd like to leave the
-  // arith.constant as is and insert bufferization.to_memref to convert the
-  // tensor to memref.
+  // bufferization.to_memref is used to bufferize constants in IREE. IREE has
+  // it's own logic to handle constants. We'd like to leave the arith.constant
+  // as is and insert bufferization.to_memref to convert the tensor to memref.
   options.opFilter.denyOperation<arith::ConstantOp>();
   options.opFilter.denyOperation<bufferization::ToMemrefOp>();
 
@@ -1115,8 +1113,8 @@ static OneShotBufferizationOptions getBufferizationOptions() {
                                       const BufferizationOptions &options) {
     auto tensorType = value.getType().cast<TensorType>();
 
-    // Special rule for ConstantOps: These always lower to some memref with
-    // a static identity layout.
+    // Special rule for ConstantOps: These always lower to some memref with a
+    // static identity layout.
     if (value.getDefiningOp<arith::ConstantOp>())
       return bufferization::getMemRefTypeWithStaticIdentityLayout(tensorType,
                                                                   memorySpace);
@@ -1155,11 +1153,11 @@ DiagnosedSilenceableFailure transform_dialect::IREEBufferizeOp::apply(
         "HAL::ExecutableVariantOp target op.");
   }
 
-  //===-------------------------------------------------------------------===//
-  // DO NOT JUST CALL `addIREEComprehensiveBufferizePasses` as this results
-  // in a lot of registration issues due to nested pass pipeline mess.
-  // Instead, take what we need from it.
-  //===-------------------------------------------------------------------===//
+  //===--------------------------------------------------------------------===//
+  // DO NOT JUST CALL `addIREEComprehensiveBufferizePasses` as this results in a
+  // lot of registration issues due to nested pass pipeline mess. Instead, take
+  // what we need from it.
+  //===--------------------------------------------------------------------===//
   // Bufferize the dispatch.
   using mlir::bufferization::BufferizationOptions;
   BufferizationOptions::AllocationFn allocationFn =

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -17,6 +17,8 @@ include "mlir/Dialect/SCF/IR/DeviceMappingInterface.td"
 include "mlir/IR/EnumAttr.td"
 include "mlir/IR/OpBase.td"
 
+def Transform_FuncOp : Transform_ConcreteOpType<"func.func">;
+
 def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
     [DeclareOpInterfaceMethods<MemoryEffectsOpInterface>,
      TransformEachOpTrait,
@@ -484,18 +486,22 @@ def PackGreedilyOp : Op<Transform_Dialect,
   let description = [{
     Target the whole func op and rewrite known LinalgOp to packed form greedily.
 
-    Return modes:
-    =============
+    #### Return modes
+    
     This operation ignores non-Func ops and drops them in the return.
 
-    It returns the same Func ops where all supported containing LinalgOps are
+    It returns the same Func ops where all supported contained LinalgOps are
     packed.
   }];
 
-  let arguments = (ins PDL_Operation:$target);
-  let results = (outs PDL_Operation:$transformed);
+  let arguments = (ins Transform_FuncOp:$target);
+  let results = (outs Transform_FuncOp:$transformed);
 
-  let assemblyFormat = "$target attr-dict";
+  let assemblyFormat = [{
+    $target
+    attr-dict
+    `:` functional-type($target, results)
+  }];
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 
   let builders = [

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -475,4 +475,39 @@ def ApplyBufferOptimizationsOp :
   }];
 }
 
+def PackGreedilyOp : Op<Transform_Dialect,
+    "iree.pack_greedily",
+    [FunctionalStyleTransformOpTrait,
+     MemoryEffectsOpInterface,
+     TransformOpInterface,
+     TransformEachOpTrait]> {
+  let description = [{
+    Target the whole func op and rewrite known LinalgOp to packed form greedily.
+
+    Return modes:
+    =============
+    This operation ignores non-Func ops and drops them in the return.
+
+    It returns the same Func ops where all supported containing LinalgOps are
+    packed.
+  }];
+
+  let arguments = (ins PDL_Operation:$target);
+  let results = (outs PDL_Operation:$transformed);
+
+  let assemblyFormat = "$target attr-dict";
+  let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
+
+  let builders = [
+    OpBuilder<(ins "Value":$target)>
+  ];
+
+  let extraClassDeclaration = [{
+    ::mlir::DiagnosedSilenceableFailure applyToOne(
+        ::mlir::func::FuncOp target,
+        ::mlir::transform::ApplyToEachResultList &results,
+        ::mlir::transform::TransformState &state);
+  }];
+}
+
 #endif // IREE_COMPILER_CODEGEN_COMMON_TRANSFORMEXTENSIONS_COMMONEXTENSIONS

--- a/tests/transform_dialect/cpu/BUILD
+++ b/tests/transform_dialect/cpu/BUILD
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     srcs = [
         "eltwise_reduction_eltwise.mlir",
         "matmul.mlir",
+        "packing.mlir",
     ],
     cfg = "//tests:lit.cfg.py",
     # transform dialect spec files are MLIR files that specify a transformation,

--- a/tests/transform_dialect/cpu/CMakeLists.txt
+++ b/tests/transform_dialect/cpu/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "eltwise_reduction_eltwise.mlir"
     "matmul.mlir"
+    "packing.mlir"
   TOOLS
     ${IREE_LLD_TARGET}
     FileCheck

--- a/tests/transform_dialect/cpu/packing.mlir
+++ b/tests/transform_dialect/cpu/packing.mlir
@@ -1,0 +1,154 @@
+// // RUN: iree-opt %s --iree-transform-dialect-interpreter --transform-dialect-drop-schedule --split-input-file | FileCheck %s
+
+!A_mk = tensor<1023x255xf32>
+!B_kn = tensor<255x127xf32>
+!C_mn = tensor<1023x127xf32>
+
+// Normalized dims pre-packing are:         ( k,  m,  n)
+// CHECK-DAG: #[[$mk_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
+// CHECK-DAG: #[[$kn_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
+// CHECK-DAG: #[[$mn_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d4, d5)>
+
+// CHECK-LABEL: @matmul_mk_kn_mn(
+func.func @matmul_mk_kn_mn(%A : !A_mk, %B : !B_kn, %C : !C_mn) -> !C_mn {
+  //      CHECK: linalg.generic
+  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]],
+  // CHECK-SAME:   ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
+  // CHECK-SAME:   ins(%{{.*}} : tensor<128x8x32x8xf32>, tensor<8x8x32x16xf32>)
+  // CHECK-SAME:  outs(%{{.*}} : tensor<128x8x8x16xf32>)
+  %0 = linalg.matmul ins(%A, %B : !A_mk, !B_kn) outs(%C : !C_mn) -> !C_mn
+  return %0 : !C_mn
+}
+
+transform.sequence failures(propagate) {
+^bb1(%module_op: !pdl.operation):
+  %func = transform.structured.match ops{["func.func"]} in %module_op
+  %func_2 = transform.iree.pack_greedily %func
+}
+
+// -----
+
+!A_mk = tensor<1023x255xf32>
+!B_nk = tensor<127x255xf32>
+!C_nm = tensor<127x1023xf32>
+
+#mkn_accesses = [
+  affine_map<(m, n, k) -> (m, k)>,
+  affine_map<(m, n, k) -> (n, k)>,
+  affine_map<(m, n, k) -> (n, m)>
+]
+#mkn_trait = {
+  indexing_maps = #mkn_accesses,
+  iterator_types = ["parallel", "parallel", "reduction"]
+}
+
+// Normalized dims pre-packing are:         ( k,  m,  n)
+// CHECK-DAG: #[[$km_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
+// CHECK-DAG: #[[$kn_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>
+// CHECK-DAG: #[[$mn_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d4, d5)>
+
+// CHECK-LABEL: @matmul_mk_nk_nm(
+func.func @matmul_mk_nk_nm(%A : !A_mk, %B : !B_nk, %C : !C_nm) -> !C_nm {
+  //      CHECK: linalg.generic
+  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]],
+  // CHECK-SAME:   ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
+  // CHECK-SAME:   ins(%{{.*}} : tensor<128x8x32x8xf32>, tensor<8x8x32x16xf32>)
+  // CHECK-SAME:  outs(%{{.*}} : tensor<8x128x8x16xf32>)
+  %0 = linalg.generic #mkn_trait ins(%A, %B : !A_mk, !B_nk) outs(%C : !C_nm) {
+    ^bb0(%a: f32, %b: f32, %c: f32):
+      %d = arith.mulf %a, %b : f32
+      %e = arith.addf %c, %d : f32
+      linalg.yield %e : f32
+  } -> !C_nm
+  return %0 : !C_nm
+}
+
+transform.sequence failures(propagate) {
+^bb1(%module_op: !pdl.operation):
+  %func = transform.structured.match ops{["func.func"]} in %module_op
+  %func_2 = transform.iree.pack_greedily %func
+}
+
+// -----
+
+!A_mk = tensor<1023x255xf32>
+!B_nk = tensor<127x255xf32>
+!C_nm = tensor<127x1023xf32>
+
+#mkn_accesses = [
+  affine_map<(k, m, n) -> (m, k)>,
+  affine_map<(k, m, n) -> (n, k)>,
+  affine_map<(k, m, n) -> (n, m)>
+]
+#mkn_trait = {
+  indexing_maps = #mkn_accesses,
+  iterator_types = ["reduction", "parallel", "parallel"]
+}
+
+// CHECK-DAG: #[[$mk_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
+// CHECK-DAG: #[[$kn_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>
+// CHECK-DAG: #[[$mn_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d4, d5)>
+
+// CHECK-LABEL: @matmul_mk_nk_nm_transposed(
+func.func @matmul_mk_nk_nm_transposed(%A : !A_mk, %B : !B_nk, %C : !C_nm) -> !C_nm {
+  //      CHECK: linalg.generic
+  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]],
+  // CHECK-SAME:   ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
+  // CHECK-SAME:   ins(%{{.*}} : tensor<128x8x32x8xf32>, tensor<8x8x32x16xf32>)
+  // CHECK-SAME:  outs(%{{.*}} : tensor<8x128x8x16xf32>)
+  %0 = linalg.generic #mkn_trait ins(%A, %B : !A_mk, !B_nk) outs(%C : !C_nm) {
+    ^bb0(%a: f32, %b: f32, %c: f32):
+      %d = arith.mulf %a, %b : f32
+      %e = arith.addf %c, %d : f32
+      linalg.yield %e : f32
+  } -> !C_nm
+  return %0 : !C_nm
+}
+
+transform.sequence failures(propagate) {
+^bb1(%module_op: !pdl.operation):
+  %func = transform.structured.match ops{["func.func"]} in %module_op
+  %func_2 = transform.iree.pack_greedily %func
+}
+
+// -----
+
+!A_bmkm2 = tensor<42x1023x255x33xf32>
+!B_nkb = tensor<127x255x42xf32>
+!C_nbm = tensor<127x42x1023xf32>
+
+#mkn_accesses = [
+  affine_map<(k, m, n, b, m2) -> (b, m, k, m2)>,
+  affine_map<(k, m, n, b, m2) -> (n, k, b)>,
+  affine_map<(k, m, n, b, m2) -> (n, b, m)>
+]
+#mkn_trait = {
+  indexing_maps = #mkn_accesses,
+  iterator_types = ["reduction", "parallel", "parallel", "parallel", "parallel"]
+}
+
+// CHECK-DAG: #[[$bmkm2_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d3, d2, d1, d5, d6)>
+// CHECK-DAG: #[[$nkb_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d4, d2, d0, d5, d7)>
+// CHECK-DAG: #[[$nbm_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d4, d0, d3, d6, d7)>
+
+// CHECK-LABEL: @contraction_bmkm2_nkb_nbm(
+func.func @contraction_bmkm2_nkb_nbm(%A : !A_bmkm2, %B : !B_nkb, %C : !C_nbm) -> !C_nbm {
+  //      CHECK: linalg.generic
+  // CHECK-SAME: indexing_maps = [#[[$bmkm2_kkmm]], #[[$nkb_kknn]], #[[$nbm_mmnn]]],
+  // CHECK-SAME:   ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
+  // CHECK-SAME:   ins(%{{.*}} : tensor<42x128x8x33x32x8xf32>, tensor<8x8x42x32x16xf32>)
+  // CHECK-SAME:  outs(%{{.*}} : tensor<8x42x128x8x16xf32>)
+  %0 = linalg.generic #mkn_trait ins(%A, %B : !A_bmkm2, !B_nkb) outs(%C : !C_nbm) {
+    ^bb0(%a: f32, %b: f32, %c: f32):
+      %d = arith.mulf %a, %b : f32
+      %e = arith.addf %c, %d : f32
+      linalg.yield %e : f32
+  } -> !C_nbm
+  return %0 : !C_nbm
+}
+
+transform.sequence failures(propagate) {
+^bb1(%module_op: !pdl.operation):
+  %func = transform.structured.match ops{["func.func"]} in %module_op
+  %func_2 = transform.iree.pack_greedily %func
+}

--- a/tests/transform_dialect/cpu/packing.mlir
+++ b/tests/transform_dialect/cpu/packing.mlir
@@ -1,4 +1,4 @@
-// // RUN: iree-opt %s --iree-transform-dialect-interpreter --transform-dialect-drop-schedule -mlir-elide-elementsattrs-if-larger=4 --split-input-file | FileCheck %s
+// RUN: iree-opt %s --iree-transform-dialect-interpreter --transform-dialect-drop-schedule -mlir-elide-elementsattrs-if-larger=4 --split-input-file | FileCheck %s
 
 !A_mk = tensor<1023x255xf32>
 !B_kn = tensor<255x127xf32>
@@ -22,8 +22,8 @@ func.func @matmul_mk_kn_mn(%A : !A_mk, %B : !B_kn, %C : !C_mn) -> !C_mn {
 
 transform.sequence failures(propagate) {
 ^bb1(%module_op: !pdl.operation):
-  %func = transform.structured.match ops{["func.func"]} in %module_op
-  %func_2 = transform.iree.pack_greedily %func
+  %func = transform.structured.match ops{["func.func"]} in %module_op : (!pdl.operation) -> !transform.op<"func.func">
+  %func_2 = transform.iree.pack_greedily %func: (!transform.op<"func.func">) -> !transform.op<"func.func">
 }
 
 // -----
@@ -65,8 +65,8 @@ func.func @matmul_mk_nk_nm(%A : !A_mk, %B : !B_nk, %C : !C_nm) -> !C_nm {
 
 transform.sequence failures(propagate) {
 ^bb1(%module_op: !pdl.operation):
-  %func = transform.structured.match ops{["func.func"]} in %module_op
-  %func_2 = transform.iree.pack_greedily %func
+  %func = transform.structured.match ops{["func.func"]} in %module_op : (!pdl.operation) -> !transform.op<"func.func">
+  %func_2 = transform.iree.pack_greedily %func : (!transform.op<"func.func">) -> !transform.op<"func.func">
 }
 
 // -----
@@ -108,8 +108,8 @@ func.func @matmul_mk_nk_nm_transposed(%A : !A_mk, %B : !B_nk, %C : !C_nm) -> !C_
 
 transform.sequence failures(propagate) {
 ^bb1(%module_op: !pdl.operation):
-  %func = transform.structured.match ops{["func.func"]} in %module_op
-  %func_2 = transform.iree.pack_greedily %func
+  %func = transform.structured.match ops{["func.func"]} in %module_op : (!pdl.operation) -> !transform.op<"func.func">
+  %func_2 = transform.iree.pack_greedily %func : (!transform.op<"func.func">) -> !transform.op<"func.func">
 }
 
 // -----
@@ -151,8 +151,8 @@ func.func @contraction_bmkm2_nkb_nbm(%A : !A_bmkm2, %B : !B_nkb, %C : !C_nbm) ->
 
 transform.sequence failures(propagate) {
 ^bb1(%module_op: !pdl.operation):
-  %func = transform.structured.match ops{["func.func"]} in %module_op
-  %func_2 = transform.iree.pack_greedily %func
+  %func = transform.structured.match ops{["func.func"]} in %module_op : (!pdl.operation) -> !transform.op<"func.func">
+  %func_2 = transform.iree.pack_greedily %func : (!transform.op<"func.func">) -> !transform.op<"func.func">
 }
 
 // -----
@@ -183,8 +183,8 @@ func.func @conv_2d_nchw_fchw(%arg0: tensor<?x47x16x16xf32>, %arg2: tensor<?x16x1
 
 transform.sequence failures(propagate) {
 ^bb1(%module_op: !pdl.operation):
-  %func = transform.structured.match ops{["func.func"]} in %module_op
-  %func_2 = transform.iree.pack_greedily %func
+  %func = transform.structured.match ops{["func.func"]} in %module_op : (!pdl.operation) -> !transform.op<"func.func">
+  %func_2 = transform.iree.pack_greedily %func : (!transform.op<"func.func">) -> !transform.op<"func.func">
 }
 
 
@@ -209,6 +209,6 @@ func.func @reduce_and_map(%arg0: tensor<10x100xf32>,
 
 transform.sequence failures(propagate) {
 ^bb1(%module_op: !pdl.operation):
-  %func = transform.structured.match ops{["func.func"]} in %module_op
-  %func_2 = transform.iree.pack_greedily %func
+  %func = transform.structured.match ops{["func.func"]} in %module_op : (!pdl.operation) -> !transform.op<"func.func">
+  %func_2 = transform.iree.pack_greedily %func : (!transform.op<"func.func">) -> !transform.op<"func.func">
 }

--- a/tests/transform_dialect/cpu/packing.mlir
+++ b/tests/transform_dialect/cpu/packing.mlir
@@ -1,10 +1,10 @@
-// // RUN: iree-opt %s --iree-transform-dialect-interpreter --transform-dialect-drop-schedule --split-input-file | FileCheck %s
+// // RUN: iree-opt %s --iree-transform-dialect-interpreter --transform-dialect-drop-schedule -mlir-elide-elementsattrs-if-larger=4 --split-input-file | FileCheck %s
 
 !A_mk = tensor<1023x255xf32>
 !B_kn = tensor<255x127xf32>
 !C_mn = tensor<1023x127xf32>
 
-// Normalized dims pre-packing are:         ( k,  m,  n)
+// Normalized dims are:                     ( k,  m,  n)(kk, mm, nn)
 // CHECK-DAG: #[[$mk_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
 // CHECK-DAG: #[[$kn_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d0, d2, d3, d5)>
 // CHECK-DAG: #[[$mn_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d2, d4, d5)>
@@ -12,7 +12,7 @@
 // CHECK-LABEL: @matmul_mk_kn_mn(
 func.func @matmul_mk_kn_mn(%A : !A_mk, %B : !B_kn, %C : !C_mn) -> !C_mn {
   //      CHECK: linalg.generic
-  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]],
+  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]]
   // CHECK-SAME:   ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
   // CHECK-SAME:   ins(%{{.*}} : tensor<128x8x32x8xf32>, tensor<8x8x32x16xf32>)
   // CHECK-SAME:  outs(%{{.*}} : tensor<128x8x8x16xf32>)
@@ -42,7 +42,7 @@ transform.sequence failures(propagate) {
   iterator_types = ["parallel", "parallel", "reduction"]
 }
 
-// Normalized dims pre-packing are:         ( k,  m,  n)
+// Normalized dims are:                     ( k,  m,  n)(kk, mm, nn)
 // CHECK-DAG: #[[$km_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
 // CHECK-DAG: #[[$kn_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>
 // CHECK-DAG: #[[$mn_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d4, d5)>
@@ -50,7 +50,7 @@ transform.sequence failures(propagate) {
 // CHECK-LABEL: @matmul_mk_nk_nm(
 func.func @matmul_mk_nk_nm(%A : !A_mk, %B : !B_nk, %C : !C_nm) -> !C_nm {
   //      CHECK: linalg.generic
-  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]],
+  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]]
   // CHECK-SAME:   ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
   // CHECK-SAME:   ins(%{{.*}} : tensor<128x8x32x8xf32>, tensor<8x8x32x16xf32>)
   // CHECK-SAME:  outs(%{{.*}} : tensor<8x128x8x16xf32>)
@@ -85,6 +85,7 @@ transform.sequence failures(propagate) {
   iterator_types = ["reduction", "parallel", "parallel"]
 }
 
+// Normalized dims are:                     ( k,  m,  n)(kk, mm, nn)
 // CHECK-DAG: #[[$mk_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d1, d0, d3, d4)>
 // CHECK-DAG: #[[$kn_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d0, d3, d5)>
 // CHECK-DAG: #[[$mn_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5) -> (d2, d1, d4, d5)>
@@ -92,7 +93,7 @@ transform.sequence failures(propagate) {
 // CHECK-LABEL: @matmul_mk_nk_nm_transposed(
 func.func @matmul_mk_nk_nm_transposed(%A : !A_mk, %B : !B_nk, %C : !C_nm) -> !C_nm {
   //      CHECK: linalg.generic
-  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]],
+  // CHECK-SAME: indexing_maps = [#[[$mk_kkmm]], #[[$kn_kknn]], #[[$mn_mmnn]]]
   // CHECK-SAME:   ["reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
   // CHECK-SAME:   ins(%{{.*}} : tensor<128x8x32x8xf32>, tensor<8x8x32x16xf32>)
   // CHECK-SAME:  outs(%{{.*}} : tensor<8x128x8x16xf32>)
@@ -127,14 +128,15 @@ transform.sequence failures(propagate) {
   iterator_types = ["reduction", "parallel", "parallel", "parallel", "parallel"]
 }
 
+// Normalized dims are:                        ( ?,  ?,  k,  m,  n)(kk, mm, nn)
 // CHECK-DAG: #[[$bmkm2_kkmm:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d0, d3, d2, d1, d5, d6)>
-// CHECK-DAG: #[[$nkb_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d4, d2, d0, d5, d7)>
-// CHECK-DAG: #[[$nbm_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d4, d0, d3, d6, d7)>
+// CHECK-DAG:   #[[$nkb_kknn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d4, d2, d0, d5, d7)>
+// CHECK-DAG:   #[[$nbm_mmnn:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7) -> (d4, d0, d3, d6, d7)>
 
 // CHECK-LABEL: @contraction_bmkm2_nkb_nbm(
 func.func @contraction_bmkm2_nkb_nbm(%A : !A_bmkm2, %B : !B_nkb, %C : !C_nbm) -> !C_nbm {
   //      CHECK: linalg.generic
-  // CHECK-SAME: indexing_maps = [#[[$bmkm2_kkmm]], #[[$nkb_kknn]], #[[$nbm_mmnn]]],
+  // CHECK-SAME: indexing_maps = [#[[$bmkm2_kkmm]], #[[$nkb_kknn]], #[[$nbm_mmnn]]]
   // CHECK-SAME:   ["parallel", "parallel", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]} 
   // CHECK-SAME:   ins(%{{.*}} : tensor<42x128x8x33x32x8xf32>, tensor<8x8x42x32x16xf32>)
   // CHECK-SAME:  outs(%{{.*}} : tensor<8x42x128x8x16xf32>)
@@ -145,6 +147,36 @@ func.func @contraction_bmkm2_nkb_nbm(%A : !A_bmkm2, %B : !B_nkb, %C : !C_nbm) ->
       linalg.yield %e : f32
   } -> !C_nbm
   return %0 : !C_nbm
+}
+
+transform.sequence failures(propagate) {
+^bb1(%module_op: !pdl.operation):
+  %func = transform.structured.match ops{["func.func"]} in %module_op
+  %func_2 = transform.iree.pack_greedily %func
+}
+
+// -----
+
+// Conv linguo:                          h   w  kh  kw   c   n   f  cc  nn  ff
+// Normalized dims are:                ( ?,  ?,  ?,  ?,  k,  m,  n)(kk, mm, nn)
+//                                                                                   n   c   h + kh   w + kw  cc  nn
+// CHECK-DAG: #[[$M1:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d5, d4, d0 + d2, d1 + d3, d7, d8)>
+//                                                                                   f   c  kh  kw  cc  ff
+// CHECK-DAG: #[[$M2:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d6, d4, d2, d3, d7, d9)>
+//                                                                                   n   f   h   w  nn  ff
+// CHECK-DAG: #[[$M3:.*]] = affine_map<(d0, d1, d2, d3, d4, d5, d6, d7, d8, d9) -> (d5, d6, d0, d1, d8, d9)>
+func.func @conv_2d_nchw_fchw(%arg0: tensor<?x47x16x16xf32>, %arg2: tensor<?x16x14x14xf32>) -> tensor<?x16x14x14xf32> {
+  %c0 = arith.constant dense<0.1> : tensor<16x47x3x3xf32>
+  //      CHECK: linalg.generic
+  // CHECK-SAME: indexing_maps = [#[[$M1]], #[[$M2]], #[[$M3]]]
+  // CHECK-SAME: iterator_types = ["parallel", "parallel", "reduction", "reduction", "reduction", "parallel", "parallel", "reduction", "parallel", "parallel"]
+  // CHECK-SAME:  ins(%{{.*}} : tensor<?x2x16x16x32x8xf32>, tensor<1x2x3x3x32x16xf32>)
+  // CHECK-SAME: outs(%{{.*}} : tensor<?x1x14x14x8x16xf32>)
+  %0 = linalg.conv_2d_nchw_fchw
+    {dilations = dense<1> : tensor<2xi64>, strides = dense<1> : tensor<2xi64> }
+     ins(%arg0, %c0: tensor<?x47x16x16xf32>, tensor<16x47x3x3xf32>)
+    outs(%arg2: tensor<?x16x14x14xf32>) -> tensor<?x16x14x14xf32>
+  return %0 : tensor<?x16x14x14xf32>
 }
 
 transform.sequence failures(propagate) {


### PR DESCRIPTION
This PR adds a transform.iree.pack_greedily operation that infers the packing for 2-D contractions embedded in any linalg op and packs accordingly.

A normalization step guarantees that we get the innermost op dimensions in one of 8 possible `(m, n, k)` orders, specified as a parameter, from which we can emit all packed forms.

The current implementation takes an arbitrary `linalg` op and tries to pack it along dimensions ordered as `kk, mm, nn` and with sizes `32, 8, 16`. This is an arbitrary choice that can be lifted to a transform.pack_greedily.

This achieves a new level of normalization and generalization for any n-D linalg op that contains a contraction hidden within it: we will always see a predictable packed form for any of these ops.

Followups will generalize to non-D-contractions within matvec, reductions and pointwise ops.