### PR TITLE
Moving `--device_allocator=` flag parsing to `iree/hal/utils/`.

### DIFF
--- a/runtime/bindings/python/CMakeLists.txt
+++ b/runtime/bindings/python/CMakeLists.txt
@@ -52,6 +52,7 @@ iree_pyext_module(
     iree::base::tracing
     iree::hal
     iree::hal::drivers
+    iree::hal::utils::allocator_flags
     iree::modules::hal
     iree::vm
     iree::vm::bytecode_module

--- a/runtime/src/iree/hal/utils/BUILD
+++ b/runtime/src/iree/hal/utils/BUILD
@@ -14,6 +14,21 @@ package(
 )
 
 iree_runtime_cc_library(
+    name = "allocator_flags",
+    srcs = ["allocator_flags.c"],
+    hdrs = ["allocator_flags.h"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":caching_allocator",
+        ":debug_allocator",
+        "//runtime/src/iree/base",
+        "//runtime/src/iree/base:tracing",
+        "//runtime/src/iree/base/internal:flags",
+        "//runtime/src/iree/hal",
+    ],
+)
+
+iree_runtime_cc_library(
     name = "buffer_transfer",
     srcs = ["buffer_transfer.c"],
     hdrs = ["buffer_transfer.h"],

--- a/runtime/src/iree/hal/utils/CMakeLists.txt
+++ b/runtime/src/iree/hal/utils/CMakeLists.txt
@@ -12,6 +12,23 @@ iree_add_all_subdirs()
 
 iree_cc_library(
   NAME
+    allocator_flags
+  HDRS
+    "allocator_flags.h"
+  SRCS
+    "allocator_flags.c"
+  DEPS
+    ::caching_allocator
+    ::debug_allocator
+    iree::base
+    iree::base::internal::flags
+    iree::base::tracing
+    iree::hal
+  PUBLIC
+)
+
+iree_cc_library(
+  NAME
     buffer_transfer
   HDRS
     "buffer_transfer.h"

--- a/runtime/src/iree/hal/utils/allocator_flags.c
+++ b/runtime/src/iree/hal/utils/allocator_flags.c
@@ -1,0 +1,76 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "iree/hal/utils/allocator_flags.h"
+
+#include "iree/base/internal/flags.h"
+#include "iree/base/tracing.h"
+#include "iree/hal/utils/caching_allocator.h"
+#include "iree/hal/utils/debug_allocator.h"
+
+IREE_FLAG_LIST(
+    string, device_allocator,
+    "Specifies one or more HAL device allocator specs to augment the base\n"
+    "device allocator. See each allocator type for supported configurations.");
+
+iree_status_t iree_hal_configure_allocator_from_spec(
+    iree_string_view_t spec, iree_hal_device_t* device,
+    iree_hal_allocator_t* base_allocator,
+    iree_hal_allocator_t** out_wrapped_allocator) {
+  iree_string_view_t allocator_name = iree_string_view_empty();
+  iree_string_view_t config_pairs = iree_string_view_empty();
+  iree_string_view_split(spec, ':', &allocator_name, &config_pairs);
+  iree_status_t status = iree_ok_status();
+  iree_allocator_t host_allocator =
+      iree_hal_allocator_host_allocator(base_allocator);
+  if (iree_string_view_equal(allocator_name, IREE_SV("caching"))) {
+    status = iree_hal_caching_allocator_create_from_spec(
+        config_pairs, base_allocator, host_allocator, out_wrapped_allocator);
+  } else if (iree_string_view_equal(allocator_name, IREE_SV("debug"))) {
+    status = iree_hal_debug_allocator_create(
+        device, base_allocator, host_allocator, out_wrapped_allocator);
+  } else {
+    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
+                            "unrecognized allocator '%.*s'",
+                            (int)allocator_name.size, allocator_name.data);
+  }
+  if (iree_status_is_ok(status)) {
+    // New wrapping allocator has taken ownership of the base allocator.
+    iree_hal_allocator_release(base_allocator);
+  }
+  return status;
+}
+
+iree_status_t iree_hal_configure_allocator_from_flags(
+    iree_hal_device_t* device) {
+  IREE_ASSERT_ARGUMENT(device);
+  IREE_TRACE_ZONE_BEGIN(z0);
+
+  const iree_flag_string_list_t list = FLAG_device_allocator_list();
+
+  // The current device allocator should be the base one registered or created
+  // with the device. If no allocator flags were provided this may be no-op and
+  // we'll just pass it right back in.
+  iree_hal_allocator_t* device_allocator = iree_hal_device_allocator(device);
+  iree_hal_allocator_retain(device_allocator);
+
+  // Walk the specs provided and wrap in order from base to last specified.
+  iree_status_t status = iree_ok_status();
+  for (iree_host_size_t i = 0; i < list.count; ++i) {
+    status = iree_hal_configure_allocator_from_spec(
+        list.values[i], device, device_allocator, &device_allocator);
+    if (!iree_status_is_ok(status)) break;
+  }
+
+  // Swap the allocator on the device - this is only safe because we know no
+  // allocations have been made yet.
+  if (iree_status_is_ok(status)) {
+    iree_hal_device_replace_allocator(device, device_allocator);
+  }
+  iree_hal_allocator_release(device_allocator);
+  IREE_TRACE_ZONE_END(z0);
+  return status;
+}

--- a/runtime/src/iree/hal/utils/allocator_flags.h
+++ b/runtime/src/iree/hal/utils/allocator_flags.h
@@ -1,0 +1,46 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#ifndef IREE_HAL_UTILS_ALLOCATOR_FLAGS_H_
+#define IREE_HAL_UTILS_ALLOCATOR_FLAGS_H_
+
+#include "iree/base/api.h"
+#include "iree/hal/api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+// WARNING: including this file will pull in flags code as well as all allocator
+// implementations. Only use this if you need the flag and otherwise prefer
+// directly instantiating the allocators you want with their structured options
+// instead of strings.
+
+// Parses a single flag value and wraps |base_allocator|.
+// Flag values are specifications and may include configuration values.
+// Examples:
+//   some_allocator
+//   some_allocator:key=value
+//   some_allocator:key=value,key=value
+iree_status_t iree_hal_configure_allocator_from_spec(
+    iree_string_view_t spec, iree_hal_device_t* device,
+    iree_hal_allocator_t* base_allocator,
+    iree_hal_allocator_t** out_wrapped_allocator);
+
+// Configures the |device| allocator based on the --device_allocator= flag.
+// This will wrap the underlying device allocator in zero or more configurable
+// allocator shims.
+//
+// WARNING: not thread-safe and must only be called immediately after device
+// creation.
+iree_status_t iree_hal_configure_allocator_from_flags(
+    iree_hal_device_t* device);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // IREE_HAL_UTILS_ALLOCATOR_FLAGS_H_

--- a/runtime/src/iree/tooling/BUILD
+++ b/runtime/src/iree/tooling/BUILD
@@ -103,8 +103,7 @@ cc_library(
         "//runtime/src/iree/base/internal:synchronization",
         "//runtime/src/iree/hal",
         "//runtime/src/iree/hal/drivers",
-        "//runtime/src/iree/hal/utils:caching_allocator",
-        "//runtime/src/iree/hal/utils:debug_allocator",
+        "//runtime/src/iree/hal/utils:allocator_flags",
     ],
 )
 

--- a/runtime/src/iree/tooling/CMakeLists.txt
+++ b/runtime/src/iree/tooling/CMakeLists.txt
@@ -115,8 +115,7 @@ iree_cc_library(
     iree::base::tracing
     iree::hal
     iree::hal::drivers
-    iree::hal::utils::caching_allocator
-    iree::hal::utils::debug_allocator
+    iree::hal::utils::allocator_flags
   PUBLIC
 )
 

--- a/runtime/src/iree/tooling/device_util.c
+++ b/runtime/src/iree/tooling/device_util.c
@@ -10,8 +10,7 @@
 #include "iree/base/internal/flags.h"
 #include "iree/base/tracing.h"
 #include "iree/hal/drivers/init.h"
-#include "iree/hal/utils/caching_allocator.h"
-#include "iree/hal/utils/debug_allocator.h"
+#include "iree/hal/utils/allocator_flags.h"
 
 //===----------------------------------------------------------------------===//
 // Shared driver registry
@@ -281,86 +280,6 @@ IREE_FLAG_CALLBACK(
     "Examples:\n"
     "  Show all devices from all drivers: --dump_devices\n"
     "  Show all devices from a particular driver: --dump_devices=vulkan\n");
-
-//===----------------------------------------------------------------------===//
-// Allocator configuration
-//===----------------------------------------------------------------------===//
-
-IREE_FLAG_LIST(
-    string, device_allocator,
-    "Specifies one or more HAL device allocator specs to augment the base\n"
-    "device allocator. See each allocator type for supported configurations.");
-
-// Parses a single flag and wraps |base_allocator|.
-// Flag values are specifications and may include configuration values.
-// Examples:
-//   some_allocator
-//   some_allocator:key=value
-//   some_allocator:key=value,key=value
-static iree_status_t iree_hal_configure_allocator_from_spec(
-    iree_string_view_t spec, iree_hal_device_t* device,
-    iree_hal_allocator_t* base_allocator,
-    iree_hal_allocator_t** out_wrapped_allocator) {
-  iree_string_view_t allocator_name = iree_string_view_empty();
-  iree_string_view_t config_pairs = iree_string_view_empty();
-  iree_string_view_split(spec, ':', &allocator_name, &config_pairs);
-  iree_status_t status = iree_ok_status();
-  iree_allocator_t host_allocator =
-      iree_hal_allocator_host_allocator(base_allocator);
-  if (iree_string_view_equal(allocator_name, IREE_SV("caching"))) {
-    status = iree_hal_caching_allocator_create_from_spec(
-        config_pairs, base_allocator, host_allocator, out_wrapped_allocator);
-  } else if (iree_string_view_equal(allocator_name, IREE_SV("debug"))) {
-    status = iree_hal_debug_allocator_create(
-        device, base_allocator, host_allocator, out_wrapped_allocator);
-  } else {
-    return iree_make_status(IREE_STATUS_INVALID_ARGUMENT,
-                            "unrecognized allocator '%.*s'",
-                            (int)allocator_name.size, allocator_name.data);
-  }
-  if (iree_status_is_ok(status)) {
-    // New wrapping allocator has taken ownership of the base allocator.
-    iree_hal_allocator_release(base_allocator);
-  }
-  return status;
-}
-
-// Configures the |device| allocator based on the --device_allocator= flag.
-// This will wrap the underlying device allocator in zero or more configurable
-// allocator shims.
-//
-// WARNING: not thread-safe and must only be called immediately after device
-// creation.
-static iree_status_t iree_hal_configure_allocator_from_flags(
-    iree_hal_device_t* device) {
-  IREE_ASSERT_ARGUMENT(device);
-  IREE_TRACE_ZONE_BEGIN(z0);
-
-  const iree_flag_string_list_t list = FLAG_device_allocator_list();
-
-  // The current device allocator should be the base one registered or created
-  // with the device. If no allocator flags were provided this may be no-op and
-  // we'll just pass it right back in.
-  iree_hal_allocator_t* device_allocator = iree_hal_device_allocator(device);
-  iree_hal_allocator_retain(device_allocator);
-
-  // Walk the specs provided and wrap in order from base to last specified.
-  iree_status_t status = iree_ok_status();
-  for (iree_host_size_t i = 0; i < list.count; ++i) {
-    status = iree_hal_configure_allocator_from_spec(
-        list.values[i], device, device_allocator, &device_allocator);
-    if (!iree_status_is_ok(status)) break;
-  }
-
-  // Swap the allocator on the device - this is only safe because we know no
-  // allocations have been made yet.
-  if (iree_status_is_ok(status)) {
-    iree_hal_device_replace_allocator(device, device_allocator);
-  }
-  iree_hal_allocator_release(device_allocator);
-  IREE_TRACE_ZONE_END(z0);
-  return status;
-}
 
 //===----------------------------------------------------------------------===//
 // Device selection


### PR DESCRIPTION
This will allow user applications and bindings to configure allocators in the same way the tools do without pulling in all the private `tooling/` code. It's still a factory that pulls in flags/every allocator and should only be used by layers that are ok with taking on those dependencies.

This also wires up the python bindings to configure the device allocator before returning it to users. We could expose allocators directly to give more pythonic control but for now this matches several other internal mechanisms we control with flags (task system, etc).