### PR TITLE
Switch to use adaptor folder API to silence deprecation warnings

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanBase.td
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanBase.td
@@ -32,6 +32,7 @@ def VK_Dialect : Dialect {
     dialect contains useful utilities for targeting Vulkan both in CodeGen and
     runtime.
   }];
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/LinalgTransformOps.td
@@ -19,6 +19,7 @@ def Linalg_Transform_Dialect : Dialect {
   let dependentDialects = [
     "linalg::LinalgDialect",
   ];
+  let useFoldAPI = kEmitFoldAdaptorFolder;
 }
 
 // Operations with this trait must provide the following methods:


### PR DESCRIPTION
We are not actually having op folders in these two dialects. So just switch it over.