### PR TITLE
Rework the logic that avoids fusions when that lead to stack allocatiions.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_default.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_default.mlir
@@ -30,38 +30,6 @@ func.func @no_fuse_quantized(%arg0 : tensor<?x113x113x64xi8>, %arg1 : tensor<3x3
 
 // -----
 
-#map1 = affine_map<(d0, d1, d2) -> (d0, d1)>
-#map2 = affine_map<(d0, d1, d2) -> (d0, d1, d2)>
-
-func.func @reduction_broadcast_elementwise_type_mismatch(%a: tensor<12x16x16xf32>, %b: tensor<12x16x32xf32>) -> tensor<12x16x32xi32> {
-  %cst_47 = arith.constant 0.000000e+00 : f32
-  %37 = tensor.empty() : tensor<12x16xf32>
-  %38 = linalg.fill ins(%cst_47 : f32) outs(%37 : tensor<12x16xf32>) -> tensor<12x16xf32>
-  %39 = linalg.generic {indexing_maps = [#map2, #map1], iterator_types = ["parallel", "parallel", "reduction"]} ins(%a : tensor<12x16x16xf32>) outs(%38 : tensor<12x16xf32>) {
-    ^bb0(%arg3: f32, %arg4: f32):
-    %780 = arith.maxf %arg3, %arg4 : f32
-    linalg.yield %780 : f32
-  } -> tensor<12x16xf32>
-  %40 = tensor.empty() : tensor<12x16x32xi32>
-  %42 = linalg.generic {indexing_maps = [#map2, #map1, #map2], iterator_types = ["parallel", "parallel", "parallel"]} ins(%b, %39 : tensor<12x16x32xf32>, tensor<12x16xf32>) outs(%40 : tensor<12x16x32xi32>) {
-    ^bb0(%arg3: f32, %arg4: f32, %arg5: i32):
-    %780 = arith.subf %arg3, %arg4 : f32
-    %781 = arith.fptosi %780 : f32 to i32
-    linalg.yield %781 : i32
-  } -> tensor<12x16x32xi32>
-  return %42 : tensor<12x16x32xi32>
-}
-
-// Check that two generic ops are NOT dispatched together since the input type
-// for reduction is different from the output type of the elementwise op. We
-// should see two flow.dispatch.workgroups.
-
-// CHECK-LABEL: func.func @reduction_broadcast_elementwise_type_mismatch
-//      CHECK: flow.dispatch.workgroups
-//      CHECK: flow.dispatch.workgroups
-
-// -----
-
 #map = affine_map<(d0, d1) -> (d1)>
 #map1 = affine_map<(d0, d1) -> (d0, d1)>
 func.func @elem_set_encoding(%arg0: tensor<512xf32>, %arg1: tensor<384x512xf32>,


### PR DESCRIPTION
Rework the logic that prevents fusions that result in stack allocation. This is mostly a WAR since these dispatches should be lowered without any stack allocation. The root cause is that these dispatches are not vectorized. When vectorized there wont be a stack allocation.

benchmarks: x86_64, cuda