### PR TITLE
[Benchmark migration] Switch to Github benchmark pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1047,8 +1047,7 @@ jobs:
             "${BENCHMARK_COMMENT_ARTIFACT}" \
             "${BENCHMARK_COMMENT_GCS_ARTIFACT}"
       - name: Uploading results to dashboard
-        # TODO(#11076): Temporarily disabled until we migrate the database.
-        if: false && needs.setup.outputs.ci-stage == 'postsubmit'
+        if: needs.setup.outputs.ci-stage == 'postsubmit'
         env:
           EXECUTION_BENCHMARK_RESULTS_PATTERN: ${{ steps.download-execution-results.outputs.execution-benchmark-results-pattern }}
           IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}

--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -55,10 +55,7 @@ jobs:
         id: check
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO(#11076): Temporarily matches a non-existent job so we don't
-          # post comments by default before the migration. And a test PR with
-          # the modified benchmark job name can still do end-to-end test.
-          BENCHMARK_PROCESS_JOB: process_benchmark_results_disabled
+          BENCHMARK_PROCESS_JOB: process_benchmark_results
         run: |
           # Assume the workflow has fewer than 100 jobs.
           export CONCLUSION=$(gh api \


### PR DESCRIPTION
Step 6 of the migration:

- Enable posting benchmark comments in the CI workflow.
- Enable uploading benchmark results in the CI workflow.

This should be merged after we restart the perf dashboard server.

See details in: https://github.com/iree-org/iree/discussions/11883#discussioncomment-4940686

