### PR TITLE
Functional support mma.sync.1688.f32.tf32 for F32 datatype

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -56,7 +56,7 @@ hal.executable @mma_fused_fp16 {
 }
 }
 
-// mma.sync case:
+// mma.sync.16816.f16.f16 / TensorCore(f16):
 //    CHECK-LABEL: hal.executable public @mma_fused_fp16
 //          CHECK:   hal.executable.variant public @cuda
 //      CHECK-NOT:   llvm.store
@@ -71,7 +71,7 @@ hal.executable @mma_fused_fp16 {
 //          CHECK:   llvm.br
 //          CHECK:   nvvm.cp.async.wait.group 3
 //  CHECK-COUNT-4:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
-//  CHECK-COUNT-4:   nvvm.mma.sync
+//  CHECK-COUNT-4:   nvvm.mma.sync {{.*}}, shape = #nvvm.shape<m = 16, n = 8, k = 16
 //  CHECK-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
 //          CHECK:   nvvm.cp.async.commit.group
 //          CHECK:   llvm.br
@@ -81,3 +81,87 @@ hal.executable @mma_fused_fp16 {
 //          CHECK:   llvm.store {{.*}} : !llvm.ptr<vector<8xf16>>
 
 // -----
+
+
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>,
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @mma_fused {
+  hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
+  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @_large_aligned_dispatch_0() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f32
+      %c2048 = arith.constant 2048 : index
+      %c512 = arith.constant 512 : index
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>>
+      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
+      %di = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>>
+      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1024], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>> -> tensor<2048x1024xf32>
+      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
+      %d = flow.dispatch.tensor.load %di, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
+          : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>> -> tensor<2048x512xf32>
+      %init = tensor.empty() : tensor<2048x512xf32>
+      %f = linalg.fill ins(%cst : f32) outs(%init : tensor<2048x512xf32>) -> tensor<2048x512xf32>
+      %m = linalg.matmul ins(%3, %4 : tensor<2048x1024xf32>, tensor<1024x512xf32>) outs(%f : tensor<2048x512xf32>) -> tensor<2048x512xf32>
+      %init2 = tensor.empty() : tensor<2048x512xf32>
+      %a = linalg.generic {
+          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+          iterator_types = ["parallel", "parallel"]}
+          ins(%m, %d : tensor<2048x512xf32>, tensor<2048x512xf32>) outs(%init2 : tensor<2048x512xf32>) {
+        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
+          %19 = arith.addf %arg3, %arg4 : f32
+          linalg.yield %19 : f32
+        } -> (tensor<2048x512xf32>)
+        flow.dispatch.tensor.store %a, %2, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
+          : tensor<2048x512xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
+      return
+    }
+  }
+}
+}
+
+// mma.sync.1688.f32.tf32 / TensorCore(f32):
+//    MMASYNC-LABEL: hal.executable public @mma_fused
+//          MMASYNC:   hal.executable.variant public @cuda
+//      MMASYNC-NOT:   llvm.store
+//  MMASYNC-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
+//          MMASYNC:   nvvm.cp.async.commit.group
+//  MMASYNC-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
+//          MMASYNC:   nvvm.cp.async.commit.group
+//  MMASYNC-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
+//          MMASYNC:   nvvm.cp.async.commit.group
+//  MMASYNC-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
+//          MMASYNC:   nvvm.cp.async.commit.group
+//          MMASYNC:   llvm.br
+//          MMASYNC:   nvvm.cp.async.wait.group 3
+//  MMASYNC-COUNT-4:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32)
+//  MMASYNC-COUNT-8:   nvvm.mma.sync
+//  MMASYNC-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
+//          MMASYNC:   nvvm.cp.async.commit.group
+//          MMASYNC:   llvm.br
+//      MMASYNC-NOT:   nvvm.mma.sync {{.*}}, shape = #nvvm.shape<m = 16, n = 8, k = 8
+//  MMASYNC-COUNT-4:   llvm.store {{.*}} : !llvm.ptr<vector<2xf32>, 3>
+//    MMASYNC-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//    MMASYNC-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//    MMASYNC-COUNT:   nvvm.barrier0
+//    MMASYNC-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    MMASYNC-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
+//    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
+//    MMASYNC-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
+//    MMASYNC-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
+//    MMASYNC-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -209,6 +209,35 @@ py_binary(
     "LLVMGPUMatmulTensorCore",
 ]]
 
+# MMA.SYNC TensorCore(F32): mma.sync.1688.f32.t32
+[iree_generated_trace_runner_test(
+    name = "e2e_matmul_direct_f32_gpu_large_mma_sync_%s" % compilation_info,
+    compiler_flags = [
+        "--iree-hal-cuda-llvm-target-arch=sm_80",
+        "--iree-codegen-llvmgpu-use-mma-sync=true",
+    ],
+    generator = ":generate_e2e_matmul_tests",
+    generator_args = [
+        "--lhs_rhs_type=f32",
+        "--shapes=gpu_large",
+        "--compilation_info=%s" % compilation_info,
+    ],
+    tags = [
+        # CUDA cuInit fails with sanitizer on.
+        "noasan",
+        "nomsan",
+        "notsan",
+        "noubsan",
+        "requires-gpu-nvidia",
+    ],
+    target_backends_and_drivers = [
+        ("cuda", "cuda"),
+    ],
+    trace_runner = "//tools:iree-e2e-matmul-test",
+) for compilation_info in [
+    "LLVMGPUMatmulTensorCore",
+]]
+
 # WMMA TensorCore(F16): wmma.161616.f16.f16
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_f16_gpu_large_%s" % compilation_info,

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -294,6 +294,32 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
+    e2e_matmul_direct_f32_gpu_large_mma_sync_LLVMGPUMatmulTensorCore
+  GENERATOR
+    "generate_e2e_matmul_tests.py"
+  GENERATOR_ARGS
+    "--lhs_rhs_type=f32"
+    "--shapes=gpu_large"
+    "--compilation_info=LLVMGPUMatmulTensorCore"
+  TRACE_RUNNER
+    iree-e2e-matmul-test
+  TARGET_BACKENDS
+    "cuda"
+  DRIVERS
+    "cuda"
+  COMPILER_FLAGS
+    "--iree-hal-cuda-llvm-target-arch=sm_80"
+    "--iree-codegen-llvmgpu-use-mma-sync=true"
+  LABELS
+    "noasan"
+    "nomsan"
+    "notsan"
+    "noubsan"
+    "requires-gpu-nvidia"
+)
+
+iree_generated_trace_runner_test(
+  NAME
     e2e_matmul_direct_f16_gpu_large_LLVMGPUMatmulTensorCore
   GENERATOR
     "generate_e2e_matmul_tests.py"


### PR DESCRIPTION
**Adds native Tensor Core (F32) support for NVIDIA A100 GPU** 

The PR targets`mma.sync.aligned.m16n8k8.row.col.f32.tf32.tf32.f32`, `ldmatrix` for operandA and `ld.shared` for operandB on NVIDIA A100 GPUs. For now, these instructions are not enabled by default and are behind iree-compile flag `--iree-codegen-llvmgpu-use-mma-sync=true`.

IREE runs row-row matmul, the native Tensor Core support is enabled through `ldmatrix` for operandA. However, 
`ldmatrix.trans` for operandB can only work at 16-bit granularity. Thus, `ld.shared` instruction is used for operandB to transposes the data while loading data into register. This allows the use of Tensor Core `mma.sync*row.col*` instruction.

