### PR TITLE
Fixing runtime flag string lists to not grow exponentially.

### DIFF
--- a/runtime/src/iree/base/internal/flags_test.txt
+++ b/runtime/src/iree/base/internal/flags_test.txt
@@ -74,6 +74,12 @@
 // FLAG-LIST-1: FLAG[test_strings] = 1: a
 // RUN: ( flags_demo --test_strings=a --test_strings=b ) | FileCheck --check-prefix=FLAG-LIST-2 %s
 // FLAG-LIST-2: FLAG[test_strings] = 2: a, b
+// RUN: ( flags_demo --test_strings=a --test_strings=b --test_strings=c ) | FileCheck --check-prefix=FLAG-LIST-3 %s
+// FLAG-LIST-3: FLAG[test_strings] = 3: a, b, c
+// RUN: ( flags_demo --test_strings=a --test_strings=b --test_strings=c --test_strings=d ) | FileCheck --check-prefix=FLAG-LIST-4 %s
+// FLAG-LIST-4: FLAG[test_strings] = 4: a, b, c, d
+// RUN: ( flags_demo --test_strings=a --test_strings=b --test_strings=c --test_strings=d --test_strings=e ) | FileCheck --check-prefix=FLAG-LIST-5 %s
+// FLAG-LIST-5: FLAG[test_strings] = 5: a, b, c, d, e
 
 // RUN: ( flags_demo arg1 ) | FileCheck --check-prefix=FLAG-POSITIONAL-1 %s
 // FLAG-POSITIONAL-1: ARG(1) = arg1

--- a/tests/transform_dialect/cpu/matmul.mlir
+++ b/tests/transform_dialect/cpu/matmul.mlir
@@ -64,7 +64,7 @@ func.func @matmul_static(
 // RUN: iree-run-module --entry_function=matmul_static \
 // RUN:   --function_input="3x5xf32=1" \
 // RUN:   --function_input="5x3xf32=2" \
-// RUN:   --function_input="3x3xf32=42"| \
+// RUN:   --function_input="3x3xf32=42" | \
 // RUN: FileCheck %s --check-prefixes=EXEC
 
 // EXEC: 3x3xf32=[52 52 52][52 52 52][52 52 52]


### PR DESCRIPTION
Not noticable when there's a handful of repeated flags but when there are 100+ things get sad.