### PR TITLE
Introduce MatcherContext so user no longer holds matchers

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/set_transform_strategy.mlir
@@ -228,10 +228,10 @@ hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb",
 //   CHECK-LABEL: func.func @group_reduction_12345
 //         CHECK:   transform.structured.canonicalized_sequence failures(propagate)
 //         CHECK:   transform.iree.tile_to_foreach_thread_and_workgroup_count_region %{{.*}} num_threads [] tile_sizes [1](mapping = [#gpu.block<x>])
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [0, 1024] tile_sizes [](mapping = [#gpu.thread<x>])
-//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [0, 1024] tile_sizes [](mapping = [#gpu.thread<x>])
 //         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [] tile_sizes [1](mapping = [#gpu.thread<y>])
 //         CHECK:   transform.structured.split %{{.*}} after 8192  {dimension = 1 : i64}
 //         CHECK:   transform.structured.tile %{{.*}}[0, 8192]
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [0, 1024] tile_sizes [](mapping = [#gpu.thread<x>])
+//         CHECK:   transform.structured.tile_to_foreach_thread_op %{{.*}}   num_threads [0, 1024] tile_sizes [](mapping = [#gpu.thread<x>])
 //         CHECK:   transform.iree.map_nested_foreach_thread_to_gpu_threads %{{.*}} {workgroup_size = [1024, 1, 1]}
 //         CHECK:   transform.iree.vector.to_warp_execute_on_lane_0{{.*}}{warp_size = 1024 : i64}

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/CPU/Common.cpp
@@ -101,10 +101,11 @@ static ReductionConfig getReductionConfig(
 LogicalResult iree_compiler::cpu::matchAndSetReductionStrategy(
     func::FuncOp entryPoint, linalg::LinalgOp op, const CPUModel &cpuModel) {
   // 1. Match a reduction and surrounding ops.
-  StructuredOpMatcher reduction, fill, leading, trailing;
+  StructuredOpMatcher *reduction;
   transform_ext::MatchedReductionCaptures captures;
-  makeReductionMatcher(reduction, fill, leading, trailing, captures);
-  if (!matchPattern(op, reduction)) return failure();
+  transform_ext::MatcherContext matcherContext;
+  makeReductionMatcher(matcherContext, reduction, captures);
+  if (!matchPattern(op, *reduction)) return failure();
 
   // 2. Construct the configuration and the strategy builder.
   // TODO: Generalize along the HW axis.

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/GPU/Common.cpp
@@ -385,10 +385,11 @@ static ReductionConfig getReductionConfig(
 LogicalResult mlir::iree_compiler::gpu::matchAndSetReductionStrategy(
     func::FuncOp entryPoint, linalg::LinalgOp op, const GPUModel &gpuModel) {
   // 1. Match a reduction and surrounding ops.
-  StructuredOpMatcher reduction, fill, leading, trailing;
+  StructuredOpMatcher *reduction;
   transform_ext::MatchedReductionCaptures captures;
-  makeReductionMatcher(reduction, fill, leading, trailing, captures);
-  if (!matchPattern(op, reduction)) return failure();
+  transform_ext::MatcherContext matcherContext;
+  makeReductionMatcher(matcherContext, reduction, captures);
+  if (!matchPattern(op, *reduction)) return failure();
 
   // 2. Construct the configuration and the strategy builder.
   // TODO: Generalize along the HW axis.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/RaiseSpecialOps.cpp
@@ -36,24 +36,12 @@ struct RaiseSpecialOpsPass : public RaiseSpecialOpsBase<RaiseSpecialOpsPass> {
     SmallVector<std::pair<linalg::LinalgOp, Value>> softmaxRoots;
     getOperation()->walk([&](linalg::LinalgOp op) {
       {
-        transform_ext::StructuredOpMatcher fillMinusInf;
-        transform_ext::StructuredOpMatcher maxReduction;
-        transform_ext::StructuredOpMatcher maybeBroadcastMax;
-        transform_ext::StructuredOpMatcher sub;
-        transform_ext::StructuredOpMatcher broadcastedSub;
-        transform_ext::StructuredOpMatcher expOperand;
-        transform_ext::StructuredOpMatcher fillzero;
-        transform_ext::StructuredOpMatcher sum;
-        transform_ext::StructuredOpMatcher maybeBroadcastSum;
-        transform_ext::StructuredOpMatcher rcpOperand;
-        transform_ext::StructuredOpMatcher matmulOperand;
-        transform_ext::StructuredOpMatcher divOperand;
-        transform_ext::StructuredOpMatcher softmaxroot;
-        makeSoftmaxMatcher(fillMinusInf, maxReduction, sub, expOperand,
-                           fillzero, sum, rcpOperand, matmulOperand, divOperand,
-                           softmaxroot);
-        if (matchPattern(op, softmaxroot)) {
-          Value src = maxReduction.getCaptured()->getOperand(0);
+        transform_ext::MatcherContext matcherContext;
+        transform_ext::StructuredOpMatcher *maxReduction;
+        transform_ext::StructuredOpMatcher *softmaxroot;
+        makeSoftmaxMatcher(matcherContext, maxReduction, softmaxroot);
+        if (matchPattern(op, *softmaxroot)) {
+          Value src = maxReduction->getCaptured()->getOperand(0);
           softmaxRoots.push_back(std::make_pair(op, src));
         }
       }


### PR DESCRIPTION
When matching complex subgraphs, the caller often doesn't care about all intermediate nodes (operations) in the graph and shouldn't need to hold matcher objects for those. These matchers can be created in this context.