### PR TITLE
Blocking stream resource subview walks at timeline ops.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.cpp
@@ -761,6 +761,9 @@ IREE::Stream::ResourceSubviewOp ResourceSubviewOp::findSubviewOp(Value value) {
     if (!definingOp) {
       // Defined as a block argument - stop walk.
       break;
+    } else if (isa<IREE::Stream::TimelineOpInterface>(definingOp)) {
+      // Don't traverse timeline ops as time travel isn't possible (yet).
+      break;
     } else if (auto subviewOp =
                    dyn_cast<IREE::Stream::ResourceSubviewOp>(definingOp)) {
       // Found!

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -588,6 +588,7 @@ def Stream_ResourceSubviewOp : Stream_PureOp<"resource.subview", [
     Value getSubrangeResult() { return getResult(); }
 
     // Walks up the use-def chain to find a subview op that feeds into |value|.
+    // Stops at any timeline op that may indicate a change in resource contents.
     static IREE::Stream::ResourceSubviewOp findSubviewOp(Value value);
   }];
 


### PR DESCRIPTION
There are canonicalizers performing this walk to switch the resource they were sourcing from and if a timeline op was in the middle they'd pull a version of the resource from earlier in the timeline.

It appears there's no real change in final outputs as the canonicalizers on the timeline ops that are now blocking the walk do the work instead.