### PR TITLE
Fix tests for mid-air collision

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_promote_operands.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/transform_dialect_promote_operands.mlir
@@ -32,7 +32,7 @@ hal.executable private @pad_matmul_static_dispatch_0  {
 
   transform.structured.canonicalized_sequence failures(propagate) {
   ^bb1(%variant_op: !pdl.operation):
-    %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op
+    %matmul = transform.structured.match ops{["linalg.matmul"]} in %variant_op : (!pdl.operation) -> !pdl.operation
     transform.iree.promote_operands %matmul [0, 1] : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
   }
 }


### PR DESCRIPTION
There is a mid-air collision in the test added by https://github.com/iree-org/iree/commit/21e5ddf416c580e5fe1f8ed881e8c990dbc69ffc. This fixes the issue.