### PR TITLE
Add E2E MNIST training test

### DIFF
--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -30,10 +30,16 @@ iree_py_test(
     "requires-gpu-nvidia"
     "driver=cuda"
 )
+
+# Mark the CUDA test as WILL_FAIL if it was defined.
 iree_package_path(PKG_PATH)
-set_tests_properties(
-  ${PKG_PATH}/mnist_train_test_cuda
-  PROPERTIES WILL_FAIL TRUE)
+set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
+get_directory_property(TESTS_LIST TESTS)
+if(${CUDA_TEST_NAME} IN_LIST TESTS_LIST)
+  set_tests_properties(
+    ${CUDA_TEST_NAME}
+    PROPERTIES WILL_FAIL TRUE)
+endif()
 
 iree_py_test(
   NAME

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -32,6 +32,7 @@ iree_py_test(
 )
 
 # Mark the CUDA test as WILL_FAIL if it was defined.
+# TODO(#13007): Thread this through the test rule instead of custom logic.
 iree_package_path(PKG_PATH)
 set(CUDA_TEST_NAME ${PKG_PATH}/mnist_train_test_cuda)
 get_directory_property(TESTS_LIST TESTS)

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+iree_py_test(
+  NAME
+    mnist_train_test_cpu
+  SRCS
+    "mnist_train_test.py"
+  ARGS
+    "--target_backend=llvm-cpu"
+    "--driver=local-task"
+  LABELS
+    "driver=local-task"
+)
+
+iree_py_test(
+  NAME
+    mnist_train_test_cuda
+  SRCS
+    "mnist_train_test.py"
+  ARGS
+    "--target_backend=cuda"
+    "--driver=cuda"
+  LABELS
+    "requires-gpu-nvidia"
+    "driver=cuda"
+)
+
+iree_py_test(
+  NAME
+    mnist_train_test_vulkan
+  SRCS
+    "mnist_train_test.py"
+  ARGS
+    "--target_backend=vulkan-spirv"
+    "--driver=vulkan"
+  LABELS
+    "driver=vulkan"
+)

--- a/tests/e2e/models/mnist_train_test/CMakeLists.txt
+++ b/tests/e2e/models/mnist_train_test/CMakeLists.txt
@@ -4,6 +4,8 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+include(iree_macros)
+
 iree_py_test(
   NAME
     mnist_train_test_cpu
@@ -28,6 +30,10 @@ iree_py_test(
     "requires-gpu-nvidia"
     "driver=cuda"
 )
+iree_package_path(PKG_PATH)
+set_tests_properties(
+  ${PKG_PATH}/mnist_train_test_cuda
+  PROPERTIES WILL_FAIL TRUE)
 
 iree_py_test(
   NAME

--- a/tests/e2e/models/mnist_train_test/README.md
+++ b/tests/e2e/models/mnist_train_test/README.md
@@ -1,0 +1,25 @@
+Test that IREE has the correct model and optimizer state after doing one train
+step and after initialization of parameters. The ground truth is extracted from
+a JAX model. The MLIR model is generated with IREE JAX.
+
+To regenerate the model together with the test data use
+
+```shell
+python -m venv generate_mnist.venv
+source generate_mnist.venv/bin/activate
+# Add IREE Python to your PYTHONPATH, following
+# https://iree-org.github.io/iree/building-from-source/python-bindings-and-importers
+pip install -r generate_test_data_requirements.txt
+python ./generate_test_data.py
+```
+
+Upload to gcs
+
+```shell
+tar --remove-files -v -c -f mnist_train.tar *.npz *.mlirbc
+DIGEST="$(sha256sum mnist_train.tar | awk '{print $1}')"
+gcloud storage mv mnist_train.tar "gs://iree-model-artifacts/mnist_train.${DIGEST}.tar"
+sed -i \
+  "s|MODEL_ARTIFACTS_URL =.*|MODEL_ARTIFACTS_URL = \"https://storage.googleapis.com/iree-model-artifacts/mnist_train.${DIGEST}.tar\"|" \
+  mnist_train_test.py
+```

--- a/tests/e2e/models/mnist_train_test/datasets.py
+++ b/tests/e2e/models/mnist_train_test/datasets.py
@@ -1,0 +1,84 @@
+# Copyright 2018 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Datasets used in examples."""
+
+import array
+import gzip
+import os
+from os import path
+import struct
+import urllib.request
+
+import numpy as np
+
+_DATA = "/tmp/jax_example_data/"
+
+
+def _download(url, filename):
+  """Download a url to a file in the JAX data temp directory."""
+  if not path.exists(_DATA):
+    os.makedirs(_DATA)
+  out_file = path.join(_DATA, filename)
+  if not path.isfile(out_file):
+    urllib.request.urlretrieve(url, out_file)
+    print("downloaded {} to {}".format(url, _DATA))
+
+
+def _partial_flatten(x):
+  """Flatten all but the first dimension of an ndarray."""
+  return np.reshape(x, (x.shape[0], -1))
+
+
+def _one_hot(x, k, dtype=np.float32):
+  """Create a one-hot encoding of x of size k."""
+  return np.array(x[:, None] == np.arange(k), dtype)
+
+
+def mnist_raw():
+  """Download and parse the raw MNIST dataset."""
+  # CVDF mirror of http://yann.lecun.com/exdb/mnist/
+  base_url = "https://storage.googleapis.com/cvdf-datasets/mnist/"
+
+  def parse_labels(filename):
+    with gzip.open(filename, "rb") as fh:
+      _ = struct.unpack(">II", fh.read(8))
+      return np.array(array.array("B", fh.read()), dtype=np.uint8)
+
+  def parse_images(filename):
+    with gzip.open(filename, "rb") as fh:
+      _, num_data, rows, cols = struct.unpack(">IIII", fh.read(16))
+      return np.array(array.array("B", fh.read()),
+                      dtype=np.uint8).reshape(num_data, rows, cols)
+
+  for filename in [
+      "train-images-idx3-ubyte.gz", "train-labels-idx1-ubyte.gz",
+      "t10k-images-idx3-ubyte.gz", "t10k-labels-idx1-ubyte.gz"
+  ]:
+    _download(base_url + filename, filename)
+
+  train_images = parse_images(path.join(_DATA, "train-images-idx3-ubyte.gz"))
+  train_labels = parse_labels(path.join(_DATA, "train-labels-idx1-ubyte.gz"))
+  test_images = parse_images(path.join(_DATA, "t10k-images-idx3-ubyte.gz"))
+  test_labels = parse_labels(path.join(_DATA, "t10k-labels-idx1-ubyte.gz"))
+
+  return train_images, train_labels, test_images, test_labels
+
+
+def mnist(permute_train=False):
+  """Download, parse and process MNIST data to unit scale and one-hot labels."""
+  train_images, train_labels, test_images, test_labels = mnist_raw()
+
+  train_images = _partial_flatten(train_images) / np.float32(255.)
+  test_images = _partial_flatten(test_images) / np.float32(255.)
+  train_labels = _one_hot(train_labels, 10)
+  test_labels = _one_hot(test_labels, 10)
+
+  if permute_train:
+    perm = np.random.RandomState(0).permutation(train_images.shape[0])
+    train_images = train_images[perm]
+    train_labels = train_labels[perm]
+
+  return train_images, train_labels, test_images, test_labels

--- a/tests/e2e/models/mnist_train_test/generate_test_data.py
+++ b/tests/e2e/models/mnist_train_test/generate_test_data.py
@@ -1,0 +1,211 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import jax
+import numpy.random as npr
+import datasets
+import jax.core
+import jax.numpy as jnp
+from jax import grad, random
+from jax.example_libraries import optimizers, stax
+from jax.example_libraries.stax import Dense, Relu, LogSoftmax
+from jax.tree_util import tree_flatten
+from iree.jax import (
+    like,
+    kernel,
+    Program,
+)
+import numpy as np
+import argparse
+
+
+def get_example_batch():
+  batch_size = 128
+  train_images, train_labels, _, _ = datasets.mnist()
+  num_train = train_images.shape[0]
+  num_complete_batches, leftover = divmod(num_train, batch_size)
+  num_batches = num_complete_batches + bool(leftover)
+
+  def data_stream():
+    rng = npr.RandomState(0)
+    while True:
+      perm = rng.permutation(num_train)
+      for i in range(num_batches):
+        batch_idx = perm[i * batch_size:(i + 1) * batch_size]
+        yield train_images[batch_idx], train_labels[batch_idx]
+
+  batches = data_stream()
+  return next(batches)
+
+
+def get_model():
+  init_random_params, predict = stax.serial(
+      Dense(128),
+      Relu,
+      Dense(128),
+      Relu,
+      Dense(10),
+      LogSoftmax,
+  )
+  return init_random_params, predict
+
+
+def loss(params, batch, predict_fn):
+  inputs, targets = batch
+  preds = predict_fn(params, inputs)
+  return -jnp.mean(jnp.sum(preds * targets, axis=1))
+
+
+def create_iree_jax_module():
+  init_random_params, forward = get_model()
+
+  rng = random.PRNGKey(12345)
+  _, init_params = init_random_params(rng, (-1, 28 * 28))
+  opt_init, opt_update, opt_get_params = optimizers.momentum(0.001, mass=0.9)
+  opt_state = opt_init(init_params)
+
+  example_batch = get_example_batch()
+
+  class IreeJaxMnistModule(Program):
+    _opt_state = opt_state
+
+    def get_params(self):
+      return opt_get_params(self._opt_state)
+
+    def get_opt_state(self):
+      return self._opt_state
+
+    def set_opt_state(self, new_opt_state=like(opt_state)):
+      self._opt_state = new_opt_state
+
+    def initialize(self, rng=like(rng)):
+      self._opt_state = self._initialize_optimizer(rng)
+
+    def update(self, batch=like(example_batch)):
+      new_opt_state = self._update_step(batch, self._opt_state)
+      self._opt_state = new_opt_state
+
+    def forward(self, inputs=like(example_batch[0])):
+      return self._forward(opt_get_params(self._opt_state), inputs)
+
+    @kernel
+    def _initialize_optimizer(rng):
+      _, init_params = init_random_params(rng, (-1, 28 * 28))
+      return opt_init(init_params)
+
+    @kernel
+    def _update_step(batch, opt_state):
+      params = opt_get_params(opt_state)
+      return opt_update(0, grad(loss)(params, batch, forward), opt_state)
+
+    @kernel
+    def _forward(params, inputs):
+      return forward(params, inputs)
+
+  return IreeJaxMnistModule()
+
+
+def build_mlir_module(output_filepath):
+  module = create_iree_jax_module()
+  with open(output_filepath, "wb") as f:
+    Program.get_mlir_module(module).operation.write_bytecode(f)
+
+
+def build_jax_module():
+  init_random_params, forward = get_model()
+
+  rng = random.PRNGKey(12345)
+  _, init_params = init_random_params(rng, (-1, 28 * 28))
+  opt_init, opt_update, opt_get_params = optimizers.momentum(0.001, mass=0.9)
+  opt_state = opt_init(init_params)
+
+  example_batch = get_example_batch()
+
+  class JaxMnistModule:
+    _opt_state = opt_state
+
+    def get_params(self):
+      return opt_get_params(self._opt_state)
+
+    def get_opt_state(self):
+      return self._opt_state
+
+    def set_opt_state(self, new_opt_state):
+      self._opt_state = new_opt_state
+
+    def initialize(self, rng):
+      self._opt_state = JaxMnistModule._initialize_optimizer(rng)
+
+    def update(self, batch):
+      new_opt_state = JaxMnistModule._update_step(batch, self._opt_state)
+      self._opt_state = new_opt_state
+
+    def forward(self, inputs):
+      return JaxMnistModule._forward(opt_get_params(self._opt_state), inputs)
+
+    @jax.jit
+    def _initialize_optimizer(rng):
+      _, init_params = init_random_params(rng, (-1, 28 * 28))
+      return opt_init(init_params)
+
+    @jax.jit
+    def _update_step(batch, opt_state):
+      params = opt_get_params(opt_state)
+      return opt_update(0, grad(loss)(params, batch, forward), opt_state)
+
+    @jax.jit
+    def _forward(params, inputs):
+      return forward(params, inputs)
+
+  return JaxMnistModule()
+
+
+def generate_test_data(output_mlir_filepath: str, batch_filepath: str,
+                       expected_optimizer_state_after_init_filepath: str,
+                       expected_optimizer_state_after_train_step_filepath: str,
+                       expected_prediction_after_train_step_filepath: str):
+  build_mlir_module(output_mlir_filepath)
+  example_batch = get_example_batch()
+  np.savez_compressed(batch_filepath, *example_batch)
+  jax_module = build_jax_module()
+  jax_module.update(example_batch)
+  np.savez_compressed(expected_optimizer_state_after_train_step_filepath,
+                      *tree_flatten(jax_module.get_opt_state())[0])
+  prediction_jax = jax_module.forward(example_batch[0])
+  np.savez_compressed(expected_prediction_after_train_step_filepath,
+                      prediction_jax)
+  rng = random.PRNGKey(6789)
+  jax_module.initialize(rng)
+  np.savez_compressed(expected_optimizer_state_after_init_filepath,
+                      *tree_flatten(jax_module.get_opt_state())[0])
+
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--output_mlir_filepath",
+                      help="Output to the compiled IREE Jax MLIR model.",
+                      type=str,
+                      default="mnist_train.mlirbc")
+  parser.add_argument("--batch_filepath", type=str, default="batch.npz")
+  parser.add_argument("--expected_optimizer_state_after_init_filepath",
+                      type=str,
+                      default="expected_optimizer_state_after_init.npz")
+  parser.add_argument("--expected_optimizer_state_after_train_step_filepath",
+                      type=str,
+                      default="expected_optimizer_state_after_train_step.npz")
+  parser.add_argument("--expected_prediction_after_train_step_filepath",
+                      type=str,
+                      default="expected_prediction_after_train_step.npz")
+  return parser.parse_args()
+
+
+def generate_test_data_cli():
+  kwargs = vars(parse_args())
+  generate_test_data(**kwargs)
+
+
+if __name__ == "__main__":
+  generate_test_data_cli()

--- a/tests/e2e/models/mnist_train_test/generate_test_data_requirements.txt
+++ b/tests/e2e/models/mnist_train_test/generate_test_data_requirements.txt
@@ -1,0 +1,4 @@
+--find-links https://iree-org.github.io/iree/pip-release-links.html
+git+https://github.com/iree-org/iree-jax@26006ef5842a604e28ea71e65e9224ad20f028e9#egg=iree-jax
+jax==0.4.2
+numpy==1.24.2

--- a/tests/e2e/models/mnist_train_test/mnist_train_test.py
+++ b/tests/e2e/models/mnist_train_test/mnist_train_test.py
@@ -25,8 +25,7 @@ Tensor = TypeVar('Tensor')
 
 def build_module(artifacts_dir: str):
   vmfb_file = os.path.join(artifacts_dir, "mnist_train.vmfb")
-  compile_file(input_file=os.path.join(
-      artifacts_dir, "tests/e2e/models/mnist_train_test/mnist_train.mlirbc"),
+  compile_file(input_file=os.path.join(artifacts_dir, "mnist_train.mlirbc"),
                output_file=vmfb_file,
                target_backends=[args.target_backend],
                input_type=InputType.MHLO)
@@ -107,7 +106,7 @@ class MnistTrainTest(unittest.TestCase):
           expected_optimizer_state_after_init,
           expected_optimizer_state_after_train_step,
           expected_prediction_after_train_step,
-      ) = load_data(os.path.join(tmp_dir, "tests/e2e/models/mnist_train_test"))
+      ) = load_data(tmp_dir)
 
     module.update(*batch)
     assert_array_list_allclose(module.get_opt_state(),

--- a/tests/e2e/models/mnist_train_test/mnist_train_test.py
+++ b/tests/e2e/models/mnist_train_test/mnist_train_test.py
@@ -1,0 +1,126 @@
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import argparse
+import os
+import sys
+import tarfile
+import tempfile
+import unittest
+from typing import List, TypeVar
+from urllib.request import urlretrieve
+
+import numpy as np
+
+from iree.compiler.tools import InputType, compile_file
+from iree.runtime import load_vm_flatbuffer_file
+
+MODEL_ARTIFACTS_URL = "https://storage.googleapis.com/iree-model-artifacts/mnist_train.a49ba1535a45ac0f3e6be22a7ed5dddf4a53cd1f41126af938f0667b998f8e11.tar"
+
+Tensor = TypeVar('Tensor')
+
+
+def build_module(artifacts_dir: str):
+  vmfb_file = os.path.join(artifacts_dir, "mnist_train.vmfb")
+  compile_file(input_file=os.path.join(
+      artifacts_dir, "tests/e2e/models/mnist_train_test/mnist_train.mlirbc"),
+               output_file=vmfb_file,
+               target_backends=[args.target_backend],
+               input_type=InputType.MHLO)
+  return load_vm_flatbuffer_file(vmfb_file, driver=args.driver)
+
+
+def load_data(data_dir: str):
+  batch = list(np.load(os.path.join(data_dir, "batch.npz")).values())
+  expected_optimizer_state_after_init = list(
+      np.load(os.path.join(data_dir,
+                           "expected_optimizer_state_after_init.npz")).values())
+  expected_optimizer_state_after_train_step = list(
+      np.load(
+          os.path.join(
+              data_dir,
+              "expected_optimizer_state_after_train_step.npz")).values())
+  expected_prediction_after_train_step = list(
+      np.load(os.path.join(
+          data_dir, "expected_prediction_after_train_step.npz")).values())[0]
+  return (
+      batch,
+      expected_optimizer_state_after_init,
+      expected_optimizer_state_after_train_step,
+      expected_prediction_after_train_step,
+  )
+
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--target_backend", type=str, default="llvm-cpu")
+  parser.add_argument("--driver", type=str, default="local-task")
+  return parser.parse_known_args()
+
+
+DEFAULT_REL_TOLERANCE = 1e-5
+DEFAULT_ABS_TOLERANCE = 1e-5
+
+
+def allclose(a: Tensor,
+             b: Tensor,
+             rtol=DEFAULT_REL_TOLERANCE,
+             atol=DEFAULT_ABS_TOLERANCE):
+  return np.allclose(np.asarray(a), np.asarray(b), rtol, atol)
+
+
+def assert_array_list_compare(array_compare_fn, a: Tensor, b: Tensor):
+  assert (len(a) == len(b))
+  for x, y in zip(a, b):
+    np.testing.assert_array_compare(array_compare_fn, x, y)
+
+
+def assert_array_list_allclose(a: List[Tensor],
+                               b: List[Tensor],
+                               rtol=DEFAULT_REL_TOLERANCE,
+                               atol=DEFAULT_ABS_TOLERANCE):
+  assert_array_list_compare(lambda x, y: allclose(x, y, rtol, atol), a, b)
+
+
+def download_test_data(out_path: str):
+  urlretrieve(MODEL_ARTIFACTS_URL, out_path)
+
+
+def extract_test_data(archive_path: str, out_dir: str):
+  with tarfile.open(archive_path) as tar:
+    tar.extractall(out_dir)
+
+
+class MnistTrainTest(unittest.TestCase):
+
+  def test_mnist_training(self):
+    with tempfile.TemporaryDirectory() as tmp_dir:
+      archive_path = os.path.join(tmp_dir, "mnist_train.tar")
+      download_test_data(archive_path)
+      extract_test_data(archive_path, tmp_dir)
+      module = build_module(tmp_dir)
+      (
+          batch,
+          expected_optimizer_state_after_init,
+          expected_optimizer_state_after_train_step,
+          expected_prediction_after_train_step,
+      ) = load_data(os.path.join(tmp_dir, "tests/e2e/models/mnist_train_test"))
+
+    module.update(*batch)
+    assert_array_list_allclose(module.get_opt_state(),
+                               expected_optimizer_state_after_train_step)
+    prediction = module.forward(batch[0])
+    np.testing.assert_allclose(prediction, expected_prediction_after_train_step,
+                               DEFAULT_REL_TOLERANCE, DEFAULT_ABS_TOLERANCE)
+    rng_state = np.array([0, 6789], dtype=np.int32)
+    module.initialize(rng_state)
+    assert_array_list_allclose(module.get_opt_state(),
+                               expected_optimizer_state_after_init)
+
+
+if __name__ == '__main__':
+  args, remaining_args = parse_args()
+  unittest.main(argv=[sys.argv[0]] + remaining_args)


### PR DESCRIPTION
Add a test that verifies the accuracy of performing a training step on an MNIST model. The model was exported using IREE Jax. Along with the test there are some facilities for Python testing that are included to be used by other future tests.

This test reproduces the problem at https://github.com/iree-org/iree/issues/11991 but without the dependency to Jax and IREE Jax.

I am not sure that it is correct to add the model and the expected output data to this source tree. They are 2.5 MB in total.