### PR TITLE
Configure LLVM external projects explicitly instead of as part of LLVM build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -585,13 +585,6 @@ else()
   # Stash cmake build type in case LLVM messes with it.
   set(_CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}")
 
-  # Add default external projects.
-  iree_add_llvm_external_project(mlir-iree-dialects MLIR_IREE_DIALECTS ${CMAKE_CURRENT_SOURCE_DIR}/llvm-external-projects/iree-dialects)
-  iree_add_llvm_external_project(mlir-hlo MLIR_HLO ${CMAKE_CURRENT_SOURCE_DIR}/third_party/mlir-hlo)
-  if(IREE_INPUT_TORCH)
-    iree_add_llvm_external_project(torch-mlir-dialects TORCH_MLIR_DIALECTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/torch-mlir-dialects)
-  endif()
-
   add_subdirectory("third_party/llvm-project/llvm" EXCLUDE_FROM_ALL)
 
   # Reset CMAKE_BUILD_TYPE to its previous setting.
@@ -639,6 +632,13 @@ else()
     target_include_directories(IREELLVMIncludeSetup INTERFACE ${_COMMON_INCLUDE_DIRS})
   endfunction()
   _hack_llvm_include_paths()
+
+  # Add default external projects.
+  iree_add_llvm_external_project(mlir-iree-dialects ${CMAKE_CURRENT_SOURCE_DIR}/llvm-external-projects/iree-dialects)
+  iree_add_llvm_external_project(mlir-hlo ${CMAKE_CURRENT_SOURCE_DIR}/third_party/mlir-hlo)
+  if(IREE_INPUT_TORCH)
+    iree_add_llvm_external_project(torch-mlir-dialects ${CMAKE_CURRENT_SOURCE_DIR}/third_party/torch-mlir-dialects)
+  endif()
 endif()
 
 #-------------------------------------------------------------------------------

--- a/build_tools/cmake/iree_external_cmake_options.cmake
+++ b/build_tools/cmake/iree_external_cmake_options.cmake
@@ -103,15 +103,20 @@ macro(iree_set_llvm_cmake_options)
   message(VERBOSE "Building LLVM Projects: ${LLVM_ENABLE_PROJECTS}")
 endmacro()
 
-macro(iree_add_llvm_external_project name identifier location)
-  message(STATUS "Adding LLVM external project ${name} (${identifier}) -> ${location}")
+# Adds a project as if by appending to the LLVM_EXTERNAL_PROJECTS CMake
+# variable. This is done by setting the same top-level variables that the LLVM
+# machinery is expected to export and including the sub directory explicitly.
+# The project binary dir will be llvm-external-projects/${name}
+# Call this after appropriate LLVM/MLIR packages have been loaded.
+function(iree_add_llvm_external_project name location)
+  message(STATUS "Adding LLVM external project ${name} -> ${location}")
   if(NOT EXISTS "${location}/CMakeLists.txt")
     message(FATAL_ERROR "External project location ${location} is not valid")
   endif()
-  list(APPEND LLVM_EXTERNAL_PROJECTS ${name})
-  list(REMOVE_DUPLICATES LLVM_EXTERNAL_PROJECTS)
-  set(LLVM_EXTERNAL_${identifier}_SOURCE_DIR ${location})
-endmacro()
+  set(LLVM_MAIN_SRC_DIR "${IREE_SOURCE_DIR}/third_party/llvm-project/llvm")
+  set(LLVM_BINARY_DIR "${IREE_BINARY_DIR}/third_party/llvm-project/llvm")
+  add_subdirectory(${location} "llvm-external-projects/${name}" EXCLUDE_FROM_ALL)
+endfunction()
 
 macro(iree_set_spirv_headers_cmake_options)
   set(SPIRV_HEADERS_SKIP_EXAMPLES ON CACHE BOOL "" FORCE)

--- a/build_tools/cmake/iree_external_cmake_options.cmake
+++ b/build_tools/cmake/iree_external_cmake_options.cmake
@@ -115,6 +115,7 @@ function(iree_add_llvm_external_project name location)
   endif()
   set(LLVM_MAIN_SRC_DIR "${IREE_SOURCE_DIR}/third_party/llvm-project/llvm")
   set(LLVM_BINARY_DIR "${IREE_BINARY_DIR}/third_party/llvm-project/llvm")
+  set(LLVM_EXTERNAL_LIT "${IREE_BINARY_DIR}/third_party/llvm-project/llvm/bin/llvm-lit")
   add_subdirectory(${location} "llvm-external-projects/${name}" EXCLUDE_FROM_ALL)
 endfunction()
 

--- a/build_tools/third_party/mlir-hlo/CMakeLists.txt
+++ b/build_tools/third_party/mlir-hlo/CMakeLists.txt
@@ -8,7 +8,7 @@ set(TF_MLIR_HLO_SOURCE_DIR
   "${IREE_SOURCE_DIR}/third_party/mlir-hlo/"
 )
 set(TF_MLIR_HLO_BINARY_DIR
-  "${IREE_BINARY_DIR}/third_party/llvm-project/llvm/tools/mlir-hlo/"
+  "${IREE_BINARY_DIR}/llvm-external-projects/mlir-hlo"
 )
 
 external_cc_library(

--- a/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformDialectInterpreterPass.cpp
@@ -53,7 +53,7 @@ namespace {
 /// This needs to be its own pass because the registration mechanism and ops
 /// available are different than for other interpreters.
 class TransformDialectInterpreterPass
-    : public transform::TransformInterpreterPassBase<
+    : public transform::iree_dialects::TransformInterpreterPassBase<
           TransformDialectInterpreterPass,
           iree_compiler::TransformDialectInterpreterBase> {
  public:

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/DispatchWithTransformDialect.cpp
@@ -31,7 +31,7 @@ namespace Flow {
 /// formation. This needs to be its own pass because the registration mechanism
 /// and ops available are different than for other interpreters.
 struct DispatchWithTransformDialect
-    : public transform::TransformInterpreterPassBase<
+    : public transform::iree_dialects::TransformInterpreterPassBase<
           DispatchWithTransformDialect, DispatchWithTransformDialectBase> {
   void getDependentDialects(DialectRegistry &registry) const override {
     // clang-format off

--- a/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/TransformInterpreterPassBase.h
+++ b/llvm-external-projects/iree-dialects/include/iree-dialects/Dialect/LinalgTransform/TransformInterpreterPassBase.h
@@ -21,6 +21,7 @@ class OwningOpRef;
 class Region;
 
 namespace transform {
+namespace iree_dialects {
 namespace detail {
 /// Template-free implementation of TransformInterpreterPassBase::initialize.
 LogicalResult
@@ -145,6 +146,7 @@ private:
   std::shared_ptr<OwningOpRef<ModuleOp>> sharedTransformModule = nullptr;
 };
 
+} // namespace iree_dialects
 } // namespace transform
 } // namespace mlir
 #endif // IREE_DIALECTS_LINALG_TRANSFORM_TRANSFORM_INTERPRETER_UTILS_H

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreter.cpp
@@ -43,7 +43,7 @@ class PassWrapperStub : public PassWrapper<T, Pass> {};
 /// This needs to be its own pass because the registration mechanism and ops
 /// available are different than for other interpreters.
 class TransformDialectInterpreter
-    : public transform::TransformInterpreterPassBase<
+    : public transform::iree_dialects::TransformInterpreterPassBase<
           TransformDialectInterpreter, PassWrapperStub> {
 public:
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TransformDialectInterpreter)

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreterPassBase.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgTransform/Passes/TransformInterpreterPassBase.cpp
@@ -201,8 +201,9 @@ printIreeOptReproCall(llvm::raw_ostream &os, StringRef rootOpName,
 
 /// Prints the module rooted at `root` to `os` and appends
 /// `transformContainer` if it is not nested in `root`.
-llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os, Operation *root,
-                                       Operation *transformContainer) {
+static llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os,
+                                              Operation *root,
+                                              Operation *transformContainer) {
   root->print(os);
   if (!root->isAncestor(transformContainer)) {
     transformContainer->print(os);
@@ -212,10 +213,11 @@ llvm::raw_ostream &printModuleForRepro(llvm::raw_ostream &os, Operation *root,
 
 /// Saves the payload and the transform IR into a temporary file and reports
 /// the file name to `os`.
-void saveReproToTempFile(
-    llvm::raw_ostream &os, Operation *target, Operation *transformContainer,
-    StringRef passName, const Pass::Option<std::string> &debugPayloadRootTag,
-    const Pass::Option<std::string> &debugTransformRootTag) {
+static void
+saveReproToTempFile(llvm::raw_ostream &os, Operation *target,
+                    Operation *transformContainer, StringRef passName,
+                    const Pass::Option<std::string> &debugPayloadRootTag,
+                    const Pass::Option<std::string> &debugTransformRootTag) {
   using llvm::sys::fs::TempFile;
   Operation *root = getRootOperation(target);
 
@@ -366,7 +368,8 @@ static void performOptionalDebugActions(
   });
 }
 
-LogicalResult transform::detail::interpreterBaseRunOnOperationImpl(
+LogicalResult
+transform::iree_dialects::detail::interpreterBaseRunOnOperationImpl(
     Operation *target, StringRef passName,
     const std::shared_ptr<OwningOpRef<ModuleOp>> &sharedTransformModule,
     const Pass::Option<std::string> &transformFileName,
@@ -468,7 +471,7 @@ LogicalResult transform::detail::interpreterBaseRunOnOperationImpl(
   return success();
 }
 
-LogicalResult transform::detail::interpreterBaseInitializeImpl(
+LogicalResult transform::iree_dialects::detail::interpreterBaseInitializeImpl(
     MLIRContext *context, StringRef transformFileName,
     std::shared_ptr<OwningOpRef<ModuleOp>> &module) {
   OwningOpRef<ModuleOp> parsed;

--- a/llvm-external-projects/iree-dialects/test/lit.cfg.py
+++ b/llvm-external-projects/iree-dialects/test/lit.cfg.py
@@ -65,6 +65,12 @@ llvm_config.with_environment('PATH', config.llvm_tools_dir, append_path=True)
 tool_dirs = [config.llvm_tools_dir]
 tools = [
     ToolSubst('%PYTHON', config.python_executable, unresolved='ignore'),
+    # Since we build iree-dialects out of tree, we don't have a common tools
+    # directory, so substitute binaries needed to an explicit path.
+    ToolSubst(
+        'iree-dialects-opt',
+        os.path.join(config.iree_dialects_obj_root,
+                     'tools/iree-dialects-opt/iree-dialects-opt'))
 ]
 
 llvm_config.add_tool_substitutions(tools, tool_dirs)


### PR DESCRIPTION
This is a necessary pre-requisite for #12231.

There are quite a few ways that this can be improved, but severing the nesting within the LLVM build system is necessary to maneuver anything else.

This includes a couple of other fixes:

* Allows usage of iree-dialects-opt without being installed into the common LLVM tools dir (it is now under `./llvm-external-projects/mlir-iree-dialects/tools/iree-dialects-opt/iree-dialects-opt`, which lines up the trees).
* There was a latent ODR issue with the TransformDialectInterpreterBase in IREE having the same name/namespace as the upstream version. Due to some vagary of linking order, this patch uncovered the duplicate symbols on my machine. I namespaced the forked version to account for this but am not thrilled with the overall layering of this piece.