### PR TITLE
Redo handling of operand reuse to prevent stack allocation.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.h
@@ -53,7 +53,19 @@ class BufferizationPlan {
   void insert(Value v) { mappedTensors.insert(getPointer(v)); }
 
   void unionSets(Value v1, Value v2) {
+    // If one the sets was part of the store set, the store set
+    // needs to be updated to drop the all leaders from the store set
+    // and add the new leader to it.
+    Value leader1 = getLeaderValue(v1);
+    Value leader2 = getLeaderValue(v2);
+    bool insertNewStoreLeader =
+        storeLeaders.count(leader1) || storeLeaders.count(leader2);
+    storeLeaders.erase(leader1);
+    storeLeaders.erase(leader2);
     mappedTensors.unionSets(getPointer(v1), getPointer(v2));
+    if (insertNewStoreLeader) {
+      storeLeaders.insert(getLeaderValue(v1));
+    }
   }
 
   /// Sets the equivalance class that contains `v` as the set that contains the

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -281,26 +281,26 @@ static LogicalResult duplicateInitTensorOps(OpBuilder &b,
   return success();
 }
 
-// Checks if the `inOperand` can be used in place of the `outOperand`
+// Checks if the `inOperand` can be used in place of the `initOperand`
 // to mimic in-place update behavior for parallel elementwise ops.
-static bool canUseInOperandAsOutOperand(
-    OpOperand *inOperand, OpOperand *outOperand,
+static bool canUseInOperandAsInitOperand(
+    OpOperand *inOperand, OpOperand *initOperand,
     bool useWARForCooperativeMatrixCodegen = false) {
   if (isReadOnly(inOperand->get())) {
     return false;
   }
 
-  if (inOperand->getOwner() != outOperand->getOwner()) return false;
+  if (inOperand->getOwner() != initOperand->getOwner()) return false;
 
   auto linalgOp = dyn_cast<linalg::LinalgOp>(inOperand->getOwner());
   if (!linalgOp) return false;
 
   if (linalgOp.getMatchingIndexingMap(inOperand) !=
-      linalgOp.getMatchingIndexingMap(outOperand)) {
+      linalgOp.getMatchingIndexingMap(initOperand)) {
     return false;
   }
 
-  if (inOperand->get().getType() != outOperand->get().getType()) return false;
+  if (inOperand->get().getType() != initOperand->get().getType()) return false;
 
   if (useWARForCooperativeMatrixCodegen) {
     return true;
@@ -315,70 +315,155 @@ static bool canUseInOperandAsOutOperand(
   return true;
 }
 
-namespace {
-/// Adapts Linalg ops input operand to output operand. This is required for not
-/// creating extra alloca ops. For more details, see
-/// https://github.com/iree-org/iree/issues/8303
-struct AdaptLinalgInputOperandToOutputOperand
-    : public OpRewritePattern<linalg::GenericOp> {
-  AdaptLinalgInputOperandToOutputOperand(MLIRContext *context,
-                                         bool useWARForCooperativeMatrixCodegen,
-                                         PatternBenefit benefit = 1)
-      : OpRewritePattern(context, benefit),
-        useWARForCooperativeMatrixCodegen(useWARForCooperativeMatrixCodegen) {}
+/// Checks if the use of a result of a compute op can be modified
+/// so that it can be moved into a store set.
+static std::optional<OpOperand *> canModifyUseToGetValueIntoStoreSet(
+    BufferizationPlan &plan, OpOperand *use,
+    bool useWARForCooperativeMatrixCodegen) {
+  assert(!plan.isInStoreSet(use->get()) &&
+         "attempting to move a value into a store set, when it is already part "
+         "of one");
 
-  LogicalResult matchAndRewrite(linalg::GenericOp op,
-                                PatternRewriter &rewriter) const override {
-    // All the loops should be parallel loops.
-    if (op.getNumLoops() != op.getNumParallelLoops()) return failure();
-    // There is only one result tensor.
-    if (op->getNumResults() != 1) return failure();
-    // The output tensor is unused in the body computation.
-    auto outputOperand = op.getDpsInitOperand(0);
-    if (op.payloadUsesValueFromOperand(outputOperand)) return failure();
+  // Currently only look at use in linalg.generic ops.
+  auto genericOpConsumer = dyn_cast<linalg::GenericOp>(use->getOwner());
+  if (!genericOpConsumer) return std::nullopt;
 
-    // Find an input operand which meets:
-    //   1. It has the same indexing map and type.
-    //   2. It is not from a readonly tensor.
-    OpOperand *operand = nullptr;
-    SmallVector<Value> newOperands;
-    SmallVector<AffineMap> maps;
-    for (auto in : op.getDpsInputOperands()) {
-      if (!operand &&
-          canUseInOperandAsOutOperand(in, outputOperand,
-                                      useWARForCooperativeMatrixCodegen)) {
-        operand = in;
-      } else {
-        newOperands.push_back(in->get());
-        maps.push_back(op.getMatchingIndexingMap(in));
-      }
-    }
-    if (!operand) return failure();
-    maps.push_back(op.getMatchingIndexingMap(operand));
-
-    Location loc = op.getLoc();
-    SmallVector<utils::IteratorType> iterTypes(op.getNumLoops(),
-                                               utils::IteratorType::parallel);
-    auto newOp = rewriter.create<linalg::GenericOp>(
-        loc, op.getResultTypes(), newOperands, operand->get(), maps, iterTypes,
-        /*bodyBuild=*/nullptr, linalg::getPrunedAttributeList(op));
-    rewriter.inlineRegionBefore(op.getRegion(), newOp.getRegion(),
-                                newOp.getRegion().begin());
-
-    // Repair the payload entry block.
-    Block &payload = newOp.getRegion().front();
-    payload.getArgument(operand->getOperandNumber())
-        .replaceAllUsesWith(payload.getArgument(op.getNumDpsInputs()));
-    payload.eraseArgument(operand->getOperandNumber());
-
-    rewriter.replaceOp(op, newOp.getResults());
-    return success();
+  // All loops need to be parallel.
+  if (genericOpConsumer.getNumLoops() !=
+      genericOpConsumer.getNumParallelLoops()) {
+    return std::nullopt;
   }
 
- private:
-  bool useWARForCooperativeMatrixCodegen;
-};
+  if (genericOpConsumer.isDpsInit(use)) return std::nullopt;
 
+  for (auto [index, initOperand] :
+       llvm::enumerate(genericOpConsumer.getDpsInitOperands())) {
+    // Output tensor is unused in the body computation.
+    if (genericOpConsumer.payloadUsesValueFromOperand(initOperand)) continue;
+    // The result of this operation needs to be in a store set.
+    if (!plan.isInStoreSet(genericOpConsumer->getResult(index))) continue;
+    if (!canUseInOperandAsInitOperand(use, initOperand,
+                                      useWARForCooperativeMatrixCodegen)) {
+      continue;
+    }
+    return initOperand;
+  }
+  return std::nullopt;
+}
+
+/// For a compute op which has a result not in the store set, but has a user
+/// with an `inOperand`/`initOperand` pair (`inOperand` being the use of result
+/// of the compute op) modify the user to replace `initOperand` with a use of
+/// the result. This avoids the need for a temporary stack for result of the
+/// `initOperand`.
+static LogicalResult modifyUseToGetValueIntoStoreSet(RewriterBase &rewriter,
+                                                     OpOperand *inOperand,
+                                                     OpOperand *initOperand) {
+  /// Currently handle only uses as `ins` of `linalg.generic`. Replace the
+  /// `initOperand` with the `inOperand`, and drop its use from the `ins`
+  /// operand list.
+  auto genericOp = cast<linalg::GenericOp>(inOperand->getOwner());
+  assert(genericOp == initOperand->getOwner() &&
+         "expected in operand and out operand to be the same op");
+  SmallVector<Value> newInputs;
+  SmallVector<Value> newOutputs;
+  SmallVector<Type> newResultTypes;
+  SmallVector<AffineMap> maps;
+  for (OpOperand *in : genericOp.getDpsInputOperands()) {
+    if (in != inOperand) {
+      newInputs.push_back(in->get());
+      maps.push_back(genericOp.getMatchingIndexingMap(in));
+    }
+  }
+  for (OpOperand *out : genericOp.getDpsInitOperands()) {
+    maps.push_back(genericOp.getMatchingIndexingMap(out));
+    if (initOperand == out) {
+      newOutputs.push_back(inOperand->get());
+      newResultTypes.push_back(inOperand->get().getType());
+    } else {
+      newOutputs.push_back(out->get());
+      newResultTypes.push_back(out->get().getType());
+    }
+  }
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPoint(genericOp);
+
+  Location loc = genericOp.getLoc();
+  SmallVector<utils::IteratorType> iterTypes(genericOp.getNumLoops(),
+                                             utils::IteratorType::parallel);
+  auto newOp = rewriter.create<linalg::GenericOp>(
+      loc, newResultTypes, newInputs, newOutputs, maps, iterTypes,
+      /*bodyBuild=*/nullptr, linalg::getPrunedAttributeList(genericOp));
+  rewriter.inlineRegionBefore(genericOp.getRegion(), newOp.getRegion(),
+                              newOp.getRegion().begin());
+
+  // Repair the payload entry block.
+  Block &payload = newOp.getRegion().front();
+  payload.getArgument(inOperand->getOperandNumber())
+      .replaceAllUsesWith(payload.getArgument(initOperand->getOperandNumber()));
+  payload.eraseArgument(inOperand->getOperandNumber());
+
+  rewriter.replaceOp(genericOp, newOp.getResults());
+  return success();
+}
+
+/// For results of compute ops that are not part of a store set, tries to modify
+/// its users to get the result into a store set, avoiding the use of stack
+/// allocation. This is done by looking for users
+/// 1) The result of the user is in the store set.
+/// 2) The use of the result of the compute op can be updated such that
+///    the new use is tied to the result of the user.
+/// This makes the result of the compute op be in the store set, and
+/// bufferizable without using a new stack. See
+/// https://github.com/iree-org/iree/issues/8303.
+static LogicalResult adaptComputeConsumerToAvoidStackAllocation(
+    func::FuncOp funcOp, bool useWARForCooperativeMatrixCodegen) {
+  IRRewriter rewriter(funcOp.getContext());
+
+  constexpr int kMaxNumIterations = 6;
+  int numIterations = 0;
+  while (numIterations < kMaxNumIterations) {
+    numIterations++;
+    BufferizationPlan plan;
+    if (failed(createTensorEquivalenceClasses(funcOp, plan))) {
+      return funcOp.emitOpError("failed to create tensor equivalance classes");
+    }
+
+    auto resultMovedIntoStoreSet =
+        [&](TilingInterface computeOp) -> WalkResult {
+      for (auto result : computeOp->getResults()) {
+        // If result is already in a store set. Nothing to do.
+        if (plan.isInStoreSet(result)) continue;
+
+        // Check if there are any uses that can be modified to reuse the output
+        // buffer.
+        for (OpOperand &use : result.getUses()) {
+          std::optional<OpOperand *> reusableOperand =
+              canModifyUseToGetValueIntoStoreSet(
+                  plan, &use, useWARForCooperativeMatrixCodegen);
+          if (!reusableOperand) continue;
+          if (failed(modifyUseToGetValueIntoStoreSet(rewriter, &use,
+                                                     reusableOperand.value())))
+            continue;
+          return WalkResult::interrupt();
+        }
+      }
+      return WalkResult::advance();
+    };
+
+    // If walk wasnt interrupted, then there wasnt any modifications. So break;
+    if (!funcOp.walk(resultMovedIntoStoreSet).wasInterrupted()) {
+      break;
+    }
+  }
+  if (numIterations >= kMaxNumIterations) {
+    return funcOp.emitOpError(
+        "Hit maximum number of iterations to avoid stack allocation");
+  }
+  return success();
+}
+
+namespace {
 struct RemoveCstOutsDependency
     : public OpInterfaceRewritePattern<linalg::LinalgOp> {
   using OpInterfaceRewritePattern<linalg::LinalgOp>::OpInterfaceRewritePattern;
@@ -418,16 +503,6 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
   func::FuncOp funcOp = getOperation();
   MLIRContext *context = &getContext();
 
-  {
-    RewritePatternSet patterns(context);
-    patterns.insert<AdaptLinalgInputOperandToOutputOperand>(
-        context, useWARForCooperativeMatrixCodegen);
-    patterns.insert<RemoveCstOutsDependency>(context);
-    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
-      return signalPassFailure();
-    }
-  }
-
   OpBuilder b(context);
   SmallVector<tensor::EmptyOp> emptyTensorOps;
   funcOp.walk([&](tensor::EmptyOp emptyTensorOp) {
@@ -437,6 +512,19 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
         return failed(duplicateInitTensorOps(b, emptyTensorOp));
       })) {
     return signalPassFailure();
+  }
+
+  if (failed(adaptComputeConsumerToAvoidStackAllocation(
+          funcOp, useWARForCooperativeMatrixCodegen))) {
+    return signalPassFailure();
+  }
+
+  {
+    RewritePatternSet patterns(context);
+    patterns.insert<RemoveCstOutsDependency>(context);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
   }
 
   if (failed(convertToDestinationPassingStyle(b, funcOp))) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/convert_to_destination_passing_style.mlir
@@ -472,67 +472,6 @@ func.func @unused_ins_operand() {
 
 // -----
 
-func.func @three_init_tensor_uses() {
-  %c6400 = arith.constant 6400 : index
-  %c64 = arith.constant 64 : index
-  %c1654784 = arith.constant 1654784 : index
-  %c1638400 = arith.constant 1638400 : index
-  %c0 = arith.constant 0 : index
-  %cst = arith.constant 3.40282347E+38 : f32
-  %cst_0 = arith.constant dense_resource<__elided__> : tensor<64xf32>
-  %cst_1 = arith.constant 0.000000e+00 : f32
-  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32) offset(%c0) : !flow.dispatch.tensor<readonly:tensor<6400x64xf32>>
-  %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(32) offset(%c1638400) : !flow.dispatch.tensor<readonly:tensor<64x64xf32>>
-  %2 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(32) offset(%c1654784) : !flow.dispatch.tensor<writeonly:tensor<6400x64xf32>>
-  %workgroup_id_x = hal.interface.workgroup.id[0] : index
-  %workgroup_count_x = hal.interface.workgroup.count[0] : index
-  %workgroup_id_y = hal.interface.workgroup.id[1] : index
-  %workgroup_count_y = hal.interface.workgroup.count[1] : index
-  %3 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_y]
-  %4 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_y]
-  scf.for %arg0 = %3 to %c6400 step %4 {
-    %5 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_id_x]
-    %6 = affine.apply affine_map<()[s0] -> (s0 * 64)>()[%workgroup_count_x]
-    scf.for %arg1 = %5 to %c64 step %6 {
-      %7 = tensor.empty() : tensor<64x64xf32>
-      %8 = tensor.extract_slice %cst_0[%arg1] [64] [1] : tensor<64xf32> to tensor<64xf32>
-      %9 = flow.dispatch.tensor.load %0, offsets = [%arg0, 0], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<6400x64xf32>> -> tensor<64x64xf32>
-      %10 = flow.dispatch.tensor.load %1, offsets = [0, %arg1], sizes = [64, 64], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<64x64xf32>> -> tensor<64x64xf32>
-      %11 = linalg.fill ins(%cst_1 : f32) outs(%7 : tensor<64x64xf32>) -> tensor<64x64xf32>
-      %12 = linalg.matmul {lowering_config = #iree_codegen.lowering_config<tile_sizes = [[64, 64, 0], [8, 32, 0], [0, 0, 16]]>} ins(%9, %10 : tensor<64x64xf32>, tensor<64x64xf32>) outs(%11 : tensor<64x64xf32>) -> tensor<64x64xf32>
-      %13 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%8, %12 : tensor<64xf32>, tensor<64x64xf32>) outs(%7 : tensor<64x64xf32>) {
-      ^bb0(%arg2: f32, %arg3: f32, %arg4: f32):
-        %15 = arith.addf %arg2, %arg3 : f32
-        linalg.yield %15 : f32
-      } -> tensor<64x64xf32>
-      %14 = linalg.generic {indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>], iterator_types = ["parallel", "parallel"]} ins(%13 : tensor<64x64xf32>) outs(%7 : tensor<64x64xf32>) {
-      ^bb0(%arg2: f32, %arg3: f32):
-        %15 = arith.cmpf olt, %arg2, %cst_1 : f32
-        %16 = arith.select %15, %cst_1, %arg2 : f32
-        %17 = arith.cmpf olt, %cst, %arg2 : f32
-        %18 = arith.select %17, %cst, %16 : f32
-        linalg.yield %18 : f32
-      } -> tensor<64x64xf32>
-      flow.dispatch.tensor.store %14, %2, offsets = [%arg0, %arg1], sizes = [64, 64], strides = [1, 1] : tensor<64x64xf32> -> !flow.dispatch.tensor<writeonly:tensor<6400x64xf32>>
-    }
-  }
-  return
-}
-// CHECK-LABEL: func.func @three_init_tensor_uses()
-//       CHECK: %[[OUTPUT:.+]] = hal.interface.binding.subspan set(0) binding(1)
-//   CHECK-NOT:   tensor.empty()
-//       CHECK:   %[[LOAD:.+]] = flow.dispatch.tensor.load %[[OUTPUT]]
-//   CHECK-NOT:   tensor.empty()
-//       CHECK:   linalg.fill
-//  CHECK-SAME:       outs(%[[LOAD]] :
-//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
-//       CHECK:   %[[GENERIC:.+]] = linalg.generic
-//  CHECK-SAME:       ins(%{{.+}}, %[[MATMUL]] :
-//       CHECK:   linalg.generic
-//  CHECK-SAME:       ins(%[[GENERIC]] :
-
-// -----
-
 func.func @fill_matmul_exp() {
   %cst = arith.constant 0.000000e+00 : f32
   %c0 = arith.constant 0 : index
@@ -891,8 +830,23 @@ func.func @multi_result_dispatches() {
   return
 }
 // CHECK-LABEL: func @multi_result_dispatches()
+//   CHECK-DAG:   %[[LHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(0)
+//   CHECK-DAG:   %[[RHS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(1)
+//   CHECK-DAG:   %[[BIAS_BINDING:.+]] = hal.interface.binding.subspan set(0) binding(2)
 //   CHECK-DAG:   %[[RESULT_BINDING0:.+]] = hal.interface.binding.subspan set(0) binding(3)
+//   CHECK-DAG:   %[[RESULT0:.+]] = flow.dispatch.tensor.load %[[RESULT_BINDING0]]
 //   CHECK-DAG:   %[[RESULT_BINDING1:.+]] = hal.interface.binding.subspan set(0) binding(4)
-//       CHECK:   %[[LOAD1:.+]] = flow.dispatch.tensor.load %[[RESULT_BINDING1]]
-//       CHECK:   linalg.fill
-//  CHECK-SAME:       outs(%[[LOAD1]] :
+//   CHECK-DAG:   %[[RESULT1:.+]] = flow.dispatch.tensor.load %[[RESULT_BINDING1]]
+//       CHECK:   %[[FILL:.+]] = linalg.fill
+//  CHECK-SAME:       outs(%[[RESULT1]] :
+//       CHECK:   %[[LHS:.+]] = flow.dispatch.tensor.load %[[LHS_BINDING]]
+//       CHECK:   %[[RHS:.+]] = flow.dispatch.tensor.load %[[RHS_BINDING]]
+//       CHECK:   %[[MATMUL:.+]] = linalg.matmul
+//  CHECK-SAME:       ins(%[[LHS]], %[[RHS]] :
+//  CHECK-SAME:       outs(%[[FILL]] :
+//       CHECK:   %[[BIAS:.+]] = flow.dispatch.tensor.load %[[BIAS_BINDING]]
+//       CHECK:   %[[GENERIC:.+]] = linalg.generic
+//  CHECK-SAME:       ins(%[[MATMUL]], %[[BIAS]] :
+//  CHECK-SAME:       outs(%[[RESULT0]] :
+//       CHECK:   flow.dispatch.tensor.store %[[MATMUL]], %[[RESULT_BINDING1]]
+//       CHECK:   flow.dispatch.tensor.store %[[GENERIC]], %[[RESULT_BINDING0]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -137,16 +137,16 @@ static void addTileAndDistributePasses(
     OpPassManager &pm, bool useFuseTensorPadWithConsumerPass = true) {
   pm.addPass(createTileAndDistributeToWorkgroupsPass());
   auto &nestedModulePM = pm.nest<ModuleOp>();
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      IREE::LinalgExt::createTileAndDecomposeAttentionPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      IREE::LinalgExt::createDecomposeSoftmaxPass());
   if (clEnablePadConsumerFusion && useFuseTensorPadWithConsumerPass) {
     nestedModulePM.addNestedPass<func::FuncOp>(
         createFuseTensorPadWithConsumerPass());
   }
   nestedModulePM.addNestedPass<func::FuncOp>(
       createConvertToDestinationPassingStylePass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createTileAndDecomposeAttentionPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      IREE::LinalgExt::createDecomposeSoftmaxPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createFoldAffineMinInDistributedLoopsPass());
   nestedModulePM.addPass(createCanonicalizerPass());

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -104,12 +104,12 @@ static void tileAndDistributeToWorkgroup(
 
   auto &nestedModulePM = pm.nest<ModuleOp>();
   nestedModulePM.addNestedPass<func::FuncOp>(
+      createConvertToDestinationPassingStylePass(
+          useWARForCooperativeMatrixCodegen));
+  nestedModulePM.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createTileAndDecomposeAttentionPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       IREE::LinalgExt::createDecomposeSoftmaxPass());
-  nestedModulePM.addNestedPass<func::FuncOp>(
-      createConvertToDestinationPassingStylePass(
-          useWARForCooperativeMatrixCodegen));
   nestedModulePM.addPass(createCanonicalizerPass());
   nestedModulePM.addPass(createCSEPass());
 }


### PR DESCRIPTION
For dispatches with

```
%r = <some compute op>
%store = linalg.generic ... ins(%r, ...) outs(%empty :)
```

where the value of `%store` is the final result of the dispatch, to avoid creation of stacks for `%r` when vectorization does not kick in, the user is converted to

```
%store = linalg.generic ... ins(, ...) outs(%r :)
```

This is a very specific change to work around something that really should be handled later on during bufferization (but is outside scope of bufferization today). This change needs to kick in very specific conditions (since its a work-around, and really the created `linalg.generic` is somewhat of an anti-pattern), using a pattern rewrite to make this change does not allow controlling the transformation. Change this to use a walk and trigger only when needed.

Fixes #12019.