### PR TITLE
Undo special-case 1x1 tiling for VMVX

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1649,14 +1649,6 @@ static LogicalResult setRootConfig(
   auto translationInfo = IREE::Codegen::TranslationInfoAttr::get(
       entryPointFn->getContext(), pipeline);
 
-  // Always vectorize the ops for VMVX pipeline because stack allocation is not
-  // allowed.
-  if (pipeline == DispatchLoweringPassPipeline::VMVXDefault) {
-    for (int i = 0, e = ubs.size(); i < e; ++i) {
-      if (ubs[i] == ShapedType::kDynamic) ubs[i] = 1;
-    }
-  }
-
   if (failed(setTranslationInfo(entryPointFn, translationInfo))) {
     return failure();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/materialize_vmvx_launch_configuration.mlir
@@ -73,7 +73,7 @@ hal.executable @copy_op_dynamic {
     }
   }
 }
-//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 1]]>
+//  CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 64]]>
 //  CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //      CHECK: hal.executable.export public @copy_op_dynamic
 // CHECK-SAME:     translation_info = #[[TRANSLATION]]
@@ -176,7 +176,7 @@ hal.executable @fusion_quant_matmul_generic {
     }
   }
 }
-//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[1, 16, 0]]>
+//   CHECK-DAG: #[[CONFIG:.+]] = #iree_codegen.lowering_config<tile_sizes = {{\[}}[64, 16, 0]]>
 //   CHECK-DAG: #[[TRANSLATION:.+]] = #iree_codegen.translation_info<VMVXDefault>
 //       CHECK: hal.executable.export public @fusion_quant_matmul_generic
 //  CHECK-SAME:     translation_info = #[[TRANSLATION]]

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -36,29 +36,14 @@ BACKEND_TESTS = [
 
 iree_lit_test_suite(
     name = "lit",
-    srcs = enforce_glob(
-        [
-            "fill_i64.mlir",
-            "globals.mlir",
-            "libm_linking.mlir",
-            "scalar.mlir",
-            "trace_dispatch_tensors.mlir",
-            "unused_args.mlir",
-        ],
-        include =
-            ["*.mlir"],
-        # TODO(#5897): enable these for codegen linalg on tensors/etc.
-        exclude = [
-            "associative_reordering.mlir",
-            "disable_demote_f64_to_f32.mlir",
-            "globals_ml_program.mlir",
-            "large_reduction.mlir",
-            "layernorm.mlir",
-            "linalg_quantized_matmul_vs_linalg_matmul.mlir",
-            "lowering_config.mlir",
-            "softmax_large.mlir",
-        ] + BACKEND_TESTS,
-    ),
+    srcs = [
+        "fill_i64.mlir",
+        "globals.mlir",
+        "libm_linking.mlir",
+        "scalar.mlir",
+        "trace_dispatch_tensors.mlir",
+        "unused_args.mlir",
+    ],
     cfg = "//tests:lit.cfg.py",
     tags = [
         "driver=local-task",

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -8,7 +8,6 @@
 # These should focus on support by IREE itself, not for issues with specific runner tools.
 # Place those tests in tools/test/
 
-load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_lit_test.bzl", "iree_lit_test_suite")
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
 

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -178,3 +178,22 @@ iree_check_single_backend_test_suite(
     driver = "local-task",
     target_backend = "llvm-cpu",
 )
+
+# Compilation-only (no driver specified, the default None means compile only)
+# regression testcases for VMVX backend with microkernels. Indeed we have had
+# a couple of hard-to-diagnose issues that were purely compilation issue, no
+# particular concern about correctness once compilation succeeds, and having
+# compilation-only tests allows us to import the original unmodified testcase.
+iree_check_single_backend_test_suite(
+    name = "check_regression_compilation_only_vmvx_ukernels",
+    srcs = [
+        "dynamic_matmuls_on_same_accumulator_issue_12060.mlir",
+        "dynamic_tosa_clamp.mlir",
+        "dynamic_tosa_quantized_fully_connected_issue_10859.mlir",
+    ],
+    compiler_flags = [
+        "--iree-input-type=tosa",
+        "--iree-vmvx-enable-microkernels",
+    ],
+    target_backend = "vmvx",
+)

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -206,4 +206,18 @@ iree_check_single_backend_test_suite(
     "--iree-flow-enable-aggressive-fusion"
 )
 
+iree_check_single_backend_test_suite(
+  NAME
+    check_regression_compilation_only_vmvx_ukernels
+  SRCS
+    "dynamic_matmuls_on_same_accumulator_issue_12060.mlir"
+    "dynamic_tosa_clamp.mlir"
+    "dynamic_tosa_quantized_fully_connected_issue_10859.mlir"
+  TARGET_BACKEND
+    "vmvx"
+  COMPILER_FLAGS
+    "--iree-input-type=tosa"
+    "--iree-vmvx-enable-microkernels"
+)
+
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/tests/e2e/regression/dynamic_matmuls_on_same_accumulator_issue_12060.mlir
+++ b/tests/e2e/regression/dynamic_matmuls_on_same_accumulator_issue_12060.mlir
@@ -1,0 +1,8 @@
+// Regression testcase from https://github.com/iree-org/iree/issues/12060
+
+func.func @matmul_i8(%lhs: tensor<?x?xi8>, %rhs: tensor<?x?xi8>, %acc: tensor<?x?xi32>) -> tensor<?x?xi32> {
+  %result1 = linalg.matmul ins(%lhs, %rhs: tensor<?x?xi8>, tensor<?x?xi8>) outs(%acc: tensor<?x?xi32>) -> tensor<?x?xi32>
+  %result2 = linalg.matmul ins(%lhs, %rhs: tensor<?x?xi8>, tensor<?x?xi8>) outs(%result1: tensor<?x?xi32>) -> tensor<?x?xi32>
+  %result3 = linalg.matmul ins(%lhs, %rhs: tensor<?x?xi8>, tensor<?x?xi8>) outs(%result2: tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %result3: tensor<?x?xi32>
+}

--- a/tests/e2e/regression/dynamic_tosa_clamp.mlir
+++ b/tests/e2e/regression/dynamic_tosa_clamp.mlir
@@ -1,0 +1,6 @@
+// Minimized from dynamic_tosa_quantized_fully_connected_issue_10859.mlir
+
+func.func @clamp(%arg0: tensor<?xi8>) ->tensor<?xi8>{
+  %1 = "tosa.clamp"(%arg0) {max_fp = 0.000000e+00 : f32, max_int = 127 : i64, min_fp = 0.000000e+00 : f32, min_int = -128 : i64} : (tensor<?xi8>) -> tensor<?xi8>
+  return %1 : tensor<?xi8>
+}

--- a/tests/e2e/regression/dynamic_tosa_quantized_fully_connected_issue_10859.mlir
+++ b/tests/e2e/regression/dynamic_tosa_quantized_fully_connected_issue_10859.mlir
@@ -1,0 +1,14 @@
+// Regression testcase from https://github.com/iree-org/iree/issues/10859
+
+func.func @main(%arg0: tensor<256xi8>, %arg1: tensor<2xi32>, %arg2: tensor<2x32xi8>, %arg3: tensor<32xi32>, %arg4: tensor<32x32xi8>, %arg5: tensor<32xi32>, %arg6: tensor<32x3360xi8>, %arg7: tensor<?x3360xi8>) -> (tensor<?x2xi8>) {
+  %0 = "tosa.fully_connected"(%arg7, %arg6, %arg5) {quantization_info = #tosa.conv_quant<input_zp = -128, weight_zp = 0>} : (tensor<?x3360xi8>, tensor<32x3360xi8>, tensor<32xi32>) -> tensor<?x32xi32>
+  %1 = "tosa.rescale"(%0) {double_round = true, input_zp = 0 : i32, multiplier = array<i32:1101627623>, output_zp = -128 : i32, per_channel = false, scale32 = true, shift = array<i32:36>} : (tensor<?x32xi32>) -> tensor<?x32xi8>
+  %2 = "tosa.clamp"(%1) {max_fp = 0.000000e+00 : f32, max_int = 127 : i64, min_fp = 0.000000e+00 : f32, min_int = -128 : i64} : (tensor<?x32xi8>) -> tensor<?x32xi8>
+  %3 = "tosa.fully_connected"(%2, %arg4, %arg3) {quantization_info = #tosa.conv_quant<input_zp = -128, weight_zp = 0>} : (tensor<?x32xi8>, tensor<32x32xi8>, tensor<32xi32>) -> tensor<?x32xi32>
+  %4 = "tosa.rescale"(%3) {double_round = true, input_zp = 0 : i32, multiplier = array<i32:1255393165>, output_zp = -128 : i32, per_channel = false, scale32 = true, shift = array<i32:35>} : (tensor<?x32xi32>) -> tensor<?x32xi8>
+  %5 = "tosa.clamp"(%4) {max_fp = 0.000000e+00 : f32, max_int = 127 : i64, min_fp = 0.000000e+00 : f32, min_int = -128 : i64} : (tensor<?x32xi8>) -> tensor<?x32xi8>
+  %6 = "tosa.fully_connected"(%5, %arg2, %arg1) {quantization_info = #tosa.conv_quant<input_zp = -128, weight_zp = 0>} : (tensor<?x32xi8>, tensor<2x32xi8>, tensor<2xi32>) -> tensor<?x2xi32>
+  %7 = "tosa.rescale"(%6) {double_round = true, input_zp = 0 : i32, multiplier = array<i32:1879992488>, output_zp = 44 : i32, per_channel = false, scale32 = true, shift = array<i32:39>} : (tensor<?x2xi32>) -> tensor<?x2xi8>
+  %8 = "tosa.table"(%7, %arg0) : (tensor<?x2xi8>, tensor<256xi8>) -> tensor<?x2xi8>
+  return %8 : tensor<?x2xi8>
+}


### PR DESCRIPTION
Fixes #12073.

This is essentially a rollback of #11323, but keeping the useful test that it introduced, and adding known testcases as e2e regression tests (compilation only).

This is a gigantic performance improvement in my case -- two orders of magnitude on large (1024x1024) matmul benchmarks on VMVX + ukernels on ARM64 (which is where we currently have optimized ukernels). The reason is that while the ukernel is happy to handle a dispatch of any size, with VMVX there is a high reward for having larger ukernel dispatches, since anything outside of ukernels is very slow in VMVX.