### PR TITLE
Fix device_allocator option in new benchmark suite

### DIFF
--- a/build_tools/benchmarks/common/benchmark_definition.py
+++ b/build_tools/benchmarks/common/benchmark_definition.py
@@ -138,7 +138,6 @@ def get_iree_benchmark_module_arguments(
     repetitions = 10
 
   cmd = [
-      "--device_allocator=caching",
       "--time_unit=ns",
       "--benchmark_format=json",
       "--benchmark_out_format=json",

--- a/build_tools/python/benchmark_suites/iree/module_execution_configs.py
+++ b/build_tools/python/benchmark_suites/iree/module_execution_configs.py
@@ -29,32 +29,32 @@ def _with_caching_allocator(
 
 ELF_LOCAL_SYNC_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_SYNC,
-    tags=["full-inference", "default-flags", "caching-allocator"],
+    tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
     driver=iree_definitions.RuntimeDriver.LOCAL_SYNC)
 
 CUDA_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_CUDA,
-    tags=["full-inference", "default-flags", "caching-allocator"],
+    tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.CUDA)
 
 VULKAN_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN,
-    tags=["full-inference", "default-flags", "caching-allocator"],
+    tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN)
 
 VULKAN_BATCH_SIZE_16_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_16,
-    tags=["full-inference", "experimental-flags", "caching-allocator"],
+    tags=["full-inference", "experimental-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN,
     extra_flags=["--batch_size=16"])
 
 VULKAN_BATCH_SIZE_32_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_32,
-    tags=["full-inference", "experimental-flags", "caching-allocator"],
+    tags=["full-inference", "experimental-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN,
     extra_flags=["--batch_size=32"])
@@ -64,10 +64,7 @@ def get_elf_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_TASK_BASE}-{thread_num}"
   return _with_caching_allocator(
       id=config_id,
-      tags=[
-          f"{thread_num}-thread", "full-inference", "default-flags",
-          "caching-allocator"
-      ],
+      tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
       driver=iree_definitions.RuntimeDriver.LOCAL_TASK,
       extra_flags=[f"--task_topology_group_count={thread_num}"])
@@ -77,10 +74,7 @@ def get_vmvx_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_VMVX_LOCAL_TASK_BASE}-{thread_num}"
   return _with_caching_allocator(
       id=config_id,
-      tags=[
-          f"{thread_num}-thread", "full-inference", "default-flags",
-          "caching-allocator"
-      ],
+      tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.VMVX_MODULE,
       driver=iree_definitions.RuntimeDriver.LOCAL_TASK,
       extra_flags=[f"--task_topology_group_count={thread_num}"])

--- a/build_tools/python/benchmark_suites/iree/module_execution_configs.py
+++ b/build_tools/python/benchmark_suites/iree/module_execution_configs.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Defines ModuleExecutionConfig for benchmarks."""
 
-from typing import List
+from typing import List, Optional, Sequence
 
 from e2e_test_framework.definitions import iree_definitions
 from e2e_test_framework import unique_ids
@@ -16,43 +16,46 @@ def _with_caching_allocator(
     tags: List[str],
     loader: iree_definitions.RuntimeLoader,
     driver: iree_definitions.RuntimeDriver,
-    extra_flags: List[str] = []) -> iree_definitions.ModuleExecutionConfig:
-  return iree_definitions.ModuleExecutionConfig(
-      id=id,
-      tags=tags,
-      loader=loader,
-      driver=driver,
-      extra_flags=["--device_allocator=caching"] + extra_flags)
+    extra_flags: Optional[Sequence[str]] = None
+) -> iree_definitions.ModuleExecutionConfig:
+  flags = ["--device_allocator=caching"]
+  if extra_flags is not None:
+    flags.extend(extra_flags)
+  return iree_definitions.ModuleExecutionConfig(id=id,
+                                                tags=tags,
+                                                loader=loader,
+                                                driver=driver,
+                                                extra_flags=flags)
 
 
 ELF_LOCAL_SYNC_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_SYNC,
-    tags=["full-inference", "default-flags"],
+    tags=["full-inference", "default-flags", "caching-allocator"],
     loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
     driver=iree_definitions.RuntimeDriver.LOCAL_SYNC)
 
 CUDA_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_CUDA,
-    tags=["full-inference", "default-flags"],
+    tags=["full-inference", "default-flags", "caching-allocator"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.CUDA)
 
 VULKAN_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN,
-    tags=["full-inference", "default-flags"],
+    tags=["full-inference", "default-flags", "caching-allocator"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN)
 
 VULKAN_BATCH_SIZE_16_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_16,
-    tags=["full-inference", "experimental-flags"],
+    tags=["full-inference", "experimental-flags", "caching-allocator"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN,
     extra_flags=["--batch_size=16"])
 
 VULKAN_BATCH_SIZE_32_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_32,
-    tags=["full-inference", "experimental-flags"],
+    tags=["full-inference", "experimental-flags", "caching-allocator"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN,
     extra_flags=["--batch_size=32"])
@@ -62,7 +65,10 @@ def get_elf_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_TASK_BASE}-{thread_num}"
   return _with_caching_allocator(
       id=config_id,
-      tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
+      tags=[
+          f"{thread_num}-thread", "full-inference", "default-flags",
+          "caching-allocator"
+      ],
       loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
       driver=iree_definitions.RuntimeDriver.LOCAL_TASK,
       extra_flags=[f"--task_topology_group_count={thread_num}"])
@@ -72,7 +78,10 @@ def get_vmvx_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_VMVX_LOCAL_TASK_BASE}-{thread_num}"
   return _with_caching_allocator(
       id=config_id,
-      tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
+      tags=[
+          f"{thread_num}-thread", "full-inference", "default-flags",
+          "caching-allocator"
+      ],
       loader=iree_definitions.RuntimeLoader.VMVX_MODULE,
       driver=iree_definitions.RuntimeDriver.LOCAL_TASK,
       extra_flags=[f"--task_topology_group_count={thread_num}"])

--- a/build_tools/python/benchmark_suites/iree/module_execution_configs.py
+++ b/build_tools/python/benchmark_suites/iree/module_execution_configs.py
@@ -18,14 +18,13 @@ def _with_caching_allocator(
     driver: iree_definitions.RuntimeDriver,
     extra_flags: Optional[Sequence[str]] = None
 ) -> iree_definitions.ModuleExecutionConfig:
-  flags = ["--device_allocator=caching"]
-  if extra_flags is not None:
-    flags.extend(extra_flags)
-  return iree_definitions.ModuleExecutionConfig(id=id,
-                                                tags=tags,
-                                                loader=loader,
-                                                driver=driver,
-                                                extra_flags=flags)
+  extra_flags = [] if extra_flags is None else list(extra_flags)
+  return iree_definitions.ModuleExecutionConfig(
+      id=id,
+      tags=tags,
+      loader=loader,
+      driver=driver,
+      extra_flags=["--device_allocator=caching"] + extra_flags)
 
 
 ELF_LOCAL_SYNC_CONFIG = _with_caching_allocator(

--- a/build_tools/python/benchmark_suites/iree/module_execution_configs.py
+++ b/build_tools/python/benchmark_suites/iree/module_execution_configs.py
@@ -5,35 +5,55 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 """Defines ModuleExecutionConfig for benchmarks."""
 
+from typing import List
+
 from e2e_test_framework.definitions import iree_definitions
 from e2e_test_framework import unique_ids
 
-ELF_LOCAL_SYNC_CONFIG = iree_definitions.ModuleExecutionConfig(
+# Special flags that we want to enable for all benchmarks. We would like to
+# keep these flags in the config so the exported config contains all
+# information for reproducing. Add/remove flags with caution.
+GLOBAL_FLAGS = ["--device_allocator=caching"]
+
+
+class BenchmarkExecutionConfig(iree_definitions.ModuleExecutionConfig):
+  """ModuleExecutionConfig with benchmark specific config."""
+
+  def __init__(
+      self,
+      *,
+      extra_flags: List[str] = [],
+      **kwargs,
+  ):
+    super().__init__(**kwargs, extra_flags=GLOBAL_FLAGS + extra_flags)
+
+
+ELF_LOCAL_SYNC_CONFIG = BenchmarkExecutionConfig(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_SYNC,
     tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
     driver=iree_definitions.RuntimeDriver.LOCAL_SYNC)
 
-CUDA_CONFIG = iree_definitions.ModuleExecutionConfig(
+CUDA_CONFIG = BenchmarkExecutionConfig(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_CUDA,
     tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.CUDA)
 
-VULKAN_CONFIG = iree_definitions.ModuleExecutionConfig(
+VULKAN_CONFIG = BenchmarkExecutionConfig(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN,
     tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN)
 
-VULKAN_BATCH_SIZE_16_CONFIG = iree_definitions.ModuleExecutionConfig(
+VULKAN_BATCH_SIZE_16_CONFIG = BenchmarkExecutionConfig(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_16,
     tags=["full-inference", "experimental-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN,
     extra_flags=["--batch_size=16"])
 
-VULKAN_BATCH_SIZE_32_CONFIG = iree_definitions.ModuleExecutionConfig(
+VULKAN_BATCH_SIZE_32_CONFIG = BenchmarkExecutionConfig(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_32,
     tags=["full-inference", "experimental-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
@@ -43,7 +63,7 @@ VULKAN_BATCH_SIZE_32_CONFIG = iree_definitions.ModuleExecutionConfig(
 
 def get_elf_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_TASK_BASE}-{thread_num}"
-  return iree_definitions.ModuleExecutionConfig(
+  return BenchmarkExecutionConfig(
       id=config_id,
       tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
@@ -53,7 +73,7 @@ def get_elf_local_task_config(thread_num: int):
 
 def get_vmvx_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_VMVX_LOCAL_TASK_BASE}-{thread_num}"
-  return iree_definitions.ModuleExecutionConfig(
+  return BenchmarkExecutionConfig(
       id=config_id,
       tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.VMVX_MODULE,

--- a/build_tools/python/benchmark_suites/iree/module_execution_configs.py
+++ b/build_tools/python/benchmark_suites/iree/module_execution_configs.py
@@ -10,50 +10,47 @@ from typing import List
 from e2e_test_framework.definitions import iree_definitions
 from e2e_test_framework import unique_ids
 
-# Special flags that we want to enable for all benchmarks. We would like to
-# keep these flags in the config so the exported config contains all
-# information for reproducing. Add/remove flags with caution.
-GLOBAL_FLAGS = ["--device_allocator=caching"]
+
+def _with_caching_allocator(
+    id: str,
+    tags: List[str],
+    loader: iree_definitions.RuntimeLoader,
+    driver: iree_definitions.RuntimeDriver,
+    extra_flags: List[str] = []) -> iree_definitions.ModuleExecutionConfig:
+  return iree_definitions.ModuleExecutionConfig(
+      id=id,
+      tags=tags,
+      loader=loader,
+      driver=driver,
+      extra_flags=["--device_allocator=caching"] + extra_flags)
 
 
-class BenchmarkExecutionConfig(iree_definitions.ModuleExecutionConfig):
-  """ModuleExecutionConfig with benchmark specific config."""
-
-  def __init__(
-      self,
-      *,
-      extra_flags: List[str] = [],
-      **kwargs,
-  ):
-    super().__init__(**kwargs, extra_flags=GLOBAL_FLAGS + extra_flags)
-
-
-ELF_LOCAL_SYNC_CONFIG = BenchmarkExecutionConfig(
+ELF_LOCAL_SYNC_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_SYNC,
     tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
     driver=iree_definitions.RuntimeDriver.LOCAL_SYNC)
 
-CUDA_CONFIG = BenchmarkExecutionConfig(
+CUDA_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_CUDA,
     tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.CUDA)
 
-VULKAN_CONFIG = BenchmarkExecutionConfig(
+VULKAN_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN,
     tags=["full-inference", "default-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN)
 
-VULKAN_BATCH_SIZE_16_CONFIG = BenchmarkExecutionConfig(
+VULKAN_BATCH_SIZE_16_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_16,
     tags=["full-inference", "experimental-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
     driver=iree_definitions.RuntimeDriver.VULKAN,
     extra_flags=["--batch_size=16"])
 
-VULKAN_BATCH_SIZE_32_CONFIG = BenchmarkExecutionConfig(
+VULKAN_BATCH_SIZE_32_CONFIG = _with_caching_allocator(
     id=unique_ids.IREE_MODULE_EXECUTION_CONFIG_VULKAN_BATCH_SIZE_32,
     tags=["full-inference", "experimental-flags"],
     loader=iree_definitions.RuntimeLoader.NONE,
@@ -63,7 +60,7 @@ VULKAN_BATCH_SIZE_32_CONFIG = BenchmarkExecutionConfig(
 
 def get_elf_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_LOCAL_TASK_BASE}-{thread_num}"
-  return BenchmarkExecutionConfig(
+  return _with_caching_allocator(
       id=config_id,
       tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
@@ -73,7 +70,7 @@ def get_elf_local_task_config(thread_num: int):
 
 def get_vmvx_local_task_config(thread_num: int):
   config_id = f"{unique_ids.IREE_MODULE_EXECUTION_CONFIG_VMVX_LOCAL_TASK_BASE}-{thread_num}"
-  return BenchmarkExecutionConfig(
+  return _with_caching_allocator(
       id=config_id,
       tags=[f"{thread_num}-thread", "full-inference", "default-flags"],
       loader=iree_definitions.RuntimeLoader.VMVX_MODULE,

--- a/build_tools/python/e2e_model_tests/cmake_generator.py
+++ b/build_tools/python/e2e_model_tests/cmake_generator.py
@@ -26,10 +26,10 @@ def generate_rules() -> List[str]:
     runner_args = run_module_utils.build_run_flags_for_model(
         model=model,
         model_input_data=test_config.input_data) + test_config.extra_test_flags
-    # TODO(#11136): We should pick up the execution args from
-    # `build_run_flags_for_execution_config`. But currently the DRIVER needs to
-    # be populated separately in the CMake rule.
-    runner_args.append("--device_allocator=caching")
+    # TODO(#11136): Currently the DRIVER is a separate field in the CMake rule (
+    # and has effect on test labels). Generates the flags without the driver.
+    runner_args += run_module_utils.build_run_flags_for_execution_config(
+        test_config.execution_config, without_driver=True)
     cmake_rule = cmake_builder.rules.build_iree_benchmark_suite_module_test(
         target_name=test_config.name,
         model=f"{model.id}_{model.name}",

--- a/build_tools/python/e2e_model_tests/cmake_generator.py
+++ b/build_tools/python/e2e_model_tests/cmake_generator.py
@@ -29,7 +29,7 @@ def generate_rules() -> List[str]:
     # TODO(#11136): Currently the DRIVER is a separate field in the CMake rule (
     # and has effect on test labels). Generates the flags without the driver.
     runner_args += run_module_utils.build_run_flags_for_execution_config(
-        test_config.execution_config, without_driver=True)
+        test_config.execution_config, with_driver=False)
     cmake_rule = cmake_builder.rules.build_iree_benchmark_suite_module_test(
         target_name=test_config.name,
         model=f"{model.id}_{model.name}",

--- a/build_tools/python/e2e_model_tests/cmake_generator.py
+++ b/build_tools/python/e2e_model_tests/cmake_generator.py
@@ -26,6 +26,10 @@ def generate_rules() -> List[str]:
     runner_args = run_module_utils.build_run_flags_for_model(
         model=model,
         model_input_data=test_config.input_data) + test_config.extra_test_flags
+    # TODO(#11136): We should pick up the execution args from
+    # `build_run_flags_for_execution_config`. But currently the DRIVER needs to
+    # be populated separately in the CMake rule.
+    runner_args.append("--device_allocator=caching")
     cmake_rule = cmake_builder.rules.build_iree_benchmark_suite_module_test(
         target_name=test_config.name,
         model=f"{model.id}_{model.name}",

--- a/build_tools/python/e2e_model_tests/cmake_generator.py
+++ b/build_tools/python/e2e_model_tests/cmake_generator.py
@@ -27,7 +27,8 @@ def generate_rules() -> List[str]:
         model=model,
         model_input_data=test_config.input_data) + test_config.extra_test_flags
     # TODO(#11136): Currently the DRIVER is a separate field in the CMake rule (
-    # and has effect on test labels). Generates the flags without the driver.
+    # and has effect on test labels). Rules should be generated in another way
+    # to avoid that. Generates the flags without the driver for now.
     runner_args += run_module_utils.build_run_flags_for_execution_config(
         test_config.execution_config, with_driver=False)
     cmake_rule = cmake_builder.rules.build_iree_benchmark_suite_module_test(

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -17,9 +17,7 @@ def build_run_flags_for_model(
     model_input_data: common_definitions.ModelInputData) -> List[str]:
   """Returns the IREE run module flags for the model and its inputs."""
 
-  run_flags = [
-      f"--function={model.entry_function}", "--device_allocator=caching"
-  ]
+  run_flags = [f"--function={model.entry_function}"]
   if model_input_data != common_definitions.ZEROS_MODEL_INPUT_DATA:
     raise ValueError("Currently only support all-zeros data.")
   run_flags += [f"--input={input_type}=0" for input_type in model.input_types]
@@ -32,6 +30,7 @@ def build_run_flags_for_execution_config(
   """Returns the IREE run module flags of the execution config."""
 
   run_flags = list(module_execution_config.extra_flags)
+  run_flags.append("--device_allocator=caching")
   driver = module_execution_config.driver
   if driver == RuntimeDriver.CUDA:
     run_flags.append(f"--device=cuda://{gpu_id}")

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -29,8 +29,8 @@ def build_run_flags_for_execution_config(
     gpu_id: str = "0") -> List[str]:
   """Returns the IREE run module flags of the execution config."""
 
-  run_flags = list(module_execution_config.extra_flags)
-  run_flags.append("--device_allocator=caching")
+  run_flags = list(module_execution_config.global_flags)
+  run_flags.extend(module_execution_config.extra_flags)
   driver = module_execution_config.driver
   if driver == RuntimeDriver.CUDA:
     run_flags.append(f"--device=cuda://{gpu_id}")

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -27,7 +27,7 @@ def build_run_flags_for_model(
 def build_run_flags_for_execution_config(
     module_execution_config: ModuleExecutionConfig,
     gpu_id: str = "0",
-    without_driver: bool = False) -> List[str]:
+    with_driver: bool = True) -> List[str]:
   """Returns the IREE run module flags of the execution config.
 
   Args:
@@ -40,7 +40,7 @@ def build_run_flags_for_execution_config(
   """
 
   run_flags = list(module_execution_config.extra_flags)
-  if not without_driver:
+  if with_driver:
     driver = module_execution_config.driver
     if driver == RuntimeDriver.CUDA:
       run_flags.append(f"--device=cuda://{gpu_id}")

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -26,15 +26,26 @@ def build_run_flags_for_model(
 
 def build_run_flags_for_execution_config(
     module_execution_config: ModuleExecutionConfig,
-    gpu_id: str = "0") -> List[str]:
-  """Returns the IREE run module flags of the execution config."""
+    gpu_id: str = "0",
+    without_driver: bool = False) -> List[str]:
+  """Returns the IREE run module flags of the execution config.
+
+  Args:
+    module_execution_config: execution config.
+    gpu_id: target gpu id, if runs on GPUs.
+    without_driver: don't populate the driver flags if true. Useful for
+      generating flags for some CMake rules with a separate DRIVER arg.
+  Returns:
+    List of flags.
+  """
 
   run_flags = list(module_execution_config.extra_flags)
-  driver = module_execution_config.driver
-  if driver == RuntimeDriver.CUDA:
-    run_flags.append(f"--device=cuda://{gpu_id}")
-  else:
-    run_flags.append(f"--device={driver.value}")
+  if not without_driver:
+    driver = module_execution_config.driver
+    if driver == RuntimeDriver.CUDA:
+      run_flags.append(f"--device=cuda://{gpu_id}")
+    else:
+      run_flags.append(f"--device={driver.value}")
   return run_flags
 
 

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -29,8 +29,7 @@ def build_run_flags_for_execution_config(
     gpu_id: str = "0") -> List[str]:
   """Returns the IREE run module flags of the execution config."""
 
-  run_flags = list(module_execution_config.global_flags)
-  run_flags.extend(module_execution_config.extra_flags)
+  run_flags = list(module_execution_config.extra_flags)
   driver = module_execution_config.driver
   if driver == RuntimeDriver.CUDA:
     run_flags.append(f"--device=cuda://{gpu_id}")

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -17,7 +17,9 @@ def build_run_flags_for_model(
     model_input_data: common_definitions.ModelInputData) -> List[str]:
   """Returns the IREE run module flags for the model and its inputs."""
 
-  run_flags = [f"--function={model.entry_function}"]
+  run_flags = [
+      f"--function={model.entry_function}", "--device_allocator=caching"
+  ]
   if model_input_data != common_definitions.ZEROS_MODEL_INPUT_DATA:
     raise ValueError("Currently only support all-zeros data.")
   run_flags += [f"--input={input_type}=0" for input_type in model.input_types]

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -33,7 +33,7 @@ def build_run_flags_for_execution_config(
   Args:
     module_execution_config: execution config.
     gpu_id: target gpu id, if runs on GPUs.
-    without_driver: don't populate the driver flags if true. Useful for
+    with_driver: populate the driver flags if true. False can be used for
       generating flags for some CMake rules with a separate DRIVER arg.
   Returns:
     List of flags.

--- a/build_tools/python/e2e_model_tests/run_module_utils.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils.py
@@ -39,7 +39,7 @@ def build_run_flags_for_execution_config(
     List of flags.
   """
 
-  run_flags = list(module_execution_config.extra_flags)
+  run_flags = module_execution_config.extra_flags.copy()
   if with_driver:
     driver = module_execution_config.driver
     if driver == RuntimeDriver.CUDA:

--- a/build_tools/python/e2e_model_tests/run_module_utils_test.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils_test.py
@@ -55,6 +55,19 @@ class RunModuleTuilsTest(unittest.TestCase):
 
     self.assertEqual(flags, ["--device=cuda://3"])
 
+  def test_build_run_flags_for_execution_config_without_driver(self):
+    execution_config = iree_definitions.ModuleExecutionConfig(
+        id="123",
+        tags=["test"],
+        loader=iree_definitions.RuntimeLoader.EMBEDDED_ELF,
+        driver=iree_definitions.RuntimeDriver.LOCAL_TASK,
+        extra_flags=["--task=10"])
+
+    flags = run_module_utils.build_run_flags_for_execution_config(
+        execution_config, without_driver=True)
+
+    self.assertEqual(flags, ["--task=10"])
+
   def test_build_linux_wrapper_cmds_for_device_spec(self):
     device_spec = common_definitions.DeviceSpec(
         id="abc",

--- a/build_tools/python/e2e_model_tests/run_module_utils_test.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils_test.py
@@ -64,7 +64,7 @@ class RunModuleTuilsTest(unittest.TestCase):
         extra_flags=["--task=10"])
 
     flags = run_module_utils.build_run_flags_for_execution_config(
-        execution_config, without_driver=True)
+        execution_config, with_driver=False)
 
     self.assertEqual(flags, ["--task=10"])
 

--- a/build_tools/python/e2e_model_tests/run_module_utils_test.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils_test.py
@@ -40,9 +40,7 @@ class RunModuleTuilsTest(unittest.TestCase):
     flags = run_module_utils.build_run_flags_for_execution_config(
         execution_config)
 
-    self.assertEqual(
-        flags,
-        ["--device_allocator=caching", "--task=10", "--device=local-task"])
+    self.assertEqual(flags, ["--task=10", "--device=local-task"])
 
   def test_build_run_flags_for_execution_config_with_cuda(self):
     execution_config = iree_definitions.ModuleExecutionConfig(
@@ -55,7 +53,7 @@ class RunModuleTuilsTest(unittest.TestCase):
     flags = run_module_utils.build_run_flags_for_execution_config(
         execution_config, gpu_id="3")
 
-    self.assertEqual(flags, ["--device_allocator=caching", "--device=cuda://3"])
+    self.assertEqual(flags, ["--device=cuda://3"])
 
   def test_build_linux_wrapper_cmds_for_device_spec(self):
     device_spec = common_definitions.DeviceSpec(

--- a/build_tools/python/e2e_model_tests/run_module_utils_test.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils_test.py
@@ -40,7 +40,9 @@ class RunModuleTuilsTest(unittest.TestCase):
     flags = run_module_utils.build_run_flags_for_execution_config(
         execution_config)
 
-    self.assertEqual(flags, ["--task=10", "--device=local-task"])
+    self.assertEqual(
+        flags,
+        ["--task=10", "--device_allocator=caching", "--device=local-task"])
 
   def test_build_run_flags_for_execution_config_with_cuda(self):
     execution_config = iree_definitions.ModuleExecutionConfig(
@@ -53,7 +55,7 @@ class RunModuleTuilsTest(unittest.TestCase):
     flags = run_module_utils.build_run_flags_for_execution_config(
         execution_config, gpu_id="3")
 
-    self.assertEqual(flags, ["--device=cuda://3"])
+    self.assertEqual(flags, ["--device_allocator=caching", "--device=cuda://3"])
 
   def test_build_linux_wrapper_cmds_for_device_spec(self):
     device_spec = common_definitions.DeviceSpec(

--- a/build_tools/python/e2e_model_tests/run_module_utils_test.py
+++ b/build_tools/python/e2e_model_tests/run_module_utils_test.py
@@ -42,7 +42,7 @@ class RunModuleTuilsTest(unittest.TestCase):
 
     self.assertEqual(
         flags,
-        ["--task=10", "--device_allocator=caching", "--device=local-task"])
+        ["--device_allocator=caching", "--task=10", "--device=local-task"])
 
   def test_build_run_flags_for_execution_config_with_cuda(self):
     execution_config = iree_definitions.ModuleExecutionConfig(

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
@@ -80,12 +80,6 @@ class ModuleExecutionConfig(object):
   loader: RuntimeLoader
   driver: RuntimeDriver
   extra_flags: List[str] = dataclasses.field(default_factory=list)
-  # Special flags that we want to enable for all benchmarks. We would like to
-  # keep these flags in the config so the exported config contains all
-  # information for reproducing. Add/remove flags with caution.
-  # TODO(#11588): Replace with tuple once the serializer support tuple.
-  global_flags: List[str] = dataclasses.field(
-      default_factory=lambda: ["--device_allocator=caching"], init=False)
 
 
 class ImportTool(Enum):

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
@@ -80,6 +80,12 @@ class ModuleExecutionConfig(object):
   loader: RuntimeLoader
   driver: RuntimeDriver
   extra_flags: List[str] = dataclasses.field(default_factory=list)
+  # Special flags that we want to enable for all benchmarks. We would like to
+  # keep these flags in the config so the exported config contains all
+  # information for reproducing. Add/remove flags with caution.
+  # TODO(#11588): Replace with tuple once the serializer support tuple.
+  global_flags: List[str] = dataclasses.field(
+      default_factory=lambda: ["--device_allocator=caching"], init=False)
 
 
 class ImportTool(Enum):

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -31,6 +31,7 @@ iree_benchmark_suite_module_test(
     "mobilenet_v1_fp32_expected_output.txt"
   RUNNER_ARGS
     "--function=main"
+    "--device_allocator=caching"
     "--input=1x224x224x3xf32=0"
   UNSUPPORTED_PLATFORMS
     "riscv32-Linux"
@@ -48,6 +49,7 @@ iree_benchmark_suite_module_test(
     "efficientnet_int8_expected_output.txt"
   RUNNER_ARGS
     "--function=main"
+    "--device_allocator=caching"
     "--input=1x224x224x3xui8=0"
   UNSUPPORTED_PLATFORMS
     "android-arm64-v8a"
@@ -64,6 +66,7 @@ iree_benchmark_suite_module_test(
     "deeplab_v3_fp32_input_0_expected_output.npy"
   RUNNER_ARGS
     "--function=main"
+    "--device_allocator=caching"
     "--input=1x257x257x3xf32=0"
     "--expected_f32_threshold=0.001"
   UNSUPPORTED_PLATFORMS
@@ -81,6 +84,7 @@ iree_benchmark_suite_module_test(
     "1x2xi8=[72 -72]"
   RUNNER_ARGS
     "--function=main"
+    "--device_allocator=caching"
     "--input=1x96x96x1xi8=0"
   UNSUPPORTED_PLATFORMS
     "android-arm64-v8a"

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -31,8 +31,8 @@ iree_benchmark_suite_module_test(
     "mobilenet_v1_fp32_expected_output.txt"
   RUNNER_ARGS
     "--function=main"
-    "--device_allocator=caching"
     "--input=1x224x224x3xf32=0"
+    "--device_allocator=caching"
   UNSUPPORTED_PLATFORMS
     "riscv32-Linux"
     "android-arm64-v8a"
@@ -49,8 +49,8 @@ iree_benchmark_suite_module_test(
     "efficientnet_int8_expected_output.txt"
   RUNNER_ARGS
     "--function=main"
-    "--device_allocator=caching"
     "--input=1x224x224x3xui8=0"
+    "--device_allocator=caching"
   UNSUPPORTED_PLATFORMS
     "android-arm64-v8a"
 )
@@ -66,9 +66,9 @@ iree_benchmark_suite_module_test(
     "deeplab_v3_fp32_input_0_expected_output.npy"
   RUNNER_ARGS
     "--function=main"
-    "--device_allocator=caching"
     "--input=1x257x257x3xf32=0"
     "--expected_f32_threshold=0.001"
+    "--device_allocator=caching"
   UNSUPPORTED_PLATFORMS
     "riscv32-Linux"
 )
@@ -84,8 +84,8 @@ iree_benchmark_suite_module_test(
     "1x2xi8=[72 -72]"
   RUNNER_ARGS
     "--function=main"
-    "--device_allocator=caching"
     "--input=1x96x96x1xi8=0"
+    "--device_allocator=caching"
   UNSUPPORTED_PLATFORMS
     "android-arm64-v8a"
 )


### PR DESCRIPTION
Move `--device_allocator=caching` from tool to the place generates run flags (introduced in #11979). Also enable the option for e2e benchmark model tests.

The option is correctly enabled on the legacy benchmark suite in the original PR.

benchmarks: x86_64, cuda