### PR TITLE
Fix iree_linalg_ext.scatter tiling failure due to static shapes #11877

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -143,8 +143,8 @@ static SmallVector<scf::ForOp> generateTileLoopNest(
     // No loops if tile size is zero. Set offset and size to the loop
     // offset and size.
     if (matchPattern(tileSizeVals[index], m_Zero())) {
-      offsets[index] = lb;
-      sizes[index] = ub;
+      offsets[index] = getAsOpFoldResult(lb);
+      sizes[index] = getAsOpFoldResult(ub);
       continue;
     }
 


### PR DESCRIPTION
During tiling of iree_linalg_ext tiling it is possible for cleanup to only partially determine static shapes due to only partial shape propagation. Guaranteeing that offsets/shapes are used as static values when possible seems to correct the issue.