### PR TITLE
Use `MatmulType` to check for right element type configuration of matmul.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -114,6 +114,7 @@ iree_compiler_cc_library(
         "CleanupBufferAllocViewPass.cpp",
         "ConcretizePadResultShape.cpp",
         "ConvertToDestinationPassingStylePass.cpp",
+        "EncodingInfo.cpp",
         "EraseHALDescriptorTypeFromMemRef.cpp",
         "FlattenMemRefSubspanPass.cpp",
         "FoldTensorExtractOpPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -89,6 +89,7 @@ iree_cc_library(
     "CleanupBufferAllocViewPass.cpp"
     "ConcretizePadResultShape.cpp"
     "ConvertToDestinationPassingStylePass.cpp"
+    "EncodingInfo.cpp"
     "EraseHALDescriptorTypeFromMemRef.cpp"
     "FlattenMemRefSubspanPass.cpp"
     "FoldTensorExtractOpPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingInfo.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingInfo.cpp
@@ -1,0 +1,29 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/compiler/Codegen/Common/EncodingInfo.h"
+
+#include "mlir/IR/BuiltinTypes.h"
+
+namespace mlir {
+namespace iree_compiler {
+
+std::optional<MatmulType> getMatmulType(Type lhsElementType,
+                                        Type rhsElementType,
+                                        Type resultElementType) {
+  if (lhsElementType.isSignlessInteger(8) &&
+      rhsElementType.isSignlessInteger(8) &&
+      resultElementType.isSignlessInteger(32)) {
+    return MatmulType::I8I8I32;
+  } else if (lhsElementType.isF32() && rhsElementType.isF32() &&
+             resultElementType.isF32()) {
+    return MatmulType::F32F32F32;
+  }
+  return std::nullopt;
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Common/EncodingInfo.h
+++ b/compiler/src/iree/compiler/Codegen/Common/EncodingInfo.h
@@ -37,6 +37,10 @@ Optional<IREE::LinalgExt::TensorEncoding> getEncoding(
 
 Optional<MatmulType> getMatmulType(IREE::LinalgExt::TensorEncoding encoding);
 
+std::optional<MatmulType> getMatmulType(Type lhsElementType,
+                                        Type rhsElementType,
+                                        Type resultElementType);
+
 Optional<MatmulOperandRole> getMatmulOperandRole(
     IREE::LinalgExt::TensorEncoding encoding);
 


### PR DESCRIPTION
This is followup for comments in #12085.