### PR TITLE
Fix compiler crash on unsupported LLVM types at interface boundary.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.cpp
@@ -25,6 +25,25 @@
 namespace mlir {
 namespace iree_compiler {
 
+LogicalResult verifyLLVMConversionCompatibility(ModuleOp moduleOp) {
+  LogicalResult compatible = success();
+
+  moduleOp.walk([&](IREE::HAL::InterfaceBindingSubspanOp subspanOp) {
+    auto memrefType = subspanOp.getType().dyn_cast<MemRefType>();
+    if (memrefType) {
+      Type elType = memrefType.getElementType();
+      if (!elType.isa<FloatType, IntegerType>()) {
+        subspanOp.emitError()
+            << "only integer and floating point element types "
+               "are supported at interface boundary";
+        compatible = failure();
+      }
+    }
+  });
+
+  return compatible;
+}
+
 void ConvertToDynamicSharedMemory(ModuleOp moduleOp) {
   SymbolTableCollection symbolTableCollection;
   // Collect all the adressOfOps to static shared memory globals.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
@@ -12,6 +12,13 @@
 namespace mlir {
 namespace iree_compiler {
 
+/// Verifies compatibility of the module for application of the LLVM
+/// conversion patterns. If not compatible, an error is issued and the
+/// pass should be failed.
+/// This is primarily used to eagerly reject modules with features not
+/// (yet) supported by the NVVM conversions.
+LogicalResult verifyLLVMConversionCompatibility(ModuleOp moduleOp);
+
 void populateLLVMConversionPatterns(MLIRContext *context,
                                     RewritePatternSet &patterns,
                                     LLVMTypeConverter &converter);

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToNVVM.cpp
@@ -63,6 +63,10 @@ struct ConvertToNVVMPass : public ConvertToNVVMBase<ConvertToNVVMPass> {
   }
   void runOnOperation() override {
     ModuleOp m = getOperation();
+    if (failed(verifyLLVMConversionCompatibility(m))) {
+      signalPassFailure();
+      return;
+    }
 
     /// Customize the bitwidth used for the device side index computations.
     LowerToLLVMOptions options(m.getContext(), DataLayout(m));

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -20,6 +20,7 @@ iree_lit_test_suite(
         [
             "conv_pipeline_test.mlir",
             "convert_to_nvvm.mlir",
+            "convert_to_nvvm_error.mlir",
             "convert_to_rocdl.mlir",
             "distribute_to_thread.mlir",
             "distribute_foreach.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_lit_test_suite(
   SRCS
     "conv_pipeline_test.mlir"
     "convert_to_nvvm.mlir"
+    "convert_to_nvvm_error.mlir"
     "convert_to_rocdl.mlir"
     "distribute_foreach.mlir"
     "distribute_to_thread.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm_error.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/convert_to_nvvm_error.mlir
@@ -1,0 +1,26 @@
+// RUN: iree-opt --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(builtin.module(iree-convert-to-nvvm))))" --split-input-file %s --verify-diagnostics
+
+// Test that that standard and GPU ops are converted to LLVM and NVVM.
+#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<4, storage_buffer>
+  ]>,
+  #hal.descriptor_set.layout<1, bindings = [
+    #hal.descriptor_set.binding<2, storage_buffer>
+  ]>
+]>
+hal.executable @abs_ex_dispatch_0 {
+  hal.executable.variant @cuda, target = <"cuda", "cuda-nvptx-fb"> {
+    hal.executable.export @abs_ex_dispatch_0 layout(#pipeline_layout)
+    builtin.module {
+      func.func @abs_ex_dispatch_0() {
+        %c0 = arith.constant 0 : index
+        %c128 = arith.constant 128 : index
+        // expected-error @+1 {{only integer and floating point element types are supported at interface boundary}}
+        %0 = hal.interface.binding.subspan set(0) binding(4) type(storage_buffer) offset(%c128) flags(ReadOnly) : memref<16xcomplex<f32>>
+        return
+      }
+    }
+  }
+}

--- a/compiler/src/iree/compiler/Tools/BUILD
+++ b/compiler/src/iree/compiler/Tools/BUILD
@@ -121,6 +121,7 @@ cc_library(
         "@llvm-project//mlir:ArmNeon2dToIntr",
         "@llvm-project//mlir:ArmNeonDialect",
         "@llvm-project//mlir:BufferizationDialect",
+        "@llvm-project//mlir:ComplexDialect",
         "@llvm-project//mlir:ControlFlowDialect",
         "@llvm-project//mlir:ConversionPasses",
         "@llvm-project//mlir:EmitCDialect",

--- a/compiler/src/iree/compiler/Tools/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Tools/CMakeLists.txt
@@ -146,6 +146,7 @@ iree_cc_library(
     MLIRArmNeonDialect
     MLIRArmNeon2dToIntr
     MLIRBufferizationDialect
+    MLIRComplexDialect
     MLIRControlFlowDialect
     MLIRGPUOps
     MLIRGPUToSPIRV

--- a/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_mlir_dialects.h
@@ -15,6 +15,7 @@
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/ArmNeon/ArmNeonDialect.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Complex/IR/Complex.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -46,8 +47,9 @@ namespace mlir {
 inline void registerMlirDialects(DialectRegistry &registry) {
   // clang-format off
   registry.insert<AffineDialect,
-                  cf::ControlFlowDialect,
                   bufferization::BufferizationDialect,
+                  cf::ControlFlowDialect,
+                  complex::ComplexDialect,
                   gpu::GPUDialect,
                   nvgpu::NVGPUDialect,
                   LLVM::LLVMDialect,


### PR DESCRIPTION
Eliminates the crash for #12067 (but does not make it pass). This should give us time to have a better way of handling these high level types.