### PR TITLE
Add support for calling micro kernel operations from Codegen backends.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -120,6 +120,7 @@ iree_compiler_cc_library(
         "FuseTensorPadWithConsumer.cpp",
         "HoistStaticallyBoundAllocations.cpp",
         "IREEComprehensiveBufferizePass.cpp",
+        "LowerMicroKernelsToCalls.cpp",
         "MaterializeEncodingIntoPackUnPack.cpp",
         "OptimizeVectorTransferPass.cpp",
         "PolynomialApproximationPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -143,6 +143,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Codegen/Common:FoldTensorExtractOpIncGen",
         "//compiler/src/iree/compiler/Codegen/Dialect:IREECodegenDialect",
         "//compiler/src/iree/compiler/Codegen/Interfaces:BufferizationInterfaces",
+        "//compiler/src/iree/compiler/Codegen/Interfaces:MicroKernelOpInterface",
         "//compiler/src/iree/compiler/Codegen/Interfaces:PartitionableLoopsInterface",
         "//compiler/src/iree/compiler/Codegen/Transforms",
         "//compiler/src/iree/compiler/Codegen/Utils",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -95,6 +95,7 @@ iree_cc_library(
     "FuseTensorPadWithConsumer.cpp"
     "HoistStaticallyBoundAllocations.cpp"
     "IREEComprehensiveBufferizePass.cpp"
+    "LowerMicroKernelsToCalls.cpp"
     "MaterializeEncodingIntoPackUnPack.cpp"
     "OptimizeVectorTransferPass.cpp"
     "PolynomialApproximationPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -151,6 +151,7 @@ iree_cc_library(
     iree::compiler::Codegen::Common::FoldTensorExtractOpIncGen
     iree::compiler::Codegen::Dialect::IREECodegenDialect
     iree::compiler::Codegen::Interfaces::BufferizationInterfaces
+    iree::compiler::Codegen::Interfaces::MicroKernelOpInterface
     iree::compiler::Codegen::Interfaces::PartitionableLoopsInterface
     iree::compiler::Codegen::PassHeaders
     iree::compiler::Codegen::Transforms

--- a/compiler/src/iree/compiler/Codegen/Common/LowerMicroKernelsToCalls.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerMicroKernelsToCalls.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 
@@ -17,7 +18,7 @@ namespace {
 struct LowerMicroKernelOpsToCallsPass
     : LowerMicroKernelOpsToCallsBase<LowerMicroKernelOpsToCallsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
-    registry.insert<memref::MemRefDialect>();
+    registry.insert<memref::MemRefDialect, func::FuncDialect>();
   }
   void runOnOperation() override;
 };

--- a/compiler/src/iree/compiler/Codegen/Common/LowerMicroKernelsToCalls.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerMicroKernelsToCalls.cpp
@@ -1,0 +1,61 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+struct LowerMicroKernelOpsToCallsPass
+    : LowerMicroKernelOpsToCallsBase<LowerMicroKernelOpsToCallsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<memref::MemRefDialect>();
+  }
+  void runOnOperation() override;
+};
+}  // namespace
+
+void LowerMicroKernelOpsToCallsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  SmallVector<Operation *> toDelete;
+  Operation *errorOp = nullptr;
+  IRRewriter rewriter(context);
+  WalkResult result = getOperation().walk(
+      [&](IREE::Codegen::MicroKernelOpInterface microKernelOp) -> WalkResult {
+        OpBuilder::InsertionGuard g(rewriter);
+        rewriter.setInsertionPoint(microKernelOp);
+        FailureOr<func::CallOp> callOp =
+            microKernelOp.lowerToFunctionCall(rewriter);
+        if (failed(callOp)) {
+          errorOp = microKernelOp;
+          return WalkResult::interrupt();
+        }
+        toDelete.push_back(microKernelOp);
+        return WalkResult::advance();
+      });
+  if (result.wasInterrupted()) {
+    errorOp->emitOpError(
+        "failed to lower micro kernel operation to function call");
+    return signalPassFailure();
+  }
+  for (auto op : toDelete) {
+    op->erase();
+  }
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createLowerMicroKernelOpsToCallsPass() {
+  return std::make_unique<LowerMicroKernelOpsToCallsPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -35,6 +35,7 @@ iree_lit_test_suite(
             "gpu_vectorization.mlir",
             "hoist_statically_bound_allocations.mlir",
             "iree_comprehensive_bufferize.mlir",
+            "lower_micro_kernel_to_calls.mlir",
             "pad_dynamic_alloc.mlir",
             "rematerialize_parallel_ops.mlir",
             "reduce_bank_conflicts.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "gpu_vectorization.mlir"
     "hoist_statically_bound_allocations.mlir"
     "iree_comprehensive_bufferize.mlir"
+    "lower_micro_kernel_to_calls.mlir"
     "pad_dynamic_alloc.mlir"
     "reduce_bank_conflicts.mlir"
     "reductions.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_micro_kernel_to_calls.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_micro_kernel_to_calls.mlir
@@ -1,0 +1,129 @@
+// RUN: iree-opt --iree-codegen-lower-micro-kernel-ops-to-calls -split-input-file --verify-diagnostics --cse %s | FileCheck %s
+
+func.func @scalar_types(%arg0: i32, %arg1 : f64, %arg2 : index, %arg3 : memref<f32>) {
+  iree_codegen.generic_micro_kernel "scalar_fn" ins(%arg0, %arg1, %arg2 : i32, f64, index) outs(%arg3 : memref<f32>)
+  return
+}
+//      CHECK: func.func private @scalar_fn(i32, f64, index, memref<f32>)
+//      CHECK: func.func @scalar_types
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: i32
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: f64
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: index
+// CHECK-SAME:     %[[ARG3:[a-zA-Z0-9]+]]: memref<f32>
+//      CHECK:   %[[BASE:.+]], %[[OFFSET:.+]] = memref.extract_strided_metadata %[[ARG3]]
+//      CHECK:   call @scalar_fn(%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[BASE]])
+
+// -----
+
+func.func @memref_1D(%arg0 : memref<?xf32, strided<[1], offset: ?>>) {
+  iree_codegen.generic_micro_kernel "test1d" outs(%arg0 : memref<?xf32, strided<[1], offset: ?>>)
+  return
+}
+//      CHECK: func.func private @test1d(memref<f32>, index)
+//      CHECK: func.func @memref_1D
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: memref<?xf32, strided<[1], offset: ?>>
+//      CHECK:   %[[BASE:.+]], %[[OFFSET:.+]], %[[SIZE:.+]], %[[STRIDES:.+]] = memref.extract_strided_metadata %[[ARG0]]
+//      CHECK:   call @test1d(%[[BASE]], %[[OFFSET]])
+
+// -----
+
+func.func @memref_3D(%arg0 : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>) {
+  iree_codegen.generic_micro_kernel "test3d" outs(%arg0 : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>)
+  return
+}
+//      CHECK: func.func private @test3d(memref<f32>, index, index, index)
+//      CHECK: func.func @memref_3D
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>
+//      CHECK:   %[[BASE:.+]], %[[OFFSET:.+]], %[[SIZE:.+]]:3, %[[STRIDES:.+]]:3 = memref.extract_strided_metadata %[[ARG0]]
+//      CHECK:   call @test3d(%[[BASE]], %[[OFFSET]], %[[STRIDES]]#0, %[[STRIDES]]#1)
+
+// -----
+
+func.func @return_value(%arg0 : tensor<f32>) -> tensor<f32> {
+  // expected-error @+1 {{failed to lower micro kernel operation to function call}}
+  %0 = iree_codegen.generic_micro_kernel "err" outs(%arg0 : tensor<f32>) -> tensor<f32>
+  return %0 : tensor<f32>
+}
+
+// -----
+
+func.func @generic_micro_kernel(%arg0 : memref<?x?xf32>, %arg1 : memref<?x?xf32>,
+    %arg2 : memref<?x?xf32>) {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c0_i32 = arith.constant 0 : i32
+  %dim_1 = memref.dim %arg0, %c0 : memref<?x?xf32>
+  %dim_2 = memref.dim %arg1, %c1 : memref<?x?xf32>
+  %dim_3 = memref.dim %arg2, %c1 : memref<?x?xf32>
+  iree_codegen.generic_micro_kernel "vmvx.matmul.f32.f32.f32" ins(%arg0, %arg1 : memref<?x?xf32>, memref<?x?xf32>) outs(%arg2 : memref<?x?xf32>) (%dim_1, %dim_2, %dim_3, %c0_i32 : index, index, index, i32)
+  return
+}
+// CHECK-LABEL: func.func private @vmvx.matmul.f32.f32.f32
+//  CHECK-SAME:     (memref<f32>, index, index, memref<f32>, index, index,
+//  CHECK-SAME:     memref<f32>, index, index, index, index, index, i32)
+// CHECK-LABEL: func.func @generic_micro_kernel
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: memref<?x?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: memref<?x?xf32>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: memref<?x?xf32>
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[C0_I32:.+]] = arith.constant 0 : i32
+//   CHECK-DAG:   %[[D0:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:   %[[D1:.+]] = memref.dim %[[ARG1]], %[[C1]]
+//   CHECK-DAG:   %[[D2:.+]] = memref.dim %[[ARG2]], %[[C1]]
+//       CHECK:   %[[BASE0:.+]], %[[OFFSET0:.+]], %[[SIZE0:.+]]:2, %[[STRIDES0:.+]]:2 = memref.extract_strided_metadata %[[ARG0]]
+//       CHECK:   %[[BASE1:.+]], %[[OFFSET1:.+]], %[[SIZE1:.+]]:2, %[[STRIDES1:.+]]:2 = memref.extract_strided_metadata %[[ARG1]]
+//       CHECK:   %[[BASE2:.+]], %[[OFFSET2:.+]], %[[SIZE2:.+]]:2, %[[STRIDES2:.+]]:2 = memref.extract_strided_metadata %[[ARG2]]
+//       CHECK:   call @vmvx.matmul.f32.f32.f32(%[[BASE0]], %[[OFFSET0]], %[[STRIDES0]]#0
+//  CHECK-SAME:       %[[BASE1]], %[[OFFSET1]], %[[STRIDES1]]#0
+//  CHECK-SAME:       %[[BASE2]], %[[OFFSET2]], %[[STRIDES2]]#0
+//  CHECK-SAME:       %[[D0]], %[[D1]], %[[D2]], %[[C0_I32]])
+
+// -----
+
+func.func @mmt4d_micro_kernel(%arg0 : memref<?x?x?x?xf32>, %arg1 : memref<?x?x?x?xf32>,
+    %arg2 : memref<?x?x?x?xf32>) {
+  iree_codegen.mmt4d_micro_kernel lhs(%arg0 : memref<?x?x?x?xf32>) rhs(%arg1 : memref<?x?x?x?xf32>)
+      outs(%arg2 : memref<?x?x?x?xf32>) accumulate(false)
+  return
+}
+// CHECK-LABEL: func.func private @vmvx.mmt4d.f32.f32.f32
+//  CHECK-SAME:     (memref<f32>, index, index, memref<f32>, index, index,
+//  CHECK-SAME:     memref<f32>, index, index, index, index, index, i32, i32, i32, i32)
+// CHECK-LABEL: func.func @mmt4d_micro_kernel(
+//  CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
+//  CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
+//  CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
+//       CHECK:   %[[BASE0:.+]], %[[OFFSET0:.+]], %[[SIZE0:.+]]:4, %[[STRIDES0:.+]]:4 = memref.extract_strided_metadata %[[ARG0]]
+//       CHECK:   %[[BASE1:.+]], %[[OFFSET1:.+]], %[[SIZE1:.+]]:4, %[[STRIDES1:.+]]:4 = memref.extract_strided_metadata %[[ARG1]]
+//       CHECK:   %[[BASE2:.+]], %[[OFFSET2:.+]], %[[SIZE2:.+]]:4, %[[STRIDES2:.+]]:4 = memref.extract_strided_metadata %[[ARG2]]
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//   CHECK-DAG:   %[[D0:.+]] = memref.dim %[[ARG0]], %[[C0]]
+//   CHECK-DAG:   %[[D1:.+]] = memref.dim %[[ARG1]], %[[C0]]
+//   CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//   CHECK-DAG:   %[[D2:.+]] = memref.dim %[[ARG0]], %[[C1]]
+//   CHECK-DAG:   %[[C2:.+]] = arith.constant 2 : index
+//   CHECK-DAG:   %[[D3:.+]] = memref.dim %[[ARG0]], %[[C2]]
+//   CHECK-DAG:   %[[D3_I32:.+]] = arith.index_cast %[[D3]]
+//   CHECK-DAG:   %[[D4:.+]] = memref.dim %[[ARG1]], %[[C2]]
+//   CHECK-DAG:   %[[D4_I32:.+]] = arith.index_cast %[[D4]]
+//   CHECK-DAG:   %[[C3:.+]] = arith.constant 3 : index
+//   CHECK-DAG:   %[[D5:.+]] = memref.dim %[[ARG0]], %[[C3]]
+//   CHECK-DAG:   %[[D5_I32:.+]] = arith.index_cast %[[D5]]
+//   CHECK-DAG:   %[[C0_I32:.+]] = arith.constant 0 : i32
+//       CHECK:   call @vmvx.mmt4d.f32.f32.f32(%[[BASE0]], %[[OFFSET0]], %[[STRIDES0]]#0
+//  CHECK-SAME:       %[[BASE1]], %[[OFFSET1]], %[[STRIDES1]]#0
+//  CHECK-SAME:       %[[BASE2]], %[[OFFSET2]], %[[STRIDES2]]#0
+//  CHECK-SAME:       %[[D0]], %[[D1]], %[[D2]],
+//  CHECK-SAME:       %[[D3_I32]], %[[D4_I32]], %[[D5_I32]], %[[C0_I32]])
+
+// -----
+
+func.func @mmt4d_micro_kernel_i8i8i32(%arg0 : memref<?x?x?x?xi8>, %arg1 : memref<?x?x?x?xi8>,
+    %arg2 : memref<?x?x?x?xi32>) {
+  iree_codegen.mmt4d_micro_kernel lhs(%arg0 : memref<?x?x?x?xi8>) rhs(%arg1 : memref<?x?x?x?xi8>)
+      outs(%arg2 : memref<?x?x?x?xi32>) accumulate(false)
+  return
+}
+// CHECK-LABEL: func @mmt4d_micro_kernel_i8i8i32(
+//       CHECK:   call @vmvx.mmt4d.i8.i8.i32

--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_micro_kernel_to_calls.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_micro_kernel_to_calls.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt --iree-codegen-lower-micro-kernel-ops-to-calls -split-input-file --verify-diagnostics --cse %s | FileCheck %s
 
 func.func @scalar_types(%arg0: i32, %arg1 : f64, %arg2 : index, %arg3 : memref<f32>) {
-  iree_codegen.generic.ukernel "scalar_fn" ins(%arg0, %arg1, %arg2 : i32, f64, index) outs(%arg3 : memref<f32>)
+  iree_codegen.ukernel.generic "scalar_fn" ins(%arg0, %arg1, %arg2 : i32, f64, index) outs(%arg3 : memref<f32>)
   return
 }
 //      CHECK: func.func private @scalar_fn(i32, f64, index, memref<f32>)
@@ -16,7 +16,7 @@ func.func @scalar_types(%arg0: i32, %arg1 : f64, %arg2 : index, %arg3 : memref<f
 // -----
 
 func.func @memref_1D(%arg0 : memref<?xf32, strided<[1], offset: ?>>) {
-  iree_codegen.generic.ukernel "test1d" outs(%arg0 : memref<?xf32, strided<[1], offset: ?>>)
+  iree_codegen.ukernel.generic "test1d" outs(%arg0 : memref<?xf32, strided<[1], offset: ?>>)
   return
 }
 //      CHECK: func.func private @test1d(memref<f32>, index)
@@ -28,7 +28,7 @@ func.func @memref_1D(%arg0 : memref<?xf32, strided<[1], offset: ?>>) {
 // -----
 
 func.func @memref_3D(%arg0 : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>) {
-  iree_codegen.generic.ukernel "test3d" outs(%arg0 : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>)
+  iree_codegen.ukernel.generic "test3d" outs(%arg0 : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>)
   return
 }
 //      CHECK: func.func private @test3d(memref<f32>, index, index, index)
@@ -41,7 +41,7 @@ func.func @memref_3D(%arg0 : memref<?x?x?xf32, strided<[?, ?, 1], offset: ?>>) {
 
 func.func @return_value(%arg0 : tensor<f32>) -> tensor<f32> {
   // expected-error @+1 {{failed to lower micro kernel operation to function call}}
-  %0 = iree_codegen.generic.ukernel "err" outs(%arg0 : tensor<f32>) -> tensor<f32>
+  %0 = iree_codegen.ukernel.generic "err" outs(%arg0 : tensor<f32>) -> tensor<f32>
   return %0 : tensor<f32>
 }
 
@@ -55,7 +55,7 @@ func.func @generic_ukernel(%arg0 : memref<?x?xf32>, %arg1 : memref<?x?xf32>,
   %dim_1 = memref.dim %arg0, %c0 : memref<?x?xf32>
   %dim_2 = memref.dim %arg1, %c1 : memref<?x?xf32>
   %dim_3 = memref.dim %arg2, %c1 : memref<?x?xf32>
-  iree_codegen.generic.ukernel "vmvx.matmul.f32.f32.f32" ins(%arg0, %arg1 : memref<?x?xf32>, memref<?x?xf32>) outs(%arg2 : memref<?x?xf32>) (%dim_1, %dim_2, %dim_3, %c0_i32 : index, index, index, i32)
+  iree_codegen.ukernel.generic "vmvx.matmul.f32.f32.f32" ins(%arg0, %arg1 : memref<?x?xf32>, memref<?x?xf32>) outs(%arg2 : memref<?x?xf32>) (%dim_1, %dim_2, %dim_3, %c0_i32 : index, index, index, i32)
   return
 }
 // CHECK-LABEL: func.func private @vmvx.matmul.f32.f32.f32
@@ -83,7 +83,7 @@ func.func @generic_ukernel(%arg0 : memref<?x?xf32>, %arg1 : memref<?x?xf32>,
 
 func.func @mmt4d_ukernel(%arg0 : memref<?x?x?x?xf32>, %arg1 : memref<?x?x?x?xf32>,
     %arg2 : memref<?x?x?x?xf32>) {
-  iree_codegen.mmt4d.ukernel lhs(%arg0 : memref<?x?x?x?xf32>) rhs(%arg1 : memref<?x?x?x?xf32>)
+  iree_codegen.ukernel.mmt4d lhs(%arg0 : memref<?x?x?x?xf32>) rhs(%arg1 : memref<?x?x?x?xf32>)
       outs(%arg2 : memref<?x?x?x?xf32>) accumulate(false)
   return
 }
@@ -121,7 +121,7 @@ func.func @mmt4d_ukernel(%arg0 : memref<?x?x?x?xf32>, %arg1 : memref<?x?x?x?xf32
 
 func.func @mmt4d_ukernel_i8i8i32(%arg0 : memref<?x?x?x?xi8>, %arg1 : memref<?x?x?x?xi8>,
     %arg2 : memref<?x?x?x?xi32>) {
-  iree_codegen.mmt4d.ukernel lhs(%arg0 : memref<?x?x?x?xi8>) rhs(%arg1 : memref<?x?x?x?xi8>)
+  iree_codegen.ukernel.mmt4d lhs(%arg0 : memref<?x?x?x?xi8>) rhs(%arg1 : memref<?x?x?x?xi8>)
       outs(%arg2 : memref<?x?x?x?xi32>) accumulate(false)
   return
 }

--- a/compiler/src/iree/compiler/Codegen/Dialect/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Dialect/BUILD
@@ -19,6 +19,7 @@ exports_files([
     "IREECodegenAttributes.td",
     "IREECodegenDialect.td",
     "LoweringConfig.td",
+    "MicroKernelOps.td",
 ])
 
 td_library(
@@ -28,13 +29,13 @@ td_library(
             "IREECodegenAttributes.td",
             "IREECodegenDialect.td",
             "LoweringConfig.td",
-            "MicroKernelOps.td"
+            "MicroKernelOps.td",
         ],
         include = ["*.td"],
     ),
     deps = [
-        "@llvm-project//mlir:OpBaseTdFiles",
         "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",
+        "@llvm-project//mlir:OpBaseTdFiles",
     ],
 )
 
@@ -66,6 +67,7 @@ iree_compiler_cc_library(
         ":MicroKernelOpsGen",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//compiler/src/iree/compiler/Codegen/Interfaces:MicroKernelOpInterface",
         "//runtime/src/iree/builtins/ukernel:exported_bits",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Dialect/BUILD
@@ -28,11 +28,13 @@ td_library(
             "IREECodegenAttributes.td",
             "IREECodegenDialect.td",
             "LoweringConfig.td",
+            "MicroKernelOps.td"
         ],
         include = ["*.td"],
     ),
     deps = [
         "@llvm-project//mlir:OpBaseTdFiles",
+        "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",
     ],
 )
 
@@ -41,10 +43,12 @@ iree_compiler_cc_library(
     srcs = [
         "IREECodegenDialect.cpp",
         "LoweringConfig.cpp",
+        "MicroKernelOps.cpp",
     ],
     hdrs = [
         "IREECodegenDialect.h",
         "LoweringConfig.h",
+        "MicroKernelOps.h",
     ],
     textual_hdrs = [
         "IREECodegenDialect.cpp.inc",
@@ -53,18 +57,24 @@ iree_compiler_cc_library(
         "LoweringConfig.h.inc",
         "LoweringConfigEnums.cpp.inc",
         "LoweringConfigEnums.h.inc",
+        "MicroKernelOps.cpp.inc",
+        "MicroKernelOps.h.inc",
     ],
     deps = [
         ":IREECodegenDialectGen",
         ":LoweringConfigGen",
+        ":MicroKernelOpsGen",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
+        "//runtime/src/iree/builtins/ukernel:exported_bits",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:Parser",
+        "@llvm-project//mlir:Support",
     ],
 )
 
@@ -107,5 +117,22 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "LoweringConfig.td",
+    deps = [":td_files"],
+)
+
+iree_gentbl_cc_library(
+    name = "MicroKernelOpsGen",
+    tbl_outs = [
+        (
+            ["--gen-op-decls"],
+            "MicroKernelOps.h.inc",
+        ),
+        (
+            ["--gen-op-defs"],
+            "MicroKernelOps.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "MicroKernelOps.td",
     deps = [":td_files"],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Dialect/BUILD
@@ -76,6 +76,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
+        "@llvm-project//mlir:MemRefDialect",
         "@llvm-project//mlir:Parser",
         "@llvm-project//mlir:Support",
     ],

--- a/compiler/src/iree/compiler/Codegen/Dialect/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Dialect/BUILD
@@ -34,6 +34,7 @@ td_library(
         include = ["*.td"],
     ),
     deps = [
+        "//compiler/src/iree/compiler/Codegen/Interfaces:td_files",
         "@llvm-project//mlir:DestinationStyleOpInterfaceTdFiles",
         "@llvm-project//mlir:OpBaseTdFiles",
     ],
@@ -65,9 +66,9 @@ iree_compiler_cc_library(
         ":IREECodegenDialectGen",
         ":LoweringConfigGen",
         ":MicroKernelOpsGen",
+        "//compiler/src/iree/compiler/Codegen/Interfaces:MicroKernelOpInterface",
         "//compiler/src/iree/compiler/Codegen/Utils",
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
-        "//compiler/src/iree/compiler/Codegen/Interfaces:MicroKernelOpInterface",
         "//runtime/src/iree/builtins/ukernel:exported_bits",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
@@ -136,5 +137,8 @@ iree_gentbl_cc_library(
     ],
     tblgen = "@llvm-project//mlir:mlir-tblgen",
     td_file = "MicroKernelOps.td",
-    deps = [":td_files"],
+    deps = [
+        ":td_files",
+        "//compiler/src/iree/compiler/Codegen/Interfaces:td_files",
+    ],
 )

--- a/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
@@ -16,6 +16,7 @@ iree_cc_library(
   HDRS
     "IREECodegenDialect.h"
     "LoweringConfig.h"
+    "MicroKernelOps.h"
   TEXTUAL_HDRS
     "IREECodegenDialect.cpp.inc"
     "IREECodegenDialect.h.inc"
@@ -23,17 +24,24 @@ iree_cc_library(
     "LoweringConfig.h.inc"
     "LoweringConfigEnums.cpp.inc"
     "LoweringConfigEnums.h.inc"
+    "MicroKernelOps.cpp.inc"
+    "MicroKernelOps.h.inc"
   SRCS
     "IREECodegenDialect.cpp"
     "LoweringConfig.cpp"
+    "MicroKernelOps.cpp"
   DEPS
     ::IREECodegenDialectGen
     ::LoweringConfigGen
+    ::MicroKernelOpsGen
     LLVMSupport
     MLIRArithDialect
+    MLIRDestinationStyleOpInterface
     MLIRFuncDialect
     MLIRIR
     MLIRParser
+    MLIRSupport
+    iree::builtins::ukernel::exported_bits
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::HAL::IR
   PUBLIC
@@ -59,6 +67,16 @@ iree_tablegen_library(
     --gen-attrdef-defs LoweringConfig.cpp.inc
     --gen-enum-decls LoweringConfigEnums.h.inc
     --gen-enum-defs LoweringConfigEnums.cpp.inc
+)
+
+iree_tablegen_library(
+  NAME
+    MicroKernelOpsGen
+  TD_FILE
+    "MicroKernelOps.td"
+  OUTS
+    --gen-op-decls MicroKernelOps.h.inc
+    --gen-op-defs MicroKernelOps.cpp.inc
 )
 
 ### BAZEL_TO_CMAKE_PRESERVES_ALL_CONTENT_BELOW_THIS_LINE ###

--- a/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
@@ -42,6 +42,7 @@ iree_cc_library(
     MLIRParser
     MLIRSupport
     iree::builtins::ukernel::exported_bits
+    iree::compiler::Codegen::Interfaces::MicroKernelOpInterface
     iree::compiler::Codegen::Utils
     iree::compiler::Dialect::HAL::IR
   PUBLIC

--- a/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
@@ -39,6 +39,7 @@ iree_cc_library(
     MLIRDestinationStyleOpInterface
     MLIRFuncDialect
     MLIRIR
+    MLIRMemRefDialect
     MLIRParser
     MLIRSupport
     iree::builtins::ukernel::exported_bits

--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.cpp
@@ -8,6 +8,7 @@
 
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.cpp.inc"
 #include "iree/compiler/Codegen/Dialect/LoweringConfig.h"
+#include "iree/compiler/Codegen/Dialect/MicroKernelOps.h"
 #include "mlir/IR/DialectImplementation.h"
 
 namespace mlir {
@@ -35,6 +36,11 @@ struct IREECodegenDialectOpAsmInterface : public OpAsmDialectInterface {
 void IREECodegenDialect::initialize() {
   initializeCodegenAttrs();
   addInterfaces<IREECodegenDialectOpAsmInterface>();
+
+  addOperations<
+#define GET_OP_LIST
+#include "iree/compiler/Codegen/Dialect/MicroKernelOps.cpp.inc"
+      >();
 }
 
 }  // namespace Codegen

--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.td
@@ -40,4 +40,10 @@ def IREECodegen_Dialect : Dialect {
   let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
+def AnyRankedTensorOrMemRefType : AnyTypeOf<[AnyRankedTensor, AnyMemRef]>;
+
+class RankedTensorOrMemRefType<list<Type> allowedTypes, list<int> ranks>
+    : AnyTypeOf<[TensorRankOf<allowedTypes, ranks>,
+        MemRefRankOf<allowedTypes, ranks>]>;
+
 #endif // IREE_CODEGEN_DIALECT_IREECODEGEN_DIALECT

--- a/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.cpp
@@ -1,0 +1,63 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Dialect/MicroKernelOps.h"
+
+#include "iree/builtins/ukernel/exported_bits.h"
+#include "llvm/Support/FormatVariadic.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Support/LLVM.h"
+
+// clang-format off
+#define GET_OP_CLASSES
+#include "iree/compiler/Codegen/Dialect/MicroKernelOps.cpp.inc" // IWYU pragma: keep
+// clang-format on
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Codegen {
+
+/// Returns true if the dimensions of ShapedType are compatible.
+static bool isShapedTypeDimCompatible(int64_t lhs, int64_t rhs) {
+  return lhs == ShapedType::kDynamic || rhs == ShapedType::kDynamic ||
+         lhs == rhs;
+}
+
+/// Returns true if the dimensions of ShapedType are compatible.
+static bool areShapesCompatible(ArrayRef<int64_t> lhs, ArrayRef<int64_t> rhs) {
+  if (lhs.size() != rhs.size()) {
+    return false;
+  }
+  return llvm::all_of(llvm::zip(lhs, rhs), [](std::tuple<int64_t, int64_t> it) {
+    return isShapedTypeDimCompatible(std::get<0>(it), std::get<1>(it));
+  });
+}
+
+//===---------------------------------------------------------------------===//
+// GenericMicroKernelOp
+//===---------------------------------------------------------------------===//
+
+std::pair<int64_t, int64_t> GenericMicroKernelOp::getDpsInitsPositionRange() {
+  std::pair<unsigned, unsigned> outsPosAndSize = getODSOperandIndexAndLength(1);
+  return {static_cast<int64_t>(outsPosAndSize.first),
+          static_cast<int64_t>(outsPosAndSize.first + outsPosAndSize.second)};
+}
+
+//===---------------------------------------------------------------------===//
+// MMT4DMicroKernelOp
+//===---------------------------------------------------------------------===//
+
+std::pair<int64_t, int64_t> Mmt4DMicroKernelOp::getDpsInitsPositionRange() {
+  std::pair<unsigned, unsigned> outsPosAndSize = getODSOperandIndexAndLength(2);
+  return {static_cast<int64_t>(outsPosAndSize.first),
+          static_cast<int64_t>(outsPosAndSize.first + outsPosAndSize.second)};
+}
+
+}  // namespace Codegen
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.cpp
@@ -83,7 +83,7 @@ std::pair<int64_t, int64_t> GenericUKernelOp::getDpsInitsPositionRange() {
   return {static_cast<int64_t>(pos), static_cast<int64_t>(pos + size)};
 }
 
-/// Map type of operand of a `iree_codegen.generic.ukernel` operation to
+/// Map type of operand of a `iree_codegen.ukernel.generic` operation to
 /// the type(s) of the function call arguments(s) it lowers to.
 static LogicalResult getCallOpType(MLIRContext *context,
                                    Type microKernelOpOperandType,
@@ -115,7 +115,7 @@ static LogicalResult getCallOpType(MLIRContext *context,
       .Default([&](Type t) { return failure(); });
 }
 
-/// Map `operand` of a `generic.ukernel` operation to the operand(s) of
+/// Map `operand` of a `ukernel.generic` operation to the operand(s) of
 /// the function call it lowers to.
 static LogicalResult lowerToCallOperands(Location loc, RewriterBase &rewriter,
                                          Value operand,

--- a/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.h
@@ -1,0 +1,21 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_DIALECT_MICROKERNELOPS_H_
+#define IREE_COMPILER_CODEGEN_DIALECT_MICROKERNELOPS_H_
+
+#include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Interfaces/DestinationStyleOpInterface.h"
+
+// clang-format off
+#define GET_OP_CLASSES
+#include "iree/compiler/Codegen/Dialect/MicroKernelOps.h.inc" // IWYU pragma: export
+// clang-format on
+
+#endif  // #ifndef IREE_COMPILER_CODEGEN_DIALECT_MICROKERNELOPS_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
@@ -18,7 +18,7 @@ class IREECodegen_MicroKernelOp<string mnemonic, list<Trait> traits = []> :
      DeclareOpInterfaceMethods<DestinationStyleOpInterface>])> {}
   
 def IREECodegen_GenericUKernelOp :
-    IREECodegen_MicroKernelOp<"generic.ukernel", [
+    IREECodegen_MicroKernelOp<"ukernel.generic", [
       AttrSizedOperandSegments]> {
   let summary = "Generic Microkernel operator";
 
@@ -66,7 +66,7 @@ def IREECodegen_GenericUKernelOp :
 }
 
 def IREECodegen_Mmt4DUKernelOp :
-    IREECodegen_MicroKernelOp<"mmt4d.ukernel", []>  {
+    IREECodegen_MicroKernelOp<"ukernel.mmt4d", []>  {
   let summary = "Mmt4D Microkernel operator";
 
   let description = [{
@@ -74,7 +74,7 @@ def IREECodegen_Mmt4DUKernelOp :
     forwarded to a microkernel.
 
     This operation is meant to wrap a DAG whose is `linalg.mmt4d`-like
-    operation and forwarded to a micro kernel. Unlike `generic.ukernel`,
+    operation and forwarded to a micro kernel. Unlike `ukernel.generic`,
     lowering into this operation does not fix the ABI of the micro kernel
     function. When lowering to a function, the function call is expected
     to match the ABI of the corresponding micro-kernel used.

--- a/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
@@ -17,8 +17,8 @@ class IREECodegen_MicroKernelOp<string mnemonic, list<Trait> traits = []> :
         ["lowerToFunctionCall"]>,
      DeclareOpInterfaceMethods<DestinationStyleOpInterface>])> {}
   
-def IREECodegen_GenericMicroKernelOp :
-    IREECodegen_MicroKernelOp<"generic_micro_kernel", [
+def IREECodegen_GenericUKernelOp :
+    IREECodegen_MicroKernelOp<"generic.ukernel", [
       AttrSizedOperandSegments]> {
   let summary = "Generic Microkernel operator";
 
@@ -65,8 +65,8 @@ def IREECodegen_GenericMicroKernelOp :
   }];
 }
 
-def IREECodegen_Mmt4DMicroKernelOp :
-    IREECodegen_MicroKernelOp<"mmt4d_micro_kernel", []>  {
+def IREECodegen_Mmt4DUKernelOp :
+    IREECodegen_MicroKernelOp<"mmt4d.ukernel", []>  {
   let summary = "Mmt4D Microkernel operator";
 
   let description = [{
@@ -74,7 +74,7 @@ def IREECodegen_Mmt4DMicroKernelOp :
     forwarded to a microkernel.
 
     This operation is meant to wrap a DAG whose is `linalg.mmt4d`-like
-    operation and forwarded to a micro kernel. Unlike `generic_micro_kernel`,
+    operation and forwarded to a micro kernel. Unlike `generic.ukernel`,
     lowering into this operation does not fix the ABI of the micro kernel
     function. When lowering to a function, the function call is expected
     to match the ABI of the corresponding micro-kernel used.

--- a/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
@@ -1,0 +1,96 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_CODEGEN_DIALECT_MICRO_KERNEL_OPS
+#define IREE_CODEGEN_DIALECT_MICRO_KERNEL_OPS
+
+include "iree/compiler/Codegen/Dialect/IREECodegenDialect.td"
+include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.td"
+include "mlir/Interfaces/DestinationStyleOpInterface.td"
+
+class IREECodegen_MicroKernelOp<string mnemonic, list<Trait> traits = []> : 
+  Op<IREECodegen_Dialect, mnemonic, !listconcat(traits,
+    [DeclareOpInterfaceMethods<MicroKernelOpInterface>,
+     DeclareOpInterfaceMethods<DestinationStyleOpInterface>])> {}
+  
+def IREECodegen_GenericMicroKernelOp :
+    IREECodegen_MicroKernelOp<"generic_micro_kernel", [
+      AttrSizedOperandSegments]> {
+  let summary = "Generic Microkernel operator";
+
+  let description = [{
+    Operation to wrap a computation forwarded to a microkernel.
+
+    This operation is a generic representation of the DAG that is to be
+    lowered into a micro-kernel. The name of the microkernel is specified
+    as a `StrAttr`. The DAG to be forwarded is meant to be captured at
+    tensor-level. The operation implements the `DestinationStyleOpInterface`
+    so all tensors in the `outs` list must match the number and type of the
+    results of the operation.
+    After bufferization the tensor operands in `outs` are converted to
+    a memref type. At the memref-level, the operands are expected to
+    match directly into a function call with the arguments to the
+    function call being the `ins`, `outs` and `other_operands`.
+    
+    The operands of `memref` type are expected to lower to the following
+    argument sequence.
+    - `memref<f32> lowers to base_ptr.
+    - `memref<?xf32, <strides = [s0, 1], offsets = f>>
+          lowers to (base_ptr, f, index s0)
+    - `memref<?x?xf32, <strides = [s1, s0, 1], offsets = f>>
+          lowers to (base_ptr, f, s1, s0)
+    and so on....
+
+    Innermost stride of `memref`s are expected to be 1.
+    All other operands are expected to be scalar types.
+    TODO: `vector` types can be supported as well, but needs better
+    ABI specification.
+  }];
+
+  let arguments = (ins
+    StrAttr:$micro_kernel_fn_name,
+    Variadic<AnyType>:$inputs,
+    Variadic<AnyRankedTensorOrMemRefType>:$outputs,
+    Variadic<AnyType>:$other_operands);
+  let results = (outs Variadic<AnyRankedTensor>:$results);
+  let assemblyFormat = [{
+    attr-dict $micro_kernel_fn_name
+    (`ins` `(` $inputs^ `:` type($inputs) `)`)?
+    `outs` `(` $outputs  `:` type($outputs) `)`
+    (`(` $other_operands^ `:` type($other_operands) `)`)? (`->` type($results)^)?
+  }];
+}
+
+def IREECodegen_Mmt4DMicroKernelOp :
+    IREECodegen_MicroKernelOp<"mmt4d_micro_kernel", []>  {
+  let summary = "Mmt4D Microkernel operator";
+
+  let description = [{
+    Operation to wrap a computation with root being a `linalg.mmt4d` 
+    forwarded to a microkernel.
+
+    This operation is meant to wrap a DAG whose is `linalg.mmt4d`-like
+    operation and forwarded to a micro kernel. Unlike `generic_micro_kernel`,
+    lowering into this operation does not fix the ABI of the micro kernel
+    function. When lowering to a function, the function call is expected
+    to match the ABI of the corresponding micro-kernel used.
+  }];
+
+  let arguments = (ins
+    RankedTensorOrMemRefType<[AnyType], [4]>:$lhs,
+    RankedTensorOrMemRefType<[AnyType], [4]>:$rhs,
+    RankedTensorOrMemRefType<[AnyType], [4]>:$output,
+    DefaultValuedAttr<BoolAttr, "false">:$accumulate);
+  let results = (outs Optional<AnyRankedTensor>:$result);
+  let assemblyFormat = [{
+    attr-dict `lhs` `(` $lhs `:` type($lhs) `)`
+    `rhs` `(` $rhs `:` type($rhs) `)`
+    `outs` `(` $output `:` type($output) `)`
+    `accumulate` `(` $accumulate `)` (`->` type($result)^)?
+  }];
+}
+
+#endif // IREE_CODEGEN_DIALECT_MICRO_KERNEL_OPS

--- a/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/MicroKernelOps.td
@@ -13,7 +13,8 @@ include "mlir/Interfaces/DestinationStyleOpInterface.td"
 
 class IREECodegen_MicroKernelOp<string mnemonic, list<Trait> traits = []> : 
   Op<IREECodegen_Dialect, mnemonic, !listconcat(traits,
-    [DeclareOpInterfaceMethods<MicroKernelOpInterface>,
+    [DeclareOpInterfaceMethods<MicroKernelOpInterface,
+        ["lowerToFunctionCall"]>,
      DeclareOpInterfaceMethods<DestinationStyleOpInterface>])> {}
   
 def IREECodegen_GenericMicroKernelOp :
@@ -59,7 +60,7 @@ def IREECodegen_GenericMicroKernelOp :
   let assemblyFormat = [{
     attr-dict $micro_kernel_fn_name
     (`ins` `(` $inputs^ `:` type($inputs) `)`)?
-    `outs` `(` $outputs  `:` type($outputs) `)`
+    (`outs` `(` $outputs^  `:` type($outputs) `)`)?
     (`(` $other_operands^ `:` type($other_operands) `)`)? (`->` type($results)^)?
   }];
 }
@@ -90,6 +91,17 @@ def IREECodegen_Mmt4DMicroKernelOp :
     `rhs` `(` $rhs `:` type($rhs) `)`
     `outs` `(` $output `:` type($output) `)`
     `accumulate` `(` $accumulate `)` (`->` type($result)^)?
+  }];
+  let extraClassDeclaration = [{
+    Type getLhsElementType() {
+      return getLhs().getType().cast<ShapedType>().getElementType();
+    }
+    Type getRhsElementType() {
+      return getRhs().getType().cast<ShapedType>().getElementType();
+    }
+    Type getOutputElementType() {
+      return getOutput().getType().cast<ShapedType>().getElementType();
+    }
   }];
 }
 

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/BUILD
@@ -19,6 +19,7 @@ iree_lit_test_suite(
     srcs = enforce_glob(
         [
             "lowering_config_attr.mlir",
+            "micro_kernel_ops.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/CMakeLists.txt
@@ -15,6 +15,7 @@ iree_lit_test_suite(
     lit
   SRCS
     "lowering_config_attr.mlir"
+    "micro_kernel_ops.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
@@ -1,23 +1,23 @@
 // RUN: iree-opt --split-input-file --verify-diagnostics %s | FileCheck %s
 
-func.func @generic_micro_kernel(
+func.func @generic_ukernel(
     %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
     %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
     %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
-  %0:2 = iree_codegen.generic_micro_kernel "foo"
+  %0:2 = iree_codegen.generic.ukernel "foo"
       ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
       outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
       (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
   return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
 }
-//      CHECK: func @generic_micro_kernel(
+//      CHECK: func @generic_ukernel(
 // CHECK-SAME:     %[[IN0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[IN1:[a-zA-Z0-9]+]]: tensor<?xf32>
 // CHECK-SAME:     %[[OUT0:[a-zA-Z0-9]+]]: tensor<?xf32>
 // CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
 // CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
-//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic_micro_kernel
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic.ukernel
 // CHECK-SAME:       "foo"
 // CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
 // CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
@@ -26,24 +26,24 @@ func.func @generic_micro_kernel(
 
 // -----
 
-func.func @generic_micro_kernel_memref(
+func.func @generic_ukernel_memref(
     %in0: memref<?x?xf32>, %in1: memref<?xf32>,
     %out0: memref<?xf32>, %out1 : memref<?x?xf32>,
     %b0: f32, %b1: i64) {
-  iree_codegen.generic_micro_kernel "foo"
+  iree_codegen.generic.ukernel "foo"
       ins(%in0, %in1: memref<?x?xf32>, memref<?xf32>)
       outs(%out0, %out1 : memref<?xf32>, memref<?x?xf32>)
       (%b0, %b1 : f32, i64)
   return
 }
-//      CHECK: func @generic_micro_kernel_memref(
+//      CHECK: func @generic_ukernel_memref(
 // CHECK-SAME:     %[[IN0:[a-zA-Z0-9]+]]: memref<?x?xf32>
 // CHECK-SAME:     %[[IN1:[a-zA-Z0-9]+]]: memref<?xf32>
 // CHECK-SAME:     %[[OUT0:[a-zA-Z0-9]+]]: memref<?xf32>
 // CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: memref<?x?xf32>
 // CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
 // CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
-//      CHECK:   iree_codegen.generic_micro_kernel
+//      CHECK:   iree_codegen.generic.ukernel
 // CHECK-SAME:       "foo"
 // CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
 // CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
@@ -51,146 +51,146 @@ func.func @generic_micro_kernel_memref(
 
 // -----
 
-func.func @generic_micro_kernel_optional_input(
+func.func @generic_ukernel_optional_input(
     %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
     %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
-  %0:2 = iree_codegen.generic_micro_kernel "foo"
+  %0:2 = iree_codegen.generic.ukernel "foo"
       outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
       (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
   return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
 }
-//      CHECK: func @generic_micro_kernel_optional_input(
-//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic_micro_kernel
+//      CHECK: func @generic_ukernel_optional_input(
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic.ukernel
 //  CHECK-NOT:       ins
 
 // -----
 
-func.func @generic_micro_kernel_memref_optional_input(
+func.func @generic_ukernel_memref_optional_input(
     %out0: memref<?xf32>, %out1 : memref<?x?xf32>,
     %b0: f32, %b1: i64) {
-  iree_codegen.generic_micro_kernel "foo"
+  iree_codegen.generic.ukernel "foo"
       outs(%out0, %out1 : memref<?xf32>, memref<?x?xf32>)
       (%b0, %b1 : f32, i64)
   return
 }
-//      CHECK: func @generic_micro_kernel_memref_optional_input(
-//      CHECK:   iree_codegen.generic_micro_kernel
+//      CHECK: func @generic_ukernel_memref_optional_input(
+//      CHECK:   iree_codegen.generic.ukernel
 //  CHECK-NOT:       ins
 
 // -----
 
-func.func @generic_micro_kernel_optional_other_operands(
+func.func @generic_ukernel_optional_other_operands(
     %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
     %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>) -> (tensor<?xf32>, tensor<?x?xf32>) {
-  %0:2 = iree_codegen.generic_micro_kernel "foo"
+  %0:2 = iree_codegen.generic.ukernel "foo"
       ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
       outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
       -> tensor<?xf32>, tensor<?x?xf32>
   return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
 }
-//      CHECK: func @generic_micro_kernel_optional_other_operands(
-//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic_micro_kernel
+//      CHECK: func @generic_ukernel_optional_other_operands(
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic.ukernel
 // CHECK-SAME:       outs(%{{.+}}, %{{.+}} : tensor<?xf32>, tensor<?x?xf32>) ->
 
 // -----
 
-func.func @generic_micro_kernel_non_tensor_memref_outs(
+func.func @generic_ukernel_non_tensor_memref_outs(
    %out0 : f32) -> f32 {
   // expected-error @+1 {{operand #0 must be ranked tensor of any type values or memref of any type values, but got 'f32'}}
-  %0 = iree_codegen.generic_micro_kernel "foo"
+  %0 = iree_codegen.generic.ukernel "foo"
       outs(%out0 : f32) -> f32
   return %0 : f32
 }
 
 // -----
 
-func.func @generic_micro_kernel_err_tensor_outs(
+func.func @generic_ukernel_err_tensor_outs(
     %out0: tensor<?xf32>, %out1 : memref<?x?xf32>) {
   // expected-error @+1 {{expected the number of results (0) to be equal to the number of output tensors (1)}}
-  iree_codegen.generic_micro_kernel "foo"
+  iree_codegen.generic.ukernel "foo"
       outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>)
 }
 
 // -----
 
-func.func @generic_micro_kernel_mixed_tensor_memref(
+func.func @generic_ukernel_mixed_tensor_memref(
     %out0: tensor<?xf32>, %out1 : memref<?x?xf32>)
     -> tensor<?xf32> {
-  %0 = iree_codegen.generic_micro_kernel "foo"
+  %0 = iree_codegen.generic.ukernel "foo"
       outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
-//      CHECK: func @generic_micro_kernel_mixed_tensor_memref(
+//      CHECK: func @generic_ukernel_mixed_tensor_memref(
 // CHECK-SAME:     %[[OUT0:.+]]: tensor<?xf32>
 // CHECK-SAME:     %[[OUT1:.+]]: memref<?x?xf32>
-//      CHECK:   %[[RESULT:.+]] = iree_codegen.generic_micro_kernel
+//      CHECK:   %[[RESULT:.+]] = iree_codegen.generic.ukernel
 // CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
 //      CHECK:   return %[[RESULT]]
 
 // -----
 
-func.func @generic_micro_kernel_err_memref_outs(
+func.func @generic_ukernel_err_memref_outs(
     %out0: tensor<?xf32>, %out1 : memref<?x?xf32>)
     -> (tensor<?xf32>, tensor<?x?xf32>){
   // expected-error @+1 {{expected the number of results (2) to be equal to the number of output tensors (1)}}
-  %0:2 = iree_codegen.generic_micro_kernel "foo"
+  %0:2 = iree_codegen.generic.ukernel "foo"
       outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>) -> tensor<?xf32>, tensor<?x?xf32>
 }
 
 // -----
 
-func.func @generic_micro_kernel_err_elementtype(
+func.func @generic_ukernel_err_elementtype(
     %out0: tensor<?xf32>) -> tensor<?xi32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<?xf32>') to match type of corresponding result ('tensor<?xi32>')}}
-  %0 = iree_codegen.generic_micro_kernel "foo"
+  %0 = iree_codegen.generic.ukernel "foo"
       outs(%out0 : tensor<?xf32>) -> tensor<?xi32>
   return %0 : tensor<?xi32>
 }
 
 // -----
 
-func.func @generic_micro_kernel_err_shape_mismatch(
+func.func @generic_ukernel_err_shape_mismatch(
     %out0: tensor<?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<?xf32>') to match type of corresponding result ('tensor<?x?xf32>')}}
-  %0 = iree_codegen.generic_micro_kernel "foo"
+  %0 = iree_codegen.generic.ukernel "foo"
       outs(%out0 : tensor<?xf32>) -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
 
 // -----
 
-func.func @generic_micro_kernel_err_static_shape_mismatch(
+func.func @generic_ukernel_err_static_shape_mismatch(
     %out0: tensor<10xf32>) -> tensor<20xf32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<10xf32>') to match type of corresponding result ('tensor<20xf32>')}}
-  %0 = iree_codegen.generic_micro_kernel "foo"
+  %0 = iree_codegen.generic.ukernel "foo"
       outs(%out0 : tensor<10xf32>) -> tensor<20xf32>
   return %0 : tensor<20xf32>
 }
 
 // -----
 
-func.func @generic_micro_kernel_static_dynamic_shape_match(
+func.func @generic_ukernel_static_dynamic_shape_match(
     %out0: tensor<10xf32>) -> tensor<?xf32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<10xf32>') to match type of corresponding result ('tensor<?xf32>')}}
-  %0 = iree_codegen.generic_micro_kernel "foo"
+  %0 = iree_codegen.generic.ukernel "foo"
       outs(%out0 : tensor<10xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
 
 // -----
 
-func.func @mmt4d_micro_kernel(%lhs : tensor<?x?x?x?xf32>,
+func.func @mmt4d_ukernel(%lhs : tensor<?x?x?x?xf32>,
     %rhs : tensor<?x?x?x?xf32>, %outs : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-  %0 = iree_codegen.mmt4d_micro_kernel lhs(%lhs : tensor<?x?x?x?xf32>)
+  %0 = iree_codegen.mmt4d.ukernel lhs(%lhs : tensor<?x?x?x?xf32>)
       rhs(%rhs : tensor<?x?x?x?xf32>) outs(%outs : tensor<?x?x?x?xf32>)
       accumulate(true) -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
 }
-//      CHECK: func @mmt4d_micro_kernel(
+//      CHECK: func @mmt4d_ukernel(
 // CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[OUTS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//      CHECK:   %[[RESULT:.+]] = iree_codegen.mmt4d_micro_kernel
+//      CHECK:   %[[RESULT:.+]] = iree_codegen.mmt4d.ukernel
 // CHECK-SAME:       lhs(%[[LHS]] :
 // CHECK-SAME:       rhs(%[[RHS]] :
 // CHECK-SAME:       outs(%[[OUTS]] :
@@ -199,18 +199,18 @@ func.func @mmt4d_micro_kernel(%lhs : tensor<?x?x?x?xf32>,
 
 // -----
 
-func.func @mmt4d_micro_kernel_memref(%lhs : memref<?x?x?x?xf32>,
+func.func @mmt4d_ukernel_memref(%lhs : memref<?x?x?x?xf32>,
     %rhs : memref<?x?x?x?xf32>, %outs : memref<?x?x?x?xf32>) {
-  iree_codegen.mmt4d_micro_kernel lhs(%lhs : memref<?x?x?x?xf32>)
+  iree_codegen.mmt4d.ukernel lhs(%lhs : memref<?x?x?x?xf32>)
       rhs(%rhs : memref<?x?x?x?xf32>) outs(%outs : memref<?x?x?x?xf32>)
       accumulate(false)
   return
 }
-//      CHECK: func @mmt4d_micro_kernel_memref(
+//      CHECK: func @mmt4d_ukernel_memref(
 // CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
 // CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
 // CHECK-SAME:     %[[OUTS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
-//      CHECK:   iree_codegen.mmt4d_micro_kernel
+//      CHECK:   iree_codegen.mmt4d.ukernel
 // CHECK-SAME:       lhs(%[[LHS]] :
 // CHECK-SAME:       rhs(%[[RHS]] :
 // CHECK-SAME:       outs(%[[OUTS]] :

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
@@ -4,7 +4,7 @@ func.func @generic_ukernel(
     %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
     %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
     %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
-  %0:2 = iree_codegen.generic.ukernel "foo"
+  %0:2 = iree_codegen.ukernel.generic "foo"
       ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
       outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
       (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
@@ -17,7 +17,7 @@ func.func @generic_ukernel(
 // CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
 // CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
 // CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
-//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic.ukernel
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.ukernel.generic
 // CHECK-SAME:       "foo"
 // CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
 // CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
@@ -30,7 +30,7 @@ func.func @generic_ukernel_memref(
     %in0: memref<?x?xf32>, %in1: memref<?xf32>,
     %out0: memref<?xf32>, %out1 : memref<?x?xf32>,
     %b0: f32, %b1: i64) {
-  iree_codegen.generic.ukernel "foo"
+  iree_codegen.ukernel.generic "foo"
       ins(%in0, %in1: memref<?x?xf32>, memref<?xf32>)
       outs(%out0, %out1 : memref<?xf32>, memref<?x?xf32>)
       (%b0, %b1 : f32, i64)
@@ -43,7 +43,7 @@ func.func @generic_ukernel_memref(
 // CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: memref<?x?xf32>
 // CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
 // CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
-//      CHECK:   iree_codegen.generic.ukernel
+//      CHECK:   iree_codegen.ukernel.generic
 // CHECK-SAME:       "foo"
 // CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
 // CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
@@ -54,13 +54,13 @@ func.func @generic_ukernel_memref(
 func.func @generic_ukernel_optional_input(
     %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
     %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
-  %0:2 = iree_codegen.generic.ukernel "foo"
+  %0:2 = iree_codegen.ukernel.generic "foo"
       outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
       (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
   return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
 }
 //      CHECK: func @generic_ukernel_optional_input(
-//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic.ukernel
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.ukernel.generic
 //  CHECK-NOT:       ins
 
 // -----
@@ -68,13 +68,13 @@ func.func @generic_ukernel_optional_input(
 func.func @generic_ukernel_memref_optional_input(
     %out0: memref<?xf32>, %out1 : memref<?x?xf32>,
     %b0: f32, %b1: i64) {
-  iree_codegen.generic.ukernel "foo"
+  iree_codegen.ukernel.generic "foo"
       outs(%out0, %out1 : memref<?xf32>, memref<?x?xf32>)
       (%b0, %b1 : f32, i64)
   return
 }
 //      CHECK: func @generic_ukernel_memref_optional_input(
-//      CHECK:   iree_codegen.generic.ukernel
+//      CHECK:   iree_codegen.ukernel.generic
 //  CHECK-NOT:       ins
 
 // -----
@@ -82,14 +82,14 @@ func.func @generic_ukernel_memref_optional_input(
 func.func @generic_ukernel_optional_other_operands(
     %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
     %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>) -> (tensor<?xf32>, tensor<?x?xf32>) {
-  %0:2 = iree_codegen.generic.ukernel "foo"
+  %0:2 = iree_codegen.ukernel.generic "foo"
       ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
       outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
       -> tensor<?xf32>, tensor<?x?xf32>
   return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
 }
 //      CHECK: func @generic_ukernel_optional_other_operands(
-//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic.ukernel
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.ukernel.generic
 // CHECK-SAME:       outs(%{{.+}}, %{{.+}} : tensor<?xf32>, tensor<?x?xf32>) ->
 
 // -----
@@ -97,7 +97,7 @@ func.func @generic_ukernel_optional_other_operands(
 func.func @generic_ukernel_non_tensor_memref_outs(
    %out0 : f32) -> f32 {
   // expected-error @+1 {{operand #0 must be ranked tensor of any type values or memref of any type values, but got 'f32'}}
-  %0 = iree_codegen.generic.ukernel "foo"
+  %0 = iree_codegen.ukernel.generic "foo"
       outs(%out0 : f32) -> f32
   return %0 : f32
 }
@@ -107,7 +107,7 @@ func.func @generic_ukernel_non_tensor_memref_outs(
 func.func @generic_ukernel_err_tensor_outs(
     %out0: tensor<?xf32>, %out1 : memref<?x?xf32>) {
   // expected-error @+1 {{expected the number of results (0) to be equal to the number of output tensors (1)}}
-  iree_codegen.generic.ukernel "foo"
+  iree_codegen.ukernel.generic "foo"
       outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>)
 }
 
@@ -116,14 +116,14 @@ func.func @generic_ukernel_err_tensor_outs(
 func.func @generic_ukernel_mixed_tensor_memref(
     %out0: tensor<?xf32>, %out1 : memref<?x?xf32>)
     -> tensor<?xf32> {
-  %0 = iree_codegen.generic.ukernel "foo"
+  %0 = iree_codegen.ukernel.generic "foo"
       outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
 //      CHECK: func @generic_ukernel_mixed_tensor_memref(
 // CHECK-SAME:     %[[OUT0:.+]]: tensor<?xf32>
 // CHECK-SAME:     %[[OUT1:.+]]: memref<?x?xf32>
-//      CHECK:   %[[RESULT:.+]] = iree_codegen.generic.ukernel
+//      CHECK:   %[[RESULT:.+]] = iree_codegen.ukernel.generic
 // CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
 //      CHECK:   return %[[RESULT]]
 
@@ -133,7 +133,7 @@ func.func @generic_ukernel_err_memref_outs(
     %out0: tensor<?xf32>, %out1 : memref<?x?xf32>)
     -> (tensor<?xf32>, tensor<?x?xf32>){
   // expected-error @+1 {{expected the number of results (2) to be equal to the number of output tensors (1)}}
-  %0:2 = iree_codegen.generic.ukernel "foo"
+  %0:2 = iree_codegen.ukernel.generic "foo"
       outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>) -> tensor<?xf32>, tensor<?x?xf32>
 }
 
@@ -142,7 +142,7 @@ func.func @generic_ukernel_err_memref_outs(
 func.func @generic_ukernel_err_elementtype(
     %out0: tensor<?xf32>) -> tensor<?xi32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<?xf32>') to match type of corresponding result ('tensor<?xi32>')}}
-  %0 = iree_codegen.generic.ukernel "foo"
+  %0 = iree_codegen.ukernel.generic "foo"
       outs(%out0 : tensor<?xf32>) -> tensor<?xi32>
   return %0 : tensor<?xi32>
 }
@@ -152,7 +152,7 @@ func.func @generic_ukernel_err_elementtype(
 func.func @generic_ukernel_err_shape_mismatch(
     %out0: tensor<?xf32>) -> tensor<?x?xf32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<?xf32>') to match type of corresponding result ('tensor<?x?xf32>')}}
-  %0 = iree_codegen.generic.ukernel "foo"
+  %0 = iree_codegen.ukernel.generic "foo"
       outs(%out0 : tensor<?xf32>) -> tensor<?x?xf32>
   return %0 : tensor<?x?xf32>
 }
@@ -162,7 +162,7 @@ func.func @generic_ukernel_err_shape_mismatch(
 func.func @generic_ukernel_err_static_shape_mismatch(
     %out0: tensor<10xf32>) -> tensor<20xf32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<10xf32>') to match type of corresponding result ('tensor<20xf32>')}}
-  %0 = iree_codegen.generic.ukernel "foo"
+  %0 = iree_codegen.ukernel.generic "foo"
       outs(%out0 : tensor<10xf32>) -> tensor<20xf32>
   return %0 : tensor<20xf32>
 }
@@ -172,7 +172,7 @@ func.func @generic_ukernel_err_static_shape_mismatch(
 func.func @generic_ukernel_static_dynamic_shape_match(
     %out0: tensor<10xf32>) -> tensor<?xf32> {
   // expected-error @+1 {{expected type of operand #0 ('tensor<10xf32>') to match type of corresponding result ('tensor<?xf32>')}}
-  %0 = iree_codegen.generic.ukernel "foo"
+  %0 = iree_codegen.ukernel.generic "foo"
       outs(%out0 : tensor<10xf32>) -> tensor<?xf32>
   return %0 : tensor<?xf32>
 }
@@ -181,7 +181,7 @@ func.func @generic_ukernel_static_dynamic_shape_match(
 
 func.func @mmt4d_ukernel(%lhs : tensor<?x?x?x?xf32>,
     %rhs : tensor<?x?x?x?xf32>, %outs : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
-  %0 = iree_codegen.mmt4d.ukernel lhs(%lhs : tensor<?x?x?x?xf32>)
+  %0 = iree_codegen.ukernel.mmt4d lhs(%lhs : tensor<?x?x?x?xf32>)
       rhs(%rhs : tensor<?x?x?x?xf32>) outs(%outs : tensor<?x?x?x?xf32>)
       accumulate(true) -> tensor<?x?x?x?xf32>
   return %0 : tensor<?x?x?x?xf32>
@@ -190,7 +190,7 @@ func.func @mmt4d_ukernel(%lhs : tensor<?x?x?x?xf32>,
 // CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[OUTS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//      CHECK:   %[[RESULT:.+]] = iree_codegen.mmt4d.ukernel
+//      CHECK:   %[[RESULT:.+]] = iree_codegen.ukernel.mmt4d
 // CHECK-SAME:       lhs(%[[LHS]] :
 // CHECK-SAME:       rhs(%[[RHS]] :
 // CHECK-SAME:       outs(%[[OUTS]] :
@@ -201,7 +201,7 @@ func.func @mmt4d_ukernel(%lhs : tensor<?x?x?x?xf32>,
 
 func.func @mmt4d_ukernel_memref(%lhs : memref<?x?x?x?xf32>,
     %rhs : memref<?x?x?x?xf32>, %outs : memref<?x?x?x?xf32>) {
-  iree_codegen.mmt4d.ukernel lhs(%lhs : memref<?x?x?x?xf32>)
+  iree_codegen.ukernel.mmt4d lhs(%lhs : memref<?x?x?x?xf32>)
       rhs(%rhs : memref<?x?x?x?xf32>) outs(%outs : memref<?x?x?x?xf32>)
       accumulate(false)
   return
@@ -210,7 +210,7 @@ func.func @mmt4d_ukernel_memref(%lhs : memref<?x?x?x?xf32>,
 // CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
 // CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
 // CHECK-SAME:     %[[OUTS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
-//      CHECK:   iree_codegen.mmt4d.ukernel
+//      CHECK:   iree_codegen.ukernel.mmt4d
 // CHECK-SAME:       lhs(%[[LHS]] :
 // CHECK-SAME:       rhs(%[[RHS]] :
 // CHECK-SAME:       outs(%[[OUTS]] :

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics %s | FileCheck %s
 
 func.func @generic_micro_kernel(
     %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,

--- a/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Dialect/test/micro_kernel_ops.mlir
@@ -1,0 +1,217 @@
+// RUN: iree-opt --split-input-file %s | FileCheck %s
+
+func.func @generic_micro_kernel(
+    %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
+    %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
+    %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
+  %0:2 = iree_codegen.generic_micro_kernel "foo"
+      ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
+      outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
+      (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
+  return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
+}
+//      CHECK: func @generic_micro_kernel(
+// CHECK-SAME:     %[[IN0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[IN1:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:     %[[OUT0:[a-zA-Z0-9]+]]: tensor<?xf32>
+// CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
+// CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic_micro_kernel
+// CHECK-SAME:       "foo"
+// CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
+// CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
+// CHECK-SAME:       (%[[B0]], %[[B1]] :
+//      CHECK:   return %[[RESULT]]#0, %[[RESULT]]#1
+
+// -----
+
+func.func @generic_micro_kernel_memref(
+    %in0: memref<?x?xf32>, %in1: memref<?xf32>,
+    %out0: memref<?xf32>, %out1 : memref<?x?xf32>,
+    %b0: f32, %b1: i64) {
+  iree_codegen.generic_micro_kernel "foo"
+      ins(%in0, %in1: memref<?x?xf32>, memref<?xf32>)
+      outs(%out0, %out1 : memref<?xf32>, memref<?x?xf32>)
+      (%b0, %b1 : f32, i64)
+  return
+}
+//      CHECK: func @generic_micro_kernel_memref(
+// CHECK-SAME:     %[[IN0:[a-zA-Z0-9]+]]: memref<?x?xf32>
+// CHECK-SAME:     %[[IN1:[a-zA-Z0-9]+]]: memref<?xf32>
+// CHECK-SAME:     %[[OUT0:[a-zA-Z0-9]+]]: memref<?xf32>
+// CHECK-SAME:     %[[OUT1:[a-zA-Z0-9]+]]: memref<?x?xf32>
+// CHECK-SAME:     %[[B0:[a-zA-Z0-9]+]]: f32
+// CHECK-SAME:     %[[B1:[a-zA-Z0-9]+]]: i64
+//      CHECK:   iree_codegen.generic_micro_kernel
+// CHECK-SAME:       "foo"
+// CHECK-SAME:       ins(%[[IN0]], %[[IN1]] :
+// CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
+// CHECK-SAME:       (%[[B0]], %[[B1]] :
+
+// -----
+
+func.func @generic_micro_kernel_optional_input(
+    %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>,
+    %b0: f32, %b1: i64) -> (tensor<?xf32>, tensor<?x?xf32>) {
+  %0:2 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
+      (%b0, %b1 : f32, i64) -> tensor<?xf32>, tensor<?x?xf32>
+  return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
+}
+//      CHECK: func @generic_micro_kernel_optional_input(
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic_micro_kernel
+//  CHECK-NOT:       ins
+
+// -----
+
+func.func @generic_micro_kernel_memref_optional_input(
+    %out0: memref<?xf32>, %out1 : memref<?x?xf32>,
+    %b0: f32, %b1: i64) {
+  iree_codegen.generic_micro_kernel "foo"
+      outs(%out0, %out1 : memref<?xf32>, memref<?x?xf32>)
+      (%b0, %b1 : f32, i64)
+  return
+}
+//      CHECK: func @generic_micro_kernel_memref_optional_input(
+//      CHECK:   iree_codegen.generic_micro_kernel
+//  CHECK-NOT:       ins
+
+// -----
+
+func.func @generic_micro_kernel_optional_other_operands(
+    %in0: tensor<?x?xf32>, %in1: tensor<?xf32>,
+    %out0: tensor<?xf32>, %out1 : tensor<?x?xf32>) -> (tensor<?xf32>, tensor<?x?xf32>) {
+  %0:2 = iree_codegen.generic_micro_kernel "foo"
+      ins(%in0, %in1: tensor<?x?xf32>, tensor<?xf32>)
+      outs(%out0, %out1 : tensor<?xf32>, tensor<?x?xf32>)
+      -> tensor<?xf32>, tensor<?x?xf32>
+  return %0#0, %0#1 : tensor<?xf32>, tensor<?x?xf32>
+}
+//      CHECK: func @generic_micro_kernel_optional_other_operands(
+//      CHECK:   %[[RESULT:.+]]:2 = iree_codegen.generic_micro_kernel
+// CHECK-SAME:       outs(%{{.+}}, %{{.+}} : tensor<?xf32>, tensor<?x?xf32>) ->
+
+// -----
+
+func.func @generic_micro_kernel_non_tensor_memref_outs(
+   %out0 : f32) -> f32 {
+  // expected-error @+1 {{operand #0 must be ranked tensor of any type values or memref of any type values, but got 'f32'}}
+  %0 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0 : f32) -> f32
+  return %0 : f32
+}
+
+// -----
+
+func.func @generic_micro_kernel_err_tensor_outs(
+    %out0: tensor<?xf32>, %out1 : memref<?x?xf32>) {
+  // expected-error @+1 {{expected the number of results (0) to be equal to the number of output tensors (1)}}
+  iree_codegen.generic_micro_kernel "foo"
+      outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>)
+}
+
+// -----
+
+func.func @generic_micro_kernel_mixed_tensor_memref(
+    %out0: tensor<?xf32>, %out1 : memref<?x?xf32>)
+    -> tensor<?xf32> {
+  %0 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+//      CHECK: func @generic_micro_kernel_mixed_tensor_memref(
+// CHECK-SAME:     %[[OUT0:.+]]: tensor<?xf32>
+// CHECK-SAME:     %[[OUT1:.+]]: memref<?x?xf32>
+//      CHECK:   %[[RESULT:.+]] = iree_codegen.generic_micro_kernel
+// CHECK-SAME:       outs(%[[OUT0]], %[[OUT1]] :
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @generic_micro_kernel_err_memref_outs(
+    %out0: tensor<?xf32>, %out1 : memref<?x?xf32>)
+    -> (tensor<?xf32>, tensor<?x?xf32>){
+  // expected-error @+1 {{expected the number of results (2) to be equal to the number of output tensors (1)}}
+  %0:2 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0, %out1 : tensor<?xf32>, memref<?x?xf32>) -> tensor<?xf32>, tensor<?x?xf32>
+}
+
+// -----
+
+func.func @generic_micro_kernel_err_elementtype(
+    %out0: tensor<?xf32>) -> tensor<?xi32> {
+  // expected-error @+1 {{expected type of operand #0 ('tensor<?xf32>') to match type of corresponding result ('tensor<?xi32>')}}
+  %0 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0 : tensor<?xf32>) -> tensor<?xi32>
+  return %0 : tensor<?xi32>
+}
+
+// -----
+
+func.func @generic_micro_kernel_err_shape_mismatch(
+    %out0: tensor<?xf32>) -> tensor<?x?xf32> {
+  // expected-error @+1 {{expected type of operand #0 ('tensor<?xf32>') to match type of corresponding result ('tensor<?x?xf32>')}}
+  %0 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0 : tensor<?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+
+// -----
+
+func.func @generic_micro_kernel_err_static_shape_mismatch(
+    %out0: tensor<10xf32>) -> tensor<20xf32> {
+  // expected-error @+1 {{expected type of operand #0 ('tensor<10xf32>') to match type of corresponding result ('tensor<20xf32>')}}
+  %0 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0 : tensor<10xf32>) -> tensor<20xf32>
+  return %0 : tensor<20xf32>
+}
+
+// -----
+
+func.func @generic_micro_kernel_static_dynamic_shape_match(
+    %out0: tensor<10xf32>) -> tensor<?xf32> {
+  // expected-error @+1 {{expected type of operand #0 ('tensor<10xf32>') to match type of corresponding result ('tensor<?xf32>')}}
+  %0 = iree_codegen.generic_micro_kernel "foo"
+      outs(%out0 : tensor<10xf32>) -> tensor<?xf32>
+  return %0 : tensor<?xf32>
+}
+
+// -----
+
+func.func @mmt4d_micro_kernel(%lhs : tensor<?x?x?x?xf32>,
+    %rhs : tensor<?x?x?x?xf32>, %outs : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %0 = iree_codegen.mmt4d_micro_kernel lhs(%lhs : tensor<?x?x?x?xf32>)
+      rhs(%rhs : tensor<?x?x?x?xf32>) outs(%outs : tensor<?x?x?x?xf32>)
+      accumulate(true) -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+}
+//      CHECK: func @mmt4d_micro_kernel(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+// CHECK-SAME:     %[[OUTS:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+//      CHECK:   %[[RESULT:.+]] = iree_codegen.mmt4d_micro_kernel
+// CHECK-SAME:       lhs(%[[LHS]] :
+// CHECK-SAME:       rhs(%[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+// CHECK-SAME:       accumulate(true)
+//      CHECK:   return %[[RESULT]]
+
+// -----
+
+func.func @mmt4d_micro_kernel_memref(%lhs : memref<?x?x?x?xf32>,
+    %rhs : memref<?x?x?x?xf32>, %outs : memref<?x?x?x?xf32>) {
+  iree_codegen.mmt4d_micro_kernel lhs(%lhs : memref<?x?x?x?xf32>)
+      rhs(%rhs : memref<?x?x?x?xf32>) outs(%outs : memref<?x?x?x?xf32>)
+      accumulate(false)
+  return
+}
+//      CHECK: func @mmt4d_micro_kernel_memref(
+// CHECK-SAME:     %[[LHS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
+// CHECK-SAME:     %[[RHS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
+// CHECK-SAME:     %[[OUTS:[a-zA-Z0-9]+]]: memref<?x?x?x?xf32>
+//      CHECK:   iree_codegen.mmt4d_micro_kernel
+// CHECK-SAME:       lhs(%[[LHS]] :
+// CHECK-SAME:       rhs(%[[RHS]] :
+// CHECK-SAME:       outs(%[[OUTS]] :
+// CHECK-SAME:       accumulate(false)

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD
@@ -16,6 +16,7 @@ package(
 )
 
 exports_files([
+    "MicroKernelOpInterface.td",
     "ProcessorOpInterfaces.td",
 ])
 
@@ -106,6 +107,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":MicroKernelOpInterfaceGen",
+        "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
     ],
 )

--- a/compiler/src/iree/compiler/Codegen/Interfaces/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/BUILD
@@ -23,6 +23,7 @@ td_library(
     name = "td_files",
     srcs = enforce_glob(
         [
+            "MicroKernelOpInterface.td",
             "PartitionableLoopsInterface.td",
             "ProcessorOpInterfaces.td",
         ],
@@ -43,6 +44,7 @@ iree_compiler_cc_library(
     ],
     deps = [
         ":BufferizationInterfaces",
+        ":MicroKernelOpInterface",
         ":PartitionableLoopsInterface",
         ":ProcessorOpInterfaces",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransformOps",
@@ -88,6 +90,41 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorTransforms",
         "@llvm-project//mlir:VectorTransforms",
     ],
+)
+
+iree_compiler_cc_library(
+    name = "MicroKernelOpInterface",
+    srcs = [
+        "MicroKernelOpInterface.cpp",
+    ],
+    hdrs = [
+        "MicroKernelOpInterface.h",
+    ],
+    textual_hdrs = [
+        "MicroKernelOpInterface.cpp.inc",
+        "MicroKernelOpInterface.h.inc",
+    ],
+    deps = [
+        ":MicroKernelOpInterfaceGen",
+        "@llvm-project//mlir:IR",
+    ],
+)
+
+iree_gentbl_cc_library(
+    name = "MicroKernelOpInterfaceGen",
+    tbl_outs = [
+        (
+            ["--gen-op-interface-decls"],
+            "MicroKernelOpInterface.h.inc",
+        ),
+        (
+            ["--gen-op-interface-defs"],
+            "MicroKernelOpInterface.cpp.inc",
+        ),
+    ],
+    tblgen = "@llvm-project//mlir:mlir-tblgen",
+    td_file = "MicroKernelOpInterface.td",
+    deps = ["@llvm-project//mlir:OpBaseTdFiles"],
 )
 
 iree_compiler_cc_library(

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -19,6 +19,7 @@ iree_cc_library(
     "Interfaces.cpp"
   DEPS
     ::BufferizationInterfaces
+    ::MicroKernelOpInterface
     ::PartitionableLoopsInterface
     ::ProcessorOpInterfaces
     IREELinalgExtTransformOps
@@ -61,6 +62,32 @@ iree_cc_library(
     iree::compiler::Dialect::Flow::IR
     iree::compiler::Dialect::HAL::IR
   PUBLIC
+)
+
+iree_cc_library(
+  NAME
+    MicroKernelOpInterface
+  HDRS
+    "MicroKernelOpInterface.h"
+  TEXTUAL_HDRS
+    "MicroKernelOpInterface.cpp.inc"
+    "MicroKernelOpInterface.h.inc"
+  SRCS
+    "MicroKernelOpInterface.cpp"
+  DEPS
+    ::MicroKernelOpInterfaceGen
+    MLIRIR
+  PUBLIC
+)
+
+iree_tablegen_library(
+  NAME
+    MicroKernelOpInterfaceGen
+  TD_FILE
+    "MicroKernelOpInterface.td"
+  OUTS
+    --gen-op-interface-decls MicroKernelOpInterface.h.inc
+    --gen-op-interface-defs MicroKernelOpInterface.cpp.inc
 )
 
 iree_cc_library(

--- a/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/CMakeLists.txt
@@ -76,6 +76,7 @@ iree_cc_library(
     "MicroKernelOpInterface.cpp"
   DEPS
     ::MicroKernelOpInterfaceGen
+    MLIRFuncDialect
     MLIRIR
   PUBLIC
 )

--- a/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.cpp
@@ -1,0 +1,13 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+// clang-format off
+#include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.cpp.inc" // IWYU pragma: keep
+// clang-format on

--- a/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.cpp
@@ -6,7 +6,10 @@
 
 #include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h"
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/BuiltinTypes.h"
+
+using namespace mlir;
 
 // clang-format off
 #include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.cpp.inc" // IWYU pragma: keep

--- a/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h
@@ -7,7 +7,9 @@
 #ifndef IREE_COMPILER_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE_H_
 #define IREE_COMPILER_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE_H_
 
+#include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
 
 // clang-format off
 #include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h.inc" // IWYU pragma: export

--- a/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h
@@ -1,0 +1,16 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_COMPILER_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE_H_
+#define IREE_COMPILER_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE_H_
+
+#include "mlir/IR/OpDefinition.h"
+
+// clang-format off
+#include "iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.h.inc" // IWYU pragma: export
+// clang-format on
+
+#endif  // IREE_COMPILER_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE_H_

--- a/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.td
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.td
@@ -1,0 +1,20 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE
+#define IREE_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE
+
+include "mlir/IR/OpBase.td"
+
+def MicroKernelOpInterface : OpInterface<"MicroKernelOpInterface"> {
+  let cppNamespace = "::mlir::iree_compiler::IREE::Codegen";
+
+  let description = [{
+    An interface for ops that wrap a call to microkernels.
+  }];
+}
+
+#endif // IREE_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE

--- a/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.td
+++ b/compiler/src/iree/compiler/Codegen/Interfaces/MicroKernelOpInterface.td
@@ -15,6 +15,18 @@ def MicroKernelOpInterface : OpInterface<"MicroKernelOpInterface"> {
   let description = [{
     An interface for ops that wrap a call to microkernels.
   }];
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/[{
+        Method to lower the Micro Kernel operation into a function call.
+      }],
+      /*retType=*/"FailureOr<func::CallOp>",
+      /*methodName=*/"lowerToFunctionCall",
+      /*args=*/(ins "RewriterBase &":$rewriter),
+      /*methodBody=*/"",
+      /*defautImplementation=*/"return failure();"
+    >,
+  ];
 }
 
 #endif // IREE_CODEGEN_INTERFACES_MICRO_KERNEL_OP_INTERFACE

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgTransformDialectPasses",
+        "//runtime/src/iree/builtins/ukernel:exported_bits",
         "@llvm-project//llvm:BinaryFormat",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineDialect",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -24,6 +24,7 @@ iree_compiler_cc_library(
         "LLVMCPUEmitVectorizationRemarks.cpp",
         "LLVMCPULinkExecutables.cpp",
         "LLVMCPULowerExecutableTarget.cpp",
+        "LLVMCPULowerToMicroKernels.cpp",
         "LLVMCPUMaterializeEncodingPass.cpp",
         "LLVMCPUMmt4dVectorLowering.cpp",
         "LLVMCPUSynchronizeSymbolVisibility.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -86,6 +86,7 @@ iree_cc_library(
     MLIRVectorToLLVM
     MLIRVectorToSCF
     MLIRVectorTransforms
+    iree::builtins::ukernel::exported_bits
     iree::compiler::Codegen::Common
     iree::compiler::Codegen::Common::CommonPasses
     iree::compiler::Codegen::Dialect::IREECodegenDialect

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -27,6 +27,7 @@ iree_cc_library(
     "LLVMCPUEmitVectorizationRemarks.cpp"
     "LLVMCPULinkExecutables.cpp"
     "LLVMCPULowerExecutableTarget.cpp"
+    "LLVMCPULowerToMicroKernels.cpp"
     "LLVMCPUMaterializeEncodingPass.cpp"
     "LLVMCPUMmt4dVectorLowering.cpp"
     "LLVMCPUSynchronizeSymbolVisibility.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToMicroKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToMicroKernels.cpp
@@ -96,7 +96,7 @@ static FailureOr<IREE::Codegen::MicroKernelOpInterface> matchDAGForMicroKernel(
   Type outElemType = outType.getElementType();
   if (lhsElemType.isSignlessInteger(8) && rhsElemType.isSignlessInteger(8) &&
       outElemType.isSignlessInteger(32)) {
-    fnName = "vmvx.matmul.i8i8i32";
+    fnName = "vmvx.matmul.i8.i8.i32";
   } else if (lhsElemType.isF32() && rhsElemType.isF32() &&
              outElemType.isF32()) {
     fnName = "vmvx.matmul.f32.f32.f32";

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToMicroKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToMicroKernels.cpp
@@ -1,0 +1,186 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/builtins/ukernel/exported_bits.h"
+#include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
+#include "iree/compiler/Codegen/Dialect/MicroKernelOps.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/IR/Matchers.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+namespace {
+struct LLVMCPULowerToMicroKernelsPass
+    : LLVMCPULowerToMicroKernelsBase<LLVMCPULowerToMicroKernelsPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Codegen::IREECodegenDialect>();
+  }
+  void runOnOperation() override;
+};
+}  // namespace
+
+/// Returns `true` if an `outsOperand` value is initialized to zero.
+static bool isInitializedToZero(Value outsOperand) {
+  auto fillOp = outsOperand.getDefiningOp<linalg::FillOp>();
+  if (!fillOp) return false;
+  Value fillVal = fillOp.getDpsInputOperand(0)->get();
+  return matchPattern(fillVal, m_Zero()) ||
+         matchPattern(fillVal, m_AnyZeroFloat());
+}
+
+/// Matches an (linalg.fill -> )? linalg.mmt4d operation sequence and converts
+/// it into a iree_codegen.mmt4d_micro_kernel operation, that is later lowered
+/// into a call to the microkernel.
+static FailureOr<IREE::Codegen::MicroKernelOpInterface> matchDAGForMicroKernel(
+    RewriterBase &rewriter, linalg::Mmt4DOp op) {
+  if (!op.hasTensorSemantics()) {
+    return rewriter.notifyMatchFailure(
+        op, "operations needs to have tensor semantics");
+  }
+  Value lhs = op.getDpsInputOperand(0)->get();
+  Value rhs = op.getDpsInputOperand(1)->get();
+  Value out = op.getDpsInitOperand(0)->get();
+  auto lhsType = lhs.getType().cast<ShapedType>();
+  auto rhsType = rhs.getType().cast<ShapedType>();
+  auto outType = out.getType().cast<ShapedType>();
+  Type lhsElemType = lhsType.getElementType();
+  Type rhsElemType = rhsType.getElementType();
+  Type outElemType = outType.getElementType();
+  if (!((lhsElemType.isSignlessInteger(8) && rhsElemType.isSignlessInteger(8) &&
+         outElemType.isSignlessInteger(32)) ||
+        (lhsElemType.isF32() && rhsElemType.isF32() && outElemType.isF32()))) {
+    return rewriter.notifyMatchFailure(
+        op, "unsupported type for lowering to microkernels");
+  }
+  // check if the result has to be accumulated into a buffer.
+  bool accumulate = !isInitializedToZero(out);
+  if (!accumulate) {
+    // Update the `out` value to encompass the dest of the op.
+    if (auto fillOp = out.getDefiningOp<linalg::FillOp>()) {
+      out = fillOp.getDpsInitOperand(0)->get();
+    }
+  }
+  Location loc = op.getLoc();
+  auto microKernelOp = rewriter.create<IREE::Codegen::Mmt4DMicroKernelOp>(
+      loc, outType, lhs, rhs, out, rewriter.getBoolAttr(accumulate));
+  return cast<IREE::Codegen::MicroKernelOpInterface>(
+      microKernelOp.getOperation());
+}
+
+/// Matches an (linalg.fill -> )? linalg.matmul operation sequence and converts
+/// it into a iree_codegen.generic_micro_kernel operation, that is lowered
+/// into a call to the microkernel.
+static FailureOr<IREE::Codegen::MicroKernelOpInterface> matchDAGForMicroKernel(
+    RewriterBase &rewriter, linalg::MatmulOp op) {
+  if (!op.hasTensorSemantics()) {
+    return rewriter.notifyMatchFailure(
+        op, "operations needs to have tensor semantics");
+  }
+  Value lhs = op.getDpsInputOperand(0)->get();
+  Value rhs = op.getDpsInputOperand(1)->get();
+  Value out = op.getDpsInitOperand(0)->get();
+  auto lhsType = lhs.getType().cast<ShapedType>();
+  auto rhsType = rhs.getType().cast<ShapedType>();
+  auto outType = out.getType().cast<ShapedType>();
+  std::string fnName = "";
+  Type lhsElemType = lhsType.getElementType();
+  Type rhsElemType = rhsType.getElementType();
+  Type outElemType = outType.getElementType();
+  if (lhsElemType.isSignlessInteger(8) && rhsElemType.isSignlessInteger(8) &&
+      outElemType.isSignlessInteger(32)) {
+    fnName = "vmvx.matmul.i8i8i32";
+  } else if (lhsElemType.isF32() && rhsElemType.isF32() &&
+             outElemType.isF32()) {
+    fnName = "vmvx.matmul.f32.f32.f32";
+  }
+  if (fnName.empty()) {
+    return rewriter.notifyMatchFailure(op,
+                                       "unable to match micro kernel to op");
+  }
+  bool accumulate = !isInitializedToZero(out);
+  int flags = 0;
+  if (accumulate) {
+    flags |= IREE_UK_FLAG_ACCUMULATE;
+  } else {  // Update the `out` value to encompass the dest of the op.
+    if (auto fillOp = out.getDefiningOp<linalg::FillOp>()) {
+      out = fillOp.getDpsInitOperand(0)->get();
+    }
+  }
+
+  Location loc = op.getLoc();
+  Value m = rewriter.create<tensor::DimOp>(loc, lhs, 0);
+  Value n = rewriter.create<tensor::DimOp>(loc, rhs, 1);
+  Value k = rewriter.create<tensor::DimOp>(loc, out, 1);
+  Value flagsVal = rewriter.create<arith::ConstantOp>(
+      loc, rewriter.getI32IntegerAttr(flags));
+  auto genericMicroKernelOp =
+      rewriter.create<IREE::Codegen::GenericMicroKernelOp>(
+          loc, outType, fnName, ValueRange{lhs, rhs}, out,
+          ValueRange{m, n, k, flagsVal});
+  return cast<IREE::Codegen::MicroKernelOpInterface>(
+      genericMicroKernelOp.getOperation());
+}
+
+namespace {
+
+/// Pattern to lower (linalg.fill -> )? linalg.matmul operation sequence and
+/// converts it into a iree_codegen.generic_micro_kernel operation
+struct MatmulMicroKernelPattern : OpRewritePattern<linalg::MatmulOp> {
+  using OpRewritePattern<linalg::MatmulOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::MatmulOp matmulOp,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<IREE::Codegen::MicroKernelOpInterface> microKernelOp =
+        matchDAGForMicroKernel(rewriter, matmulOp);
+    if (failed(microKernelOp)) {
+      return rewriter.notifyMatchFailure(
+          matmulOp, "failed to find microkernel op to replace with");
+    }
+    rewriter.replaceOp(matmulOp, microKernelOp.value()->getResults());
+    return success();
+  }
+};
+
+/// Pattern to lower (linalg.fill -> )? linalg.mmt4d operation sequence and
+/// converts it into a iree_codegen.mmt4d_micro_kernel operation
+struct Mmt4DMicroKernelPattern : OpRewritePattern<linalg::Mmt4DOp> {
+  using OpRewritePattern<linalg::Mmt4DOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::Mmt4DOp matmulOp,
+                                PatternRewriter &rewriter) const override {
+    FailureOr<IREE::Codegen::MicroKernelOpInterface> microKernelOp =
+        matchDAGForMicroKernel(rewriter, matmulOp);
+    if (failed(microKernelOp)) {
+      return rewriter.notifyMatchFailure(
+          matmulOp, "failed to find microkernel op to replace with");
+    }
+    rewriter.replaceOp(matmulOp, microKernelOp.value()->getResults());
+    return success();
+  }
+};
+}  // namespace
+
+void LLVMCPULowerToMicroKernelsPass::runOnOperation() {
+  MLIRContext *context = &getContext();
+  RewritePatternSet patterns(context);
+  patterns.insert<MatmulMicroKernelPattern, Mmt4DMicroKernelPattern>(context);
+  if (failed(
+          applyPatternsAndFoldGreedily(getOperation(), std::move(patterns)))) {
+    return signalPassFailure();
+  }
+}
+
+std::unique_ptr<OperationPass<>> createLLVMCPULowerToMicroKernelsPass() {
+  return std::make_unique<LLVMCPULowerToMicroKernelsPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToMicroKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToMicroKernels.cpp
@@ -37,7 +37,7 @@ static bool isInitializedToZero(Value outsOperand) {
 }
 
 /// Matches an (linalg.fill -> )? linalg.mmt4d operation sequence and converts
-/// it into a iree_codegen.mmt4d.ukernel operation, that is later lowered
+/// it into a iree_codegen.ukernel.mmt4d operation, that is later lowered
 /// into a call to the microkernel.
 static FailureOr<IREE::Codegen::MicroKernelOpInterface> matchDAGForMicroKernel(
     RewriterBase &rewriter, linalg::Mmt4DOp op) {
@@ -76,7 +76,7 @@ static FailureOr<IREE::Codegen::MicroKernelOpInterface> matchDAGForMicroKernel(
 }
 
 /// Matches an (linalg.fill -> )? linalg.matmul operation sequence and converts
-/// it into a iree_codegen.generic.ukernel operation, that is lowered
+/// it into a iree_codegen.ukernel.generic operation, that is lowered
 /// into a call to the microkernel.
 static FailureOr<IREE::Codegen::MicroKernelOpInterface> matchDAGForMicroKernel(
     RewriterBase &rewriter, linalg::MatmulOp op) {
@@ -131,7 +131,7 @@ static FailureOr<IREE::Codegen::MicroKernelOpInterface> matchDAGForMicroKernel(
 namespace {
 
 /// Pattern to lower (linalg.fill -> )? linalg.matmul operation sequence and
-/// converts it into a iree_codegen.generic.ukernel operation
+/// converts it into a iree_codegen.ukernel.generic operation
 struct MatmulMicroKernelPattern : OpRewritePattern<linalg::MatmulOp> {
   using OpRewritePattern<linalg::MatmulOp>::OpRewritePattern;
 
@@ -149,7 +149,7 @@ struct MatmulMicroKernelPattern : OpRewritePattern<linalg::MatmulOp> {
 };
 
 /// Pattern to lower (linalg.fill -> )? linalg.mmt4d operation sequence and
-/// converts it into a iree_codegen.mmt4d.ukernel operation
+/// converts it into a iree_codegen.ukernel.mmt4d operation
 struct Mmt4DUKernelPattern : OpRewritePattern<linalg::Mmt4DOp> {
   using OpRewritePattern<linalg::Mmt4DOp>::OpRewritePattern;
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -34,6 +34,7 @@ iree_lit_test_suite(
             "hal_interface_constants.mlir",
             "hal_interface_workgroup_info.mlir",
             "illegal_configuration.mlir",
+            "lower_to_micro_kernel_ops.mlir",
             "materialize_aarch64_launch_configuration.mlir",
             "materialize_encoding.mlir",
             "materialize_riscv_launch_configuration.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "hal_interface_constants.mlir"
     "hal_interface_workgroup_info.mlir"
     "illegal_configuration.mlir"
+    "lower_to_micro_kernel_ops.mlir"
     "materialize_aarch64_launch_configuration.mlir"
     "materialize_encoding.mlir"
     "materialize_riscv_launch_configuration.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
@@ -70,7 +70,7 @@ func.func @matmul_i8i8i32(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>,
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.i8i8i32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.i8.i8.i32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
@@ -1,0 +1,143 @@
+// RUN: iree-opt --iree-llvmcpu-lower-to-micro-kernels %s | FileCheck %s
+
+func.func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
+    %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%arg2 : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//      CHECK: func @matmul(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1 : i32
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.f32.f32.f32"
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
+//      CHECK:   return %[[MICRO_KERNEL]] : tensor<?x?xf32>
+
+// -----
+
+func.func @matmul_fill(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %m = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %n = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %empty = tensor.empty(%m, %n) : tensor<?x?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<?x?xf32>) -> tensor<?x?xf32>
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)
+      outs(%fill : tensor<?x?xf32>) -> tensor<?x?xf32>
+  return %0 : tensor<?x?xf32>
+}
+//      CHECK: func @matmul_fill(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 0 : i32
+//      CHECK:   %[[EMPTY:.+]] = tensor.empty
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[EMPTY]], %[[C1]]
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.f32.f32.f32"
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// CHECK-SAME:       outs(%[[EMPTY]] :
+// CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
+//      CHECK:   return %[[MICRO_KERNEL]] : tensor<?x?xf32>
+
+// -----
+
+func.func @matmul_i8i8i32(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>,
+    %arg2 : tensor<?x?xi32>) -> tensor<?x?xi32> {
+  %0 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xi8>, tensor<?x?xi8>)
+      outs(%arg2 : tensor<?x?xi32>) -> tensor<?x?xi32>
+  return %0 : tensor<?x?xi32>
+}
+//      CHECK: func @matmul_i8i8i32(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xi8>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xi8>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xi32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1
+//  CHECK-DAG:   %[[FLAGS:.+]] = arith.constant 1 : i32
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.i8i8i32"
+// CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
+//      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+func.func @mmt4d(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>,
+    %arg2 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %0 = linalg.mmt4d ins(%arg0, %arg1 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>)
+      outs(%arg2 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+}
+//      CHECK: func @mmt4d(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d_micro_kernel
+// CHECK-SAME:       lhs(%[[ARG0]] :
+// CHECK-SAME:       rhs(%[[ARG1]] :
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       accumulate(true)
+//      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c2 = arith.constant 2 : index
+  %cst = arith.constant 0.0 : f32
+  %m = tensor.dim %arg0, %c0 : tensor<?x?x?x?xf32>
+  %n = tensor.dim %arg1, %c1 : tensor<?x?x?x?xf32>
+  %m0 = tensor.dim %arg0, %c2 : tensor<?x?x?x?xf32>
+  %n0 = tensor.dim %arg1, %c2 : tensor<?x?x?x?xf32>
+  %empty = tensor.empty(%m, %n, %m0, %n0) : tensor<?x?x?x?xf32>
+  %fill = linalg.fill ins(%cst : f32) outs(%empty : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+  %0 = linalg.mmt4d ins(%arg0, %arg1 : tensor<?x?x?x?xf32>, tensor<?x?x?x?xf32>)
+      outs(%fill : tensor<?x?x?x?xf32>) -> tensor<?x?x?x?xf32>
+  return %0 : tensor<?x?x?x?xf32>
+}
+//      CHECK: func @mmt4d_fill(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
+//      CHECK:   %[[DST:.+]] = tensor.empty
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d_micro_kernel
+// CHECK-SAME:       lhs(%[[ARG0]] :
+// CHECK-SAME:       rhs(%[[ARG1]] :
+// CHECK-SAME:       outs(%[[DST]] :
+// CHECK-SAME:       accumulate(false)
+//      CHECK:   return %[[MICRO_KERNEL]]
+
+// -----
+
+func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
+    %arg2 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32> {
+  %0 = linalg.mmt4d ins(%arg0, %arg1 : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>)
+      outs(%arg2 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+  return %0 : tensor<?x?x?x?xi32>
+}
+//      CHECK: func @mmt4d_i8i8i32(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d_micro_kernel
+// CHECK-SAME:       lhs(%[[ARG0]] :
+// CHECK-SAME:       rhs(%[[ARG1]] :
+// CHECK-SAME:       outs(%[[ARG2]] :
+// CHECK-SAME:       accumulate(true)
+//      CHECK:   return %[[MICRO_KERNEL]]

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
@@ -16,7 +16,7 @@ func.func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.f32.f32.f32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic.ukernel "vmvx.matmul.f32.f32.f32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -46,7 +46,7 @@ func.func @matmul_fill(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tens
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[EMPTY]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.f32.f32.f32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic.ukernel "vmvx.matmul.f32.f32.f32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[EMPTY]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -70,7 +70,7 @@ func.func @matmul_i8i8i32(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>,
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic_micro_kernel "vmvx.matmul.i8.i8.i32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic.ukernel "vmvx.matmul.i8.i8.i32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -88,7 +88,7 @@ func.func @mmt4d(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>,
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d_micro_kernel
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d.ukernel
 // CHECK-SAME:       lhs(%[[ARG0]] :
 // CHECK-SAME:       rhs(%[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
@@ -116,7 +116,7 @@ func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>) 
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 //      CHECK:   %[[DST:.+]] = tensor.empty
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d_micro_kernel
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d.ukernel
 // CHECK-SAME:       lhs(%[[ARG0]] :
 // CHECK-SAME:       rhs(%[[ARG1]] :
 // CHECK-SAME:       outs(%[[DST]] :
@@ -135,7 +135,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d_micro_kernel
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d.ukernel
 // CHECK-SAME:       lhs(%[[ARG0]] :
 // CHECK-SAME:       rhs(%[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_micro_kernel_ops.mlir
@@ -16,7 +16,7 @@ func.func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic.ukernel "vmvx.matmul.f32.f32.f32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.f32.f32.f32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -46,7 +46,7 @@ func.func @matmul_fill(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tens
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[EMPTY]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic.ukernel "vmvx.matmul.f32.f32.f32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.f32.f32.f32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[EMPTY]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -70,7 +70,7 @@ func.func @matmul_i8i8i32(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>,
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.generic.ukernel "vmvx.matmul.i8.i8.i32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.i8.i8.i32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -88,7 +88,7 @@ func.func @mmt4d(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>,
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d.ukernel
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.mmt4d
 // CHECK-SAME:       lhs(%[[ARG0]] :
 // CHECK-SAME:       rhs(%[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
@@ -116,7 +116,7 @@ func.func @mmt4d_fill(%arg0 : tensor<?x?x?x?xf32>, %arg1 : tensor<?x?x?x?xf32>) 
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xf32>
 //      CHECK:   %[[DST:.+]] = tensor.empty
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d.ukernel
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.mmt4d
 // CHECK-SAME:       lhs(%[[ARG0]] :
 // CHECK-SAME:       rhs(%[[ARG1]] :
 // CHECK-SAME:       outs(%[[DST]] :
@@ -135,7 +135,7 @@ func.func @mmt4d_i8i8i32(%arg0 : tensor<?x?x?x?xi8>, %arg1 : tensor<?x?x?x?xi8>,
 // CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi8>
 // CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?x?x?xi32>
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.mmt4d.ukernel
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.mmt4d
 // CHECK-SAME:       lhs(%[[ARG0]] :
 // CHECK-SAME:       rhs(%[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -127,6 +127,9 @@ std::unique_ptr<OperationPass<func::FuncOp>> createVectorizePackUnPackOpsPass();
 std::unique_ptr<OperationPass<func::FuncOp>> createOptimizeVectorTransferPass(
     bool flatten = false);
 
+/// Pass to lower micro_kernel operations into their defined function calls.
+std::unique_ptr<OperationPass<ModuleOp>> createLowerMicroKernelOpsToCallsPass();
+
 /// Pass to optimize vector transfer_read and transfer_write. See Passes.td for
 /// `option` details.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -273,6 +273,10 @@ createLLVMCPUCheckIRBeforeLLVMConversionPass();
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createLLVMCPULowerExecutableTargetPass();
 
+/// Pass to lower a sequence of operations to a iree_codegen.micro_kernel
+/// operation.
+std::unique_ptr<OperationPass<>> createLLVMCPULowerToMicroKernelsPass();
+
 /// Materialize the encoding of operations. The layout to use for the encoded
 /// operations are LLVMCPU specific.
 std::unique_ptr<OperationPass<func::FuncOp>>

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -106,6 +106,12 @@ def IREEComprehensiveBufferize :
   ];
 }
 
+def LowerMicroKernelOpsToCalls :
+    Pass<"iree-codegen-lower-micro-kernel-ops-to-calls", "ModuleOp"> {
+  let summary = "Lower micro-kernel wrapper ops into function calls";
+  let constructor = "mlir::iree_compiler::createLowerMicroKernelOpsToCallsPass()";
+}
+
 def OptimizeVectorTransfer :
     Pass<"iree-codegen-optimize-vector-transfer", "func::FuncOp"> {
   let summary =

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -368,6 +368,14 @@ def LLVMCPULowerExecutableTarget :
       "mlir::iree_compiler::createLLVMCPULowerExecutableTargetPass()";
 }
 
+def LLVMCPULowerToMicroKernels :
+    Pass<"iree-llvmcpu-lower-to-micro-kernels", ""> {
+  let summary =
+      "Separate out parts of the IR that lower to a micro-kernel";
+  let constructor =
+      "mlir::iree_compiler::createLLVMCPULowerToMicroKernelsPass()";
+}
+
 def LLVMCPUMaterializeEncoding :
     Pass<"iree-llvmcpu-materialize-encoding", "func::FuncOp"> {
   let summary = "Materialize the encoding for tensor as specified by the backend";


### PR DESCRIPTION
Currently support for invoking micro kernels is only present on the VMVX backend. To be able to invoke these micro-kernels from the codegen backend (and to improve the path of calling micro kernels from VMVX backend) as well, this PR adds

1) A `MicroKernelOpInterface`. This interface is meant to have just
   a single method that lowers the op into a function call that
   is the micro kernel that is being used.
2) Two classes of MicroKernel ops are added.
   a) a `generic_micro_kernel` operation. This operation has a set
      ABI that it lowers into. So once a DAG of operations is mapped
      to this op, it also sets the ABI of the micro kernel function.
   b) There might be cases where the ABI of the micro kernel does not
      conform to the fixed ABI. Such ops are free form, and can lower
      to a custom ABI as specified by the micro-kernel. This PR adds
      one such op for micro kernels for `linalg.mmt4d` related paths
      where the function ABI is not consistent with what the
      `generic_micro_kernel` lowers into.

Since all the MicroKernel ops are expected to implement the 
`DestinationStyleOpInterface` bufferization handles them out of the
box. There is some matchers needed to recognize the DAG to forward
to a micro kernel, but after that the interface added can be used to 
handle lowering to function calls for all of the ops that implement the
interface.