### PR TITLE
Require compiler static linking when using compiler tracing.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,6 +336,13 @@ if(IREE_BYTECODE_MODULE_ENABLE_TSAN)
   endif()
 endif()
 
+if(IREE_LINK_COMPILER_SHARED_LIBRARY AND IREE_ENABLE_COMPILER_TRACING)
+  message(SEND_ERROR
+      "IREE_ENABLE_COMPILER_TRACING requires "
+      "-DIREE_LINK_COMPILER_SHARED_LIBRARY=OFF (the compiler library must not "
+      "be unloaded before Tracy finishes, static linking is one workaround)")
+endif()
+
 option(IREE_ENABLE_CCACHE
     "[DEPRECATED: Use CMAKE_<LANG>_COMPILER_LAUNCHER configure options or environment variables instead.] Use ccache if installed."
     OFF)


### PR DESCRIPTION
Progress on https://github.com/iree-org/iree/issues/11994 (tested on Windows, not Linux)

I've been seeing this "Connection lost!" error when tracing the compiler (specifically using sampling or instrumentation with memory profiling - basically anything that increases the amount of data that Tracy needs to pull across): 
![image](https://user-images.githubusercontent.com/4010439/217367796-afb7636a-a4a9-4284-a84a-2099f7f43599.png)

We've had similar errors before with other dynamic libraries and have this patch in IREE's _runtime_: https://github.com/iree-org/iree/blob/eadd7498d7cbe4564ab5f12321dfeb882f7ff1d7/runtime/src/iree/base/internal/dynamic_library_win32.c#L268-L284

I don't see how to make an equivalent change in https://github.com/iree-org/iree/tree/main/compiler/src/iree/compiler/API2, so just making `IREE_LINK_COMPILER_SHARED_LIBRARY` and `IREE_ENABLE_COMPILER_TRACING` mutually exclusive seems to be an acceptable workaround.