### PR TITLE
Extending `iree_hal_allocator_t` with memory heaps and compat queries.

### DIFF
--- a/experimental/rocm/rocm_allocator.c
+++ b/experimental/rocm/rocm_allocator.c
@@ -141,7 +141,7 @@ static iree_status_t iree_hal_rocm_allocator_query_memory_heaps(
 }
 
 static iree_hal_buffer_compatibility_t
-iree_hal_rocm_allocator_query_compatibility(
+iree_hal_rocm_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t allocation_size) {
@@ -299,7 +299,8 @@ static const iree_hal_allocator_vtable_t iree_hal_rocm_allocator_vtable = {
     .trim = iree_hal_rocm_allocator_trim,
     .query_statistics = iree_hal_rocm_allocator_query_statistics,
     .query_memory_heaps = iree_hal_rocm_allocator_query_memory_heaps,
-    .query_compatibility = iree_hal_rocm_allocator_query_compatibility,
+    .query_buffer_compatibility =
+        iree_hal_rocm_allocator_query_buffer_compatibility,
     .allocate_buffer = iree_hal_rocm_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_rocm_allocator_deallocate_buffer,
     .import_buffer = iree_hal_rocm_allocator_import_buffer,

--- a/experimental/rocm/rocm_allocator.c
+++ b/experimental/rocm/rocm_allocator.c
@@ -85,6 +85,61 @@ static void iree_hal_rocm_allocator_query_statistics(
   });
 }
 
+static iree_status_t iree_hal_rocm_allocator_query_memory_heaps(
+    iree_hal_allocator_t* IREE_RESTRICT base_allocator,
+    iree_host_size_t capacity,
+    iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
+    iree_host_size_t* IREE_RESTRICT out_count) {
+  const iree_host_size_t count = 3;
+  if (out_count) *out_count = count;
+  if (capacity < count) {
+    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
+  }
+
+  // NOTE: this is all a guess - someone who is familiar with rocm will want
+  // to refine this further.
+
+  // Don't think there's a query for these.
+  // Max allocation size may be much smaller in certain memory types such as
+  // page-locked memory and it'd be good to enforce that.
+  const iree_device_size_t max_allocation_size = ~(iree_device_size_t)0;
+  const iree_device_size_t min_alignment = 64;
+
+  // Device-local memory (dispatch resources):
+  heaps[0] = (iree_hal_allocator_memory_heap_t){
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ,
+      .max_allocation_size = max_allocation_size,
+      .min_alignment = min_alignment,
+  };
+
+  // Write-combined page-locked host-local memory (upload):
+  heaps[1] = (iree_hal_allocator_memory_heap_t){
+      .type =
+          IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_HOST_COHERENT,
+      .allowed_usage =
+          IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING,
+      .max_allocation_size = max_allocation_size,
+      .min_alignment = min_alignment,
+  };
+
+  // Cached page-locked host-local memory (download):
+  heaps[2] = (iree_hal_allocator_memory_heap_t){
+      .type = IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+              IREE_HAL_MEMORY_TYPE_HOST_COHERENT |
+              IREE_HAL_MEMORY_TYPE_HOST_CACHED,
+      .allowed_usage =
+          IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING,
+      .max_allocation_size = max_allocation_size,
+      .min_alignment = min_alignment,
+  };
+
+  return iree_ok_status();
+}
+
 static iree_hal_buffer_compatibility_t
 iree_hal_rocm_allocator_query_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
@@ -243,6 +298,7 @@ static const iree_hal_allocator_vtable_t iree_hal_rocm_allocator_vtable = {
     .host_allocator = iree_hal_rocm_allocator_host_allocator,
     .trim = iree_hal_rocm_allocator_trim,
     .query_statistics = iree_hal_rocm_allocator_query_statistics,
+    .query_memory_heaps = iree_hal_rocm_allocator_query_memory_heaps,
     .query_compatibility = iree_hal_rocm_allocator_query_compatibility,
     .allocate_buffer = iree_hal_rocm_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_rocm_allocator_deallocate_buffer,

--- a/experimental/rocm/rocm_allocator.c
+++ b/experimental/rocm/rocm_allocator.c
@@ -93,6 +93,7 @@ static iree_status_t iree_hal_rocm_allocator_query_memory_heaps(
   const iree_host_size_t count = 3;
   if (out_count) *out_count = count;
   if (capacity < count) {
+    // NOTE: lightweight as this is hit in normal pre-sizing usage.
     return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
   }
 
@@ -108,10 +109,8 @@ static iree_status_t iree_hal_rocm_allocator_query_memory_heaps(
   // Device-local memory (dispatch resources):
   heaps[0] = (iree_hal_allocator_memory_heap_t){
       .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
-      .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
-                       IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
-                       IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
-                       IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ,
+      .allowed_usage =
+          IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_DISPATCH,
       .max_allocation_size = max_allocation_size,
       .min_alignment = min_alignment,
   };
@@ -143,8 +142,8 @@ static iree_status_t iree_hal_rocm_allocator_query_memory_heaps(
 static iree_hal_buffer_compatibility_t
 iree_hal_rocm_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
-    const iree_hal_buffer_params_t* IREE_RESTRICT params,
-    iree_device_size_t allocation_size) {
+    iree_hal_buffer_params_t* IREE_RESTRICT params,
+    iree_device_size_t* IREE_RESTRICT allocation_size) {
   // All buffers can be allocated on the heap.
   iree_hal_buffer_compatibility_t compatibility =
       IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE;
@@ -160,6 +159,14 @@ iree_hal_rocm_allocator_query_buffer_compatibility(
       compatibility |= IREE_HAL_BUFFER_COMPATIBILITY_QUEUE_DISPATCH;
     }
   }
+
+  // We are now optimal.
+  params->type &= ~IREE_HAL_MEMORY_TYPE_OPTIMAL;
+
+  // Guard against the corner case where the requested buffer size is 0. The
+  // application is unlikely to do anything when requesting a 0-byte buffer; but
+  // it can happen in real world use cases. So we should at least not crash.
+  if (*allocation_size == 0) *allocation_size = 4;
 
   return compatibility;
 }
@@ -184,17 +191,24 @@ static iree_status_t iree_hal_rocm_allocator_allocate_buffer(
     iree_hal_buffer_t** IREE_RESTRICT out_buffer) {
   iree_hal_rocm_allocator_t* allocator =
       iree_hal_rocm_allocator_cast(base_allocator);
-  // Guard against the corner case where the requested buffer size is 0. The
-  // application is unlikely to do anything when requesting a 0-byte buffer; but
-  // it can happen in real world use cases. So we should at least not crash.
-  if (allocation_size == 0) allocation_size = 4;
+  // Coerce options into those required by the current device.
+  iree_hal_buffer_params_t compat_params = *params;
+  if (!iree_all_bits_set(iree_hal_rocm_allocator_query_buffer_compatibility(
+                             base_allocator, &compat_params, &allocation_size),
+                         IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE)) {
+    return iree_make_status(
+        IREE_STATUS_INVALID_ARGUMENT,
+        "allocator cannot allocate a buffer with the given parameters");
+  }
 
   iree_status_t status = iree_ok_status();
   void* host_ptr = NULL;
   hipDeviceptr_t device_ptr = 0;
-  if (iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
+  if (iree_all_bits_set(compat_params.type,
+                        IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL)) {
     // Device local case.
-    if (iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)) {
+    if (iree_all_bits_set(compat_params.type,
+                          IREE_HAL_MEMORY_TYPE_HOST_VISIBLE)) {
       status = ROCM_RESULT_TO_STATUS(
           allocator->context->syms,
           hipMallocManaged(&device_ptr, allocation_size, hipMemAttachGlobal));
@@ -206,7 +220,8 @@ static iree_status_t iree_hal_rocm_allocator_allocate_buffer(
     }
   } else {
     unsigned int flags = hipHostMallocMapped;
-    if (!iree_all_bits_set(params->type, IREE_HAL_MEMORY_TYPE_HOST_CACHED)) {
+    if (!iree_all_bits_set(compat_params.type,
+                           IREE_HAL_MEMORY_TYPE_HOST_CACHED)) {
       flags |= hipHostMallocWriteCombined;
     }
     status = ROCM_RESULT_TO_STATUS(
@@ -222,8 +237,8 @@ static iree_status_t iree_hal_rocm_allocator_allocate_buffer(
   iree_hal_buffer_t* buffer = NULL;
   if (iree_status_is_ok(status)) {
     status = iree_hal_rocm_buffer_wrap(
-        (iree_hal_allocator_t*)allocator, params->type, params->access,
-        params->usage, allocation_size,
+        (iree_hal_allocator_t*)allocator, compat_params.type,
+        compat_params.access, compat_params.usage, allocation_size,
         /*byte_offset=*/0,
         /*byte_length=*/allocation_size, device_ptr, host_ptr, &buffer);
   }
@@ -242,12 +257,12 @@ static iree_status_t iree_hal_rocm_allocator_allocate_buffer(
 
   if (iree_status_is_ok(status)) {
     IREE_STATISTICS(iree_hal_allocator_statistics_record_alloc(
-        &allocator->statistics, params->type, allocation_size));
+        &allocator->statistics, compat_params.type, allocation_size));
     *out_buffer = buffer;
   } else {
     if (!buffer) {
-      iree_hal_rocm_buffer_free(allocator->context, params->type, device_ptr,
-                                host_ptr);
+      iree_hal_rocm_buffer_free(allocator->context, compat_params.type,
+                                device_ptr, host_ptr);
     } else {
       iree_hal_buffer_release(buffer);
     }

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -622,13 +622,13 @@ void SetupHalBindings(pybind11::module m) {
       .def_property_readonly("formatted_statistics",
                              &HalAllocator::FormattedStatistics)
       .def(
-          "query_compatibility",
+          "query_buffer_compatibility",
           [](HalAllocator& self, int memory_type, int allowed_usage,
              int intended_usage, iree_device_size_t allocation_size) -> int {
             iree_hal_buffer_params_t params = {0};
             params.type = memory_type;
             params.usage = allowed_usage & intended_usage;
-            return iree_hal_allocator_query_compatibility(
+            return iree_hal_allocator_query_buffer_compatibility(
                 self.raw_ptr(), params, allocation_size);
           },
           py::arg("memory_type"), py::arg("allowed_usage"),

--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -629,7 +629,8 @@ void SetupHalBindings(pybind11::module m) {
             params.type = memory_type;
             params.usage = allowed_usage & intended_usage;
             return iree_hal_allocator_query_buffer_compatibility(
-                self.raw_ptr(), params, allocation_size);
+                self.raw_ptr(), params, allocation_size,
+                /*out_params=*/nullptr, /*out_allocation_size=*/0);
           },
           py::arg("memory_type"), py::arg("allowed_usage"),
           py::arg("intended_usage"), py::arg("allocation_size"))

--- a/runtime/bindings/python/tests/hal_test.py
+++ b/runtime/bindings/python/tests/hal_test.py
@@ -96,7 +96,7 @@ class DeviceHalTest(unittest.TestCase):
       self.assertIn("HOST_LOCAL", stats_str)
 
   def testQueryCompatibility(self):
-    compat = self.allocator.query_compatibility(
+    compat = self.allocator.query_buffer_compatibility(
         memory_type=iree.runtime.MemoryType.DEVICE_LOCAL,
         allowed_usage=iree.runtime.BufferUsage.DEFAULT,
         intended_usage=iree.runtime.BufferUsage.DEFAULT,

--- a/runtime/src/iree/base/bitfield.h
+++ b/runtime/src/iree/base/bitfield.h
@@ -30,7 +30,30 @@ typedef struct iree_bitfield_string_mapping_t {
   iree_string_view_t string;
 } iree_bitfield_string_mapping_t;
 
-// Appends the formatted contents of the given bitfield value.
+// Parses the bitfield |value| from a string.
+// The provided |mappings| table is used for string lookup. Unknown values
+// result in a failure.
+//
+// Usage:
+//  // Static mapping table:
+//  static const iree_bitfield_string_mapping_t my_bitfield_mappings[] = {
+//    {MY_BITFIELD_ALL, IREE_SVL("ALL")},  // combined flags first
+//    {MY_BITFIELD_A,   IREE_SVL("A")},
+//    {MY_BITFIELD_B,   IREE_SVL("B")},
+//    {MY_BITFIELD_C,   IREE_SVL("C")},
+//  };
+//
+//  // Produces the bits MY_BITFIELD_A|MY_BITFIELD_B:
+//  uint32_t value_ab = 0;
+//  IREE_RETURN_IF_ERROR(iree_bitfield_parse(
+//      IREE_SV("A|B"),
+//      IREE_ARRAYSIZE(my_bitfield_mappings), my_bitfield_mappings,
+//      &value_ab));
+IREE_API_EXPORT iree_status_t iree_bitfield_parse(
+    iree_string_view_t value, iree_host_size_t mapping_count,
+    const iree_bitfield_string_mapping_t* mappings, uint32_t* out_value);
+
+// Appends the formatted contents of the given bitfield |value|.
 // Processes values in the order of the mapping table provided and will only
 // use each bit once. Use this to prioritize combined flags over split ones.
 //

--- a/runtime/src/iree/base/bitfield_test.cc
+++ b/runtime/src/iree/base/bitfield_test.cc
@@ -13,6 +13,9 @@
 namespace iree {
 namespace {
 
+using iree::testing::status::IsOkAndHolds;
+using iree::testing::status::StatusIs;
+
 enum my_bitfield_e {
   MY_BITFIELD_NONE = 0,
   MY_BITFIELD_A = 1 << 0,
@@ -20,6 +23,62 @@ enum my_bitfield_e {
   MY_BITFIELD_ALL = MY_BITFIELD_A | MY_BITFIELD_B,
 };
 typedef uint32_t my_bitfield_t;
+
+template <size_t mapping_count>
+StatusOr<uint32_t> ParseBitfieldValue(
+    const char* value,
+    const iree_bitfield_string_mapping_t (&mappings)[mapping_count]) {
+  uint32_t bits_value = 0;
+  IREE_RETURN_IF_ERROR(iree_bitfield_parse(
+      iree_make_cstring_view(value), mapping_count, mappings, &bits_value));
+  return bits_value;
+}
+
+// Tests general parser usage.
+TEST(BitfieldTest, ParseBitfieldValue) {
+  static const iree_bitfield_string_mapping_t mappings[] = {
+      {MY_BITFIELD_A, IREE_SV("A")},
+      {MY_BITFIELD_B, IREE_SV("B")},
+  };
+  EXPECT_THAT(ParseBitfieldValue("", mappings), IsOkAndHolds(MY_BITFIELD_NONE));
+  EXPECT_THAT(ParseBitfieldValue("A", mappings), IsOkAndHolds(MY_BITFIELD_A));
+  EXPECT_THAT(ParseBitfieldValue("A|B", mappings),
+              IsOkAndHolds(MY_BITFIELD_A | MY_BITFIELD_B));
+  EXPECT_THAT(ParseBitfieldValue("a|b", mappings),
+              IsOkAndHolds(MY_BITFIELD_A | MY_BITFIELD_B));
+  EXPECT_THAT(ParseBitfieldValue("|a||B|", mappings),
+              IsOkAndHolds(MY_BITFIELD_A | MY_BITFIELD_B));
+}
+
+// Tests that empty mapping tables behave ok.
+TEST(BitfieldTest, ParseBitfieldValueEmpty) {
+  static const iree_bitfield_string_mapping_t mappings[1] = {
+      {0, IREE_SV("UNUSED")},  // unused; required for C++ compat
+  };
+  // Empty strings always mean 0, no mapping fields needed.
+  EXPECT_THAT(ParseBitfieldValue("", mappings), IsOkAndHolds(0));
+  // If any named values are provided, though, we fail.
+  EXPECT_THAT(ParseBitfieldValue("foo", mappings),
+              StatusIs(StatusCode::kInvalidArgument));
+  // Manually-specified values are ok, though.
+  EXPECT_THAT(ParseBitfieldValue("2h|1h", mappings), IsOkAndHolds(0x2u | 0x1u));
+}
+
+// Tests that values not found in the mappings are still parsed.
+TEST(BitfieldTest, ParseBitfieldValueUnhandledValues) {
+  static const iree_bitfield_string_mapping_t mappings[] = {
+      {MY_BITFIELD_A, IREE_SV("A")},
+      {MY_BITFIELD_B, IREE_SV("B")},
+  };
+  EXPECT_THAT(ParseBitfieldValue("A|2", mappings),
+              IsOkAndHolds(MY_BITFIELD_A | MY_BITFIELD_B));
+  EXPECT_THAT(ParseBitfieldValue("A|2h", mappings),
+              IsOkAndHolds(MY_BITFIELD_A | MY_BITFIELD_B));
+  EXPECT_THAT(ParseBitfieldValue("A|0x2", mappings),
+              IsOkAndHolds(MY_BITFIELD_A | MY_BITFIELD_B));
+  EXPECT_THAT(ParseBitfieldValue("A|a08", mappings),
+              StatusIs(StatusCode::kInvalidArgument));
+}
 
 template <size_t mapping_count>
 std::string FormatBitfieldValue(
@@ -30,7 +89,7 @@ std::string FormatBitfieldValue(
   return std::string(sv.data, sv.size);
 }
 
-// Tests general usage.
+// Tests general formatting usage.
 TEST(BitfieldTest, FormatBitfieldValue) {
   static const iree_bitfield_string_mapping_t mappings[] = {
       {MY_BITFIELD_A, IREE_SV("A")},
@@ -45,7 +104,7 @@ TEST(BitfieldTest, FormatBitfieldValue) {
 // Tests that empty mapping tables are fine.
 TEST(BitfieldTest, FormatBitfieldValueEmpty) {
   static const iree_bitfield_string_mapping_t mappings[1] = {
-      {0, IREE_SV("UNUSED")},
+      {0, IREE_SV("UNUSED")},  // unused; required for C++ compat
   };
   iree_bitfield_string_temp_t temp;
   auto sv = iree_bitfield_format_inline(MY_BITFIELD_NONE, 0, mappings, &temp);

--- a/runtime/src/iree/base/string_view.c
+++ b/runtime/src/iree/base/string_view.c
@@ -18,11 +18,30 @@ static inline size_t iree_min_host_size(size_t a, size_t b) {
   return a < b ? a : b;
 }
 
+// Here to ensure that we don't pull in locale-specific code:
+static bool iree_isupper(char c) { return (unsigned)c - 'A' < 26; }
+static bool iree_islower(char c) { return (unsigned)c - 'a' < 26; }
+static inline char iree_toupper(char c) {
+  return iree_islower(c) ? (c & 0x5F) : c;
+}
+static inline char iree_tolower(char c) {
+  return iree_isupper(c) ? (c | 32) : c;
+}
+
 IREE_API_EXPORT bool iree_string_view_equal(iree_string_view_t lhs,
                                             iree_string_view_t rhs) {
   if (lhs.size != rhs.size) return false;
   for (iree_host_size_t i = 0; i < lhs.size; ++i) {
     if (lhs.data[i] != rhs.data[i]) return false;
+  }
+  return true;
+}
+
+IREE_API_EXPORT bool iree_string_view_equal_case(iree_string_view_t lhs,
+                                                 iree_string_view_t rhs) {
+  if (lhs.size != rhs.size) return false;
+  for (iree_host_size_t i = 0; i < lhs.size; ++i) {
+    if (iree_tolower(lhs.data[i]) != iree_tolower(rhs.data[i])) return false;
   }
   return true;
 }

--- a/runtime/src/iree/base/string_view.h
+++ b/runtime/src/iree/base/string_view.h
@@ -99,6 +99,10 @@ static inline iree_string_pair_t iree_make_cstring_pair(const char* first,
 // Returns true if the two strings are equal (compare == 0).
 IREE_API_EXPORT bool iree_string_view_equal(iree_string_view_t lhs,
                                             iree_string_view_t rhs);
+// Returns true if the two strings are equal (compare == 0) ignoring case.
+// Equivalent to strcasecmp.
+IREE_API_EXPORT bool iree_string_view_equal_case(iree_string_view_t lhs,
+                                                 iree_string_view_t rhs);
 
 // Like std::string::compare but with iree_string_view_t values.
 IREE_API_EXPORT int iree_string_view_compare(iree_string_view_t lhs,

--- a/runtime/src/iree/base/string_view_test.cc
+++ b/runtime/src/iree/base/string_view_test.cc
@@ -35,6 +35,25 @@ TEST(StringViewTest, Equal) {
   EXPECT_FALSE(equal("b", "ab"));
   EXPECT_TRUE(equal("abc", "abc"));
   EXPECT_FALSE(equal("abc", "aBc"));
+  EXPECT_TRUE(equal("a_c", "a_c"));
+}
+
+TEST(StringViewTest, EqualCase) {
+  auto equal_case = [](const char* lhs, const char* rhs) -> bool {
+    return iree_string_view_equal_case(iree_make_cstring_view(lhs),
+                                       iree_make_cstring_view(rhs));
+  };
+  EXPECT_TRUE(equal_case("", ""));
+  EXPECT_FALSE(equal_case("a", ""));
+  EXPECT_FALSE(equal_case("", "a"));
+  EXPECT_TRUE(equal_case("a", "a"));
+  EXPECT_TRUE(equal_case("A", "a"));
+  EXPECT_TRUE(equal_case("a", "A"));
+  EXPECT_FALSE(equal_case("a", "ab"));
+  EXPECT_FALSE(equal_case("b", "ab"));
+  EXPECT_TRUE(equal_case("abc", "abc"));
+  EXPECT_TRUE(equal_case("abc", "aBc"));
+  EXPECT_TRUE(equal_case("a_c", "a_C"));
 }
 
 TEST(StringViewTest, FindChar) {

--- a/runtime/src/iree/hal/allocator.c
+++ b/runtime/src/iree/hal/allocator.c
@@ -105,6 +105,16 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
 #endif  // IREE_STATISTICS_ENABLE
 }
 
+IREE_API_EXPORT iree_status_t iree_hal_allocator_query_memory_heaps(
+    iree_hal_allocator_t* IREE_RESTRICT allocator, iree_host_size_t capacity,
+    iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
+    iree_host_size_t* IREE_RESTRICT out_count) {
+  IREE_ASSERT_ARGUMENT(allocator);
+  if (out_count) *out_count = 0;
+  return _VTABLE_DISPATCH(allocator, query_memory_heaps)(allocator, capacity,
+                                                         heaps, out_count);
+}
+
 IREE_API_EXPORT iree_hal_buffer_compatibility_t
 iree_hal_allocator_query_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
@@ -137,6 +147,8 @@ IREE_API_EXPORT void iree_hal_allocator_deallocate_buffer(
   IREE_ASSERT_ARGUMENT(allocator);
   IREE_ASSERT_ARGUMENT(buffer);
   IREE_TRACE_ZONE_BEGIN(z0);
+  IREE_TRACE_ZONE_APPEND_VALUE(
+      z0, (int64_t)iree_hal_buffer_allocation_size(buffer));
   _VTABLE_DISPATCH(allocator, deallocate_buffer)(allocator, buffer);
   IREE_TRACE_ZONE_END(z0);
 }

--- a/runtime/src/iree/hal/allocator.c
+++ b/runtime/src/iree/hal/allocator.c
@@ -116,13 +116,13 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_query_memory_heaps(
 }
 
 IREE_API_EXPORT iree_hal_buffer_compatibility_t
-iree_hal_allocator_query_compatibility(
+iree_hal_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
     iree_hal_buffer_params_t params, iree_device_size_t allocation_size) {
   IREE_ASSERT_ARGUMENT(allocator);
   iree_hal_buffer_params_canonicalize(&params);
-  return _VTABLE_DISPATCH(allocator, query_compatibility)(allocator, &params,
-                                                          allocation_size);
+  return _VTABLE_DISPATCH(allocator, query_buffer_compatibility)(
+      allocator, &params, allocation_size);
 }
 
 IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -409,7 +409,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_query_memory_heaps(
 // be transferred externally into a buffer compatible with the device the
 // allocator services.
 IREE_API_EXPORT iree_hal_buffer_compatibility_t
-iree_hal_allocator_query_compatibility(
+iree_hal_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
     iree_hal_buffer_params_t params, iree_device_size_t allocation_size);
 
@@ -427,8 +427,8 @@ iree_hal_allocator_query_compatibility(
 //
 // |out_buffer| must be released by the caller.
 // Fails if the memory type requested for the given usage cannot be serviced.
-// Callers can use iree_hal_allocator_query_compatibility to decide their memory
-// use strategy.
+// Callers can use iree_hal_allocator_query_buffer_compatibility to decide their
+// memory use strategy.
 IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
     iree_hal_allocator_t* IREE_RESTRICT allocator,
     iree_hal_buffer_params_t params, iree_device_size_t allocation_size,
@@ -446,7 +446,7 @@ IREE_API_EXPORT iree_status_t iree_hal_allocator_allocate_buffer(
 // iree_hal_buffer_t. The returned external buffer may only be usable with the
 // same driver/device.
 //
-// iree_hal_allocator_query_compatibility can be used to query whether a
+// iree_hal_allocator_query_buffer_compatibility can be used to query whether a
 // buffer can be imported when using the given memory type and usage. A
 // compatibility result containing IREE_HAL_BUFFER_COMPATIBILITY_IMPORTABLE
 // means the import _may_ succeed however if the pointer/page range is not in a
@@ -524,7 +524,7 @@ typedef struct iree_hal_allocator_vtable_t {
       iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
       iree_host_size_t* IREE_RESTRICT out_count);
 
-  iree_hal_buffer_compatibility_t(IREE_API_PTR* query_compatibility)(
+  iree_hal_buffer_compatibility_t(IREE_API_PTR* query_buffer_compatibility)(
       iree_hal_allocator_t* IREE_RESTRICT allocator,
       const iree_hal_buffer_params_t* IREE_RESTRICT params,
       iree_device_size_t allocation_size);

--- a/runtime/src/iree/hal/allocator.h
+++ b/runtime/src/iree/hal/allocator.h
@@ -47,6 +47,37 @@ enum iree_hal_allocator_pool_bits_t {
 };
 typedef uint32_t iree_hal_allocator_pool_t;
 
+// Describes a heap of allocatable memory of a specific type.
+// Each allocator exposes one or more heaps with differing characteristics. In
+// local CPU execution or GPUs with unified memory there may only be one heap
+// that covers all memory types and usage while in an out-of-process/sandboxed
+// or discrete GPU configuration there may be multiple heaps representing the
+// differing memory system properties.
+//
+// Allocation requests are routed to heaps based on the provided buffer
+// properties by matching the first heap in the list that meets the
+// requirements. When enumerated the heaps will be in preferred usage order such
+// that the matching will always select the most preferred memory heap first
+// (intended to be the fastest for a given usage). If no heaps can satisfy a
+// given request then allocation will fail.
+typedef struct iree_hal_allocator_memory_heap_t {
+  // Bits that describe the residency and behavior of the memory type.
+  iree_hal_memory_type_t type;
+
+  // Indicates what kind of usage is allowed of buffers allocated from this
+  // heap. For example, exclusive device local memory may not allow mapping
+  // while cached host local memory may not allow usage in dispatches.
+  iree_hal_buffer_usage_t allowed_usage;
+
+  // Maximum size, in bytes, of any individual allocation of this type.
+  // Due to fragmentation it's possible for allocations under this size to fail.
+  iree_device_size_t max_allocation_size;
+
+  // Minimum alignment, in bytes, of allocations of this type.
+  // Allocation requests will have their alignment rounded up to at least this.
+  iree_device_size_t min_alignment;
+} iree_hal_allocator_memory_heap_t;
+
 // Parameters defining how a buffer should be allocated.
 //
 // Designed to be zero-initialized: any field with a 0 value will be assigned
@@ -348,6 +379,25 @@ IREE_API_EXPORT void iree_hal_allocator_query_statistics(
 IREE_API_EXPORT iree_status_t iree_hal_allocator_statistics_fprint(
     FILE* file, iree_hal_allocator_t* IREE_RESTRICT allocator);
 
+// Queries the available memory heaps used for servicing allocation requests.
+// The resulting heaps are sorted in preferred performance order for common
+// execution with the most preferred first.
+//
+// If |heaps| is NULL then the call will query the heap count. This allows for
+// preallocation of storage:
+//   iree_host_size_t count = 0;
+//   iree_hal_allocator_query_memory_heaps(allocator, 0, NULL, &count);
+//   ... heaps = iree_alloca(sizeof(heap) * count);
+//   iree_hal_allocator_query_memory_heaps(allocator, count, heaps, &count);
+//
+// Returns the total count in |out_count| and if |capacity| is large enough
+// will fill |heaps| with the heap information.
+// Returns IREE_STATUS_OUT_OF_RANGE if |capacity| is too small.
+IREE_API_EXPORT iree_status_t iree_hal_allocator_query_memory_heaps(
+    iree_hal_allocator_t* IREE_RESTRICT allocator, iree_host_size_t capacity,
+    iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
+    iree_host_size_t* IREE_RESTRICT out_count);
+
 // Returns a bitmask indicating what operations with buffers of the given type
 // are available on the allocator.
 //
@@ -468,6 +518,11 @@ typedef struct iree_hal_allocator_vtable_t {
   void(IREE_API_PTR* query_statistics)(
       iree_hal_allocator_t* IREE_RESTRICT allocator,
       iree_hal_allocator_statistics_t* IREE_RESTRICT out_statistics);
+
+  iree_status_t(IREE_API_PTR* query_memory_heaps)(
+      iree_hal_allocator_t* IREE_RESTRICT allocator, iree_host_size_t capacity,
+      iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
+      iree_host_size_t* IREE_RESTRICT out_count);
 
   iree_hal_buffer_compatibility_t(IREE_API_PTR* query_compatibility)(
       iree_hal_allocator_t* IREE_RESTRICT allocator,

--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -134,7 +134,7 @@ static iree_status_t iree_hal_heap_allocator_query_memory_heaps(
 }
 
 static iree_hal_buffer_compatibility_t
-iree_hal_heap_allocator_query_compatibility(
+iree_hal_heap_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t allocation_size) {
@@ -265,7 +265,8 @@ static const iree_hal_allocator_vtable_t iree_hal_heap_allocator_vtable = {
     .trim = iree_hal_heap_allocator_trim,
     .query_statistics = iree_hal_heap_allocator_query_statistics,
     .query_memory_heaps = iree_hal_heap_allocator_query_memory_heaps,
-    .query_compatibility = iree_hal_heap_allocator_query_compatibility,
+    .query_buffer_compatibility =
+        iree_hal_heap_allocator_query_buffer_compatibility,
     .allocate_buffer = iree_hal_heap_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_heap_allocator_deallocate_buffer,
     .import_buffer = iree_hal_heap_allocator_import_buffer,

--- a/runtime/src/iree/hal/allocator_heap.c
+++ b/runtime/src/iree/hal/allocator_heap.c
@@ -100,6 +100,39 @@ static void iree_hal_heap_allocator_query_statistics(
   });
 }
 
+static iree_status_t iree_hal_heap_allocator_query_memory_heaps(
+    iree_hal_allocator_t* IREE_RESTRICT base_allocator,
+    iree_host_size_t capacity,
+    iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
+    iree_host_size_t* IREE_RESTRICT out_count) {
+  const iree_host_size_t count = 1;
+  if (out_count) *out_count = count;
+  if (capacity < count) {
+    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
+  }
+  heaps[0] = (iree_hal_allocator_memory_heap_t){
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+              IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+              IREE_HAL_MEMORY_TYPE_HOST_COHERENT,
+      .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                       IREE_HAL_BUFFER_USAGE_SHARING_EXPORT |
+                       IREE_HAL_BUFFER_USAGE_SHARING_REPLICATE |
+                       IREE_HAL_BUFFER_USAGE_SHARING_CONCURRENT |
+                       IREE_HAL_BUFFER_USAGE_SHARING_IMMUTABLE |
+                       IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED |
+                       IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT |
+                       IREE_HAL_BUFFER_USAGE_MAPPING_OPTIONAL |
+                       IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_RANDOM |
+                       IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_SEQUENTIAL_WRITE,
+      .max_allocation_size = ~(iree_device_size_t)0,
+      .min_alignment = IREE_HAL_HEAP_BUFFER_ALIGNMENT,
+  };
+  return iree_ok_status();
+}
+
 static iree_hal_buffer_compatibility_t
 iree_hal_heap_allocator_query_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
@@ -231,6 +264,7 @@ static const iree_hal_allocator_vtable_t iree_hal_heap_allocator_vtable = {
     .host_allocator = iree_hal_heap_allocator_host_allocator,
     .trim = iree_hal_heap_allocator_trim,
     .query_statistics = iree_hal_heap_allocator_query_statistics,
+    .query_memory_heaps = iree_hal_heap_allocator_query_memory_heaps,
     .query_compatibility = iree_hal_heap_allocator_query_compatibility,
     .allocate_buffer = iree_hal_heap_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_heap_allocator_deallocate_buffer,

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -80,6 +80,7 @@ IREE_API_EXPORT iree_string_view_t iree_hal_memory_access_format(
 static const iree_bitfield_string_mapping_t iree_hal_buffer_usage_mappings[] = {
   // Combined:
   {IREE_HAL_BUFFER_USAGE_TRANSFER, IREE_SVL("TRANSFER")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH, IREE_SVL("DISPATCH")},
   {IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE, IREE_SVL("DISPATCH_STORAGE")},
   {IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE, IREE_SVL("DISPATCH_IMAGE")},
   {IREE_HAL_BUFFER_USAGE_MAPPING, IREE_SVL("MAPPING")},

--- a/runtime/src/iree/hal/buffer.c
+++ b/runtime/src/iree/hal/buffer.c
@@ -21,70 +21,101 @@
 // String utils
 //===----------------------------------------------------------------------===//
 
+static const iree_bitfield_string_mapping_t iree_hal_memory_type_mappings[] = {
+    // Combined:
+    {IREE_HAL_MEMORY_TYPE_HOST_LOCAL, IREE_SVL("HOST_LOCAL")},
+    {IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL, IREE_SVL("DEVICE_LOCAL")},
+    // Separate:
+    {IREE_HAL_MEMORY_TYPE_OPTIMAL, IREE_SVL("OPTIMAL")},
+    {IREE_HAL_MEMORY_TYPE_HOST_VISIBLE, IREE_SVL("HOST_VISIBLE")},
+    {IREE_HAL_MEMORY_TYPE_HOST_COHERENT, IREE_SVL("HOST_COHERENT")},
+    {IREE_HAL_MEMORY_TYPE_HOST_CACHED, IREE_SVL("HOST_CACHED")},
+    {IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE, IREE_SVL("DEVICE_VISIBLE")},
+};
+
+IREE_API_EXPORT iree_status_t iree_hal_memory_type_parse(
+    iree_string_view_t value, iree_hal_memory_type_t* out_value) {
+  return iree_bitfield_parse(value,
+                             IREE_ARRAYSIZE(iree_hal_memory_type_mappings),
+                             iree_hal_memory_type_mappings, out_value);
+}
+
 IREE_API_EXPORT iree_string_view_t iree_hal_memory_type_format(
     iree_hal_memory_type_t value, iree_bitfield_string_temp_t* out_temp) {
-  static const iree_bitfield_string_mapping_t mappings[] = {
-      // Combined:
-      {IREE_HAL_MEMORY_TYPE_HOST_LOCAL, IREE_SVL("HOST_LOCAL")},
-      {IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL, IREE_SVL("DEVICE_LOCAL")},
-      // Separate:
-      {IREE_HAL_MEMORY_TYPE_OPTIMAL, IREE_SVL("OPTIMAL")},
-      {IREE_HAL_MEMORY_TYPE_HOST_VISIBLE, IREE_SVL("HOST_VISIBLE")},
-      {IREE_HAL_MEMORY_TYPE_HOST_COHERENT, IREE_SVL("HOST_COHERENT")},
-      {IREE_HAL_MEMORY_TYPE_HOST_CACHED, IREE_SVL("HOST_CACHED")},
-      {IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE, IREE_SVL("DEVICE_VISIBLE")},
-  };
-  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
-                                     out_temp);
+  return iree_bitfield_format_inline(
+      value, IREE_ARRAYSIZE(iree_hal_memory_type_mappings),
+      iree_hal_memory_type_mappings, out_temp);
+}
+static const iree_bitfield_string_mapping_t iree_hal_memory_access_mappings[] =
+    {
+        // Combined:
+        {IREE_HAL_MEMORY_ACCESS_ALL, IREE_SVL("ALL")},
+        {IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE, IREE_SVL("DISCARD_WRITE")},
+        // Separate:
+        {IREE_HAL_MEMORY_ACCESS_READ, IREE_SVL("READ")},
+        {IREE_HAL_MEMORY_ACCESS_WRITE, IREE_SVL("WRITE")},
+        {IREE_HAL_MEMORY_ACCESS_DISCARD, IREE_SVL("DISCARD")},
+        {IREE_HAL_MEMORY_ACCESS_MAY_ALIAS, IREE_SVL("MAY_ALIAS")},
+        {IREE_HAL_MEMORY_ACCESS_ANY, IREE_SVL("ANY")},
+};
+
+IREE_API_EXPORT iree_status_t iree_hal_memory_access_parse(
+    iree_string_view_t value, iree_hal_memory_access_t* out_value) {
+  uint32_t value_u32 = 0;
+  IREE_RETURN_IF_ERROR(iree_bitfield_parse(
+      value, IREE_ARRAYSIZE(iree_hal_memory_access_mappings),
+      iree_hal_memory_access_mappings, &value_u32));
+  *out_value = (iree_hal_memory_access_t)value_u32;
+  return iree_ok_status();
 }
 
 IREE_API_EXPORT iree_string_view_t iree_hal_memory_access_format(
     iree_hal_memory_access_t value, iree_bitfield_string_temp_t* out_temp) {
-  static const iree_bitfield_string_mapping_t mappings[] = {
-      // Combined:
-      {IREE_HAL_MEMORY_ACCESS_ALL, IREE_SVL("ALL")},
-      {IREE_HAL_MEMORY_ACCESS_DISCARD_WRITE, IREE_SVL("DISCARD_WRITE")},
-      // Separate:
-      {IREE_HAL_MEMORY_ACCESS_READ, IREE_SVL("READ")},
-      {IREE_HAL_MEMORY_ACCESS_WRITE, IREE_SVL("WRITE")},
-      {IREE_HAL_MEMORY_ACCESS_DISCARD, IREE_SVL("DISCARD")},
-      {IREE_HAL_MEMORY_ACCESS_MAY_ALIAS, IREE_SVL("MAY_ALIAS")},
-      {IREE_HAL_MEMORY_ACCESS_ANY, IREE_SVL("ANY")},
-  };
-  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
-                                     out_temp);
+  return iree_bitfield_format_inline(
+      value, IREE_ARRAYSIZE(iree_hal_memory_access_mappings),
+      iree_hal_memory_access_mappings, out_temp);
+}
+
+// clang-format off
+static const iree_bitfield_string_mapping_t iree_hal_buffer_usage_mappings[] = {
+  // Combined:
+  {IREE_HAL_BUFFER_USAGE_TRANSFER, IREE_SVL("TRANSFER")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE, IREE_SVL("DISPATCH_STORAGE")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE, IREE_SVL("DISPATCH_IMAGE")},
+  {IREE_HAL_BUFFER_USAGE_MAPPING, IREE_SVL("MAPPING")},
+  // Separate:
+  {IREE_HAL_BUFFER_USAGE_TRANSFER_SOURCE, IREE_SVL("TRANSFER_SOURCE")},
+  {IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET, IREE_SVL("TRANSFER_TARGET")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS, IREE_SVL("DISPATCH_INDIRECT_PARAMS")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ, IREE_SVL("DISPATCH_UNIFORM_READ")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE_READ, IREE_SVL("DISPATCH_STORAGE_READ")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE_WRITE, IREE_SVL("DISPATCH_STORAGE_WRITE")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE_READ, IREE_SVL("DISPATCH_IMAGE_READ")},
+  {IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE_WRITE, IREE_SVL("DISPATCH_IMAGE_WRITE")},
+  {IREE_HAL_BUFFER_USAGE_SHARING_EXPORT, IREE_SVL("SHARING_EXPORT")},
+  {IREE_HAL_BUFFER_USAGE_SHARING_REPLICATE, IREE_SVL("SHARING_REPLICATE")},
+  {IREE_HAL_BUFFER_USAGE_SHARING_CONCURRENT, IREE_SVL("SHARING_CONCURRENT")},
+  {IREE_HAL_BUFFER_USAGE_SHARING_IMMUTABLE, IREE_SVL("SHARING_IMMUTABLE")},
+  {IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED, IREE_SVL("MAPPING_SCOPED")},
+  {IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT, IREE_SVL("MAPPING_PERSISTENT")},
+  {IREE_HAL_BUFFER_USAGE_MAPPING_OPTIONAL, IREE_SVL("MAPPING_OPTIONAL")},
+  {IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_RANDOM, IREE_SVL("MAPPING_ACCESS_RANDOM")},
+  {IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_SEQUENTIAL_WRITE, IREE_SVL("MAPPING_ACCESS_SEQUENTIAL_WRITE")},
+};
+// clang-format on
+
+IREE_API_EXPORT iree_status_t iree_hal_buffer_usage_parse(
+    iree_string_view_t value, iree_hal_buffer_usage_t* out_value) {
+  return iree_bitfield_parse(value,
+                             IREE_ARRAYSIZE(iree_hal_buffer_usage_mappings),
+                             iree_hal_buffer_usage_mappings, out_value);
 }
 
 IREE_API_EXPORT iree_string_view_t iree_hal_buffer_usage_format(
     iree_hal_buffer_usage_t value, iree_bitfield_string_temp_t* out_temp) {
-  // clang-format off
-  static const iree_bitfield_string_mapping_t mappings[] = {
-    // Combined:
-    {IREE_HAL_BUFFER_USAGE_TRANSFER, IREE_SVL("TRANSFER")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE, IREE_SVL("DISPATCH_STORAGE")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE, IREE_SVL("DISPATCH_IMAGE")},
-    {IREE_HAL_BUFFER_USAGE_MAPPING, IREE_SVL("MAPPING")},
-    // Separate:
-    {IREE_HAL_BUFFER_USAGE_TRANSFER_SOURCE, IREE_SVL("TRANSFER_SOURCE")},
-    {IREE_HAL_BUFFER_USAGE_TRANSFER_TARGET, IREE_SVL("TRANSFER_TARGET")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS, IREE_SVL("DISPATCH_INDIRECT_PARAMS")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ, IREE_SVL("DISPATCH_UNIFORM_READ")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE_READ, IREE_SVL("DISPATCH_STORAGE_READ")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE_WRITE, IREE_SVL("DISPATCH_STORAGE_WRITE")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE_READ, IREE_SVL("DISPATCH_IMAGE_READ")},
-    {IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE_WRITE, IREE_SVL("DISPATCH_IMAGE_WRITE")},
-    {IREE_HAL_BUFFER_USAGE_SHARING_EXPORT, IREE_SVL("SHARING_EXPORT")},
-    {IREE_HAL_BUFFER_USAGE_SHARING_REPLICATE, IREE_SVL("SHARING_REPLICATE")},
-    {IREE_HAL_BUFFER_USAGE_SHARING_CONCURRENT, IREE_SVL("SHARING_CONCURRENT")},
-    {IREE_HAL_BUFFER_USAGE_SHARING_IMMUTABLE, IREE_SVL("SHARING_IMMUTABLE")},
-    {IREE_HAL_BUFFER_USAGE_MAPPING_SCOPED, IREE_SVL("MAPPING_SCOPED")},
-    {IREE_HAL_BUFFER_USAGE_MAPPING_PERSISTENT, IREE_SVL("MAPPING_PERSISTENT")},
-    {IREE_HAL_BUFFER_USAGE_MAPPING_OPTIONAL, IREE_SVL("MAPPING_OPTIONAL")},
-    {IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_RANDOM, IREE_SVL("MAPPING_ACCESS_RANDOM")},
-    {IREE_HAL_BUFFER_USAGE_MAPPING_ACCESS_SEQUENTIAL_WRITE, IREE_SVL("MAPPING_ACCESS_SEQUENTIAL_WRITE")},
-  };
-  return iree_bitfield_format_inline(value, IREE_ARRAYSIZE(mappings), mappings,
-                                     out_temp);
+  return iree_bitfield_format_inline(
+      value, IREE_ARRAYSIZE(iree_hal_buffer_usage_mappings),
+      iree_hal_buffer_usage_mappings, out_temp);
 }
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/hal/buffer.h
+++ b/runtime/src/iree/hal/buffer.h
@@ -449,15 +449,30 @@ typedef struct iree_hal_buffer_mapping_t {
   iree_hal_buffer_mapping_impl_t impl;
 } iree_hal_buffer_mapping_t;
 
+// Parses a memory type bitfield from a string.
+// See iree_bitfield_parse for usage.
+IREE_API_EXPORT iree_status_t iree_hal_memory_type_parse(
+    iree_string_view_t value, iree_hal_memory_type_t* out_value);
+
 // Formats a memory type bitfield as a string.
 // See iree_bitfield_format for usage.
 IREE_API_EXPORT iree_string_view_t iree_hal_memory_type_format(
     iree_hal_memory_type_t value, iree_bitfield_string_temp_t* out_temp);
 
+// Parses a memory access bitfield from a string.
+// See iree_bitfield_parse for usage.
+IREE_API_EXPORT iree_status_t iree_hal_memory_access_parse(
+    iree_string_view_t value, iree_hal_memory_access_t* out_value);
+
 // Formats a memory access bitfield as a string.
 // See iree_bitfield_format for usage.
 IREE_API_EXPORT iree_string_view_t iree_hal_memory_access_format(
     iree_hal_memory_access_t value, iree_bitfield_string_temp_t* out_temp);
+
+// Parses a buffer usage bitfield from a string.
+// See iree_bitfield_parse for usage.
+IREE_API_EXPORT iree_status_t iree_hal_buffer_usage_parse(
+    iree_string_view_t value, iree_hal_buffer_usage_t* out_value);
 
 // Formats a buffer usage bitfield as a string.
 // See iree_bitfield_format for usage.

--- a/runtime/src/iree/hal/buffer.h
+++ b/runtime/src/iree/hal/buffer.h
@@ -279,6 +279,13 @@ enum iree_hal_buffer_usage_bits_t {
       IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE_READ |
       IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE_WRITE,
 
+  // Buffer contents are available for use by all dispatch-related operations.
+  IREE_HAL_BUFFER_USAGE_DISPATCH =
+      IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+      IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ |
+      IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+      IREE_HAL_BUFFER_USAGE_DISPATCH_IMAGE,
+
   // ==== IREE_HAL_BUFFER_USAGE_SHARING_* ======================================
 
   // Buffer can be exported via iree_hal_allocator_export_buffer.

--- a/runtime/src/iree/hal/buffer_view_util.c
+++ b/runtime/src/iree/hal/buffer_view_util.c
@@ -298,10 +298,14 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_generate_buffer(
   mappable_params.type |= IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
   mappable_params.usage |= IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_compatibility_t compatibility =
-      iree_hal_allocator_query_buffer_compatibility(allocator, mappable_params,
-                                                    allocation_size);
-  bool is_mappable = iree_all_bits_set(
-      compatibility, IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE);
+      iree_hal_allocator_query_buffer_compatibility(
+          allocator, mappable_params, allocation_size, &mappable_params,
+          &allocation_size);
+  bool is_mappable =
+      iree_all_bits_set(compatibility,
+                        IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE) &&
+      !iree_any_bit_set(compatibility,
+                        IREE_HAL_BUFFER_COMPATIBILITY_LOW_PERFORMANCE);
 
   iree_status_t status = iree_ok_status();
   if (is_mappable) {

--- a/runtime/src/iree/hal/buffer_view_util.c
+++ b/runtime/src/iree/hal/buffer_view_util.c
@@ -298,8 +298,8 @@ IREE_API_EXPORT iree_status_t iree_hal_buffer_view_generate_buffer(
   mappable_params.type |= IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
   mappable_params.usage |= IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_compatibility_t compatibility =
-      iree_hal_allocator_query_compatibility(allocator, mappable_params,
-                                             allocation_size);
+      iree_hal_allocator_query_buffer_compatibility(allocator, mappable_params,
+                                                    allocation_size);
   bool is_mappable = iree_all_bits_set(
       compatibility, IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE);
 

--- a/runtime/src/iree/hal/command_buffer_validation.c
+++ b/runtime/src/iree/hal/command_buffer_validation.c
@@ -62,7 +62,8 @@ static iree_status_t iree_hal_command_buffer_validate_buffer_compatibility(
               .type = iree_hal_buffer_memory_type(buffer),
               .usage = iree_hal_buffer_allowed_usage(buffer) & intended_usage,
           },
-          iree_hal_buffer_allocation_size(buffer));
+          iree_hal_buffer_allocation_size(buffer), /*out_params=*/NULL,
+          /*out_allocation_size=*/NULL);
   if (!iree_all_bits_set(allowed_compatibility, required_compatibility)) {
 #if IREE_STATUS_MODE
     // Buffer cannot be used on the queue for the given usage.

--- a/runtime/src/iree/hal/command_buffer_validation.c
+++ b/runtime/src/iree/hal/command_buffer_validation.c
@@ -56,7 +56,7 @@ static iree_status_t iree_hal_command_buffer_validate_buffer_compatibility(
     iree_hal_buffer_compatibility_t required_compatibility,
     iree_hal_buffer_usage_t intended_usage) {
   iree_hal_buffer_compatibility_t allowed_compatibility =
-      iree_hal_allocator_query_compatibility(
+      iree_hal_allocator_query_buffer_compatibility(
           iree_hal_device_allocator(validation_state->device),
           (iree_hal_buffer_params_t){
               .type = iree_hal_buffer_memory_type(buffer),

--- a/runtime/src/iree/hal/cts/allocator_test.h
+++ b/runtime/src/iree/hal/cts/allocator_test.h
@@ -37,17 +37,23 @@ TEST_P(allocator_test, BaselineBufferCompatibility) {
   host_local_params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   host_local_params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
+  iree_device_size_t host_local_allocation_size = 0;
   iree_hal_buffer_compatibility_t transfer_compatibility_host =
       iree_hal_allocator_query_buffer_compatibility(
-          device_allocator_, host_local_params, kAllocationSize);
+          device_allocator_, host_local_params, kAllocationSize,
+          &host_local_params, &host_local_allocation_size);
+  EXPECT_GE(host_local_allocation_size, kAllocationSize);
 
   iree_hal_buffer_params_t device_local_params = {0};
   device_local_params.type =
       IREE_HAL_MEMORY_TYPE_HOST_VISIBLE | IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   device_local_params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
+  iree_device_size_t device_allocation_size = 0;
   iree_hal_buffer_compatibility_t transfer_compatibility_device =
       iree_hal_allocator_query_buffer_compatibility(
-          device_allocator_, device_local_params, kAllocationSize);
+          device_allocator_, device_local_params, kAllocationSize,
+          &device_local_params, &device_allocation_size);
+  EXPECT_GE(device_allocation_size, kAllocationSize);
 
   iree_hal_buffer_compatibility_t required_transfer_compatibility =
       IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE |
@@ -62,9 +68,12 @@ TEST_P(allocator_test, BaselineBufferCompatibility) {
   dispatch_params.type =
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   dispatch_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE;
+  iree_device_size_t dispatch_allocation_size = 0;
   iree_hal_buffer_compatibility_t dispatch_compatibility =
       iree_hal_allocator_query_buffer_compatibility(
-          device_allocator_, dispatch_params, kAllocationSize);
+          device_allocator_, dispatch_params, kAllocationSize, &dispatch_params,
+          &dispatch_allocation_size);
+  EXPECT_GE(dispatch_allocation_size, kAllocationSize);
   EXPECT_TRUE(
       iree_all_bits_set(dispatch_compatibility,
                         IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE |

--- a/runtime/src/iree/hal/cts/allocator_test.h
+++ b/runtime/src/iree/hal/cts/allocator_test.h
@@ -38,7 +38,7 @@ TEST_P(allocator_test, BaselineBufferCompatibility) {
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   host_local_params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_compatibility_t transfer_compatibility_host =
-      iree_hal_allocator_query_compatibility(
+      iree_hal_allocator_query_buffer_compatibility(
           device_allocator_, host_local_params, kAllocationSize);
 
   iree_hal_buffer_params_t device_local_params = {0};
@@ -46,7 +46,7 @@ TEST_P(allocator_test, BaselineBufferCompatibility) {
       IREE_HAL_MEMORY_TYPE_HOST_VISIBLE | IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   device_local_params.usage = IREE_HAL_BUFFER_USAGE_TRANSFER;
   iree_hal_buffer_compatibility_t transfer_compatibility_device =
-      iree_hal_allocator_query_compatibility(
+      iree_hal_allocator_query_buffer_compatibility(
           device_allocator_, device_local_params, kAllocationSize);
 
   iree_hal_buffer_compatibility_t required_transfer_compatibility =
@@ -63,8 +63,8 @@ TEST_P(allocator_test, BaselineBufferCompatibility) {
       IREE_HAL_MEMORY_TYPE_HOST_LOCAL | IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE;
   dispatch_params.usage = IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE;
   iree_hal_buffer_compatibility_t dispatch_compatibility =
-      iree_hal_allocator_query_compatibility(device_allocator_, dispatch_params,
-                                             kAllocationSize);
+      iree_hal_allocator_query_buffer_compatibility(
+          device_allocator_, dispatch_params, kAllocationSize);
   EXPECT_TRUE(
       iree_all_bits_set(dispatch_compatibility,
                         IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE |

--- a/runtime/src/iree/hal/cts/buffer_mapping_test.h
+++ b/runtime/src/iree/hal/cts/buffer_mapping_test.h
@@ -63,20 +63,22 @@ TEST_P(buffer_mapping_test, AllocatorSupportsBufferMapping) {
   iree_hal_buffer_params_t params = {0};
   params.type = IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_MAPPING;
+  iree_device_size_t allocation_size = 0;
   iree_hal_buffer_compatibility_t compatibility =
       iree_hal_allocator_query_buffer_compatibility(device_allocator_, params,
-                                                    kDefaultAllocationSize);
+                                                    kDefaultAllocationSize,
+                                                    &params, &allocation_size);
   EXPECT_TRUE(iree_all_bits_set(compatibility,
                                 IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE));
 
   iree_hal_buffer_t* buffer = NULL;
-  AllocateUninitializedBuffer(kDefaultAllocationSize, &buffer);
+  AllocateUninitializedBuffer(allocation_size, &buffer);
 
   EXPECT_TRUE(
       iree_all_bits_set(iree_hal_buffer_memory_type(buffer), params.type));
   EXPECT_TRUE(
       iree_all_bits_set(iree_hal_buffer_allowed_usage(buffer), params.usage));
-  EXPECT_GE(iree_hal_buffer_allocation_size(buffer), kDefaultAllocationSize);
+  EXPECT_GE(iree_hal_buffer_allocation_size(buffer), allocation_size);
 
   iree_hal_buffer_release(buffer);
 }

--- a/runtime/src/iree/hal/cts/buffer_mapping_test.h
+++ b/runtime/src/iree/hal/cts/buffer_mapping_test.h
@@ -64,8 +64,8 @@ TEST_P(buffer_mapping_test, AllocatorSupportsBufferMapping) {
   params.type = IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
   params.usage = IREE_HAL_BUFFER_USAGE_MAPPING;
   iree_hal_buffer_compatibility_t compatibility =
-      iree_hal_allocator_query_compatibility(device_allocator_, params,
-                                             kDefaultAllocationSize);
+      iree_hal_allocator_query_buffer_compatibility(device_allocator_, params,
+                                                    kDefaultAllocationSize);
   EXPECT_TRUE(iree_all_bits_set(compatibility,
                                 IREE_HAL_BUFFER_COMPATIBILITY_ALLOCATABLE));
 

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -118,6 +118,93 @@ static void iree_hal_cuda_allocator_query_statistics(
   });
 }
 
+static iree_status_t iree_hal_cuda_allocator_query_memory_heaps(
+    iree_hal_allocator_t* IREE_RESTRICT base_allocator,
+    iree_host_size_t capacity,
+    iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
+    iree_host_size_t* IREE_RESTRICT out_count) {
+  iree_hal_cuda_allocator_t* allocator =
+      iree_hal_cuda_allocator_cast(base_allocator);
+
+  // TODO(benvanik): check CU_DEVICE_ATTRIBUTE_INTEGRATED and return a unified
+  // set of heaps (likely still a cached and uncached, at minimum).
+  iree_host_size_t count = 3;
+  if (allocator->supports_concurrent_managed_access) {
+    ++count;  // device-local | host-visible
+  }
+  if (out_count) *out_count = count;
+  if (capacity < count) {
+    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
+  }
+
+  // Don't think there's a query for these.
+  // Max allocation size may be much smaller in certain memory types such as
+  // page-locked memory and it'd be good to enforce that.
+  const iree_device_size_t max_allocation_size = ~(iree_device_size_t)0;
+  const iree_device_size_t min_alignment = 64;
+
+  int i = 0;
+
+  // Device-local memory (dispatch resources):
+  heaps[i++] = (iree_hal_allocator_memory_heap_t){
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL,
+      .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE,
+      .max_allocation_size = max_allocation_size,
+      .min_alignment = min_alignment,
+  };
+
+  if (allocator->supports_concurrent_managed_access) {
+    // Device-local managed memory with host mapping support:
+    heaps[i++] = (iree_hal_allocator_memory_heap_t){
+        .type = IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL |
+                IREE_HAL_MEMORY_TYPE_HOST_VISIBLE |
+                IREE_HAL_MEMORY_TYPE_HOST_COHERENT,
+        .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                         IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                         IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ |
+                         IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                         IREE_HAL_BUFFER_USAGE_MAPPING,
+        .max_allocation_size = max_allocation_size,
+        .min_alignment = min_alignment,
+    };
+  }
+
+  // Write-combined page-locked host-local memory (upload):
+  heaps[i++] = (iree_hal_allocator_memory_heap_t){
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE |
+              IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+              IREE_HAL_MEMORY_TYPE_HOST_COHERENT,
+      .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                       IREE_HAL_BUFFER_USAGE_MAPPING,
+      .max_allocation_size = max_allocation_size,
+      .min_alignment = min_alignment,
+  };
+
+  // Cached page-locked host-local memory (download):
+  heaps[i++] = (iree_hal_allocator_memory_heap_t){
+      .type = IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE |
+              IREE_HAL_MEMORY_TYPE_HOST_LOCAL |
+              IREE_HAL_MEMORY_TYPE_HOST_COHERENT |
+              IREE_HAL_MEMORY_TYPE_HOST_CACHED,
+      .allowed_usage = IREE_HAL_BUFFER_USAGE_TRANSFER |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ |
+                       IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                       IREE_HAL_BUFFER_USAGE_MAPPING,
+      .max_allocation_size = max_allocation_size,
+      .min_alignment = min_alignment,
+  };
+
+  IREE_ASSERT(i == count);
+  return iree_ok_status();
+}
+
 static iree_hal_buffer_compatibility_t
 iree_hal_cuda_allocator_query_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
@@ -430,6 +517,7 @@ static const iree_hal_allocator_vtable_t iree_hal_cuda_allocator_vtable = {
     .host_allocator = iree_hal_cuda_allocator_host_allocator,
     .trim = iree_hal_cuda_allocator_trim,
     .query_statistics = iree_hal_cuda_allocator_query_statistics,
+    .query_memory_heaps = iree_hal_cuda_allocator_query_memory_heaps,
     .query_compatibility = iree_hal_cuda_allocator_query_compatibility,
     .allocate_buffer = iree_hal_cuda_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_cuda_allocator_deallocate_buffer,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_allocator.c
@@ -206,7 +206,7 @@ static iree_status_t iree_hal_cuda_allocator_query_memory_heaps(
 }
 
 static iree_hal_buffer_compatibility_t
-iree_hal_cuda_allocator_query_compatibility(
+iree_hal_cuda_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t allocation_size) {
@@ -518,7 +518,8 @@ static const iree_hal_allocator_vtable_t iree_hal_cuda_allocator_vtable = {
     .trim = iree_hal_cuda_allocator_trim,
     .query_statistics = iree_hal_cuda_allocator_query_statistics,
     .query_memory_heaps = iree_hal_cuda_allocator_query_memory_heaps,
-    .query_compatibility = iree_hal_cuda_allocator_query_compatibility,
+    .query_buffer_compatibility =
+        iree_hal_cuda_allocator_query_buffer_compatibility,
     .allocate_buffer = iree_hal_cuda_allocator_allocate_buffer,
     .deallocate_buffer = iree_hal_cuda_allocator_deallocate_buffer,
     .import_buffer = iree_hal_cuda_allocator_import_buffer,

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -135,7 +135,8 @@ static iree_status_t iree_hal_cuda_device_create_internal(
     status = iree_hal_cuda_stream_command_buffer_create(
         (iree_hal_device_t*)device, &device->context_wrapper,
         device->tracing_context,
-        IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION,
+        IREE_HAL_COMMAND_BUFFER_MODE_ALLOW_INLINE_EXECUTION |
+            IREE_HAL_COMMAND_BUFFER_MODE_UNVALIDATED,
         IREE_HAL_COMMAND_CATEGORY_ANY, /*binding_capacity=*/0, device->stream,
         &device->block_pool, &device->stream_command_buffer);
   }

--- a/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
@@ -576,7 +576,7 @@ static iree_status_t iree_hal_vulkan_vma_allocator_query_memory_heaps(
 }
 
 static iree_hal_buffer_compatibility_t
-iree_hal_vulkan_vma_allocator_query_compatibility(
+iree_hal_vulkan_vma_allocator_query_buffer_compatibility(
     iree_hal_allocator_t* IREE_RESTRICT base_allocator,
     const iree_hal_buffer_params_t* IREE_RESTRICT params,
     iree_device_size_t allocation_size) {
@@ -765,8 +765,8 @@ const iree_hal_allocator_vtable_t iree_hal_vulkan_vma_allocator_vtable = {
     /*.trim=*/iree_hal_vulkan_vma_allocator_trim,
     /*.query_statistics=*/iree_hal_vulkan_vma_allocator_query_statistics,
     /*.query_memory_heaps=*/iree_hal_vulkan_vma_allocator_query_memory_heaps,
-    /*.query_compatibility=*/
-    iree_hal_vulkan_vma_allocator_query_compatibility,
+    /*.query_buffer_compatibility=*/
+    iree_hal_vulkan_vma_allocator_query_buffer_compatibility,
     /*.allocate_buffer=*/iree_hal_vulkan_vma_allocator_allocate_buffer,
     /*.deallocate_buffer=*/iree_hal_vulkan_vma_allocator_deallocate_buffer,
     /*.import_buffer=*/iree_hal_vulkan_vma_allocator_import_buffer,

--- a/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
+++ b/runtime/src/iree/hal/drivers/vulkan/vma_allocator.cc
@@ -10,6 +10,7 @@
 #include <cstring>
 
 #include "iree/base/api.h"
+#include "iree/base/internal/math.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/vulkan/dynamic_symbols.h"
 #include "iree/hal/drivers/vulkan/status_util.h"
@@ -18,13 +19,271 @@
 
 using namespace iree::hal::vulkan;
 
+//===----------------------------------------------------------------------===//
+// Memory types
+//===----------------------------------------------------------------------===//
+
+// Set of memory type indices into VkPhysicalDeviceMemoryProperties.
+// The set is bucketed by usage semantics to allow us to quickly map an
+// allocation request to an underlying memory type. Some buckets may point to
+// the same index - for example, on a CPU or integrated GPU all of them may
+// point at the same memory space.
+//
+// Major categories:
+// - Dispatch
+//   High-bandwidth device-local memory where we want to ensure that all
+//   accesses don't require going over a slow bus (PCI/etc).
+// - Bulk transfer
+//   Low-bandwidth often host-local or host-visible memory for
+//   uploading/downloading large buffers, usually backed by system memory.
+//   Not expected to be usable by dispatches and just used for staging.
+// - Staging transfer
+//   High-bandwidth device-local memory that is also host-visible for
+//   low-latency staging. These are generally small buffers used by dispatches
+//   (like uniform buffers) as the amount of memory available can be very
+//   limited (~256MB). Because of the device limits we only use these for
+//   TRANSIENT allocations that are used by dispatches.
+typedef union {
+  struct {
+    // Preferred memory type for device-local dispatch operations.
+    // This memory _may_ be host visible, though we try to select the most
+    // exclusive device local memory when available.
+    int dispatch_idx;
+
+    // Preferred memory type for bulk uploads (host->device).
+    // These may be slow to access from dispatches or not possible at all, but
+    // generally have the entire system memory available for storage.
+    int bulk_upload_idx;
+    // Preferred memory type for bulk downloads (device->host).
+    int bulk_download_idx;
+
+    // Preferred memory type for staging uploads (host->device).
+    int staging_upload_idx;
+    // Preferred memory type for staging downloads (device->host).
+    int staging_download_idx;
+  };
+  int indices[5];
+} iree_hal_vulkan_memory_types_t;
+
+// Returns the total unique memory types.
+static int iree_hal_vulkan_memory_types_unique_count(
+    const iree_hal_vulkan_memory_types_t* memory_types) {
+  uint32_t indices = 0;
+  for (size_t i = 0; i < IREE_ARRAYSIZE(memory_types->indices); ++i) {
+    indices |= 1u << memory_types->indices[i];
+  }
+  return iree_math_count_ones_u32(indices);
+}
+
+// Returns true if the memory type at |type_idx| is in a device-local heap.
+static bool iree_hal_vulkan_is_heap_device_local(
+    const VkPhysicalDeviceMemoryProperties* memory_props, uint32_t type_idx) {
+  const uint32_t heap_idx = memory_props->memoryTypes[type_idx].heapIndex;
+  return iree_all_bits_set(memory_props->memoryHeaps[heap_idx].flags,
+                           VK_MEMORY_HEAP_DEVICE_LOCAL_BIT);
+}
+
+// Returns true if the memory type is not usable by us (today).
+static bool iree_hal_vulkan_is_memory_type_usable(VkMemoryPropertyFlags flags) {
+  return !iree_all_bits_set(flags, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) &&
+         !iree_all_bits_set(flags, VK_MEMORY_PROPERTY_PROTECTED_BIT);
+}
+
+static void iree_hal_vulkan_populate_dispatch_memory_types(
+    const VkPhysicalDeviceProperties* device_props,
+    const VkPhysicalDeviceMemoryProperties* memory_props,
+    iree_hal_vulkan_memory_types_t* out_types) {
+  int least_bits_count = 0;
+  int least_bits_idx = -1;
+  for (uint32_t i = 0; i < memory_props->memoryTypeCount; ++i) {
+    VkMemoryPropertyFlags flags = memory_props->memoryTypes[i].propertyFlags;
+    if (!iree_hal_vulkan_is_heap_device_local(memory_props, i) ||
+        !iree_hal_vulkan_is_memory_type_usable(flags)) {
+      // Only want device-local memory that is usable for storage buffers.
+      continue;
+    }
+    // Prefer the type that is device-local and has as few other bits set as
+    // possible (host-visible/etc). On integrated systems we may not have any
+    // type that is purely device-local but still want to ensure we pick
+    // uncached over cached.
+    int bit_count = iree_math_count_ones_u32(flags);
+    if (least_bits_idx == -1) {
+      least_bits_count = bit_count;
+      least_bits_idx = (int)i;
+    } else if (bit_count < least_bits_count) {
+      least_bits_count = bit_count;
+      least_bits_idx = (int)i;
+    }
+  }
+  out_types->dispatch_idx = least_bits_idx;
+}
+
+static void iree_hal_vulkan_find_transfer_memory_types(
+    const VkPhysicalDeviceProperties* device_props,
+    const VkPhysicalDeviceMemoryProperties* memory_props,
+    VkMemoryPropertyFlags include_flags, VkMemoryPropertyFlags exclude_flags,
+    int* out_upload_idx, int* out_download_idx) {
+  int cached_idx = -1;
+  int uncached_idx = -1;
+  int visible_idx = -1;
+  for (uint32_t i = 0; i < memory_props->memoryTypeCount; ++i) {
+    VkMemoryPropertyFlags flags = memory_props->memoryTypes[i].propertyFlags;
+    if (!iree_all_bits_set(flags, include_flags) ||
+        iree_any_bit_set(flags, exclude_flags)) {
+      // Caller allows/disallows certain flags.
+      continue;
+    } else if (!iree_hal_vulkan_is_memory_type_usable(flags)) {
+      // Only want memory that is usable for storage buffers.
+      continue;
+    } else if (!iree_all_bits_set(flags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
+      // Must be host-visible for transfers.
+      continue;
+    }
+    if (visible_idx == -1) visible_idx = i;
+    if (iree_all_bits_set(flags, VK_MEMORY_PROPERTY_HOST_CACHED_BIT)) {
+      if (cached_idx == -1) cached_idx = i;
+    } else {
+      if (uncached_idx == -1) uncached_idx = i;
+    }
+  }
+  // Prefer uncached for uploads to enable write-through to the device.
+  *out_upload_idx = uncached_idx != -1 ? uncached_idx : visible_idx;
+  // Prefer cached for downloads to enable prefetching/read caching.
+  *out_download_idx = cached_idx != -1 ? cached_idx : visible_idx;
+}
+
+static void iree_hal_vulkan_populate_transfer_memory_types(
+    const VkPhysicalDeviceProperties* device_props,
+    const VkPhysicalDeviceMemoryProperties* memory_props,
+    iree_hal_vulkan_memory_types_t* out_types) {
+  int host_local_upload_idx = -1;
+  int host_local_download_idx = -1;
+  iree_hal_vulkan_find_transfer_memory_types(
+      device_props, memory_props, /*include_flags=*/0,
+      /*exclude_flags=*/VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+      &host_local_upload_idx, &host_local_download_idx);
+  int device_local_upload_idx = -1;
+  int device_local_download_idx = -1;
+  iree_hal_vulkan_find_transfer_memory_types(
+      device_props, memory_props,
+      /*include_flags=*/VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+      /*exclude_flags=*/0, &device_local_upload_idx,
+      &device_local_download_idx);
+
+  // For bulk try first to select host-local memory.
+  // In case that fails we will use device-local memory; common on integrated.
+  out_types->bulk_upload_idx = host_local_upload_idx != -1
+                                   ? host_local_upload_idx
+                                   : device_local_upload_idx;
+  out_types->bulk_download_idx = host_local_download_idx != -1
+                                     ? host_local_download_idx
+                                     : device_local_download_idx;
+
+  // Always use device-local for staging if we have it. This is BAR/page-locked
+  // memory on discrete devices but may just be the same has
+  out_types->staging_upload_idx = device_local_upload_idx != -1
+                                      ? device_local_upload_idx
+                                      : host_local_upload_idx;
+  out_types->staging_download_idx = device_local_download_idx != -1
+                                        ? device_local_download_idx
+                                        : host_local_download_idx;
+}
+
+// Queries the underlying Vulkan implementation to decide which memory type
+// should be used for particular operations.
+//
+// This is a train-wreck of a decision space and definitely wrong in some cases.
+// The only thing we can do is try to be less wrong than RNG.
+//
+// Common Android:
+//   - DEVICE_LOCAL (dispatch)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_COHERENT (upload)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_CACHED (download)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_COHERENT | HOST_CACHED (everything)
+// Samsung Android: 🤡
+// (https://vulkan.gpuinfo.org/displayreport.php?id=14487#memory)
+//
+// Swiftshader/Intel (VK_PHYSICAL_DEVICE_TYPE_CPU):
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_COHERENT | HOST_CACHED (everything)
+//
+// iOS via MoltenVK (VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU):
+//   - DEVICE_LOCAL (dispatch)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_COHERENT | HOST_CACHED (everything)
+//
+// NVIDIA Tegra-like (VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU):
+//   - DEVICE_LOCAL (dispatch)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_COHERENT (upload)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_CACHED (everything)
+//
+// NVIDIA/AMD discrete (VK_PHYSICAL_DEVICE_TYPE_GPU):
+//   - DEVICE_LOCAL (dispatch)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_COHERENT (staging upload)
+//   - DEVICE_LOCAL | HOST_VISIBLE | HOST_CACHED (staging download)
+//   - HOST_VISIBLE | HOST_COHERENT (upload)
+//   - HOST_VISIBLE | HOST_CACHED (download)
+static iree_status_t iree_hal_vulkan_populate_memory_types(
+    const VkPhysicalDeviceProperties* device_props,
+    const VkPhysicalDeviceMemoryProperties* memory_props,
+    iree_hal_vulkan_memory_types_t* out_memory_types) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  // NOT_FOUND sentinel.
+  for (size_t i = 0; i < IREE_ARRAYSIZE(out_memory_types->indices); ++i) {
+    out_memory_types->indices[i] = -1;
+  }
+
+  // Find the memory type that is most device-local.
+  // We try to satisfy all device access requests with this type.
+  iree_hal_vulkan_populate_dispatch_memory_types(device_props, memory_props,
+                                                 out_memory_types);
+
+  // Find the memory types for upload/download.
+  iree_hal_vulkan_populate_transfer_memory_types(device_props, memory_props,
+                                                 out_memory_types);
+
+  // Because this is all bananas we trace out what indices we chose; this will
+  // let us correlate the memory types with vulkan-info and see if we got the
+  // "right" ones.
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, "dispatch:");
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->dispatch_idx);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, "bulk-upload:");
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->bulk_upload_idx);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, "bulk-download:");
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->bulk_download_idx);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, "staging-upload:");
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->staging_upload_idx);
+  IREE_TRACE_ZONE_APPEND_TEXT(z0, "staging-download:");
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, out_memory_types->staging_download_idx);
+  IREE_TRACE_ZONE_END(z0);
+
+  // Check to make sure all memory types were found. If we didn't find any
+  // special staging transfer memory we reuse bulk memory.
+  if (out_memory_types->dispatch_idx == -1) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "dispatch-compatible memory type not found");
+  } else if (out_memory_types->bulk_upload_idx == -1 ||
+             out_memory_types->bulk_download_idx == -1 ||
+             out_memory_types->staging_upload_idx == -1 ||
+             out_memory_types->staging_download_idx == -1) {
+    return iree_make_status(IREE_STATUS_INTERNAL,
+                            "transfer-compatible memory types not found");
+  }
+  return iree_ok_status();
+}
+
+//===----------------------------------------------------------------------===//
+// iree_hal_vulkan_vma_allocator_t
+//===----------------------------------------------------------------------===//
+
 typedef struct iree_hal_vulkan_vma_allocator_t {
   iree_hal_resource_t resource;
   iree_hal_device_t* device;  // unretained to avoid cycles
   iree_allocator_t host_allocator;
   VmaAllocator vma;
 
-  IREE_STATISTICS(VkPhysicalDeviceMemoryProperties memory_props;)
+  // Used to quickly look up the memory type index used for a particular usage.
+  iree_hal_vulkan_memory_types_t memory_types;
+
   IREE_STATISTICS(iree_hal_allocator_statistics_t statistics;)
 } iree_hal_vulkan_vma_allocator_t;
 
@@ -44,8 +303,10 @@ static iree_hal_memory_type_t iree_hal_vulkan_vma_allocator_lookup_memory_type(
     iree_hal_vulkan_vma_allocator_t* allocator, uint32_t memory_type_ordinal) {
   // We could better map the types however today we only use the
   // device/host-local bits.
+  const VkPhysicalDeviceMemoryProperties* memory_props = NULL;
+  vmaGetMemoryProperties(allocator->vma, &memory_props);
   VkMemoryPropertyFlags flags =
-      allocator->memory_props.memoryTypes[memory_type_ordinal].propertyFlags;
+      memory_props->memoryTypes[memory_type_ordinal].propertyFlags;
   if (iree_all_bits_set(flags, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
     return IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
   } else {
@@ -153,13 +414,16 @@ iree_status_t iree_hal_vulkan_vma_allocator_create(
   if (iree_status_is_ok(status)) {
     allocator->vma = vma;
 
-    IREE_STATISTICS({
-      const VkPhysicalDeviceMemoryProperties* memory_props = NULL;
-      vmaGetMemoryProperties(allocator->vma, &memory_props);
-      memcpy(&allocator->memory_props, memory_props,
-             sizeof(allocator->memory_props));
-    });
+    // TODO(benvanik): when not using VMA we'll want to cache these ourselves.
+    const VkPhysicalDeviceProperties* device_props = NULL;
+    vmaGetPhysicalDeviceProperties(allocator->vma, &device_props);
+    const VkPhysicalDeviceMemoryProperties* memory_props = NULL;
+    vmaGetMemoryProperties(allocator->vma, &memory_props);
+    status = iree_hal_vulkan_populate_memory_types(device_props, memory_props,
+                                                   &allocator->memory_types);
+  }
 
+  if (iree_status_is_ok(status)) {
     *out_allocator = (iree_hal_allocator_t*)allocator;
   } else {
     vmaDestroyAllocator(vma);
@@ -202,6 +466,113 @@ static void iree_hal_vulkan_vma_allocator_query_statistics(
         iree_hal_vulkan_vma_allocator_cast(base_allocator);
     memcpy(out_statistics, &allocator->statistics, sizeof(*out_statistics));
   });
+}
+
+// Maps a Vulkan device memory type enum to an allocator heap structure.
+static void iree_hal_vulkan_map_memory_type_to_heap(
+    const VkPhysicalDeviceMemoryProperties* memory_props, int type_idx,
+    iree_device_size_t max_allocation_size, iree_device_size_t min_alignment,
+    iree_hal_allocator_memory_heap_t* out_heap) {
+  VkMemoryPropertyFlags flags =
+      memory_props->memoryTypes[type_idx].propertyFlags;
+  iree_hal_memory_type_t memory_type = 0;
+  iree_hal_buffer_usage_t allowed_usage = 0;
+  if (iree_all_bits_set(flags, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
+    memory_type |= IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL;
+    allowed_usage |= IREE_HAL_BUFFER_USAGE_TRANSFER |
+                     IREE_HAL_BUFFER_USAGE_DISPATCH_INDIRECT_PARAMS |
+                     IREE_HAL_BUFFER_USAGE_DISPATCH_STORAGE |
+                     IREE_HAL_BUFFER_USAGE_DISPATCH_UNIFORM_READ;
+  }
+  if (iree_all_bits_set(flags, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
+    memory_type |= IREE_HAL_MEMORY_TYPE_HOST_VISIBLE;
+    allowed_usage |=
+        IREE_HAL_BUFFER_USAGE_TRANSFER | IREE_HAL_BUFFER_USAGE_MAPPING;
+  }
+  if (iree_all_bits_set(flags, VK_MEMORY_PROPERTY_HOST_COHERENT_BIT)) {
+    memory_type |= IREE_HAL_MEMORY_TYPE_HOST_COHERENT;
+  }
+  if (iree_all_bits_set(flags, VK_MEMORY_PROPERTY_HOST_CACHED_BIT)) {
+    memory_type |= IREE_HAL_MEMORY_TYPE_HOST_CACHED;
+  }
+  out_heap->type = memory_type;
+  out_heap->allowed_usage = allowed_usage;
+
+  // Some memory heaps have very small limits (like 256MB or less) and it may
+  // be less than the maximum allocation size of the API.
+  const VkMemoryHeap* memory_heap =
+      &memory_props->memoryHeaps[memory_props->memoryTypes[type_idx].heapIndex];
+  out_heap->max_allocation_size =
+      iree_min(max_allocation_size, memory_heap->size);
+  out_heap->min_alignment = min_alignment;
+}
+
+static iree_status_t iree_hal_vulkan_vma_allocator_query_memory_heaps(
+    iree_hal_allocator_t* IREE_RESTRICT base_allocator,
+    iree_host_size_t capacity,
+    iree_hal_allocator_memory_heap_t* IREE_RESTRICT heaps,
+    iree_host_size_t* IREE_RESTRICT out_count) {
+  IREE_TRACE_ZONE_BEGIN(z0);
+  iree_hal_vulkan_vma_allocator_t* allocator =
+      iree_hal_vulkan_vma_allocator_cast(base_allocator);
+
+  // TODO(benvanik): when not using VMA we'll want to cache these ourselves.
+  const VkPhysicalDeviceProperties* device_props = NULL;
+  vmaGetPhysicalDeviceProperties(allocator->vma, &device_props);
+  const VkPhysicalDeviceMemoryProperties* memory_props = NULL;
+  vmaGetMemoryProperties(allocator->vma, &memory_props);
+
+  const iree_device_size_t max_allocation_size =
+      device_props->limits.maxStorageBufferRange;
+  const iree_device_size_t min_alignment =
+      iree_max(16, device_props->limits.minStorageBufferOffsetAlignment);
+
+  const iree_hal_vulkan_memory_types_t* memory_types = &allocator->memory_types;
+  iree_host_size_t count =
+      iree_hal_vulkan_memory_types_unique_count(memory_types);
+  if (capacity >= count) {
+    uint32_t has_idx = 0;
+    iree_host_size_t i = 0;
+    if (!(has_idx & (1u << memory_types->dispatch_idx))) {
+      has_idx |= 1u << memory_types->dispatch_idx;
+      iree_hal_vulkan_map_memory_type_to_heap(
+          memory_props, memory_types->dispatch_idx, max_allocation_size,
+          min_alignment, &heaps[i++]);
+    }
+    if (!(has_idx & (1u << memory_types->bulk_upload_idx))) {
+      has_idx |= 1u << memory_types->bulk_upload_idx;
+      iree_hal_vulkan_map_memory_type_to_heap(
+          memory_props, memory_types->bulk_upload_idx, max_allocation_size,
+          min_alignment, &heaps[i++]);
+    }
+    if (!(has_idx & (1u << memory_types->bulk_download_idx))) {
+      has_idx |= 1u << memory_types->bulk_download_idx;
+      iree_hal_vulkan_map_memory_type_to_heap(
+          memory_props, memory_types->bulk_download_idx, max_allocation_size,
+          min_alignment, &heaps[i++]);
+    }
+    if (!(has_idx & (1u << memory_types->staging_upload_idx))) {
+      has_idx |= 1u << memory_types->staging_upload_idx;
+      iree_hal_vulkan_map_memory_type_to_heap(
+          memory_props, memory_types->staging_upload_idx, max_allocation_size,
+          min_alignment, &heaps[i++]);
+    }
+    if (!(has_idx & (1u << memory_types->staging_download_idx))) {
+      has_idx |= 1u << memory_types->staging_download_idx;
+      iree_hal_vulkan_map_memory_type_to_heap(
+          memory_props, memory_types->staging_download_idx, max_allocation_size,
+          min_alignment, &heaps[i++]);
+    }
+    IREE_ASSERT(i == count);
+  }
+
+  if (out_count) *out_count = count;
+  IREE_TRACE_ZONE_APPEND_VALUE(z0, count);
+  IREE_TRACE_ZONE_END(z0);
+  if (capacity < count) {
+    return iree_status_from_code(IREE_STATUS_OUT_OF_RANGE);
+  }
+  return iree_ok_status();
 }
 
 static iree_hal_buffer_compatibility_t
@@ -393,6 +764,7 @@ const iree_hal_allocator_vtable_t iree_hal_vulkan_vma_allocator_vtable = {
     /*.host_allocator=*/iree_hal_vulkan_vma_allocator_host_allocator,
     /*.trim=*/iree_hal_vulkan_vma_allocator_trim,
     /*.query_statistics=*/iree_hal_vulkan_vma_allocator_query_statistics,
+    /*.query_memory_heaps=*/iree_hal_vulkan_vma_allocator_query_memory_heaps,
     /*.query_compatibility=*/
     iree_hal_vulkan_vma_allocator_query_compatibility,
     /*.allocate_buffer=*/iree_hal_vulkan_vma_allocator_allocate_buffer,


### PR DESCRIPTION
The new `iree_hal_allocator_query_memory_heaps` API allows allocators to expose the available memory heaps to external layers that need to make decisions based on the characteristics of the underlying allocator.

The update to `iree_hal_allocator_query_buffer_compatibility` provides pooling layers the ability to ask implementations to adjust the parameters and allocation size of a request without performing the allocation. A pooling layer that was trying to find an appropriate bucket or virtual addressing layer that needed to query for reservation ranges can take the user params, have the implementation adjust them, and assume that any allocations made would have those exact parameters.

To aid flag/configuration utilities some bitfield parsing has been added for HAL memory types that can be extended to all enums in the future.