### PR TITLE
Handle multi-result dispatches that all route into update ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/EmplaceAllocations.cpp
@@ -63,6 +63,12 @@ static bool tryEmplaceDispatchOp(IREE::Stream::AsyncDispatchOp dispatchOp) {
         continue;
       }
       targetResource = updateOp.getTarget();
+      if (targetResource.getDefiningOp() == dispatchOp) {
+        // NOTE: we may have already replaced the update target with one of our
+        // results - if so we need to find the operand to capture tied to that
+        // new result instead of our own new result (which would make a cycle).
+        targetResource = dispatchOp.getTiedResultOperand(targetResource);
+      }
       targetResourceSize = updateOp.getTargetSize();
       targetOffset = updateOp.getTargetOffset();
       targetEnd = updateOp.getTargetEnd();


### PR DESCRIPTION
As is common in concat patterns it's possible for more than one result of a single dispatch to be placed into the same allocation. Previously this wouldn't check that a result had been placed and create cycles as we'd try to place a subsequent result into another result.

Fixes #11981.