### PR TITLE
fix bad stride in pack_benchmark

### DIFF
--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -109,7 +109,7 @@ static iree_status_t iree_pack_benchmark(
   }
   params.in_size0 = iree_max(0, out_size0 * out_size2 - FLAG_padding_size);
   params.in_size1 = iree_max(0, out_size1 * out_size3 - FLAG_padding_size);
-  params.in_stride0 = out_size0 * out_size2;
+  params.in_stride0 = params.in_size1;
   params.out_stride0 = params.out_size1 * params.out_size2 * params.out_size3;
   iree_uk_ssize_t in_buffer_size = iree_uk_test_2d_buffer_length(
       in_type, params.in_size0, params.in_stride0);


### PR DESCRIPTION
Fixes #12008
Regression introduced in #11987

I had tweaked the strides in the benchmark as I thought for a moment that it was more realistic to benchmark round (power of two) strides even when padding makes sizes a little smaller. But now I'm not so sure anymore what's the more important case in practice, so this just reverts to the old state.

The crash was because instead of the correct ` out_size1 * out_size3` (value for `in_size1` before adjustment for padding) I had incorrectly typed `out_size0 * out_size2`.
