### PR TITLE
Add `--output=` flag to iree-run-module/iree-run-mlir.

### DIFF
--- a/runtime/src/iree/tooling/vm_util.h
+++ b/runtime/src/iree/tooling/vm_util.h
@@ -49,13 +49,24 @@ iree_status_t iree_tooling_append_async_fence_inputs(
 // described in
 // https://github.com/iree-org/iree/tree/main/iree/hal/api.h
 iree_status_t iree_tooling_append_variant_list_lines(
-    iree_vm_list_t* variant_list, size_t max_element_count,
+    iree_vm_list_t* list, iree_host_size_t max_element_count,
     iree_string_builder_t* builder);
 
 // Prints a variant list to a file.
-iree_status_t iree_tooling_variant_list_fprint(iree_vm_list_t* variant_list,
-                                               size_t max_element_count,
-                                               FILE* file);
+iree_status_t iree_tooling_variant_list_fprint(
+    iree_vm_list_t* list, iree_host_size_t max_element_count, FILE* file);
+
+// Prints a variant |list| to targets based on the provided |output_strings|.
+//
+// |output_strings| format:
+//   (empty): ignore output
+//   `-`: print textual form to |file|
+//   `@file.npy`: create/overwrite a numpy .npy file.
+//   `+file.npy': create/append a numpy .npy file.
+iree_status_t iree_tooling_output_variant_list(
+    iree_vm_list_t* list, const iree_string_view_t* output_strings,
+    iree_host_size_t output_strings_count, iree_host_size_t max_element_count,
+    FILE* file);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/samples/simple_embedding/simple_embedding_test.mlir
+++ b/samples/simple_embedding/simple_embedding_test.mlir
@@ -1,4 +1,4 @@
-func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> tensor<4xf32> {
+func.func @simple_mul(%arg0: tensor<4xf32>, %arg1: tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>) {
   %0 = arith.mulf %arg0, %arg1 : tensor<4xf32>
-  return %0 : tensor<4xf32>
+  return %0, %arg0 : tensor<4xf32>, tensor<4xf32>
 }

--- a/tools/iree-run-mlir-main.cc
+++ b/tools/iree-run-mlir-main.cc
@@ -140,17 +140,50 @@ static llvm::cl::list<std::string> run_args_flag{
 
 IREE_FLAG_LIST(
     string, input,
-    "An input value or buffer of the format:\n"
-    "  [shape]xtype=[value]\n"
-    "  2x2xi32=1 2 3 4\n"
+    "An input (a) value or (b) buffer of the format:\n"
+    "  (a) scalar value\n"
+    "     value\n"
+    "     e.g.: --input=\"3.14\"\n"
+    "  (b) buffer:\n"
+    "     [shape]xtype=[value]\n"
+    "     e.g.: --input=\"2x2xi32=1 2 3 4\"\n"
     "Optionally, brackets may be used to separate the element values:\n"
     "  2x2xi32=[[1 2][3 4]]\n"
     "Raw binary files can be read to provide buffer contents:\n"
     "  2x2xi32=@some/file.bin\n"
-    "numpy npy files (from numpy.save) can be read to provide 1+ values:\n"
+    "\n"
+    "Numpy npy files from numpy.save can be read to provide 1+ values:\n"
     "  @some.npy\n"
+    "\n"
     "Each occurrence of the flag indicates an input in the order they were\n"
     "specified on the command line.");
+
+IREE_FLAG_LIST(
+    string, output,
+    "Specifies how to handle an output from the invocation:\n"
+    "  `` (empty): ignore output\n"
+    "     e.g.: --output=\n"
+    "  `-`: print textual form to stdout\n"
+    "     e.g.: --output=-\n"
+    "  `@file.npy`: create/overwrite a numpy npy file and write buffer view\n"
+    "     e.g.: --output=@file.npy\n"
+    "  `+file.npy`: create/append a numpy npy file and write buffer view\n"
+    "     e.g.: --output=+file.npy\n"
+    "\n"
+    "Numpy npy files can be read in Python using numpy.load, for example an\n"
+    "invocation producing two outputs can be concatenated as:\n"
+    "    --output=@file.npy --output=+file.npy\n"
+    "And then loaded in Python by reading from the same file:\n"
+    "  with open('file.npy', 'rb') as f:\n"
+    "    print(numpy.load(f))\n"
+    "    print(numpy.load(f))\n"
+    "\n"
+    "Each occurrence of the flag indicates an output in the order they were\n"
+    "specified on the command line.");
+
+IREE_FLAG(int32_t, output_max_element_count, 1024,
+          "Prints up to the maximum number of elements of output tensors, "
+          "eliding the remainder.");
 
 namespace iree {
 namespace {
@@ -347,8 +380,19 @@ Status EvaluateFunction(iree_vm_context_t* context, iree_hal_device_t* device,
   }
 
   // Print outputs.
-  IREE_RETURN_IF_ERROR(iree_tooling_variant_list_fprint(
-      outputs.get(), /*max_element_count=*/1024, stdout));
+  if (FLAG_output_list().count == 0) {
+    IREE_RETURN_IF_ERROR(
+        iree_tooling_variant_list_fprint(
+            outputs.get(), (iree_host_size_t)FLAG_output_max_element_count,
+            stdout),
+        "printing results");
+  } else {
+    IREE_RETURN_IF_ERROR(
+        iree_tooling_output_variant_list(
+            outputs.get(), FLAG_output_list().values, FLAG_output_list().count,
+            (iree_host_size_t)FLAG_output_max_element_count, stdout),
+        "outputting results");
+  }
 
   return OkStatus();
 }

--- a/tools/iree-run-module-main.cc
+++ b/tools/iree-run-module-main.cc
@@ -27,10 +27,6 @@ IREE_FLAG(string, function, "",
           "Name of a function contained in the module specified by --module= "
           "to run.");
 
-IREE_FLAG(int32_t, print_max_element_count, 1024,
-          "Prints up to the maximum number of elements of output tensors, "
-          "eliding the remainder.");
-
 IREE_FLAG(bool, print_statistics, false,
           "Prints runtime statistics to stderr on exit.");
 
@@ -47,9 +43,34 @@ IREE_FLAG_LIST(
     "  2x2xi32=[[1 2][3 4]]\n"
     "Raw binary files can be read to provide buffer contents:\n"
     "  2x2xi32=@some/file.bin\n"
-    "numpy npy files (from numpy.save) can be read to provide 1+ values:\n"
+    "\n"
+    "Numpy npy files from numpy.save can be read to provide 1+ values:\n"
     "  @some.npy\n"
+    "\n"
     "Each occurrence of the flag indicates an input in the order they were\n"
+    "specified on the command line.");
+
+IREE_FLAG_LIST(
+    string, output,
+    "Specifies how to handle an output from the invocation:\n"
+    "  `` (empty): ignore output\n"
+    "     e.g.: --output=\n"
+    "  `-`: print textual form to stdout\n"
+    "     e.g.: --output=-\n"
+    "  `@file.npy`: create/overwrite a numpy npy file and write buffer view\n"
+    "     e.g.: --output=@file.npy\n"
+    "  `+file.npy`: create/append a numpy npy file and write buffer view\n"
+    "     e.g.: --output=+file.npy\n"
+    "\n"
+    "Numpy npy files can be read in Python using numpy.load, for example an\n"
+    "invocation producing two outputs can be concatenated as:\n"
+    "    --output=@file.npy --output=+file.npy\n"
+    "And then loaded in Python by reading from the same file:\n"
+    "  with open('file.npy', 'rb') as f:\n"
+    "    print(numpy.load(f))\n"
+    "    print(numpy.load(f))\n"
+    "\n"
+    "Each occurrence of the flag indicates an output in the order they were\n"
     "specified on the command line.");
 
 IREE_FLAG_LIST(string, expected_output,
@@ -58,6 +79,10 @@ IREE_FLAG_LIST(string, expected_output,
                "invocation will be compared against these values and the "
                "tool will return non-zero if any differ. If the value of a "
                "particular output is not of interest provide `(ignored)`.");
+
+IREE_FLAG(int32_t, output_max_element_count, 1024,
+          "Prints up to the maximum number of elements of output tensors, "
+          "eliding the remainder.");
 
 namespace iree {
 namespace {
@@ -129,10 +154,20 @@ iree_status_t Run(int* out_exit_code) {
   IREE_RETURN_IF_ERROR(iree_hal_end_profiling_from_flags(device.get()));
 
   if (FLAG_expected_output_list().count == 0) {
-    IREE_RETURN_IF_ERROR(
-        iree_tooling_variant_list_fprint(
-            outputs.get(), (size_t)FLAG_print_max_element_count, stdout),
-        "printing results");
+    if (FLAG_output_list().count == 0) {
+      IREE_RETURN_IF_ERROR(
+          iree_tooling_variant_list_fprint(
+              outputs.get(), (iree_host_size_t)FLAG_output_max_element_count,
+              stdout),
+          "printing results");
+    } else {
+      IREE_RETURN_IF_ERROR(
+          iree_tooling_output_variant_list(
+              outputs.get(), FLAG_output_list().values,
+              FLAG_output_list().count,
+              (iree_host_size_t)FLAG_output_max_element_count, stdout),
+          "outputting results");
+    }
   } else {
     // Parse expected list into host-local memory that we can easily access.
     // Note that we return a status here as this can fail on user inputs.

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -24,6 +24,7 @@ iree_lit_test_suite(
             "iree-run-mlir.mlir",
             "iree-run-module.mlir",
             "iree-run-module-expected.mlir",
+            "iree-run-module-outputs.mlir",
             "multiple_args.mlir",
             "multiple_exported_functions.mlir",
             "null_values.mlir",
@@ -33,6 +34,9 @@ iree_lit_test_suite(
         include = ["*.mlir"],
     ),
     cfg = "//tools:lit.cfg.py",
+    data = [
+        "echo_npy.py",
+    ],
     tags = [
         "driver=local-task",
         "driver=vulkan",

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     "iree-benchmark-module.mlir"
     "iree-run-mlir.mlir"
     "iree-run-module-expected.mlir"
+    "iree-run-module-outputs.mlir"
     "iree-run-module.mlir"
     "multiple_args.mlir"
     "multiple_exported_functions.mlir"
@@ -33,6 +34,8 @@ iree_lit_test_suite(
     iree-run-mlir
     iree-run-module
     not
+  DATA
+    echo_npy.py
   LABELS
     "driver=local-task"
     "driver=vulkan"

--- a/tools/test/echo_npy.py
+++ b/tools/test/echo_npy.py
@@ -1,0 +1,16 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import numpy
+import os
+import sys
+
+with open(os.path.realpath(sys.argv[1]), 'rb') as f:
+  f.seek(0, 2)
+  file_len = f.tell()
+  f.seek(0, 0)
+  while f.tell() < file_len:
+    print(numpy.load(f))

--- a/tools/test/iree-run-module-outputs.mlir
+++ b/tools/test/iree-run-module-outputs.mlir
@@ -1,0 +1,53 @@
+// Tests that execution providing no outputs is ok.
+
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
+// RUN:  iree-run-module --device=local-sync --function=no_output) | \
+// RUN: FileCheck --check-prefix=NO-OUTPUT %s
+// NO-OUTPUT-LABEL: EXEC @no_output
+func.func @no_output() {
+  return
+}
+
+// -----
+
+// Tests the default output printing to stdout.
+
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
+// RUN:  iree-run-module --device=local-sync --function=default) | \
+// RUN: FileCheck --check-prefix=OUTPUT-DEFAULT %s
+// OUTPUT-DEFAULT-LABEL: EXEC @default
+func.func @default() -> (i32, tensor<f32>, tensor<?x4xi32>) {
+  // OUTPUT-DEFAULT: result[0]: i32=123
+  %0 = arith.constant 123 : i32
+  // OUTPUT-DEFAULT: result[1]: hal.buffer_view
+  // OUTPUT-DEFAULT-NEXT: f32=4
+  %1 = arith.constant dense<4.0> : tensor<f32>
+  // OUTPUT-DEFAULT: result[2]: hal.buffer_view
+  // OUTPUT-DEFAULT-NEXT: 2x4xi32=[0 1 2 3][4 5 6 7]
+  %2 = flow.tensor.constant dense<[[0,1,2,3],[4,5,6,7]]> : tensor<2x4xi32> -> tensor<?x4xi32>
+  return %0, %1, %2 : i32, tensor<f32>, tensor<?x4xi32>
+}
+
+// -----
+
+// Tests explicit output to npy files by producing a concatenated .npy and then
+// printing the results in python. This also verifies our npy files can be
+// parsed by numpy.
+
+// RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
+// RUN:  iree-run-module --device=local-sync --function=numpy \
+// RUN:                  --output= \
+// RUN:                  --output=@%t \
+// RUN:                  --output=+%t) && \
+// RUN:  python3 %S/echo_npy.py %t | \
+// RUN: FileCheck --check-prefix=OUTPUT-NUMPY %s
+func.func @numpy() -> (i32, tensor<f32>, tensor<?x4xi32>) {
+  // Output skipped:
+  %0 = arith.constant 123 : i32
+  // OUTPUT-NUMPY{LITERAL}: 4.0
+  %1 = arith.constant dense<4.0> : tensor<f32>
+  // OUTPUT-NUMPY-NEXT{LITERAL}: [[0 1 2 3]
+  // OUTPUT-NUMPY-NEXT{LITERAL}:  [4 5 6 7]]
+  %2 = flow.tensor.constant dense<[[0,1,2,3],[4,5,6,7]]> : tensor<2x4xi32> -> tensor<?x4xi32>
+  return %0, %1, %2 : i32, tensor<f32>, tensor<?x4xi32>
+}


### PR DESCRIPTION
This allows for ignoring outputs, routing them to stdout, or writing them to numpy .npy files that can be easily loaded in python.

Example writing two outputs to an npy file:
`iree-run-module ... --output=@file.npy --output=+file.npy`
```py
with open('file.npy', 'rb') as f:
  print(numpy.load(f))
  print(numpy.load(f))
```

The `@` sigil will create/overwrite a file while the `+` sigil will create/append. This allows for multiple outputs to route to the same file even across runs (so you could run several times and accumulate the results in a single npy to process later). Shorthand for writing all outputs to an npy would be useful but is not yet implemented. We can extend this in many ways in the future by supporting binary payload writing (ala `--input=2xf32=@file.bin`), merging functionality with the `--expected_output=` flags, etc. For now this is better than users trying to string parse stdout, though :)

Progress on #9462 (still need to rename/clean up vm_util).