### PR TITLE
Generate `L1::no_allocate` for load/store in PTX

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -198,6 +198,7 @@ iree_compiler_cc_library(
     srcs = [
         "DecomposeLinalgGeneric.cpp",
         "FoldAffineMinInDistributedLoops.cpp",
+        "GPUCoalascedAccess.cpp",
         "GPUDistributeSharedMemoryCopy.cpp",
         "GPUMultiBuffering.cpp",
         "GPUPatterns.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -171,6 +171,7 @@ iree_cc_library(
   SRCS
     "DecomposeLinalgGeneric.cpp"
     "FoldAffineMinInDistributedLoops.cpp"
+    "GPUCoalascedAccess.cpp"
     "GPUDistributeSharedMemoryCopy.cpp"
     "GPUMultiBuffering.cpp"
     "GPUPatterns.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractOp.td
+++ b/compiler/src/iree/compiler/Codegen/Common/FoldTensorExtractOp.td
@@ -15,6 +15,6 @@ include "mlir/IR/PatternBase.td"
 // Canonicalize unnecessary tensor_load when the load is used just for
 // an extract
 def : Pat<(Tensor_ExtractOp (Bufferization_ToTensorOp $value), $indices),
-          (LoadOp $value, $indices)>;
+          (LoadOp $value, $indices, ConstantAttr<BoolAttr, "false">)>;
 
 #endif // IREE_COMPILER_CODEGEN_COMMON_FOLDTENSOREXTRACTOP

--- a/compiler/src/iree/compiler/Codegen/Common/GPUCoalascedAccess.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUCoalascedAccess.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/Linalg/IR/LinalgInterfaces.h"
+
+#define DEBUG_TYPE "iree-gpu-coalasced-access"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+/// Finds stride-1 access on genericOp's inputs and set
+/// DescriptorFlags::Streaming flag. This data will not need caching since it is
+/// read by cache-line and once. perfectly coalasced data.
+void setStreamingDataflag(linalg::GenericOp genericOp) {
+  auto inputs = genericOp.getInputs();
+  for (auto [idx, indexingMap] :
+       llvm::enumerate(genericOp.getIndexingMapsArray())) {
+    if (inputs.size() <= idx) break;
+    int numRes = indexingMap.getNumResults() - 1;
+    // Traverse readonly inputs if their indexing is stride-1 mark streaming
+    // flag. Check the last dimension, for example (..., dn) -> (..., dn)
+    if (indexingMap.getNumDims() >= numRes &&
+        indexingMap.getDimPosition(numRes) == numRes) {
+      if (auto loadOp =
+              inputs[idx].getDefiningOp<IREE::Flow::DispatchTensorLoadOp>()) {
+        if (auto subspanOp =
+                loadOp.getSource()
+                    .getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>()) {
+          auto flags = IREE::HAL::DescriptorFlags::Streaming;
+          if (subspanOp.getDescriptorFlags().has_value())
+            flags = flags | subspanOp.getDescriptorFlags().value();
+          subspanOp.setDescriptorFlags(flags);
+        }
+      }
+    }
+  }
+}
+
+struct GPUCoalascedAccessPass
+    : public GPUCoalascedAccessBase<GPUCoalascedAccessPass> {
+  void getDependentDialects(DialectRegistry& registry) const override {
+    registry.insert<AffineDialect, gpu::GPUDialect>();
+  }
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    funcOp->walk(
+        [&](linalg::GenericOp genericOp) { setStreamingDataflag(genericOp); });
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>> createGPUCoalascedAccessPass() {
+  return std::make_unique<GPUCoalascedAccessPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/test/gpu_coalasced_access.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/gpu_coalasced_access.mlir
@@ -1,0 +1,32 @@
+// RUN: iree-opt --iree-gpu-coalasced-access --split-input-file %s | FileCheck %s
+
+func.func @dispatch_region() {
+  %c0 = arith.constant 0 : index
+  %c536870912 = arith.constant 536870912 : index
+  %c1073741824 = arith.constant 1073741824 : index
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c0) alignment(64) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<512x512x512xf32>>
+  %1 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c536870912) alignment(64) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<512x512x512xf32>>
+  %2 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%c1073741824) alignment(64) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<512x512x512xf32>>
+  %3 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%c0) alignment(64) flags(WriteOnly) : !flow.dispatch.tensor<writeonly:tensor<512x512x512xf32>>
+  %4 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0], sizes = [512, 512, 512], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<512x512x512xf32>> -> tensor<512x512x512xf32>
+  %5 = flow.dispatch.tensor.load %1, offsets = [0, 0, 0], sizes = [512, 512, 512], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<512x512x512xf32>> -> tensor<512x512x512xf32>
+  %6 = flow.dispatch.tensor.load %2, offsets = [0, 0, 0], sizes = [512, 512, 512], strides = [1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<512x512x512xf32>> -> tensor<512x512x512xf32>
+  %7 = tensor.empty() : tensor<512x512x512xf32>
+  %8 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2) -> (d1, d0, d2)>, affine_map<(d0, d1, d2) -> (d1, d2, d1)>, affine_map<(d0, d1, d2) -> (d1, d2, d0)>, affine_map<(d0, d1, d2) -> (d1, d2, d0)>], iterator_types = ["parallel", "parallel", "parallel"]} ins(%4, %5, %6 : tensor<512x512x512xf32>, tensor<512x512x512xf32>, tensor<512x512x512xf32>) outs(%7 : tensor<512x512x512xf32>) {
+  ^bb0(%in: f32, %in_0: f32, %in_1: f32, %out: f32):
+    %9 = arith.divf %in, %in_1 : f32
+    %10 = arith.mulf %9, %in_0 : f32
+    linalg.yield %10 : f32
+  } -> tensor<512x512x512xf32>
+  flow.dispatch.tensor.store %8, %3, offsets = [0, 0, 0], sizes = [512, 512, 512], strides = [1, 1, 1] : tensor<512x512x512xf32> -> !flow.dispatch.tensor<writeonly:tensor<512x512x512xf32>>
+  return
+}
+
+//  CHECK: func.func @dispatch_region()
+//  CHECK:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK:   %[[c536870912:.+]] = arith.constant 536870912 : index
+//  CHECK:   %[[c1073741824:.+]] = arith.constant 1073741824 : index
+//  CHECK:   hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[C0]]) alignment(64) flags("ReadOnly|Streaming")
+//  CHECK:   hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[c536870912]]) alignment(64) flags(ReadOnly)
+//  CHECK:   hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%[[c1073741824]]) alignment(64) flags(ReadOnly)
+//  CHECK:   hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) offset(%[[C0]]) alignment(64) flags(WriteOnly)

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -21,6 +21,7 @@ iree_compiler_cc_library(
         "KernelConfig.cpp",
         "LLVMGPUDistribute.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
+        "LLVMGPUSpecialLoad.cpp",
         "LLVMGPUTensorAlloc.cpp",
         "LLVMGPUTensorCoreVectorization.cpp",
         "LLVMGPUTensorPad.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     "KernelConfig.cpp"
     "LLVMGPUDistribute.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
+    "LLVMGPUSpecialLoad.cpp"
     "LLVMGPUTensorAlloc.cpp"
     "LLVMGPUTensorCoreVectorization.cpp"
     "LLVMGPUTensorPad.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
@@ -26,6 +26,13 @@ void populateConvertSharedMemoryAllocOps(RewritePatternSet &patterns);
 
 void ConvertToDynamicSharedMemory(ModuleOp moduleOp);
 
+/// Add patterns to generates special load and store op if the source is subspan
+/// with special flags
+void populateSpecialLoadStore(RewritePatternSet &patterns, MLIRContext *ctx);
+
+/// Add patterns to generates special load and store op to PTX
+void populateSpecialLoadStorePTX(RewritePatternSet &patterns, MLIRContext *ctx);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.h
@@ -7,10 +7,20 @@
 #ifndef IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
 #define IREE_COMPILER_CODEGEN_LLVMGPU_KERNELCONFIG_H_
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinOps.h"
 
 namespace mlir {
 namespace iree_compiler {
+/// Structure to represent target features.
+struct TargetInfo {
+  // TODO: add finer grain control for other tensorcore types.
+  bool hasTF32TensorCore = false;
+  bool hasWarpShuffle = false;
+  bool hasCacheEvictionPriority = false;
+};
+
+TargetInfo getTargetInfo(func::FuncOp entryPoint);
 
 LogicalResult initGPULaunchConfig(ModuleOp moduleOp);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSpecialLoad.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUSpecialLoad.cpp
@@ -1,0 +1,137 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "iree/compiler/Dialect/Util/IR/UtilOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/LogicalResult.h"
+
+#define DEBUG_TYPE "iree-llvmgpu-special-load-store"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+
+/// Insert nontemporal to memref.load if the subspanOp has
+/// DescriptorFlags::Streaming flag.
+struct MemrefLoadSetNonTemporal : public OpRewritePattern<memref::LoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::LoadOp op,
+                                PatternRewriter &rewriter) const override {
+    if (auto subspanOp =
+            (op.getMemRef()
+                 .getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>())) {
+      if (!op.getNontemporal() &&
+          bitEnumContainsAny(subspanOp.getDescriptorFlags().value_or(
+                                 IREE::HAL::DescriptorFlags::None),
+                             IREE::HAL::DescriptorFlags::Streaming)) {
+        rewriter.replaceOpWithNewOp<memref::LoadOp>(
+            op, op->getResultTypes(), op.getMemRef(), op.getIndices(), true);
+        return success();
+      }
+    }
+    return failure();
+  }
+};
+
+/// Insert nontemporal to memref.store if the subspanOp has
+/// DescriptorFlags::WriteOnly flag
+struct MemrefStoreSetNonTemporal : public OpRewritePattern<memref::StoreOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(memref::StoreOp op,
+                                PatternRewriter &rewriter) const override {
+    if (auto subspanOp =
+            (op.getMemRef()
+                 .getDefiningOp<IREE::HAL::InterfaceBindingSubspanOp>())) {
+      if (!op.getNontemporal() &&
+          bitEnumContainsAny(subspanOp.getDescriptorFlags().value_or(
+                                 IREE::HAL::DescriptorFlags::None),
+                             IREE::HAL::DescriptorFlags::WriteOnly)) {
+        rewriter.replaceOpWithNewOp<memref::StoreOp>(
+            op, op.getValue(), op.getMemRef(), op.getIndices(), true);
+      }
+    }
+    return failure();
+  }
+};
+
+/// Generate load PTX for llvm.load {nontemporal}. This is the only way since
+/// cache eviction suffixes are not implemented in llvm core.
+struct GenerateLoadPTX : public OpRewritePattern<LLVM::LoadOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::LoadOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.getNontemporal()) return failure();
+    auto gepOp = op.getAddr().getDefiningOp<LLVM::GEPOp>();
+    if (!gepOp) return failure();
+
+    const char *asmStr = "ld.global.nc.L1::no_allocate.f32 $0, [$1];\n";
+    const char *asmConstraints = "=f, l";
+    SmallVector<Value> asmVals{gepOp->getResults()};
+    auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                                    LLVM::AsmDialect::AD_ATT);
+    rewriter.replaceOpWithNewOp<LLVM::InlineAsmOp>(
+        op, op.getRes().getType(),
+        /*operands=*/asmVals,
+        /*asm_string=*/asmStr,
+        /*constraints=*/asmConstraints, /*has_side_effects=*/true,
+        /*is_align_stack=*/false, /*asm_dialect=*/asmDialectAttr,
+        /*operand_attrs=*/ArrayAttr());
+
+    return success();
+  }
+};
+
+/// Generate load PTX for llvm.store {nontemporal}.
+struct GenerateStorePTX : public OpRewritePattern<LLVM::StoreOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::StoreOp op,
+                                PatternRewriter &rewriter) const override {
+    if (!op.getNontemporal()) return failure();
+
+    auto gepOp = op.getAddr().getDefiningOp<LLVM::GEPOp>();
+    if (!gepOp) return failure();
+
+    const char *asmStr = "st.global.L1::no_allocate.f32 [$0], $1;\n";
+    const char *asmConstraints = "l, f";
+    SmallVector<Value> asmVals{gepOp->getResults().front(), op.getValue()};
+    auto asmDialectAttr = LLVM::AsmDialectAttr::get(rewriter.getContext(),
+                                                    LLVM::AsmDialect::AD_ATT);
+    auto voidtype = LLVM::LLVMVoidType::get(getContext());
+
+    rewriter.create<LLVM::InlineAsmOp>(
+        op->getLoc(), voidtype,
+        /*operands=*/asmVals,
+        /*asm_string=*/asmStr,
+        /*constraints=*/asmConstraints, /*has_side_effects=*/true,
+        /*is_align_stack=*/false, /*asm_dialect=*/asmDialectAttr,
+        /*operand_attrs=*/ArrayAttr());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+}  // namespace
+
+void populateSpecialLoadStore(RewritePatternSet &patterns, MLIRContext *ctx) {
+  patterns.insert<MemrefLoadSetNonTemporal, MemrefStoreSetNonTemporal>(ctx);
+}
+
+void populateSpecialLoadStorePTX(RewritePatternSet &patterns,
+                                 MLIRContext *ctx) {
+  patterns.insert<GenerateLoadPTX, GenerateStorePTX>(ctx);
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -100,6 +100,9 @@ static void addBufferizePasses(OpPassManager &passManager) {
 
 static void tileAndDistributeToWorkgroup(
     OpPassManager &pm, bool useWARForCooperativeMatrixCodegen = false) {
+  pm.nest<ModuleOp>().addNestedPass<func::FuncOp>(
+      createGPUCoalascedAccessPass());
+
   pm.addPass(createTileAndDistributeToWorkgroupsPass());
 
   auto &nestedModulePM = pm.nest<ModuleOp>();

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -155,6 +155,8 @@ std::unique_ptr<OperationPass<func::FuncOp>> createMemrefCopyToLinalgPass();
 std::unique_ptr<OperationPass<func::FuncOp>>
 createGPUDistributeSharedMemoryCopy();
 
+std::unique_ptr<OperationPass<func::FuncOp>> createGPUCoalascedAccessPass();
+
 /// Apply multi-buffering transformation.
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUMultiBuffering(
     unsigned numBuffers = 5);

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -193,6 +193,12 @@ def GPUDistributeSharedMemoryCopy :
   let constructor = "mlir::iree_compiler::createGPUDistributeSharedMemoryCopy()";
 }
 
+def GPUCoalascedAccess :
+    Pass<"iree-gpu-coalasced-access", "func::FuncOp"> {
+  let summary = "Pass to find coalasced memory access.";
+  let constructor = "mlir::iree_compiler::createGPUCoalascedAccessPass()";
+}
+
 def GPUReduceBankConflicts :
     Pass<"iree-gpu-reduce-bank-conflicts", "func::FuncOp"> {
   let summary = "Pass to try to reduce the number of bank conflicts.";

--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
@@ -101,6 +101,12 @@ static PipelineLayout deriveExportLayout(
         // Read-only.
         bindingFlags[i] =
             bindingFlags[i] | IREE::HAL::DescriptorFlags::ReadOnly;
+      } else if (!bitEnumContainsAll(
+                     resourceAccess,
+                     IREE::Stream::ResourceAccessBitfield::Read)) {
+        // Write-only.
+        bindingFlags[i] =
+            bindingFlags[i] | IREE::HAL::DescriptorFlags::WriteOnly;
       }
     }
   }

--- a/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
+++ b/compiler/src/iree/compiler/Dialect/HAL/IR/HALBase.td
@@ -149,10 +149,14 @@ def HAL_DescriptorTypeAttr :
 
 def HAL_DescriptorFlags_None : I32BitEnumAttrCase<"None", 0x0000>;
 def HAL_DescriptorFlags_ReadOnly : I32BitEnumAttrCase<"ReadOnly", 0x0001>;
+def HAL_DescriptorFlags_Streaming : I32BitEnumAttrCase<"Streaming", 0x0002>;
+def HAL_DescriptorFlags_WriteOnly : I32BitEnumAttrCase<"WriteOnly", 0x0004>;
 def HAL_DescriptorFlagsAttr :
     I32BitEnumAttr<"DescriptorFlags", "valid Descriptor flags", [
       HAL_DescriptorFlags_None,
       HAL_DescriptorFlags_ReadOnly,
+      HAL_DescriptorFlags_WriteOnly,
+      HAL_DescriptorFlags_Streaming
     ]> {
   let cppNamespace = "::mlir::iree_compiler::IREE::HAL";
 }


### PR DESCRIPTION
PTX 7.4 introduced cache eviction policies on load and store instruction [1]. This PR leverages one of them which is `L1::no_allocate`. It tells hardware to bypass L1 cache for this specific load or store.

If the data won't require the L1 cache, adding this policy avoids cache pollution. Note that L1 is very small, 192kb for A100, 128kb for V100. Other data that needs cache can use more efficiently. Having this policy on appropriate load or store can potentially yield performance.

I identified two cases where we can use this policy : 
1) `WriteOnly` data. We guarantee noalias, so writeonly data will never need caching. 
2) `Streaming ` data : This means that when the hardware executes a load instruction, it brings a cache line and is 100% consumed by the threads, and is never read again. More simply, data that is read once and coalasced.

The PR implements followings:

**GPUCoalascedAccessPass**
Finds stride-1 access inputs of `linalg.generic`.

**MemrefLoadSetNonTemporal, MemrefStoreSetNonTemporal** patterns Sets `nontemporal` flag on `memset.load/store` if subspan has Streaming or Writeonly flag.

**GenerateLoadPTX, GenerateStorePTX** patterns
Generates special load/store with `L1::no_allocate` if `memref.load/store` has `nontemporal` flag. It generates inline assembly.

[1] https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#cache-eviction-priority-hints