### PR TITLE
Add `--no-divider` to configure_ci check.

### DIFF
--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -83,12 +83,13 @@ def get_trailers() -> Mapping[str, str]:
 
   print("Parsing PR description:", description, sep="\n")
 
-  trailer_lines = subprocess.run(["git", "interpret-trailers", "--parse"],
-                                 input=description,
-                                 stdout=subprocess.PIPE,
-                                 check=True,
-                                 text=True,
-                                 timeout=60).stdout.splitlines()
+  trailer_lines = subprocess.run(
+      ["git", "interpret-trailers", "--parse", "--no-divider"],
+      input=description,
+      stdout=subprocess.PIPE,
+      check=True,
+      text=True,
+      timeout=60).stdout.splitlines()
   return {
       k.lower().strip(): v.strip()
       for k, v in (line.split(":", maxsplit=1) for line in trailer_lines)


### PR DESCRIPTION
This allows trailers after `---` section breaks

---

Like this one

skip-ci: testing that it works