### PR TITLE
Expose unroll vector for gpu mma ops to the transform.apply_patterns …

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -14,6 +14,7 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/Interfaces/BufferizationInterfaces.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Codegen/Utils/Utils.h"
 #include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALOps.h"
@@ -86,6 +87,7 @@ void transform_dialect::ApplyPatternsOp::build(
   ADD_PATTERN(swapPaddingElideConditional,
               getSwapPaddingElideConditionalAttrName)
   ADD_PATTERN(swappingPatterns, getSwappingPatternsAttrName)
+  ADD_PATTERN(unrollVectorsGpuMma, getUnrollVectorsGpuMmaAttrName)
 #undef ADD_PATTERN
   result.addTypes({pdl::OperationType::get(ctx)});
 }
@@ -202,6 +204,23 @@ static void addSwappingPatterns(RewritePatternSet &patterns,
       });
 }
 
+static Optional<SmallVector<int64_t>> getGPUTensorCoreNativeVectorSize(
+    Operation *op) {
+  return getWmmaNativeVectorSize(op);
+}
+
+static void addUnrollVectorsGpuMmaPatterns(RewritePatternSet &patterns) {
+  auto unrollOrder = [](Operation *op) -> Optional<SmallVector<int64_t>> {
+    auto contract = dyn_cast<vector::ContractionOp>(op);
+    if (!contract) return std::nullopt;
+    return mlir::iree_compiler::gpuMmaUnrollOrder(contract);
+  };
+  vector::populateVectorUnrollPatterns(
+      patterns, vector::UnrollVectorOptions()
+                    .setNativeShapeFn(getGPUTensorCoreNativeVectorSize)
+                    .setUnrollTraversalOrderFn(unrollOrder));
+}
+
 static void addAdditionalIreePatterns(RewritePatternSet &patterns) {
   patterns.add<GenerateToConstant>(patterns.getContext());
 }
@@ -246,6 +265,7 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
     linalg::populateFoldReshapeOpsByExpansionPatterns(
         patterns, [](OpOperand *) { return true; });
   }
+  if (getUnrollVectorsGpuMma()) addUnrollVectorsGpuMmaPatterns(patterns);
 
   TrackingListener listener(state);
   GreedyRewriteConfig config;
@@ -770,12 +790,22 @@ transform_dialect::TileToForeachThreadAndWorkgroupCountRegionOp::apply(
     transform::TransformResults &transformResults,
     transform::TransformState &state) {
   ArrayRef<Operation *> targetOps = state.getPayloadOps(getTarget());
-  assert(targetOps.size() == 1 && "expected single target op in payload");
+  if (targetOps.empty()) {
+    transformResults.set(getForeachThreadOp().cast<OpResult>(), {});
+    transformResults.set(getTiledOp().cast<OpResult>(), {});
+    return DiagnosedSilenceableFailure::success();
+  }
+  if (targetOps.size() != 1) {
+    return mlir::emitDefiniteFailure(
+               state.getTopLevel(),
+               "expected single target op in payload, got: ")
+           << targetOps.size();
+  }
   auto funcOp = targetOps.front()->getParentOfType<func::FuncOp>();
   FailureOr<IREE::HAL::ExecutableExportOp> exportOp = getEntryPoint(funcOp);
   if (failed(exportOp)) {
-    return mlir::emitDefiniteFailure(
-        state.getTopLevel(), "couldn't find top level HAL export op for func");
+    return mlir::emitDefiniteFailure(state.getTopLevel(),
+                                     "couldn't find export op for func");
   }
 
   /// Lower the workgroup count region in keeping with the way dispatch

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -50,6 +50,7 @@ struct ApplyPatternsOpPatterns {
   bool rewritePackOps = false;
   bool swapPaddingElideConditional = false;
   bool swappingPatterns = false;
+  bool unrollVectorsGpuMma = false;
 };
 }  // namespace transform_dialect
 }  // namespace IREE

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -68,8 +68,10 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
       tensor.extract_slice swapping pattern. This injects static information
       that guarantees padding is smaller than the window size which guarantees
       we never see a tile comprised of padding-only.
-      This allows dropping the generation or an annoying internal scf.if but may
-      yield incorrect code in pathological cases.
+      - unroll_vectors_gpu_mma: adds patterns that unroll vectors to a native tile
+      size for GPUs with mma operations. The size is currently hardcoded but 
+      should be refactored upstream and made pluggable.
+
 
     #### Return modes:
 
@@ -98,7 +100,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
                        UnitAttr:$rank_reducing_vector,
                        UnitAttr:$rewrite_pack_ops,
                        UnitAttr:$swap_padding_elide_conditional,
-                       UnitAttr:$swapping_patterns);
+                       UnitAttr:$swapping_patterns,
+                       UnitAttr:$unroll_vectors_gpu_mma);
   let results = (outs PDL_Operation:$result);
 
   let assemblyFormat = "$target attr-dict";

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUTensorCoreVectorization.cpp
@@ -46,38 +46,6 @@ static void populateVectorizationPatterns(RewritePatternSet &patterns) {
   vector::populateVectorReductionToContractPatterns(patterns);
 }
 
-static Optional<SmallVector<int64_t>> unrollOrder(Operation *op) {
-  auto contract = dyn_cast<vector::ContractionOp>(op);
-  if (!contract) return std::nullopt;
-  SmallVector<int64_t> order;
-  // Pick an unrolling order that will allow tensorcore operation to reuse LHS
-  // register. This is needed to get good performance on sm_80 target.
-  // First make reduction the outer dimensions.
-  for (auto [index, iter] : llvm::enumerate(contract.getIteratorTypes())) {
-    if (vector::isReductionIterator(iter)) {
-      order.push_back(index);
-    }
-  }
-
-  llvm::SmallDenseSet<int64_t> dims;
-  for (AffineExpr expr : contract.getIndexingMapsArray()[0].getResults()) {
-    dims.insert(expr.cast<AffineDimExpr>().getPosition());
-  }
-  // Then parallel dimensions that are part of Lhs as we want to re-use Lhs.
-  for (auto [index, iter] : llvm::enumerate(contract.getIteratorTypes())) {
-    if (vector::isParallelIterator(iter) && dims.count(index)) {
-      order.push_back(index);
-    }
-  }
-  // Then the remaining parallel loops.
-  for (auto [index, iter] : llvm::enumerate(contract.getIteratorTypes())) {
-    if (vector::isParallelIterator(iter) && !dims.count(index)) {
-      order.push_back(index);
-    }
-  }
-  return order;
-}
-
 /// Returns vector::ContractionOp operand's index where the result is used.
 static Optional<int> getVectorContractOpOperandId(
     vector::ContractionOp contractOp, OpResult result) {
@@ -230,6 +198,11 @@ static Optional<SmallVector<int64_t>> getGPUTensorCoreNativeVectorSize(
 }
 
 static void populateVectorUnrollPatterns(RewritePatternSet &patterns) {
+  auto unrollOrder = [](Operation *op) -> Optional<SmallVector<int64_t>> {
+    auto contract = dyn_cast<vector::ContractionOp>(op);
+    if (!contract) return std::nullopt;
+    return gpuMmaUnrollOrder(contract);
+  };
   vector::populateVectorUnrollPatterns(
       patterns, vector::UnrollVectorOptions()
                     .setNativeShapeFn(getGPUTensorCoreNativeVectorSize)

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -112,6 +112,37 @@ bool canPerformVectorAccessUsingAllThreads(ArrayRef<int64_t> shape,
   return threadsAvailable == 1;
 }
 
+/// Pick an unrolling order that will allow tensorcore operation to reuse LHS
+/// register. This is needed to get good performance on sm_80 target.
+Optional<SmallVector<int64_t>> gpuMmaUnrollOrder(
+    vector::ContractionOp contract) {
+  SmallVector<int64_t> order;
+  // First make reduction the outer dimensions.
+  for (auto [index, iter] : llvm::enumerate(contract.getIteratorTypes())) {
+    if (vector::isReductionIterator(iter)) {
+      order.push_back(index);
+    }
+  }
+
+  llvm::SmallDenseSet<int64_t> dims;
+  for (AffineExpr expr : contract.getIndexingMapsArray()[0].getResults()) {
+    dims.insert(expr.cast<AffineDimExpr>().getPosition());
+  }
+  // Then parallel dimensions that are part of Lhs as we want to re-use Lhs.
+  for (auto [index, iter] : llvm::enumerate(contract.getIteratorTypes())) {
+    if (vector::isParallelIterator(iter) && dims.count(index)) {
+      order.push_back(index);
+    }
+  }
+  // Then the remaining parallel loops.
+  for (auto [index, iter] : llvm::enumerate(contract.getIteratorTypes())) {
+    if (vector::isParallelIterator(iter) && !dims.count(index)) {
+      order.push_back(index);
+    }
+  }
+  return order;
+}
+
 //===----------------------------------------------------------------------===//
 // GPU workgroup memory
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -48,6 +48,11 @@ bool canPerformVectorAccessUsingAllThreads(ArrayRef<int64_t> shape,
                                            int64_t threadCount,
                                            int64_t vectorSize);
 
+/// Pick an unrolling order that will allow tensorcore operation to reuse LHS
+/// register. This is needed to get good performance on sm_80 target.
+Optional<SmallVector<int64_t>> gpuMmaUnrollOrder(
+    vector::ContractionOp contract);
+
 //===----------------------------------------------------------------------===//
 // GPU workgroup memory
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
…op (#12138)

This PR allows the functionality that unrolls vectors to a mma native size to be called from the transform dialect.