### PR TITLE
Replace `riscv-v-vector-bits-min` with `+zvl*b` in RISC-V configs

### DIFF
--- a/benchmarks/TFLite/linux-riscv.cmake
+++ b/benchmarks/TFLite/linux-riscv.cmake
@@ -21,8 +21,7 @@ set(LINUX_RV64_GENERIC_CPU_COMPILATION_FLAGS
   "--iree-llvm-target-triple=riscv64"
   "--iree-llvm-target-cpu=generic-rv64"
   "--iree-llvm-target-abi=lp64d"
-  "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-  "--riscv-v-vector-bits-min=512"
+  "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
   "--riscv-v-fixed-length-vector-lmul-max=8"
 )
 
@@ -32,7 +31,6 @@ set(LINUX_RV32_GENERIC_CPU_COMPILATION_FLAGS
   "--iree-llvm-target-cpu=generic-rv32"
   "--iree-llvm-target-abi=ilp32"
   "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
-  "--riscv-v-vector-bits-min=512"
   "--riscv-v-fixed-length-vector-lmul-max=8"
 )
 

--- a/build_tools/cmake/riscv.toolchain.cmake
+++ b/build_tools/cmake/riscv.toolchain.cmake
@@ -52,9 +52,8 @@ if(RISCV_CPU STREQUAL "linux-riscv_64")
     "--iree-llvm-target-triple=riscv64"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c,+v"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+c,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
-    "--riscv-v-vector-bits-min=512"
     CACHE INTERNAL "Default llvm codegen flags for testing purposes")
 elseif(RISCV_CPU STREQUAL "linux-riscv_32")
   set(CMAKE_SYSTEM_PROCESSOR riscv32)
@@ -73,7 +72,6 @@ elseif(RISCV_CPU STREQUAL "linux-riscv_32")
     "--iree-llvm-target-abi=ilp32d"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"
-    "--riscv-v-vector-bits-min=512"
     CACHE INTERNAL "Default llvm codegen flags for testing purposes")
 elseif(RISCV_CPU STREQUAL "generic-riscv_32")
   set(CMAKE_SYSTEM_PROCESSOR riscv32)

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -145,8 +145,7 @@ class IreeRuleBuilder(object):
       flags = [
           f"--iree-llvm-target-triple=riscv64-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv64", "--iree-llvm-target-abi=lp64d",
-          "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v",
-          "--riscv-v-vector-bits-min=512",
+          "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v",
           "--riscv-v-fixed-length-vector-lmul-max=8"
       ]
     elif arch_info.architecture == "riscv_32":
@@ -154,7 +153,6 @@ class IreeRuleBuilder(object):
           f"--iree-llvm-target-triple=riscv32-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv32", "--iree-llvm-target-abi=ilp32",
           "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x",
-          "--riscv-v-vector-bits-min=512",
           "--riscv-v-fixed-length-vector-lmul-max=8"
       ]
     elif arch_info.architecture == "adreno":
@@ -189,7 +187,7 @@ def generate_rules(
         iree_definitions.ModuleGenerationConfig],
     model_rule_map: Dict[str, model_rule_generator.ModelRule]) -> List[str]:
   """Generates all rules to build IREE artifacts.
-  
+
   Args:
     package_name: CMake package name for rules.
     root_path: path of the root artifact directory.

--- a/docs/website/docs/building-from-source/riscv.md
+++ b/docs/website/docs/building-from-source/riscv.md
@@ -150,8 +150,8 @@ tools/iree-compile \
   --iree-llvm-target-triple=riscv64 \
   --iree-llvm-target-cpu=generic-rv64 \
   --iree-llvm-target-abi=lp64d \
-  --iree-llvm-target-cpu-features="+m,+a,+f,+d,+v" \
-  --riscv-v-vector-bits-min=512 --riscv-v-fixed-length-vector-lmul-max=8 \
+  --iree-llvm-target-cpu-features="+m,+a,+f,+d,+zvl512b,+v" \
+  --riscv-v-fixed-length-vector-lmul-max=8 \
   iree_input.mlir -o mobilenet_cpu.vmfb
 ```
 

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -673,8 +673,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -692,8 +691,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -711,8 +709,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -730,8 +727,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -749,8 +745,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -768,8 +763,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -788,7 +782,6 @@ iree_bytecode_module(
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
-    "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -807,7 +800,6 @@ iree_bytecode_module(
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
-    "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -826,7 +818,6 @@ iree_bytecode_module(
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
-    "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -2277,8 +2268,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2298,8 +2288,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2319,8 +2308,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2340,8 +2328,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2361,8 +2348,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2382,8 +2368,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv64-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv64"
     "--iree-llvm-target-abi=lp64d"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+v"
-    "--riscv-v-vector-bits-min=512"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+d,+zvl512b,+v"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2404,7 +2389,6 @@ iree_bytecode_module(
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
-    "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2425,7 +2409,6 @@ iree_bytecode_module(
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
-    "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2446,7 +2429,6 @@ iree_bytecode_module(
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
     "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
-    "--riscv-v-vector-bits-min=512"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"


### PR DESCRIPTION
LLVM is moving towards using the `+zvl*b` target feature instead of using the flag.