### PR TITLE
[cmake] Build iree-sample-deps with iree-test-deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -748,22 +748,29 @@ if(IREE_BUILD_DOCS)
   add_custom_target(iree-doc ALL)
 endif()
 
+# Samples may require additional files to be built/configured and will add
+# dependencies to this target.
+# Note: These will be automatically built with test dependencies
+# (`iree-test-deps`).
+add_custom_target(iree-sample-deps
+  COMMENT
+    "Building IREE sample data targets"
+)
+
 # Testing rules that require generation will add dependencies to this target.
 # This allows them to be EXCLUDE_FROM_ALL but still invokable.
-add_custom_target(iree-test-deps COMMENT "Building IREE test deps")
+add_custom_target(iree-test-deps
+  COMMENT
+    "Building IREE test deps"
+  DEPENDS
+    iree-sample-deps
+)
 
 # Testing rules that generate test scripts for iree-run-module-test will add
 # dependencies to this target. It is a subset of `iree-test-deps`.
 add_custom_target(iree-run-module-test-deps
   COMMENT
     "Building IREE run module test targets"
-)
-
-# Samples may require additional files to be built/configured and will add
-# dependencies to this target.
-add_custom_target(iree-sample-deps
-  COMMENT
-    "Building IREE sample data targets"
 )
 
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -63,10 +63,6 @@ echo "Building test deps"
 echo "------------------"
 "$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
 
-echo "Building sample deps"
-echo "------------------"
-"$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-sample-deps -- -k 0
-
 if (( IREE_USE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/build_and_test_asan.sh
+++ b/build_tools/cmake/build_and_test_asan.sh
@@ -50,10 +50,6 @@ echo "Building test deps"
 echo "------------------"
 "${CMAKE_BIN?}" --build "${BUILD_DIR?}" --target iree-test-deps -- -k 0
 
-echo "Building sample deps"
-echo "------------------"
-"${CMAKE_BIN?}" --build "${BUILD_DIR?}" --target iree-sample-deps -- -k 0
-
 echo "Building microbenchmark suites"
 echo "------------------"
 "${CMAKE_BIN?}" --build "${BUILD_DIR?}" --target iree-microbenchmark-suites -- -k 0

--- a/build_tools/cmake/build_and_test_tsan.sh
+++ b/build_tools/cmake/build_and_test_tsan.sh
@@ -60,10 +60,6 @@ echo "Building test deps"
 echo "------------------"
 "$CMAKE_BIN" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
 
-echo "Building sample deps"
-echo "------------------"
-"$CMAKE_BIN" --build "${BUILD_DIR?}" --target iree-sample-deps -- -k 0
-
 if (( IREE_USE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/build_android.sh
+++ b/build_tools/cmake/build_android.sh
@@ -90,10 +90,6 @@ echo "Building test deps for device"
 echo "------------------"
 "${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
 
-echo "Building sample deps for device"
-echo "------------------"
-"${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-sample-deps -- -k 0
-
 if (( IREE_USE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/build_host_and_android.sh
+++ b/build_tools/cmake/build_host_and_android.sh
@@ -86,7 +86,3 @@ echo "------------"
 echo "Building test deps for device"
 echo "------------------"
 "$CMAKE_BIN" --build . --target iree-test-deps -- -k 0
-
-echo "Building sample deps for device"
-echo "------------------"
-"$CMAKE_BIN" --build . --target iree-sample-deps -- -k 0

--- a/build_tools/cmake/build_riscv.sh
+++ b/build_tools/cmake/build_riscv.sh
@@ -116,8 +116,5 @@ else
     echo "Building test deps for RISC-V"
     echo "-----------------------------"
     "${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-test-deps -- -k 0
-    echo "Building sample deps for RISC-V"
-    echo "------------------"
-    "${CMAKE_BIN}" --build "${BUILD_DIR}" --target iree-sample-deps -- -k 0
   fi
 fi

--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -50,10 +50,6 @@ echo "Building test deps"
 echo "------------------"
 "${CMAKE_BIN?}" --build . --target iree-test-deps -- -k 0
 
-echo "Building sample deps"
-echo "------------------"
-"${CMAKE_BIN?}" --build . --target iree-sample-deps -- -k 0
-
 if (( IREE_USE_CCACHE == 1 )); then
   ccache --show-stats
 fi

--- a/build_tools/cmake/rebuild.sh
+++ b/build_tools/cmake/rebuild.sh
@@ -57,7 +57,3 @@ echo "------------"
 echo "Building test deps"
 echo "------------------"
 "$CMAKE_BIN" --build . --target iree-test-deps -- -k 0
-
-echo "Building sample deps"
-echo "------------------"
-"$CMAKE_BIN" --build . --target iree-sample-deps -- -k 0


### PR DESCRIPTION
This is so that running all tests with `ctest` does not require building both `iree-test-deps` and `iree-sample-deps`. At the same time, it is still possible to build samples without building all the other test dependencies.

Update all build scripts so that they build `iree-test-deps` only.