### PR TITLE
pack microkernel padding improvements

### DIFF
--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_tile_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_tile_arm_64.c
@@ -10,11 +10,11 @@
 
 void* iree_uk_pack_tile_8x1_x32_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   return iree_uk_pack_tile_8x4_x8_arm_64_direct(out_tile_ptr, in_tile_ptr,
-                                                outer_size1, out_stride_l1 * 4,
+                                                outer_size1, out_stride1 * 4,
                                                 in_stride0 * 4, 1, 8, 4);
 }
 
@@ -183,7 +183,7 @@ static inline void iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor_tiled_1x4(
 
 void* iree_uk_pack_tile_8x1_x8_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   iree_uk_ssize_t outer_i1 = 0;
@@ -193,14 +193,14 @@ void* iree_uk_pack_tile_8x1_x8_arm_64_direct(
   // thanks to using 16-byte loads. Is it worth the code size? This 8x1 tile is
   // used on baseline aarch64 where the matmul kernel is slow anyway.
   for (; outer_i1 <= outer_size1 - 8; outer_i1 += 8) {
-    iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor(out_ptr, in_ptr,
-                                                  out_stride_l1, in_stride0);
-    out_ptr += 8 * out_stride_l1;
+    iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor(out_ptr, in_ptr, out_stride1,
+                                                  in_stride0);
+    out_ptr += 8 * out_stride1;
     in_ptr += 8;
   }
   for (; outer_i1 < outer_size1; ++outer_i1) {
     iree_uk_neon_copy_8x1xi8_strided_to_unstrided(out_ptr, in_ptr, in_stride0);
-    out_ptr += out_stride_l1;
+    out_ptr += out_stride1;
     in_ptr += 1;
   }
   return out_ptr;
@@ -208,7 +208,7 @@ void* iree_uk_pack_tile_8x1_x8_arm_64_direct(
 
 void* iree_uk_pack_tile_8x4_x8_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   iree_uk_ssize_t outer_i1 = 0;
@@ -216,21 +216,21 @@ void* iree_uk_pack_tile_8x4_x8_arm_64_direct(
   const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
   for (; outer_i1 <= outer_size1 - 2; outer_i1 += 2) {
     iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor_tiled_1x4(
-        out_ptr, in_ptr, out_stride_l1, in_stride0);
-    out_ptr += 2 * out_stride_l1;
+        out_ptr, in_ptr, out_stride1, in_stride0);
+    out_ptr += 2 * out_stride1;
     in_ptr += 8;
   }
   for (; outer_i1 < outer_size1; outer_i1++) {
     iree_uk_neon_copy_8x4xi8_rowmajor_strided_to_unstrided(out_ptr, in_ptr,
                                                            in_stride0);
-    out_ptr += out_stride_l1;
+    out_ptr += out_stride1;
     in_ptr += 4;
   }
   return out_ptr;
 }
 void* iree_uk_pack_tile_8x8_x8_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
@@ -238,7 +238,7 @@ void* iree_uk_pack_tile_8x8_x8_arm_64_direct(
   for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
     iree_uk_neon_copy_8x8xi8_rowmajor_strided_to_unstrided(out_ptr, in_ptr,
                                                            in_stride0);
-    out_ptr += out_stride_l1;
+    out_ptr += out_stride1;
     in_ptr += 8;
   }
   return out_ptr;
@@ -246,14 +246,14 @@ void* iree_uk_pack_tile_8x8_x8_arm_64_direct(
 
 void* iree_uk_pack_tile_8x1_x32_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   const iree_uk_int32_t* restrict in_tile_ptr_i32 = in_tile_ptr;
   iree_uk_int32_t* restrict out_tile_i32_ptr = out_tile_ptr;
   for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
     iree_uk_memcpy(out_tile_i32_ptr, in_tile_ptr_i32, 32);
-    out_tile_i32_ptr += out_stride_l1;
+    out_tile_i32_ptr += out_stride1;
     in_tile_ptr_i32 += 8;
   }
   return out_tile_i32_ptr;
@@ -261,23 +261,23 @@ void* iree_uk_pack_tile_8x1_x32_arm_64_transpose(
 
 void* iree_uk_pack_tile_8x1_x8_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
   iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
   iree_uk_ssize_t outer_i1 = 0;
   for (; outer_i1 <= outer_size1 - 4; outer_i1 += 4) {
-    iree_uk_memcpy(out_ptr + 0 * out_stride_l1, in_ptr + 0, 8);
-    iree_uk_memcpy(out_ptr + 1 * out_stride_l1, in_ptr + 8, 8);
-    iree_uk_memcpy(out_ptr + 2 * out_stride_l1, in_ptr + 16, 8);
-    iree_uk_memcpy(out_ptr + 3 * out_stride_l1, in_ptr + 24, 8);
-    out_ptr += 4 * out_stride_l1;
+    iree_uk_memcpy(out_ptr + 0 * out_stride1, in_ptr + 0, 8);
+    iree_uk_memcpy(out_ptr + 1 * out_stride1, in_ptr + 8, 8);
+    iree_uk_memcpy(out_ptr + 2 * out_stride1, in_ptr + 16, 8);
+    iree_uk_memcpy(out_ptr + 3 * out_stride1, in_ptr + 24, 8);
+    out_ptr += 4 * out_stride1;
     in_ptr += 32;
   }
   for (; outer_i1 < outer_size1; ++outer_i1) {
     iree_uk_memcpy(out_ptr, in_ptr, 8);
-    out_ptr += out_stride_l1;
+    out_ptr += out_stride1;
     in_ptr += 8;
   }
   return out_ptr;
@@ -285,7 +285,7 @@ void* iree_uk_pack_tile_8x1_x8_arm_64_transpose(
 
 void* iree_uk_pack_tile_8x4_x8_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
@@ -301,7 +301,7 @@ void* iree_uk_pack_tile_8x4_x8_arm_64_transpose(
         iree_uk_neon_zip_8xi16_as_4xi32(zip_i16.val[0], zip_i16.val[1]);
     vst1q_s8(out_ptr, vreinterpretq_s8_s32(zip_i32.val[0]));
     vst1q_s8(out_ptr + 16, vreinterpretq_s8_s32(zip_i32.val[1]));
-    out_ptr += out_stride_l1;
+    out_ptr += out_stride1;
     in_ptr += 8;
   }
   return out_ptr;
@@ -309,7 +309,7 @@ void* iree_uk_pack_tile_8x4_x8_arm_64_transpose(
 
 void* iree_uk_pack_tile_8x8_x8_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1,
+    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
   const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
@@ -317,7 +317,7 @@ void* iree_uk_pack_tile_8x8_x8_arm_64_transpose(
   for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
     iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor(out_ptr, in_ptr, 8,
                                                   in_stride0);
-    out_ptr += out_stride_l1;
+    out_ptr += out_stride1;
     in_ptr += 8;
   }
   return out_ptr;

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_tile_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_tile_arm_64.c
@@ -8,14 +8,14 @@
 
 #include <arm_neon.h>
 
-void* iree_uk_pack_tile_8x1_x32_arm_64_direct(
+void iree_uk_pack_tile_8x1_x32_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
     iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  return iree_uk_pack_tile_8x4_x8_arm_64_direct(out_tile_ptr, in_tile_ptr,
-                                                outer_size1, out_stride1 * 4,
-                                                in_stride0 * 4, 1, 8, 4);
+  iree_uk_pack_tile_8x4_x8_arm_64_direct(out_tile_ptr, in_tile_ptr, outer_size1,
+                                         out_stride1 * 4, in_stride0 * 4, 1, 8,
+                                         4);
 }
 
 static inline int8x8_t iree_uk_neon_load_8xi8_strided(const iree_uk_int8_t* src,
@@ -181,7 +181,7 @@ static inline void iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor_tiled_1x4(
   vst1q_s8(out_ptr + 16 + 1 * out_stride, vreinterpretq_s8_s32(c1.val[1]));
 }
 
-void* iree_uk_pack_tile_8x1_x8_arm_64_direct(
+void iree_uk_pack_tile_8x1_x8_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
@@ -203,10 +203,9 @@ void* iree_uk_pack_tile_8x1_x8_arm_64_direct(
     out_ptr += out_stride1;
     in_ptr += 1;
   }
-  return out_ptr;
 }
 
-void* iree_uk_pack_tile_8x4_x8_arm_64_direct(
+void iree_uk_pack_tile_8x4_x8_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
@@ -226,9 +225,8 @@ void* iree_uk_pack_tile_8x4_x8_arm_64_direct(
     out_ptr += out_stride1;
     in_ptr += 4;
   }
-  return out_ptr;
 }
-void* iree_uk_pack_tile_8x8_x8_arm_64_direct(
+void iree_uk_pack_tile_8x8_x8_arm_64_direct(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
@@ -241,10 +239,9 @@ void* iree_uk_pack_tile_8x8_x8_arm_64_direct(
     out_ptr += out_stride1;
     in_ptr += 8;
   }
-  return out_ptr;
 }
 
-void* iree_uk_pack_tile_8x1_x32_arm_64_transpose(
+void iree_uk_pack_tile_8x1_x32_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
@@ -256,10 +253,9 @@ void* iree_uk_pack_tile_8x1_x32_arm_64_transpose(
     out_tile_i32_ptr += out_stride1;
     in_tile_ptr_i32 += 8;
   }
-  return out_tile_i32_ptr;
 }
 
-void* iree_uk_pack_tile_8x1_x8_arm_64_transpose(
+void iree_uk_pack_tile_8x1_x8_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
@@ -280,10 +276,9 @@ void* iree_uk_pack_tile_8x1_x8_arm_64_transpose(
     out_ptr += out_stride1;
     in_ptr += 8;
   }
-  return out_ptr;
 }
 
-void* iree_uk_pack_tile_8x4_x8_arm_64_transpose(
+void iree_uk_pack_tile_8x4_x8_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
@@ -304,10 +299,9 @@ void* iree_uk_pack_tile_8x4_x8_arm_64_transpose(
     out_ptr += out_stride1;
     in_ptr += 8;
   }
-  return out_ptr;
 }
 
-void* iree_uk_pack_tile_8x8_x8_arm_64_transpose(
+void iree_uk_pack_tile_8x8_x8_arm_64_transpose(
     void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
     iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
     iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
@@ -320,5 +314,4 @@ void* iree_uk_pack_tile_8x8_x8_arm_64_transpose(
     out_ptr += out_stride1;
     in_ptr += 8;
   }
-  return out_ptr;
 }

--- a/runtime/src/iree/builtins/ukernel/common.h
+++ b/runtime/src/iree/builtins/ukernel/common.h
@@ -102,6 +102,14 @@
 // Include IREE_UK_STATIC_ASSERT.
 #include "iree/builtins/ukernel/static_assert.h"
 
+// Clang on Windows has __builtin_clzll; otherwise we need to use the
+// windows intrinsic functions.
+#if defined(_MSC_VER)
+#include <intrin.h>
+#pragma intrinsic(_BitScanReverse)
+#pragma intrinsic(_BitScanForward)
+#endif  // defined(_MSC_VER)
+
 #ifdef __cplusplus
 extern "C" {
 #endif  // __cplusplus
@@ -195,6 +203,21 @@ extern "C" {
 #define IREE_UK_ATTRIBUTE_NOINLINE
 #endif  // IREE_UK_HAVE_ATTRIBUTE(noinline)
 
+#if defined(__GNUC__) || defined(__clang__)
+#define IREE_UK_LIKELY(x) (__builtin_expect(!!(x), 1))
+#define IREE_UK_UNLIKELY(x) (__builtin_expect(!!(x), 0))
+#else
+#define IREE_UK_LIKELY(x) (x)
+#define IREE_UK_UNLIKELY(x) (x)
+#endif  // IREE_HAVE_ATTRIBUTE(likely)
+
+#if IREE_UK_HAVE_ATTRIBUTE(aligned) || \
+    (defined(__GNUC__) && !defined(__clang__))
+#define IREE_UK_ATTRIBUTE_ALIGNED(N) __attribute__((aligned(N)))
+#else
+#define IREE_UK_ATTRIBUTE_ALIGNED(N)
+#endif  // IREE_UK_HAVE_ATTRIBUTE(noinline)
+
 //===----------------------------------------------------------------------===//
 // Local replacements for stdint.h types and constants
 // Refer to the comment at the top of this file for why we can't include
@@ -261,6 +284,14 @@ static inline void iree_uk_ssize_swap(iree_uk_ssize_t* a, iree_uk_ssize_t* b) {
   iree_uk_ssize_t t = *a;
   *a = *b;
   *b = t;
+}
+
+static inline iree_uk_ssize_t iree_uk_ssize_clamp(iree_uk_ssize_t val,
+                                                  iree_uk_ssize_t min,
+                                                  iree_uk_ssize_t max) {
+  if (val < min) val = min;
+  if (val > max) val = max;
+  return val;
 }
 
 //===----------------------------------------------------------------------===//
@@ -458,8 +489,7 @@ static inline iree_uk_type_t iree_uk_untie_type(int pos,
 //===----------------------------------------------------------------------===//
 
 // The `restrict` here have the effect of enabling the compiler to rewrite this
-// as a memcpy call, shrinking code size of the (slow anyway) generic code paths
-// that would use this.
+// as a memcpy call.
 static inline void iree_uk_memcpy(void* IREE_UK_RESTRICT dst,
                                   const void* IREE_UK_RESTRICT src,
                                   iree_uk_ssize_t size) {
@@ -468,12 +498,63 @@ static inline void iree_uk_memcpy(void* IREE_UK_RESTRICT dst,
 }
 
 static inline void iree_uk_memset(void* buf, int val, iree_uk_ssize_t n) {
-  // No need for memset builtins: this naive loop is already transformed into a
-  // memset by both clang and gcc on ARM64. As __builtin_memset_inline requires
-  // a compile-time-constant size, it would require writing more complex code,
-  // which could actually prevent the optimization matching it as a single
-  // memset!
+  // This naive loop is lifted to a memset by both clang and gcc on ARM64.
   for (iree_uk_ssize_t i = 0; i < n; ++i) ((char*)buf)[i] = val;
+}
+
+//===----------------------------------------------------------------------===//
+// Count leading zeros (extracted from base/internal/math.h and adapted
+// to be able to be used standalone).
+//===----------------------------------------------------------------------===//
+
+static inline int iree_uk_count_leading_zeros_u32(const iree_uk_uint32_t n) {
+#if defined(_MSC_VER)
+  unsigned long result = 0;  // NOLINT(runtime/int)
+  if (_BitScanReverse(&result, n)) {
+    return (int)(31 - result);
+  }
+  return 32;
+#elif defined(__GNUC__) || defined(__clang__)
+#if defined(__LCZNT__)
+  // NOTE: LZCNT is a risky instruction; it is not supported on architectures
+  // before Haswell, yet it is encoded as 'rep bsr', which typically ignores
+  // invalid rep prefixes, and interprets it as the 'bsr' instruction, which
+  // returns the index of the value rather than the count, resulting in
+  // incorrect code.
+  return (int)__lzcnt32(n);
+#endif  // defined(__LCZNT__)
+
+  // Handle 0 as a special case because __builtin_clz(0) is undefined.
+  if (n == 0) return 32;
+  // Use __builtin_clz, which uses the following instructions:
+  //  x86: bsr
+  //  ARM64: clz
+  //  PPC: cntlzd
+  return (int)__builtin_clz(n);
+#else
+#error No clz for this arch.
+#endif  // MSVC / GCC / CLANG
+}
+
+//===----------------------------------------------------------------------===//
+// Power-of-two math helpers
+//===----------------------------------------------------------------------===//
+
+static inline bool iree_uk_is_po2_u32(const iree_uk_uint32_t n) {
+  return !(n & (n - 1));
+}
+
+static inline int iree_uk_floor_log2_u32(const iree_uk_uint32_t n) {
+  return 31 - iree_uk_count_leading_zeros_u32(n);
+}
+
+static inline int iree_uk_po2_log2_u32(const iree_uk_uint32_t n) {
+  IREE_UK_ASSERT(iree_uk_is_po2_u32(n));
+  return iree_uk_floor_log2_u32(n);
+}
+
+static inline int iree_uk_ceil_log2_u32(const iree_uk_uint32_t n) {
+  return n <= 1 ? 0 : (1 + iree_uk_floor_log2_u32(n - 1));
 }
 
 #ifdef __cplusplus

--- a/runtime/src/iree/builtins/ukernel/elementwise_impl.c.inc
+++ b/runtime/src/iree/builtins/ukernel/elementwise_impl.c.inc
@@ -61,48 +61,6 @@ typedef enum {
 #define ASSI32(ptr) *((iree_uk_int32_t*)ptr)
 
 //===----------------------------------------------------------------------===//
-// Math helper functions (extracted from base/internal/math.h and adapted
-// to be able to be used standalone).
-//===----------------------------------------------------------------------===//
-
-// Clang on Windows has __builtin_clzll; otherwise we need to use the
-// windows intrinsic functions.
-#if defined(_MSC_VER)
-#include <intrin.h>
-#pragma intrinsic(_BitScanReverse)
-#pragma intrinsic(_BitScanForward)
-#endif  // IREE_COMPILER_MSVC
-
-static inline int iree_uk_count_leading_zeros_u32(const iree_uk_uint32_t n) {
-#if defined(_MSC_VER)
-  unsigned long result = 0;  // NOLINT(runtime/int)
-  if (_BitScanReverse(&result, n)) {
-    return (int)(31 - result);
-  }
-  return 32;
-#elif defined(__GNUC__) || defined(__clang__)
-#if defined(__LCZNT__)
-  // NOTE: LZCNT is a risky instruction; it is not supported on architectures
-  // before Haswell, yet it is encoded as 'rep bsr', which typically ignores
-  // invalid rep prefixes, and interprets it as the 'bsr' instruction, which
-  // returns the index of the value rather than the count, resulting in
-  // incorrect code.
-  return (int)__lzcnt32(n);
-#endif  // defined(__LCZNT__)
-
-  // Handle 0 as a special case because __builtin_clz(0) is undefined.
-  if (n == 0) return 32;
-  // Use __builtin_clz, which uses the following instructions:
-  //  x86: bsr
-  //  ARM64: clz
-  //  PPC: cntlzd
-  return (int)__builtin_clz(n);
-#else
-#error No clz for this arch.
-#endif  // MSVC / GCC / CLANG
-}
-
-//===----------------------------------------------------------------------===//
 // Implementation macros.
 //===----------------------------------------------------------------------===//
 

--- a/runtime/src/iree/builtins/ukernel/mmt4d.c
+++ b/runtime/src/iree/builtins/ukernel/mmt4d.c
@@ -101,8 +101,7 @@ static void iree_uk_mmt4d_zero_out(const iree_uk_mmt4d_params_t* params) {
 // Early-return code paths, including trivial or near-trivial cases (when one
 // of the dimensions is 0) and in the future, hardware ports that specialize
 // the entire loop nest.
-// The value |true| is written to the out-param |*done| if an early-return path
-// was taken and the mmt4d work is already done.
+// Returns true if already done.
 static bool iree_uk_mmt4d_early(const iree_uk_mmt4d_params_t* params) {
   // Trivial cases
   if (params->M == 0 || params->N == 0) {

--- a/runtime/src/iree/builtins/ukernel/pack.c
+++ b/runtime/src/iree/builtins/ukernel/pack.c
@@ -9,6 +9,8 @@
 #include "iree/builtins/ukernel/arch/pack_arch.h"
 #include "iree/builtins/ukernel/pack_generic.h"
 
+enum { iree_uk_pack_tmp_buf_size = 4096 };
+
 static void iree_uk_pack_validate(const iree_uk_pack_params_t* params) {
 #ifdef IREE_UK_ENABLE_ASSERTS
   const iree_uk_uint32_t allflags =
@@ -45,11 +47,14 @@ static void iree_uk_pack_validate(const iree_uk_pack_params_t* params) {
 #endif  // IREE_UK_ENABLE_ASSERTS
 }
 
+// Early-return implementation for this ukernel. Returns true if already done.
 static bool iree_uk_pack_early(const iree_uk_pack_params_t* params) {
   return (params->out_size0 == 0 || params->out_size1 == 0 ||
           params->out_size2 == 0 || params->out_size3 == 0);
 }
 
+// Select the 'tile function' that is the typically target-optimized inner loop
+// implementation.
 static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func(
     const iree_uk_pack_params_t* params) {
   iree_uk_pack_tile_func_t arch_tile_func =
@@ -58,6 +63,111 @@ static iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func(
     return arch_tile_func;
   }
   return iree_uk_pack_select_tile_func_generic(params);
+}
+
+// Returns true if the `num_bytes` bytes at `buf` are all equal.
+static bool iree_uk_is_single_byte_pattern(const char* buf,
+                                           iree_uk_ssize_t num_bytes) {
+  for (iree_uk_ssize_t i = 1; i < num_bytes; ++i) {
+    if (buf[i] != buf[0]) return false;
+  }
+  return true;
+}
+
+// Fills `buf` with `num_elems` times the `pattern` of size `elem_size`.
+// If this pattern's `elem_size` bytes are all equal, then it is legal to pass
+// `is_single_byte_pattern=true`, which allows the impl to use memset.
+static void iree_uk_fill(char* buf, iree_uk_ssize_t num_elems,
+                         iree_uk_ssize_t elem_size, bool is_single_byte_pattern,
+                         const char* pattern) {
+  if (is_single_byte_pattern) {
+    iree_uk_memset(buf, pattern[0], num_elems * elem_size);
+  } else {
+    for (iree_uk_ssize_t i = 0; i < num_elems; ++i) {
+      iree_uk_memcpy(buf + i * elem_size, pattern, elem_size);
+    }
+  }
+}
+
+// Copy from a source 2D buffer to a destination 2D buffer, padding to the
+// destination size.
+static void iree_uk_copy_and_pad(iree_uk_ssize_t src_size0,
+                                 iree_uk_ssize_t src_size1,
+                                 iree_uk_ssize_t src_stride0,
+                                 const char* src_buf, iree_uk_ssize_t dst_size0,
+                                 iree_uk_ssize_t dst_size1,
+                                 iree_uk_ssize_t dst_stride0, char* dst_buf,
+                                 iree_uk_ssize_t elem_size, const char* padding,
+                                 bool padding_is_single_byte) {
+  iree_uk_fill(dst_buf, dst_size1 + (dst_size0 - 1) * dst_stride0, elem_size,
+               padding_is_single_byte, padding);
+  for (iree_uk_ssize_t in_i0 = 0; in_i0 < src_size0; in_i0++) {
+    iree_uk_memcpy(dst_buf, src_buf, src_size1 * elem_size);
+    dst_buf += dst_stride0 * elem_size;
+    src_buf += src_stride0 * elem_size;
+  }
+}
+
+// Return x/y for x>=0 and y>0, with a fast path for when y is a power of two.
+static iree_uk_ssize_t iree_uk_div_nonneg_by_pos_and_likely_po2_i32(
+    iree_uk_ssize_t x, iree_uk_int32_t y) {
+  IREE_UK_ASSERT(x >= 0);
+  IREE_UK_ASSERT(y > 0);
+  return IREE_UK_LIKELY(iree_uk_is_po2_u32(y)) ? (x >> iree_uk_po2_log2_u32(y))
+                                               : (x / y);
+}
+
+// Holds some information and a temporary buffer for performing padding.
+typedef struct iree_uk_pack_padding_helper {
+  // Temporary buffer to pad the source data into, to pass to the tile_func.
+  // Cache line alignment helps in pack_benchmark on ARM Cortex-A510/A710.
+  IREE_UK_ATTRIBUTE_ALIGNED(64) char tmp_buf[iree_uk_pack_tmp_buf_size];
+  // How many tiles fit in `tmp_buf`.
+  int max_tiles_in_tmp_buf;
+  // Is the padding value as single-byte pattern (so we can use memset).
+  bool is_padding_single_byte;
+} iree_uk_pack_padding_helper;
+
+// Initializes a `iree_uk_pack_padding_helper`.
+static void iree_uk_pack_padding_helper_init(
+    iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1,
+    iree_uk_ssize_t elem_size, const void* padding_value,
+    iree_uk_pack_padding_helper* helper) {
+  helper->max_tiles_in_tmp_buf = iree_uk_div_nonneg_by_pos_and_likely_po2_i32(
+      iree_uk_pack_tmp_buf_size, tile_size0 * tile_size1 * elem_size);
+  IREE_UK_ASSERT(max_tiles_in_tmp_buf > 0);
+  helper->is_padding_single_byte =
+      iree_uk_is_single_byte_pattern(padding_value, elem_size);
+}
+
+// Pads and packs an entire row. In cases that are known not to require padding,
+// it is more efficient to call tile_func directly.
+static void iree_uk_pad_and_pack_row_using_tile_func(
+    iree_uk_pack_tile_func_t tile_func, iree_uk_ssize_t dim1_tile_start,
+    iree_uk_ssize_t dim1_tile_end, iree_uk_ssize_t dim0_src_read_size,
+    iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t in_size1,
+    iree_uk_ssize_t in_stride0, iree_uk_ssize_t out_stride1,
+    const void* padding_value, iree_uk_pack_padding_helper* helper,
+    const char* in_buf, char* out_buf) {
+  iree_uk_ssize_t dim1_tile = dim1_tile_start;
+  while (dim1_tile < dim1_tile_end) {
+    iree_uk_ssize_t dim1_chunk_tiles = iree_uk_ssize_clamp(
+        dim1_tile_end - dim1_tile, 0, helper->max_tiles_in_tmp_buf);
+    iree_uk_ssize_t dim1_chunk_src_width = dim1_chunk_tiles * tile_size1;
+    iree_uk_ssize_t dim1_chunk_src_pos = dim1_tile * tile_size1;
+    iree_uk_ssize_t i1_read_size = iree_uk_ssize_clamp(
+        in_size1 - dim1_chunk_src_pos, 0, dim1_chunk_src_width);
+    iree_uk_copy_and_pad(dim0_src_read_size, i1_read_size, in_stride0,
+                         in_buf + dim1_chunk_src_pos * elem_size, tile_size0,
+                         dim1_chunk_src_width, dim1_chunk_src_width,
+                         helper->tmp_buf, elem_size, padding_value,
+                         helper->is_padding_single_byte);
+    tile_func(out_buf + (dim1_tile * out_stride1 * elem_size), helper->tmp_buf,
+              dim1_chunk_tiles, out_stride1, dim1_chunk_src_width, elem_size,
+              tile_size0, tile_size1);
+    dim1_tile += dim1_chunk_tiles;
+  }
 }
 
 static void iree_uk_pack_using_tile_func(const iree_uk_pack_params_t* params,
@@ -70,65 +180,55 @@ static void iree_uk_pack_using_tile_func(const iree_uk_pack_params_t* params,
   iree_uk_ssize_t tile_size0 = params->out_size2;
   iree_uk_ssize_t tile_size1 = params->out_size3;
   iree_uk_ssize_t out_stride_l0 = params->out_stride0;
-  iree_uk_ssize_t out_stride_l1 = params->out_size3 * params->out_size2;
+  iree_uk_ssize_t out_stride1 = params->out_size3 * params->out_size2;
   iree_uk_ssize_t out_stride_l2 = params->out_size3;
   iree_uk_ssize_t out_stride_l3 = 1;
   if (params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_OUTER) {
     iree_uk_ssize_swap(&outer_size0, &outer_size1);
-    iree_uk_ssize_swap(&out_stride_l0, &out_stride_l1);
+    iree_uk_ssize_swap(&out_stride_l0, &out_stride1);
   }
   if (params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER) {
     iree_uk_ssize_swap(&tile_size0, &tile_size1);
     iree_uk_ssize_swap(&out_stride_l2, &out_stride_l3);
   }
-  const char* in_row_ptr = params->in_buffer;
-  char* out_row_ptr = params->out_buffer;
-  bool l0_has_padding = outer_size0 * tile_size0 != params->in_size0;
-  bool l1_has_padding = outer_size1 * tile_size1 != params->in_size1;
-  iree_uk_ssize_t l0_full_tile_end = outer_size0 - (l0_has_padding ? 1 : 0);
-  iree_uk_ssize_t l1_full_tile_end = outer_size1 - (l1_has_padding ? 1 : 0);
-
-  // TODO(#11632): this fix-up is needed only because at the moment,
-  // there may actually be padding in more than just the last tile along each
-  // dimension, because dispatch region formation rounds small sizes up.
-  while (l0_full_tile_end * tile_size0 > params->in_size0) --l0_full_tile_end;
-  while (l1_full_tile_end * tile_size1 > params->in_size1) --l1_full_tile_end;
-
-  for (iree_uk_ssize_t outer_i0 = 0; outer_i0 < outer_size0; ++outer_i0) {
-    // If we're on the final iteration of outer loop 0 and there is padding,
-    // set l1_full_tile_end to 0, so henceforth it is sufficient to check
-    // against l1_full_tile_end to tell if we are padding.
-    if (outer_i0 >= l0_full_tile_end) {
-      l1_full_tile_end = 0;
-    }
-    // Handle full tiles, using the (fast) tile_func.
-    char* out_tile_ptr =
-        tile_func(out_row_ptr, in_row_ptr, l1_full_tile_end, out_stride_l1,
-                  params->in_stride0, elem_size, tile_size0, tile_size1);
-    // Handle incomplete tiles, with padding, using slow code here.
-    for (iree_uk_ssize_t outer_i1 = l1_full_tile_end; outer_i1 < outer_size1;
-         ++outer_i1) {
-      for (iree_uk_ssize_t tile_i0 = 0; tile_i0 < tile_size0; ++tile_i0) {
-        for (iree_uk_ssize_t tile_i1 = 0; tile_i1 < tile_size1; ++tile_i1) {
-          iree_uk_ssize_t i0 = outer_i0 * tile_size0 + tile_i0;
-          iree_uk_ssize_t i1 = outer_i1 * tile_size1 + tile_i1;
-          char* out_ptr =
-              out_tile_ptr +
-              (tile_i0 * out_stride_l2 + tile_i1 * out_stride_l3) * elem_size;
-          if (i0 >= params->in_size0 || i1 >= params->in_size1) {
-            iree_uk_memcpy(out_ptr, params->padding_value, elem_size);
-          } else {
-            iree_uk_ssize_t in_offset = i1 + i0 * params->in_stride0;
-            const char* in_ptr =
-                ((char*)params->in_buffer) + in_offset * elem_size;
-            iree_uk_memcpy(out_ptr, in_ptr, elem_size);
-          }
-        }
-      }
-      out_tile_ptr += out_stride_l1 * elem_size;
-    }
-    out_row_ptr += out_stride_l0 * elem_size;
-    in_row_ptr += tile_size0 * params->in_stride0 * elem_size;
+  const char* in_buf = params->in_buffer;
+  char* out_buf = params->out_buffer;
+  // Compute number of tiles along both dimensions that fit entirely within the
+  // source buffer's boundaries.
+  int dim0_full_tiles_end = iree_uk_div_nonneg_by_pos_and_likely_po2_i32(
+      params->in_size0, tile_size0);
+  int dim1_full_tiles_end = iree_uk_div_nonneg_by_pos_and_likely_po2_i32(
+      params->in_size1, tile_size1);
+  // Prepare for padding.
+  iree_uk_pack_padding_helper padding_helper;
+  if (dim0_full_tiles_end < outer_size0 || dim1_full_tiles_end < outer_size1) {
+    iree_uk_pack_padding_helper_init(tile_size0, tile_size1, elem_size,
+                                     params->padding_value, &padding_helper);
+  }
+  iree_uk_ssize_t outer_i0 = 0;
+  for (; outer_i0 < dim0_full_tiles_end; ++outer_i0) {
+    // Pack whole tiles that do not require padding (entirely within the source
+    // buffer's boundaries).
+    tile_func(out_buf, in_buf, dim1_full_tiles_end, out_stride1,
+              params->in_stride0, elem_size, tile_size0, tile_size1);
+    // Right-padding.
+    iree_uk_pad_and_pack_row_using_tile_func(
+        tile_func, dim1_full_tiles_end, outer_size1, tile_size0, tile_size0,
+        tile_size1, elem_size, params->in_size1, params->in_stride0,
+        out_stride1, params->padding_value, &padding_helper, in_buf, out_buf);
+    out_buf += out_stride_l0 * elem_size;
+    in_buf += tile_size0 * params->in_stride0 * elem_size;
+  }
+  // Bottom-padding.
+  for (; outer_i0 < outer_size0; ++outer_i0) {
+    iree_uk_ssize_t dim0_src_read_size = iree_uk_ssize_clamp(
+        params->in_size0 - outer_i0 * tile_size0, 0, tile_size0);
+    iree_uk_pad_and_pack_row_using_tile_func(
+        tile_func, 0, outer_size1, dim0_src_read_size, tile_size0, tile_size1,
+        elem_size, params->in_size1, params->in_stride0, out_stride1,
+        params->padding_value, &padding_helper, in_buf, out_buf);
+    out_buf += out_stride_l0 * elem_size;
+    in_buf += tile_size0 * params->in_stride0 * elem_size;
   }
 }
 

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -45,7 +45,7 @@ typedef struct iree_uk_pack_params_t {
   const iree_uk_uint64_t* cpu_data;
 } iree_uk_pack_params_t;
 
-typedef void* (*iree_uk_pack_tile_func_t)(
+typedef void (*iree_uk_pack_tile_func_t)(
     void* IREE_UK_RESTRICT /*out_tile_ptr*/,
     const void* IREE_UK_RESTRICT /*in_tile_ptr*/,
     iree_uk_ssize_t /*outer_size1*/, iree_uk_ssize_t /*out_stride1*/,
@@ -53,12 +53,12 @@ typedef void* (*iree_uk_pack_tile_func_t)(
     iree_uk_ssize_t /*tile_size0*/, iree_uk_ssize_t /*tile_size1*/);
 
 // Tile kernel declarations. Prototype matches iree_uk_pack_tile_func_t.
-#define IREE_UK_PACK_TILE_FUNC_DECL(NAME)                              \
-  void* NAME(void* IREE_UK_RESTRICT out_tile_ptr,                      \
-             const void* IREE_UK_RESTRICT in_tile_ptr,                 \
-             iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1, \
-             iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,    \
-             iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
+#define IREE_UK_PACK_TILE_FUNC_DECL(NAME)                             \
+  void NAME(void* IREE_UK_RESTRICT out_tile_ptr,                      \
+            const void* IREE_UK_RESTRICT in_tile_ptr,                 \
+            iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1, \
+            iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,    \
+            iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
 
 // Main entry point.
 IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params);

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -48,16 +48,16 @@ typedef struct iree_uk_pack_params_t {
 typedef void* (*iree_uk_pack_tile_func_t)(
     void* IREE_UK_RESTRICT /*out_tile_ptr*/,
     const void* IREE_UK_RESTRICT /*in_tile_ptr*/,
-    iree_uk_ssize_t /*outer_size1*/, iree_uk_ssize_t /*out_stride_l1*/,
+    iree_uk_ssize_t /*outer_size1*/, iree_uk_ssize_t /*out_stride1*/,
     iree_uk_ssize_t /*in_stride0*/, iree_uk_ssize_t /*elem_size*/,
     iree_uk_ssize_t /*tile_size0*/, iree_uk_ssize_t /*tile_size1*/);
 
 // Tile kernel declarations. Prototype matches iree_uk_pack_tile_func_t.
-#define IREE_UK_PACK_TILE_FUNC_DECL(NAME)                                \
-  void* NAME(void* IREE_UK_RESTRICT out_tile_ptr,                        \
-             const void* IREE_UK_RESTRICT in_tile_ptr,                   \
-             iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1, \
-             iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,      \
+#define IREE_UK_PACK_TILE_FUNC_DECL(NAME)                              \
+  void* NAME(void* IREE_UK_RESTRICT out_tile_ptr,                      \
+             const void* IREE_UK_RESTRICT in_tile_ptr,                 \
+             iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1, \
+             iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,    \
              iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
 
 // Main entry point.

--- a/runtime/src/iree/builtins/ukernel/pack_generic.c
+++ b/runtime/src/iree/builtins/ukernel/pack_generic.c
@@ -6,7 +6,7 @@
 
 #include "iree/builtins/ukernel/pack_generic.h"
 
-static void* iree_uk_pack_tile_generic_direct(
+static void iree_uk_pack_tile_generic_direct(
     void* IREE_UK_RESTRICT out_tile_ptr,
     const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
     iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
@@ -25,10 +25,9 @@ static void* iree_uk_pack_tile_generic_direct(
     out_ptr_l1 += out_stride1 * elem_size;
     in_ptr_l1 += tile_size1 * elem_size;
   }
-  return out_ptr_l1;
 }
 
-static void* iree_uk_pack_tile_generic_transpose(
+static void iree_uk_pack_tile_generic_transpose(
     void* IREE_UK_RESTRICT out_tile_ptr,
     const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
     iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
@@ -53,7 +52,6 @@ static void* iree_uk_pack_tile_generic_transpose(
     out_ptr_l1 += out_stride1 * elem_size;
     in_ptr_l1 += tile_size1 * elem_size;
   }
-  return out_ptr_l1;
 }
 
 iree_uk_pack_tile_func_t iree_uk_pack_select_tile_func_generic(

--- a/runtime/src/iree/builtins/ukernel/pack_generic.c
+++ b/runtime/src/iree/builtins/ukernel/pack_generic.c
@@ -9,7 +9,7 @@
 static void* iree_uk_pack_tile_generic_direct(
     void* IREE_UK_RESTRICT out_tile_ptr,
     const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
-    iree_uk_ssize_t out_stride_l1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
     iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
     iree_uk_ssize_t tile_size1) {
   const char* IREE_UK_RESTRICT in_ptr_l1 = in_tile_ptr;
@@ -22,7 +22,7 @@ static void* iree_uk_pack_tile_generic_direct(
       out_ptr += tile_size1 * elem_size;
       in_ptr += in_stride0 * elem_size;
     }
-    out_ptr_l1 += out_stride_l1 * elem_size;
+    out_ptr_l1 += out_stride1 * elem_size;
     in_ptr_l1 += tile_size1 * elem_size;
   }
   return out_ptr_l1;
@@ -31,7 +31,7 @@ static void* iree_uk_pack_tile_generic_direct(
 static void* iree_uk_pack_tile_generic_transpose(
     void* IREE_UK_RESTRICT out_tile_ptr,
     const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
-    iree_uk_ssize_t out_stride_l1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
     iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
     iree_uk_ssize_t tile_size1) {
   const char* IREE_UK_RESTRICT in_ptr_l1 = in_tile_ptr;
@@ -50,7 +50,7 @@ static void* iree_uk_pack_tile_generic_transpose(
       out_ptr_l2 += elem_size;
       in_ptr_l2 += in_stride0 * elem_size;
     }
-    out_ptr_l1 += out_stride_l1 * elem_size;
+    out_ptr_l1 += out_stride1 * elem_size;
     in_ptr_l1 += tile_size1 * elem_size;
   }
   return out_ptr_l1;

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -109,7 +109,7 @@ static iree_status_t iree_pack_benchmark(
   }
   params.in_size0 = iree_max(0, out_size0 * out_size2 - FLAG_padding_size);
   params.in_size1 = iree_max(0, out_size1 * out_size3 - FLAG_padding_size);
-  params.in_stride0 = params.in_size1;
+  params.in_stride0 = out_size0 * out_size2;
   params.out_stride0 = params.out_size1 * params.out_size2 * params.out_size3;
   iree_uk_ssize_t in_buffer_size = iree_uk_test_2d_buffer_length(
       in_type, params.in_size0, params.in_stride0);
@@ -126,8 +126,8 @@ static iree_status_t iree_pack_benchmark(
   iree_uk_test_write_random_buffer(in_buffer, in_buffer_size, in_type, engine);
   iree_uk_test_write_random_buffer(out_buffer, out_buffer_size, out_type,
                                    engine);
-  iree_uk_test_write_random_buffer(padding_value_buffer, out_type_size,
-                                   out_type, engine);
+  // Test single-byte padding pattern, most common use case as 0.0f is 0 bytes.
+  memset(padding_value_buffer, 0, out_type_size);
   iree_uk_test_random_engine_destroy(engine);
   params.in_buffer = in_buffer;
   params.out_buffer = out_buffer;

--- a/runtime/src/iree/builtins/ukernel/unpack.c
+++ b/runtime/src/iree/builtins/ukernel/unpack.c
@@ -42,6 +42,7 @@ static void iree_uk_unpack_validate(const iree_uk_unpack_params_t* params) {
 #endif  // IREE_UK_ENABLE_ASSERTS
 }
 
+// Early-return implementation for this ukernel. Returns true if already done.
 static bool iree_uk_unpack_early(const iree_uk_unpack_params_t* params) {
   return (params->out_size0 == 0 || params->out_size1 == 0);
 }


### PR DESCRIPTION
- More correct: the old code was incorrect for really large padding (test expanded).
- Faster: padding is handled with an intermediate buffer, which allows padded tiles to still be packed by the fast target-specific tile func, as opposed to a super slow generic fallback. Moreover, we optimize the common case where the padding byte pattern is a single-byte pattern so we can use memset.

Even with that, padding is still surprisingly slow. This means that compiler-level ways to remove padding overhead (pad fusions) are important in a way that is not diminished by the ability to call microkernels. @MaheshRavishankar @hanhanW 

Note: in ruy and XNNPACK, padding is handled by having separate source pointers for N strided rows being packed (so padding rows can just have their pointer point at some zeros). This does not scale well to the degree of generality and runtime-flexibility that we are aiming for here (this essentially requires knowing some tile dimensions at compile time, and being able to design the whole system around a restricted range of values for these tile sizes). While not the fastest, the intermediate-buffer approach taken here is not that slow in principle (that it happens to be less fast than I hoped seems to be an accident of how it's compiled by Clang, but I haven't been able to dig to the bottom of that), and at least it makes for smaller code and insulates the target-optimized kernels from any padding consideration.

At first I thought that in large-stride cases, L1  cache aliasing would be a major issue, so I thought that the temporary buffer would be useful to deal with that. But it almost never was a net win in benchmarks. So the PR evolved towards its current state where the temp buffer is only used to deal with padding. But at least it's still easy to revisit that later.