### PR TITLE
Allow contolling the default workgroup tile size for unpack op

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -74,7 +74,7 @@ static llvm::cl::opt<int> defaultWorkgroupTileSizeForUnpackOp(
     "iree-codegen-llvm-generic-ops-workgroup-size-for-unpack-op",
     llvm::cl::desc("Like iree-codegen-llvm-generic-ops-workgroup-size but "
                    "specifically for UnpackOp"),
-    llvm::cl::init(64));
+    llvm::cl::init(16));
 
 // TODO(hanchung): Remove the flag. This is the flag for fastly falling back to
 // the previous snapshot.

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -69,6 +69,13 @@ static llvm::cl::opt<int> defaultWorkgroupTileSize(
         "linalg.generic and linalg.indexed_generic workgroup tile size"),
     llvm::cl::init(64));
 
+// TODO(#12135): remove defaultWorkgroupTileSizeForUnpackOp
+static llvm::cl::opt<int> defaultWorkgroupTileSizeForUnpackOp(
+    "iree-codegen-llvm-generic-ops-workgroup-size-for-unpack-op",
+    llvm::cl::desc("Like iree-codegen-llvm-generic-ops-workgroup-size but "
+                   "specifically for UnpackOp"),
+    llvm::cl::init(64));
+
 // TODO(hanchung): Remove the flag. This is the flag for fastly falling back to
 // the previous snapshot.
 
@@ -1101,8 +1108,8 @@ static LogicalResult setRootConfig(
         DispatchLoweringPassPipeline::CPUDataTiling) {
   // TODO(#11505): Consider multi-level tiling for handling unpack + generic
   // cases.
-  SmallVector<int64_t> tileSizes =
-      getLinalgExtDefaultWorkgroupTileSizes(op, /*defaultSize=*/16);
+  SmallVector<int64_t> tileSizes = getLinalgExtDefaultWorkgroupTileSizes(
+      op, /*defaultSize=*/defaultWorkgroupTileSizeForUnpackOp);
 
   // Fixup for making tileSizes be multiple of inner_tile_sizes.
   SmallVector<int64_t> innerTiles = op.getStaticTiles();


### PR DESCRIPTION
The value 16 here didn't work well. It's in destination space, so for e.g. a 8x8 tile size, the default 16x16 means unpacking only a tiny 2x2x8x8 tile, not enough to reach high performance in a ukernel. Just the generic `defaultWorkgroupTileSize` used for other ops, with its default value 64, gives me a large speedup by default and allows me to tune this more easily along with the rest.