### PR TITLE
Perform GPU address space lowering during LLVM lowering

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/ConvertToLLVM.h
@@ -29,7 +29,7 @@ void populateScalarizeMathOps(RewritePatternSet &patterns);
 void populateLowerHALInterfaceOp(RewritePatternSet &patterns);
 
 /// Add patterns to convert AllocOp of shared memory to a global variable.
-void populateConvertSharedMemoryAllocOps(RewritePatternSet &patterns);
+void populateConvertSharedMemoryAllocOps(RewritePatternSet &patterns, unsigned addrSpace);
 
 void ConvertToDynamicSharedMemory(ModuleOp moduleOp);
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -410,7 +410,6 @@ static void addLowerToLLVMGPUPasses(OpPassManager &pm, bool useROCM) {
   pm.addNestedPass<func::FuncOp>(memref::createExpandOpsPass());
   pm.addPass(memref::createExpandStridedMetadataPass());
   pm.addPass(createLowerAffinePass());
-  pm.addPass(createGPULowerMemorySpaceAttributesPass());
   // Strip out the debug info for the kernel as CUDA driver doesn't diggest PTX
   // debug info well.
   pm.addPass(createStripDebugInfoPass());

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -86,6 +86,11 @@ Value emitGPUGroupReduction(Location loc, OpBuilder &builder, Value input,
 // TODO: Make this take HW specific sizes.
 Optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op);
 
+LogicalResult lowerAddressSpaceEnum(MLIRContext *ctx, ModuleOp &op,
+                                    unsigned globalAddrSpace,
+                                    unsigned workgroupAddrSpace,
+                                    unsigned privateAddrSpace);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 


### PR DESCRIPTION
This patch removes the standalone GPU address space lowering pass and performs that conversion from the address space enum during the respective LLVM conversion passes. That matches upstream LLVM. This allows the removal of a hard-coded address space constant from the conversion of shared memory AllocOps to global variables. The correct address space has to be provided as an option for the pattern.