### PR TITLE
unpack ukernel (ARM64 code, test, benchmark) + pack improvements

### DIFF
--- a/runtime/src/iree/builtins/ukernel/BUILD
+++ b/runtime/src/iree/builtins/ukernel/BUILD
@@ -59,6 +59,8 @@ iree_runtime_cc_library(
         "pack_tile.c",
         "mmt4d_tile.h",
         "pack_tile.h",
+        "unpack_tile.c",
+        "unpack_tile.h",
     ] + ukernel_headers,
     hdrs = ["api.h"],
     deps = [

--- a/runtime/src/iree/builtins/ukernel/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/CMakeLists.txt
@@ -70,6 +70,8 @@ iree_cc_library(
     "query_tile_sizes.h"
     "unpack.c"
     "unpack.h"
+    "unpack_tile.c"
+    "unpack_tile.h"
   DEPS
     ::exported_bits
     ::headers

--- a/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/CMakeLists.txt
@@ -31,6 +31,7 @@ if(IREE_UK_ENABLE_ARCH_SPECIFIC_CODE)
       "iree::builtins::ukernel::arch::arm_64::mmt4d_arm_64"
       "iree::builtins::ukernel::arch::arm_64::pack_arm_64"
       "iree::builtins::ukernel::arch::arm_64::query_tile_sizes_arm_64"
+      "iree::builtins::ukernel::arch::arm_64::unpack_arm_64"
     )
   endif()
 endif()  # IREE_UK_ENABLE_ARCH_SPECIFIC_CODE

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/BUILD
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/BUILD
@@ -32,3 +32,10 @@ iree_runtime_cc_library(
         "query_tile_sizes_arm_64.h",
     ],
 )
+
+iree_runtime_cc_library(
+    name = "unpack_arm_64",
+    hdrs = [
+        "unpack_arm_64.h",
+    ],
+)

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/CMakeLists.txt
@@ -15,6 +15,13 @@ iree_cc_library(
     "assembly.h"
 )
 
+iree_cc_library(
+  NAME
+    common_arm_neon
+  HDRS
+    "common_arm_neon.h"
+)
+
 if(IREE_UK_BUILD_ARM_64_DOTPROD)
   iree_cc_library(
     NAME
@@ -74,15 +81,12 @@ iree_cc_library(
   SRCS
     "pack_arm_64.c"
   DEPS
+    ::common_arm_neon
     iree::base::core_headers
     iree::schemas::cpu_data
     iree::builtins::ukernel::headers
   PUBLIC
 )
-
-###############################################################################
-# query_tile_sizes entry point
-###############################################################################
 
 iree_cc_library(
   NAME
@@ -92,6 +96,21 @@ iree_cc_library(
   SRCS
     "query_tile_sizes_arm_64.c"
   DEPS
+    iree::base::core_headers
+    iree::schemas::cpu_data
+    iree::builtins::ukernel::headers
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    unpack_arm_64
+  HDRS
+    "unpack_arm_64.h"
+  SRCS
+    "unpack_arm_64.c"
+  DEPS
+    ::common_arm_neon
     iree::base::core_headers
     iree::schemas::cpu_data
     iree::builtins::ukernel::headers

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/common_arm_neon.h
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/common_arm_neon.h
@@ -1,0 +1,281 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_ARM_64_COMMON_ARM_NEON_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_ARM_64_COMMON_ARM_NEON_H_
+
+#include <arm_neon.h>
+
+#include "iree/builtins/ukernel/common.h"
+
+static inline int8x16x2_t iree_uk_neon_load_32(
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr) {
+  int8x16x2_t v;
+  v.val[0] = vld1q_s8(in_ptr);
+  v.val[1] = vld1q_s8(in_ptr + 16);
+  return v;
+}
+
+static inline int8x16x4_t iree_uk_neon_load_64(
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr) {
+  int8x16x4_t v;
+  v.val[0] = vld1q_s8(in_ptr);
+  v.val[1] = vld1q_s8(in_ptr + 16);
+  v.val[2] = vld1q_s8(in_ptr + 32);
+  v.val[3] = vld1q_s8(in_ptr + 48);
+  return v;
+}
+
+static inline int8x16x2_t iree_uk_neon_load_8x4xi8_strided(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
+  int32x4_t v0_i32 = vdupq_n_s32(0);
+  int32x4_t v1_i32 = vdupq_n_s32(0);
+  v0_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 0 * stride), v0_i32, 0);
+  v0_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 1 * stride), v0_i32, 1);
+  v0_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 2 * stride), v0_i32, 2);
+  v0_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 3 * stride), v0_i32, 3);
+  v1_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 4 * stride), v1_i32, 0);
+  v1_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 5 * stride), v1_i32, 1);
+  v1_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 6 * stride), v1_i32, 2);
+  v1_i32 =
+      vld1q_lane_s32((const iree_uk_int32_t*)(src + 7 * stride), v1_i32, 3);
+  int8x16x2_t v;
+  v.val[0] = vreinterpretq_s8_s32(v0_i32);
+  v.val[1] = vreinterpretq_s8_s32(v1_i32);
+  return v;
+}
+
+static inline int8x16x4_t iree_uk_neon_load_8x8xi8_strided_permute(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride, int p0, int p1, int p2,
+    int p3, int p4, int p5, int p6, int p7) {
+  int8x8_t row0 = vld1_s8(src + p0 * stride);
+  int8x8_t row1 = vld1_s8(src + p1 * stride);
+  int8x8_t row2 = vld1_s8(src + p2 * stride);
+  int8x8_t row3 = vld1_s8(src + p3 * stride);
+  int8x8_t row4 = vld1_s8(src + p4 * stride);
+  int8x8_t row5 = vld1_s8(src + p5 * stride);
+  int8x8_t row6 = vld1_s8(src + p6 * stride);
+  int8x8_t row7 = vld1_s8(src + p7 * stride);
+  int8x16x4_t v;
+  v.val[0] = vcombine_s8(row0, row1);
+  v.val[1] = vcombine_s8(row2, row3);
+  v.val[2] = vcombine_s8(row4, row5);
+  v.val[3] = vcombine_s8(row6, row7);
+  return v;
+}
+
+static inline int8x16x4_t iree_uk_neon_load_8x8xi8_strided(
+    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
+  return iree_uk_neon_load_8x8xi8_strided_permute(src, stride, 0, 1, 2, 3, 4, 5,
+                                                  6, 7);
+}
+
+static inline int16x8x2_t iree_uk_neon_zip_16xi8_as_8xi16(int8x16_t a,
+                                                          int8x16_t b) {
+  int8x16x2_t z = vzipq_s8(a, b);
+  int16x8x2_t r;
+  r.val[0] = vreinterpretq_s16_s8(z.val[0]);
+  r.val[1] = vreinterpretq_s16_s8(z.val[1]);
+  return r;
+}
+
+static inline int32x4x2_t iree_uk_neon_zip_8xi16_as_4xi32(int16x8_t a,
+                                                          int16x8_t b) {
+  int16x8x2_t z = vzipq_s16(a, b);
+  int32x4x2_t r;
+  r.val[0] = vreinterpretq_s32_s16(z.val[0]);
+  r.val[1] = vreinterpretq_s32_s16(z.val[1]);
+  return r;
+}
+
+static inline int64x2x2_t iree_uk_neon_zip_4xi32_as_2xi64(int32x4_t a,
+                                                          int32x4_t b) {
+  int32x4x2_t z = vzipq_s32(a, b);
+  int64x2x2_t r;
+  r.val[0] = vreinterpretq_s64_s32(z.val[0]);
+  r.val[1] = vreinterpretq_s64_s32(z.val[1]);
+  return r;
+}
+
+static inline void iree_uk_neon_copy_8x1xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  int8x8_t v = vdup_n_s8(0);
+  v = vld1_lane_s8(in_ptr + 0 * in_stride, v, 0);
+  v = vld1_lane_s8(in_ptr + 1 * in_stride, v, 1);
+  v = vld1_lane_s8(in_ptr + 2 * in_stride, v, 2);
+  v = vld1_lane_s8(in_ptr + 3 * in_stride, v, 3);
+  v = vld1_lane_s8(in_ptr + 4 * in_stride, v, 4);
+  v = vld1_lane_s8(in_ptr + 5 * in_stride, v, 5);
+  v = vld1_lane_s8(in_ptr + 6 * in_stride, v, 6);
+  v = vld1_lane_s8(in_ptr + 7 * in_stride, v, 7);
+  vst1_s8(out_ptr, v);
+}
+
+static inline void iree_uk_neon_copy_8x4xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  int8x16x2_t in = iree_uk_neon_load_8x4xi8_strided(in_ptr, in_stride);
+  vst1q_s8(out_ptr + 0, in.val[0]);
+  vst1q_s8(out_ptr + 16, in.val[1]);
+}
+
+static inline void iree_uk_neon_copy_8x8xi8_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  int8x16x4_t in = iree_uk_neon_load_8x8xi8_strided(in_ptr, in_stride);
+  vst1q_s8(out_ptr + 0, in.val[0]);
+  vst1q_s8(out_ptr + 16, in.val[1]);
+  vst1q_s8(out_ptr + 32, in.val[2]);
+  vst1q_s8(out_ptr + 48, in.val[3]);
+}
+
+static inline void
+iree_uk_neon_copy_8x8xi8_tiled_1x4_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  int8x16x4_t in = iree_uk_neon_load_8x8xi8_strided_permute(
+      in_ptr, in_stride, 0, 2, 1, 3, 4, 6, 5, 7);
+  int32x4x2_t c0 = vtrnq_s32(vreinterpretq_s32_s8(in.val[0]),
+                             vreinterpretq_s32_s8(in.val[1]));
+  int32x4x2_t c1 = vtrnq_s32(vreinterpretq_s32_s8(in.val[2]),
+                             vreinterpretq_s32_s8(in.val[3]));
+  vst1q_s8(out_ptr + 0 + 0 * out_stride, vreinterpretq_s8_s32(c0.val[0]));
+  vst1q_s8(out_ptr + 16 + 0 * out_stride, vreinterpretq_s8_s32(c1.val[0]));
+  vst1q_s8(out_ptr + 0 + 1 * out_stride, vreinterpretq_s8_s32(c0.val[1]));
+  vst1q_s8(out_ptr + 16 + 1 * out_stride, vreinterpretq_s8_s32(c1.val[1]));
+}
+
+static inline void iree_uk_neon_copy_8x8xi8_unstrided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride) {
+  int8x16x4_t in = iree_uk_neon_load_64(in_ptr);
+  vst1_s8(out_ptr + 0 * out_stride, vget_low_s8(in.val[0]));
+  vst1_s8(out_ptr + 1 * out_stride, vget_high_s8(in.val[0]));
+  vst1_s8(out_ptr + 2 * out_stride, vget_low_s8(in.val[1]));
+  vst1_s8(out_ptr + 3 * out_stride, vget_high_s8(in.val[1]));
+  vst1_s8(out_ptr + 4 * out_stride, vget_low_s8(in.val[2]));
+  vst1_s8(out_ptr + 5 * out_stride, vget_high_s8(in.val[2]));
+  vst1_s8(out_ptr + 6 * out_stride, vget_low_s8(in.val[3]));
+  vst1_s8(out_ptr + 7 * out_stride, vget_high_s8(in.val[3]));
+}
+
+static inline void iree_uk_neon_copy_8x8xi8_transpose_unstrided_to_strided(
+    iree_uk_int8_t* out_ptr, iree_uk_ssize_t out_stride,
+    const iree_uk_int8_t* in_ptr) {
+  int8x16x4_t in = vld4q_s8(in_ptr);
+  int8x16x2_t t0 = vuzpq_s8(in.val[0], in.val[1]);
+  int8x16x2_t t1 = vuzpq_s8(in.val[2], in.val[3]);
+  vst1q_lane_s64(out_ptr + 0 * out_stride, vreinterpretq_s64_s8(t0.val[0]), 0);
+  vst1q_lane_s64(out_ptr + 1 * out_stride, vreinterpretq_s64_s8(t0.val[0]), 1);
+  vst1q_lane_s64(out_ptr + 2 * out_stride, vreinterpretq_s64_s8(t1.val[0]), 0);
+  vst1q_lane_s64(out_ptr + 3 * out_stride, vreinterpretq_s64_s8(t1.val[0]), 1);
+  vst1q_lane_s64(out_ptr + 4 * out_stride, vreinterpretq_s64_s8(t0.val[1]), 0);
+  vst1q_lane_s64(out_ptr + 5 * out_stride, vreinterpretq_s64_s8(t0.val[1]), 1);
+  vst1q_lane_s64(out_ptr + 6 * out_stride, vreinterpretq_s64_s8(t1.val[1]), 0);
+  vst1q_lane_s64(out_ptr + 7 * out_stride, vreinterpretq_s64_s8(t1.val[1]), 1);
+}
+
+static inline void iree_uk_neon_copy_8x8xi8_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  int8x16x4_t in = iree_uk_neon_load_8x8xi8_strided_permute(
+      in_ptr, in_stride, 0, 4, 1, 5, 2, 6, 3, 7);
+  int16x8x2_t zip_i16_0 = iree_uk_neon_zip_16xi8_as_8xi16(in.val[0], in.val[1]);
+  int16x8x2_t zip_i16_1 = iree_uk_neon_zip_16xi8_as_8xi16(in.val[2], in.val[3]);
+  int32x4x2_t zip_i32_0 =
+      iree_uk_neon_zip_8xi16_as_4xi32(zip_i16_0.val[0], zip_i16_1.val[0]);
+  int32x4x2_t zip_i32_1 =
+      iree_uk_neon_zip_8xi16_as_4xi32(zip_i16_0.val[1], zip_i16_1.val[1]);
+  int64x2x2_t zip_i64_0 =
+      iree_uk_neon_zip_4xi32_as_2xi64(zip_i32_0.val[0], zip_i32_1.val[0]);
+  int64x2x2_t zip_i64_1 =
+      iree_uk_neon_zip_4xi32_as_2xi64(zip_i32_0.val[1], zip_i32_1.val[1]);
+  int8x16x4_t out;
+  out.val[0] = vreinterpretq_s8_s64(zip_i64_0.val[0]);
+  out.val[1] = vreinterpretq_s8_s64(zip_i64_0.val[1]);
+  out.val[2] = vreinterpretq_s8_s64(zip_i64_1.val[0]);
+  out.val[3] = vreinterpretq_s8_s64(zip_i64_1.val[1]);
+  vst1_s8(out_ptr + 0 * out_stride, vget_low_s8(out.val[0]));
+  vst1_s8(out_ptr + 1 * out_stride, vget_high_s8(out.val[0]));
+  vst1_s8(out_ptr + 2 * out_stride, vget_low_s8(out.val[1]));
+  vst1_s8(out_ptr + 3 * out_stride, vget_high_s8(out.val[1]));
+  vst1_s8(out_ptr + 4 * out_stride, vget_low_s8(out.val[2]));
+  vst1_s8(out_ptr + 5 * out_stride, vget_high_s8(out.val[2]));
+  vst1_s8(out_ptr + 6 * out_stride, vget_low_s8(out.val[3]));
+  vst1_s8(out_ptr + 7 * out_stride, vget_high_s8(out.val[3]));
+}
+
+static inline void iree_uk_neon_copy_8x8xi8_transpose_strided_to_unstrided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t in_stride) {
+  // Clang (Android NDK r25) actually produces worse code when this code is
+  // specialized for out_stride==8 using longer contiguous stores!
+  iree_uk_neon_copy_8x8xi8_transpose_strided_to_strided(out_ptr, in_ptr, 8,
+                                                        in_stride);
+}
+
+static inline void
+iree_uk_neon_copy_8x8xi8_tiled_8x4_transpose_strided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr, iree_uk_ssize_t out_stride,
+    iree_uk_ssize_t in_stride) {
+  int32x4_t in0 = vreinterpretq_s32_s8(vld1q_s8(in_ptr));
+  int32x4_t in1 = vreinterpretq_s32_s8(vld1q_s8(in_ptr + 16));
+  int32x4_t in2 = vreinterpretq_s32_s8(vld1q_s8(in_ptr + in_stride));
+  int32x4_t in3 = vreinterpretq_s32_s8(vld1q_s8(in_ptr + in_stride + 16));
+  int64x2x2_t c0 = iree_uk_neon_zip_4xi32_as_2xi64(in0, in2);
+  int64x2x2_t c1 = iree_uk_neon_zip_4xi32_as_2xi64(in1, in3);
+  vst1q_lane_s64(out_ptr + 0 * out_stride, c0.val[0], 0);
+  vst1q_lane_s64(out_ptr + 1 * out_stride, c0.val[0], 1);
+  vst1q_lane_s64(out_ptr + 2 * out_stride, c0.val[1], 0);
+  vst1q_lane_s64(out_ptr + 3 * out_stride, c0.val[1], 1);
+  vst1q_lane_s64(out_ptr + 4 * out_stride, c1.val[0], 0);
+  vst1q_lane_s64(out_ptr + 5 * out_stride, c1.val[0], 1);
+  vst1q_lane_s64(out_ptr + 6 * out_stride, c1.val[1], 0);
+  vst1q_lane_s64(out_ptr + 7 * out_stride, c1.val[1], 1);
+}
+
+static inline void iree_uk_neon_copy_8x1xi8_unstrided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr, iree_uk_ssize_t out_stride,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr) {
+  int8x8_t v = vld1_s8(in_ptr);
+  vst1_lane_s8(out_ptr + 0 * out_stride, v, 0);
+  vst1_lane_s8(out_ptr + 1 * out_stride, v, 1);
+  vst1_lane_s8(out_ptr + 2 * out_stride, v, 2);
+  vst1_lane_s8(out_ptr + 3 * out_stride, v, 3);
+  vst1_lane_s8(out_ptr + 4 * out_stride, v, 4);
+  vst1_lane_s8(out_ptr + 5 * out_stride, v, 5);
+  vst1_lane_s8(out_ptr + 6 * out_stride, v, 6);
+  vst1_lane_s8(out_ptr + 7 * out_stride, v, 7);
+}
+
+static inline void iree_uk_neon_copy_8x4_unstrided_to_strided(
+    iree_uk_int8_t* IREE_UK_RESTRICT out_ptr, iree_uk_ssize_t out_stride,
+    const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr) {
+  int8x16x2_t in = iree_uk_neon_load_32(in_ptr);
+  int32x4_t v0 = vreinterpretq_s32_s8(in.val[0]);
+  int32x4_t v1 = vreinterpretq_s32_s8(in.val[1]);
+  vst1q_lane_s32(out_ptr + 0 * out_stride, v0, 0);
+  vst1q_lane_s32(out_ptr + 1 * out_stride, v0, 1);
+  vst1q_lane_s32(out_ptr + 2 * out_stride, v0, 2);
+  vst1q_lane_s32(out_ptr + 3 * out_stride, v0, 3);
+  vst1q_lane_s32(out_ptr + 4 * out_stride, v1, 0);
+  vst1q_lane_s32(out_ptr + 5 * out_stride, v1, 1);
+  vst1q_lane_s32(out_ptr + 6 * out_stride, v1, 2);
+  vst1q_lane_s32(out_ptr + 7 * out_stride, v1, 3);
+}
+
+#endif  // IREE_BUILTINS_UKERNEL_ARCH_ARM_64_COMMON_ARM_NEON_H_

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/pack_arm_64.c
@@ -8,272 +8,121 @@
 
 #include <arm_neon.h>
 
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x1_x32_arm_64_direct)
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x1_x32_arm_64_transpose)
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x1_x8_arm_64_direct)
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x1_x8_arm_64_transpose)
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x4_x8_arm_64_direct)
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x4_x8_arm_64_transpose)
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x8_x8_arm_64_direct)
-IREE_UK_PACK_TILE_FUNC_DECL(iree_uk_pack_tile_8x8_x8_arm_64_transpose)
+#include "iree/builtins/ukernel/arch/arm_64/common_arm_neon.h"
 
-static inline int8x8_t iree_uk_neon_load_8xi8_strided(const iree_uk_int8_t* src,
-                                                      iree_uk_ssize_t stride) {
-  int8x8_t v = vdup_n_s8(0);
-  v = vld1_lane_s8(src + 0 * stride, v, 0);
-  v = vld1_lane_s8(src + 1 * stride, v, 1);
-  v = vld1_lane_s8(src + 2 * stride, v, 2);
-  v = vld1_lane_s8(src + 3 * stride, v, 3);
-  v = vld1_lane_s8(src + 4 * stride, v, 4);
-  v = vld1_lane_s8(src + 5 * stride, v, 5);
-  v = vld1_lane_s8(src + 6 * stride, v, 6);
-  v = vld1_lane_s8(src + 7 * stride, v, 7);
-  return v;
-}
-
-static inline int8x16x2_t iree_uk_neon_load_8x4xi8_rowmajor_strided(
-    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
-  int32x4_t v0_i32 = vdupq_n_s32(0);
-  int32x4_t v1_i32 = vdupq_n_s32(0);
-  v0_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 0 * stride), v0_i32, 0);
-  v0_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 1 * stride), v0_i32, 1);
-  v0_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 2 * stride), v0_i32, 2);
-  v0_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 3 * stride), v0_i32, 3);
-  v1_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 4 * stride), v1_i32, 0);
-  v1_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 5 * stride), v1_i32, 1);
-  v1_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 6 * stride), v1_i32, 2);
-  v1_i32 =
-      vld1q_lane_s32((const iree_uk_int32_t*)(src + 7 * stride), v1_i32, 3);
-  int8x16x2_t v;
-  v.val[0] = vreinterpretq_s8_s32(v0_i32);
-  v.val[1] = vreinterpretq_s8_s32(v1_i32);
-  return v;
-}
-
-static inline int8x16x4_t
-iree_uk_neon_load_8x8xi8_rowmajor_strided_permute_rows(
-    const iree_uk_int8_t* src, iree_uk_ssize_t stride, int p0, int p1, int p2,
-    int p3, int p4, int p5, int p6, int p7) {
-  int8x8_t row0 = vld1_s8(src + p0 * stride);
-  int8x8_t row1 = vld1_s8(src + p1 * stride);
-  int8x8_t row2 = vld1_s8(src + p2 * stride);
-  int8x8_t row3 = vld1_s8(src + p3 * stride);
-  int8x8_t row4 = vld1_s8(src + p4 * stride);
-  int8x8_t row5 = vld1_s8(src + p5 * stride);
-  int8x8_t row6 = vld1_s8(src + p6 * stride);
-  int8x8_t row7 = vld1_s8(src + p7 * stride);
-  int8x16x4_t v;
-  v.val[0] = vcombine_s8(row0, row1);
-  v.val[1] = vcombine_s8(row2, row3);
-  v.val[2] = vcombine_s8(row4, row5);
-  v.val[3] = vcombine_s8(row6, row7);
-  return v;
-}
-
-static inline int8x16x4_t iree_uk_neon_load_8x8xi8_rowmajor_strided(
-    const iree_uk_int8_t* src, iree_uk_ssize_t stride) {
-  return iree_uk_neon_load_8x8xi8_rowmajor_strided_permute_rows(
-      src, stride, 0, 1, 2, 3, 4, 5, 6, 7);
-}
-
-static inline void iree_uk_neon_copy_8x1xi8_strided_to_unstrided(
-    iree_uk_int8_t* restrict out_ptr, const iree_uk_int8_t* restrict in_ptr,
-    iree_uk_ssize_t in_stride) {
-  int8x8_t in = iree_uk_neon_load_8xi8_strided(in_ptr, in_stride);
-  vst1_s8(out_ptr, in);
-}
-
-static inline void iree_uk_neon_copy_8x4xi8_rowmajor_strided_to_unstrided(
-    iree_uk_int8_t* restrict out_ptr, const iree_uk_int8_t* restrict in_ptr,
-    iree_uk_ssize_t in_stride) {
-  int8x16x2_t in = iree_uk_neon_load_8x4xi8_rowmajor_strided(in_ptr, in_stride);
-  vst1q_s8(out_ptr + 0, in.val[0]);
-  vst1q_s8(out_ptr + 16, in.val[1]);
-}
-
-static inline void iree_uk_neon_copy_8x8xi8_rowmajor_strided_to_unstrided(
-    iree_uk_int8_t* restrict out_ptr, const iree_uk_int8_t* restrict in_ptr,
-    iree_uk_ssize_t in_stride) {
-  int8x16x4_t in = iree_uk_neon_load_8x8xi8_rowmajor_strided(in_ptr, in_stride);
-  vst1q_s8(out_ptr + 0, in.val[0]);
-  vst1q_s8(out_ptr + 16, in.val[1]);
-  vst1q_s8(out_ptr + 32, in.val[2]);
-  vst1q_s8(out_ptr + 48, in.val[3]);
-}
-
-static inline int16x8x2_t iree_uk_neon_zip_16xi8_as_8xi16(int8x16_t a,
-                                                          int8x16_t b) {
-  int8x16x2_t z = vzipq_s8(a, b);
-  int16x8x2_t r;
-  r.val[0] = vreinterpretq_s16_s8(z.val[0]);
-  r.val[1] = vreinterpretq_s16_s8(z.val[1]);
-  return r;
-}
-
-static inline int32x4x2_t iree_uk_neon_zip_8xi16_as_4xi32(int16x8_t a,
-                                                          int16x8_t b) {
-  int16x8x2_t z = vzipq_s16(a, b);
-  int32x4x2_t r;
-  r.val[0] = vreinterpretq_s32_s16(z.val[0]);
-  r.val[1] = vreinterpretq_s32_s16(z.val[1]);
-  return r;
-}
-
-static inline int64x2x2_t iree_uk_neon_zip_4xi32_as_2xi64(int32x4_t a,
-                                                          int32x4_t b) {
-  int32x4x2_t z = vzipq_s32(a, b);
-  int64x2x2_t r;
-  r.val[0] = vreinterpretq_s64_s32(z.val[0]);
-  r.val[1] = vreinterpretq_s64_s32(z.val[1]);
-  return r;
-}
-
-static inline void iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor(
-    iree_uk_int8_t* restrict out_ptr, const iree_uk_int8_t* restrict in_ptr,
-    iree_uk_ssize_t out_stride, iree_uk_ssize_t in_stride) {
-  int8x16x4_t in = iree_uk_neon_load_8x8xi8_rowmajor_strided_permute_rows(
-      in_ptr, in_stride, 0, 4, 1, 5, 2, 6, 3, 7);
-  int16x8x2_t zip_i16_0 = iree_uk_neon_zip_16xi8_as_8xi16(in.val[0], in.val[1]);
-  int16x8x2_t zip_i16_1 = iree_uk_neon_zip_16xi8_as_8xi16(in.val[2], in.val[3]);
-  int32x4x2_t zip_i32_0 =
-      iree_uk_neon_zip_8xi16_as_4xi32(zip_i16_0.val[0], zip_i16_1.val[0]);
-  int32x4x2_t zip_i32_1 =
-      iree_uk_neon_zip_8xi16_as_4xi32(zip_i16_0.val[1], zip_i16_1.val[1]);
-  int64x2x2_t zip_i64_0 =
-      iree_uk_neon_zip_4xi32_as_2xi64(zip_i32_0.val[0], zip_i32_1.val[0]);
-  int64x2x2_t zip_i64_1 =
-      iree_uk_neon_zip_4xi32_as_2xi64(zip_i32_0.val[1], zip_i32_1.val[1]);
-  int8x16x4_t out;
-  out.val[0] = vreinterpretq_s8_s64(zip_i64_0.val[0]);
-  out.val[1] = vreinterpretq_s8_s64(zip_i64_0.val[1]);
-  out.val[2] = vreinterpretq_s8_s64(zip_i64_1.val[0]);
-  out.val[3] = vreinterpretq_s8_s64(zip_i64_1.val[1]);
-  vst1_s8(out_ptr + 0 * out_stride, vget_low_s8(out.val[0]));
-  vst1_s8(out_ptr + 1 * out_stride, vget_high_s8(out.val[0]));
-  vst1_s8(out_ptr + 2 * out_stride, vget_low_s8(out.val[1]));
-  vst1_s8(out_ptr + 3 * out_stride, vget_high_s8(out.val[1]));
-  vst1_s8(out_ptr + 4 * out_stride, vget_low_s8(out.val[2]));
-  vst1_s8(out_ptr + 5 * out_stride, vget_high_s8(out.val[2]));
-  vst1_s8(out_ptr + 6 * out_stride, vget_low_s8(out.val[3]));
-  vst1_s8(out_ptr + 7 * out_stride, vget_high_s8(out.val[3]));
-}
-
-static inline void iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor_tiled_1x4(
-    iree_uk_int8_t* restrict out_ptr, const iree_uk_int8_t* restrict in_ptr,
-    iree_uk_ssize_t out_stride, iree_uk_ssize_t in_stride) {
-  int8x16x4_t in = iree_uk_neon_load_8x8xi8_rowmajor_strided_permute_rows(
-      in_ptr, in_stride, 0, 2, 1, 3, 4, 6, 5, 7);
-  int32x4x2_t c0 = vtrnq_s32(vreinterpretq_s32_s8(in.val[0]),
-                             vreinterpretq_s32_s8(in.val[1]));
-  int32x4x2_t c1 = vtrnq_s32(vreinterpretq_s32_s8(in.val[2]),
-                             vreinterpretq_s32_s8(in.val[3]));
-  vst1q_s8(out_ptr + 0 + 0 * out_stride, vreinterpretq_s8_s32(c0.val[0]));
-  vst1q_s8(out_ptr + 16 + 0 * out_stride, vreinterpretq_s8_s32(c1.val[0]));
-  vst1q_s8(out_ptr + 0 + 1 * out_stride, vreinterpretq_s8_s32(c0.val[1]));
-  vst1q_s8(out_ptr + 16 + 1 * out_stride, vreinterpretq_s8_s32(c1.val[1]));
-}
-
-void iree_uk_pack_tile_8x1_x8_arm_64_direct(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  iree_uk_ssize_t outer_i1 = 0;
-  iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
-  const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
-  // A further 2x unrolling (outer_i1+=16) yields another 1.2x speedup on A710
-  // thanks to using 16-byte loads. Is it worth the code size? This 8x1 tile is
-  // used on baseline aarch64 where the matmul kernel is slow anyway.
-  for (; outer_i1 <= outer_size1 - 8; outer_i1 += 8) {
-    iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor(out_ptr, in_ptr, out_stride1,
-                                                  in_stride0);
+static void iree_uk_pack_tile_8x1_x8_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 1);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  // A further 2x unrolling (outer_size1-=16) yields another 1.2x speedup on
+  // A710 thanks to using 16-byte loads. Is it worth the code size? This 8x1
+  // tile is used on baseline aarch64 where the matmul kernel is slow anyway.
+  for (; outer_size1 >= 8; outer_size1 -= 8) {
+    iree_uk_neon_copy_8x8xi8_transpose_strided_to_strided(
+        out_ptr, in_ptr, out_stride1, in_stride0);
     out_ptr += 8 * out_stride1;
     in_ptr += 8;
   }
-  for (; outer_i1 < outer_size1; ++outer_i1) {
+  for (; outer_size1 > 0; --outer_size1) {
     iree_uk_neon_copy_8x1xi8_strided_to_unstrided(out_ptr, in_ptr, in_stride0);
     out_ptr += out_stride1;
     in_ptr += 1;
   }
 }
 
-void iree_uk_pack_tile_8x4_x8_arm_64_direct(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  iree_uk_ssize_t outer_i1 = 0;
-  iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
-  const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
-  for (; outer_i1 <= outer_size1 - 2; outer_i1 += 2) {
-    iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor_tiled_1x4(
+static void iree_uk_pack_tile_8x4_x8_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 4);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 >= 2; outer_size1 -= 2) {
+    iree_uk_neon_copy_8x8xi8_tiled_1x4_transpose_strided_to_strided(
         out_ptr, in_ptr, out_stride1, in_stride0);
     out_ptr += 2 * out_stride1;
     in_ptr += 8;
   }
-  for (; outer_i1 < outer_size1; outer_i1++) {
-    iree_uk_neon_copy_8x4xi8_rowmajor_strided_to_unstrided(out_ptr, in_ptr,
-                                                           in_stride0);
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_neon_copy_8x4xi8_strided_to_unstrided(out_ptr, in_ptr, in_stride0);
     out_ptr += out_stride1;
     in_ptr += 4;
   }
 }
 
-void iree_uk_pack_tile_8x1_x32_arm_64_direct(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
+static void iree_uk_pack_tile_8x1_x32_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 1);
   iree_uk_pack_tile_8x4_x8_arm_64_direct(out_tile_ptr, in_tile_ptr, outer_size1,
                                          out_stride1 * 4, in_stride0 * 4, 1, 8,
                                          4);
 }
 
-void iree_uk_pack_tile_8x8_x8_arm_64_direct(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
-  const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
-  for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
-    iree_uk_neon_copy_8x8xi8_rowmajor_strided_to_unstrided(out_ptr, in_ptr,
-                                                           in_stride0);
+static void iree_uk_pack_tile_8x8_x8_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_neon_copy_8x8xi8_strided_to_unstrided(out_ptr, in_ptr, in_stride0);
     out_ptr += out_stride1;
     in_ptr += 8;
   }
 }
 
-void iree_uk_pack_tile_8x1_x32_arm_64_transpose(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  const iree_uk_int32_t* restrict in_tile_ptr_i32 = in_tile_ptr;
-  iree_uk_int32_t* restrict out_tile_i32_ptr = out_tile_ptr;
-  for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
+static void iree_uk_pack_tile_8x1_x32_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 1);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int32_t* IREE_UK_RESTRICT in_tile_ptr_i32 = in_tile_ptr;
+  iree_uk_int32_t* IREE_UK_RESTRICT out_tile_i32_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
     iree_uk_memcpy(out_tile_i32_ptr, in_tile_ptr_i32, 32);
     out_tile_i32_ptr += out_stride1;
     in_tile_ptr_i32 += 8;
   }
 }
 
-void iree_uk_pack_tile_8x1_x8_arm_64_transpose(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
-  iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
-  iree_uk_ssize_t outer_i1 = 0;
-  for (; outer_i1 <= outer_size1 - 4; outer_i1 += 4) {
+static void iree_uk_pack_tile_8x1_x8_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 1);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 >= 4; outer_size1 -= 4) {
     iree_uk_memcpy(out_ptr + 0 * out_stride1, in_ptr + 0, 8);
     iree_uk_memcpy(out_ptr + 1 * out_stride1, in_ptr + 8, 8);
     iree_uk_memcpy(out_ptr + 2 * out_stride1, in_ptr + 16, 8);
@@ -281,21 +130,25 @@ void iree_uk_pack_tile_8x1_x8_arm_64_transpose(
     out_ptr += 4 * out_stride1;
     in_ptr += 32;
   }
-  for (; outer_i1 < outer_size1; ++outer_i1) {
+  for (; outer_size1 > 0; --outer_size1) {
     iree_uk_memcpy(out_ptr, in_ptr, 8);
     out_ptr += out_stride1;
     in_ptr += 8;
   }
 }
 
-void iree_uk_pack_tile_8x4_x8_arm_64_transpose(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
-  iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
-  for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
+static void iree_uk_pack_tile_8x4_x8_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 4);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
     int8x16x2_t in;
     in.val[0] = vcombine_s8(vld1_s8(in_ptr + 0 * in_stride0),
                             vld1_s8(in_ptr + 2 * in_stride0));
@@ -311,16 +164,21 @@ void iree_uk_pack_tile_8x4_x8_arm_64_transpose(
   }
 }
 
-void iree_uk_pack_tile_8x8_x8_arm_64_transpose(
-    void* restrict out_tile_ptr, const void* restrict in_tile_ptr,
-    iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1,
-    iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size_unused,
-    iree_uk_ssize_t tile_size0_unused, iree_uk_ssize_t tile_size1_unused) {
-  const iree_uk_int8_t* restrict in_ptr = in_tile_ptr;
-  iree_uk_int8_t* restrict out_ptr = out_tile_ptr;
-  for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
-    iree_uk_neon_copy_8x8xi8_rowmajor_to_colmajor(out_ptr, in_ptr, 8,
-                                                  in_stride0);
+static void iree_uk_pack_tile_8x8_x8_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride1, iree_uk_ssize_t in_stride0,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_neon_copy_8x8xi8_transpose_strided_to_unstrided(out_ptr, in_ptr,
+                                                            in_stride0);
+
     out_ptr += out_stride1;
     in_ptr += 8;
   }

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.c
@@ -1,0 +1,199 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/arch/arm_64/unpack_arm_64.h"
+
+#include <arm_neon.h>
+
+#include "iree/builtins/ukernel/arch/arm_64/common_arm_neon.h"
+
+static void iree_uk_unpack_tile_8x1_x8_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 1);
+  const char* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  char* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 >= 8; outer_size1 -= 8) {
+    iree_uk_neon_copy_8x8xi8_transpose_strided_to_strided(
+        out_ptr, in_ptr, out_stride0, in_stride1);
+    out_ptr += 8;
+    in_ptr += 8 * in_stride1;
+  }
+  for (; outer_size1 > 0; outer_size1--) {
+    iree_uk_neon_copy_8x1xi8_unstrided_to_strided(out_ptr, out_stride0, in_ptr);
+    in_ptr += in_stride1;
+    out_ptr += 1;
+  }
+}
+
+static void iree_uk_unpack_tile_8x4_x8_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 4);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 >= 2; outer_size1 -= 2) {
+    iree_uk_neon_copy_8x8xi8_tiled_8x4_transpose_strided_to_strided(
+        out_ptr, in_ptr, out_stride0, in_stride1);
+    in_ptr += 2 * in_stride1;
+    out_ptr += 8;
+  }
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_neon_copy_8x4_unstrided_to_strided(out_ptr, out_stride0, in_ptr);
+    in_ptr += in_stride1;
+    out_ptr += 4;
+  }
+}
+
+static void iree_uk_unpack_tile_8x1_x32_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 1);
+  iree_uk_unpack_tile_8x4_x8_arm_64_direct(out_tile_ptr, in_tile_ptr,
+                                           outer_size1, 4 * out_stride0,
+                                           4 * in_stride1, 1, 8, 4);
+}
+
+static void iree_uk_unpack_tile_8x8_x8_arm_64_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_neon_copy_8x8xi8_unstrided_to_strided(out_ptr, in_ptr, out_stride0);
+    out_ptr += 8;
+    in_ptr += in_stride1;
+  }
+}
+
+static void iree_uk_unpack_tile_8x1_x32_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 4);
+  IREE_UK_ASSERT(tile_size0 == 1);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int32_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int32_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_memcpy(out_ptr, in_ptr, 32);
+    in_ptr += in_stride1;
+    out_ptr += 8;
+  }
+}
+
+static void iree_uk_unpack_tile_8x1_x8_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 1);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const char* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  char* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 >= 4; outer_size1 -= 4) {
+    iree_uk_memcpy(out_ptr, in_ptr, 8);
+    iree_uk_memcpy(out_ptr + 8, in_ptr + in_stride1, 8);
+    iree_uk_memcpy(out_ptr + 16, in_ptr + 2 * in_stride1, 8);
+    iree_uk_memcpy(out_ptr + 24, in_ptr + 3 * in_stride1, 8);
+    in_ptr += 4 * in_stride1;
+    out_ptr += 32;
+  }
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_memcpy(out_ptr, in_ptr, 8);
+    in_ptr += in_stride1;
+    out_ptr += 8;
+  }
+}
+
+static void iree_uk_unpack_tile_8x4_x8_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 4);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const char* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  char* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    int8x8x4_t in = vld4_s8(in_ptr);
+    vst1_s8(out_ptr + 0 * out_stride0, in.val[0]);
+    vst1_s8(out_ptr + 1 * out_stride0, in.val[1]);
+    vst1_s8(out_ptr + 2 * out_stride0, in.val[2]);
+    vst1_s8(out_ptr + 3 * out_stride0, in.val[3]);
+    in_ptr += in_stride1;
+    out_ptr += 8;
+  }
+}
+
+static void iree_uk_unpack_tile_8x8_x8_arm_64_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  IREE_UK_ASSERT(elem_size == 1);
+  IREE_UK_ASSERT(tile_size0 == 8);
+  IREE_UK_ASSERT(tile_size1 == 8);
+  const iree_uk_int8_t* IREE_UK_RESTRICT in_ptr = in_tile_ptr;
+  iree_uk_int8_t* IREE_UK_RESTRICT out_ptr = out_tile_ptr;
+  for (; outer_size1 > 0; --outer_size1) {
+    iree_uk_neon_copy_8x8xi8_transpose_unstrided_to_strided(
+        out_ptr, out_stride0, in_ptr);
+    out_ptr += 8;
+    in_ptr += in_stride1;
+  }
+}
+
+iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_arm_64(
+    const iree_uk_unpack_params_t* params) {
+  // At the moment, as sum-reductions are not yet part of pack ops,
+  // no arithmetic whatsoever is being done here, so only the element type
+  // size matters, not the type itself.
+  int esize = iree_uk_type_size(iree_uk_unpack_out_type(params->type));
+  bool transpose = params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER;
+  if (esize == 4 && params->in_size2 == 8 && params->in_size3 == 1) {
+    return transpose ? iree_uk_unpack_tile_8x1_x32_arm_64_transpose
+                     : iree_uk_unpack_tile_8x1_x32_arm_64_direct;
+  } else if (esize == 1 && params->in_size2 == 8 && params->in_size3 == 1) {
+    return transpose ? iree_uk_unpack_tile_8x1_x8_arm_64_transpose
+                     : iree_uk_unpack_tile_8x1_x8_arm_64_direct;
+  } else if (esize == 1 && params->in_size2 == 8 && params->in_size3 == 4) {
+    return transpose ? iree_uk_unpack_tile_8x4_x8_arm_64_transpose
+                     : iree_uk_unpack_tile_8x4_x8_arm_64_direct;
+  } else if (esize == 1 && params->in_size2 == 8 && params->in_size3 == 8) {
+    return transpose ? iree_uk_unpack_tile_8x8_x8_arm_64_transpose
+                     : iree_uk_unpack_tile_8x8_x8_arm_64_direct;
+  }
+  return 0;
+}

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.h
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/unpack_arm_64.h
@@ -1,0 +1,17 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_ARCH_ARM_64_UNPACK_ARM_64_H_
+#define IREE_BUILTINS_UKERNEL_ARCH_ARM_64_UNPACK_ARM_64_H_
+
+#include "iree/builtins/ukernel/unpack.h"
+
+// Returns the arm64 tile function to use for the unpack op with given params,
+// or NULL if none is available, so the caller may fall back to generic code.
+iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_arm_64(
+    const iree_uk_unpack_params_t* params);
+
+#endif  // IREE_BUILTINS_UKERNEL_ARCH_ARM_64_UNPACK_ARM_64_H_

--- a/runtime/src/iree/builtins/ukernel/pack.c
+++ b/runtime/src/iree/builtins/ukernel/pack.c
@@ -180,15 +180,12 @@ static void iree_uk_pack_using_tile_func(const iree_uk_pack_params_t* params,
   iree_uk_ssize_t tile_size1 = params->out_size3;
   iree_uk_ssize_t out_stride_l0 = params->out_stride0;
   iree_uk_ssize_t out_stride1 = params->out_size3 * params->out_size2;
-  iree_uk_ssize_t out_stride_l2 = params->out_size3;
-  iree_uk_ssize_t out_stride_l3 = 1;
   if (params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_OUTER) {
     iree_uk_ssize_swap(&outer_size0, &outer_size1);
     iree_uk_ssize_swap(&out_stride_l0, &out_stride1);
   }
   if (params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER) {
     iree_uk_ssize_swap(&tile_size0, &tile_size1);
-    iree_uk_ssize_swap(&out_stride_l2, &out_stride_l3);
   }
   const char* in_buf = params->in_buffer;
   char* out_buf = params->out_buffer;
@@ -235,8 +232,7 @@ IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params) {
 
   if (iree_uk_pack_early(params)) return;
 
-  // Select a target-specific tile_func (inner loop on K, computing one M0xN0
-  // tile) and use that with generic outer loops.
-  iree_uk_pack_tile_func_t row_func = iree_uk_pack_select_tile_func(params);
-  iree_uk_pack_using_tile_func(params, row_func);
+  // Select a target-specific tile_func and use that with generic outer loops.
+  iree_uk_pack_tile_func_t tile_func = iree_uk_pack_select_tile_func(params);
+  iree_uk_pack_using_tile_func(params, tile_func);
 }

--- a/runtime/src/iree/builtins/ukernel/pack.h
+++ b/runtime/src/iree/builtins/ukernel/pack.h
@@ -52,14 +52,6 @@ typedef void (*iree_uk_pack_tile_func_t)(
     iree_uk_ssize_t /*in_stride0*/, iree_uk_ssize_t /*elem_size*/,
     iree_uk_ssize_t /*tile_size0*/, iree_uk_ssize_t /*tile_size1*/);
 
-// Tile kernel declarations. Prototype matches iree_uk_pack_tile_func_t.
-#define IREE_UK_PACK_TILE_FUNC_DECL(NAME)                             \
-  void NAME(void* IREE_UK_RESTRICT out_tile_ptr,                      \
-            const void* IREE_UK_RESTRICT in_tile_ptr,                 \
-            iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride1, \
-            iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,    \
-            iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
-
 // Main entry point.
 IREE_UK_EXPORT void iree_uk_pack(const iree_uk_pack_params_t* params);
 

--- a/runtime/src/iree/builtins/ukernel/tools/BUILD
+++ b/runtime/src/iree/builtins/ukernel/tools/BUILD
@@ -75,3 +75,29 @@ iree_runtime_cc_test(
         "//runtime/src/iree/testing:gtest",
     ],
 )
+
+cc_binary_benchmark(
+    name = "unpack_benchmark",
+    srcs = ["unpack_benchmark.c"],
+    deps = [
+        ":ukernel_test_utils",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:cpu",
+        "//runtime/src/iree/base/internal:flags",
+        "//runtime/src/iree/builtins/ukernel",
+        "//runtime/src/iree/testing:benchmark",
+    ],
+)
+
+iree_runtime_cc_test(
+    name = "unpack_test",
+    srcs = ["unpack_test.cc"],
+    deps = [
+        ":ukernel_test_utils",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base/internal:cpu",
+        "//runtime/src/iree/base/internal:flags",
+        "//runtime/src/iree/builtins/ukernel",
+        "//runtime/src/iree/testing:gtest",
+    ],
+)

--- a/runtime/src/iree/builtins/ukernel/tools/CMakeLists.txt
+++ b/runtime/src/iree/builtins/ukernel/tools/CMakeLists.txt
@@ -82,4 +82,33 @@ iree_cc_test(
     iree::testing::gtest
 )
 
+iree_cc_binary_benchmark(
+  NAME
+    unpack_benchmark
+  SRCS
+    "unpack_benchmark.c"
+  DEPS
+    ::ukernel_test_utils
+    iree::base
+    iree::base::internal::cpu
+    iree::base::internal::flags
+    iree::builtins::ukernel
+    iree::testing::benchmark
+  TESTONLY
+)
+
+iree_cc_test(
+  NAME
+    unpack_test
+  SRCS
+    "unpack_test.cc"
+  DEPS
+    ::ukernel_test_utils
+    iree::base
+    iree::base::internal::cpu
+    iree::base::internal::flags
+    iree::builtins::ukernel
+    iree::testing::gtest
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
@@ -84,13 +84,6 @@ static void test_one_pack_using_given_input(
   iree_pack_reference(reference_params);
   iree_uk_pack(&actual_params);
 
-  // For now we use exact comparisons, even for float, even though the reference
-  // code accumulates in a different order compared to the actual code. This
-  // relies on picking input test matrix elements so that all intermediate
-  // values are exactly representable - i.e. small integer numerators. This
-  // become problematic when we do float16. See the comment at the top of this
-  // file explaining how we refrain from letting this grow into a 1000-line-long
-  // fully-featured test.
   if (memcmp(actual_params.out_buffer, reference_params.out_buffer,
              out_buffer_size)) {
     const auto& p = actual_params;
@@ -106,16 +99,6 @@ static void test_one_pack_using_given_input(
             (int)p.out_size1, (int)p.out_size2, (int)p.out_size3);
     fprintf(stderr, "  input stride: %d\n", (int)p.in_stride0);
     fprintf(stderr, "  output stride: %d\n", (int)p.out_stride0);
-    // Don't even try to pretty-print matrices. See the comment at the top of
-    // this file. Don't try to use GTest primitives to show expected vs actual
-    // since that would require dispatching to type-specific code paths.
-    // Also, at this point it's easy for the user to rerun this test
-    // in a debugger and manually inspect values.
-    //
-    // We want fatal here - that is what the user running this in a debugger
-    // wants us to do, so they can inspect values while they exist in memory.
-    // What's the GTest-sanctioned fatal error? GTEST_FAIL() has a comment that
-    // says that it's fatal, but that's a lie at least here on Android.
     iree_abort();
   }
 
@@ -159,9 +142,12 @@ static void pack_test_for_various_tile_shapes_and_flags(
       {1, 0},
       // Non-degenerate cases.
       {1, 1},
-      {2, 2},
-      {3, 2},
-      {8, 8},
+      {2, 3},
+      {3, 4},
+      {4, 5},
+      {5, 6},
+      {6, 7},
+      {7, 8},
       {11, 13},
       {13, 11},
       {31, 33},

--- a/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
@@ -8,6 +8,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <random>
 
 #include "iree/schemas/cpu_data.h"
@@ -31,6 +32,21 @@ iree_uk_ssize_t iree_uk_test_2d_buffer_length(iree_uk_type_t type,
                                               iree_uk_ssize_t stride0) {
   // Just for testing purposes, so it's OK to overestimate size.
   return size0 * stride0 << iree_uk_type_size_log2(type);
+}
+
+bool iree_uk_test_2d_buffers_equal(const void* buf1, const void* buf2,
+                                   iree_uk_type_t type, iree_uk_ssize_t size0,
+                                   iree_uk_ssize_t size1,
+                                   iree_uk_ssize_t stride0) {
+  iree_uk_ssize_t elem_size = iree_uk_type_size(type);
+  const char* buf1_ptr = static_cast<const char*>(buf1);
+  const char* buf2_ptr = static_cast<const char*>(buf2);
+  for (iree_uk_ssize_t i0 = 0; i0 < size0; ++i0) {
+    if (memcmp(buf1_ptr, buf2_ptr, elem_size * size1)) return false;
+    buf1_ptr += elem_size * stride0;
+    buf2_ptr += elem_size * stride0;
+  }
+  return true;
 }
 
 struct iree_uk_test_random_engine_t {

--- a/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.h
+++ b/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.h
@@ -18,6 +18,11 @@ iree_uk_ssize_t iree_uk_test_2d_buffer_length(iree_uk_type_t type,
                                               iree_uk_ssize_t size0,
                                               iree_uk_ssize_t size1);
 
+bool iree_uk_test_2d_buffers_equal(const void* buf1, const void* buf2,
+                                   iree_uk_type_t type, iree_uk_ssize_t size0,
+                                   iree_uk_ssize_t size1,
+                                   iree_uk_ssize_t stride0);
+
 // Helpers to fill buffers with pseudorandom values. The main entry point here
 // is iree_uk_test_write_random_buffer.
 struct iree_uk_test_random_engine_t;

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -1,0 +1,251 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/cpu.h"
+#include "iree/base/internal/flags.h"
+#include "iree/builtins/ukernel/api.h"
+#include "iree/builtins/ukernel/tools/ukernel_test_utils.h"
+#include "iree/testing/benchmark.h"
+
+IREE_FLAG(int64_t, batch_min_traversal_size, 1000000000,
+          "Minimum number of bytes to be traversed in each batch.");
+
+IREE_FLAG(
+    int64_t, working_set_size, 1000000,
+    "Number of bytes to be traversed by the benchmark workload (input and "
+    "output buffers together). Matrix shapes are computed accordingly.");
+IREE_FLAG(
+    int32_t, padding_size, 0,
+    "Padding size (same value used for both dimensions, 0 means no padding)");
+
+typedef struct iree_unpack_benchmark_user_data_t {
+  iree_uk_unpack_type_t type;
+  int size2;
+  int size3;
+  iree_uk_uint32_t flags;
+  const iree_uk_uint64_t* cpu_data;
+} iree_unpack_benchmark_user_data_t;
+
+IREE_UK_ATTRIBUTE_NOINLINE static void iree_memcpy_noinline(
+    void* restrict dst, const void* restrict src, size_t size) {
+  memcpy(dst, src, size);
+}
+
+static iree_status_t iree_memcpy_benchmark(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  iree_uk_int64_t total_iterations = 0;
+  iree_uk_int64_t batch_count =
+      (FLAG_batch_min_traversal_size + FLAG_working_set_size - 1) /
+      FLAG_working_set_size;
+  iree_uk_ssize_t buffer_size = FLAG_working_set_size / 2;
+  uint8_t* in_buffer = malloc(buffer_size);
+  uint8_t* out_buffer = malloc(buffer_size);
+  for (iree_uk_ssize_t i = 0; i < buffer_size; ++i) in_buffer[i] = (i & 0xFF);
+  while (iree_benchmark_keep_running(benchmark_state,
+                                     /*batch_count=*/batch_count)) {
+    for (int i = 0; i < batch_count; ++i) {
+      iree_memcpy_noinline(out_buffer, in_buffer, buffer_size);
+    }
+    total_iterations += batch_count;
+  }
+  // Report bytes per second, so that can be easily compared to known memory
+  // system performance metrics (e.g. RAM bandwidth, to tell whether this is
+  // memory-bound).
+  iree_benchmark_set_items_processed(benchmark_state,
+                                     total_iterations * buffer_size);
+  assert(!memcmp(in_buffer, out_buffer, buffer_size));
+  free(in_buffer);
+  free(out_buffer);
+  return iree_ok_status();
+}
+
+static iree_status_t iree_unpack_benchmark(
+    const iree_benchmark_def_t* benchmark_def,
+    iree_benchmark_state_t* benchmark_state) {
+  const iree_unpack_benchmark_user_data_t* user_data = benchmark_def->user_data;
+  iree_uk_type_t in_type = iree_uk_unpack_in_type(user_data->type);
+  iree_uk_type_t out_type = iree_uk_unpack_out_type(user_data->type);
+  iree_uk_ssize_t in_type_size = iree_uk_type_size(in_type);
+  iree_uk_ssize_t out_type_size = iree_uk_type_size(out_type);
+
+  // The inner dims 2, 3 are given to us as part of the benchmark user_data.
+  // The outer dims 0, 1 are to be determined based on FLAG_working_set_size.
+  iree_uk_ssize_t in_size0 = 1;
+  iree_uk_ssize_t in_size1 = 1;
+  iree_uk_ssize_t in_size2 = user_data->size2;
+  iree_uk_ssize_t in_size3 = user_data->size3;
+  int target_matrix_size_in_elems =
+      FLAG_working_set_size / (in_type_size + out_type_size);
+  int target_product_of_outer_sizes_0_1 =
+      target_matrix_size_in_elems / (in_size2 * in_size3);
+  while (target_product_of_outer_sizes_0_1 >= 4) {
+    target_product_of_outer_sizes_0_1 /= 4;
+    in_size0 *= 2;
+    in_size1 *= 2;
+  }
+  in_size1 *= target_product_of_outer_sizes_0_1;
+
+  iree_uk_unpack_params_t params;
+  memset(&params, 0, sizeof params);
+  params.type = user_data->type;
+  params.flags = user_data->flags;
+  params.in_size0 = in_size0;
+  params.in_size1 = in_size1;
+  params.in_size2 = in_size2;
+  params.in_size3 = in_size3;
+  if (params.flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER) {
+    iree_uk_ssize_swap(&in_size0, &in_size1);
+  }
+  if (params.flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER) {
+    iree_uk_ssize_swap(&in_size2, &in_size3);
+  }
+  params.out_size0 = iree_max(0, in_size0 * in_size2 - FLAG_padding_size);
+  params.out_size1 = iree_max(0, in_size1 * in_size3 - FLAG_padding_size);
+  params.out_stride0 = params.out_size1;
+  params.in_stride0 = params.in_size1 * params.in_size2 * params.in_size3;
+  iree_uk_ssize_t in_buffer_size = iree_uk_test_2d_buffer_length(
+      in_type, params.in_size0, params.in_stride0);
+  iree_uk_ssize_t out_buffer_size = iree_uk_test_2d_buffer_length(
+      out_type, params.out_size0, params.out_stride0);
+  void* in_buffer = malloc(in_buffer_size);
+  void* out_buffer = malloc(out_buffer_size);
+  iree_uk_test_random_engine_t* engine = iree_uk_test_random_engine_create();
+  // It's just about plausible that on some platform, for some number type,
+  // performance might be different on zero buffers vs random buffers. But it
+  // shouldn't matter that we recreate the random engine every time, getting
+  // the same random values again.
+  iree_uk_test_write_random_buffer(in_buffer, in_buffer_size, in_type, engine);
+  iree_uk_test_write_random_buffer(out_buffer, out_buffer_size, out_type,
+                                   engine);
+  iree_uk_test_random_engine_destroy(engine);
+  params.in_buffer = in_buffer;
+  params.out_buffer = out_buffer;
+  iree_uk_int64_t total_iterations = 0;
+  iree_uk_int64_t batch_count =
+      (FLAG_batch_min_traversal_size + FLAG_working_set_size - 1) /
+      FLAG_working_set_size;
+  while (iree_benchmark_keep_running(benchmark_state,
+                                     /*batch_count=*/batch_count)) {
+    for (int i = 0; i < batch_count; ++i) {
+      iree_uk_unpack(&params);
+    }
+    total_iterations += batch_count;
+  }
+  // Report bytes per second, so that can be easily compared to known memory
+  // system performance metrics (e.g. RAM bandwidth, to tell whether this is
+  // memory-bound).
+  iree_benchmark_set_items_processed(benchmark_state,
+                                     total_iterations * out_buffer_size);
+  free(in_buffer);
+  free(out_buffer);
+  return iree_ok_status();
+}
+
+static void iree_unpack_benchmark_register(
+    const iree_unpack_benchmark_user_data_t* user_data, const char* name) {
+  // Does this benchmark require an optional CPU feature?
+  if (user_data->cpu_data[0]) {
+    if ((iree_cpu_data_field(0) & user_data->cpu_data[0]) !=
+        user_data->cpu_data[0]) {
+      // The CPU does not meet this benchmark's requirements. The builtin
+      // would crash.
+      return;
+    }
+  }
+
+  // benchmark_def does not need to be static, it will be cloned.
+  const iree_benchmark_def_t benchmark_def = {
+      .flags = IREE_BENCHMARK_FLAG_USE_REAL_TIME,
+      .time_unit = IREE_BENCHMARK_UNIT_MICROSECOND,
+      .minimum_duration_ns = 0,
+      .iteration_count = 0,
+      .run = iree_unpack_benchmark,
+      .user_data = user_data,
+  };
+  iree_benchmark_register(IREE_SV(name), &benchmark_def);
+}
+
+#define UNPACK_BENCHMARK_REGISTER_WITH_FLAGS(                                  \
+    _flags, _flags_suffix, _type, _size2, _size3, _cpu_data_field_0, _label)   \
+  do {                                                                         \
+    static const iree_uk_uint64_t local_cpu_data[IREE_CPU_DATA_FIELD_COUNT] =  \
+        {_cpu_data_field_0};                                                   \
+    static const iree_unpack_benchmark_user_data_t user_data = {               \
+        .type = iree_uk_unpack_type_##_type,                                   \
+        .size2 = _size2,                                                       \
+        .size3 = _size3,                                                       \
+        .flags = _flags,                                                       \
+        .cpu_data = local_cpu_data,                                            \
+    };                                                                         \
+    iree_unpack_benchmark_register(&user_data,                                 \
+                                   "iree_uk_unpack_" #_type "_" #_size2        \
+                                   "x" #_size3 "_" _flags_suffix "_" #_label); \
+  } while (0)
+
+#define UNPACK_BENCHMARK_REGISTER(...)                                      \
+  UNPACK_BENCHMARK_REGISTER_WITH_FLAGS(0, "TRANSPOSE_NONE", __VA_ARGS__);   \
+  UNPACK_BENCHMARK_REGISTER_WITH_FLAGS(IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER, \
+                                       "TRANSPOSE_INNER", __VA_ARGS__);     \
+  UNPACK_BENCHMARK_REGISTER_WITH_FLAGS(IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER, \
+                                       "TRANSPOSE_OUTER", __VA_ARGS__);     \
+  UNPACK_BENCHMARK_REGISTER_WITH_FLAGS(                                     \
+      IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER |                                 \
+          IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER,                              \
+      "TRANSPOSE_BOTH", __VA_ARGS__);
+
+#define UNPACK_BENCHMARK_REGISTER_GENERIC(_type, _size2, _size3) \
+  UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3, 0, generic)
+
+#define UNPACK_BENCHMARK_REGISTER_ARM_64(_type, _size2, _size3) \
+  UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3, 0, arm_64)
+
+#define UNPACK_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(                     \
+    _type, _size2, _size3, _cpu_feature)                                       \
+  UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3,                             \
+                            IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_##_cpu_feature, \
+                            arm_64_##_cpu_feature)
+
+int main(int argc, char** argv) {
+  iree_flags_set_usage("unpack_benchmark",
+                       "Benchmarks the pack microkernel.\n"
+                       "\n");
+
+  iree_flags_parse_checked(IREE_FLAGS_PARSE_MODE_UNDEFINED_OK, &argc, &argv);
+  iree_benchmark_initialize(&argc, argv);
+  iree_cpu_initialize(iree_allocator_system());
+
+  const iree_benchmark_def_t memcpy_benchmark_def = {
+      .flags = IREE_BENCHMARK_FLAG_USE_REAL_TIME,
+      .time_unit = IREE_BENCHMARK_UNIT_MICROSECOND,
+      .minimum_duration_ns = 0,
+      .iteration_count = 0,
+      .run = iree_memcpy_benchmark,
+      .user_data = 0,
+  };
+  iree_benchmark_register(IREE_SV("memcpy"), &memcpy_benchmark_def);
+
+  // Generic code paths, not actually used, but interesting to get a sense
+  // of how slow generic code goes vs decent SIMD kernels.
+  UNPACK_BENCHMARK_REGISTER_GENERIC(f32f32, 4, 4);
+
+// ARM_64 benchmarks.
+#if defined(IREE_UK_ARCH_ARM_64)
+
+  UNPACK_BENCHMARK_REGISTER_ARM_64(f32f32, 8, 1);
+  UNPACK_BENCHMARK_REGISTER_ARM_64(i8i8, 8, 1);
+  UNPACK_BENCHMARK_REGISTER_ARM_64(i8i8, 8, 4);
+  UNPACK_BENCHMARK_REGISTER_ARM_64(i8i8, 8, 8);
+
+#endif  // defined(IREE_UK_ARCH_ARM_64)
+
+  iree_benchmark_run_specified();
+  return 0;
+}

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_test.cc
@@ -1,0 +1,273 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+#include <cstring>
+#include <vector>
+
+#include "iree/base/api.h"
+#include "iree/base/internal/cpu.h"
+#include "iree/builtins/ukernel/api.h"
+#include "iree/builtins/ukernel/tools/ukernel_test_utils.h"
+#include "iree/testing/gtest.h"
+#include "iree/testing/status_matchers.h"
+
+static void iree_unpack_reference(const iree_uk_unpack_params_t* params) {
+  // For now, the input and output element types are always the same.
+  iree_uk_type_t elem_type = iree_uk_unpack_in_type(params->type);
+  iree_uk_ssize_t elem_size = iree_uk_type_size(elem_type);
+  iree_uk_ssize_t outer_size0 = params->in_size0;
+  iree_uk_ssize_t outer_size1 = params->in_size1;
+  iree_uk_ssize_t tile_size0 = params->in_size2;
+  iree_uk_ssize_t tile_size1 = params->in_size3;
+  iree_uk_ssize_t in_stride_outer0 = params->in_stride0;
+  iree_uk_ssize_t in_stride_outer1 = params->in_size3 * params->in_size2;
+  iree_uk_ssize_t in_stride_tile0 = params->in_size3;
+  iree_uk_ssize_t in_stride_tile1 = 1;
+  if (params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER) {
+    iree_uk_ssize_swap(&outer_size0, &outer_size1);
+    iree_uk_ssize_swap(&in_stride_outer0, &in_stride_outer1);
+  }
+  if (params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER) {
+    iree_uk_ssize_swap(&tile_size0, &tile_size1);
+    iree_uk_ssize_swap(&in_stride_tile0, &in_stride_tile1);
+  }
+  for (iree_uk_ssize_t outer_i0 = 0; outer_i0 < outer_size0; ++outer_i0) {
+    for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
+      for (iree_uk_ssize_t tile_i0 = 0; tile_i0 < tile_size0; ++tile_i0) {
+        for (iree_uk_ssize_t tile_i1 = 0; tile_i1 < tile_size1; ++tile_i1) {
+          iree_uk_ssize_t in_offset =
+              outer_i0 * in_stride_outer0 + tile_i0 * in_stride_tile0 +
+              outer_i1 * in_stride_outer1 + tile_i1 * in_stride_tile1;
+          iree_uk_ssize_t i0 = outer_i0 * tile_size0 + tile_i0;
+          iree_uk_ssize_t i1 = outer_i1 * tile_size1 + tile_i1;
+          if (!(i0 >= params->out_size0 || i1 >= params->out_size1)) {
+            iree_uk_ssize_t out_offset = i1 + i0 * params->out_stride0;
+            const char* in_ptr =
+                ((char*)params->in_buffer) + in_offset * elem_size;
+            char* out_ptr =
+                ((char*)params->out_buffer) + out_offset * elem_size;
+            iree_uk_memcpy(out_ptr, in_ptr, elem_size);
+          }
+        }
+      }
+    }
+  }
+}
+
+static void test_one_unpack_using_given_input(
+    const iree_uk_unpack_params_t& shared_params,
+    iree_uk_test_random_engine_t* engine) {
+  assert(!shared_params.out_buffer);
+
+  iree_uk_unpack_params_t reference_params;
+  memcpy(&reference_params, &shared_params, sizeof shared_params);
+  iree_uk_type_t out_type = iree_uk_unpack_out_type(shared_params.type);
+  iree_uk_ssize_t out_buffer_size = iree_uk_test_2d_buffer_length(
+      out_type, shared_params.out_size0, shared_params.out_stride0);
+  reference_params.out_buffer = malloc(out_buffer_size);
+  iree_uk_test_write_random_buffer(reference_params.out_buffer, out_buffer_size,
+                                   out_type, engine);
+
+  iree_uk_unpack_params_t actual_params;
+  memcpy(&actual_params, &shared_params, sizeof shared_params);
+  actual_params.out_buffer = malloc(out_buffer_size);
+  iree_uk_test_write_random_buffer(actual_params.out_buffer, out_buffer_size,
+                                   out_type, engine);
+
+  iree_unpack_reference(&reference_params);
+  iree_uk_unpack(&actual_params);
+
+  if (!iree_uk_test_2d_buffers_equal(
+          actual_params.out_buffer, reference_params.out_buffer, out_type,
+          shared_params.out_size0, shared_params.out_size1,
+          shared_params.out_stride0)) {
+    const auto& p = actual_params;
+    fprintf(stderr, "unpack test failure with the following params:\n");
+    char types_str[32];
+    iree_uk_test_type_pair_str(types_str, sizeof types_str, p.type);
+    fprintf(stderr, "  types: %s\n", types_str);
+    fprintf(stderr, "  flags: transpose_inner=%d, transpose_outer=%d\n",
+            (bool)(p.flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER),
+            (bool)(p.flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER));
+    fprintf(stderr, "  input shape: %dx%dx%dx%d\n", (int)p.in_size0,
+            (int)p.in_size1, (int)p.in_size2, (int)p.in_size3);
+    fprintf(stderr, "  output shape: %dx%d\n", (int)p.out_size0,
+            (int)p.out_size1);
+    fprintf(stderr, "  input stride: %d\n", (int)p.in_stride0);
+    fprintf(stderr, "  output stride: %d\n", (int)p.out_stride0);
+    iree_abort();
+  }
+
+  free(reference_params.out_buffer);
+  free(actual_params.out_buffer);
+}
+
+static void test_one_unpack_creating_input_for_given_shape(
+    const iree_uk_unpack_params_t& shared_params,
+    iree_uk_test_random_engine_t* engine) {
+  iree_uk_unpack_params_t params;
+  memcpy(&params, &shared_params, sizeof params);
+  assert(!params.in_buffer);
+  assert(!params.out_buffer);
+  assert(!params.in_stride0);
+  assert(!params.out_stride0);
+  // Populate strides first - we need them below to compute buffer lengths.
+  // Randomly make strides either tight or not to exercise all cases.
+  params.out_stride0 =
+      params.out_size1 + iree_uk_test_random_engine_get_0_1(engine);
+  params.in_stride0 = params.in_size1 * params.in_size2 * params.in_size3 +
+                      iree_uk_test_random_engine_get_0_1(engine);
+  iree_uk_type_t in_type = iree_uk_unpack_in_type(params.type);
+  iree_uk_ssize_t in_buffer_size = iree_uk_test_2d_buffer_length(
+      in_type, params.in_size0, params.in_stride0);
+  void* in_buffer = malloc(in_buffer_size);
+  iree_uk_test_write_random_buffer(in_buffer, in_buffer_size, in_type, engine);
+  params.in_buffer = in_buffer;
+  test_one_unpack_using_given_input(params, engine);
+  free(in_buffer);
+}
+
+static void test_unpack_for_various_tile_shapes_and_flags(
+    iree_uk_unpack_type_t type, int tile_size0, int tile_size1,
+    const iree_uk_uint64_t* cpu_data, iree_uk_test_random_engine_t* engine) {
+  struct outer_shape_t {
+    int size0, size1;
+  };
+  std::vector<outer_shape_t> outer_shapes{
+      // Degenerate cases. Vacuous.
+      {0, 1},
+      {1, 0},
+      // Non-degenerate cases.
+      {1, 1},
+      {2, 2},
+      {3, 2},
+      {8, 8},
+      {11, 13},
+      {13, 11},
+      {31, 33},
+      {33, 31},
+      {123, 89},
+  };
+  enum class Pad { None, OneIncompleteTile, TonsOfPaddingTiles };
+  for (const auto& outer_shape : outer_shapes) {
+    for (bool transpose_inner : {false, true}) {
+      for (bool transpose_outer : {false, true}) {
+        for (Pad pad :
+             {Pad::None, Pad::OneIncompleteTile, Pad::TonsOfPaddingTiles}) {
+          iree_uk_unpack_params_t params = {};
+          params.type = type;
+          params.cpu_data = cpu_data;
+          iree_uk_ssize_t in_size0 = outer_shape.size0;
+          iree_uk_ssize_t in_size1 = outer_shape.size1;
+          iree_uk_ssize_t in_size2 = tile_size0;
+          iree_uk_ssize_t in_size3 = tile_size1;
+          params.in_size0 = in_size0;
+          params.in_size1 = in_size1;
+          if (pad == Pad::TonsOfPaddingTiles) {
+            params.in_size0 += 64;
+            params.in_size1 += 64;
+          }
+          params.in_size2 = in_size2;
+          params.in_size3 = in_size3;
+          params.flags = 0;
+          if (transpose_outer) {
+            params.flags |= IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER;
+            std::swap(in_size0, in_size1);
+          }
+          if (transpose_inner) {
+            params.flags |= IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER;
+            std::swap(in_size2, in_size3);
+          }
+          params.out_size0 = in_size0 * in_size2;
+          params.out_size1 = in_size1 * in_size3;
+          if (pad == Pad::OneIncompleteTile) {
+            iree_uk_ssize_t pad_size0 =
+                iree_uk_test_random_engine_get_0_65535(engine) % in_size2;
+            iree_uk_ssize_t pad_size1 =
+                iree_uk_test_random_engine_get_0_65535(engine) % in_size3;
+            params.out_size0 =
+                std::max<iree_uk_ssize_t>(0, params.out_size0 - pad_size0);
+            params.out_size1 =
+                std::max<iree_uk_ssize_t>(0, params.out_size1 - pad_size1);
+          }
+          test_one_unpack_creating_input_for_given_shape(params, engine);
+        }
+      }
+    }
+  }
+}
+
+static void unpack_test(iree_uk_unpack_type_t type, int tile_size0,
+                        int tile_size1, iree_uk_uint64_t cpu_data_field_0_bit) {
+  const iree_uk_uint64_t local_cpu_data_default[IREE_CPU_DATA_FIELD_COUNT] = {
+      0};
+  iree_uk_test_random_engine_t* engine = iree_uk_test_random_engine_create();
+  // First try without any optional CPU feature. This matters even when the
+  // feature is supported by the CPU because we want to test the fallback to
+  // architecture-default or generic code.
+  test_unpack_for_various_tile_shapes_and_flags(type, tile_size0, tile_size1,
+                                                local_cpu_data_default, engine);
+  // If this is nonzero, we are asked to test again with this CPU feature.
+  if (cpu_data_field_0_bit) {
+    const iree_uk_uint64_t local_cpu_data_with_bit[IREE_CPU_DATA_FIELD_COUNT] =
+        {cpu_data_field_0_bit};
+    // Check if the CPU supports the feature (otherwise, we crash).
+    bool supported = iree_cpu_data_field(0) & cpu_data_field_0_bit;
+    char cpu_feat_str[32];
+    iree_uk_test_cpu_features_str(cpu_feat_str, sizeof cpu_feat_str,
+                                  local_cpu_data_with_bit, 1);
+    if (supported) {
+      // Run with the optional CPU feature.
+      printf("Device supports CPU feature: %s\n", cpu_feat_str);
+      test_unpack_for_various_tile_shapes_and_flags(
+          type, tile_size0, tile_size1, local_cpu_data_with_bit, engine);
+    } else {
+      printf("Skipped: device does not support CPU feature: %s\n",
+             cpu_feat_str);
+    }
+  }
+
+  iree_uk_test_random_engine_destroy(engine);
+}
+
+#define UNPACK_TEST(type, tile_size0, tile_size1, test_suffix, feature_bit)   \
+  TEST(UnpackTest, type##_tile_##tile_size0##x##tile_size1##_##test_suffix) { \
+    unpack_test(iree_uk_unpack_type_##type, tile_size0, tile_size1,           \
+                feature_bit);                                                 \
+  }
+
+// Generic tests, not matching any particular CPU feature. This is the place to
+// test weird tile shapes to ensure e.g. that we haven't unwittingly baked in a
+// power-of-two assumption
+UNPACK_TEST(f32f32, 3, 5, generic, 0)
+UNPACK_TEST(i8i8, 4, 2, generic, 0)
+UNPACK_TEST(i32i32, 3, 4, generic, 0)
+UNPACK_TEST(i8i8, 8, 8, generic, 0)
+
+// ARM_64 tests.
+#if defined(IREE_UK_ARCH_ARM_64)
+
+#define UNPACK_ARM_64_TEST(type, tile_size0, tile_size1) \
+  UNPACK_TEST(type, tile_size0, tile_size1, arm_64, 0)
+
+#define UNPACK_ARM_64_TEST_WITH_CPU_FEATURE(type, tile_size0, tile_size1, \
+                                            FEATURE)                      \
+  UNPACK_TEST(type, tile_size0, tile_size1, arm_64_##FEATURE,             \
+              IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_##FEATURE)
+
+UNPACK_ARM_64_TEST(f32f32, 8, 1)
+UNPACK_ARM_64_TEST(i8i8, 8, 1)
+UNPACK_ARM_64_TEST_WITH_CPU_FEATURE(i8i8, 8, 4, DOTPROD)
+UNPACK_ARM_64_TEST_WITH_CPU_FEATURE(i8i8, 8, 8, I8MM)
+
+#endif  // defined(IREE_UK_ARCH_ARM_64)
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  iree_cpu_initialize(iree_allocator_system());
+  return RUN_ALL_TESTS();
+}

--- a/runtime/src/iree/builtins/ukernel/unpack.c
+++ b/runtime/src/iree/builtins/ukernel/unpack.c
@@ -6,10 +6,42 @@
 
 #include "iree/builtins/ukernel/unpack.h"
 
+#include "iree/builtins/ukernel/unpack_tile.h"
+
+enum { iree_uk_unpack_tmp_buf_size = 4096 };
+
+// Holds some information and a temporary buffer for performing padding.
+typedef struct iree_uk_unpack_tmpbuf_helper_t {
+  // Temporary buffer to pad the source data into, to pass to the tile_func.
+  // Cache line alignment helps in pack_benchmark on ARM Cortex-A510/A710.
+  IREE_UK_ATTRIBUTE_ALIGNED(64) char tmp_buf[iree_uk_unpack_tmp_buf_size];
+  // How many tiles fit in `tmp_buf`.
+  int max_tiles_in_tmp_buf;
+} iree_uk_unpack_tmpbuf_helper_t;
+
+// Return x/y for x>=0 and y>0, with a fast path for when y is a power of two.
+static iree_uk_ssize_t iree_uk_div_nonneg_by_pos_and_likely_po2_i32(
+    iree_uk_ssize_t x, iree_uk_int32_t y) {
+  IREE_UK_ASSERT(x >= 0);
+  IREE_UK_ASSERT(y > 0);
+  return IREE_UK_LIKELY(iree_uk_is_po2_u32(y)) ? (x >> iree_uk_po2_log2_u32(y))
+                                               : (x / y);
+}
+
+// Initializes a `iree_uk_unpack_padding_helper`. Asserts if the temporary
+// buffer is smaller than one tile.
+static void iree_uk_unpack_tmpbuf_helper_init(
+    iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1,
+    iree_uk_ssize_t elem_size, iree_uk_unpack_tmpbuf_helper_t* helper) {
+  helper->max_tiles_in_tmp_buf = iree_uk_div_nonneg_by_pos_and_likely_po2_i32(
+      iree_uk_unpack_tmp_buf_size, tile_size0 * tile_size1 * elem_size);
+  IREE_UK_ASSERT(helper->max_tiles_in_tmp_buf > 0);
+}
+
 static void iree_uk_unpack_validate(const iree_uk_unpack_params_t* params) {
 #ifdef IREE_UK_ENABLE_ASSERTS
   const iree_uk_uint32_t allflags =
-      IREE_UK_FLAG_PACK_TRANSPOSE_INNER | IREE_UK_FLAG_PACK_TRANSPOSE_OUTER;
+      IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER | IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER;
   IREE_UK_ASSERT(!(params->flags & ~allflags));
   IREE_UK_ASSERT(params->type == iree_uk_unpack_type_f32f32 ||
                  params->type == iree_uk_unpack_type_i8i8 ||
@@ -28,10 +60,10 @@ static void iree_uk_unpack_validate(const iree_uk_unpack_params_t* params) {
   iree_uk_ssize_t outer_size1 = params->in_size1;
   iree_uk_ssize_t tile_size0 = params->in_size2;
   iree_uk_ssize_t tile_size1 = params->in_size3;
-  if (params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_OUTER) {
+  if (params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER) {
     iree_uk_ssize_swap(&outer_size0, &outer_size1);
   }
-  if (params->flags & IREE_UK_FLAG_PACK_TRANSPOSE_INNER) {
+  if (params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER) {
     iree_uk_ssize_swap(&tile_size0, &tile_size1);
   }
   IREE_UK_ASSERT(outer_size0 * tile_size0 >= params->out_size0);
@@ -39,6 +71,16 @@ static void iree_uk_unpack_validate(const iree_uk_unpack_params_t* params) {
   // TODO(#11632): reenable these conditions.
   // IREE_UK_ASSERT((outer_size0 - 1) * tile_size0 < params->out_size0);
   // IREE_UK_ASSERT((outer_size1 - 1) * tile_size1 < params->out_size1);
+
+  // Initialize a padding helper, just to get the assertion that the tile size
+  // does not exceed the internal temporary buffer size, without having to
+  // duplicate this arithmetic. Generally, we want to hit all failure modes
+  // in the validation function so that the subsequent ukernel code can be
+  // treated as infallible.
+  iree_uk_unpack_tmpbuf_helper_t helper;
+  iree_uk_type_t elem_type = iree_uk_unpack_in_type(params->type);
+  iree_uk_ssize_t elem_size = iree_uk_type_size(elem_type);
+  iree_uk_unpack_tmpbuf_helper_init(tile_size0, tile_size1, elem_size, &helper);
 #endif  // IREE_UK_ENABLE_ASSERTS
 }
 
@@ -47,7 +89,49 @@ static bool iree_uk_unpack_early(const iree_uk_unpack_params_t* params) {
   return (params->out_size0 == 0 || params->out_size1 == 0);
 }
 
-static void iree_unpack_reference(const iree_uk_unpack_params_t* params) {
+static void iree_uk_copy_slice(iree_uk_ssize_t src_stride0, const char* src_buf,
+                               iree_uk_ssize_t dst_size0,
+                               iree_uk_ssize_t dst_size1,
+                               iree_uk_ssize_t dst_stride0, char* dst_buf,
+                               iree_uk_ssize_t elem_size) {
+  for (iree_uk_ssize_t in_i0 = 0; in_i0 < dst_size0; in_i0++) {
+    iree_uk_memcpy(dst_buf, src_buf, dst_size1 * elem_size);
+    dst_buf += dst_stride0 * elem_size;
+    src_buf += src_stride0 * elem_size;
+  }
+}
+
+// Unpacks an entire row, going through the temporary buffer to handle
+// incomplete tiles. In cases involving only complete tiles, it is faster to
+// call tile_func directly.
+static void iree_uk_unpack_row_using_tmpbuf(
+    iree_uk_unpack_tile_func_t tile_func, iree_uk_ssize_t dim1_tile_start,
+    iree_uk_ssize_t dim1_tile_end, iree_uk_ssize_t dim0_write_size,
+    iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t out_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_unpack_tmpbuf_helper_t* helper, const char* in_buf, char* out_buf) {
+  iree_uk_ssize_t dim1_tile = dim1_tile_start;
+  while (dim1_tile < dim1_tile_end) {
+    iree_uk_ssize_t dim1_chunk_tiles = iree_uk_ssize_clamp(
+        dim1_tile_end - dim1_tile, 0, helper->max_tiles_in_tmp_buf);
+    iree_uk_ssize_t dim1_chunk_src_width = dim1_chunk_tiles * tile_size1;
+    iree_uk_ssize_t dim1_chunk_src_pos = dim1_tile * tile_size1;
+    iree_uk_ssize_t dim1_write_size = iree_uk_ssize_clamp(
+        out_size1 - dim1_chunk_src_pos, 0, dim1_chunk_src_width);
+    tile_func(helper->tmp_buf, in_buf + dim1_tile * in_stride1 * elem_size,
+              dim1_chunk_tiles, dim1_chunk_src_width, in_stride1, elem_size,
+              tile_size0, tile_size1);
+    iree_uk_copy_slice(dim1_chunk_src_width, helper->tmp_buf, dim0_write_size,
+                       dim1_write_size, out_stride0,
+                       out_buf + dim1_tile * tile_size1 * elem_size, elem_size);
+    dim1_tile += dim1_chunk_tiles;
+  }
+}
+
+static void iree_uk_unpack_using_tile_func(
+    const iree_uk_unpack_params_t* params,
+    iree_uk_unpack_tile_func_t tile_func) {
   // For now, the input and output element types are always the same.
   iree_uk_type_t elem_type = iree_uk_unpack_in_type(params->type);
   iree_uk_ssize_t elem_size = iree_uk_type_size(elem_type);
@@ -55,38 +139,52 @@ static void iree_unpack_reference(const iree_uk_unpack_params_t* params) {
   iree_uk_ssize_t outer_size1 = params->in_size1;
   iree_uk_ssize_t tile_size0 = params->in_size2;
   iree_uk_ssize_t tile_size1 = params->in_size3;
-  iree_uk_ssize_t in_stride_l0 = params->in_stride0;
-  iree_uk_ssize_t in_stride_l1 = params->in_size3 * params->in_size2;
-  iree_uk_ssize_t in_stride_l2 = params->in_size3;
-  iree_uk_ssize_t in_stride_l3 = 1;
+  iree_uk_ssize_t in_stride0 = params->in_stride0;
+  iree_uk_ssize_t in_stride1 = params->in_size3 * params->in_size2;
   if (params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_OUTER) {
     iree_uk_ssize_swap(&outer_size0, &outer_size1);
-    iree_uk_ssize_swap(&in_stride_l0, &in_stride_l1);
+    iree_uk_ssize_swap(&in_stride0, &in_stride1);
   }
   if (params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER) {
     iree_uk_ssize_swap(&tile_size0, &tile_size1);
-    iree_uk_ssize_swap(&in_stride_l2, &in_stride_l3);
   }
-  for (iree_uk_ssize_t outer_i0 = 0; outer_i0 < outer_size0; ++outer_i0) {
-    for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
-      for (iree_uk_ssize_t tile_i0 = 0; tile_i0 < tile_size0; ++tile_i0) {
-        for (iree_uk_ssize_t tile_i1 = 0; tile_i1 < tile_size1; ++tile_i1) {
-          iree_uk_ssize_t in_offset =
-              outer_i0 * in_stride_l0 + tile_i0 * in_stride_l2 +
-              outer_i1 * in_stride_l1 + tile_i1 * in_stride_l3;
-          iree_uk_ssize_t i0 = outer_i0 * tile_size0 + tile_i0;
-          iree_uk_ssize_t i1 = outer_i1 * tile_size1 + tile_i1;
-          if (!(i0 >= params->out_size0 || i1 >= params->out_size1)) {
-            iree_uk_ssize_t out_offset = i1 + i0 * params->out_stride0;
-            const char* in_ptr =
-                ((char*)params->in_buffer) + in_offset * elem_size;
-            char* out_ptr =
-                ((char*)params->out_buffer) + out_offset * elem_size;
-            iree_uk_memcpy(out_ptr, in_ptr, elem_size);
-          }
-        }
-      }
-    }
+  const char* in_buf = params->in_buffer;
+  char* out_buf = params->out_buffer;
+  // Prepare for handling incomplete tiles with a temporary buffer.
+  iree_uk_unpack_tmpbuf_helper_t tmpbuf_helper;
+  if (params->out_size0 < outer_size0 * tile_size0 ||
+      params->out_size1 < outer_size1 * tile_size1) {
+    iree_uk_unpack_tmpbuf_helper_init(tile_size0, tile_size1, elem_size,
+                                      &tmpbuf_helper);
+  }
+  // Compute number of tiles along both dimensions that fit entirely within the
+  // source buffer's boundaries.
+  int dim1_full_tiles = iree_uk_div_nonneg_by_pos_and_likely_po2_i32(
+      params->out_size1, tile_size1);
+  iree_uk_ssize_t i0 = 0;
+  for (; i0 <= params->out_size0 - tile_size0; i0 += tile_size0) {
+    // Pack whole tiles that do not require padding (entirely within the source
+    // buffer's boundaries).
+    tile_func(out_buf, in_buf, dim1_full_tiles, params->out_stride0, in_stride1,
+              elem_size, tile_size0, tile_size1);
+    // Right-padding.
+    iree_uk_unpack_row_using_tmpbuf(
+        tile_func, dim1_full_tiles, outer_size1, tile_size0, tile_size0,
+        tile_size1, elem_size, params->out_size1, params->out_stride0,
+        in_stride1, &tmpbuf_helper, in_buf, out_buf);
+    out_buf += tile_size0 * params->out_stride0 * elem_size;
+    in_buf += in_stride0 * elem_size;
+  }
+  // Bottom-padding.
+  for (; i0 < outer_size0 * tile_size0; i0 += tile_size0) {
+    iree_uk_ssize_t dim0_write_size =
+        iree_uk_ssize_clamp(params->out_size0 - i0, 0, tile_size0);
+    iree_uk_unpack_row_using_tmpbuf(
+        tile_func, 0, outer_size1, dim0_write_size, tile_size0, tile_size1,
+        elem_size, params->out_size1, params->out_stride0, in_stride1,
+        &tmpbuf_helper, in_buf, out_buf);
+    out_buf += tile_size0 * params->out_stride0 * elem_size;
+    in_buf += in_stride0 * elem_size;
   }
 }
 
@@ -95,5 +193,7 @@ IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params) {
 
   if (iree_uk_unpack_early(params)) return;
 
-  iree_unpack_reference(params);
+  // Select a target-specific tile_func and use that with generic outer loops.
+  iree_uk_unpack_tile_func_t func = iree_uk_unpack_select_tile_func(params);
+  iree_uk_unpack_using_tile_func(params, func);
 }

--- a/runtime/src/iree/builtins/ukernel/unpack.h
+++ b/runtime/src/iree/builtins/ukernel/unpack.h
@@ -46,20 +46,12 @@ typedef struct iree_uk_unpack_params_t {
   const iree_uk_uint64_t* cpu_data;
 } iree_uk_unpack_params_t;
 
-typedef void* (*iree_uk_unpack_tile_func_t)(
+typedef void (*iree_uk_unpack_tile_func_t)(
     void* IREE_UK_RESTRICT /*out_tile_ptr*/,
     const void* IREE_UK_RESTRICT /*in_tile_ptr*/,
-    iree_uk_ssize_t /*outer_size1*/, iree_uk_ssize_t /*out_stride_l1*/,
-    iree_uk_ssize_t /*in_stride0*/, iree_uk_ssize_t /*elem_size*/,
+    iree_uk_ssize_t /*outer_size1*/, iree_uk_ssize_t /*out_stride0*/,
+    iree_uk_ssize_t /*in_stride1*/, iree_uk_ssize_t /*elem_size*/,
     iree_uk_ssize_t /*tile_size0*/, iree_uk_ssize_t /*tile_size1*/);
-
-// Tile kernel declarations. Prototype matches iree_uk_unpack_tile_func_t.
-#define IREE_UK_UNPACK_TILE_FUNC_DECL(NAME)                              \
-  void* NAME(void* IREE_UK_RESTRICT out_tile_ptr,                        \
-             const void* IREE_UK_RESTRICT in_tile_ptr,                   \
-             iree_uk_ssize_t outer_size1, iree_uk_ssize_t out_stride_l1, \
-             iree_uk_ssize_t in_stride0, iree_uk_ssize_t elem_size,      \
-             iree_uk_ssize_t tile_size0, iree_uk_ssize_t tile_size1);
 
 // Main entry point.
 IREE_UK_EXPORT void iree_uk_unpack(const iree_uk_unpack_params_t* params);

--- a/runtime/src/iree/builtins/ukernel/unpack_tile.c
+++ b/runtime/src/iree/builtins/ukernel/unpack_tile.c
@@ -1,0 +1,88 @@
+// Copyright 2022 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/unpack_tile.h"
+
+#if defined(IREE_UK_ARCH_ARM_64)
+#include "iree/builtins/ukernel/arch/arm_64/unpack_arm_64.h"
+#endif
+
+static void iree_uk_unpack_tile_generic_direct(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  const char* IREE_UK_RESTRICT in_ptr_l1 = in_tile_ptr;
+  char* IREE_UK_RESTRICT out_ptr_l1 = out_tile_ptr;
+  for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
+    const char* IREE_UK_RESTRICT in_ptr = in_ptr_l1;
+    char* IREE_UK_RESTRICT out_ptr = out_ptr_l1;
+    for (iree_uk_ssize_t tile_i0 = 0; tile_i0 < tile_size0; ++tile_i0) {
+      iree_uk_memcpy(out_ptr, in_ptr, tile_size1 * elem_size);
+      in_ptr += tile_size1 * elem_size;
+      out_ptr += out_stride0 * elem_size;
+    }
+    in_ptr_l1 += in_stride1 * elem_size;
+    out_ptr_l1 += tile_size1 * elem_size;
+  }
+}
+
+static void iree_uk_unpack_tile_generic_transpose(
+    void* IREE_UK_RESTRICT out_tile_ptr,
+    const void* IREE_UK_RESTRICT in_tile_ptr, iree_uk_ssize_t outer_size1,
+    iree_uk_ssize_t out_stride0, iree_uk_ssize_t in_stride1,
+    iree_uk_ssize_t elem_size, iree_uk_ssize_t tile_size0,
+    iree_uk_ssize_t tile_size1) {
+  const char* IREE_UK_RESTRICT in_ptr_l1 = in_tile_ptr;
+  char* IREE_UK_RESTRICT out_ptr_l1 = out_tile_ptr;
+  for (iree_uk_ssize_t outer_i1 = 0; outer_i1 < outer_size1; ++outer_i1) {
+    const char* IREE_UK_RESTRICT in_ptr_l2 = in_ptr_l1;
+    char* IREE_UK_RESTRICT out_ptr_l2 = out_ptr_l1;
+    for (iree_uk_ssize_t tile_i0 = 0; tile_i0 < tile_size0; ++tile_i0) {
+      const char* IREE_UK_RESTRICT in_ptr = in_ptr_l2;
+      char* IREE_UK_RESTRICT out_ptr = out_ptr_l2;
+      for (iree_uk_ssize_t tile_i1 = 0; tile_i1 < tile_size1; ++tile_i1) {
+        iree_uk_memcpy(out_ptr, in_ptr, elem_size);
+        in_ptr += tile_size0 * elem_size;
+        out_ptr += elem_size;
+      }
+      in_ptr_l2 += elem_size;
+      out_ptr_l2 += out_stride0 * elem_size;
+    }
+    in_ptr_l1 += in_stride1 * elem_size;
+    out_ptr_l1 += tile_size1 * elem_size;
+  }
+}
+
+static iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_generic(
+    const iree_uk_unpack_params_t* params) {
+  if (params->flags & IREE_UK_FLAG_UNPACK_TRANSPOSE_INNER) {
+    return iree_uk_unpack_tile_generic_transpose;
+  } else {
+    return iree_uk_unpack_tile_generic_direct;
+  }
+}
+
+static iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func_arch(
+    const iree_uk_unpack_params_t* params) {
+#if defined(IREE_UK_ARCH_ARM_64)
+  return iree_uk_unpack_select_tile_func_arm_64(params);
+#endif
+  return 0;
+}
+
+// Select the 'tile function' that is the typically target-optimized inner loop
+// implementation.
+iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func(
+    const iree_uk_unpack_params_t* params) {
+  iree_uk_unpack_tile_func_t arch_tile_func =
+      iree_uk_unpack_select_tile_func_arch(params);
+  if (arch_tile_func) {
+    return arch_tile_func;
+  }
+  return iree_uk_unpack_select_tile_func_generic(params);
+}

--- a/runtime/src/iree/builtins/ukernel/unpack_tile.h
+++ b/runtime/src/iree/builtins/ukernel/unpack_tile.h
@@ -1,0 +1,16 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_BUILTINS_UKERNEL_UNPACK_TILE_H_
+#define IREE_BUILTINS_UKERNEL_UNPACK_TILE_H_
+
+#include "iree/builtins/ukernel/unpack.h"
+
+// Returns the tile function to use for the unpack op with the given params.
+iree_uk_unpack_tile_func_t iree_uk_unpack_select_tile_func(
+    const iree_uk_unpack_params_t* params);
+
+#endif  // IREE_BUILTINS_UKERNEL_UNPACK_TILE_H_


### PR DESCRIPTION
`unpack` ukernel:

- ARM64 code (NEON intrinsics - good enough for now but boy did I have to wrestle clang / settle for suboptimal perf for the sake of simplicity).
- test and benchmark (close ports of the `pack` ukernel test and benchmark).

`pack` ukernel:

- Sharing NEON routines with `unpack`
- Improvements, keeping aligned with the `unpack` code.