### PR TITLE
Fix device_allocator=caching option for Android benchmarks

### DIFF
--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -409,8 +409,9 @@ function(iree_benchmark_suite)
       # Create the command and target for the flagfile spec used to execute
       # the generated artifacts.
       set(_FLAG_FILE "${_RUN_SPEC_DIR}/flagfile")
-      set(_BENCHMARK_FLAGS "--device_allocator=caching")
-      set(_ADDITIONAL_ARGS_CL "--additional_args=\"${_RULE_RUNTIME_FLAGS}\" \"${_BENCHMARK_FLAGS}\"")
+      set(_ADDITIONAL_ARGS "${_RULE_RUNTIME_FLAGS}")
+      list(APPEND _ADDITIONAL_ARGS "--device_allocator=caching")
+      set(_ADDITIONAL_ARGS_CL "--additional_args=\"${_ADDITIONAL_ARGS}\"")
       file(RELATIVE_PATH _MODULE_FILE_FLAG "${_RUN_SPEC_DIR}" "${_VMFB_FILE}")
       add_custom_command(
         OUTPUT "${_FLAG_FILE}"


### PR DESCRIPTION
Fix `device_allocator=caching` option in the flagfile generated by `iree_benchmark_suite`.

There was an extra whitespace in front of the `device_allocator=caching` in the flagfile, makes the option invalid.

benchmarks: x86_64, cuda