### PR TITLE
Adding iree_vm_list_swap_storage and iree_vm_list_copy.

### DIFF
--- a/runtime/src/iree/vm/list.h
+++ b/runtime/src/iree/vm/list.h
@@ -104,6 +104,32 @@ IREE_API_EXPORT iree_status_t iree_vm_list_resize(iree_vm_list_t* list,
 // Clears the list contents. Equivalent to resizing to 0.
 IREE_API_EXPORT void iree_vm_list_clear(iree_vm_list_t* list);
 
+// Swaps the storage of |list_a| and |list_b|. The list references remain the
+// same but the count, capacity, and underlying storage will be swapped. This
+// can be used to treat lists as persistent stable references to dynamically
+// mutated storage such as when emulating structs or dicts.
+//
+// WARNING: if a list is initialized in-place with iree_vm_list_initialize this
+// will still perform the storage swap but may lead to unexpected issues if the
+// lifetime of the storage is shorter than the lifetime of the newly-swapped
+// list.
+IREE_API_EXPORT void iree_vm_list_swap_storage(iree_vm_list_t* list_a,
+                                               iree_vm_list_t* list_b);
+
+// Copies |count| elements from |src_list| starting at |src_i| to |dst_list|
+// starting at |dst_i|. The ranges specified must be valid in both lists.
+//
+// Supported list types:
+//   any type -> variant list
+//   variant list -> compatible element types only
+//   same value type -> same value type
+//   same ref type -> same ref type
+IREE_API_EXPORT iree_status_t iree_vm_list_copy(iree_vm_list_t* src_list,
+                                                iree_host_size_t src_i,
+                                                iree_vm_list_t* dst_list,
+                                                iree_host_size_t dst_i,
+                                                iree_host_size_t count);
+
 // Returns the value of the element at the given index.
 // Note that the value type may vary from element to element in variant lists
 // and callers should check the |out_value| type.

--- a/runtime/src/iree/vm/ref.c
+++ b/runtime/src/iree/vm/ref.c
@@ -187,7 +187,8 @@ IREE_API_EXPORT void iree_vm_ref_retain(iree_vm_ref_t* ref,
 
 IREE_API_EXPORT iree_status_t iree_vm_ref_retain_checked(
     iree_vm_ref_t* ref, iree_vm_ref_type_t type, iree_vm_ref_t* out_ref) {
-  if (ref->type != IREE_VM_REF_TYPE_NULL && ref->type != type) {
+  if (ref->type != IREE_VM_REF_TYPE_NULL && ref->type != type &&
+      type != IREE_VM_REF_TYPE_ANY) {
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "source ref type mismatch");
   }
@@ -207,7 +208,8 @@ IREE_API_EXPORT void iree_vm_ref_retain_or_move(int is_move, iree_vm_ref_t* ref,
 IREE_API_EXPORT iree_status_t iree_vm_ref_retain_or_move_checked(
     int is_move, iree_vm_ref_t* ref, iree_vm_ref_type_t type,
     iree_vm_ref_t* out_ref) {
-  if (ref->type != IREE_VM_REF_TYPE_NULL && ref->type != type) {
+  if (ref->type != IREE_VM_REF_TYPE_NULL && ref->type != type &&
+      type != IREE_VM_REF_TYPE_ANY) {
     // Make no changes on failure.
     return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
                             "source ref type mismatch");


### PR DESCRIPTION
This covers the C implementation of these routines and adds a bunch of tests. Future changes will expose these to the compiler as VM ops.

Progress on #7014.