### PR TITLE
Fix benchmark.py issues

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -82,25 +82,25 @@ iree_py_library(
 iree_symlink_tool(
   TARGET runtime
   FROM_TOOL_TARGET iree-benchmark-module
-  TO_EXE_NAME iree-benchmark-module
+  TO_EXE_NAME iree/runtime/iree-benchmark-module
 )
 
 iree_symlink_tool(
   TARGET runtime
   FROM_TOOL_TARGET iree-benchmark-trace
-  TO_EXE_NAME iree-benchmark-trace
+  TO_EXE_NAME iree/runtime/iree-benchmark-trace
 )
 
 iree_symlink_tool(
   TARGET runtime
   FROM_TOOL_TARGET iree-run-trace
-  TO_EXE_NAME iree-run-trace
+  TO_EXE_NAME iree/runtime/iree-run-trace
 )
 
 iree_symlink_tool(
   TARGET runtime
   FROM_TOOL_TARGET iree-run-module
-  TO_EXE_NAME iree-run-module
+  TO_EXE_NAME iree/runtime/iree-run-module
 )
 
 if(_TRACY_ENABLED)

--- a/runtime/bindings/python/iree/runtime/benchmark.py
+++ b/runtime/bindings/python/iree/runtime/benchmark.py
@@ -27,8 +27,8 @@ __all__ = [
     "benchmark_module",
 ]
 
-BenchmarkResult = namedtuple("BenchmarkResult",
-                             "entry_function process_time real_time")
+BenchmarkResult = namedtuple(
+    "BenchmarkResult", "benchmark_name time cpu_time iterations user_counters")
 
 DTYPE_TO_ABI_TYPE = {
     numpy.dtype(numpy.float32): "f32",
@@ -42,8 +42,7 @@ DTYPE_TO_ABI_TYPE = {
 
 
 def benchmark_exe():
-  return os.path.join(os.path.dirname(__file__), "..", "..",
-                      "iree-benchmark-module")
+  return os.path.join(os.path.dirname(__file__), "iree-benchmark-module")
 
 
 def benchmark_module(module, entry_functiong=None, inputs=[], **kwargs):
@@ -92,10 +91,25 @@ def benchmark_module(module, entry_functiong=None, inputs=[], **kwargs):
   if "INVALID_ARGUMENT;" in err:
     raise ValueError("Invalid inputs specified for benchmarking")
 
-  out = out.decode().split("\n")[4]
-  splt = out.split()
-  process_time = splt[1]
-  real_time = splt[3]
-  return BenchmarkResult(entry_function=entry_functiong,
-                         process_time=process_time,
-                         real_time=real_time)
+  # Grab individual results by line (skip header lines)
+  bench_lines = out.decode().split("\n")[3:]
+  benchmark_results = []
+  for line in bench_lines:
+    spilt = line.split()
+    if len(spilt) == 0:
+      continue
+    benchmark_name = spilt[0]
+    time = spilt[1]
+    cpu_time = spilt[2]
+    iterations = spilt[3]
+    user_counters = None
+    if len(spilt) > 4:
+      user_counters = spilt[4]
+    benchmark_results.append(
+        BenchmarkResult(benchmark_name=benchmark_name,
+                        time=time,
+                        cpu_time=cpu_time,
+                        iterations=iterations,
+                        user_counters=user_counters))
+
+  return benchmark_results


### PR DESCRIPTION
Updates benchmark result parsing and corrects the the path for symlinked build targets to match the path of our release whls. 

Python whls place all python code and called binaries under `iree/runtime` and `iree/compiler` of the iree python whls:

```
lib/python3.10/site-packages/iree/runtime:
$ ls             
array_interop.py  _binding.py  function.py  iree-benchmark-module  iree-run-module  __pycache__  system_api.py    tracing.py
benchmark.py      flags.py     __init__.py  iree-benchmark-trace   iree-run-trace   scripts      system_setup.py  version.py
```

```
lib/python3.10/site-packages/iree/compiler: 
$ ls         
dialects  __init__.py  ir.py  _mlir_libs  passmanager.py  __pycache__  tflite.py  tf.py  tools  transforms  version.py  xla.py
```

Currently if you build and run the python bindings using https://iree-org.github.io/iree/building-from-source/python-bindings-and-importers, the binaries are being symlinked outside of the python bindings dir into `iree-build/runtime/bindings/python` instead of `iree-build/runtime/bindings/python/iree/runtime`. 
