### PR TITLE
Add a few missing CMake dependencies required for building shared libs.

### DIFF
--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/IR/CMakeLists.txt
@@ -12,12 +12,14 @@ add_mlir_library(IREELinalgExtDialect
   LINK_LIBS PUBLIC
   IREELinalgExtUtils
   MLIRAffineDialect
+  MLIRAffineUtils
   MLIRArithUtils
   MLIRDestinationStyleOpInterface
   MLIRDialectUtils
   MLIRIR
   MLIRInferTypeOpInterface
   MLIRLinalgDialect
+  MLIRLinalgUtils
   MLIRMathDialect
   MLIRMemRefDialect
   MLIRPass

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Utils/CMakeLists.txt
@@ -5,6 +5,7 @@ add_mlir_library(IREELinalgExtUtils
   DEPENDS
   mlir-headers
 
+  LINK_LIBS PUBLIC
   MLIRDialectUtils
   MLIRIR
   MLIRTensorDialect


### PR DESCRIPTION
This PR adds a few missing CMake dependencies.

IREE is built by default with [`BUILD_SHARED_LIBS=OFF`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html), so most libraries are built as static libraries. This means that not all symbols referenced by a particular library need to be present -- it is sufficient if some other library that is used in the same final executable also imports them. Some missing dependencies can therefore go unnoticed for some time. Building IREE with `BUILD_SHARED_LIBS=ON` reveals (some of) them.

I have recently fixed these dependencies in `mlir-hlo` (see [PR](https://github.com/tensorflow/tensorflow/pull/59421) and [integration commit](https://github.com/tensorflow/mlir-hlo/commit/ed069b6e)) and the dependency has now been updated, such that most of IREE now builds with  `BUILD_SHARED_LIBS=ON`.

However, the build is still broken: `IREELinalgExtTransforms` and `IREELinalgExtPasses` respectively require symbols from the other one, and cyclic dependencies are not possible in CMake, so there is no way to build (with shared libs) currently. I guess the only solution is to move code around such that one of the two does not use any symbols from the other one. I'll leave this for someone else to fix if desired.