### PR TITLE
[experiment] Integrate convert to dst style

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -550,7 +550,7 @@ LogicalResult createTensorEquivalenceClasses(func::FuncOp funcOp,
         .Case<scf::ForOp>(
             [&](scf::ForOp forOp) { return analyseScfForOp(forOp, plan); })
         .Case<scf::YieldOp, tensor::EmptyOp, tensor::DimOp, tensor::ExtractOp,
-              tensor::PadOp, bufferization::ToMemrefOp>(
+              tensor::GenerateOp, tensor::PadOp, bufferization::ToMemrefOp>(
             [&](Operation *op) { return success(); })
         .Default([&](Operation *op) -> LogicalResult {
           if (llvm::any_of(op->getOperands(),

--- a/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/IREEComprehensiveBufferizePass.cpp
@@ -155,7 +155,7 @@ LogicalResult eliminateEmptyTensors(
     Operation *op, const OneShotBufferizationOptions &options) {
   // Analyze IR.
   OneShotAnalysisState state(op, options);
-  if (failed(analyzeOp(op, state))) return failure();
+  if (failed(analyzeOp(op, state))) return success();
 
   // Rewrite tensor.empty ops that are anchored on specific ops.
   IRRewriter rewriter(op->getContext());

--- a/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/Interfaces.cpp
@@ -23,6 +23,7 @@
 #include "mlir/Dialect/Linalg/Transforms/TilingInterfaceImpl.h"
 #include "mlir/Dialect/MemRef/TransformOps/MemRefTransformOps.h"
 #include "mlir/Dialect/SCF/TransformOps/SCFTransformOps.h"
+#include "mlir/Dialect/Tensor/IR/TensorTilingInterfaceImpl.h"
 #include "mlir/Dialect/Vector/TransformOps/VectorTransformOps.h"
 
 namespace mlir {
@@ -42,13 +43,13 @@ void registerCodegenInterfaces(DialectRegistry &registry) {
   registerTransformDialectLLVMCPUExtension(registry);
   registerTransformDialectLLVMGPUExtension(registry);
   linalg::registerTilingInterfaceExternalModels(registry);
-
   affine::registerTransformDialectExtension(registry);
   gpu::registerTransformDialectExtension(registry);
   linalg::registerTransformDialectExtension(registry);
   memref::registerTransformDialectExtension(registry);
   scf::registerTransformDialectExtension(registry);
   vector::registerTransformDialectExtension(registry);
+  tensor::registerTilingInterfaceExternalModels(registry);
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/PartitionableLoopsInterface.cpp
@@ -94,7 +94,7 @@ struct OuterParallelAsPartitionableLoops
     // loops, but that needs the interface to return the static sizes of the
     // loops.
     SmallVector<unsigned> partitionableLoops;
-    auto interfaceOp = cast<OpTy>(op);
+    auto interfaceOp = cast<TilingInterface>(op);
     for (auto [index, iteratorType] :
          llvm::enumerate(interfaceOp.getLoopIteratorTypes())) {
       if (iteratorType != utils::IteratorType::parallel) {
@@ -238,6 +238,10 @@ void registerPartitionableLoopsInterfaceModels(DialectRegistry &registry) {
             IREE::LinalgExt::WinogradOutputTransformOp>>(*ctx);
     IREE::LinalgExt::SoftmaxOp::attachInterface<
         AllParallelAsPartitionableLoops<IREE::LinalgExt::SoftmaxOp>>(*ctx);
+  });
+  registry.addExtension(+[](MLIRContext *ctx, tensor::TensorDialect *dialect) {
+    tensor::PadOp::attachInterface<
+        OuterParallelAsPartitionableLoops<tensor::PadOp>>(*ctx);
   });
 }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -714,14 +714,14 @@ void addCPUDataTilingPipeline(OpPassManager &passManager) {
 void addCPUDefaultPassPipeline(OpPassManager &passManager) {
   addTileAndDistributePasses(passManager);
   OpPassManager &nestedModulePM = passManager.nest<ModuleOp>();
-  addBufferizePasses(nestedModulePM);
   if (clEnablePadConsumerFusion) {
     nestedModulePM.addNestedPass<func::FuncOp>(
         createFuseTensorPadWithConsumerPass());
     nestedModulePM.addNestedPass<func::FuncOp>(
         createConcretizePadResultShapePass());
-    nestedModulePM.addNestedPass<func::FuncOp>(createVectorizePadPass());
   }
+  nestedModulePM.addNestedPass<func::FuncOp>(createVectorizePadPass());
+  addBufferizePasses(nestedModulePM);
 }
 
 void addTransformDialectPasses(OpPassManager &passManager) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -234,10 +234,6 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   passManager.addPass(IREE::Flow::createExpandTensorShapesPass());
   buildGlobalOptimizationPassPipeline(passManager, transformOptions);
 
-  // Pad tensors.
-  passManager.addPass(IREE::Flow::createTensorPadToTensorInsertSlicePass(
-      /*skipSingleLinalgOpUses=*/clEnableFusePaddingIntoLinalgConsumerOps));
-
   FunctionLikeNest(passManager)
       // Preprocess the input to a form more amenable for fusion
       // - Convert all elementwise ops to Linalg

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -32,6 +32,7 @@
 #include "mlir/Dialect/Shape/IR/Shape.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Tensor/IR/TensorInferTypeOpInterfaceImpl.h"
+#include "mlir/Dialect/Tensor/IR/TensorTilingInterfaceImpl.h"
 #include "mlir/Dialect/Transform/IR/TransformDialect.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Dialect.h"
@@ -69,6 +70,7 @@ inline void registerMlirDialects(DialectRegistry &registry) {
                   shape::ShapeDialect>();
   // clang-format on
   tensor::registerInferTypeOpInterfaceExternalModels(registry);
+  tensor::registerTilingInterfaceExternalModels(registry);
 
 #ifdef IREE_HAVE_C_OUTPUT_FORMAT
   registry.insert<emitc::EmitCDialect>();

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -185,7 +185,7 @@ def LinalgStrategyVectorizePass
       "Which func op is the anchor to latch on.">,
     Option<"anchorOpName", "anchor-op", "std::string", /*default=*/"",
       "Which linalg op within the func is the anchor to latch on.">,
-    Option<"vectorizePadding", "vectorize-padding", "bool", "false",
+    Option<"vectorizePadding", "vectorize-padding", "bool", "true",
       "Enable vectorization of padding ops.">,
   ];
 }


### PR DESCRIPTION
This also requires a change to `mlir-hlo`. This is the minimum change to make it build:

```
diff --git a/mhlo/transforms/hlo_legalize_to_memref/hlo_legalize_to_memref.cc b/mhlo/transforms/hlo_legalize_to_memref/hlo_legalize_to_memref.cc
index b165375d..1d0bc2a9 100644
--- a/mhlo/transforms/hlo_legalize_to_memref/hlo_legalize_to_memref.cc
+++ b/mhlo/transforms/hlo_legalize_to_memref/hlo_legalize_to_memref.cc
@@ -456,7 +456,7 @@ struct DynamicBroadcastInDimOpInterface
   BufferRelation bufferRelation(Operation * /*op*/, OpResult /*opResult*/,
                                 const AnalysisState & /*state*/) const {
     // The op may allocate.
-    return BufferRelation::None;
+    return BufferRelation::Unknown;
   }
 
   LogicalResult bufferize(Operation *op, RewriterBase &rewriter,
```

There are other parts of the API that should be updated in `mlir-hlo` (renaming of `getAliasingOpOperand` etc.) but IREE builds without that. So hopefully you wouldn't need that. If you need to bufferize hlo ops, you need those changes though. Let me know if that is the case.