### PR TITLE
Remove "tests" directory from binary package.

### DIFF
--- a/build_tools/github_actions/build_dist.py
+++ b/build_tools/github_actions/build_dist.py
@@ -159,7 +159,6 @@ def build_main_dist():
   dist_entries = [
       "bin",
       "lib",
-      "tests",
   ]
   dist_archive = os.path.join(
       BINDIST_DIR, f"iree-dist{version_info['package-suffix']}"


### PR DESCRIPTION
It hasn't been populated for a long time, and prior to the previous build, it was incidentally being created empty, which was keeping things running.