### PR TITLE
Enable use of tensor-based ukernel paths end-to-end.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/Passes.cpp
@@ -465,6 +465,10 @@ void addVMVXDefaultPassPipeline(OpPassManager &passManager,
   addTileAndDistributePasses(passManager,
                              /*useFuseTensorPadWithConsumerPass=*/false);
 
+  if (enableMicrokernels) {
+    passManager.nest<ModuleOp>().addPass(createLLVMCPULowerToUKernelsPass());
+  }
+
   // Tensor-level micro-kernel optimizations.
   // Note that this must be done post-tiling because it changes the structure
   // of the dispatch region such that tiling is not always possible.
@@ -483,6 +487,7 @@ void addVMVXDefaultPassPipeline(OpPassManager &passManager,
 
   // Convert buffer-level microkernels.
   if (enableMicrokernels) {
+    nestedModulePM.addPass(createLowerUKernelOpsToCallsPass());
     nestedModulePM.addNestedPass<func::FuncOp>(
         createVMVXLowerLinalgMicrokernelsPass());
   }

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/BUILD
@@ -23,6 +23,7 @@ iree_lit_test_suite(
             "link_executables.mlir",
             "lower_linalg_microkernels.mlir",
             "materialize_encoding.mlir",
+            "pipeline.mlir",
         ],
         include = ["*.mlir"],
     ),

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/CMakeLists.txt
@@ -18,6 +18,7 @@ iree_lit_test_suite(
     "link_executables.mlir"
     "lower_linalg_microkernels.mlir"
     "materialize_encoding.mlir"
+    "pipeline.mlir"
   TOOLS
     FileCheck
     iree-opt

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
@@ -1,0 +1,91 @@
+hal.executable private @mmt4d_ukernel {
+  hal.executable.variant public @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb", {ukernels = true}> {
+    hal.executable.export public @mmt4d_i8 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @mmt4d_i8() {
+        %c0 = arith.constant 0 : index
+        %c256 = arith.constant 256 : index
+        %c512 = arith.constant 512 : index
+        %c16 = arith.constant 16 : index
+        %0:2 = vmvx.query_tile_sizes sizes(%c16, %c16) flags(1048576) -> index, index
+        %1 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%0#0]
+        %2 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%0#1]
+        %3 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%1, %2, %0#0, %0#1}
+        %4:2 = vmvx.query_tile_sizes sizes(%c16, %c16) flags(1114112) -> index, index
+        %5 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%4#0]
+        %6 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%4#1]
+        %7 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c256) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%5, %6, %4#0, %4#1}
+        %8:2 = vmvx.query_tile_sizes sizes(%c16, %c16) flags(1179648) -> index, index
+        %9 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%8#0]
+        %10 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%8#1]
+        %11 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c512) : !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%9, %10, %8#0, %8#1}
+        %12:2 = vmvx.query_tile_sizes sizes(%c16, %c16) flags(1048576) -> index, index
+        %13 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%12#0]
+        %14 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%12#1]
+        %15 = flow.dispatch.tensor.load %3, offsets = [0, 0, 0, 0], sizes = [%13, %14, %12#0, %12#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%13, %14, %12#0, %12#1} -> tensor<?x?x?x?xi8>
+        %16:2 = vmvx.query_tile_sizes sizes(%c16, %c16) flags(1114112) -> index, index
+        %17 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%16#0]
+        %18 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%16#1]
+        %19 = flow.dispatch.tensor.load %7, offsets = [0, 0, 0, 0], sizes = [%17, %18, %16#0, %16#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?x?x?xi8>>{%17, %18, %16#0, %16#1} -> tensor<?x?x?x?xi8>
+        %20:2 = vmvx.query_tile_sizes sizes(%c16, %c16) flags(1179648) -> index, index
+        %21 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%20#0]
+        %22 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%20#1]
+        %23 = flow.dispatch.tensor.load %11, offsets = [0, 0, 0, 0], sizes = [%21, %22, %20#0, %20#1], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%21, %22, %20#0, %20#1} -> tensor<?x?x?x?xi32>
+        %24 = linalg.mmt4d ins(%15, %19 : tensor<?x?x?x?xi8>, tensor<?x?x?x?xi8>) outs(%23 : tensor<?x?x?x?xi32>) -> tensor<?x?x?x?xi32>
+        %25:2 = vmvx.query_tile_sizes sizes(%c16, %c16) flags(1179648) -> index, index
+        %26 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%25#0]
+        %27 = affine.apply affine_map<()[s0] -> (16 ceildiv s0)>()[%25#1]
+        flow.dispatch.tensor.store %24, %11, offsets = [0, 0, 0, 0], sizes = [%26, %27, %25#0, %25#1], strides = [1, 1, 1, 1] : tensor<?x?x?x?xi32> -> !flow.dispatch.tensor<readwrite:tensor<?x?x?x?xi32>>{%26, %27, %25#0, %25#1}
+        return
+      }
+    }
+  }
+}
+// CHECK: func private @vmvx.mmt4d.i8i8i32(
+// CHECK: func @mmt4d_i8()
+// CHECK:   func.call @vmvx.mmt4d.i8i8i32(
+
+// -----
+
+hal.executable private @matmul_ukernel {
+  hal.executable.variant public @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb", {ukernels = true}> {
+    hal.executable.export public @matmul_f32 ordinal(0) layout(#hal.pipeline.layout<push_constants = 6, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer, ReadOnly>, <2, storage_buffer>]>]>) {
+    ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index):
+      %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3
+      hal.return %x, %y, %z : index, index, index
+    }
+    builtin.module {
+      func.func @matmul_f32() {
+        %c0 = arith.constant 0 : index
+        %0 = hal.interface.constant.load[0] : i32
+        %1 = hal.interface.constant.load[1] : i32
+        %2 = hal.interface.constant.load[2] : i32
+        %3 = hal.interface.constant.load[3] : i32
+        %4 = hal.interface.constant.load[4] : i32
+        %5 = hal.interface.constant.load[5] : i32
+        %6 = arith.index_castui %0 : i32 to index
+        %7 = arith.index_castui %1 : i32 to index
+        %8 = arith.index_castui %2 : i32 to index
+        %9 = arith.index_castui %3 : i32 to index
+        %10 = arith.index_castui %4 : i32 to index
+        %11 = arith.index_castui %5 : i32 to index
+        %12 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%6, %7}
+        %13 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%8, %9}
+        %14 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<readwrite:tensor<?x?xf32>>{%10, %11}
+        %15 = flow.dispatch.tensor.load %12, offsets = [0, 0], sizes = [%6, %7], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%6, %7} -> tensor<?x?xf32>
+        %16 = flow.dispatch.tensor.load %13, offsets = [0, 0], sizes = [%8, %9], strides = [1, 1] : !flow.dispatch.tensor<readonly:tensor<?x?xf32>>{%8, %9} -> tensor<?x?xf32>
+        %17 = flow.dispatch.tensor.load %14, offsets = [0, 0], sizes = [%10, %11], strides = [1, 1] : !flow.dispatch.tensor<readwrite:tensor<?x?xf32>>{%10, %11} -> tensor<?x?xf32>
+        %18 = linalg.matmul ins(%15, %16 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%17 : tensor<?x?xf32>) -> tensor<?x?xf32>
+        flow.dispatch.tensor.store %18, %14, offsets = [0, 0], sizes = [%10, %11], strides = [1, 1] : tensor<?x?xf32> -> !flow.dispatch.tensor<readwrite:tensor<?x?xf32>>{%10, %11}
+        return
+      }
+    }
+  }
+}
+//     CHECK: func private @vmvx.matmul.f32f32f32(
+//     CHECK: func @matmul_f32()
+//     CHECK:   func.call @vmvx.matmul.f32f32f32(

--- a/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/VMVX/test/pipeline.mlir
@@ -1,3 +1,5 @@
+// RUN: iree-opt  --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmcpu-lower-executable-target)))" --split-input-file %s | FileCheck %s
+
 hal.executable private @mmt4d_ukernel {
   hal.executable.variant public @vmvx_bytecode_fb, target = <"vmvx", "vmvx-bytecode-fb", {ukernels = true}> {
     hal.executable.export public @mmt4d_i8 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/BUILD
@@ -60,6 +60,7 @@ iree_compiler_cc_library(
         "//compiler/src/iree/compiler/Dialect/HAL/IR",
         "//compiler/src/iree/compiler/Dialect/HAL/IR:HALDialect",
         "//compiler/src/iree/compiler/Dialect/HAL/Transforms",
+        "//compiler/src/iree/compiler/Dialect/Util/Conversion",
         "//compiler/src/iree/compiler/Dialect/Util/Conversion/MemRefToUtil",
         "//compiler/src/iree/compiler/Dialect/Util/IR",
         "//compiler/src/iree/compiler/Dialect/Util/Transforms",

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/CMakeLists.txt
@@ -81,6 +81,7 @@ iree_cc_library(
     iree::compiler::Dialect::HAL::IR
     iree::compiler::Dialect::HAL::IR::HALDialect
     iree::compiler::Dialect::HAL::Transforms
+    iree::compiler::Dialect::Util::Conversion
     iree::compiler::Dialect::Util::Conversion::MemRefToUtil
     iree::compiler::Dialect::Util::IR
     iree::compiler::Dialect::Util::Transforms

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Conversion.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Conversion.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h"
 #include "iree/compiler/Codegen/Dialect/UKernelOps.h"
 #include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/Util/Conversion/ConversionPatterns.h"
 #include "iree/compiler/Dialect/Util/Conversion/MemRefToUtil/Patterns.h"
 #include "iree/compiler/Dialect/Util/IR/UtilDialect.h"
 #include "iree/compiler/Dialect/VM/IR/VMDialect.h"
@@ -95,6 +96,8 @@ class ConversionPass : public ConversionBase<ConversionPass> {
     populateMemRefToUtilPatterns(context, conversionTarget, typeConverter,
                                  patterns,
                                  IREE::Util::BufferType::get(&getContext()));
+    populateGenericStructuralConversionPatterns(context, conversionTarget,
+                                                typeConverter, patterns);
     patterns.insert<ConvertGetBasePointerOp>(typeConverter, context);
 
     // Use the default 64-bit lowering for TOSA's ApplyScale operator:

--- a/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/VMVX/Transforms/Passes.cpp
@@ -79,6 +79,8 @@ static void buildVectorVMVXTransformPassPipeline(OpPassManager &passManager) {
       createFixupSubspanWithOffsetsPass());
   nestedModulePM.addNestedPass<func::FuncOp>(
       createResolveBufferDescriptorsPass());
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createCleanupBufferAllocViewPass());
 
   // Flatten and cleanup memrefs.
   nestedModulePM.addNestedPass<func::FuncOp>(


### PR DESCRIPTION
This commit switches over the use of micro kernels for `mmt4d` and `linalg.matmul` ops. This effectively deprecates the use of `vmvx.mmt4d` and the `vmvx.matmul` operations in favor of the `iree_codegen.ukernels.*` operations.