### PR TITLE
Do not cast to TilingInterface after generating tiled ops in TileAndDistribute

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileDispatchUsingInterface.cpp
@@ -501,12 +501,7 @@ FailureOr<TileAndFuseResult> tileAndFuseDispatchUsingSCFForOp(
       return rewriter.notifyMatchFailure(sliceOp,
                                          "fusion along slice op failed");
     }
-    auto tiledProducer = tiledProducerVal->getDefiningOp<TilingInterface>();
-    if (!tiledProducer) {
-      return rewriter.notifyMatchFailure(
-          tiledProducerVal->getDefiningOp(),
-          "expected tiled implementation to implement TilingInterface as well");
-    }
+    auto tiledProducer = tiledProducerVal->getDefiningOp();
     if (tiledProducer->getNumResults() != fusableProducer->getNumResults()) {
       return rewriter.notifyMatchFailure(fusableProducer,
                                          "fused operation expected to produce "


### PR DESCRIPTION
The check logic does not require casting tiled ops into TilingInterface. Relaxing the condition which allows us to tile and distribute dynamic unpack ops with its consumers.

A proper fix might be making `generateResultTileValue` return `FailureOr<SmallVector<Value>>`, not just `FailureOr<Value>`. That would need upstream changes.

Fixes https://github.com/iree-org/iree/issues/12190