### PR TITLE
Run upload_benchmarks_to_dashboard.py in benchmark-report docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1056,10 +1056,12 @@ jobs:
           EXECUTION_BENCHMARK_RESULTS_PATTERN: ${{ steps.download-execution-results.outputs.execution-benchmark-results-pattern }}
           IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
         run: |
-          ./build_tools/benchmarks/upload_benchmarks_to_dashboard.py \
-            --verbose \
-            --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_PATTERN}" \
-            --compile_stats_files="${COMPILE_STATS_RESULTS}"
+          build_tools/github_actions/docker_run.sh \
+            gcr.io/iree-oss/benchmark-report@sha256:7498c6f32f63f13faf085463cc38656d4297519c824e63e1c99c8c258147f6ff \
+            ./build_tools/benchmarks/upload_benchmarks_to_dashboard.py \
+              --verbose \
+              --benchmark_files="${EXECUTION_BENCHMARK_RESULTS_PATTERN}" \
+              --compile_stats_files="${COMPILE_STATS_RESULTS}"
 
   ############################## Crosscompilation ##############################
   # Jobs that cross-compile IREE for other platforms


### PR DESCRIPTION
`upload_benchmarks_to_dashboard.py` unnecessarily pulled in the dependency on `markdown_strings` from `benchmark_presentation`

The right fix should factor out the `benchmark_presentation.COMPILATION_METRICS_TO_TABLE_MAPPERS` (#12250). Run the upload script in the docker with markdown_strings for now to fix the CI.

Tested locally

skip-ci: Not run in presubmit