### PR TITLE
[NFC] Switch to use upstream transform::TrivialPatternRewriter.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Common/BUILD
@@ -276,6 +276,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:TensorDialect",
         "@llvm-project//mlir:TensorTransforms",
         "@llvm-project//mlir:TilingInterface",
+        "@llvm-project//mlir:TransformDialect",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",
         "@llvm-project//mlir:VectorToSCF",

--- a/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Common/CMakeLists.txt
@@ -231,6 +231,7 @@ iree_cc_library(
     MLIRTensorDialect
     MLIRTensorTransforms
     MLIRTilingInterface
+    MLIRTransformDialect
     MLIRTransforms
     MLIRVectorDialect
     MLIRVectorToSCF

--- a/compiler/src/iree/compiler/Codegen/Common/GPUTileReduction.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUTileReduction.cpp
@@ -14,6 +14,7 @@
 #include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
+#include "mlir/Dialect/Transform/IR/TransformUtils.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "mlir/Transforms/Passes.h"
 
@@ -21,14 +22,6 @@
 
 namespace mlir {
 namespace iree_compiler {
-
-namespace {
-/// A simple pattern rewriter that implements no special logic.
-class SimpleRewriter : public PatternRewriter {
- public:
-  SimpleRewriter(MLIRContext *context) : PatternRewriter(context) {}
-};
-}  // namespace
 
 namespace {
 
@@ -39,7 +32,7 @@ static LogicalResult tileReduction(linalg::GenericOp op) {
   if (tileSize.empty() || dims.size() != 1 ||
       tileSize.back() == op.getStaticLoopRanges()[dims.back()])
     return success();
-  SimpleRewriter rewriter(op.getContext());
+  transform::TrivialPatternRewriter rewriter(op.getContext());
   SmallVector<OpFoldResult> sizes;
   for (int64_t size : tileSize) {
     sizes.push_back(rewriter.getIndexAttr(size));
@@ -52,7 +45,7 @@ static LogicalResult tileReduction(linalg::GenericOp op) {
 }
 
 static LogicalResult tileFusedOps(linalg::GenericOp op) {
-  SimpleRewriter rewriter(op.getContext());
+  transform::TrivialPatternRewriter rewriter(op.getContext());
   rewriter.setInsertionPoint(op);
   SmallVector<int64_t> tileSizes = getTileSizes(op, 1);
   if (tileSizes.empty()) return success();

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -36,6 +36,7 @@
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
+#include "mlir/Dialect/Transform/IR/TransformUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -137,11 +138,6 @@ getMaterializationInfo(IREE::LinalgExt::PackOp packOp) {
 //===---------------------------------------------------------------------===//
 
 namespace {
-
-class SimpleRewriter : public PatternRewriter {
- public:
-  SimpleRewriter(MLIRContext *context) : PatternRewriter(context) {}
-};
 
 /// The `flow.dispatch.workgroup_count_from_dag_root` op is lowered to
 /// a sequence of `affine.apply affine_map<()[s0, s1] -> ceildDiv(s0,
@@ -414,7 +410,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
             .setLoopType(linalg::LinalgTilingLoopType::Loops)
             .setTileSizeComputationFunction(tileSizeFn);
 
-    SimpleRewriter rewriter(context);
+    transform::TrivialPatternRewriter rewriter(context);
     if (failed(tileAndFuseDispatchUsingSCFForOp(
             cast<TilingInterface>(computeOps.back()), linalgTilingOptions,
             rewriter))) {

--- a/compiler/src/iree/compiler/Codegen/Common/VectorizePackUnPackOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/VectorizePackUnPackOps.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
+#include "mlir/Dialect/Transform/IR/TransformUtils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/IR/AffineMap.h"
 #include "mlir/IR/Matchers.h"
@@ -24,14 +25,6 @@
 namespace mlir {
 namespace iree_compiler {
 namespace {
-
-/// A simple pattern rewriter that implements no special logic.
-/// TODO(hanchung): Use the rewriter in TransformUtils.h after the commit is
-/// cherry-picked into IREE.
-class SimpleRewriter : public PatternRewriter {
- public:
-  SimpleRewriter(MLIRContext *context) : PatternRewriter(context) {}
-};
 
 struct VectorizePackUnPackOpsPass
     : public VectorizePackUnPackOpsBase<VectorizePackUnPackOpsPass> {
@@ -47,7 +40,7 @@ struct VectorizePackUnPackOpsPass
 
     // Apply tiling to make outer dims be all 1s.
     {
-      SimpleRewriter rewriter(ctx);
+      transform::TrivialPatternRewriter rewriter(ctx);
       auto packOptions = scf::SCFTileAndFuseOptions().setTilingOptions(
           scf::SCFTilingOptions().setTileSizeComputationFunction(
               [](OpBuilder &builder, Operation *op) -> SmallVector<Value> {

--- a/llvm-external-projects/iree-dialects/BUILD
+++ b/llvm-external-projects/iree-dialects/BUILD
@@ -430,6 +430,7 @@ cc_library(
         "@llvm-project//mlir:TensorTransforms",
         "@llvm-project//mlir:TensorUtils",
         "@llvm-project//mlir:TilingInterface",
+        "@llvm-project//mlir:TransformDialect",
         "@llvm-project//mlir:TransformUtils",
         "@llvm-project//mlir:Transforms",
         "@llvm-project//mlir:VectorDialect",

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/Tiling.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Passes/Tiling.cpp
@@ -21,6 +21,7 @@
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/TileUsingInterface.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Transform/IR/TransformUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/IR/Matchers.h"
 #include "mlir/IR/PatternMatch.h"
@@ -307,12 +308,6 @@ TilingInterfaceTilingPattern::matchAndRewrite(TilingInterface tilableOp,
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// A simple pattern rewriter that implements no special logic.
-class SimpleRewriter : public PatternRewriter {
-public:
-  SimpleRewriter(MLIRContext *context) : PatternRewriter(context) {}
-};
-
 struct TilingInterfaceTilingPass
     : public TilingInterfaceTilingBase<TilingInterfaceTilingPass> {
   void getDependentDialects(DialectRegistry &registry) const override {
@@ -420,7 +415,7 @@ void TilingInterfaceTilingPass::runOnOperation() {
   // upstream scf::tileUsingSCFForOp method. For now only uses it for packing
   // and unpacking ops.
   {
-    SimpleRewriter rewriter(context);
+    transform::TrivialPatternRewriter rewriter(context);
     auto filter = IREE::LinalgExt::LinalgTransformationFilter(
         StringAttr::get(context, "tiling_pack_input"),
         StringAttr::get(context, "tiling_pack_output"));

--- a/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
+++ b/llvm-external-projects/iree-dialects/lib/Dialect/LinalgExt/Transforms/Transforms.cpp
@@ -20,6 +20,7 @@
 #include "mlir/Dialect/SCF/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/Transforms/Transforms.h"
 #include "mlir/Dialect/Tensor/Utils/Utils.h"
+#include "mlir/Dialect/Transform/IR/TransformUtils.h"
 #include "mlir/Dialect/Utils/IndexingUtils.h"
 #include "mlir/Dialect/Utils/StaticValueUtils.h"
 #include "mlir/Dialect/Vector/Transforms/Passes.h"
@@ -837,12 +838,6 @@ createLinalgStrategyRemoveMarkersPass() {
 
 namespace {
 
-/// A simple pattern rewriter that implements no special logic.
-class SimpleRewriter : public PatternRewriter {
-public:
-  SimpleRewriter(MLIRContext *context) : PatternRewriter(context) {}
-};
-
 /// Returns a tensor.pad op if padding value is set. Otherwise, returns the
 /// input directly. The method assumes that the `packOp` has static shapes.
 Value getInputOrPaddedInput(OpBuilder &builder, PackOp packOp) {
@@ -1037,7 +1032,7 @@ struct LinalgExtVectorizationPass
     MLIRContext *ctx = &getContext();
     // Apply tiling to make outer dims be all 1s.
     {
-      SimpleRewriter rewriter(ctx);
+      transform::TrivialPatternRewriter rewriter(ctx);
       auto packOptions = scf::SCFTileAndFuseOptions().setTilingOptions(
           scf::SCFTilingOptions().setTileSizeComputationFunction(
               [](OpBuilder &builder, Operation *op) -> SmallVector<Value> {


### PR DESCRIPTION
With the commit, we dont have to declare SimpleRewriter everywhere.