### PR TITLE
Minor fixes  found while enabling micro-kernel usage e2e.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_to_calls.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/lower_ukernel_to_calls.mlir
@@ -55,10 +55,10 @@ func.func @generic_ukernel(%arg0 : memref<?x?xf32>, %arg1 : memref<?x?xf32>,
   %dim_1 = memref.dim %arg0, %c0 : memref<?x?xf32>
   %dim_2 = memref.dim %arg1, %c1 : memref<?x?xf32>
   %dim_3 = memref.dim %arg2, %c1 : memref<?x?xf32>
-  iree_codegen.ukernel.generic "vmvx.matmul.f32.f32.f32" ins(%arg0, %arg1 : memref<?x?xf32>, memref<?x?xf32>) outs(%arg2 : memref<?x?xf32>) (%dim_1, %dim_2, %dim_3, %c0_i32 : index, index, index, i32)
+  iree_codegen.ukernel.generic "vmvx.matmul.f32f32f32" ins(%arg0, %arg1 : memref<?x?xf32>, memref<?x?xf32>) outs(%arg2 : memref<?x?xf32>) (%dim_1, %dim_2, %dim_3, %c0_i32 : index, index, index, i32)
   return
 }
-// CHECK-LABEL: func.func private @vmvx.matmul.f32.f32.f32
+// CHECK-LABEL: func.func private @vmvx.matmul.f32f32f32
 //  CHECK-SAME:     (memref<f32>, index, index, memref<f32>, index, index,
 //  CHECK-SAME:     memref<f32>, index, index, index, index, index, i32)
 // CHECK-LABEL: func.func @generic_ukernel
@@ -74,7 +74,7 @@ func.func @generic_ukernel(%arg0 : memref<?x?xf32>, %arg1 : memref<?x?xf32>,
 //       CHECK:   %[[BASE0:.+]], %[[OFFSET0:.+]], %[[SIZE0:.+]]:2, %[[STRIDES0:.+]]:2 = memref.extract_strided_metadata %[[ARG0]]
 //       CHECK:   %[[BASE1:.+]], %[[OFFSET1:.+]], %[[SIZE1:.+]]:2, %[[STRIDES1:.+]]:2 = memref.extract_strided_metadata %[[ARG1]]
 //       CHECK:   %[[BASE2:.+]], %[[OFFSET2:.+]], %[[SIZE2:.+]]:2, %[[STRIDES2:.+]]:2 = memref.extract_strided_metadata %[[ARG2]]
-//       CHECK:   call @vmvx.matmul.f32.f32.f32(%[[BASE0]], %[[OFFSET0]], %[[STRIDES0]]#0
+//       CHECK:   call @vmvx.matmul.f32f32f32(%[[BASE0]], %[[OFFSET0]], %[[STRIDES0]]#0
 //  CHECK-SAME:       %[[BASE1]], %[[OFFSET1]], %[[STRIDES1]]#0
 //  CHECK-SAME:       %[[BASE2]], %[[OFFSET2]], %[[STRIDES2]]#0
 //  CHECK-SAME:       %[[D0]], %[[D1]], %[[D2]], %[[C0_I32]])
@@ -87,7 +87,7 @@ func.func @mmt4d_ukernel(%arg0 : memref<?x?x?x?xf32>, %arg1 : memref<?x?x?x?xf32
       outs(%arg2 : memref<?x?x?x?xf32>) accumulate(false)
   return
 }
-// CHECK-LABEL: func.func private @vmvx.mmt4d.f32.f32.f32
+// CHECK-LABEL: func.func private @vmvx.mmt4d.f32f32f32
 //  CHECK-SAME:     (memref<f32>, index, index, memref<f32>, index, index,
 //  CHECK-SAME:     memref<f32>, index, index, index, index, index, i32, i32, i32, i32)
 // CHECK-LABEL: func.func @mmt4d_ukernel(
@@ -111,7 +111,7 @@ func.func @mmt4d_ukernel(%arg0 : memref<?x?x?x?xf32>, %arg1 : memref<?x?x?x?xf32
 //   CHECK-DAG:   %[[D5:.+]] = memref.dim %[[ARG0]], %[[C3]]
 //   CHECK-DAG:   %[[D5_I32:.+]] = arith.index_cast %[[D5]]
 //   CHECK-DAG:   %[[C0_I32:.+]] = arith.constant 0 : i32
-//       CHECK:   call @vmvx.mmt4d.f32.f32.f32(%[[BASE0]], %[[OFFSET0]], %[[STRIDES0]]#0
+//       CHECK:   call @vmvx.mmt4d.f32f32f32(%[[BASE0]], %[[OFFSET0]], %[[STRIDES0]]#0
 //  CHECK-SAME:       %[[BASE1]], %[[OFFSET1]], %[[STRIDES1]]#0
 //  CHECK-SAME:       %[[BASE2]], %[[OFFSET2]], %[[STRIDES2]]#0
 //  CHECK-SAME:       %[[D0]], %[[D1]], %[[D2]],
@@ -126,4 +126,4 @@ func.func @mmt4d_ukernel_i8i8i32(%arg0 : memref<?x?x?x?xi8>, %arg1 : memref<?x?x
   return
 }
 // CHECK-LABEL: func @mmt4d_ukernel_i8i8i32(
-//       CHECK:   call @vmvx.mmt4d.i8.i8.i32
+//       CHECK:   call @vmvx.mmt4d.i8i8i32

--- a/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/Dialect/UKernelOps.cpp
@@ -50,6 +50,10 @@ static FailureOr<func::CallOp> createFunctionCall(RewriterBase &rewriter,
     rewriter.setInsertionPointToStart(&moduleOp->getRegion(0).front());
     fnDecl = rewriter.create<func::FuncOp>(loc, fnName, functionType);
     SymbolTable::setSymbolVisibility(fnDecl, SymbolTable::Visibility::Private);
+    // TODO(#12327): Based on description in the issue, add an attribute
+    // `vm.import.module` and set it to `vmvx`. This only works on `vmvx`
+    // backend (obviously), but is enough to unblock while the proper fix lands.
+    fnDecl->setAttr("vm.import.module", rewriter.getStringAttr("vmvx"));
   } else if (fnDecl.getFunctionType() != functionType) {
     return rewriter.notifyMatchFailure(
         op, llvm::formatv("mismatch in function type computed during lowering "
@@ -288,10 +292,10 @@ FailureOr<func::CallOp> UKernelMmt4DOp::lowerToFunctionCall(
   std::string fnName = "vmvx.mmt4d.";
   switch (matmulType.value()) {
     case MatmulType::I8I8I32:
-      fnName.append("i8.i8.i32");
+      fnName.append("i8i8i32");
       break;
     case MatmulType::F32F32F32:
-      fnName.append("f32.f32.f32");
+      fnName.append("f32f32f32");
       break;
   }
 

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/LLVMCPULowerToUKernels.cpp
@@ -66,10 +66,10 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
   std::string fnName = "";
   switch (matmulType.value()) {
     case MatmulType::I8I8I32:
-      fnName = "vmvx.matmul.i8.i8.i32";
+      fnName = "vmvx.matmul.i8i8i32";
       break;
     case MatmulType::F32F32F32:
-      fnName = "vmvx.matmul.f32.f32.f32";
+      fnName = "vmvx.matmul.f32f32f32";
       break;
   }
 
@@ -108,10 +108,10 @@ static FailureOr<IREE::Codegen::UKernelOpInterface> matchDAGForUKernel(
   Type outElemType = outType.getElementType();
   if (lhsElemType.isSignlessInteger(8) && rhsElemType.isSignlessInteger(8) &&
       outElemType.isSignlessInteger(32)) {
-    fnName = "vmvx.matmul.i8.i8.i32";
+    fnName = "vmvx.matmul.i8i8i32";
   } else if (lhsElemType.isF32() && rhsElemType.isF32() &&
              outElemType.isF32()) {
-    fnName = "vmvx.matmul.f32.f32.f32";
+    fnName = "vmvx.matmul.f32f32f32";
   }
   if (fnName.empty()) {
     return rewriter.notifyMatchFailure(op,

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/test/lower_to_ukernel_ops.mlir
@@ -16,7 +16,7 @@ func.func @matmul(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.f32.f32.f32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.f32f32f32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -46,7 +46,7 @@ func.func @matmul_fill(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>) -> tens
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[EMPTY]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.f32.f32.f32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.f32f32f32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[EMPTY]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :
@@ -70,7 +70,7 @@ func.func @matmul_i8i8i32(%arg0 : tensor<?x?xi8>, %arg1 : tensor<?x?xi8>,
 //  CHECK-DAG:   %[[D0:.+]] = tensor.dim %[[ARG0]], %[[C0]]
 //  CHECK-DAG:   %[[D1:.+]] = tensor.dim %[[ARG1]], %[[C1]]
 //  CHECK-DAG:   %[[D2:.+]] = tensor.dim %[[ARG2]], %[[C1]]
-//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.i8.i8.i32"
+//      CHECK:   %[[MICRO_KERNEL:.+]] = iree_codegen.ukernel.generic "vmvx.matmul.i8i8i32"
 // CHECK-SAME:       ins(%[[ARG0]], %[[ARG1]] :
 // CHECK-SAME:       outs(%[[ARG2]] :
 // CHECK-SAME:       (%[[D0]], %[[D1]], %[[D2]], %[[FLAGS]] :


### PR DESCRIPTION
- Rename `vmvx.*.i8.i8.i32` -> `vmvx.*.i8i8i32`.
- Rename `vmvx.*.f32.f32.f32` -> `vmvx.*.f32f32f32`.
- Fix insertion point for `hal.interface.binding.subspan` in `ResolveBufferDescriptors` pass.
- Set the `vm.import.module` attribute to `vmvx` in ukernel function declaration.
- Remove offset from newly created `hal.interface.binding.subspan` in `ResolveBufferDesscriptors`.