### PR TITLE
Pass by reference in reproducer causes crash

### DIFF
--- a/compiler/src/iree/compiler/API2/Internal/Embed.cpp
+++ b/compiler/src/iree/compiler/API2/Internal/Embed.cpp
@@ -692,7 +692,7 @@ void ireeCompilerInvocationSetCrashHandler(
   };
 
   unwrap(inv)->passManager.enableCrashReproducerGeneration(
-      [&](std::string &errorMessage)
+      [=](std::string &errorMessage)
           -> std::unique_ptr<mlir::PassManager::ReproducerStream> {
         iree_compiler_output_t *output = nullptr;
         auto error = onCrashCallback(&output, userData);


### PR DESCRIPTION
This pass by reference should be a pass by value as the crash callback is invoked after this stack frame is destroyed.