### PR TITLE
Scoping the tensor.empty -> flow pass to top level ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -249,10 +249,12 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       ////////////////////////////////////////////////////////////////////////
       .addPass(createCaptureDispatchDynamicDimsPass)
       .addPass(mlir::createCanonicalizerPass)
-      .addPass(createCSEPass);
+      .addPass(createCSEPass)
 
-  // Initialize any empty tensors to zero.
-  passManager.addPass(createInitializeEmptyTensorsPass(clZeroFillEmptyTensors));
+      // Initialize any empty tensors to zero.
+      .addPass([&]() {
+        return createInitializeEmptyTensorsPass(clZeroFillEmptyTensors);
+      });
 
   // Module pass to outline the dispatch regions into their own functions
   // wrapped in executables.


### PR DESCRIPTION
This was incorrectly running recursively on all ops (executables too).