### PR TITLE
Replace `zve32x` with `zve32f` in CI configurations

### DIFF
--- a/benchmarks/TFLite/linux-riscv.cmake
+++ b/benchmarks/TFLite/linux-riscv.cmake
@@ -25,6 +25,7 @@ set(LINUX_RV64_GENERIC_CPU_COMPILATION_FLAGS
   "--riscv-v-fixed-length-vector-lmul-max=8"
 )
 
+# TODO(llvm-project/60463): Replace 'zve32f' with 'zve32x'.
 set(LINUX_RV32_GENERIC_CPU_COMPILATION_FLAGS
   "--iree-input-type=tosa"
   "--iree-llvm-target-triple=riscv32-pc-linux-elf"

--- a/benchmarks/TFLite/linux-riscv.cmake
+++ b/benchmarks/TFLite/linux-riscv.cmake
@@ -30,7 +30,7 @@ set(LINUX_RV32_GENERIC_CPU_COMPILATION_FLAGS
   "--iree-llvm-target-triple=riscv32-pc-linux-elf"
   "--iree-llvm-target-cpu=generic-rv32"
   "--iree-llvm-target-abi=ilp32"
-  "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+  "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f"
   "--riscv-v-fixed-length-vector-lmul-max=8"
 )
 

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -157,6 +157,7 @@ class IreeRuleBuilder(object):
           "--riscv-v-fixed-length-vector-lmul-max=8"
       ]
     elif arch_info.architecture == "riscv_32":
+      # TODO(llvm-project/60463): Replace 'zve32f' with 'zve32x'.
       flags = [
           f"--iree-llvm-target-triple=riscv32-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv32", "--iree-llvm-target-abi=ilp32",

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -160,7 +160,7 @@ class IreeRuleBuilder(object):
       flags = [
           f"--iree-llvm-target-triple=riscv32-pc-{target.target_abi.value}",
           "--iree-llvm-target-cpu=generic-rv32", "--iree-llvm-target-abi=ilp32",
-          "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x",
+          "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f",
           "--riscv-v-fixed-length-vector-lmul-max=8"
       ]
     elif arch_info.architecture == "armv8.2-a":

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -870,7 +870,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -888,7 +888,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -906,7 +906,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"
   PUBLIC
 )
@@ -2529,7 +2529,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2549,7 +2549,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
@@ -2569,7 +2569,7 @@ iree_bytecode_module(
     "--iree-llvm-target-triple=riscv32-pc-linux-gnu"
     "--iree-llvm-target-cpu=generic-rv32"
     "--iree-llvm-target-abi=ilp32"
-    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32x"
+    "--iree-llvm-target-cpu-features=+m,+a,+f,+zvl512b,+zve32f"
     "--riscv-v-fixed-length-vector-lmul-max=8"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"


### PR DESCRIPTION
The `zve32x` feature includes support for integer vectors but not fp vectors. When we send fp vector ops to the RISC-V backend with only `zve32x` support, they should be scalarized. Unfortunately, this is currently not implemented in the backend (see https://github.com/llvm/llvm-project/issues/60463). In the meantime, we are replacing 'zve32x' with 'zve32f', which also includes support for fp vector operations.