### PR TITLE
Enforce C-contiguous ndarrays

### DIFF
--- a/runtime/bindings/python/iree/runtime/array_interop.py
+++ b/runtime/bindings/python/iree/runtime/array_interop.py
@@ -209,7 +209,7 @@ def asdevicearray(device: HalDevice,
     logging.warn(
         "Implicit dtype conversion of a DeviceArray forces a host transfer")
   # First get an ndarray.
-  a = np.asarray(a, dtype=dtype)
+  a = np.asarray(a, dtype=dtype, order="C")
   element_type = map_dtype_to_element_type(a.dtype)
   if element_type is None:
     raise ValueError(f"Could not map dtype {a.dtype} to IREE element type")


### PR DESCRIPTION
Since device arrays are expected to be C-contiguous we can enforce them to have this property while creating the ndarray

This would eliminate such errors during runtime:

```
  File "...SHARK\shark\iree_utils\compile_utils.py", line 380, in <listcomp>
    device_inputs = [ireert.asdevicearray(config.device, a) for a in input]
  File "...iree\runtime\array_interop.py", line 216, in asdevicearray
    buffer_view = device.allocator.allocate_buffer_copy(
ValueError: ndarray is not C-contiguous
```