### PR TITLE
Add bufferization support for UKernel ops.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Dialect/BUILD
@@ -72,6 +72,7 @@ iree_compiler_cc_library(
         "//runtime/src/iree/builtins/ukernel:exported_bits",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:ArithDialect",
+        "@llvm-project//mlir:BufferizationDialect",
         "@llvm-project//mlir:DestinationStyleOpInterface",
         "@llvm-project//mlir:DialectUtils",
         "@llvm-project//mlir:FuncDialect",

--- a/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Dialect/CMakeLists.txt
@@ -36,6 +36,7 @@ iree_cc_library(
     ::UKernelOpsGen
     LLVMSupport
     MLIRArithDialect
+    MLIRBufferizationDialect
     MLIRDestinationStyleOpInterface
     MLIRFuncDialect
     MLIRIR

--- a/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.h
+++ b/compiler/src/iree/compiler/Codegen/Dialect/IREECodegenDialect.h
@@ -14,4 +14,12 @@
 #include "iree/compiler/Codegen/Dialect/IREECodegenDialect.h.inc"  // IWYU pragma: keep
 // clang-format on
 
+namespace mlir {
+namespace iree_compiler {
+
+void registerUKernelBufferizationInterface(DialectRegistry &registry);
+
+}  // namespace iree_compiler
+}  // namespace mlir
+
 #endif  // IREE_COMPILER_CODEGEN_DIALECT_IREECODEGEN_DIALECT_H_

--- a/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.cpp
@@ -354,7 +354,7 @@ struct UKernelOpsBufferizationInterface
     // Replace all `tensor` operands with corresponding `memref` operands.
     for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
       // For `tensor` type operands, replace with `memref` type operand.
-      if (operand.getType().isa<RankedTensorType>()) {
+      if (operand.getType().template isa<RankedTensorType>()) {
         FailureOr<Value> memrefOperand = getBuffer(rewriter, operand, options);
         if (failed(memrefOperand)) {
           return op->emitOpError(

--- a/compiler/src/iree/compiler/Tools/init_iree_dialects.h
+++ b/compiler/src/iree/compiler/Tools/init_iree_dialects.h
@@ -55,6 +55,7 @@ inline void registerIreeDialects(DialectRegistry &registry) {
   // External models.
   IREE::Util::registerUtilExternalModels(registry);
   registerCodegenInterfaces(registry);
+  registerUKernelBufferizationInterface(registry);
 }
 
 }  // namespace iree_compiler


### PR DESCRIPTION
This adds an `ExternalModel` implementation for the `BufferizationInterface` that derives from
`bufferization::DstBufferizableOpInterfaceExternalModel`, allowing the OneShot Bufferization to pick up these ops.