### PR TITLE
support dynamic size in ConvertMemRefAllocaOp

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/memref_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil/test/memref_ops.mlir
@@ -49,6 +49,18 @@ func.func @alloca() -> memref<16xi32> {
 }
 
 // -----
+// CHECK-LABEL: @alloca_dynamic_size
+// CHECK-SAME: (%[[LENGTH:.+]]: index)
+func.func @alloca_dynamic_size(%length : index) -> memref<?xi32> {
+  // CHECK: %[[ELEM_SIZE:.+]] = arith.constant 4 : index
+  // CHECK: %[[ALLOCATION_SIZE:.+]] = arith.muli %[[LENGTH]], %[[ELEM_SIZE]] : index
+  // CHECK: %[[BUFFER:.+]] = util.buffer.alloc uninitialized : !util.buffer{%[[ALLOCATION_SIZE]]}
+  %0 = memref.alloca(%length) : memref<?xi32>
+  // CHECK: return %[[BUFFER]]
+  return %0 : memref<?xi32>
+}
+
+// -----
 // CHECK-LABEL: @alloc_i16
 // CHECK-SAME: (%[[IDX0:.+]]: index) -> !util.buffer {
 func.func @alloc_i16(%idx0: index) -> memref<4xi16> {


### PR DESCRIPTION
Anyone who's tried to use VMVX has encountered the dreadful `error: failed to legalize operation 'memref.alloca'`. Users have run into and reported it multiple times, e.g.  #10859, #10855.

I had been working under the assumption that there was some fundamental difficulty here between VMVX and `memref.alloca`; after all, I thought, it made sense that the VM wouldn't support that.

Apparently, I wasn't alone: https://github.com/iree-org/iree/issues/10859#issuecomment-1329840940 says
> _In this context, we allocate a stack buffer, which is not allowed in VMVX backend [...] There are couple ways to fix it. [...] a.) Tile dynamic dims with size 1, so we can always vectorize it._

The resulting fix #11323 has helpfully unblocked users since, but more recently, as ukernels have started to make VMVX performance a reasonable thing to look into, we have found (#12073) that the fix from #11323 is currently the main performance bottleneck on VMVX/ukernels so it makes sense to revisit now. The question became how can we revert #11323 without inviting back the dreaded `alloca` errors.

So today, I was chatting with @benvanik  about a "totally crazy" idea:

- (bjacob) Actually have you considered implementing a lowering of memref.alloca to VM? That would make so many things smoother.
- (benvanik) I thought it was at some point - memref.alloca has a pattern in MemRefToUtil
- (bjacob) ooooh
- (benvanik) Oh, it bails on dynamic shapes - are these memrefs dynamic?
- (bjacob) yes, they are! is it very hard to support dynamic ?
- (benvanik) Nope!

So here you go, this PR does that. And indeed, it does allow me to revert #11323 without the `alloca` errors coming back! Looking at the testcases in filed issues #10859, #10855, #12060, they all involve dynamic shapes, so everything seems to add up.

Lesson learned: don't assume, talk. 

FYI @hanhanW @lundong 