### PR TITLE
Enable Python release building in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,6 +563,33 @@ jobs:
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
+  python-release-packages:
+    needs: setup
+    if: needs.setup.outputs.should-run == 'true'
+    runs-on:
+      - self-hosted  # must come first
+      - runner-group=${{ needs.setup.outputs.runner-group }}
+      - environment=${{ needs.setup.outputs.runner-env }}
+      - cpu
+      - os-family=Linux
+    steps:
+      - name: "Checking out repository"
+        uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+        with:
+          submodules: true
+      - name: Build runtime wheels (Linux)
+        shell: bash
+        env:
+          package_suffix: ${{ github.event.inputs.package_suffix }}
+          packages: "iree-runtime iree-runtime-instrumented"
+          output_dir: "${{ github.workspace }}/bindist"
+          # Note when upgrading: Build just one Python version synced to our
+          # minimum. Note that 3.7 is the last with this naming convention.
+          # Look at the script for the full list.
+          override_python_versions: cp37-cp37m
+        run: |
+          ./main_checkout/build_tools/python_deploy/build_linux_packages.sh
+
   asan:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,6 +588,10 @@ jobs:
           override_python_versions: cp37-cp37m
         run: |
           ./build_tools/python_deploy/build_linux_packages.sh
+      # Note that it is just a trade-off decision to have this serialized
+      # as a separate step vs parallelized as a separate job. The runtime
+      # build is fast, pays the clone/docker overhead and provides early
+      # signal (since it runs in just a couple of minutes).
       - name: Build compiler wheels (Linux)
         shell: bash
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -563,7 +563,7 @@ jobs:
   ############################### Configurations ###############################
   # Jobs that build IREE in some non-default configuration
   ##############################################################################
-  python-release-packages:
+  python_release_packages:
     needs: setup
     if: needs.setup.outputs.should-run == 'true'
     runs-on:
@@ -580,8 +580,18 @@ jobs:
       - name: Build runtime wheels (Linux)
         shell: bash
         env:
-          package_suffix: ${{ github.event.inputs.package_suffix }}
           packages: "iree-runtime iree-runtime-instrumented"
+          output_dir: "${{ github.workspace }}/bindist"
+          # Note when upgrading: Build just one Python version synced to our
+          # minimum. Note that 3.7 is the last with this naming convention.
+          # Look at the script for the full list.
+          override_python_versions: cp37-cp37m
+        run: |
+          ./build_tools/python_deploy/build_linux_packages.sh
+      - name: Build compiler wheels (Linux)
+        shell: bash
+        env:
+          packages: "iree-compiler"
           output_dir: "${{ github.workspace }}/bindist"
           # Note when upgrading: Build just one Python version synced to our
           # minimum. Note that 3.7 is the last with this naming convention.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,7 +588,7 @@ jobs:
           # Look at the script for the full list.
           override_python_versions: cp37-cp37m
         run: |
-          ./main_checkout/build_tools/python_deploy/build_linux_packages.sh
+          ./build_tools/python_deploy/build_linux_packages.sh
 
   asan:
     needs: setup


### PR DESCRIPTION
Per #12341, we should have a smoke test of python package building. Note that this is still a proxy for the actual workflow that does this, as that differs in setup, metadata, versions built and schedule and is unsuitable for direct inclusion. However, the "inside" is all scripted and invariant and run identically between the CI and release building. This should reduce the rate of breaking incidents.

The release job also builds the "main" package tarball, which is not yet included here and has the potential to break in novel ways (but historically is much easier to predict/test).

This also would enable, should we ever want to, the ability to have CI jobs *depend on* just the built Python packages, using them to do further testing and automation without rebuilding entire parts of the project. That is left for a future exercise.