### PR TITLE
Fix `IREE_FLAGS_ENABLE_FLAG_FILE` file IO support

### DIFF
--- a/runtime/src/iree/base/internal/flags.h
+++ b/runtime/src/iree/base/internal/flags.h
@@ -31,7 +31,7 @@ extern "C" {
 
 // 1 to enable --flagfile= support.
 #if !defined(IREE_FLAGS_ENABLE_FLAG_FILE)
-//The feature only works when file IO is available.
+// The feature only works when file IO is available.
 #if IREE_FILE_IO_ENABLE
 #define IREE_FLAGS_ENABLE_FLAG_FILE 1
 #else

--- a/runtime/src/iree/base/internal/flags.h
+++ b/runtime/src/iree/base/internal/flags.h
@@ -31,7 +31,12 @@ extern "C" {
 
 // 1 to enable --flagfile= support.
 #if !defined(IREE_FLAGS_ENABLE_FLAG_FILE)
+//The feature only works when file IO is available.
+#if IREE_FILE_IO_ENABLE
 #define IREE_FLAGS_ENABLE_FLAG_FILE 1
+#else
+#define IREE_FLAGS_ENABLE_FLAG_FILE 0
+#endif  // IREE_FILE_IO_ENABLE
 #endif  // !IREE_FLAGS_ENABLE_FLAG_FILE
 
 // Maximum number of flags that can be registered in a single binary.


### PR DESCRIPTION
`IREE_FLAGS_ENABLE_FLAG_FILE` only works when file IO is enabled. For generic platforms with `IREE_FILE_IO_ENABLE=0` it could cause build failure. Add additional checks for the default setting.