### PR TITLE
Link content tabs across the website.

### DIFF
--- a/docs/website/docs/bindings/python.md
+++ b/docs/website/docs/bindings/python.md
@@ -39,7 +39,14 @@ To use IREE's Python bindings, you will first need to install
     ([about](https://docs.python.org/3/library/venv.html),
     [tutorial](https://docs.python.org/3/tutorial/venv.html)):
 
-    === "Linux and MacOS"
+    === "Linux"
+
+        ``` shell
+        python -m venv .venv
+        source .venv/bin/activate
+        ```
+
+    === "macOS"
 
         ``` shell
         python -m venv .venv

--- a/docs/website/docs/building-from-source/android.md
+++ b/docs/website/docs/building-from-source/android.md
@@ -53,7 +53,20 @@ cmake --build ../iree-build/ --target install
 
 Build the runtime using the Android NDK toolchain:
 
-=== "Linux and MacOS"
+=== "Linux"
+
+    ``` shell
+    cmake -GNinja -B ../iree-build-android/ \
+      -DCMAKE_TOOLCHAIN_FILE="${ANDROID_NDK?}/build/cmake/android.toolchain.cmake" \
+      -DIREE_HOST_BIN_DIR="$PWD/../iree-build/install/bin" \
+      -DANDROID_ABI="arm64-v8a" \
+      -DANDROID_PLATFORM="android-29" \
+      -DIREE_BUILD_COMPILER=OFF \
+      .
+    cmake --build ../iree-build-android/
+    ```
+
+=== "macOS"
 
     ``` shell
     cmake -GNinja -B ../iree-build-android/ \

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -74,7 +74,7 @@ Configure then build all targets using CMake:
 
 Configure CMake:
 
-=== "Linux and MacOS"
+=== "Linux"
 
     ``` shell
     # Recommended for simple development using clang and lld:
@@ -87,12 +87,21 @@ Configure CMake:
 
     # Alternately, with system compiler and your choice of CMake generator:
     # cmake -B ../iree-build/ -S .
+    ```
 
-    # Additional quality of life CMake flags:
-    # Enable ccache:
-    # See https://github.com/iree-org/iree/blob/main/docs/developers/developing_iree/ccache.md
-    #   -DCMAKE_C_COMPILER_LAUNCHER=ccache
-    #   -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+=== "macOS"
+
+    ``` shell
+    # Recommended for simple development using clang and lld:
+    cmake -GNinja -B ../iree-build/ -S . \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DIREE_ENABLE_ASSERTIONS=ON \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DIREE_ENABLE_LLD=ON
+
+    # Alternately, with system compiler and your choice of CMake generator:
+    # cmake -B ../iree-build/ -S .
     ```
 
 === "Windows"
@@ -109,7 +118,7 @@ Build:
 cmake --build ../iree-build/
 ```
 
-???+ Tip
+???+ Tip "Tip - Build types"
     We recommend using the `RelWithDebInfo` build type by default for a good
     balance of debugging information and performance. The `Debug`, `Release`,
     and `MinSizeRel` build types are useful in more specific scenarios.
@@ -117,6 +126,17 @@ cmake --build ../iree-build/
     available in `Debug` builds. See the
     [official CMake documentation](https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html)
     for general details.
+
+???+ Tip "Tip - Faster recompilation with ccache"
+    We recommend using [`ccache`](https://ccache.dev/) together with CMake. To
+    use it, configure CMake with:
+
+    ``` shell
+    -DCMAKE_C_COMPILER_LAUNCHER=ccache
+    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+    ```
+
+    See also our [developer documentation for ccache](https://github.com/iree-org/iree/blob/main/docs/developers/developing_iree/ccache.md).
 
 
 ## What's next?

--- a/docs/website/docs/building-from-source/python-bindings-and-importers.md
+++ b/docs/website/docs/building-from-source/python-bindings-and-importers.md
@@ -49,12 +49,12 @@ as through `venv`, which may need to be installed via your system
 package manager ([about](https://docs.python.org/3/library/venv.html),
 [tutorial](https://docs.python.org/3/tutorial/venv.html)):
 
-=== "Linux and MacOS"
+=== "Linux"
 
     ``` shell
     # Make sure your 'python' is what you expect. Note that on multi-python
-    # systems, this may have a version suffix, and on many Linuxes and MacOS where
-    # python2 and python3 co-exist, you may also want to use `python3`.
+    # systems, this may have a version suffix, and on many Linuxes where
+    # python2 and python3 can co-exist, you may also want to use `python3`.
     which python
     python --version
 
@@ -68,6 +68,30 @@ package manager ([about](https://docs.python.org/3/library/venv.html),
 
     # Upgrade PIP. On Linux, many packages cannot be installed for older
     # PIP versions. See: https://github.com/pypa/manylinux
+    python -m pip install --upgrade pip
+
+    # Install IREE build pre-requisites.
+    python -m pip install -r ./runtime/bindings/python/iree/runtime/build_requirements.txt
+    ```
+
+=== "macOS"
+
+    ``` shell
+    # Make sure your 'python' is what you expect. Note that on multi-python
+    # systems, this may have a version suffix, and on macOS where python2
+    # and python3 can co-exist, you may also want to use `python3`.
+    which python
+    python --version
+
+    # Create a persistent virtual environment (first time only).
+    python -m venv iree.venv
+
+    # Activate the virtual environment (per shell).
+    # Now the `python` command will resolve to your virtual environment
+    # (even on systems where you typically use `python3`).
+    source iree.venv/bin/activate
+
+    # Upgrade PIP.
     python -m pip install --upgrade pip
 
     # Install IREE build pre-requisites.
@@ -106,7 +130,24 @@ or running `deactivate`.
 
 From the `iree-build` directory:
 
-=== "Linux and MacOS"
+=== "Linux"
+
+    ``` shell
+    cmake \
+        -GNinja \
+        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+        -DIREE_BUILD_PYTHON_BINDINGS=ON \
+        -DPython3_EXECUTABLE="$(which python)" \
+        .
+    cmake --build .
+
+    # Add the bindings/python paths to PYTHONPATH and use the API.
+    source .env && export PYTHONPATH
+    python -c "import iree.compiler"
+    python -c "import iree.runtime"
+    ```
+
+=== "macOS"
 
     ``` shell
     cmake \

--- a/docs/website/mkdocs.yml
+++ b/docs/website/mkdocs.yml
@@ -27,6 +27,10 @@ theme:
 
     - navigation.indexes # section names can link to index.md pages
 
+    - content.code.annotate # Allow inline annotations
+    - content.code.copy # Enable copy button
+    - content.tabs.link # Link content tabs across site (e.g. Windows/Linux)
+
   palette:
     # Light mode
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#linked-content-tabs

Now clicking "Windows" on one page will update all content tabs across the website to default to "Windows" too. Note that labels must match exactly, so I've also split apart all of our "Linux and MacOS" content sections to "Linux" and "macOS".