### PR TITLE
Adapt MaterializaeEncoding2 pass to use tensor.pack/unpack ops.

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.h
@@ -130,9 +130,15 @@ void populateMaterializeEncodingPatterns(
     MaterializeEncodingConversionTarget &conversionTarget,
     MaterializeEncodingTypeConverter &typeConverter,
     MaterializeEncodingValueFn materializeEncodingValueFn = {});
+void populateMaterializeEncodingPatterns2(
+    RewritePatternSet &patterns,
+    MaterializeEncodingConversionTarget &conversionTarget,
+    MaterializeEncodingTypeConverter &typeConverter,
+    MaterializeEncodingValueFn materializeEncodingValueFn = {});
 
 /// Pass to apply patterns specified by `populateMaterializeEncodingPass`.
 std::unique_ptr<OperationPass<func::FuncOp>> createMaterializeEncodingPass();
+std::unique_ptr<OperationPass<func::FuncOp>> createMaterializeEncodingPass2();
 
 /// Patterns to fold operations like `tensor.pad` and `tensor.extract_slice`
 /// into `linalg_ext.pack` and `linalg_ext.unpack` operations respectively.

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgExt/Passes/Passes.td
@@ -27,6 +27,13 @@ def MaterializeEncoding :
   let constructor = "mlir::iree_compiler::IREE::LinalgExt::createMaterializeEncodingPass()";
 }
 
+def MaterializeEncoding2 :
+    Pass<"iree-linalg-ext-materialize-encoding2", "func::FuncOp"> {
+  let summary = "Test pass to materialize ops with tensor encoding into ops with explicit data movement";
+  let constructor =
+  "mlir::iree_compiler::IREE::LinalgExt::createMaterializeEncodingPass2()";
+}
+
 def FoldIntoPackAndUnpackOps :
     Pass<"iree-linalg-ext-fold-into-pack-unpack-ops", "func::FuncOp"> {
   let summary = "Test pass to fold operations into pack and unpacl operations";

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/CMakeLists.txt
@@ -4,6 +4,7 @@ add_mlir_library(IREELinalgExtPasses
   DecomposeSoftmax.cpp
   FoldIntoPackAndUnpackOps.cpp
   MaterializeEncoding.cpp
+  MaterializeEncoding2.cpp
   PadContractionToBlockSize.cpp
   Passes.cpp
   SplitReduction.cpp

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding2.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/MaterializeEncoding2.cpp
@@ -1,0 +1,448 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree-dialects/Dialect/LinalgExt/IR/LinalgExtOps.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/PassDetail.h"
+#include "iree-dialects/Dialect/LinalgExt/Passes/Passes.h"
+#include "iree-dialects/Dialect/LinalgExt/Utils/Utils.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/MemRef/Transforms/Passes.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/Transforms/DialectConversion.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+using namespace mlir;
+using namespace mlir::iree_compiler;
+using namespace mlir::iree_compiler::IREE::LinalgExt;
+
+//===---------------------------------------------------------------------===//
+// Utility methods
+//===---------------------------------------------------------------------===//
+
+/// Extract encoding from the `tensorType` if specified.
+static Optional<TensorEncoding> getEncoding(RankedTensorType tensorType) {
+  auto encodingAttr = tensorType.getEncoding().dyn_cast_or_null<EncodingAttr>();
+  if (!encodingAttr)
+    return std::nullopt;
+  return encodingAttr.getEncoding().getValue();
+}
+
+/// For a given tensor type with an encoding, return the materialized
+/// type to use for it. If no encoding is set, then return the tensor type
+/// itself.
+static RankedTensorType
+getMaterializedType(RankedTensorType tensorType,
+                    MaterializeEncodingFn materializeEncodingFn) {
+  Optional<TensorEncoding> encoding = getEncoding(tensorType);
+  if (!encoding)
+    return tensorType;
+  FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
+      materializeEncodingFn(tensorType);
+  if (failed(materializeEncodingInfo)) {
+    return tensorType;
+  }
+  return tensor::PackOp::inferPackedType(
+             tensorType, materializeEncodingInfo->innerTileSizes,
+             materializeEncodingInfo->innerDimsPos,
+             materializeEncodingInfo->outerDimsPerm)
+      .cast<RankedTensorType>();
+}
+
+//===---------------------------------------------------------------------===//
+// Methods to convert the encoding to parameters of the Pack operation
+//===---------------------------------------------------------------------===//
+
+/// Given the `encoding` return the `MaterializeEncodingInfo` to use for
+/// materializing the pack op.
+// TODO(ravishankarm): This is currently hard-coded here for convenience. When
+// used in IREE, this will be computed based on the architecture information in
+// `hal.executable.variant`.
+// A real implementation would return tile sizes that depend on at least the
+// `tensorType`'s element type (e.g. different tile sizes for i8 vs f32, because
+// the SIMD instructions may have different shapes).
+// Moreover, in a real implementation, the tile sizes would typically also
+// depend on target information. This is demonstrated in
+// iree/compiler/src/iree/compiler/Codegen/Common/MaterializeEncodingPass.cpp
+static FailureOr<MaterializeEncodingInfo>
+chooseEncodingInfo(RankedTensorType tensorType) {
+  Optional<TensorEncoding> encoding = getEncoding(tensorType);
+  if (!encoding)
+    return failure();
+  switch (*encoding) {
+  case TensorEncoding::MATMUL_F32F32F32_LHS:
+  case TensorEncoding::MATMUL_I8I8I32_LHS:
+    return MaterializeEncodingInfo{{0, 1}, {8, 4}, {}};
+    break;
+  case TensorEncoding::MATMUL_F32F32F32_RHS:
+  case TensorEncoding::MATMUL_I8I8I32_RHS:
+    return MaterializeEncodingInfo{{0, 1}, {4, 8}, {}};
+    break;
+  case TensorEncoding::MATMUL_F32F32F32_RHS_TRANSPOSE:
+  case TensorEncoding::MATMUL_I8I8I32_RHS_TRANSPOSE:
+    return MaterializeEncodingInfo{{1, 0}, {8, 4}, {1, 0}};
+    break;
+  case TensorEncoding::MATMUL_F32F32F32_RESULT:
+  case TensorEncoding::MATMUL_I8I8I32_RESULT:
+    return MaterializeEncodingInfo{{0, 1}, {8, 8}, {}};
+    break;
+  default:
+    return failure();
+  }
+}
+
+//===---------------------------------------------------------------------===//
+// Methods to convert `set_encoding` and `unset_encoding` operations
+// to `pack` and `unpack` operations respectively.
+//===---------------------------------------------------------------------===//
+
+/// Utility method to get the optional padding value to use with pack operation
+/// if source is defined using a `tensor.pad` operation. Note `source` is
+/// passed by reference. It is updated to use the source of the pad operation.
+static Optional<Value> getPaddingValue(Value &source) {
+  auto padOp = source.getDefiningOp<tensor::PadOp>();
+  if (!padOp || padOp.getNofold() || !padOp.hasZeroLowPad())
+    return std::nullopt;
+
+  Value constantPaddingValue = padOp.getConstantPaddingValue();
+  if (!constantPaddingValue)
+    return std::nullopt;
+
+  source = padOp.getSource();
+  return constantPaddingValue;
+}
+
+/// Utility method to convert from `set_encoding` op to `pack` operation.
+/// For now this takes a `paddingValue` as input. The source is also taken
+/// as input so that these could be used with `OpConversionPatterns`.
+static FailureOr<tensor::PackOp> lowerSetEncodingOpToPackOp(
+    RewriterBase &rewriter, SetEncodingOp encodingOp, Value source,
+    MaterializeEncodingFn materializeEncodingFn,
+    MaterializeEncodingValueFn materializeEncodingValueFn) {
+  RankedTensorType resultType = encodingOp.getResultType();
+  FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
+      materializeEncodingFn(resultType);
+  if (failed(materializeEncodingInfo)) {
+    return rewriter.notifyMatchFailure(encodingOp, "unhandled result encoding");
+  }
+  // Create `tensor.empty` operation for the result of the pack operation.
+  Location loc = encodingOp.getLoc();
+  SmallVector<OpFoldResult> sourceDims = getDims(rewriter, loc, source);
+  FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr =
+      getInnerTileSizesOfr(rewriter, loc, resultType, *materializeEncodingInfo,
+                           materializeEncodingValueFn);
+  if (failed(innerTileSizesOfr)) {
+    return rewriter.notifyMatchFailure(
+        encodingOp, "failed to generate runtime tile size query");
+  }
+  Optional<TensorEncoding> encoding = getEncoding(resultType);
+  if (!encoding)
+    return failure();
+  SmallVector<OpFoldResult> resultDims = tensor::PackOp::getResultShape(
+      rewriter, loc, sourceDims, *innerTileSizesOfr,
+      materializeEncodingInfo->innerDimsPos,
+      materializeEncodingInfo->outerDimsPerm);
+  auto initTensor = rewriter.create<tensor::EmptyOp>(
+      loc, resultDims, resultType.getElementType());
+  Optional<Value> paddingValue = getPaddingValue(source);
+  auto packOp = rewriter.create<tensor::PackOp>(
+      loc, source, initTensor, materializeEncodingInfo->innerDimsPos,
+      *innerTileSizesOfr, paddingValue, materializeEncodingInfo->outerDimsPerm);
+  // As we rewrite the SetEncoding and its old result tensor, which used to hold
+  // the TensorEncodingAttr, into a pack op with a new result tensor which does
+  // not have a TensorEncodingAttr, we lose the information that used to be
+  // stored in that attr. That shouldn't matter, as the purpose of that attr
+  // was to enable exactly this rewrite, but there is a catch: at the moment,
+  // in IREE's TileAndDistributeToWorkgroupsPass.cpp, we need the encoding value
+  // again. See the comment there. So we re-add the attribute on the pack op
+  // itself as a temporary work-around.
+  packOp->setAttr(StringAttr::get(rewriter.getContext(), "encoding"),
+                  EncodingAttr::get(rewriter.getContext(), *encoding));
+  return packOp;
+}
+
+/// Utility method to convert from `set_encoding` op to `pack` operation.
+/// The source is taken as input so that these could be used with
+/// `OpConversionPatterns`.
+static FailureOr<tensor::UnPackOp> lowerUnsetEncodingToUnpackOp(
+    RewriterBase &rewriter, UnsetEncodingOp encodingOp, Value packedValue,
+    MaterializeEncodingFn materializeEncodingFn,
+    MaterializeEncodingValueFn materializeEncodingValueFn) {
+  RankedTensorType sourceType = encodingOp.getSourceType();
+  FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
+      materializeEncodingFn(sourceType);
+  if (failed(materializeEncodingInfo)) {
+    return rewriter.notifyMatchFailure(encodingOp, "unhandled source encoding");
+  }
+  // Create an `tensor.empty` for the result of the unpack operation.
+  Location loc = encodingOp.getLoc();
+  SmallVector<OpFoldResult> resultDims =
+      getDims(rewriter, loc, encodingOp.getSource());
+  auto initTensor = rewriter.create<tensor::EmptyOp>(
+      loc, resultDims, sourceType.getElementType());
+  FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr =
+      getInnerTileSizesOfr(rewriter, loc, sourceType, *materializeEncodingInfo,
+                           materializeEncodingValueFn);
+  if (failed(innerTileSizesOfr)) {
+    return rewriter.notifyMatchFailure(
+        encodingOp, "failed to generate runtime tile size query");
+  }
+  return rewriter.create<tensor::UnPackOp>(
+      loc, packedValue, initTensor, materializeEncodingInfo->innerDimsPos,
+      *innerTileSizesOfr, materializeEncodingInfo->outerDimsPerm);
+}
+
+/// Utility method to convert from `linalg.matmul` with
+/// - lhs encoding of MATMUL_*_LHS
+/// - rhs encoding of MATMUL_*_RHS_TRANSPOSE
+/// - result encoding of MATMUL_*_RESULT
+/// to linalg.mmt4d op.
+static FailureOr<Operation *>
+lowerOpWithEncoding(RewriterBase &rewriter, linalg::MatmulOp matmulOp,
+                    ValueRange convertedInputOperands,
+                    ValueRange convertedOutputOperands, MaterializeEncodingFn,
+                    MaterializeEncodingValueFn) {
+  if (!matmulOp.hasTensorSemantics())
+    return failure();
+  auto inputs = matmulOp.getDpsInputOperands();
+  auto outputs = matmulOp.getDpsInitOperands();
+  Optional<TensorEncoding> lhsEncoding =
+      getEncoding(inputs[0]->get().getType().cast<RankedTensorType>());
+  Optional<TensorEncoding> rhsEncoding =
+      getEncoding(inputs[1]->get().getType().cast<RankedTensorType>());
+  Optional<TensorEncoding> resultEncoding =
+      getEncoding(outputs[0]->get().getType().cast<RankedTensorType>());
+  if (!lhsEncoding ||
+      (lhsEncoding.value() != TensorEncoding::MATMUL_F32F32F32_LHS &&
+       lhsEncoding.value() != TensorEncoding::MATMUL_I8I8I32_LHS) ||
+      !rhsEncoding ||
+      (rhsEncoding.value() != TensorEncoding::MATMUL_F32F32F32_RHS_TRANSPOSE &&
+       rhsEncoding.value() != TensorEncoding::MATMUL_I8I8I32_RHS_TRANSPOSE) ||
+      !resultEncoding ||
+      (resultEncoding.value() != TensorEncoding::MATMUL_F32F32F32_RESULT &&
+       resultEncoding.value() != TensorEncoding::MATMUL_I8I8I32_RESULT)) {
+    return failure();
+  }
+  Operation *mmt4DOp = rewriter.create<linalg::Mmt4DOp>(
+      matmulOp.getLoc(), convertedOutputOperands[0].getType(),
+      convertedInputOperands, convertedOutputOperands);
+  return mmt4DOp;
+}
+
+/// Utility method to convert from `linalg.fill` on `tensor` type with encoding
+/// to fill of the materialized type
+static FailureOr<Operation *>
+lowerOpWithEncoding(RewriterBase &rewriter, linalg::FillOp fillOp,
+                    ValueRange convertedInputOperands,
+                    ValueRange convertedOutputOperands, MaterializeEncodingFn,
+                    MaterializeEncodingValueFn) {
+  if (!fillOp.hasTensorSemantics())
+    return failure();
+  Operation *materializedFillOp = rewriter.create<linalg::FillOp>(
+      fillOp.getLoc(), convertedOutputOperands[0].getType(),
+      convertedInputOperands, convertedOutputOperands);
+  return materializedFillOp;
+}
+
+/// Utility method to convert `tensor.empty` with encoding to a `tensor.empty`
+/// of the materialized type.
+static FailureOr<Operation *>
+lowerOpWithEncoding(RewriterBase &rewriter, tensor::EmptyOp emptyOp,
+                    ValueRange convertedOperands,
+                    MaterializeEncodingFn materializeEncodingFn,
+                    MaterializeEncodingValueFn materializeEncodingValueFn) {
+  auto result = emptyOp.getResult();
+  auto resultType = result.getType().cast<RankedTensorType>();
+  FailureOr<MaterializeEncodingInfo> materializeEncodingInfo =
+      materializeEncodingFn(resultType);
+  if (failed(materializeEncodingInfo)) {
+    return rewriter.notifyMatchFailure(emptyOp, "unhandled result encoding");
+  }
+  Location loc = emptyOp.getLoc();
+  FailureOr<SmallVector<OpFoldResult>> innerTileSizesOfr =
+      getInnerTileSizesOfr(rewriter, loc, resultType, *materializeEncodingInfo,
+                           materializeEncodingValueFn);
+  if (failed(innerTileSizesOfr)) {
+    return rewriter.notifyMatchFailure(
+        emptyOp, "failed to generate runtime tile size query");
+  }
+  SmallVector<OpFoldResult> newShape = tensor::PackOp::getResultShape(
+      rewriter, loc, emptyOp.getMixedSizes(), *innerTileSizesOfr,
+      materializeEncodingInfo->innerDimsPos,
+      materializeEncodingInfo->outerDimsPerm);
+  Operation *newEmptyOp = rewriter.create<tensor::EmptyOp>(
+      loc, newShape, resultType.getElementType());
+  return newEmptyOp;
+}
+
+namespace {
+//===---------------------------------------------------------------------===//
+// Patterns to lower ops with encodings. These are written as
+// dialect conversion patterns for now. These are just drivers around
+// the core conversion utilities.
+//===---------------------------------------------------------------------===//
+
+/// Convert `set_encoding` op to `pack` op.
+struct SetEncodingOpToPackOpConversion2
+    : public OpMaterializeEncodingPattern<SetEncodingOp> {
+  using OpMaterializeEncodingPattern<
+      SetEncodingOp>::OpMaterializeEncodingPattern;
+
+  LogicalResult
+  matchAndRewrite(SetEncodingOp encodingOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MaterializeEncodingFn materializeEncodingFn =
+        static_cast<MaterializeEncodingTypeConverter *>(getTypeConverter())
+            ->getMaterializeEncodingFn();
+    // Pack op needs a padding value. Maybe that is an overkill. For now, just
+    // use zero.
+    auto packOp = lowerSetEncodingOpToPackOp(
+        rewriter, encodingOp, adaptor.getSource(), materializeEncodingFn,
+        this->materializeEncodingValueFn);
+    if (failed(packOp))
+      return rewriter.notifyMatchFailure(encodingOp,
+                                         "failed to convert to pack op");
+    rewriter.replaceOp(encodingOp, packOp->getResult());
+    return success();
+  }
+};
+
+/// Convert `unset_encoding` op to `unpack` op.
+struct UnsetEncodingOpToPackOpConversion2
+    : public OpMaterializeEncodingPattern<UnsetEncodingOp> {
+  using OpMaterializeEncodingPattern<
+      UnsetEncodingOp>::OpMaterializeEncodingPattern;
+
+  LogicalResult
+  matchAndRewrite(UnsetEncodingOp encodingOp, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MaterializeEncodingFn materializeEncodingFn =
+        static_cast<MaterializeEncodingTypeConverter *>(
+            this->getTypeConverter())
+            ->getMaterializeEncodingFn();
+    auto unpackOp = lowerUnsetEncodingToUnpackOp(
+        rewriter, encodingOp, adaptor.getSource(), materializeEncodingFn,
+        this->materializeEncodingValueFn);
+    if (failed(unpackOp))
+      return rewriter.notifyMatchFailure(encodingOp,
+                                         "failed to convert to unpack op");
+    rewriter.replaceOp(encodingOp, unpackOp->getResult());
+    return success();
+  }
+};
+
+/// Generic pattern to convert operaiton that is in Destination Passing Style.
+template <typename OpTy>
+struct MaterializeDPSOperation2 : public OpMaterializeEncodingPattern<OpTy> {
+  using OpMaterializeEncodingPattern<OpTy>::OpMaterializeEncodingPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy dpsOp, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MaterializeEncodingFn materializeEncodingFn =
+        static_cast<MaterializeEncodingTypeConverter *>(
+            this->getTypeConverter())
+            ->getMaterializeEncodingFn();
+    FailureOr<Operation *> convertedOp = lowerOpWithEncoding(
+        rewriter, dpsOp, adaptor.getInputs(), adaptor.getOutputs(),
+        materializeEncodingFn, this->materializeEncodingValueFn);
+    if (failed(convertedOp))
+      return failure();
+    rewriter.replaceOp(dpsOp, convertedOp.value()->getResults());
+    return success();
+  }
+};
+
+/// Generic pattern to convert an operation.
+template <typename OpTy>
+struct MaterializeOperation2 : public OpMaterializeEncodingPattern<OpTy> {
+  using OpMaterializeEncodingPattern<OpTy>::OpMaterializeEncodingPattern;
+
+  LogicalResult
+  matchAndRewrite(OpTy op, typename OpTy::Adaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    MaterializeEncodingFn materializeEncodingFn =
+        static_cast<MaterializeEncodingTypeConverter *>(
+            this->getTypeConverter())
+            ->getMaterializeEncodingFn();
+    FailureOr<Operation *> convertedOp = lowerOpWithEncoding(
+        rewriter, op, adaptor.getOperands(), materializeEncodingFn,
+        this->materializeEncodingValueFn);
+    if (failed(convertedOp))
+      return failure();
+    rewriter.replaceOp(op, convertedOp.value()->getResults());
+    return success();
+  }
+};
+
+//===---------------------------------------------------------------------===//
+// Pass to materialize encoding
+//===---------------------------------------------------------------------===//
+
+struct MaterializeEncodingPass2
+    : public MaterializeEncoding2Base<MaterializeEncodingPass2> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<tensor::TensorDialect>();
+  }
+
+  void runOnOperation() override;
+};
+
+void MaterializeEncodingPass2::runOnOperation() {
+  MLIRContext *context = &getContext();
+
+  {
+    Operation *op = getOperation();
+    RewritePatternSet patterns(context);
+    MaterializeEncodingTypeConverter typeConverter(chooseEncodingInfo);
+    MaterializeEncodingConversionTarget target(*context);
+    populateMaterializeEncodingPatterns2(patterns, target, typeConverter);
+    if (failed(applyPartialConversion(op, target, std::move(patterns))))
+      return signalPassFailure();
+  }
+
+  // Add patterns to fold pack/unpack ops with pad/extract_slice ops.
+  {
+    RewritePatternSet patterns(context);
+    tensor::populateFoldIntoPackAndUnpackPatterns(patterns);
+    if (failed(
+            applyPatternsAndFoldGreedily(getOperation(), std::move(patterns))))
+      return signalPassFailure();
+  }
+}
+} // namespace
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace LinalgExt {
+
+void populateMaterializeEncodingPatterns2(
+    RewritePatternSet &patterns, MaterializeEncodingConversionTarget &target,
+    MaterializeEncodingTypeConverter &typeConverter,
+    MaterializeEncodingValueFn materializeEncodingValueFn) {
+
+  // Add all patterns for converting from encoded type to the materialized type
+  patterns.insert<MaterializeDPSOperation2<linalg::FillOp>,
+                  MaterializeDPSOperation2<linalg::MatmulOp>,
+                  MaterializeOperation2<tensor::EmptyOp>,
+                  SetEncodingOpToPackOpConversion2,
+                  UnsetEncodingOpToPackOpConversion2>(
+      patterns.getContext(), typeConverter, materializeEncodingValueFn);
+  ::mlir::memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);
+}
+
+std::unique_ptr<OperationPass<func::FuncOp>> createMaterializeEncodingPass2() {
+  return std::make_unique<MaterializeEncodingPass2>();
+}
+
+} // namespace LinalgExt
+} // namespace IREE
+} // namespace iree_compiler
+} // namespace mlir

--- a/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding2.mlir
+++ b/llvm-external-projects/iree-dialects/test/Dialect/iree_linalg_ext/materialize_encoding2.mlir
@@ -1,0 +1,177 @@
+// RUN: iree-dialects-opt --iree-linalg-ext-materialize-encoding2 -cse -split-input-file %s | FileCheck %s
+
+func.func @pack_unpack_gemm_lhs(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//      CHECK: func @pack_unpack_gemm_lhs(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG0]], %[[C1]]
+//  CHECK-DAG:   %[[OUTER_D0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
+//  CHECK-DAG:   %[[OUTER_D1:.+]] = affine.apply #[[MAP1]]()[%[[D1]]]
+//      CHECK:   %[[PACK_DEST:.+]] = tensor.empty(%[[OUTER_D0]], %[[OUTER_D1]]) : tensor<?x?x8x4xf32>
+//      CHECK:   %[[PACK:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG0]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[PACK_DEST]]
+//      CHECK:   %[[UNPACK_DEST:.+]] = tensor.empty(%[[D0]], %[[D1]]) : tensor<?x?xf32>
+//      CHECK:   %[[UNPACK:.+]] = tensor.unpack %[[PACK]] inner_dims_pos = [0, 1] inner_tiles = [8, 4] into %[[UNPACK_DEST]]
+//      CHECK:   return %[[UNPACK]]
+
+// -----
+
+func.func @pack_unpack_gemm_rhs(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @pack_unpack_gemm_rhs(
+//       CHECK:   tensor.pack
+//  CHECK-SAME:     inner_dims_pos = [0, 1] inner_tiles = [4, 8]
+//       CHECK:   tensor.unpack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [4, 8]
+
+// -----
+
+func.func @pack_unpack_gemm_rhs_transpose(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @pack_unpack_gemm_rhs_transpose(
+//       CHECK:   tensor.pack
+//  CHECK-SAME:     outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4]
+//       CHECK:   tensor.unpack %{{.+}} outer_dims_perm = [1, 0] inner_dims_pos = [1, 0] inner_tiles = [8, 4]
+
+// -----
+
+func.func @pack_unpack_gemm_result(%arg0 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %1 = iree_linalg_ext.unset_encoding %0 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>> -> tensor<?x?xf32>
+  return %1 : tensor<?x?xf32>
+}
+// CHECK-LABEL: func @pack_unpack_gemm_result(
+//       CHECK:   tensor.pack
+//  CHECK-SAME:     inner_dims_pos = [0, 1] inner_tiles = [8, 8]
+//       CHECK:   tensor.unpack %{{.+}} inner_dims_pos = [0, 1] inner_tiles = [8, 8]
+
+// -----
+
+func.func @pack_gemm(%arg0 : tensor<100x250xf32>, %arg1 : tensor<250x500xf32>, %arg2 : tensor<100x500xf32>) -> tensor<100x500xf32> {
+  %pad_value = arith.constant 0.0 : f32
+  %pad_lhs = tensor.pad %arg0 low[0, 0] high[4, 2] {
+    ^bb0(%b0: index, %b1 : index):
+      tensor.yield %pad_value : f32
+    } : tensor<100x250xf32> to tensor<104x252xf32>
+  %lhs = iree_linalg_ext.set_encoding %pad_lhs : tensor<104x252xf32> -> tensor<104x252xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>
+  %pad_rhs = tensor.pad %arg1 low[0, 0] high[2, 4] {
+    ^bb0(%b0: index, %b1 : index):
+      tensor.yield %pad_value : f32
+    } : tensor<250x500xf32> to tensor<252x504xf32>
+  %rhs = iree_linalg_ext.set_encoding %pad_rhs : tensor<252x504xf32> -> tensor<252x504xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>>
+  %pad_output = tensor.pad %arg2 low[0, 0] high[4, 4] {
+    ^bb0(%b0: index, %b1 : index):
+      tensor.yield %pad_value : f32
+    } : tensor<100x500xf32> to tensor<104x504xf32>
+  %output = iree_linalg_ext.set_encoding %pad_output : tensor<104x504xf32> -> tensor<104x504xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %gemm_packed = linalg.matmul ins(%lhs, %rhs : tensor<104x252xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>, tensor<252x504xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>>)
+      outs(%output : tensor<104x504xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>) -> tensor<104x504xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %gemm = iree_linalg_ext.unset_encoding %gemm_packed : tensor<104x504xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>> -> tensor<104x504xf32>
+  %result = tensor.extract_slice %gemm[0, 0] [100, 500] [1, 1] : tensor<104x504xf32> to tensor<100x500xf32>
+  return %result : tensor<100x500xf32>
+}
+//      CHECK: func @pack_gemm(
+// CHECK-SAME:     %[[ARG0:.+]]: tensor<100x250xf32>
+// CHECK-SAME:     %[[ARG1:.+]]: tensor<250x500xf32>
+// CHECK-SAME:     %[[ARG2:.+]]: tensor<100x500xf32>
+//      CHECK:   %[[CST:.+]] = arith.constant 0.0
+//      CHECK:   %[[INIT_LHS:.+]] = tensor.empty() : tensor<13x63x8x4xf32>
+//      CHECK:   %[[PACK_LHS:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG0]] padding_value(%[[CST]] : f32)
+// CHECK-SAME:       into %[[INIT_LHS]]
+//      CHECK:   %[[INIT_RHS:.+]] = tensor.empty() : tensor<63x63x8x4xf32>
+//      CHECK:   %[[PACK_RHS:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG1]] padding_value(%[[CST]] : f32)
+// CHECK-SAME:       into %[[INIT_RHS]]
+//      CHECK:   %[[INIT_RESULT:.+]] = tensor.empty() : tensor<13x63x8x8xf32>
+//      CHECK:   %[[PACK_RESULT:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG2]] padding_value(%[[CST]] : f32)
+// CHECK-SAME:       into %[[INIT_RESULT]]
+//      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:       ins(%[[PACK_LHS]], %[[PACK_RHS]] :
+// CHECK-SAME:       outs(%[[PACK_RESULT]] :
+//      CHECK:   %[[UNPACK:.+]] = tensor.unpack %[[MMT4D]]
+//      CHECK:   return %[[UNPACK]]
+
+// -----
+
+func.func @pack_gemm_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>, %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>
+  %1 = iree_linalg_ext.set_encoding %arg1 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>>
+  %2 = iree_linalg_ext.set_encoding %arg2 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %3 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>, tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>>)
+      outs(%2 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>) -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %4 = iree_linalg_ext.unset_encoding %3 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>> -> tensor<?x?xf32>
+  return %4 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//      CHECK: func @pack_gemm_dynamic(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG2:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//      CHECK:   %[[PACK_LHS:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG0]]
+//      CHECK:   %[[PACK_RHS:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG1]]
+//      CHECK:   %[[PACK_RESULT:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG2]]
+//      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:       ins(%[[PACK_LHS]], %[[PACK_RHS]] :
+// CHECK-SAME:       outs(%[[PACK_RESULT]] :
+//      CHECK:   %[[UNPACK:.+]] = tensor.unpack %[[MMT4D]]
+//      CHECK:   return %[[UNPACK]]
+
+// -----
+
+func.func @pack_gemm_fill_dynamic(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tensor<?x?xf32> {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %cst = arith.constant 0.0 : f32
+  %d0 = tensor.dim %arg0, %c0 : tensor<?x?xf32>
+  %d1 = tensor.dim %arg1, %c1 : tensor<?x?xf32>
+  %0 = iree_linalg_ext.set_encoding %arg0 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>
+  %1 = iree_linalg_ext.set_encoding %arg1 : tensor<?x?xf32> -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>>
+  %2 = tensor.empty(%d0, %d1) : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %3 = linalg.fill ins(%cst : f32) outs(%2 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>)
+      -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %4 = linalg.matmul ins(%0, %1 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_LHS>>, tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RHS_TRANSPOSE>>)
+      outs(%3 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>) -> tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>>
+  %5 = iree_linalg_ext.unset_encoding %4 : tensor<?x?xf32, #iree_linalg_ext.encoding<MATMUL_F32F32F32_RESULT>> -> tensor<?x?xf32>
+  return %5 : tensor<?x?xf32>
+}
+//  CHECK-DAG: #[[MAP0:.+]] = affine_map<()[s0] -> (s0 ceildiv 8)>
+//  CHECK-DAG: #[[MAP1:.+]] = affine_map<()[s0] -> (s0 ceildiv 4)>
+//      CHECK: func @pack_gemm_fill_dynamic(
+// CHECK-SAME:     %[[ARG0:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+// CHECK-SAME:     %[[ARG1:[a-zA-Z0-9]+]]: tensor<?x?xf32>
+//  CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//  CHECK-DAG:   %[[C1:.+]] = arith.constant 1 : index
+//  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
+//  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
+//  CHECK-DAG:   %[[OUT_D0:.+]] = affine.apply #[[MAP0]]()[%[[D0]]]
+//  CHECK-DAG:   %[[OUT_D1:.+]] = affine.apply #[[MAP0]]()[%[[D1]]]
+//  CHECK-DAG:   %[[PACK_LHS:.+]] = tensor.pack {{.*}}%[[ARG0]]
+//      CHECK:   %[[PACK_RHS:.+]] = tensor.pack
+// CHECK-SAME:     %[[ARG1]]
+//  CHECK-DAG:   %[[EMPTY:.+]] = tensor.empty(%[[OUT_D0]], %[[OUT_D1]]) : tensor<?x?x8x8xf32>
+//      CHECK:   %[[FILL:.+]] = linalg.fill
+// CHECK-SAME:       outs(%[[EMPTY]] :
+//      CHECK:   %[[MMT4D:.+]] = linalg.mmt4d
+// CHECK-SAME:       ins(%[[PACK_LHS]], %[[PACK_RHS]] :
+// CHECK-SAME:       outs(%[[FILL]] :
+//      CHECK:   %[[UNPACK:.+]] = tensor.unpack %[[MMT4D]]
+//      CHECK:   return %[[UNPACK]]


### PR DESCRIPTION
The implementation and tests are basically copied from `MaterializaeEncoding` pass/tests with changing `iree_linalg_ext` to `tensor`.