### PR TITLE
Transform: avoid rematching ops when already captured

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -41,6 +41,7 @@ iree_lit_test_suite(
             "reductions.mlir",
             "remove_dead_allocs.mlir",
             "remove_trivial_loops.mlir",
+            "repeated_matcher_use.mlir",
             "swizzle_workgroup.mlir",
             "test_partitionable_loops_interface.mlir",
             "tile_and_distribute_to_workgroups.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -37,6 +37,7 @@ iree_lit_test_suite(
     "rematerialize_parallel_ops.mlir"
     "remove_dead_allocs.mlir"
     "remove_trivial_loops.mlir"
+    "repeated_matcher_use.mlir"
     "swizzle_workgroup.mlir"
     "test_partitionable_loops_interface.mlir"
     "tile_and_distribute_to_workgroups.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/repeated_matcher_use.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/repeated_matcher_use.mlir
@@ -1,0 +1,159 @@
+// RUN: iree-opt %s --iree-transform-dialect-interpreter --verify-diagnostics --split-input-file
+
+module {
+  transform.structured.canonicalized_sequence failures(propagate) {
+  ^bb0(%arg0: !pdl.operation):
+    transform.iree.register_match_callbacks
+
+    %first, %second =
+      transform.iree.match_callback failures(propagate) "_test_repeated_matcher_use_callback"(%arg0)
+      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+
+    transform.iree.emit_remark "first" at %first : !pdl.operation
+    transform.iree.emit_remark "second" at %second : !pdl.operation
+  }
+
+  module {
+    func.func private @f1(f32) -> f32
+    func.func private @f2(f32, f32) -> f32
+
+    func.func @foo() -> tensor<10xf32> {
+      %dummy1 = tensor.empty() : tensor<10xf32>
+      %dummy2 = tensor.empty() : tensor<10xf32>
+      %dummy3 = tensor.empty() : tensor<10xf32>
+      %c0 = arith.constant 0.0 : f32
+      %operand = linalg.fill ins(%c0 : f32) outs(%dummy1 : tensor<10xf32>) -> tensor<10xf32>
+      
+      // expected-remark @below {{first}}
+      %first = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]
+      } ins(%operand : tensor<10xf32>)
+        outs(%dummy2 : tensor<10xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %0 = func.call @f1(%arg0) : (f32) -> f32
+        linalg.yield %0 : f32
+      } -> tensor<10xf32>
+
+      // expected-remark @below {{second}}
+      %second = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]
+      } ins(%operand, %first : tensor<10xf32>, tensor<10xf32>)
+        outs(%dummy3 : tensor<10xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+        %0 = func.call @f2(%arg0, %arg1) : (f32, f32) -> f32
+        linalg.yield %0 : f32
+      } -> tensor<10xf32>
+      return %second : tensor<10xf32>
+    }
+  }
+}
+
+// -----
+
+// expected-error @below {{transform dialect interpreter failed}}
+module {
+  transform.structured.canonicalized_sequence failures(propagate) {
+  ^bb0(%arg0: !pdl.operation):
+    transform.iree.register_match_callbacks
+
+    // expected-error @+2 {{failed to match}}
+    %first, %second =
+      transform.iree.match_callback failures(propagate) "_test_repeated_matcher_use_callback"(%arg0)
+      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+
+    transform.iree.emit_remark "first" at %first : !pdl.operation
+    transform.iree.emit_remark "second" at %second : !pdl.operation
+  }
+
+  module {
+    func.func private @f1(f32) -> f32
+    func.func private @f2(f32, f32) -> f32
+
+    func.func @foo() -> tensor<10xf32> {
+      %dummy1 = tensor.empty() : tensor<10xf32>
+      %dummy2 = tensor.empty() : tensor<10xf32>
+      %dummy3 = tensor.empty() : tensor<10xf32>
+      %dummy5 = tensor.empty() : tensor<10xf32>
+      %c0 = arith.constant 0.0 : f32
+      %c5 = arith.constant 5.0 : f32
+      %operand5 = linalg.fill ins(%c5 : f32) outs(%dummy5 : tensor<10xf32>) -> tensor<10xf32>
+      %operand = linalg.fill ins(%c0 : f32) outs(%dummy1 : tensor<10xf32>) -> tensor<10xf32>
+      
+      %first = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]
+      } ins(%operand : tensor<10xf32>)
+        outs(%dummy2 : tensor<10xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %0 = func.call @f1(%arg0) : (f32) -> f32
+        linalg.yield %0 : f32
+      } -> tensor<10xf32>
+
+      %second = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]
+      } ins(%operand5, %first : tensor<10xf32>, tensor<10xf32>)
+        outs(%dummy3 : tensor<10xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+        %0 = func.call @f2(%arg0, %arg1) : (f32, f32) -> f32
+        linalg.yield %0 : f32
+      } -> tensor<10xf32>
+      return %second : tensor<10xf32>
+    }
+  }
+}
+
+// -----
+
+// expected-error @below {{transform dialect interpreter failed}}
+module {
+  transform.structured.canonicalized_sequence failures(propagate) {
+  ^bb0(%arg0: !pdl.operation):
+    transform.iree.register_match_callbacks
+
+    // expected-error @+2 {{failed to match}}
+    %first, %second =
+      transform.iree.match_callback failures(propagate) "_test_repeated_matcher_use_callback"(%arg0)
+      : (!pdl.operation) -> (!pdl.operation, !pdl.operation)
+
+    transform.iree.emit_remark "first" at %first : !pdl.operation
+    transform.iree.emit_remark "second" at %second : !pdl.operation
+  }
+
+  module {
+    func.func private @f1(f32) -> f32
+    func.func private @f2(f32, f32) -> f32
+
+    func.func @foo() -> tensor<10xf32> {
+      %dummy1 = tensor.empty() : tensor<10xf32>
+      %dummy2 = tensor.empty() : tensor<10xf32>
+      %dummy3 = tensor.empty() : tensor<10xf32>
+      %dummy5 = tensor.empty() : tensor<10xf32>
+      %c0 = arith.constant 0.0 : f32
+      %operand = linalg.fill ins(%c0 : f32) outs(%dummy1 : tensor<10xf32>) -> tensor<10xf32>
+      
+      %first = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]
+      } ins(%operand : tensor<10xf32>)
+        outs(%dummy2 : tensor<10xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32):
+        %0 = func.call @f1(%arg0) : (f32) -> f32
+        linalg.yield %0 : f32
+      } -> tensor<10xf32>
+
+      %second = linalg.generic {
+        indexing_maps = [affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>, affine_map<(d0) -> (d0)>],
+        iterator_types = ["parallel"]
+      } ins(%first, %first : tensor<10xf32>, tensor<10xf32>)
+        outs(%dummy3 : tensor<10xf32>) {
+      ^bb0(%arg0: f32, %arg1: f32, %arg2: f32):
+        %0 = func.call @f2(%arg0, %arg1) : (f32, f32) -> f32
+        linalg.yield %0 : f32
+      } -> tensor<10xf32>
+      return %second : tensor<10xf32>
+    }
+  }
+}

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -9,8 +9,6 @@
 #include "mlir/Analysis/SliceAnalysis.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
@@ -20,6 +18,15 @@ using namespace mlir;
 
 #define DEBUG_TYPE "transform-matchers"
 #define DBGS() llvm::dbgs() << "[" DEBUG_TYPE "] "
+
+void transform_ext::CapturingOpMatcher::getAllNested(
+    SmallVectorImpl<CapturingOpMatcher *> &nested) {
+  int64_t start = nested.size();
+  llvm::append_range(nested, nestedCapturingMatchers);
+  for (int64_t position = start; position < nested.size(); ++position) {
+    llvm::append_range(nested, nested[position]->nestedCapturingMatchers);
+  }
+}
 
 //===---------------------------------------------------------------------===//
 // StructuredOpMatcher and friends.


### PR DESCRIPTION
When running the transform dialect-related matcher recursively, check if
a corresponding payload operation has been already captured. If so,
check whether the inspected operation is the same as already captured
instead of rechecking the predicates. This allows matchers to be used
repeatedly in a recursive structure to indicate that the same operation
must be used in several places.