### PR TITLE
Disable some linalg_ext_ops tests on Emscripten while failing.

### DIFF
--- a/tests/e2e/linalg_ext_ops/BUILD
+++ b/tests/e2e/linalg_ext_ops/BUILD
@@ -84,7 +84,7 @@ iree_check_single_backend_test_suite(
 
 iree_cmake_extra_content(
     content = """
-# Failing on Emscripten: https://github.com/iree-org/iree/pull/12041#discussion_r1101777536
+# Failing on Emscripten: https://github.com/iree-org/iree/issues/12129
 if(NOT EMSCRIPTEN)
 """,
     inline = True,

--- a/tests/e2e/linalg_ext_ops/BUILD
+++ b/tests/e2e/linalg_ext_ops/BUILD
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("//build_tools/bazel:build_defs.oss.bzl", "iree_cmake_extra_content")
 load("//build_tools/bazel:enforce_glob.bzl", "enforce_glob")
 load("//build_tools/bazel:iree_check_test.bzl", "iree_check_single_backend_test_suite")
 
@@ -81,6 +82,14 @@ iree_check_single_backend_test_suite(
     target_backend = "cuda",
 )
 
+iree_cmake_extra_content(
+    content = """
+# Failing on Emscripten: https://github.com/iree-org/iree/pull/12041#discussion_r1101777536
+if(NOT EMSCRIPTEN)
+""",
+    inline = True,
+)
+
 iree_check_single_backend_test_suite(
     name = "check_llvm-cpu_local-task",
     srcs = enforce_glob(
@@ -102,6 +111,13 @@ iree_check_single_backend_test_suite(
     ),
     driver = "local-task",
     target_backend = "llvm-cpu",
+)
+
+iree_cmake_extra_content(
+    content = """
+endif()
+""",
+    inline = True,
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -71,6 +71,9 @@ iree_check_single_backend_test_suite(
     "requires-gpu-nvidia"
 )
 
+# Failing on Emscripten: https://github.com/iree-org/iree/pull/12041#discussion_r1101777536
+if(NOT EMSCRIPTEN)
+
 iree_check_single_backend_test_suite(
   NAME
     check_llvm-cpu_local-task
@@ -91,6 +94,8 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-task"
 )
+
+endif()
 
 iree_check_single_backend_test_suite(
   NAME

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -71,7 +71,7 @@ iree_check_single_backend_test_suite(
     "requires-gpu-nvidia"
 )
 
-# Failing on Emscripten: https://github.com/iree-org/iree/pull/12041#discussion_r1101777536
+# Failing on Emscripten: https://github.com/iree-org/iree/issues/12129
 if(NOT EMSCRIPTEN)
 
 iree_check_single_backend_test_suite(


### PR DESCRIPTION
Least-hacky way I could think of to disable building the `iree_tests_e2e_linalg_ext_ops_check_llvm-cpu_local-task_attention.mlir` target on Emscripten while we work on a fix.

See https://github.com/iree-org/iree/pull/12041#discussion_r1101777536 and https://github.com/iree-org/iree/actions/runs/4130706149/jobs/7137719751

```
[14/350] Generating check_llvm-cpu_local-task_attention.mlir_module.vmfb from attention.mlir
FAILED: tests/e2e/linalg_ext_ops/check_llvm-cpu_local-task_attention.mlir_module.vmfb /work/build-emscripten/tests/e2e/linalg_ext_ops/check_llvm-cpu_local-task_attention.mlir_module.vmfb 
cd /work/build-emscripten/tests/e2e/linalg_ext_ops && /work/full-build-dir/install/bin/iree-compile --output-format=vm-bytecode --mlir-print-op-on-diagnostic=false --iree-hal-target-backends=llvm-cpu /work/tests/e2e/linalg_ext_ops/attention.mlir -o check_llvm-cpu_local-task_attention.mlir_module.vmfb --iree-hal-executable-object-search-path=\"/work/build-emscripten\" --iree-llvm-target-triple=wasm32-unknown-emscripten
/work/tests/e2e/linalg_ext_ops/attention.mlir:6:8: error: 'linalg.generic' op inferred input/output operand #3 has shape's dimension #0 to be 2, but found 4
  %1 = iree_linalg_ext.attention ins(%query, %key, %value : tensor<1x4x4xf32>,
       ^
```

https://github.com/iree-org/iree/pull/12081 will run the Emscripten CI on presubmit to catch errors like this sooner.