### PR TITLE
Add Bert-Large to x86 and CUDA benchmarks

### DIFF
--- a/benchmarks/TF/CMakeLists.txt
+++ b/benchmarks/TF/CMakeLists.txt
@@ -26,6 +26,8 @@ set(MINILM_L12_H384_UNCASED_INT32_SEQLEN128_MODULE
     "https://storage.googleapis.com/iree-model-artifacts/minilm-l12-h384-uncased-seqlen128-tf-model.tar.gz"
   ENTRY_FUNCTION
     "predict"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=predict"
   FUNCTION_INPUTS
     "1x128xi32,1x128xi32,1x128xi32"
 )
@@ -40,6 +42,8 @@ set(RESNET50_TF_FP32_MODULE
     "https://storage.googleapis.com/iree-model-artifacts/resnet50-tf-model.tar.gz"
   ENTRY_FUNCTION
     "forward"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=forward"
   FUNCTION_INPUTS
     "1x224x224x3xf32"
 )
@@ -54,8 +58,28 @@ set(BERT_FOR_MASKED_LM_FP32_SEQLEN512_MODULE
     "https://storage.googleapis.com/iree-model-artifacts/bert-for-masked-lm-seq512-tf-model.tar.gz"
   ENTRY_FUNCTION
     "forward"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=forward"
   FUNCTION_INPUTS
     "1x512xi32,1x512xi32"
+)
+
+# This is the model used in the MLPerf Inference Suite.
+set(BERT_LARGE_TF_FP32_SEQLEN384_MODULE
+  NAME
+     "BertLargeTf"
+  TAGS
+     "fp32,seqlen384"
+  SOURCE
+    # Derived from https://github.com/mlcommons/inference/tree/master/language/bert
+    # Instructions on how to regenerate the model: https://gist.github.com/mariecwhite/e61ccebd979d98d097946ac7725bcc29
+    "https://storage.googleapis.com/iree-model-artifacts/bert-large-seq384-tf-model.tar.gz"
+  ENTRY_FUNCTION
+    "serving_default"
+  IMPORT_FLAGS
+    "--tf-import-type=savedmodel_v1"
+  FUNCTION_INPUTS
+    "1x384xi32,1x384xi32,1x384xi32"
 )
 
 set(EFFICIENTNET_V2_S_TF_FP32_MODULE
@@ -68,6 +92,8 @@ set(EFFICIENTNET_V2_S_TF_FP32_MODULE
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet-v2-s-tf-model.tar.gz"
   ENTRY_FUNCTION
     "forward"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=forward"
   FUNCTION_INPUTS
     "1x384x384x3xf32"
 )

--- a/benchmarks/TF/linux-cuda.cmake
+++ b/benchmarks/TF/linux-cuda.cmake
@@ -31,6 +31,7 @@ iree_benchmark_suite(
     "${RESNET50_TF_FP32_MODULE}"
     "${BERT_FOR_MASKED_LM_FP32_SEQLEN512_MODULE}"
     "${EFFICIENTNET_V2_S_TF_FP32_MODULE}"
+    "${BERT_LARGE_TF_FP32_SEQLEN384_MODULE}"
 
   BENCHMARK_MODES
     "full-inference,default-flags"

--- a/benchmarks/TF/linux-x86_64.cmake
+++ b/benchmarks/TF/linux-x86_64.cmake
@@ -32,6 +32,7 @@ iree_benchmark_suite(
     "${RESNET50_TF_FP32_MODULE}"
     "${BERT_FOR_MASKED_LM_FP32_SEQLEN512_MODULE}"
     "${EFFICIENTNET_V2_S_TF_FP32_MODULE}"
+    "${BERT_LARGE_TF_FP32_SEQLEN384_MODULE}"
 
   BENCHMARK_MODES
     "full-inference,default-flags"
@@ -59,6 +60,7 @@ iree_benchmark_suite(
     "${RESNET50_TF_FP32_MODULE}"
     "${BERT_FOR_MASKED_LM_FP32_SEQLEN512_MODULE}"
     "${EFFICIENTNET_V2_S_TF_FP32_MODULE}"
+    "${BERT_LARGE_TF_FP32_SEQLEN384_MODULE}"
 
   BENCHMARK_MODES
     "1-thread,full-inference,default-flags"
@@ -88,6 +90,7 @@ iree_benchmark_suite(
     "${RESNET50_TF_FP32_MODULE}"
     "${BERT_FOR_MASKED_LM_FP32_SEQLEN512_MODULE}"
     "${EFFICIENTNET_V2_S_TF_FP32_MODULE}"
+    "${BERT_LARGE_TF_FP32_SEQLEN384_MODULE}"
 
   BENCHMARK_MODES
     "4-thread,full-inference,default-flags"
@@ -117,6 +120,7 @@ iree_benchmark_suite(
     "${RESNET50_TF_FP32_MODULE}"
     "${BERT_FOR_MASKED_LM_FP32_SEQLEN512_MODULE}"
     "${EFFICIENTNET_V2_S_TF_FP32_MODULE}"
+    "${BERT_LARGE_TF_FP32_SEQLEN384_MODULE}"
 
   BENCHMARK_MODES
     "8-thread,full-inference,default-flags"

--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -65,19 +65,19 @@ endfunction()
 # Parameters:
 #   TARGET_NAME: The target name to be created for this module.
 #   SOURCE: Source TF model direcotry
-#   ENTRY_FUNCTION: The entry function name for the input module.
+#   IMPORT_FLAGS: Flags to include in the import command.
 #   OUTPUT_MLIR_FILE: The path to output the generated MLIR file.
 function(iree_import_tf_model)
   cmake_parse_arguments(
     PARSE_ARGV 0
     _RULE
     ""
-    "TARGET_NAME;SOURCE;ENTRY_FUNCTION;OUTPUT_MLIR_FILE"
+    "TARGET_NAME;SOURCE;IMPORT_FLAGS;OUTPUT_MLIR_FILE"
     ""
   )
   iree_validate_required_arguments(
     _RULE
-    "TARGET_NAME;SOURCE;ENTRY_FUNCTION;OUTPUT_MLIR_FILE"
+    "TARGET_NAME;SOURCE;OUTPUT_MLIR_FILE"
     ""
   )
 
@@ -95,7 +95,7 @@ function(iree_import_tf_model)
       OUTPUT "${_RULE_OUTPUT_MLIR_FILE}"
       COMMAND
         "${IREE_IMPORT_TF_PATH}"
-        "--tf-savedmodel-exported-names=${_RULE_ENTRY_FUNCTION}"
+        "${_RULE_IMPORT_FLAGS}"
         "${_RULE_SOURCE}"
         "-o=${_RULE_OUTPUT_MLIR_FILE}"
       DEPENDS
@@ -214,7 +214,7 @@ function(iree_benchmark_suite)
     cmake_parse_arguments(
       _MODULE
       ""
-      "NAME;TAGS;SOURCE;ENTRY_FUNCTION;FUNCTION_INPUTS"
+      "NAME;TAGS;SOURCE;ENTRY_FUNCTION;IMPORT_FLAGS;FUNCTION_INPUTS"
       ""
       ${_MODULE}
     )
@@ -278,7 +278,7 @@ function(iree_benchmark_suite)
       iree_import_tf_model(
         TARGET_NAME "${_MODULE_SOURCE_TARGET}"
         SOURCE "${_MODULE_SOURCE}"
-        ENTRY_FUNCTION "${_MODULE_ENTRY_FUNCTION}"
+        IMPORT_FLAGS "${_MODULE_IMPORT_FLAGS}"
         OUTPUT_MLIR_FILE "${_MODULE_SOURCE}.mlir"
       )
       set(_MODULE_SOURCE "${_MODULE_SOURCE}.mlir")

--- a/build_tools/python/cmake_builder/rules.py
+++ b/build_tools/python/cmake_builder/rules.py
@@ -133,18 +133,19 @@ def build_iree_fetch_artifact(target_name: str, source_url: str, output: str,
 
 
 def build_iree_import_tf_model(target_path: str, source: str,
-                               entry_function: str,
+                               import_flags: List[str],
                                output_mlir_file: str) -> str:
   target_name_block = _get_string_arg_block("TARGET_NAME", target_path)
   source_block = _get_string_arg_block("SOURCE", source)
-  entry_function_block = _get_string_arg_block("ENTRY_FUNCTION", entry_function)
+  import_flags_block = _get_string_arg_block("IMPORT_FLAGS",
+                                             " ".join(import_flags))
   output_mlir_file_block = _get_string_arg_block("OUTPUT_MLIR_FILE",
                                                  output_mlir_file)
   return _convert_block_to_string(
       _build_call_rule(rule_name="iree_import_tf_model",
                        parameter_blocks=[
-                           target_name_block, source_block,
-                           entry_function_block, output_mlir_file_block
+                           target_name_block, source_block, import_flags_block,
+                           output_mlir_file_block
                        ]))
 
 

--- a/build_tools/python/cmake_builder/rules_test.py
+++ b/build_tools/python/cmake_builder/rules_test.py
@@ -100,7 +100,7 @@ class RulesTest(unittest.TestCase):
     rule = cmake_builder.rules.build_iree_import_tf_model(
         target_path="pkg_abcd",
         source="abcd/model",
-        entry_function="main",
+        import_flags=["--tf-savedmodel-exported-names=main"],
         output_mlir_file="abcd.mlir")
 
     self.assertEqual(
@@ -111,8 +111,8 @@ class RulesTest(unittest.TestCase):
             "pkg_abcd"
           SOURCE
             "abcd/model"
-          ENTRY_FUNCTION
-            "main"
+          IMPORT_FLAGS
+            "--tf-savedmodel-exported-names=main"
           OUTPUT_MLIR_FILE
             "abcd.mlir"
         )

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -72,7 +72,7 @@ class IreeRuleBuilder(object):
           cmake_builder.rules.build_iree_import_tf_model(
               target_path=self.build_target_path(target_name),
               source=str(source_model_rule.file_path),
-              entry_function=model.entry_function,
+              import_flags=imported_model.import_flags,
               output_mlir_file=str(output_file_path))
       ]
     else:

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
@@ -134,13 +134,19 @@ class ImportedModel(object):
   id: str
   model: common_definitions.Model
   dialect_type: MLIRDialectType
+  import_flags: List[str] = dataclasses.field(default_factory=list)
 
   @staticmethod
   def from_model(model: common_definitions.Model):
     dialect_type = MODEL_SOURCE_TO_DIALECT_TYPE_MAP[model.source_type]
+    import_flags = []
+    if model.source_type == common_definitions.ModelSourceType.EXPORTED_TF:
+      import_flags.append(
+          f"--tf-savedmodel-exported-names={model.entry_function}")
     return ImportedModel(id=f"{model.id}-{dialect_type.id}",
                          model=model,
-                         dialect_type=dialect_type)
+                         dialect_type=dialect_type,
+                         import_flags=import_flags)
 
 
 @serialization.serializable

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -102,8 +102,8 @@ iree_import_tf_model(
     "${PACKAGE_NAME}_iree-imported-model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased"
-  ENTRY_FUNCTION
-    "predict"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=predict"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
 )
@@ -113,8 +113,8 @@ iree_import_tf_model(
     "${PACKAGE_NAME}_iree-imported-model-39d157ad-f0ec-4a76-963b-d783beaed60f"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF"
-  ENTRY_FUNCTION
-    "forward"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
 )
@@ -124,8 +124,8 @@ iree_import_tf_model(
     "${PACKAGE_NAME}_iree-imported-model-ebe7897f-5613-435b-a330-3cb967704e5e"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF"
-  ENTRY_FUNCTION
-    "forward"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
 )
@@ -135,8 +135,8 @@ iree_import_tf_model(
     "${PACKAGE_NAME}_iree-imported-model-c393b4fa-beb4-45d5-982a-c6328aa05d08"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF"
-  ENTRY_FUNCTION
-    "forward"
+  IMPORT_FLAGS
+    "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
     "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
 )


### PR DESCRIPTION
Adds Bert-Large with input sequence length 384, 345M param model. This version is taken from the MLPerf repo: https://github.com/mlcommons/inference/tree/master/language/bert. Some modifications to the code was made to save it in Saved Model format. Steps to reproduce: https://gist.github.com/mariecwhite/e61ccebd979d98d097946ac7725bcc29