### PR TITLE
Support CUDA importable buffers in compatibility check.

### DIFF
--- a/runtime/src/iree/hal/buffer.h
+++ b/runtime/src/iree/hal/buffer.h
@@ -91,7 +91,7 @@ enum iree_hal_memory_type_bits_t {
   // performance penalties. Device local memory, on the other hand, is
   // guaranteed to be fast for all operations.
   IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL =
-      IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE | (1u << 5),
+      IREE_HAL_MEMORY_TYPE_DEVICE_VISIBLE | (1u << 6),
 
   // The allocator will choose the optimal memory type based on buffer usage,
   // preferring to place the allocation in device-local memory.


### PR DESCRIPTION
* Adds a clause to enable IMPORTABLE compatibility when HOST_LOCAL and DEVICE_VISIBLE.
* Extends the error message for a mismatch.
* Changes the IREE_HAL_MEMORY_TYPE_DEVICE_LOCAL bit to 6 to avoid aliasing with HOST_LOCAL (bit 5).

I am not clear if the last item is correct (or indeed, how it works at all) and welcome a proper fix. Specifically, neither bit 5 or 6 (the "LOCAL" bits) seem to be in HALBase.td definitions that the compiler uses for HAL_MemoryType.