### PR TITLE
Make benchmark posting workflow testable

### DIFF
--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -55,7 +55,9 @@ jobs:
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BENCHMARK_PROCESS_JOB: process_benchmark_results
+          # TODO(#11076): Temporarily matches nonexistent job to only enable in
+          # test until we migrate the benchmark pipeline.
+          BENCHMARK_PROCESS_JOB: process_benchmark_results_disabled
         run: |
           # Assume the workflow has fewer than 100 jobs.
           export CONCLUSION=$(gh api \
@@ -76,8 +78,7 @@ jobs:
             "${PR_CI_GCS_URL}/${BENCHMARK_COMMENT_ARTIFACT}"
           echo "benchmark-comment-artifact=${BENCHMARK_COMMENT_ARTIFACT}" >> "${GITHUB_OUTPUT}"
       - name: Posting comments
-        # TODO(#11076): Temporarily disabled until we migrate the database.
-        if: false && steps.check.outputs.job-conclusion == 'success'
+        if: steps.check.outputs.job-conclusion == 'success'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIST_BOT_TOKEN: ${{ secrets.GIST_BOT_TOKEN }}

--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -55,8 +55,8 @@ jobs:
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO(#11076): Temporarily matches nonexistent job to only enable in
-          # test until we migrate the benchmark pipeline.
+          # TODO(#11076): Temporarily matches nonexistent job to enable only in
+          # test PR until we migrate the benchmark pipeline.
           BENCHMARK_PROCESS_JOB: process_benchmark_results_disabled
         run: |
           # Assume the workflow has fewer than 100 jobs.

--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -55,8 +55,9 @@ jobs:
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO(#11076): Temporarily matches nonexistent job to enable only in
-          # test PR until we migrate the benchmark pipeline.
+          # TODO(#11076): Temporarily matches a non-existent job so we don't
+          # post comments by default before the migration. And a test PR with
+          # the modified benchmark job name can still do end-to-end test.
           BENCHMARK_PROCESS_JOB: process_benchmark_results_disabled
         run: |
           # Assume the workflow has fewer than 100 jobs.


### PR DESCRIPTION
Change `post_benchmark_comment` workflow to match a non-existent job name (and enable all steps) so we can test it with a PR before rollout.

`post_benchmark_comment` workflow runs on the main branch to fetch and post benchmark comments on PRs. The posting step is disabled for now so we won't post results from WIP benchmark workflow. But it also makes it not possible to test posting a comment with a test PR.

This change enables the posting step in the workflow but alters the benchmark job name it's looking for. So by default the posting step will be skipped because the benchmark job name is not found. But we can test the end-to-end workflow in a test PR with the modified benchmark job name.

skip-ci: Not run in presubmit.