### PR TITLE
Fix ConvertToDestinationStylePassing to handle multi-result dispatches.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -146,6 +146,12 @@ static IREE::Flow::DispatchTensorStoreOp walkUseToGetDispatchTensorStoreOp(
     if (!value) return nullptr;
     traversedUses.push_back(&use);
   }
+  // If the value has a use which is a store, then use that directly.
+  for (Operation *user : value.getUsers()) {
+    if (auto storeOp = dyn_cast<IREE::Flow::DispatchTensorStoreOp>(user)) {
+      return storeOp;
+    }
+  }
   return nullptr;
 }
 


### PR DESCRIPTION
With multi-result dispatches a store could be encountered even before walking the entire use-def change. That is enough to replace the `tensor.empty` with a destination buffer.