### PR TITLE
Matchers for nested blocks

### DIFF
--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Transforms/TransformMatchers.h
@@ -149,6 +149,7 @@ struct IsIdentity {};
 /// Predicate tag indicating that the operand is a special float constant.
 struct ConstantFloatMinOrMinusInf {};
 struct ConstantFloatZero {};
+struct ConstantFloatOne {};
 
 /// Indicates that the match optional. The matcher is still expected to run and
 /// capture if successful. The parameter can be set to false
@@ -161,12 +162,10 @@ struct OptionalMatch : public SingleValuePredicateParam<bool> {
 /// operation.
 struct SingleCombinerReduction {};
 
-namespace detail {
-template <typename T>
-using has_reset_capture_t = decltype(std::declval<T>().resetCapture());
-template <typename T>
-using has_get_capture_t = decltype(std::declval<T>().getCaptured());
-} // namespace detail
+class CapturingOpMatcher;
+class ValueMatcher;
+class CapturingValueMatcher;
+class BlockBodyMatcher;
 
 /// Base class for capturing matchers that can be owned by the context.
 class CapturingMatcherBase {
@@ -175,6 +174,37 @@ public:
   // TODO: if efficiency is a problem, consider disallowing non-trivial
   // destructors for subclasses.
   virtual ~CapturingMatcherBase() = default;
+
+protected:
+  /// Informs the matcher that it has another, nested matcher. Derived classes
+  /// must call this to keep track of nested matchers for capture resetting
+  /// purposes.
+  template <typename T>
+  void recordNestedMatcher(T &nested) {
+    if constexpr (std::is_base_of_v<CapturingOpMatcher, T>)
+      nestedCapturingMatchers.push_back(&nested);
+    if constexpr (std::is_base_of_v<CapturingValueMatcher, T>)
+      nestedCapturingValueMatchers.push_back(&nested);
+    if constexpr (std::is_base_of_v<BlockBodyMatcher, T>)
+      nestedBlockMatchers.push_back(&nested);
+  }
+
+  /// Appends all nested capturing matchers of a certain kind, excluding this
+  /// one, to `nested`.
+  void getAllNested(SmallVectorImpl<CapturingOpMatcher *> &nested);
+  void
+  getAllNestedValueMatchers(SmallVectorImpl<CapturingValueMatcher *> &nested);
+  void getAllNestedBlockMatchers(SmallVectorImpl<BlockBodyMatcher *> &nested);
+
+  /// Resets nested capturing matchers but does NOT reset the current one.
+  void resetCapture();
+
+private:
+  /// A list of (recursively) nested capturing matchers that should be reset
+  /// when the current matcher is.
+  SmallVector<CapturingOpMatcher *, 2> nestedCapturingMatchers;
+  SmallVector<CapturingValueMatcher *, 2> nestedCapturingValueMatchers;
+  SmallVector<BlockBodyMatcher *, 2> nestedBlockMatchers;
 };
 
 /// A context object holding capturing matchers, must outlive any individual
@@ -202,15 +232,104 @@ private:
   SmallVector<std::unique_ptr<CapturingMatcherBase>> ownedMatchers;
 };
 
+/// Capturing matcher for the body of a single IR block. The matching processes
+/// from the terminator backwards, e.g.
+///
+///   auto &terminator = m_Operation(context).operand(...);
+///   m_Block(context).terminator(terminator);
+///
+/// will match the block terminator and look at the operation defining its
+/// operands.
+class BlockBodyMatcher : public CapturingMatcherBase {
+  friend class CapturingMatcherBase;
+  friend class MatcherContext;
+  friend BlockBodyMatcher &m_Block(MatcherContext &);
+  friend BlockBodyMatcher &m_Block_Or(MatcherContext &, BlockBodyMatcher &,
+                                      BlockBodyMatcher &);
+
+  /// Constructs a default matcher that accepts any block.
+  BlockBodyMatcher() = default;
+
+  /// Constructs a block matcher that accepts either the predicates of the
+  /// `first` or those of the `second`. More predicates can be added later on,
+  /// they will apply in both cases.
+  BlockBodyMatcher(BlockBodyMatcher &first, BlockBodyMatcher &second);
+
+  /// Predicate function.
+  using PredicateFn = std::function<bool(Block &)>;
+
+public:
+  /// Matches the given bock.
+  bool match(Block &block);
+
+  /// Returns the block that matched.
+  Block *getCaptured() const { return captured; }
+
+  /// Resets the captured block to null. This should be called if the same
+  /// pattern needs to be applied more than once as it may keep captured values
+  /// for optional nested predicates from the previous application.
+  void resetCapture() {
+    captured = nullptr;
+    CapturingMatcherBase::resetCapture();
+  }
+
+  /// Adds a predicate checking that the block has at lest the given number of
+  /// arguments.
+  BlockBodyMatcher &argument(NumGreaterEqualTo num);
+
+  /// Adds a predicate checking that the `pos`-th block argument (recursively)
+  /// matches the given value matcher.
+  BlockBodyMatcher &argument(int64_t pos, ValueMatcher &nested);
+
+  /// Adds a predicate checking that the block has exactly the given number of
+  /// operations.
+  BlockBodyMatcher &operations(NumEqualsTo num);
+
+  /// Adds a predicate checking that the terminator of the block (recursively)
+  /// matches the given operation matcher.
+  BlockBodyMatcher &terminator(CapturingOpMatcher &nested);
+
+protected:
+  /// Appends a predicate to the list of predicates.
+  template <typename FnTy>
+  void addPredicate(FnTy &&fn) {
+    predicates.emplace_back(std::forward<FnTy>(fn));
+  }
+
+private:
+  /// Captured block if any.
+  Block *captured = nullptr;
+
+  /// List of additional predicates to be checked by the matcher, in order.
+  SmallVector<PredicateFn> predicates;
+};
+
+/// Constructs a default matcher in the given context that accepts any block.
+inline BlockBodyMatcher &m_Block(MatcherContext &matcherContext) {
+  return matcherContext.allocate<BlockBodyMatcher>();
+}
+
+/// Constructs a block matcher that accepts either the predicates of the
+/// `first` or those of the `second`. More predicates can be added later on,
+/// they will apply in both cases.
+inline BlockBodyMatcher &m_Block_Or(MatcherContext &matcherContext,
+                                    BlockBodyMatcher &first,
+                                    BlockBodyMatcher &second) {
+  return matcherContext.allocate<BlockBodyMatcher>(first, second);
+}
+
 /// Base class for value matchers that capture the matched value.
 class CapturingValueMatcher : public CapturingMatcherBase {
-  friend class CapturingOpMatcher;
+  friend class CapturingMatcherBase;
 
 public:
   /// Resets the captured value to null. This should be called if the same
   /// pattern needs to be applied more than once as it may keep captured values
   /// for optional nested predicates from the previous application.
-  void resetCapture() { captured = nullptr; }
+  void resetCapture() {
+    captured = nullptr;
+    CapturingMatcherBase::resetCapture();
+  }
 
   /// Returns the matched value if the match was successful.
   Value getCaptured() const { return captured; }
@@ -241,93 +360,146 @@ inline ValueMatcher &m_Value(MatcherContext &context) {
   return context.allocate<ValueMatcher>();
 }
 
-/// Base class for op matchers that capture the matched operation.
-class CapturingOpMatcher : public CapturingMatcherBase {
-public:
-  /// Resets the captured value to null. This should be called if the same
-  /// pattern needs to be applied more than once as it may keep captured values
-  /// for optional nested predicates from the previous application.
-  void resetCapture() {
-    captured = nullptr;
-    SmallVector<CapturingOpMatcher *> nested;
-    getAllNested(nested);
-    for (CapturingOpMatcher *matcher : nested) {
-      matcher->captured = nullptr;
-    }
-    SmallVector<CapturingValueMatcher *> nestedValue;
-    getAllNestedValueMatchers(nestedValue);
-    for (CapturingValueMatcher *matcher : nestedValue) {
-      matcher->captured = nullptr;
-    }
-  }
-
-  /// Returns the matched operation if the match was successful.
-  Operation *getCaptured() const { return captured; }
-
-protected:
-  /// Informs the matcher that it has another, nested matcher. Derived classes
-  /// must call this to keep track of nested matchers for capture resetting
-  /// purposes.
-  template <typename T>
-  void recordNestedMatcher(T &nested) {
-    if constexpr (std::is_base_of_v<CapturingOpMatcher, T>)
-      nestedCapturingMatchers.push_back(&nested);
-    if constexpr (std::is_base_of_v<CapturingValueMatcher, T>)
-      nestedCapturingValueMatchers.push_back(&nested);
-  }
-
-  /// Appends all nested capturing matchers, excluding this one, to `nested`.
-  void getAllNested(SmallVectorImpl<CapturingOpMatcher *> &nested);
-  void
-  getAllNestedValueMatchers(SmallVectorImpl<CapturingValueMatcher *> &nested);
-
-private:
-  /// A list of (recursively) nested capturing matchers that should be reset
-  /// when the current matcher is.
-  SmallVector<CapturingOpMatcher *> nestedCapturingMatchers;
-  SmallVector<CapturingValueMatcher *> nestedCapturingValueMatchers;
-
-protected:
-  /// Matched value.
-  linalg::LinalgOp captured = nullptr;
-};
-
-/// Structured op matcher with additional predicates attachable through the
+/// Matcher for operations with additional predicates attachable through the
 /// fluent, a.k.a. chainable, API. Note that public API must *not* accept
 /// additional callbacks even; new predicates should be added instead when
 /// necessary. Not only this decreases the depth of the callback stack and
 /// increases readability, it also allows us to port the matcher to a
 /// declarative format using PDL and/or Transform dialect in the future. The
 /// latter will become impossible with arbitrary C++ callbacks.
+class CapturingOpMatcher : public CapturingMatcherBase {
+  friend class CapturingMatcherBase;
+  friend class MatcherContext;
+
+  template <typename... OpTy>
+  friend CapturingOpMatcher &m_Operation(MatcherContext &matcherContext);
+
+public:
+  using PredicateFn = std::function<bool(Operation *)>;
+
+  /// Matches the given operation, hook for `matchPattern`.
+  bool match(Operation *op);
+
+  /// Resets the captured value to null. This should be called if the same
+  /// pattern needs to be applied more than once as it may keep captured values
+  /// for optional nested predicates from the previous application.
+  void resetCapture() {
+    captured = nullptr;
+    CapturingMatcherBase::resetCapture();
+  }
+
+  /// Returns the matched operation if the match was successful.
+  Operation *getCaptured() const { return captured; }
+
+  /// Adds alternative paths for predicates. In practice, this is just a
+  /// predicate that is satisfied when either the first or the second matcher is
+  /// satisfied. The alternative satisfaction is eager and short-cutting, i.e.,
+  /// the second alternative will not be processed, and therefore will not
+  /// capture values, if the first alternative succeeded.
+  CapturingOpMatcher &alternatives(CapturingOpMatcher &first,
+                                   CapturingOpMatcher &second);
+
+  //-------------------------------------------------------------------------//
+  // Predicates for operands and results.
+  //-------------------------------------------------------------------------//
+
+  /// Adds a predicate checking that the operation has exactly the given number
+  /// of operands.
+  CapturingOpMatcher &operand(NumEqualsTo num);
+
+  /// Adds a predicate checking that the `pos`-th operand of the operation is
+  /// defined by an operation that satisfies the given matcher.
+  CapturingOpMatcher &operand(int64_t pos, CapturingOpMatcher &nested);
+
+  /// Adds a predicate checking that the `pos`-th operand of the operation
+  /// satisfies the given value matcher.
+  CapturingOpMatcher &operand(int64_t pos, ValueMatcher &nested);
+
+  /// Adds a predicate checking that the `pos`-th operand of the operation is
+  /// defined by `arith.constant` with the value 1.0.
+  // TODO: better matching for attributes.
+  CapturingOpMatcher &operand(int64_t pos, ConstantFloatOne);
+
+  /// Adds a predicate checking that the operation has exactly the given number
+  /// of results.
+  CapturingOpMatcher &result(NumEqualsTo num);
+
+  /// Adds a predicate checking that the `pos`-th result of the operation
+  /// satisfies the given value matcher.
+  CapturingOpMatcher &result(int64_t pos, ValueMatcher &nested);
+
+protected:
+  /// Constructs a default operation matcher accepting any operation.
+  CapturingOpMatcher() = default;
+
+  /// Adds a predicate for the matched operation to satisfy.
+  template <typename Fn>
+  void addPredicate(Fn &&predicate) {
+    predicates.emplace_back(std::forward<Fn>(predicate));
+  }
+
+  /// Produce the debug output for `create` method in a non-templated way.
+  static void debugOutputForCreate(ArrayRef<StringRef> opNames);
+
+private:
+  /// A list of additional conditions for the operation to match.
+  SmallVector<PredicateFn> predicates;
+
+  /// Creates a matcher for an operation with one of the given types.
+  template <typename... OpType>
+  static CapturingOpMatcher create() {
+    CapturingOpMatcher matcher;
+    matcher.addPredicate([](Operation *op) {
+      debugOutputForCreate(ArrayRef<StringRef>{OpType::getOperationName()...});
+      return isa<OpType...>(op);
+    });
+    return matcher;
+  }
+
+  /// Common util for constant matcher.
+  CapturingOpMatcher &operand(int64_t position,
+                              std::function<bool(llvm::APFloat)> floatValueFn);
+
+protected:
+  /// Matched value.
+  Operation *captured = nullptr;
+};
+
+/// Creates a default operation matcher in the given context that accepts any
+/// operation.
+inline CapturingOpMatcher &m_Operation(MatcherContext &matcherContext) {
+  return matcherContext.allocate<CapturingOpMatcher>();
+}
+
+/// Creates an operation matcher in the given context that accepts only
+/// operations of the kinds provided as template arguments.
+template <typename... OpTy>
+inline CapturingOpMatcher &m_Operation(MatcherContext &matcherContext) {
+  return matcherContext.allocate<CapturingOpMatcher>(
+      CapturingOpMatcher::create<OpTy...>());
+}
+
+/// Matcher for structured aka Linalg operations. Extensions must follow the
+/// same conditions as the base class.
 class StructuredOpMatcher : public CapturingOpMatcher {
   friend class MatcherContext;
 
-  using PredicateFn = std::function<bool(linalg::LinalgOp)>;
-  using CaptureResetFn = std::function<void()>;
-  using GetCapturedFn = std::function<Operation *()>;
-
-  StructuredOpMatcher() = default;
-
-  /// Matches a structured operation if the given predicate is satisfied.
-  StructuredOpMatcher(PredicateFn &&firstPredicate) {
-    predicates.push_back(std::move(firstPredicate));
-  }
+  StructuredOpMatcher();
 
 public:
   /// Creates a matcher for a structured operation with one of the given types.
   template <typename... OpType>
   static StructuredOpMatcher create() {
-    return StructuredOpMatcher([](linalg::LinalgOp op) {
+    StructuredOpMatcher matcher;
+    matcher.addPredicate([](Operation *op) {
       debugOutputForCreate(ArrayRef<StringRef>{OpType::getOperationName()...});
-      return isa<OpType...>(op.getOperation());
+      return isa<linalg::LinalgOp>(op) && isa<OpType...>(op);
     });
+    return matcher;
   }
 
   /// Matches a structured operation if either patterns A or B match.
   StructuredOpMatcher(StructuredOpMatcher &A, StructuredOpMatcher &B);
-
-  /// Matches the given operation, hook for `matchPattern`.
-  bool match(Operation *op);
 
   //===-------------------------------------------------------------------===//
   // Constraints on op rank and dims.
@@ -378,6 +550,11 @@ public:
   StructuredOpMatcher &dim(int64_t dimension, CaptureDim capture);
   StructuredOpMatcher &dim(AllDims tag, CaptureDims captures);
   StructuredOpMatcher &convolutionDims(CaptureConvDims convDims);
+
+  //===-------------------------------------------------------------------===//
+  // Body constraints.
+  //===-------------------------------------------------------------------===//
+  StructuredOpMatcher &body(BlockBodyMatcher &body);
 
   //===-------------------------------------------------------------------===//
   // Constraints on input operands.
@@ -474,7 +651,7 @@ public:
     SmallVector<CapturingOpMatcher *> copy;
     copy.push_back(this);
     getAllNested(copy);
-    predicates.push_back([copy = std::move(copy)](linalg::LinalgOp linalgOp) {
+    addPredicate([copy = std::move(copy)](linalg::LinalgOp linalgOp) {
       Operation *parent = linalgOp->getParentOfType<OpTy>();
       return checkAllTilableMatched(parent, linalgOp, copy);
     });
@@ -571,38 +748,27 @@ public:
   // Constraints on op region.
   //===-------------------------------------------------------------------===//
 
-  /// Return true if the linalg op only contains a single ops and the arguments
-  /// of the operation match the order of the linalg operand.
-  /// Example:
-  ///   linalg.generic
-  ///     ins(%0, %1 : tensor<?x?x?xf32>, tensor<?x?xf32>)
-  ///     outs(%2 : tensor<?x?x?xf32>) {
-  ///     ^bb0(%arg0: f32, %arg1: f32):
-  ///     %3 = arith.maxf %arg0, %arg1 : f32
-  ///     linalg.yield %3 : f32
-  ///   } -> tensor<?x?xf32>
-  /// If commutative is set binary operations can have their operands swapped.
-  template <typename OpType>
-  StructuredOpMatcher &singleOpWithCanonicaleArgs(bool commutative = false) {
-    return singleOpWithCanonicaleArgs(OpType::getOperationName(), commutative);
-  }
-  StructuredOpMatcher &singleOpWithCanonicaleArgs(StringRef opname,
-                                                  bool commutative);
-  /// Check if the op is a linalg of with a single float reciprocal op.
-  StructuredOpMatcher &isFloatReciprocal();
   /// Check if the op is a linalg of with a region containing only a yield op
   /// using block arguments in order.
   StructuredOpMatcher &passThroughOp();
 
 private:
+  /// Adds a predicate for the matched operation to satisfy.
+  void addPredicate(std::function<bool(linalg::LinalgOp)> predicate) {
+    // Check that the operation implements the LinalgOp interface and dispatch
+    // to the predicate.
+    CapturingOpMatcher::addPredicate(
+        [inner = std::move(predicate)](Operation *op) {
+          auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
+          return linalgOp && inner(linalgOp);
+        });
+  }
+
   /// Checks that `matchers` captured all tilable ops nested in `parent` except
   /// for `linalgOp`. This is an implementation detail of allTilableOpsCaptured.
   static bool checkAllTilableMatched(Operation *parent,
                                      linalg::LinalgOp linalgOp,
                                      ArrayRef<CapturingOpMatcher *> matchers);
-
-  /// Produce the debug output for `create` method in a non-templated way.
-  static void debugOutputForCreate(ArrayRef<StringRef> opNames);
 
   /// Non-template implementations of nested predicate builders for inputs,
   /// outputs and results. Should not be called directly.
@@ -621,9 +787,6 @@ private:
   // Common util for constant matcher.
   StructuredOpMatcher &input(int64_t position,
                              std::function<bool(llvm::APFloat)> floatValueFn);
-
-  /// Additional predicates to be checked on the structured op.
-  SmallVector<PredicateFn> predicates;
 };
 
 /// Creates a matcher of an arbitrary structured op.

--- a/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/TransformMatchers.cpp
@@ -11,8 +11,6 @@
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/Math/IR/Math.h"
-#include "mlir/Dialect/SCF/IR/SCF.h"
-#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/Dialect/Utils/StructuredOpsUtils.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/ScopeExit.h"
@@ -25,21 +23,381 @@ using namespace mlir;
 #define DBGSNL() llvm::dbgs() << "\n[" DEBUG_TYPE "] "
 
 //===---------------------------------------------------------------------===//
-// CapturingOpMatcher
+// CapturingMatcherBase
 //===---------------------------------------------------------------------===//
 
-void transform_ext::CapturingOpMatcher::getAllNested(
+void transform_ext::CapturingMatcherBase::getAllNested(
     SmallVectorImpl<CapturingOpMatcher *> &nested) {
-  int64_t start = nested.size();
-  llvm::append_range(nested, nestedCapturingMatchers);
-  for (int64_t position = start; position < nested.size(); ++position) {
-    llvm::append_range(nested, nested[position]->nestedCapturingMatchers);
+
+  SetVector<CapturingOpMatcher *> found;
+  found.insert(nested.begin(), nested.end());
+  int64_t start = found.size();
+
+  auto appendOne = [&found](CapturingMatcherBase &one) {
+    found.insert(one.nestedCapturingMatchers.begin(),
+                 one.nestedCapturingMatchers.end());
+    for (BlockBodyMatcher *blockMatcher : one.nestedBlockMatchers) {
+      found.insert(blockMatcher->nestedCapturingMatchers.begin(),
+                   blockMatcher->nestedCapturingMatchers.end());
+    }
+    for (CapturingValueMatcher *valueMatcher :
+         one.nestedCapturingValueMatchers) {
+      found.insert(valueMatcher->nestedCapturingMatchers.begin(),
+                   valueMatcher->nestedCapturingMatchers.end());
+    }
+  };
+
+  appendOne(*this);
+  for (int64_t position = start; position < found.size(); ++position) {
+    appendOne(*found[position]);
+  }
+
+  llvm::append_range(nested, found.getArrayRef());
+}
+
+void transform_ext::CapturingMatcherBase::getAllNestedValueMatchers(
+    SmallVectorImpl<CapturingValueMatcher *> &nested) {
+
+  SetVector<CapturingValueMatcher *> found;
+  found.insert(nested.begin(), nested.end());
+  int64_t start = found.size();
+
+  auto appendOne = [&found](CapturingMatcherBase &one) {
+    found.insert(one.nestedCapturingValueMatchers.begin(),
+                 one.nestedCapturingValueMatchers.end());
+    for (BlockBodyMatcher *blockMatcher : one.nestedBlockMatchers) {
+      found.insert(blockMatcher->nestedCapturingValueMatchers.begin(),
+                   blockMatcher->nestedCapturingValueMatchers.end());
+    }
+    for (CapturingOpMatcher *opMatcher : one.nestedCapturingMatchers) {
+      found.insert(opMatcher->nestedCapturingValueMatchers.begin(),
+                   opMatcher->nestedCapturingValueMatchers.end());
+    }
+  };
+
+  appendOne(*this);
+  for (int64_t position = start; position < found.size(); ++position) {
+    appendOne(*found[position]);
+  }
+
+  llvm::append_range(nested, found.getArrayRef());
+}
+
+void transform_ext::CapturingMatcherBase::getAllNestedBlockMatchers(
+    SmallVectorImpl<BlockBodyMatcher *> &nested) {
+
+  SetVector<BlockBodyMatcher *> found;
+  found.insert(nested.begin(), nested.end());
+  int64_t start = found.size();
+
+  auto appendOne = [&found](CapturingMatcherBase &one) {
+    found.insert(one.nestedBlockMatchers.begin(),
+                 one.nestedBlockMatchers.end());
+    for (CapturingValueMatcher *valueMatcher :
+         one.nestedCapturingValueMatchers) {
+      found.insert(valueMatcher->nestedBlockMatchers.begin(),
+                   valueMatcher->nestedBlockMatchers.end());
+    }
+    for (CapturingOpMatcher *opMatcher : one.nestedCapturingMatchers) {
+      found.insert(opMatcher->nestedBlockMatchers.begin(),
+                   opMatcher->nestedBlockMatchers.end());
+    }
+  };
+
+  appendOne(*this);
+  for (int64_t position = start; position < found.size(); ++position) {
+    appendOne(*found[position]);
+  }
+
+  llvm::append_range(nested, found.getArrayRef());
+}
+
+void transform_ext::CapturingMatcherBase::resetCapture() {
+  SmallVector<CapturingOpMatcher *> nested;
+  getAllNested(nested);
+  for (CapturingOpMatcher *matcher : nested) {
+    matcher->captured = nullptr;
+  }
+  SmallVector<CapturingValueMatcher *> nestedValue;
+  getAllNestedValueMatchers(nestedValue);
+  for (CapturingValueMatcher *matcher : nestedValue) {
+    matcher->captured = nullptr;
+  }
+  SmallVector<BlockBodyMatcher *> blocks;
+  getAllNestedBlockMatchers(blocks);
+  for (BlockBodyMatcher *matcher : blocks) {
+    matcher->captured = nullptr;
   }
 }
 
-void transform_ext::CapturingOpMatcher::getAllNestedValueMatchers(
-    SmallVectorImpl<CapturingValueMatcher *> &nested) {
-  llvm::append_range(nested, nestedCapturingValueMatchers);
+//===---------------------------------------------------------------------===//
+// CapturingOpMatcher
+//===---------------------------------------------------------------------===//
+
+bool transform_ext::CapturingOpMatcher::match(Operation *op) {
+  auto debugRAII =
+      llvm::make_scope_exit([] { LLVM_DEBUG(DBGS() << "-------\n"); });
+  LLVM_DEBUG(DBGS() << "matching: " << *op << "\n");
+
+  if (getCaptured()) {
+    LLVM_DEBUG(DBGS() << "found an already captured op: ");
+    if (getCaptured() == op) {
+      LLVM_DEBUG(llvm::dbgs() << "same\n");
+      return true;
+    } else {
+      LLVM_DEBUG(llvm::dbgs() << "different\n");
+      return false;
+    }
+  }
+
+  if (!llvm::all_of(predicates, [op](const PredicateFn &fn) {
+        bool result = fn(op);
+        LLVM_DEBUG(llvm::dbgs() << ": " << result << "\n");
+        return result;
+      })) {
+    return false;
+  }
+
+  captured = op;
+  return true;
+}
+
+void transform_ext::CapturingOpMatcher::debugOutputForCreate(
+    ArrayRef<StringRef> opNames) {
+  LLVM_DEBUG(DBGS() << "operation type is one of {";
+             llvm::interleaveComma(opNames, llvm::dbgs()); llvm::dbgs() << "}");
+}
+
+/// Apply the given matcher to the given object, produce debug messages.
+template <typename Matcher, typename Object = typename llvm::function_traits<
+                                typename Matcher::match>::template args<0>>
+static bool recursiveMatch(Matcher &matcher, Object &object,
+                           StringRef extraMessage = "") {
+  LLVM_DEBUG(llvm::dbgs() << "\n[" DEBUG_TYPE "] "
+                          << "start recursive match (" << extraMessage
+                          << ") {\n");
+  bool result = matcher.match(object);
+  LLVM_DEBUG(DBGS() << "} end recursive match");
+  return result;
+}
+
+transform_ext::CapturingOpMatcher &
+transform_ext::CapturingOpMatcher::alternatives(
+    transform_ext::CapturingOpMatcher &first,
+    transform_ext::CapturingOpMatcher &second) {
+  addPredicate([&first, &second](Operation *op) {
+    LLVM_DEBUG(DBGS() << "matching alternatives\n");
+    return recursiveMatch(first, op, "alternative 1") ||
+           recursiveMatch(second, op, "alternative 2");
+  });
+  return *this;
+}
+
+//---------------------------------------------------------------------------//
+// Predicates for operands and results.
+//---------------------------------------------------------------------------//
+
+transform_ext::CapturingOpMatcher &
+transform_ext::CapturingOpMatcher::operand(transform_ext::NumEqualsTo num) {
+  addPredicate([=](Operation *op) {
+    LLVM_DEBUG(DBGS() << "operation has exactly " << num.value << " operands");
+    return num.value == op->getNumOperands();
+  });
+  return *this;
+}
+
+/// If `pos` is negative, returns the number of the operand in op starting from
+/// the last. For example, -1 means the last operand, -2 means the
+/// second-to-last, etc. Returns nullopt if pos is out-of-bounds, both positive
+/// and negative.
+static std::optional<int64_t> remapNegativeOperandNumber(int64_t pos,
+                                                         Operation *op) {
+  int64_t updated = pos < 0 ? op->getNumOperands() + pos : pos;
+  if (updated < 0 || updated >= op->getNumOperands()) {
+    LLVM_DEBUG(DBGS() << "match operand #" << pos
+                      << "that does not exist in the operation");
+    return std::nullopt;
+  }
+  return updated;
+}
+
+transform_ext::CapturingOpMatcher &
+transform_ext::CapturingOpMatcher::operand(int64_t pos,
+                                           CapturingOpMatcher &nested) {
+  addPredicate([pos, &nested](Operation *op) {
+    std::optional<int64_t> operandNo = remapNegativeOperandNumber(pos, op);
+    if (!operandNo)
+      return false;
+    LLVM_DEBUG(DBGS() << "operand #" << pos << " is defined by an operation");
+    Operation *definingOp = op->getOperand(*operandNo).getDefiningOp();
+    if (!definingOp)
+      return false;
+    return recursiveMatch(nested, definingOp);
+  });
+  recordNestedMatcher(nested);
+  return *this;
+}
+
+transform_ext::CapturingOpMatcher &
+transform_ext::CapturingOpMatcher::operand(int64_t pos, ValueMatcher &nested) {
+  addPredicate([pos, &nested](Operation *op) {
+    std::optional<int64_t> operandNo = remapNegativeOperandNumber(pos, op);
+    if (!operandNo)
+      return false;
+    LLVM_DEBUG(DBGS() << "operand #" << pos << " is");
+    Value operand = op->getOperand(*operandNo);
+    return recursiveMatch(nested, operand);
+  });
+  recordNestedMatcher(nested);
+  return *this;
+}
+
+transform_ext::CapturingOpMatcher &transform_ext::CapturingOpMatcher::operand(
+    int64_t position, std::function<bool(llvm::APFloat)> floatValueFn) {
+  addPredicate([position,
+                floatValueFn = std::move(floatValueFn)](Operation *op) -> bool {
+    std::optional<int64_t> operandNo = remapNegativeOperandNumber(position, op);
+    if (!operandNo)
+      return false;
+
+    LLVM_DEBUG(DBGS() << "operand #" << *operandNo
+                      << " is a special floating point constant");
+    auto cstOp =
+        op->getOperand(*operandNo).getDefiningOp<arith::ConstantFloatOp>();
+    if (!cstOp)
+      return false;
+    return floatValueFn(cstOp.value());
+  });
+
+  return *this;
+}
+
+transform_ext::CapturingOpMatcher &
+transform_ext::CapturingOpMatcher::operand(int64_t position, ConstantFloatOne) {
+  return operand(position,
+                 [](llvm::APFloat value) { return value.isExactlyValue(1.0); });
+}
+
+transform_ext::CapturingOpMatcher &
+transform_ext::CapturingOpMatcher::result(transform_ext::NumEqualsTo num) {
+  addPredicate([=](Operation *op) {
+    LLVM_DEBUG(DBGS() << "operation has exactly " << num.value << " results");
+    return num.value == op->getNumResults();
+  });
+  return *this;
+}
+
+transform_ext::CapturingOpMatcher &
+transform_ext::CapturingOpMatcher::result(int64_t pos, ValueMatcher &nested) {
+  addPredicate([pos, &nested](Operation *op) {
+    int64_t updated = pos < 0 ? op->getNumResults() + pos : pos;
+    if (updated < 0 || updated >= op->getNumResults()) {
+      LLVM_DEBUG(DBGS() << "matching result #" << pos
+                        << " that does not exist in the operation");
+      return false;
+    }
+    LLVM_DEBUG(DBGS() << "result #" << pos << " is");
+    Value result = op->getResult(updated);
+    return recursiveMatch(nested, result);
+  });
+  recordNestedMatcher(nested);
+  return *this;
+}
+
+//===---------------------------------------------------------------------===//
+// BlockBodyMatcher
+//===---------------------------------------------------------------------===//
+
+transform_ext::BlockBodyMatcher::BlockBodyMatcher(
+    transform_ext::BlockBodyMatcher &first,
+    transform_ext::BlockBodyMatcher &second) {
+  addPredicate([&first, &second](Block &block) {
+    LLVM_DEBUG(DBGS() << "matching block alternatives");
+    return recursiveMatch(first, block, "first") ||
+           recursiveMatch(second, block, "second");
+  });
+}
+
+namespace {
+struct WrapBlockForPrinting {
+  Block &block;
+};
+
+llvm::raw_ostream &operator<<(llvm::raw_ostream &os,
+                              const WrapBlockForPrinting &wrap) {
+  wrap.block.print(os);
+  return os;
+}
+} // end namespace
+
+bool transform_ext::BlockBodyMatcher::match(Block &block) {
+  auto debugRAII =
+      llvm::make_scope_exit([] { LLVM_DEBUG(DBGS() << "-------\n"); });
+  LLVM_DEBUG(DBGS() << "matching: " << WrapBlockForPrinting{block} << "\n");
+  if (getCaptured()) {
+    LLVM_DEBUG(DBGS() << "found an already captured block: ");
+    if (getCaptured() == &block) {
+      LLVM_DEBUG(llvm::dbgs() << "same\n");
+      return true;
+    } else {
+      LLVM_DEBUG(llvm::dbgs() << "different\n");
+      return false;
+    }
+  }
+  return llvm::all_of(predicates, [&](const PredicateFn &fn) {
+    bool result = fn(block);
+    LLVM_DEBUG(llvm::dbgs() << ": " << result << "\n");
+    return result;
+  });
+}
+
+transform_ext::BlockBodyMatcher &transform_ext::BlockBodyMatcher::argument(
+    transform_ext::NumGreaterEqualTo num) {
+  addPredicate([=](Block &block) {
+    LLVM_DEBUG(DBGS() << "block has >= " << num.value << " arguments");
+    return block.getNumArguments() >= num.value;
+  });
+  return *this;
+}
+
+transform_ext::BlockBodyMatcher &
+transform_ext::BlockBodyMatcher::argument(int64_t pos, ValueMatcher &nested) {
+  addPredicate([pos, &nested](Block &block) {
+    int64_t updatedPos = pos < 0 ? block.getNumArguments() + pos : pos;
+    if (updatedPos < 0 || updatedPos >= block.getNumArguments()) {
+      LLVM_DEBUG(DBGS() << "matching block argument #" << pos
+                        << " that does not exist");
+      return false;
+    }
+    LLVM_DEBUG(DBGS() << "block argument #" << pos << " is\n");
+    Value argument = block.getArgument(updatedPos);
+    return recursiveMatch(nested, argument);
+  });
+  recordNestedMatcher(nested);
+  return *this;
+}
+
+transform_ext::BlockBodyMatcher &
+transform_ext::BlockBodyMatcher::operations(transform_ext::NumEqualsTo num) {
+  addPredicate([=](Block &block) {
+    LLVM_DEBUG(DBGS() << "block has exactly " << num.value << " operations");
+    return num.value == std::distance(block.begin(), block.end());
+  });
+  return *this;
+}
+
+transform_ext::BlockBodyMatcher &transform_ext::BlockBodyMatcher::terminator(
+    transform_ext::CapturingOpMatcher &nested) {
+  addPredicate([&nested](Block &block) {
+    Operation *terminator = block.getTerminator();
+    LLVM_DEBUG(DBGS() << "has terminator");
+    if (!terminator) {
+      return false;
+    }
+    return recursiveMatch(nested, terminator);
+  });
+  recordNestedMatcher(nested);
+  return *this;
 }
 
 //===---------------------------------------------------------------------===//
@@ -115,44 +473,11 @@ bool transform_ext::ValueMatcher::match(Value value) {
 // StructuredOpMatcher and friends.
 //===---------------------------------------------------------------------===//
 
-void transform_ext::StructuredOpMatcher::debugOutputForCreate(
-    ArrayRef<StringRef> opNames) {
-  LLVM_DEBUG(DBGS() << "operation type is one of {";
-             llvm::interleaveComma(opNames, llvm::dbgs()); llvm::dbgs() << "}");
-}
-
-bool transform_ext::StructuredOpMatcher::match(Operation *op) {
-  auto debugRAII =
-      llvm::make_scope_exit([] { LLVM_DEBUG(DBGS() << "-------\n"); });
-  LLVM_DEBUG(DBGS() << "matching: " << *op << "\n");
-
-  if (getCaptured()) {
-    LLVM_DEBUG(DBGS() << "found an already captured op: ");
-    if (getCaptured() == op) {
-      LLVM_DEBUG(llvm::dbgs() << "same\n");
-      return true;
-    } else {
-      LLVM_DEBUG(llvm::dbgs() << "different\n");
-      return false;
-    }
-  }
-
-  auto linalgOp = dyn_cast<linalg::LinalgOp>(op);
-  if (!linalgOp) {
-    LLVM_DEBUG(DBGS() << "not a structured op\n");
-    return false;
-  }
-
-  if (!llvm::all_of(predicates, [linalgOp](const PredicateFn &fn) {
-        bool result = fn(linalgOp);
-        LLVM_DEBUG(llvm::dbgs() << ": " << result << "\n");
-        return result;
-      })) {
-    return false;
-  }
-
-  captured = linalgOp;
-  return true;
+transform_ext::StructuredOpMatcher::StructuredOpMatcher() {
+  addPredicate([](Operation *op) {
+    LLVM_DEBUG(DBGS() << "is a structured op");
+    return isa<linalg::LinalgOp>(op);
+  });
 }
 
 //===---------------------------------------------------------------------===//
@@ -161,7 +486,7 @@ bool transform_ext::StructuredOpMatcher::match(Operation *op) {
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::rank(NumGreaterEqualTo minRank) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "rank >= " << minRank.value);
     return linalgOp.getNumLoops() >= minRank.value;
   });
@@ -170,7 +495,7 @@ transform_ext::StructuredOpMatcher::rank(NumGreaterEqualTo minRank) {
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::rank(NumLowerEqualTo maxRank) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "rank <= " << maxRank.value);
     return linalgOp.getNumLoops() <= maxRank.value;
   });
@@ -190,8 +515,8 @@ StringRef stringifyShapeKind(transform_ext::ShapeKind kind) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(SmallVector<int64_t> &&dimensions,
                                         ShapeKind kind) {
-  predicates.push_back([dimensions = std::move(dimensions),
-                        kind](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([dimensions = std::move(dimensions),
+                kind](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "dimensions [";
                llvm::interleaveComma(dimensions, llvm::dbgs());
                llvm::dbgs() << "] are " << stringifyShapeKind(kind));
@@ -213,7 +538,7 @@ transform_ext::StructuredOpMatcher::dim(SmallVector<int64_t> &&dimensions,
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(AllDims tag, ShapeKind kind) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all dimensions are " << stringifyShapeKind(kind));
     SmallVector<int64_t> shape = linalgOp.getStaticLoopRanges();
     return llvm::all_of(shape, [=](int64_t dimension) {
@@ -226,8 +551,8 @@ transform_ext::StructuredOpMatcher::dim(AllDims tag, ShapeKind kind) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(SmallVector<int64_t> &&dimensions,
                                         utils::IteratorType kind) {
-  predicates.push_back([dimensions = std::move(dimensions),
-                        kind](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([dimensions = std::move(dimensions),
+                kind](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "dimensions [";
                llvm::interleaveComma(dimensions, llvm::dbgs());
                llvm::dbgs() << "] are " << utils::stringifyIteratorType(kind));
@@ -255,8 +580,8 @@ transform_ext::StructuredOpMatcher::dim(AllDims tag, utils::IteratorType kind) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(AllDimsExcept &&dims,
                                         utils::IteratorType kind) {
-  predicates.push_back([dimensions = std::move(dims),
-                        kind](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([dimensions = std::move(dims),
+                kind](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all dimensions except [";
                llvm::interleaveComma(dimensions.getExcluded(), llvm::dbgs());
                llvm::dbgs() << "] are " << utils::stringifyIteratorType(kind));
@@ -282,7 +607,7 @@ transform_ext::StructuredOpMatcher::dim(AllDimsExcept &&dims,
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(int64_t dimension,
                                         DivisibleBy divisibleBy) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "dimension " << dimension << " is divisible by "
                       << divisibleBy.value);
     int64_t rank = linalgOp.getNumLoops();
@@ -302,7 +627,7 @@ transform_ext::StructuredOpMatcher::dim(int64_t dimension,
 //===---------------------------------------------------------------------===//
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::rank(CaptureRank capture) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "capture rank");
     capture.value = linalgOp.getNumLoops();
     return true;
@@ -312,7 +637,7 @@ transform_ext::StructuredOpMatcher::rank(CaptureRank capture) {
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(int64_t dimension, CaptureDim capture) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "capture dimension");
     int64_t rank = linalgOp.getNumLoops();
     int64_t transformedDimension =
@@ -328,7 +653,7 @@ transform_ext::StructuredOpMatcher::dim(int64_t dimension, CaptureDim capture) {
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::dim(AllDims tag, CaptureDims captures) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "capture all dimensions");
     captures.value = linalgOp.getStaticLoopRanges();
     return true;
@@ -338,7 +663,7 @@ transform_ext::StructuredOpMatcher::dim(AllDims tag, CaptureDims captures) {
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::convolutionDims(CaptureConvDims convDims) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "capture convolution dimensions\n");
     StringRef convMessage = linalg::detail::getMatchConvolutionMessage(
         mlir::linalg::detail::isConvolutionInterfaceImpl(linalgOp,
@@ -355,7 +680,7 @@ transform_ext::StructuredOpMatcher::convolutionDims(CaptureConvDims convDims) {
 transform_ext::StructuredOpMatcher::StructuredOpMatcher(
     StructuredOpMatcher &A, StructuredOpMatcher &B) {
 
-  predicates.push_back([&A, &B](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([&A, &B](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "start recursive lhs OR match {\n");
     {
       auto debugRAII = llvm::make_scope_exit(
@@ -374,6 +699,20 @@ transform_ext::StructuredOpMatcher::StructuredOpMatcher(
   });
   recordNestedMatcher(A);
   recordNestedMatcher(B);
+}
+
+//===---------------------------------------------------------------------===//
+// Body constraints.
+//===---------------------------------------------------------------------===//
+
+transform_ext::StructuredOpMatcher &transform_ext::StructuredOpMatcher::body(
+    transform_ext::BlockBodyMatcher &nested) {
+  addPredicate([&nested](linalg::LinalgOp linalgOp) {
+    LLVM_DEBUG(DBGS() << "body block is\n");
+    return recursiveMatch(nested, *linalgOp.getBlock());
+  });
+  recordNestedMatcher(nested);
+  return *this;
 }
 
 //===---------------------------------------------------------------------===//
@@ -396,8 +735,8 @@ void transform_ext::StructuredOpMatcher::addInputMatcher(
 void transform_ext::StructuredOpMatcher::addInputMatcher(
     int64_t position, std::function<bool(Value)> matcher,
     OptionalMatch optional) {
-  predicates.push_back([position, optional, matcher = std::move(matcher)](
-                           linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([position, optional, matcher = std::move(matcher)](
+                   linalg::LinalgOp linalgOp) -> bool {
     int64_t transformedPosition =
         position >= 0 ? position : linalgOp.getNumDpsInputs() + position;
     if (transformedPosition >= linalgOp.getNumDpsInputs()) {
@@ -423,7 +762,7 @@ void transform_ext::StructuredOpMatcher::addInputMatcher(
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(AllOperands tag, IsPermutation) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all input operands have permutation maps");
     // all_of with a lambda requires const-casting dance, so using a loop.
     for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
@@ -438,7 +777,7 @@ transform_ext::StructuredOpMatcher::input(AllOperands tag, IsPermutation) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(AllOperands tag,
                                           IsProjectedPermutation) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all input operands have projected permutation maps");
     // all_of with a lambda requires const-casting dance, so using a loop.
     for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
@@ -481,7 +820,7 @@ static bool makeValidPositiveIndex(int64_t &index, int64_t ub) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(SmallVector<int64_t> &&positions,
                                           IsProjected dim) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "operands ";
                llvm::interleaveComma(positions, llvm::dbgs());
                llvm::dbgs() << " have a permutation maps with " << dim.value
@@ -504,7 +843,7 @@ transform_ext::StructuredOpMatcher::input(SmallVector<int64_t> &&positions,
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(AllOperands tag, IsIdentity) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all input operands have identity maps");
     // all_of with a lambda requires const-casting dance, so using a loop.
     for (OpOperand *operand : linalgOp.getDpsInputOperands()) {
@@ -519,7 +858,7 @@ transform_ext::StructuredOpMatcher::input(AllOperands tag, IsIdentity) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(SmallVector<int64_t> &&positions,
                                           IsIdentity) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "input operands ";
                llvm::interleaveComma(positions, llvm::dbgs());
                llvm::dbgs() << " have identity maps");
@@ -540,7 +879,7 @@ transform_ext::StructuredOpMatcher::input(SmallVector<int64_t> &&positions,
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(int64_t position,
                                           ElementTypeBitWidth width) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "input operand #" << position
                       << " has elemental type with bit width " << width.value);
     int64_t updatedPosition = position;
@@ -559,7 +898,7 @@ transform_ext::StructuredOpMatcher::input(int64_t position,
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(int64_t position,
                                           CaptureElementTypeBitWidth width) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "input operand #" << position << " capture bitwidth");
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInputs()))
@@ -579,7 +918,7 @@ transform_ext::StructuredOpMatcher::input(int64_t position,
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(int64_t position,
                                           CaptureElementType elem) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "input operand #" << position
                       << " capture element type");
     int64_t updatedPosition = position;
@@ -601,7 +940,7 @@ transform_ext::StructuredOpMatcher::input(int64_t position,
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::input(NumEqualsTo num) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "number of input operands == " << num.value);
     return linalgOp.getNumDpsInputs() == num.value;
   });
@@ -623,8 +962,8 @@ transform_ext::StructuredOpMatcher::input(int64_t position, ConstantFloatZero) {
 
 transform_ext::StructuredOpMatcher &transform_ext::StructuredOpMatcher::input(
     int64_t position, std::function<bool(llvm::APFloat)> floatValueFn) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
-    LLVM_DEBUG(DBGS() << "input operands " << position
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
+    LLVM_DEBUG(DBGS() << "input operand #" << position
                       << " is a special floating point constant");
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInputs()))
@@ -646,8 +985,8 @@ transform_ext::StructuredOpMatcher &transform_ext::StructuredOpMatcher::input(
 void transform_ext::StructuredOpMatcher::addOutputMatcher(
     int64_t position, std::function<bool(Operation *)> matcher,
     OptionalMatch optional) {
-  predicates.push_back([position, optional, matcher = std::move(matcher)](
-                           linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([position, optional, matcher = std::move(matcher)](
+                   linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "output operand #" << position
                       << (optional.value ? " (optional match) "
                                          : " (mandatory match) ")
@@ -672,7 +1011,7 @@ void transform_ext::StructuredOpMatcher::addOutputMatcher(
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(AllOperands tag, IsPermutation) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all output operands have permutation maps");
     for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
       if (!linalgOp.getMatchingIndexingMap(operand).isPermutation())
@@ -686,7 +1025,7 @@ transform_ext::StructuredOpMatcher::output(AllOperands tag, IsPermutation) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(AllOperands tag,
                                            IsProjectedPermutation) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all output operands have projected permutation maps");
     for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
       if (!linalgOp.getMatchingIndexingMap(operand).isProjectedPermutation())
@@ -699,7 +1038,7 @@ transform_ext::StructuredOpMatcher::output(AllOperands tag,
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(AllOperands tag, IsProjected dim) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all output operands have a maps with projected");
     int64_t updatedDim = dim.value;
     if (!makeValidPositiveIndex(updatedDim, linalgOp.getNumLoops()))
@@ -716,7 +1055,7 @@ transform_ext::StructuredOpMatcher::output(AllOperands tag, IsProjected dim) {
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(AllOperands tag, IsIdentity) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "all output operands have identity permutation maps");
     for (OpOperand *operand : linalgOp.getDpsInitOperands()) {
       if (!linalgOp.getMatchingIndexingMap(operand).isIdentity())
@@ -730,7 +1069,7 @@ transform_ext::StructuredOpMatcher::output(AllOperands tag, IsIdentity) {
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(int64_t position,
                                            ElementTypeBitWidth width) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "output operand #" << position
                       << " has elemental type with bit width " << width.value);
     int64_t updatedPosition = position;
@@ -749,7 +1088,7 @@ transform_ext::StructuredOpMatcher::output(int64_t position,
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(int64_t position,
                                            CaptureElementTypeBitWidth width) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "output operand #" << position << " capture bitwidth");
     int64_t updatedPosition = position;
     if (!makeValidPositiveIndex(updatedPosition, linalgOp.getNumDpsInits()))
@@ -771,7 +1110,7 @@ transform_ext::StructuredOpMatcher::output(int64_t position,
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(int64_t position,
                                            CaptureElementType elem) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "output operand #" << position
                       << " capture element type");
     int64_t updatedPosition = position;
@@ -794,7 +1133,7 @@ transform_ext::StructuredOpMatcher::output(int64_t position,
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(int64_t position,
                                            SingleCombinerReduction tag) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "output operand #" << position
                       << " is populated by a single-combiner reduction");
     int64_t updatedPosition = position;
@@ -810,7 +1149,7 @@ transform_ext::StructuredOpMatcher::output(int64_t position,
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::output(NumEqualsTo num) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([=](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "number of output operands == " << num.value);
     return linalgOp.getNumDpsInits() == num.value;
   });
@@ -824,8 +1163,8 @@ transform_ext::StructuredOpMatcher::output(NumEqualsTo num) {
 void transform_ext::StructuredOpMatcher::addResultMatcher(
     int64_t position, HasAnyUse tag, std::function<bool(Operation *)> matcher,
     OptionalMatch optional) {
-  predicates.push_back([matcher = std::move(matcher), optional,
-                        position](linalg::LinalgOp linalgOp) -> bool {
+  addPredicate([matcher = std::move(matcher), optional,
+                position](linalg::LinalgOp linalgOp) -> bool {
     LLVM_DEBUG(DBGS() << "result #" << position
                       << (optional.value ? " (optional match) "
                                          : " (mandatory match) ")
@@ -872,74 +1211,48 @@ bool transform_ext::StructuredOpMatcher::checkAllTilableMatched(
 // Constraints on op region.
 //===-------------------------------------------------------------------===//
 
-transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::singleOpWithCanonicaleArgs(
-    StringRef opcode, bool commutative) {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) {
-    if (linalgOp.getBlock()->getOperations().size() != 2)
-      return false;
-    Operation *innerOp = &(*linalgOp.getBlock()->getOperations().begin());
-    if (innerOp->getName().getStringRef() != opcode ||
-        innerOp->getNumResults() != 1)
-      return false;
-    Operation *yieldOp = linalgOp.getBlock()->getTerminator();
-    if (yieldOp->getNumOperands() != 1)
-      return false;
-    if (yieldOp->getOperand(0).getDefiningOp() != innerOp)
-      return false;
-    if (commutative && innerOp->getNumOperands() == 2) {
-      auto arg0 = dyn_cast<BlockArgument>(innerOp->getOperand(0));
-      auto arg1 = dyn_cast<BlockArgument>(innerOp->getOperand(1));
-      if (!arg0 || !arg1)
-        return false;
-      if (arg0.getParentBlock() != linalgOp.getBlock() ||
-          arg1.getParentBlock() != linalgOp.getBlock())
-        return false;
-      if (!((arg0.getArgNumber() == 0 && arg1.getArgNumber() == 1) ||
-            (arg1.getArgNumber() == 0 && arg0.getArgNumber() == 1)))
-        return false;
-    } else {
-      for (auto [index, operand] : llvm::enumerate(innerOp->getOperands())) {
-        auto arg = dyn_cast<BlockArgument>(operand);
-        if (!arg || arg.getParentBlock() != linalgOp.getBlock() ||
-            arg.getArgNumber() != index)
-          return false;
-      }
-    }
-    return true;
-  });
-  return *this;
+/// Configures the `body` block matcher to match a block with one operation
+/// feeding exactly one value to the terminator. Returns the matcher of this
+/// operation for further chaining.
+template <typename OpTy>
+static transform_ext::CapturingOpMatcher &
+singleOpBody(transform_ext::MatcherContext &matcherContext, size_t numArguments,
+             transform_ext::BlockBodyMatcher &body) {
+  using namespace transform_ext;
+
+  auto &inner = m_Operation<OpTy>(matcherContext)
+                    .operand(NumEqualsTo(numArguments))
+                    .result(NumEqualsTo(1));
+
+  auto &terminator =
+      m_Operation(matcherContext).operand(NumEqualsTo(1)).operand(0, inner);
+
+  body = body.operations(NumEqualsTo(2))
+             .argument(NumGreaterEqualTo(numArguments))
+             .terminator(terminator);
+  return inner;
 }
 
-transform_ext::StructuredOpMatcher &
-transform_ext::StructuredOpMatcher::isFloatReciprocal() {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) {
-    LLVM_DEBUG(DBGS() << "op region represents a reciprocal operation");
-    if (linalgOp.getBlock()->getOperations().size() != 2)
-      return false;
-    Operation *innerOp = &(*linalgOp.getBlock()->getOperations().begin());
-    if (!isa<arith::DivFOp>(innerOp) || innerOp->getNumResults() != 1)
-      return false;
-    Operation *yieldOp = linalgOp.getBlock()->getTerminator();
-    if (yieldOp->getNumOperands() != 1)
-      return false;
-    if (yieldOp->getOperand(0).getDefiningOp() != innerOp)
-      return false;
-    auto cst = innerOp->getOperand(0).getDefiningOp<arith::ConstantFloatOp>();
-    if (!cst || cst.value().convertToDouble() != 1.0)
-      return false;
-    auto arg = dyn_cast<BlockArgument>(innerOp->getOperand(1));
-    if (!arg || arg.getParentBlock() != linalgOp.getBlock() ||
-        arg.getArgNumber() != 0)
-      return false;
-    return true;
-  });
-  return *this;
+/// Adds a predicate to `op` that matches its body to be a float reciprocal
+/// (1.0/x) computation. Returns the updated `op`.
+static transform_ext::StructuredOpMatcher &
+floatReciprocalBody(transform_ext::MatcherContext &matcherContext,
+                    transform_ext::StructuredOpMatcher &op) {
+  using namespace transform_ext;
+
+  BlockBodyMatcher &body = m_Block(matcherContext);
+  CapturingOpMatcher &inner =
+      singleOpBody<arith::DivFOp>(matcherContext, /*numArguments=*/2, body);
+
+  auto &arg = m_Value(matcherContext);
+  body = body.argument(NumGreaterEqualTo(1)).argument(0, arg);
+  inner = inner.operand(0, ConstantFloatOne()).operand(1, arg);
+  return op.body(body);
 }
 
 transform_ext::StructuredOpMatcher &
 transform_ext::StructuredOpMatcher::passThroughOp() {
-  predicates.push_back([=](linalg::LinalgOp linalgOp) {
+  addPredicate([=](linalg::LinalgOp linalgOp) {
     if (linalgOp.getBlock()->getOperations().size() != 1)
       return false;
     Operation *yieldOp = linalgOp.getBlock()->getTerminator();
@@ -1121,11 +1434,57 @@ void transform_ext::makeReductionMatcher(transform_ext::MatcherContext &context,
                        captures);
 }
 
+/// Adds a predicate to `op` checking that its body has one operation of type
+/// OpTy feeding the terminator. The operation has `numArguments` operands that
+/// correspond to block arguments and is commutative if indicated so. In the
+/// latter case, the block arguments may be swapped in the operand list.
+/// Otherwise they are checked to appear in the same order as in the block
+/// argument list.
+template <typename OpTy>
+static transform_ext::StructuredOpMatcher &
+singleOpBodyWithCanonicalArgs(transform_ext::MatcherContext &matcherContext,
+                              transform_ext::StructuredOpMatcher &op,
+                              size_t numArguments, bool isCommutative) {
+  using namespace transform_ext;
+  assert((!isCommutative || numArguments == 2) &&
+         "commutative ops are expected to have 2 arguments");
+
+  BlockBodyMatcher &body = m_Block(matcherContext);
+  if (isCommutative) {
+    auto &lhs = m_Value(matcherContext);
+    auto &rhs = m_Value(matcherContext);
+
+    // It is important for the argument predicates to be listed first here:
+    // the nested value matchers will capture the values that will be later
+    // checked against in the two alternatives. Otherwise, the values will be
+    // captured by the first of the alternatives and fail for the second.
+    // TODO: consider explicit indication of when a nested matcher is allowed to
+    // capture.
+    body = body.argument(0, lhs).argument(1, rhs);
+    CapturingOpMatcher &inner =
+        singleOpBody<OpTy>(matcherContext, /*numArguments=*/numArguments, body);
+
+    inner = inner.alternatives(
+        m_Operation(matcherContext).operand(0, lhs).operand(1, rhs),
+        m_Operation(matcherContext).operand(0, rhs).operand(1, lhs));
+  } else {
+    CapturingOpMatcher &inner =
+        singleOpBody<OpTy>(matcherContext, /*numArguments=*/numArguments, body);
+    for (size_t i = 0; i < numArguments; ++i) {
+      auto &operand = m_Value(matcherContext);
+      body = body.argument(i, operand);
+      inner = inner.operand(i, operand);
+    }
+  }
+
+  return op.body(body);
+}
+
 /// Match sum(%src, broadcast(%reduction))
-static void matchSubBroadcat(transform_ext::MatcherContext &matcherContext,
-                             transform_ext::StructuredOpMatcher &maxReduction,
-                             transform_ext::ValueMatcher &softmaxSourceOperand,
-                             transform_ext::StructuredOpMatcher *&sub) {
+static void matchSubBroadcast(transform_ext::MatcherContext &matcherContext,
+                              transform_ext::StructuredOpMatcher &maxReduction,
+                              transform_ext::ValueMatcher &softmaxSourceOperand,
+                              transform_ext::StructuredOpMatcher *&sub) {
   using namespace transform_ext;
 
   auto &broadcast =
@@ -1140,7 +1499,6 @@ static void matchSubBroadcat(transform_ext::MatcherContext &matcherContext,
 
   auto &subParallel =
       transform_ext::m_StructuredOp<linalg::GenericOp>(matcherContext)
-          .singleOpWithCanonicaleArgs<arith::SubFOp>()
           .dim(AllDims(), utils::IteratorType::parallel)
           .input(NumEqualsTo(2))
           .input(0, IsIdentity())
@@ -1149,10 +1507,11 @@ static void matchSubBroadcat(transform_ext::MatcherContext &matcherContext,
           .output(AllOperands(), IsIdentity());
   subParallel = subParallel.input(0, softmaxSourceOperand);
   subParallel = subParallel.input(1, broadcast);
+  subParallel = singleOpBodyWithCanonicalArgs<arith::SubFOp>(
+      matcherContext, subParallel, /*numArguments=*/2, /*isCommutative=*/false);
 
   auto &subBroadcast =
       transform_ext::m_StructuredOp<linalg::GenericOp>(matcherContext)
-          .singleOpWithCanonicaleArgs<arith::SubFOp>()
           .dim(AllDims(), utils::IteratorType::parallel)
           .input(NumEqualsTo(2))
           .input(0, IsIdentity())
@@ -1161,6 +1520,9 @@ static void matchSubBroadcat(transform_ext::MatcherContext &matcherContext,
           .output(AllOperands(), IsIdentity());
   subBroadcast = subBroadcast.input(0, softmaxSourceOperand);
   subBroadcast = subBroadcast.input(1, maxReduction);
+  subBroadcast = singleOpBodyWithCanonicalArgs<arith::SubFOp>(
+      matcherContext, subBroadcast, /*numArguments=*/2,
+      /*isCommutative=*/false);
   auto &subOr = transform_ext::m_StructuredOp_Or(matcherContext, subBroadcast,
                                                  subParallel);
   sub = &subOr;
@@ -1185,7 +1547,6 @@ static void matchdivBroadcast(transform_ext::MatcherContext &matcherContext,
 
   auto &divNoBroadcast =
       transform_ext::m_StructuredOp<linalg::GenericOp>(matcherContext)
-          .singleOpWithCanonicaleArgs<arith::DivFOp>()
           .dim(AllDims(), utils::IteratorType::parallel)
           .input(NumEqualsTo(2))
           .input(0, IsIdentity())
@@ -1195,10 +1556,12 @@ static void matchdivBroadcast(transform_ext::MatcherContext &matcherContext,
 
   divNoBroadcast = divNoBroadcast.input(0, expOperand);
   divNoBroadcast = divNoBroadcast.input(1, broadcast);
+  divNoBroadcast = singleOpBodyWithCanonicalArgs<arith::DivFOp>(
+      matcherContext, divNoBroadcast, /*numArguments=*/2,
+      /*isCommutative=*/false);
 
   auto &divBroadcast =
       transform_ext::m_StructuredOp<linalg::GenericOp>(matcherContext)
-          .singleOpWithCanonicaleArgs<arith::DivFOp>()
           .dim(AllDims(), utils::IteratorType::parallel)
           .input(NumEqualsTo(2))
           .input(0, IsIdentity())
@@ -1208,6 +1571,9 @@ static void matchdivBroadcast(transform_ext::MatcherContext &matcherContext,
 
   divBroadcast = divBroadcast.input(0, expOperand);
   divBroadcast = divBroadcast.input(1, sum);
+  divBroadcast = singleOpBodyWithCanonicalArgs<arith::DivFOp>(
+      matcherContext, divBroadcast, /*numArguments=*/2,
+      /*isCommutative=*/false);
 
   auto &divMerge = transform_ext::m_StructuredOp_Or(
       matcherContext, divNoBroadcast, divBroadcast);
@@ -1224,7 +1590,6 @@ void transform_ext::makeSoftmaxMatcher(
                            .input(0, ConstantFloatMinOrMinusInf());
   auto &maxReduction =
       transform_ext::m_StructuredOp<linalg::GenericOp>(matcherContext)
-          .singleOpWithCanonicaleArgs<arith::MaxFOp>(/*commutative=*/true)
           // Only handle most inner reduction for now.
           .dim(-1, utils::IteratorType::reduction)
           .dim(AllDimsExcept({-1}), utils::IteratorType::parallel)
@@ -1234,48 +1599,51 @@ void transform_ext::makeSoftmaxMatcher(
           .output(AllOperands(), IsProjected(-1));
   maxReduction = maxReduction.input(0, softmaxSourceOperand);
   maxReduction = maxReduction.output(0, fillMinusInf);
+  maxReduction = singleOpBodyWithCanonicalArgs<arith::MaxFOp>(
+      matcherContext, maxReduction, /*numArguments=*/2, /*isCommutative=*/true);
   maxReductionCapture = &maxReduction;
 
   transform_ext::StructuredOpMatcher *subOperand;
-  matchSubBroadcat(matcherContext, maxReduction, softmaxSourceOperand,
-                   subOperand);
+  matchSubBroadcast(matcherContext, maxReduction, softmaxSourceOperand,
+                    subOperand);
 
   auto &expOperand = m_StructuredOp<linalg::GenericOp>(matcherContext)
-                         .singleOpWithCanonicaleArgs<math::ExpOp>()
                          .dim(AllDims(), utils::IteratorType::parallel)
                          .input(NumEqualsTo(1))
                          .input(AllOperands(), IsIdentity())
                          .output(AllOperands(), IsIdentity())
                          .output(NumEqualsTo(1));
   expOperand = expOperand.input(0, *subOperand);
+  expOperand = singleOpBodyWithCanonicalArgs<math::ExpOp>(
+      matcherContext, expOperand, /*numArguments=*/1, /*isCommutative=*/false);
 
   auto &fillZero = m_StructuredOp<linalg::FillOp>(matcherContext)
                        .input(0, ConstantFloatZero());
-  auto &sum =
-      m_StructuredOp<linalg::GenericOp>(matcherContext)
-          .singleOpWithCanonicaleArgs<arith::AddFOp>(/*commutative=*/true)
-          // Only handle most inner reduction for now.
-          .dim(-1, utils::IteratorType::reduction)
-          .dim(AllDimsExcept({-1}), utils::IteratorType::parallel)
-          .input(NumEqualsTo(1))
-          .input(AllOperands(), IsIdentity())
-          .output(AllOperands(), IsProjected(-1))
-          .output(NumEqualsTo(1));
+  auto &sum = m_StructuredOp<linalg::GenericOp>(matcherContext)
+                  // Only handle most inner reduction for now.
+                  .dim(-1, utils::IteratorType::reduction)
+                  .dim(AllDimsExcept({-1}), utils::IteratorType::parallel)
+                  .input(NumEqualsTo(1))
+                  .input(AllOperands(), IsIdentity())
+                  .output(AllOperands(), IsProjected(-1))
+                  .output(NumEqualsTo(1));
   sum = sum.input(0, expOperand);
   sum = sum.output(0, fillZero);
+  sum = singleOpBodyWithCanonicalArgs<arith::AddFOp>(
+      matcherContext, sum, /*numArguments=*/2, /*isCommutative=*/true);
 
   auto &rcpOperand = m_StructuredOp<linalg::GenericOp>(matcherContext)
-                         .isFloatReciprocal()
+                         //  .isFloatReciprocal()
                          .dim(AllDims(), utils::IteratorType::parallel)
                          .input(NumEqualsTo(1))
                          .input(AllOperands(), IsIdentity())
                          .output(AllOperands(), IsIdentity())
                          .output(NumEqualsTo(1));
   rcpOperand = rcpOperand.input(0, sum);
+  rcpOperand = floatReciprocalBody(matcherContext, rcpOperand);
 
   auto &mulOperand =
       transform_ext::m_StructuredOp<linalg::GenericOp>(matcherContext)
-          .singleOpWithCanonicaleArgs<arith::MulFOp>(/*commutative=*/true)
           .dim(AllDims(), utils::IteratorType::parallel)
           .input(NumEqualsTo(2))
           .input(0, IsIdentity())
@@ -1285,6 +1653,8 @@ void transform_ext::makeSoftmaxMatcher(
 
   mulOperand = mulOperand.input(0, expOperand);
   mulOperand = mulOperand.input(1, rcpOperand);
+  mulOperand = singleOpBodyWithCanonicalArgs<arith::MulFOp>(
+      matcherContext, mulOperand, /*numArguments=*/2, /*isCommutative=*/true);
 
   transform_ext::StructuredOpMatcher *divOperand;
   matchdivBroadcast(matcherContext, expOperand, sum, divOperand);


### PR DESCRIPTION
Extend the matcher mechanism to support matching bodies of structured operations, and blocks in general. Block matchers are similar to operation and value matchers and are rooted at the terminator for efficiency: it is cheaper to traverse from opreand use to its definition.

Restructure the capturing matcher base classes to allow any matcher to point to any other matcher as nested.

Use block body matchers to replace custom predicates for single-op bodies in softmax. The predicate for the terminator-only pass-through body cannot be replaced yet as it requires a "variadic" value matcher that corresponds to the entire list of terminator operands.