### PR TITLE
fix null deref in `tileAndFuseDispatchUsingSCFForOp`

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -501,10 +501,10 @@ FailureOr<TileAndFuseResult> tileAndFuseDispatchUsingSCFForOp(
       return rewriter.notifyMatchFailure(sliceOp,
                                          "fusion along slice op failed");
     }
-    Operation *tiledProducer = tiledProducerVal->getDefiningOp();
-    if (!llvm::dyn_cast_or_null<TilingInterface>(tiledProducer)) {
+    auto tiledProducer = tiledProducerVal->getDefiningOp<TilingInterface>();
+    if (!tiledProducer) {
       return rewriter.notifyMatchFailure(
-          tiledProducer,
+          tiledProducerVal->getDefiningOp(),
           "expected tiled implementation to implement TilingInterface as well");
     }
     if (tiledProducer->getNumResults() != fusableProducer->getNumResults()) {

--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -501,8 +501,8 @@ FailureOr<TileAndFuseResult> tileAndFuseDispatchUsingSCFForOp(
       return rewriter.notifyMatchFailure(sliceOp,
                                          "fusion along slice op failed");
     }
-    auto tiledProducer = tiledProducerVal->getDefiningOp<TilingInterface>();
-    if (!tiledProducer) {
+    Operation *tiledProducer = tiledProducerVal->getDefiningOp();
+    if (!llvm::dyn_cast_or_null<TilingInterface>(tiledProducer)) {
       return rewriter.notifyMatchFailure(
           tiledProducer,
           "expected tiled implementation to implement TilingInterface as well");


### PR DESCRIPTION
This fixes a crash (null dereference) hit when generating a match failure in this function, when the op does not implement `TilingInterface`.

Testcase provided by @lundong :

Reproduction command line:

```
tools/iree-compile --iree-input-type=tosa --iree-hal-target-backends=vmvx --iree-vmvx-enable-microkernels --iree-flow-enable-data-tiling /tmp/conv1x1_test.mlir
```

Input file:

```
module {
  func.func @main(%arg0: tensor<1x112x112x8xi8>) -> tensor<1x112x112x16xi8> {
    %0 = "tosa.const"() {value = dense<[-918, -4433, 87, -234, -21393, 7738, 529, -8835, -16817, -375, -199, 572, 5082, 15569, -186, 4955]> : tensor<16xi32>} : () -> tensor<16xi32>
    %1 = "tosa.const"() {value = dense<"0xE2E2E2E2E2EBF6E206E2E2E8EBE6DEE2E0E2E2FDDCE7E1E2E2E2E2FDDFE6E0E3EBE2E2DCEFAC213DE2E2E2E3E2D3C9E4E2E2E2E2E3E1E1FA3EE2E2E9E9E5E3E47FE2E2E4EDE2E2E3E0E2E2E4DFE9DCFEE3E2E2E2E2E2E2E2F9E2E2E6EBEADCE4E2E2E2CEE5E1E0E181E2E2D9D3DEE1DDE2E2E2E2E2E2E2E2C5E2E2E2DBE1E3E1"> : tensor<16x1x1x8xi8>} : () -> tensor<16x1x1x8xi8>
    %2 = "tosa.conv2d"(%arg0, %1, %0) {dilation = array<i64: 1, 1>, pad = array<i64: 0, 0, 0, 0>, quantization_info = #tosa.conv_quant<input_zp = -128, weight_zp = -30>, stride = array<i64: 1, 1>} : (tensor<1x112x112x8xi8>, tensor<16x1x1x8xi8>, tensor<16xi32>) -> tensor<1x112x112x16xi32>
    %3 = "tosa.rescale"(%2) {double_round = true, input_zp = 0 : i32, multiplier = array<i32: 1364139008>, output_zp = -128 : i32, per_channel = false, scale32 = true, shift = array<i32: 35>} : (tensor<1x112x112x16xi32>) -> tensor<1x112x112x16xi8>
    return %3 : tensor<1x112x112x16xi8>
  }
}
```