### PR TITLE
Enable conversion of `depthwise_conv_2d_nhwc_hwcm_q` to its fixed-point counterpart

### DIFF
--- a/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
+++ b/compiler/src/iree/compiler/InputConversion/Common/QuantizedConvToConv.cpp
@@ -9,6 +9,7 @@
 #include "iree/compiler/InputConversion/Common/Utils.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
+#include "mlir/Dialect/Linalg/Transforms/Transforms.h"
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/MemRef/Transforms/Passes.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
@@ -348,6 +349,7 @@ struct LinalgQuantizedConvToConvPass
     Operation *op = getOperation();
     MLIRContext *context = op->getContext();
     RewritePatternSet patterns(context);
+    linalg::populateLinalgNamedOpConversionPatterns(patterns);
     patterns.add<QuantizedConvToConv, QuantizedDepthwiseConvToDepthwiseConv>(
         context);
     memref::populateResolveRankedShapeTypeResultDimsPatterns(patterns);


### PR DESCRIPTION
This PR adds patterns to convert `depthwise_conv_2d_nhwc_hwcm_q` into `depthwise_conv_2d_nhwc_hwc_q` so that it can be converted to its fixed-point counterpart.

benchmarks: x86_64, cuda, comp-stats