### PR TITLE
Initialize runtime submodules before building benchmark binaries

### DIFF
--- a/build_tools/buildkite/cmake/linux/pipeline.yml
+++ b/build_tools/buildkite/cmake/linux/pipeline.yml
@@ -79,6 +79,7 @@ steps:
     key: "build-linux-benchmark-tools"
     commands: |
       # Builds tools on the host and assumes the builder is Linux x86_64.
+      build_tools/scripts/git/update_runtime_submodules.sh
       docker run --user=$(id -u):$(id -g) \
         --volume="$${HOME?}:$${HOME?}" \
         --volume="/etc/passwd:/etc/passwd:ro" \


### PR DESCRIPTION
This has just happened to work so far because the Buildkite builders
save the old repository. Discovered when testing for
https://github.com/iree-org/iree/issues/12102. Because the repo has a
different name, Buildkite uses a different directory and then no
submodules.

https://buildkite.com/iree/iree-benchmark-linux-openxla-test/builds/2#0186331f-16c6-4268-bd7e-9ef546fd4319