### PR TITLE
Fixup tests/e2e/linalg/ test definitions.

### DIFF
--- a/tests/e2e/linalg/BUILD
+++ b/tests/e2e/linalg/BUILD
@@ -28,7 +28,6 @@ LLVM_SRCS = enforce_glob(
 iree_check_single_backend_test_suite(
     name = "check_llvm-cpu_local-task",
     srcs = LLVM_SRCS,
-    compiler_flags = ["--iree-input-type=none"],
     driver = "local-task",
     target_backend = "llvm-cpu",
 )
@@ -53,9 +52,6 @@ VMVX_SRCS = enforce_glob(
 iree_check_single_backend_test_suite(
     name = "check_vmvx_local-task",
     srcs = VMVX_SRCS,
-    compiler_flags = [
-        "--iree-input-type=none",
-    ],
     driver = "local-task",
     target_backend = "vmvx",
 )
@@ -70,7 +66,6 @@ VULKAN_SRCS = enforce_glob(
 iree_check_single_backend_test_suite(
     name = "check_vulkan-spirv_vulkan",
     srcs = VULKAN_SRCS,
-    compiler_flags = ["--iree-input-type=none"],
     driver = "vulkan",
     target_backend = "vulkan-spirv",
 )
@@ -81,8 +76,8 @@ iree_check_single_backend_test_suite(
     compiler_flags = [
         "--iree-flow-enable-conv-winograd-transform",
     ],
-    driver = "local-task",
-    target_backend = "llvm-cpu",
+    driver = "vulkan",
+    target_backend = "vulkan-spirv",
 )
 
 test_suite(

--- a/tests/e2e/linalg/CMakeLists.txt
+++ b/tests/e2e/linalg/CMakeLists.txt
@@ -19,8 +19,6 @@ iree_check_single_backend_test_suite(
     "llvm-cpu"
   DRIVER
     "local-task"
-  COMPILER_FLAGS
-    "--iree-input-type=none"
 )
 
 iree_check_single_backend_test_suite(
@@ -45,8 +43,6 @@ iree_check_single_backend_test_suite(
     "vmvx"
   DRIVER
     "local-task"
-  COMPILER_FLAGS
-    "--iree-input-type=none"
 )
 
 iree_check_single_backend_test_suite(
@@ -58,8 +54,6 @@ iree_check_single_backend_test_suite(
     "vulkan-spirv"
   DRIVER
     "vulkan"
-  COMPILER_FLAGS
-    "--iree-input-type=none"
 )
 
 iree_check_single_backend_test_suite(
@@ -68,9 +62,9 @@ iree_check_single_backend_test_suite(
   SRCS
     "conv2d.mlir"
   TARGET_BACKEND
-    "llvm-cpu"
+    "vulkan-spirv"
   DRIVER
-    "local-task"
+    "vulkan"
   COMPILER_FLAGS
     "--iree-flow-enable-conv-winograd-transform"
 )


### PR DESCRIPTION
* Use Vulkan as test name suggests
* Remove redundant compiler flags