### PR TITLE
Don't enable ccache when building for Emscripten.

### DIFF
--- a/build_tools/cmake/build_runtime_emscripten.sh
+++ b/build_tools/cmake/build_runtime_emscripten.sh
@@ -25,7 +25,8 @@ BUILD_DIR="build-emscripten"
 IREE_HOST_BIN_DIR="$(realpath ${IREE_HOST_BIN_DIR})"
 
 source build_tools/cmake/setup_build.sh
-source build_tools/cmake/setup_ccache.sh
+# Note: not using ccache since this is fast enough on its own, and ccache +
+# Emscripten is unstable (it supposedly works for some people, at least).
 
 cd "${BUILD_DIR}"
 
@@ -49,7 +50,3 @@ echo "------------------------"
 echo "Building test deps"
 echo "------------------"
 "${CMAKE_BIN?}" --build . --target iree-test-deps -- -k 0
-
-if (( IREE_USE_CCACHE == 1 )); then
-  ccache --show-stats
-fi


### PR DESCRIPTION
Our runtime build is fast enough, and ccache just... doesn't work on my Windows machine with Emscripten:

```
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - not found
-- Check if compiler accepts -pthread
-- Check if compiler accepts -pthread - no
-- Could NOT find Threads (missing: Threads_FOUND)
-- Could NOT find Threads (missing: Threads_FOUND)
-- git version: v1.7.1-4-gda652a74 normalized to 1.7.1.4
-- Version: 1.7.1.4
-- Looking for shm_open in rt
-- Looking for shm_open in rt - not found
-- Performing Test HAVE_CXX_FLAG_WALL
-- Performing Test HAVE_CXX_FLAG_WALL - Failed
-- Performing Test HAVE_CXX_FLAG_WEXTRA
-- Performing Test HAVE_CXX_FLAG_WEXTRA - Failed
-- Performing Test HAVE_CXX_FLAG_WSHADOW
-- Performing Test HAVE_CXX_FLAG_WSHADOW - Failed
```