### PR TITLE
[NFC] Centralizing dispatch region constant inlining.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOpFolders.cpp
@@ -196,8 +196,12 @@ struct ReplaceDispatchResultIfZeroElements
 
 void DispatchWorkgroupsOp::getCanonicalizationPatterns(
     RewritePatternSet &results, MLIRContext *context) {
+  // Disable constant inlining as we have done it during dispatch region
+  // formation.
+  IREE::Util::ClosureOptimizationOptions closureOptions;
+  closureOptions.maxInlinedConstantBytes = 0;
   results.insert<IREE::Util::ClosureOptimizationPattern<DispatchWorkgroupsOp>>(
-      context);
+      context, closureOptions);
   results.insert<ReplaceDispatchResultIfZeroElements>(context);
 }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/IR/FlowOps.cpp
@@ -960,9 +960,14 @@ Operation::result_range DispatchWorkgroupsOp::getClosureResults() {
   return getResults();
 }
 
-// Inline operations that the dispatch region can handle natively.
-static bool canDispatchRegionContainOp(Operation *op) {
-  // Inline constant operations that are splat or small constants.
+bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
+  // For now we only allow constants; we could bring other ops across the
+  // boundary though if we want (particularly metadata ops).
+  // Note that the closure optimization may still filter out the constant op if
+  // it's not configured to inline constants of certain types/sizes.
+  // TODO(#12233): this should just be isa<ConstantOp> but today we need to
+  // ensure that we don't mess with tensors after dispatch region formation due
+  // to requirements around tensor access checking.
   if (auto constantOp = dyn_cast<arith::ConstantOp>(op)) {
     auto constantType = constantOp.getType();
     if (constantType.isIntOrIndexOrFloat()) {
@@ -970,10 +975,6 @@ static bool canDispatchRegionContainOp(Operation *op) {
     }
   }
   return false;
-}
-
-bool DispatchWorkgroupsOp::canClosureContainOp(Operation *op) {
-  return canDispatchRegionContainOp(op);
 }
 
 // Refines the tensor access from what is declared on |type| based on actual
@@ -985,15 +986,20 @@ static TensorAccess refineTensorAccess(Value value, DispatchTensorType type) {
     // If the argument is a result with `readwrite` access, return false if the
     // value is only written to. Check this by looking at the uses of the
     // argument being only the `target` of `flow.dispatch.tensor.store` ops.
-    bool onlyWrites = true;
+    bool hasReads = false;
+    bool hasWrites = false;
     for (OpOperand &uses : value.getUses()) {
-      auto storeOp = dyn_cast<DispatchTensorStoreOp>(uses.getOwner());
-      if (!(storeOp && storeOp.getTarget() == uses.get())) {
-        onlyWrites = false;
-        break;
-      }
+      TypeSwitch<Operation *>(uses.getOwner())
+          .Case<DispatchTensorLoadOp>([&](auto loadOp) { hasReads = true; })
+          .Case<DispatchTensorStoreOp>([&](auto storeOp) { hasWrites = true; })
+          .Default([&](auto op) {
+            // Treat unknown ops conservatively as read/write.
+            hasReads = true;
+            hasWrites = true;
+          });
     }
-    if (onlyWrites) tensorAccess = TensorAccess::WriteOnly;
+    if (hasReads && !hasWrites) tensorAccess = TensorAccess::ReadOnly;
+    if (!hasReads && hasWrites) tensorAccess = TensorAccess::WriteOnly;
   }
   return tensorAccess;
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchRegions.cpp
@@ -48,8 +48,8 @@
 // compiler implementation details.
 static llvm::cl::opt<int> clInlineConstantByteLength(
     "iree-flow-inline-constants-max-byte-length",
-    llvm::cl::desc("Maximum byte-length of constant that can be inlined into a "
-                   "dispatch region"),
+    llvm::cl::desc("Maximum byte-length of tensor constant that can be inlined "
+                   "into a dispatch region or 0 to disable inlining."),
     llvm::cl::init(256));
 
 static const char kRootOpAttr[] = "__root_op__";
@@ -214,6 +214,7 @@ bool isClonableIntoDispatchOp(Operation *op) {
     return true;
   }
   if (auto constantOp = dyn_cast<arith::ConstantOp>(op)) {
+    if (clInlineConstantByteLength == 0) return false;
     auto constantValueAttr = constantOp.getValue();
     auto constantType = constantOp.getType();
     if (constantValueAttr.isa<SplatElementsAttr>()) {

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/FormDispatchWorkgroups.cpp
@@ -93,6 +93,9 @@ static SmallVector<Operation *> getCloneableOps(
     }
     result.push_back(definingOp);
     worklist.append(definingOp->operand_begin(), definingOp->operand_end());
+    llvm::SetVector<Value> nestedValues;
+    mlir::getUsedValuesDefinedAbove(definingOp->getRegions(), nestedValues);
+    worklist.append(nestedValues.begin(), nestedValues.end());
   }
 
   return result;

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -437,7 +437,7 @@ func.func @subtensor_insert(%arg0: tensor<?x?xf32>, %arg1: tensor<?x?xf32>,
 //  CHECK-DAG:   %[[ARG1_D0:.+]] = tensor.dim %[[ARG1]], %[[C0]]
 //  CHECK-DAG:   %[[ARG1_D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //      CHECK:   %[[RESULT:.+]] = flow.dispatch.workgroups[%[[ARG0_D0]], %[[ARG0_D1]]]
-// CHECK-SAME:       (%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG4]], %[[ARG5]], 
+// CHECK-SAME:       (%[[ARG0]], %[[ARG1]], %[[ARG2]], %[[ARG3]], %[[ARG4]], %[[ARG5]],
 // CHECK-SAME:        %[[ARG0_D0]], %[[ARG0_D1]], %[[ARG1_D0]], %[[ARG1_D1]])
 // CHECK-SAME:       tensor<?x?xf32>{%[[ARG0_D0]], %[[ARG0_D1]]}
 // CHECK-SAME:       tensor<?x?xf32>{%[[ARG1_D0]], %[[ARG1_D1]]}


### PR DESCRIPTION
This disables tensor constant inlining during closure optimization and makes it so that dispatch region formation only inlines tensor values. This avoids some issues with constant tensor access in #12233.