### PR TITLE
Defaulting verbose debug info in LLVM CPU IR to off.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/DispatchABI.cpp
@@ -7,11 +7,17 @@
 #include "iree/compiler/Codegen/LLVMCPU/DispatchABI.h"
 
 #include "llvm/BinaryFormat/Dwarf.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Path.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Math/IR/Math.h"
+
+static llvm::cl::opt<bool> clVerboseDebugInfo(
+    "iree-codegen-llvm-verbose-debug-info",
+    llvm::cl::desc("Emit verbose debug information in LLVM IR."),
+    llvm::cl::init(false));
 
 namespace mlir {
 namespace iree_compiler {
@@ -582,6 +588,7 @@ static bool isLocationValidForDI(Location loc) {
 
 static Value buildArgDI(Operation *forOp, int argNum, Value value, Twine name,
                         LLVM::DITypeAttr type, OpBuilder &builder) {
+  if (!clVerboseDebugInfo) return value;
   auto loc = forOp->getLoc();
   if (!isLocationValidForDI(loc)) return value;
   auto scopeAttr = getLocalScopeAttr(forOp);
@@ -596,6 +603,7 @@ static Value buildArgDI(Operation *forOp, int argNum, Value value, Twine name,
 
 static Value buildValueDI(Operation *forOp, Value value, Twine name,
                           LLVM::DITypeAttr type, OpBuilder &builder) {
+  if (!clVerboseDebugInfo) return value;
   auto loc = forOp->getLoc();
   if (!isLocationValidForDI(loc)) return value;
   auto scopeAttr = getLocalScopeAttr(forOp);


### PR DESCRIPTION
Adds the `--iree-codegen-llvm-verbose-debug-info=` flag to control whether we emit per arg/field debug info. This debug info is useful if using a debugger and stepping into codegen emitted dispatch routines but MLIR is currently not very usable with so much additional debug information. All the extra debug info disables optimizations and obscures program flow (e.g. CSE breaks if DI ops are present) and leads to unreadable IR dumps due to inline attribute printing including both the per-op debug info as well as the debug info for the entire parent scope on each op.

Since the use case for this is rather limited today we'll default off for now and in the future perhaps turn it on via higher-level `-gN`-style flags.

Fixes #12114.