### PR TITLE
Correct comment bot user for finding previous post

### DIFF
--- a/.github/workflows/post_benchmark_comment.yaml
+++ b/.github/workflows/post_benchmark_comment.yaml
@@ -80,7 +80,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIST_BOT_TOKEN: ${{ secrets.GIST_BOT_TOKEN }}
-          COMMENT_BOT_USER: iree-github-actions-bot
+          COMMENT_BOT_USER: github-actions[bot]
           # Get PR number from the event instead of the untrusted comment
           # artifact, to make sure we won't incorrectly update other PRs.
           BENCHMARK_COMMENT_ARTIFACT: ${{ steps.download.outputs.benchmark-comment-artifact }}


### PR DESCRIPTION
The comment is post by github action, so the comment user should be "github-actions[bot]" when trying to find the previous post and update it.

Somehow I was confused with the test results and thought it worked correctly...

Tested on my repo again https://github.com/pzread/iree/pull/4#issuecomment-1372713961
![image](https://user-images.githubusercontent.com/2104162/219578457-1e8e68db-ff65-4e08-9eb1-dcac2f789b94.png)
