### PR TITLE
Remove dead subspan ops after FlattenMemRefSubspanPass

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/flatten_memref_subspan.mlir
@@ -475,3 +475,13 @@ func.func @store_uniform_buffer(%value : i32, %offset: index, %i0: index, %i1 : 
 //       CHECK:   %[[SUBSPAN:.+]] = hal.interface.binding.subspan set(0) binding(0) type(uniform_buffer) offset(%[[C0]]) : memref<24xi32, #hal.descriptor_type<uniform_buffer>>
 //       CHECK:   %[[INDEX:.+]] = affine.apply #[[$MAP]]()[%[[I0]], %[[I1]], %[[I2]], %[[OFFSET]]]
 //       CHECK:   memref.store %[[VAL]], %[[SUBSPAN]][%[[INDEX]]] : memref<24xi32, #hal.descriptor_type<uniform_buffer>>
+
+// -----
+
+func.func @dead_subspan(%offset : index) {
+  %subspan = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) offset(%offset) : memref<6x7x8xf32>
+  return
+}
+
+// CHECK: func.func @dead_subspan
+// CHECK-NEXT: return


### PR DESCRIPTION
Subspan ops are not automatically removed by canonicalization given they are not marked as no side effect. Leaving dead subspan ops there after transformations can be confusing.