### PR TITLE
Add a matcher for value packs

### DIFF
--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -154,6 +154,7 @@ cc_library(
         "@llvm-project//mlir:MathDialect",
         "@llvm-project//mlir:Rewrite",
         "@llvm-project//mlir:SCFDialect",
+        "@llvm-project//mlir:Support",
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TransformDialect",
         "@llvm-project//mlir:Transforms",

--- a/llvm-external-projects/iree-dialects/lib/Transforms/CMakeLists.txt
+++ b/llvm-external-projects/iree-dialects/lib/Transforms/CMakeLists.txt
@@ -14,6 +14,7 @@ add_mlir_library(IREEDialectsTransforms
   MLIRLinalgDialect
   MLIRLinalgTransforms
   MLIRMathDialect
+  MLIRSupport
 
   DEPENDS
   mlir-headers


### PR DESCRIPTION
It is sometimes useful to define matcher predicates on a pack of values
without knowing the number of values in the pack. For example, when
all results of an operation are used by another operation, regardless of
their number.

This required a small refactoring of the base matcher code to avoid base
matcher knowing about all derived classes and using complicated logic
for resetting the captured values.

Use this to replace the custom hook for a structured op being a
pass-through, i.e., for its body yielding the input block arguments.

Depends on #12196