### PR TITLE
Remove references to older planning systems from "Roadmap" section.

### DIFF
--- a/docs/website/docs/index.md
+++ b/docs/website/docs/index.md
@@ -149,19 +149,10 @@ IREE offers a low level C API, as well as several specialized sets of
 ## Roadmap
 
 IREE is in the early stages of development and is not yet ready for broad
-adoption. Check out the
-[long-term design roadmap](https://github.com/iree-org/iree/blob/main/docs/developers/design_roadmap.md)
-to get a sense of where we're headed.
-
-We plan on a quarterly basis using [OKRs](https://en.wikipedia.org/wiki/OKR).
-Review our latest
-[objectives](https://github.com/iree-org/iree/blob/main/docs/developers/objectives.md)
-to see what we're up to.
-
-We use [GitHub Projects](https://github.com/iree-org/iree/projects) to track
-progress on IREE components and specific efforts and
-[GitHub Milestones](https://github.com/iree-org/iree/milestones) to track the
-work associated with plans for each quarter.
+adoption. We use both
+[GitHub Projects](https://github.com/iree-org/iree/projects) and
+[GitHub Milestones](https://github.com/iree-org/iree/milestones) to track
+progress.
 
 [^1]:
   Pronounced "eerie" and often styled with the :iree-ghost: emoji


### PR DESCRIPTION
These pages are out of date:
* https://github.com/iree-org/iree/blob/main/docs/developers/design_roadmap.md
* https://github.com/iree-org/iree/blob/main/docs/developers/objectives.md

so I tweaked the phrasing to mention just GitHub Projects and GitHub Milestones. I also edited the primary project (https://github.com/orgs/iree-org/projects/1) so the "all" tab is the default instead of `@me` (so non-project members see _something_ when they click through).

---

We're also likely going to tweak our planning process over the coming weeks/months along with the OpenXLA organization move ([announcement here](https://groups.google.com/g/iree-discuss/c/nyKwVGXJf6U/m/xTsqxef1EQAJ)).

---

I'm not sure when we'll want to adjust the wording from
> IREE is in the early stages of development and is not yet ready for broad adoption.

on the website, or from

> IREE is still in its early phase. We have settled down on the overarching infrastructure and are actively improving various software components as well as project logistics. It is still quite far from ready for everyday use and is made available without any support at the moment.

in the project README.