### PR TITLE
fixed a bug where gpu check would always fail

### DIFF
--- a/runtime/bindings/python/hal.cc
+++ b/runtime/bindings/python/hal.cc
@@ -331,7 +331,7 @@ HalDevice HalDriver::CreateDevice(iree_hal_device_id_t device_id) {
     // {"device_id": obj, "path": str, "name": str}.
     auto record_dict = py::cast<py::dict>(record);
     py::object found_device_id = record_dict["device_id"];
-    if (found_device_id.is(compare_device_id)) {
+    if (found_device_id.equal(compare_device_id)) {
       found = true;
       break;
     }

--- a/runtime/bindings/python/tests/hal_test.py
+++ b/runtime/bindings/python/tests/hal_test.py
@@ -11,6 +11,7 @@ import numpy as np
 import unittest
 
 
+
 class NonDeviceHalTest(unittest.TestCase):
 
   def testEnums(self):
@@ -141,6 +142,14 @@ class DeviceHalTest(unittest.TestCase):
         repr(buffer),
         "<HalBufferView (3, 4), element_type=0x20000011, 48 bytes (at offset 0 into 48), memory_type=DEVICE_LOCAL|HOST_VISIBLE, allowed_access=ALL, allowed_usage=TRANSFER|DISPATCH_STORAGE|MAPPING>"
     )
+
+class IndexedDeviceHalTest(DeviceHalTest):
+
+  def setUp(self):
+    super().setUp()
+    self.driver = iree.runtime.get_driver("local-task")
+    self.device = self.driver.create_device(0)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Hi,

I experienced a bug with iree where the check to see if a device was present in the machine always failed, due to the program checking if the given device id was the id of any of the gpus, rather than if it was equal

I think this bug only occurs in amd and intel gpus

The fix is very simple, but let me know if you have any feedback