### PR TITLE
Fix warning spew related to default value of `useFolderAPI` being `kEmitRawAttributeFolder`.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.td
@@ -37,6 +37,7 @@ def IREECodegen_Dialect : Dialect {
     void initializeCodegenAttrs();
   }];
   let useDefaultAttributePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 #endif // IREE_CODEGEN_DIALECT_IREECODEGEN_DIALECT

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/Input/InputBase.td
@@ -28,6 +28,7 @@ def IREEInput_Dialect : Dialect {
   }];
   let cppNamespace = "::mlir::iree_compiler::IREE::Input";
   let useDefaultTypePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 class IREEInput_Op<string mnemonic, list<Trait> traits = []> :

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtBase.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/IR/LinalgExtBase.td
@@ -24,6 +24,7 @@ def IREELinalgExt_Dialect : Dialect {
   }];
   let hasCanonicalizer = 1;
   let useDefaultAttributePrinterParser = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/LinalgExtOps.cpp
@@ -1085,8 +1085,7 @@ LogicalResult ScanOp::getResultTilePosition(
   return failure();
 }
 
-LogicalResult ScanOp::fold(ArrayRef<Attribute>,
-                           SmallVectorImpl<OpFoldResult> &) {
+LogicalResult ScanOp::fold(FoldAdaptor, SmallVectorImpl<OpFoldResult> &) {
   return memref::foldMemRefCast(*this);
 }
 
@@ -2583,7 +2582,7 @@ LogicalResult WinogradInputTransformOp::getResultTilePosition(
   return failure();
 }
 
-LogicalResult WinogradInputTransformOp::fold(ArrayRef<Attribute>,
+LogicalResult WinogradInputTransformOp::fold(FoldAdaptor,
                                              SmallVectorImpl<OpFoldResult> &) {
   return memref::foldMemRefCast(*this);
 }
@@ -2745,7 +2744,7 @@ LogicalResult WinogradOutputTransformOp::getResultTilePosition(
   return failure();
 }
 
-LogicalResult WinogradOutputTransformOp::fold(ArrayRef<Attribute>,
+LogicalResult WinogradOutputTransformOp::fold(FoldAdaptor,
                                               SmallVectorImpl<OpFoldResult> &) {
   return memref::foldMemRefCast(*this);
 }
@@ -2834,8 +2833,7 @@ LogicalResult SoftmaxOp::getResultTilePosition(
   return failure();
 }
 
-LogicalResult SoftmaxOp::fold(ArrayRef<Attribute>,
-                              SmallVectorImpl<OpFoldResult> &) {
+LogicalResult SoftmaxOp::fold(FoldAdaptor, SmallVectorImpl<OpFoldResult> &) {
   return memref::foldMemRefCast(*this);
 }
 
@@ -2959,8 +2957,7 @@ LogicalResult AttentionOp::getResultTilePosition(
   return failure();
 }
 
-LogicalResult AttentionOp::fold(ArrayRef<Attribute>,
-                                SmallVectorImpl<OpFoldResult> &) {
+LogicalResult AttentionOp::fold(FoldAdaptor, SmallVectorImpl<OpFoldResult> &) {
   return memref::foldMemRefCast(*this);
 }
 

--- a/third_party/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorBase.td
+++ b/third_party/torch-mlir-dialects/include/torch-mlir-dialects/Dialect/TMTensor/IR/TMTensorBase.td
@@ -43,6 +43,7 @@ def TMTensor_Dialect : Dialect {
     to.
   }];
   let hasCanonicalizer = 1;
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorOps.cpp
+++ b/third_party/torch-mlir-dialects/lib/Dialect/TMTensor/IR/TMTensorOps.cpp
@@ -250,7 +250,7 @@ static LogicalResult foldMemRefCast(Operation *op) {
   return success(folded);
 }
 
-LogicalResult ScanOp::fold(ArrayRef<Attribute>,
+LogicalResult ScanOp::fold(FoldAdaptor,
                            SmallVectorImpl<OpFoldResult> &) {
   return foldMemRefCast(*this);
 }


### PR DESCRIPTION
This fixes issues in LinalgExt and TM_Tensor. Other warnings currently are from MHLO repo.