### PR TITLE
Wire vector mask

### DIFF
--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/ReductionStrategy.cpp
@@ -78,8 +78,6 @@ void mlir::iree_compiler::cpu::buildReductionStrategy(
     auto tileRes = buildTileFuseToScfFor(
         b, val, {}, getAsOpFoldResult(b.getI64ArrayAttr(tileSizes)));
 
-    // Don't know how to mask vectorize reductions yet.
-    if (val == gridReductionH) continue;
     auto vectorTileSizes = strategy.workgroupTileSizes;
     int64_t e = std::min(
         static_cast<int64_t>(strategy.workgroupTileSizes.size()), rank - 1);


### PR DESCRIPTION
This follows Nicolas's work on https://github.com/iree-org/iree/pull/11796, the work that Matthias did to fix the bufferization and Diego's work to flatten vector.mask.

@dcaballe 
The whole thing now fails on some vector.mask issue:
```
error: 'vector.mask' op expects a maskable operation
```

Essentially we turn a `vector.mask (vector.transfer_read|write)` into a `vector.mask(vector.load|store)` during `lower_vectors`. I assume we'll want to produce a `vector.maskedload|store` instead.

High level repro with iree-samples:
```
benchmark-transform-create -b llvm-cpu <iree-samples>/transform_dialect/benchmark_linalg_reductions.stub.mlir reduction_2d_static f32 121 456
```

Full repro with `iree-opt`:
```
iree-opt '--pass-pipeline=builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))'  --iree-codegen-llvmgpu-enable-transform-dialect-jit=false --iree-codegen-llvmcpu-use-transform-dialect=full_reproducer.mlir --mlir-disable-threading input.mlir
```

Repro with `mlir-opt` (make sure to build with -DMLIR_INCLUDE_TESTS=On to get the interpreter if your building within IREE):
```
mlir-opt --test-transform-dialect-interpreter      --mlir-disable-threading reduced.mlir -mlir-print-ir-after-failure
```

[input.mlir.txt](https://github.com/iree-org/iree/files/10557878/input.mlir.txt) (Note: there's a syntax difference in the input for `mlir-opt` vs. upstream `mlir-opt`. Just uncomment the types on the `match` operation for upstream.)
[full_reproducer.mlir.txt](https://github.com/iree-org/iree/files/10557880/full_reproducer.mlir.txt)
[reduced.mlir.txt](https://github.com/iree-org/iree/files/10557881/reduced.mlir.txt)
