### PR TITLE
move LowerToUKernels to Common

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -122,6 +122,7 @@ iree_compiler_cc_library(
         "GPUPipelining.cpp",
         "HoistStaticallyBoundAllocations.cpp",
         "IREEComprehensiveBufferizePass.cpp",
+        "LowerToUKernels.cpp",
         "LowerUKernelsToCalls.cpp",
         "MaterializeEncodingIntoPackUnPack.cpp",
         "OptimizeVectorTransferPass.cpp",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -97,6 +97,7 @@ iree_cc_library(
     "GPUPipelining.cpp"
     "HoistStaticallyBoundAllocations.cpp"
     "IREEComprehensiveBufferizePass.cpp"
+    "LowerToUKernels.cpp"
     "LowerUKernelsToCalls.cpp"
     "MaterializeEncodingIntoPackUnPack.cpp"
     "OptimizeVectorTransferPass.cpp"

--- a/compiler/src/iree/compiler/Codegen/Common/LowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/LowerToUKernels.cpp
@@ -19,8 +19,7 @@ namespace mlir {
 namespace iree_compiler {
 
 namespace {
-struct LLVMCPULowerToUKernelsPass
-    : LLVMCPULowerToUKernelsBase<LLVMCPULowerToUKernelsPass> {
+struct LowerToUKernelsPass : LowerToUKernelsBase<LowerToUKernelsPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<IREE::Codegen::IREECodegenDialect>();
   }
@@ -179,7 +178,7 @@ struct UKernelMmt4DPattern : OpRewritePattern<linalg::Mmt4DOp> {
 };
 }  // namespace
 
-void LLVMCPULowerToUKernelsPass::runOnOperation() {
+void LowerToUKernelsPass::runOnOperation() {
   MLIRContext *context = &getContext();
   RewritePatternSet patterns(context);
   patterns.insert<UKernelMatmulPattern, UKernelMmt4DPattern>(context);
@@ -189,8 +188,8 @@ void LLVMCPULowerToUKernelsPass::runOnOperation() {
   }
 }
 
-std::unique_ptr<OperationPass<>> createLLVMCPULowerToUKernelsPass() {
-  return std::make_unique<LLVMCPULowerToUKernelsPass>();
+std::unique_ptr<OperationPass<>> createLowerToUKernelsPass() {
+  return std::make_unique<LowerToUKernelsPass>();
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Common/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/test/BUILD
@@ -35,6 +35,7 @@ iree_lit_test_suite(
             "gpu_vectorization.mlir",
             "hoist_statically_bound_allocations.mlir",
             "iree_comprehensive_bufferize.mlir",
+            "lower_to_ukernel_ops.mlir",
             "lower_ukernel_to_calls.mlir",
             "pad_dynamic_alloc.mlir",
             "rematerialize_parallel_ops.mlir",

--- a/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/test/CMakeLists.txt
@@ -31,6 +31,7 @@ iree_lit_test_suite(
     "gpu_vectorization.mlir"
     "hoist_statically_bound_allocations.mlir"
     "iree_comprehensive_bufferize.mlir"
+    "lower_to_ukernel_ops.mlir"
     "lower_ukernel_to_calls.mlir"
     "pad_dynamic_alloc.mlir"
     "reduce_bank_conflicts.mlir"

--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_to_ukernel_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-lower-to-ukernels %s | FileCheck %s
+// RUN: iree-opt --iree-codegen-lower-to-ukernels %s | FileCheck %s
 
 func.func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
     %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {

--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_to_ukernel_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --iree-llvmcpu-lower-to-ukernels %s | FileCheck %s
+// RUN: iree-opt --iree-lower-to-ukernels %s | FileCheck %s
 
 func.func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
     %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/BUILD
@@ -24,7 +24,6 @@ iree_compiler_cc_library(
         "LLVMCPUEmitVectorizationRemarks.cpp",
         "LLVMCPULinkExecutables.cpp",
         "LLVMCPULowerExecutableTarget.cpp",
-        "LLVMCPULowerToUKernels.cpp",
         "LLVMCPUMaterializeEncodingPass.cpp",
         "LLVMCPUMmt4dVectorLowering.cpp",
         "LLVMCPUSynchronizeSymbolVisibility.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/CMakeLists.txt
@@ -27,7 +27,6 @@ iree_cc_library(
     "LLVMCPUEmitVectorizationRemarks.cpp"
     "LLVMCPULinkExecutables.cpp"
     "LLVMCPULowerExecutableTarget.cpp"
-    "LLVMCPULowerToUKernels.cpp"
     "LLVMCPUMaterializeEncodingPass.cpp"
     "LLVMCPUMmt4dVectorLowering.cpp"
     "LLVMCPUSynchronizeSymbolVisibility.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/BUILD
@@ -34,7 +34,6 @@ iree_lit_test_suite(
             "hal_interface_constants.mlir",
             "hal_interface_workgroup_info.mlir",
             "illegal_configuration.mlir",
-            "lower_to_ukernel_ops.mlir",
             "materialize_aarch64_launch_configuration.mlir",
             "materialize_encoding.mlir",
             "materialize_riscv_launch_configuration.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/CMakeLists.txt
@@ -29,7 +29,6 @@ iree_lit_test_suite(
     "hal_interface_constants.mlir"
     "hal_interface_workgroup_info.mlir"
     "illegal_configuration.mlir"
-    "lower_to_ukernel_ops.mlir"
     "materialize_aarch64_launch_configuration.mlir"
     "materialize_encoding.mlir"
     "materialize_riscv_launch_configuration.mlir"

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -278,7 +278,7 @@ createLLVMCPULowerExecutableTargetPass();
 
 /// Pass to lower a sequence of operations to a iree_codegen.ukernel.*
 /// operation.
-std::unique_ptr<OperationPass<>> createLLVMCPULowerToUKernelsPass();
+std::unique_ptr<OperationPass<>> createLowerToUKernelsPass();
 
 /// Materialize the encoding of operations. The layout to use for the encoded
 /// operations are LLVMCPU specific.

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -330,6 +330,14 @@ def RematerializeParallelOps :
   let constructor = "mlir::iree_compiler::createRematerializeParallelOpsPass()";
 }
 
+def LowerToUKernels :
+    Pass<"iree-lower-to-ukernels", ""> {
+  let summary =
+      "Separate out parts of the IR that lower to a micro-kernel";
+  let constructor =
+      "mlir::iree_compiler::createLowerToUKernelsPass()";
+}
+
 //------------------------------------------------------------------------------
 // LLVMCPU
 //------------------------------------------------------------------------------
@@ -372,14 +380,6 @@ def LLVMCPULowerExecutableTarget :
       "Lower executable target using an IREE::HAL::DispatchLoweringPassPipeline";
   let constructor =
       "mlir::iree_compiler::createLLVMCPULowerExecutableTargetPass()";
-}
-
-def LLVMCPULowerToUKernels :
-    Pass<"iree-llvmcpu-lower-to-ukernels", ""> {
-  let summary =
-      "Separate out parts of the IR that lower to a micro-kernel";
-  let constructor =
-      "mlir::iree_compiler::createLLVMCPULowerToUKernelsPass()";
 }
 
 def LLVMCPUMaterializeEncoding :

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -331,7 +331,7 @@ def RematerializeParallelOps :
 }
 
 def LowerToUKernels :
-    Pass<"iree-lower-to-ukernels", ""> {
+    Pass<"iree-codegen-lower-to-ukernels", ""> {
   let summary =
       "Separate out parts of the IR that lower to a micro-kernel";
   let constructor =


### PR DESCRIPTION
This enables incrementally migrating the VMVX backend to the new system, so we can start getting some serious e2e coverage for the new system and retiring the VMVXOps and the VMVX/LowerLinalgMicrokernels.cpp code for which we have a replacement in the new system (so far, mmt4d).