### PR TITLE
Exclude failing tests on Windows in ctest_all.sh.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -84,6 +84,7 @@ if [[ "$OSTYPE" =~ ^msys ]]; then
     "iree/tests/e2e/regression/check_regression_llvm-cpu_lowering_config.mlir"
     # TODO: Fix equality mismatch
     "iree/tests/e2e/linalg_ext_ops/check_vmvx_ukernel_local-task_unpack.mlir"
+    "iree/tests/e2e/tensor_ops/check_vmvx_ukernel_local-task_unpack.mlir"
     # TODO(#11070): Fix argument/result signature mismatch
     "iree/tests/e2e/tosa_ops/check_vmvx_local-sync_microkernels_fully_connected.mlir"
     # TODO(#11080): Fix arrays not matching in test_variant_list_buffers


### PR DESCRIPTION
This is an expected failing tests because it goes with the same pipeline as iree_linalg_ext.unpack tests.

https://github.com/iree-org/iree/actions/runs/4167636144/jobs/7213463962