### PR TITLE
Improving `hal.interface.constant.load` alignment propagation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/iree_comprehensive_bufferize.mlir
@@ -79,7 +79,8 @@ func.func @matmul_fill() {
   %m = hal.interface.constant.load[0] : index
   %n = hal.interface.constant.load[1] : index
   %k = hal.interface.constant.load[2] : index
-  %base_offset = hal.interface.constant.load[3] alignment(8) : index
+  %base_offset_i32 = hal.interface.constant.load[3] alignment(8) : i32
+  %base_offset = arith.index_castui %base_offset_i32 : i32 to index
   %lhs = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32) : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%m, %k}
   %rhs = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%base_offset) : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%k, %n}
   %result = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c1024) : !flow.dispatch.tensor<readwrite:tensor<?x?xf32>>{%m, %n}
@@ -115,7 +116,8 @@ func.func @matmul_fill() {
 //  CHECK-DAG:   %[[M:.+]] = hal.interface.constant.load[0]
 //  CHECK-DAG:   %[[N:.+]] = hal.interface.constant.load[1]
 //  CHECK-DAG:   %[[K:.+]] = hal.interface.constant.load[2]
-//  CHECK-DAG:   %[[BASE_OFFSET:.+]] = hal.interface.constant.load[3]
+//  CHECK-DAG:   %[[BASE_OFFSET_I32:.+]] = hal.interface.constant.load[3]
+//  CHECK-DAG:   %[[BASE_OFFSET:.+]] = arith.index_castui %[[BASE_OFFSET_I32]]
 //  CHECK-DAG:   %[[LHS:.+]] = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32)
 //  CHECK-DAG:   memref.assume_alignment %[[LHS]], 32
 //  CHECK-DAG:   %[[RHS:.+]] = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%[[BASE_OFFSET]])

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/Passes.cpp
@@ -266,6 +266,11 @@ void buildStreamOptimizationPassPipeline(
     // dispatches and the dispatch function argument order.
   }
 
+  // Annotate dispatch region arguments based on the operands passed at dispatch
+  // sites. This allows codegen to see the potential values for the operands
+  // when operating locally on executables.
+  passManager.addPass(IREE::Stream::createAnnotateDispatchArgumentsPass());
+
   // Pack dispatch operands on stream.executable into i32 values.
   // We do this prior to exiting the pipeline as here we can still easily
   // add/remove operands.
@@ -284,15 +289,6 @@ void buildStreamOptimizationPassPipeline(
   // TODO(benvanik): when we spill push constants spill to staging buffers.
   // Need to know push constant limit but that could be specified as a stream
   // option (max operand count).
-
-  //----------------------------------------------------------------------------
-  // Annotations to aid future lowering pipelines
-  //----------------------------------------------------------------------------
-
-  // Annotate dispatch region arguments based on the operands passed at dispatch
-  // sites. This allows codegen to see the potential values for the operands
-  // when operating locally on executables.
-  passManager.addPass(IREE::Stream::createAnnotateDispatchArgumentsPass());
 }
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings.mlir
@@ -18,8 +18,7 @@ stream.executable private @rebaseBindingsEx {
       %c0 = arith.constant 0 : index
       %c20 = arith.constant 20 : index
 
-      // CHECK: %[[SUM_OFFSET_A:.+]] = arith.addi %c0, %[[OFFSET_A]]
-      // CHECK: %[[SUBSPAN_A:.+]] = stream.binding.subspan %[[BINDING_A]][%[[SUM_OFFSET_A]]]
+      // CHECK: %[[SUBSPAN_A:.+]] = stream.binding.subspan %[[BINDING_A]][%[[OFFSET_A]]]
       %subspan_a = stream.binding.subspan %binding_a[%c0] : !stream.binding -> !flow.dispatch.tensor<readwrite:tensor<20xi8>>{%c20}
       // CHECK-NEXT: util.optimization_barrier %[[SUBSPAN_A]]
       util.optimization_barrier %subspan_a : !flow.dispatch.tensor<readwrite:tensor<20xi8>>
@@ -97,8 +96,7 @@ stream.executable private @deduplicateBindingsEx {
       %c20 = arith.constant 20 : index
       %c40 = arith.constant 40 : index
 
-      // CHECK: %[[SUM_OFFSET_A:.+]] = arith.addi %c0, %[[OFFSET_A]]
-      // CHECK: %[[SUBSPAN_A:.+]] = stream.binding.subspan %[[BINDING_A]][%[[SUM_OFFSET_A]]]
+      // CHECK: %[[SUBSPAN_A:.+]] = stream.binding.subspan %[[BINDING_A]][%[[OFFSET_A]]]
       %subspan_a = stream.binding.subspan %binding_a[%c0] : !stream.binding -> !flow.dispatch.tensor<readwrite:tensor<20xi8>>{%c20}
       // CHECK-NEXT: util.optimization_barrier %[[SUBSPAN_A]]
       util.optimization_barrier %subspan_a : !flow.dispatch.tensor<readwrite:tensor<20xi8>>

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings_noalias.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/test/fuse_dispatch_bindings_noalias.mlir
@@ -16,8 +16,7 @@ stream.executable private @deduplicateBindingsEx {
       %c20 = arith.constant 20 : index
       %c40 = arith.constant 40 : index
 
-      // CHECK: %[[SUM_OFFSET_A:.+]] = arith.addi %c0, %[[OFFSET_A]]
-      // CHECK: %[[SUBSPAN_A:.+]] = stream.binding.subspan %[[BINDING_A]][%[[SUM_OFFSET_A]]]
+      // CHECK: %[[SUBSPAN_A:.+]] = stream.binding.subspan %[[BINDING_A]][%[[OFFSET_A]]]
       %subspan_a = stream.binding.subspan %binding_a[%c0] : !stream.binding -> !flow.dispatch.tensor<readwrite:tensor<20xi8>>{%c20}
       // CHECK-NEXT: util.optimization_barrier %[[SUBSPAN_A]]
       util.optimization_barrier %subspan_a : !flow.dispatch.tensor<readwrite:tensor<20xi8>>


### PR DESCRIPTION
By moving dispatch argument annotation earlier we ensure that the annotations we provide are available before the dispatch ABI packing pass that uses them. Previously the annotation analysis was not able to make it past the new ops introduced by the packing pass. The alignment lookup was tweaked to be able to walk across `arith.index_castui` as that's the common case we encounter - it's not strictly required as dispatch ABI packing adds attributes, but this makes the lookup more robust to intermediate IR optimization.

Fixes #11969.