### PR TITLE
Add pattern to unroll vector ops before converting to mma

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/TransformExtensions/LLVMGPUExtensionsOps.td
@@ -322,7 +322,9 @@ def VectorToMMAConversionOp : Op<Transform_Dialect, "iree.vector.vector_to_mma_c
      DeclareOpInterfaceMethods<MemoryEffectsOpInterface>]> {
   let description = [{
     This converts slices of operations containing vector.contract op into
-    mma operations, targetting warp level tensorcore operations.
+    mma operations, targetting warp level tensorcore operations. If the vector
+    operations are bigger than the native mma size it will first split up those
+    vector operations.
 
     #### Return modes
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_vector_to_mma.mlir
@@ -34,19 +34,12 @@ func.func @matmul() {
   %7 = scf.for %arg0 = %c0 to %c32 step %c16 iter_args(%arg1 = %cst) -> (vector<16x16xf32>) {
     %10 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%5]
     %11 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%arg0]
-    %12 = vector.transfer_read %0[%10, %11], %cst_0 {in_bounds = [true, true]} : memref<32x32xf32>, vector<16x8xf32>
-    %13 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%5]
-    %14 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c8)[%arg0]
-    %15 = vector.transfer_read %0[%13, %14], %cst_0 {in_bounds = [true, true]} : memref<32x32xf32>, vector<16x8xf32>
+    %12 = vector.transfer_read %0[%10, %11], %cst_0 {in_bounds = [true, true]} : memref<32x32xf32>, vector<16x16xf32>
     %16 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%6]
     %17 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%arg0]
-    %18 = vector.transfer_read %1[%17, %16], %cst_0 {in_bounds = [true, true]} : memref<32x32xf32>, vector<8x16xf32>
-    %19 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%6]
-    %20 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c8)[%arg0]
-    %21 = vector.transfer_read %1[%20, %19], %cst_0 {in_bounds = [true, true]} : memref<32x32xf32>, vector<8x16xf32>
-    %22 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %12, %18, %arg1 : vector<16x8xf32>, vector<8x16xf32> into vector<16x16xf32>
-    %23 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %15, %21, %22 : vector<16x8xf32>, vector<8x16xf32> into vector<16x16xf32>
-    scf.yield %23 : vector<16x16xf32>
+    %18 = vector.transfer_read %1[%17, %16], %cst_0 {in_bounds = [true, true]} : memref<32x32xf32>, vector<16x16xf32>
+    %22 = vector.contract {indexing_maps = [affine_map<(d0, d1, d2) -> (d0, d2)>, affine_map<(d0, d1, d2) -> (d2, d1)>, affine_map<(d0, d1, d2) -> (d0, d1)>], iterator_types = ["parallel", "parallel", "reduction"], kind = #vector.kind<add>} %12, %18, %arg1 : vector<16x16xf32>, vector<16x16xf32> into vector<16x16xf32>
+    scf.yield %22 : vector<16x16xf32>
   }
   %8 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%5]
   %9 = affine.apply affine_map<(d0)[s0] -> (d0 + s0)>(%c0)[%6]

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -525,5 +525,45 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
   return laneVal;
 }
 
+Optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op) {
+  // Currently hardcode the size of wmma operation. When more cases are
+  // supported this should be picked based on what the backend supports.
+  int64_t m = 16;
+  int64_t n = 16;
+  if (auto contract = dyn_cast<vector::ContractionOp>(op)) {
+    int64_t k = contract.getLhsType().getElementType().isF16() ? 16 : 8;
+    SmallVector<int64_t> nativeSize(contract.getIteratorTypes().size() - 3, 1);
+    nativeSize.append({m, n, k});
+    return nativeSize;
+  }
+  if (auto writeOp = dyn_cast<vector::TransferWriteOp>(op)) {
+    SmallVector<int64_t> nativeSize(writeOp.getVectorType().getRank() - 2, 1);
+    nativeSize.append({m, n});
+    return nativeSize;
+  }
+  if (auto readOp = dyn_cast<vector::TransferReadOp>(op)) {
+    // Transfer read ops may need different shapes based on how they are being
+    // used. For simplicity just match the shape used by the extract strided op.
+    VectorType sliceType;
+    for (Operation *users : op->getUsers()) {
+      auto extract = dyn_cast<vector::ExtractStridedSliceOp>(users);
+      if (!extract) return std::nullopt;
+      auto vecType = extract.getResult().getType().cast<VectorType>();
+      if (sliceType && sliceType != vecType) return std::nullopt;
+      sliceType = vecType;
+    }
+    return llvm::to_vector<>(sliceType.getShape());
+  }
+  if ((OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1)) {
+    if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>()) {
+      SmallVector<int64_t> nativeSize(vecType.getRank() - 2, 1);
+      // Map elementwise ops to the output shape.
+      nativeSize.append({m, n});
+      return nativeSize;
+    }
+  }
+  return std::nullopt;
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -77,6 +77,10 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
                             vector::CombiningKind kind, uint32_t size,
                             const int warpSize);
 
+/// Return the native size of an operation used in contraction calculation.
+// TODO: Make this take HW specific sizes.
+Optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 


### PR DESCRIPTION
Change the transform dialect op to unroll vector ops to the right size before converting to mma.