### PR TITLE
Help old brains by adding iree-run-tests convenience target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -780,6 +780,30 @@ add_custom_target(iree-run-module-test-deps
     "Building IREE run module test targets"
 )
 
+# Convenience target for running IREE tests.
+add_custom_target(iree-run-tests
+  COMMENT
+    "Run IREE unit tests"
+  WORKING_DIRECTORY
+    "${CMAKE_CURRENT_BINARY_DIR}"
+  USES_TERMINAL
+  COMMAND
+    "${CMAKE_COMMAND}" -E echo
+    "The 'iree-run-tests' target is a helper for running ctest. For advanced"
+    "options, build dependencies and invoke ctest independently as in:"
+  COMMAND
+    "${CMAKE_COMMAND}" -E echo
+    "  \\(cd ${CMAKE_CURRENT_BINARY_DIR} \\&\\& cmake --build . --target iree-test-deps \\&\\& ctest --output-on-failure\\)"
+  COMMAND
+    "${CMAKE_COMMAND}" -E echo
+    "Run tests in parallel by setting a variable like CTEST_PARALLEL_LEVEL=25."
+  COMMAND
+    "${CMAKE_CTEST_COMMAND}"
+    --output-on-failure
+)
+add_dependencies(iree-run-tests iree-test-deps)
+
+
 #-------------------------------------------------------------------------------
 # IREE top-level libraries
 #-------------------------------------------------------------------------------

--- a/docs/website/docs/building-from-source/getting-started.md
+++ b/docs/website/docs/building-from-source/getting-started.md
@@ -144,18 +144,18 @@ cmake --build ../iree-build/
 
 ### Running tests
 
-Build test dependencies:
+Build test dependencies and run tests:
 
 ``` shell
-cmake --build ../iree-build --target iree-test-deps
+cmake --build ../iree-build --target iree-run-tests
 ```
 
-Run all built tests through
-[CTest](https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest):
+Internally, this builds dependencies via the `iree-test-deps` target and
+invokes [CTest](https://gitlab.kitware.com/cmake/community/-/wikis/doc/ctest/Testing-With-CTest).
 
-``` shell
-ctest --test-dir ../iree-build/ --output-on-failure
-```
+The parallel testing level can be set via the environment variable
+`CTEST_PARALLEL_LEVEL` when invoking ctest in this fashion. Instructions
+are printed to test with a custom command line.
 
 ### Take a look around
 


### PR DESCRIPTION
This is a one-stop not unlike `check-llvm` but has a bit more convenience text printed to help people self serve from there.