### PR TITLE
Check the nccl version compatibility

### DIFF
--- a/build_tools/third_party/nccl/BUILD.overlay
+++ b/build_tools/third_party/nccl/BUILD.overlay
@@ -9,4 +9,5 @@ package(default_visibility = ["//visibility:public"])
 cc_library(
     name = "headers",
     hdrs = ["nccl.h",],
+    include_prefix = "third_party/nccl",
 )

--- a/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
@@ -38,8 +38,6 @@ iree_runtime_cc_library(
         "nop_executable_cache.h",
         "pipeline_layout.c",
         "pipeline_layout.h",
-        "status_util.c",
-        "status_util.h",
         "stream_command_buffer.c",
         "stream_command_buffer.h",
         "tracing.c",
@@ -74,10 +72,10 @@ iree_runtime_cc_library(
         "cuda_headers.h",
         "dynamic_symbols.c",
         "status_util.c",
-        "status_util.h",
     ],
     hdrs = [
         "dynamic_symbols.h",
+        "status_util.h",
     ],
     textual_hdrs = [
         "dynamic_symbol_tables.h",

--- a/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
+++ b/runtime/src/iree/hal/drivers/cuda/BUILD.bazel
@@ -73,6 +73,8 @@ iree_runtime_cc_library(
     srcs = [
         "cuda_headers.h",
         "dynamic_symbols.c",
+        "status_util.c",
+        "status_util.h",
     ],
     hdrs = [
         "dynamic_symbols.h",

--- a/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
@@ -75,6 +75,8 @@ iree_cc_library(
   SRCS
     "cuda_headers.h"
     "dynamic_symbols.c"
+    "status_util.c"
+    "status_util.h"
   DEPS
     iree::base
     iree::base::core_headers

--- a/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
+++ b/runtime/src/iree/hal/drivers/cuda/CMakeLists.txt
@@ -39,8 +39,6 @@ iree_cc_library(
     "nop_executable_cache.h"
     "pipeline_layout.c"
     "pipeline_layout.h"
-    "status_util.c"
-    "status_util.h"
     "stream_command_buffer.c"
     "stream_command_buffer.h"
     "tracing.c"
@@ -70,13 +68,13 @@ iree_cc_library(
     dynamic_symbols
   HDRS
     "dynamic_symbols.h"
+    "status_util.h"
   TEXTUAL_HDRS
     "dynamic_symbol_tables.h"
   SRCS
     "cuda_headers.h"
     "dynamic_symbols.c"
     "status_util.c"
-    "status_util.h"
   DEPS
     iree::base
     iree::base::core_headers

--- a/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_driver.c
@@ -14,7 +14,7 @@
 #include "iree/hal/drivers/cuda/cuda_device.h"
 #include "iree/hal/drivers/cuda/dynamic_symbols.h"
 #include "iree/hal/drivers/cuda/status_util.h"
-#include "nccl.h"
+#include "third_party/nccl/nccl.h"
 
 // Maximum device name length we support.
 #define IREE_HAL_CUDA_MAX_DEVICE_NAME_LENGTH 128

--- a/runtime/src/iree/hal/drivers/cuda/cuda_headers.h
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_headers.h
@@ -8,5 +8,5 @@
 #define IREE_HAL_DRIVERS_CUDA_CUDA_HEADERS_H_
 
 #include "cuda.h"  // IWYU pragma: export
-#include "nccl.h"  // IWYU pragma: export
+#include "third_party/nccl/nccl.h"  // IWYU pragma: export
 #endif  // IREE_HAL_DRIVERS_CUDA_CUDA_HEADERS_H_

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.c
@@ -130,7 +130,8 @@ iree_status_t iree_hal_cuda_nccl_dynamic_symbols_initialize(
   }
 
   // Check the NCCL version compatibility
-  int nccl_version;
+  int nccl_version = 0;
+
   if (iree_status_is_ok(status)) {
     status = NCCL_RESULT_TO_STATUS(out_syms, ncclGetVersion(&nccl_version));
   }
@@ -146,17 +147,12 @@ iree_status_t iree_hal_cuda_nccl_dynamic_symbols_initialize(
       minor = (nccl_version % 10000) / 100;
     }
 
-    if (major != NCCL_MAJOR) {
-      return iree_make_status(IREE_STATUS_INTERNAL,
-                              "Unsupported major NCCL version %d is used. The "
-                              "support version is %d.",
-                              major, NCCL_MAJOR);
-    }
-    if (minor < NCCL_MINOR) {
-      return iree_make_status(IREE_STATUS_INTERNAL,
-                              "Unsupported NCCL version %d.%d is used. The "
-                              "minimum support version is %d.%d.",
-                              major, minor, NCCL_MAJOR, NCCL_MINOR);
+    if (nccl_version < NCCL_VERSION(NCCL_MAJOR, NCCL_MINOR, 0) ||
+        major != NCCL_MAJOR) {
+      return iree_make_status(
+          IREE_STATUS_INTERNAL,
+          "NCCL version %d.%d found but at least version %d.%d is required",
+          major, minor, NCCL_MAJOR, NCCL_MINOR);
     }
   }
 

--- a/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.h
+++ b/runtime/src/iree/hal/drivers/cuda/dynamic_symbols.h
@@ -10,7 +10,7 @@
 #include "iree/base/api.h"
 #include "iree/base/internal/dynamic_library.h"
 #include "iree/hal/drivers/cuda/cuda_headers.h"
-#include "nccl.h"
+#include "third_party/nccl/nccl.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
+++ b/runtime/src/iree/hal/drivers/cuda/nccl_channel.c
@@ -12,7 +12,7 @@
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/cuda/cuda_buffer.h"
 #include "iree/hal/drivers/cuda/status_util.h"
-#include "nccl.h"
+#include "third_party/nccl/nccl.h"
 
 // Returns the same value as NCCL's init.cc hashUniqueId.
 // These magic constants were chosen by their implementation and unlikely to


### PR DESCRIPTION
The nccl.h now is picked up from the repo even when the system has a NCCL library installed. The version is dynamically checked at runtime.