### PR TITLE
Remove assert for number of results in FuseElementwiseOpsWithMultipleUses

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FusionOfTensorOps.cpp
@@ -129,8 +129,6 @@ struct FuseElementwiseOpsWithMultipleUses
       return rewriter.notifyMatchFailure(consumerOp,
                                          "failed to fuse with producer");
     }
-    assert(fusedOperation.value()->getNumResults() ==
-           producerOp->getNumResults() + consumerOp->getNumResults());
     auto fusedResults = fusedOperation.value()->getResults();
     rewriter.replaceOp(producerOp,
                        fusedResults.take_front(producerOp->getNumResults()));


### PR DESCRIPTION
mlir::linalg::fuseElementwiseOps has logic to drop results that are not used outside of the consumer.
This causes a discrepancy between the number of results in the fused op and the number of results of the producer + consumer.