### PR TITLE
[Flow] Add options for targeted tracing/breaking on dispatches

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/BUILD.bazel
@@ -52,6 +52,7 @@ iree_compiler_cc_library(
         "InferNumericNarrowing.cpp",
         "InitializeEmptyTensors.cpp",
         "InjectDispatchTracing.cpp",
+        "InsertDispatchDebugTargets.cpp",
         "InterchangeGenericOps.cpp",
         "InterchangeTransposeGenericOps.cpp",
         "OptimizeNumerics.cpp",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/CMakeLists.txt
@@ -51,6 +51,7 @@ iree_cc_library(
     "InferNumericNarrowing.cpp"
     "InitializeEmptyTensors.cpp"
     "InjectDispatchTracing.cpp"
+    "InsertDispatchDebugTargets.cpp"
     "InterchangeGenericOps.cpp"
     "InterchangeTransposeGenericOps.cpp"
     "OptimizeNumerics.cpp"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -39,10 +39,14 @@ static std::tuple<std::string, int> getOrdinalFromDebugTarget(
   if (marker.empty() || marker[0] != '@') return std::make_tuple("", -1);
 
   SmallVector<StringRef, 2> parts;
-  llvm::SplitString(marker.substr(1), parts, ":");
+  auto cropped = marker.substr(1);
+  llvm::SplitString(llvm::StringRef(cropped), parts, ":");
   if (parts.size() != 2) return std::make_tuple("", -1);
 
-  return std::make_tuple(parts[0].str(), std::stoi(parts[1].str()));
+  int ordinal;
+  if (parts[1].getAsInteger(10, ordinal)) return std::make_tuple("", -1);
+
+  return std::make_tuple(parts[0].str(), ordinal);
 }
 
 // Inserts flow.tensor.trace ops around the specified dispatch op.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/InsertDispatchDebugTargets.cpp
@@ -1,0 +1,249 @@
+// Copyright 2020 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <utility>
+
+#include "iree/compiler/Dialect/Flow/IR/FlowOps.h"
+#include "iree/compiler/Dialect/Flow/Transforms/PassDetail.h"
+#include "iree/compiler/Dialect/Flow/Transforms/Passes.h"
+#include "iree/compiler/Dialect/HAL/IR/HALDialect.h"
+#include "iree/compiler/Dialect/HAL/IR/HALOps.h"
+#include "llvm/ADT/StringExtras.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/Pass/Pass.h"
+
+namespace mlir {
+namespace iree_compiler {
+namespace IREE {
+namespace Flow {
+
+// Filters out non-tensor values for tracing.
+static SmallVector<Value, 4> filterNonTensorValues(ValueRange &&range) {
+  SmallVector<Value, 4> result;
+  for (auto value : range) {
+    if (value.getType().isa<TensorType>()) result.push_back(value);
+  }
+  return result;
+}
+
+// Attempts to interpret a pass arg as @<function_name>:<ordinal>, else returns
+// a negative ordinal indicating no match.
+static std::tuple<std::string, int> getOrdinalFromDebugTarget(
+    std::string marker) {
+  if (marker.empty() || marker[0] != '@') return std::make_tuple("", -1);
+
+  SmallVector<StringRef, 2> parts;
+  llvm::SplitString(marker.substr(1), parts, ":");
+  if (parts.size() != 2) return std::make_tuple("", -1);
+
+  return std::make_tuple(parts[0].str(), std::stoi(parts[1].str()));
+}
+
+// Inserts flow.tensor.trace ops around the specified dispatch op.
+static void traceOpWithName(DispatchOp dispatchOp, std::string name) {
+  OpBuilder builder(dispatchOp);
+  // Input tensors:
+  builder.create<TensorTraceOp>(
+      dispatchOp.getLoc(), builder.getStringAttr(name + " inputs"),
+      filterNonTensorValues(dispatchOp.getArguments()));
+
+  // Output tensors:
+  OpBuilder::InsertionGuard guard(builder);
+  builder.setInsertionPointAfter(dispatchOp);
+  builder.create<TensorTraceOp>(dispatchOp.getLoc(),
+                                builder.getStringAttr(name + " outputs"),
+                                filterNonTensorValues(dispatchOp.getResults()));
+}
+
+// Breaks the given function on the specified op by simply returning immediately
+// after the op. Updates the function signature to match the return type of the
+// target operation.
+static LogicalResult replaceReturnWithOpResults(mlir::ModuleOp moduleOp,
+                                                mlir::func::FuncOp funcOp,
+                                                Operation *op) {
+  if (!funcOp->isProperAncestor(op)) return failure();
+
+  // TODO: Handle nested function calls.
+  if (!SymbolTable::symbolKnownUseEmpty(funcOp, moduleOp)) return failure();
+
+  // TODO: Handle (nested) control flow.
+  auto funcBlock = op->getBlock();
+  if (funcBlock->getParentOp() != funcOp ||
+      &funcOp.getBody().front() != funcBlock)
+    return failure();
+
+  // Collect the op results and create export ops for any tensor results.
+  OpBuilder builder(funcOp);
+  auto context = op->getContext();
+  auto loc = op->getLoc();
+  auto oldTerminator = funcBlock->getTerminator();
+  builder.setInsertionPoint(oldTerminator);
+  SmallVector<Value> exports;
+  SmallVector<Type> newTypes;
+  for (auto retVal : op->getResults()) {
+    if (retVal.getType().isa<TensorType>()) {
+      auto type = IREE::HAL::BufferViewType::get(context);
+      auto exportOp =
+          builder.create<IREE::HAL::TensorExportOp>(loc, type, retVal);
+      exports.push_back(exportOp.getResult());
+      newTypes.push_back(type);
+    } else {
+      exports.push_back(retVal);
+      newTypes.push_back(retVal.getType());
+    }
+  }
+
+  // Create the new return and update the function type.
+  IRRewriter rewriter(builder);
+  rewriter.replaceOpWithNewOp<mlir::func::ReturnOp>(oldTerminator, exports);
+
+  SmallVector<Type> argTypes;
+  for (const auto &arg : llvm::enumerate(funcOp.getArguments()))
+    argTypes.push_back(arg.value().getType());
+
+  funcOp.setType(FunctionType::get(context,
+                                   /*inputs=*/argTypes, /*results=*/newTypes));
+  return success();
+}
+
+// Insert break/tracing by ordinal for the specified function.
+struct InsertDebugTargetAtOrdinalPass
+    : public InsertDebugTargetAtOrdinalBase<InsertDebugTargetAtOrdinalPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Flow::FlowDialect, IREE::HAL::HALDialect>();
+  }
+  InsertDebugTargetAtOrdinalPass(std::string breakStr, std::string traceStr) {
+    this->breakDebugTarget = breakStr;
+    this->traceDebugTarget = traceStr;
+  };
+  InsertDebugTargetAtOrdinalPass(const InsertDebugTargetAtOrdinalPass &pass)
+      : InsertDebugTargetAtOrdinalPass(pass.breakDebugTarget,
+                                       pass.traceDebugTarget) {}
+
+  void runOnOperation() override {
+    auto [breakFname, breakOrdinal] =
+        getOrdinalFromDebugTarget(breakDebugTarget);
+    auto [traceFname, traceOrdinal] =
+        getOrdinalFromDebugTarget(traceDebugTarget);
+
+    for (auto it :
+         llvm::enumerate(getOperation().getOps<FunctionOpInterface>())) {
+      FunctionOpInterface op = it.value();
+      Operation *operation = op;
+
+      // Only look for dispatches in upstream func ops.
+      auto funcOp = llvm::dyn_cast<mlir::func::FuncOp>(operation);
+      if (!funcOp) continue;
+
+      std::string fName = funcOp.getName().str();
+      int localBreakOrdinal = -1;
+      if (fName == breakFname) localBreakOrdinal = breakOrdinal;
+      int localTraceOrdinal = -1;
+      if (fName == traceFname) localTraceOrdinal = traceOrdinal;
+
+      auto &bodyRegion = op.getFunctionBody();
+      auto dispatchOps = llvm::to_vector<8>(bodyRegion.getOps<DispatchOp>());
+
+      // Trace on a valid ordinal.
+      if (localTraceOrdinal > 0 && localTraceOrdinal < dispatchOps.size()) {
+        auto traceTarget = dispatchOps[localTraceOrdinal];
+        std::string entryPointName =
+            traceTarget.getEntryPoint().getRootReference().getValue().str();
+        for (FlatSymbolRefAttr nestedRef :
+             traceTarget.getEntryPoint().getNestedReferences()) {
+          entryPointName = (entryPointName + "::" + nestedRef.getValue()).str();
+        }
+        // Append the ordinal to the trace name.
+        traceOpWithName(traceTarget, entryPointName + std::string("::") +
+                                         std::to_string(localTraceOrdinal));
+      }
+
+      // Break on a valid ordinal, updating the function signature in the
+      // process. Currently only a single ordinal is supported so no need to
+      // check for overlapping breaks.
+      if (localBreakOrdinal > 0 && localBreakOrdinal < dispatchOps.size()) {
+        auto breakTarget = dispatchOps[localBreakOrdinal];
+        if (failed(replaceReturnWithOpResults(getOperation(), funcOp,
+                                              breakTarget)))
+          return signalPassFailure();
+      }
+    }
+  }
+};
+
+// Break/trace by symbol, after outlining dispatch regions and
+// deduplication.
+struct InsertDebugTargetAtSymbolPass
+    : public InsertDebugTargetAtSymbolBase<InsertDebugTargetAtSymbolPass> {
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<IREE::Flow::FlowDialect, IREE::HAL::HALDialect>();
+  }
+  InsertDebugTargetAtSymbolPass(std::string breakStr, std::string traceStr) {
+    this->breakDebugTarget = breakStr;
+    this->traceDebugTarget = traceStr;
+  };
+  InsertDebugTargetAtSymbolPass(const InsertDebugTargetAtSymbolPass &pass)
+      : InsertDebugTargetAtSymbolPass(pass.breakDebugTarget,
+                                      pass.traceDebugTarget) {}
+
+  void runOnOperation() override {
+    for (auto it :
+         llvm::enumerate(getOperation().getOps<FunctionOpInterface>())) {
+      FunctionOpInterface funcOp = it.value();
+
+      DispatchOp breakTarget = DispatchOp();
+      funcOp.walk([&](DispatchOp dispatchOp) {
+        std::string entryPointName =
+            dispatchOp.getEntryPoint().getRootReference().getValue().str();
+        for (FlatSymbolRefAttr nestedRef :
+             dispatchOp.getEntryPoint().getNestedReferences()) {
+          entryPointName = (entryPointName + "::" + nestedRef.getValue()).str();
+        }
+        if (!traceDebugTarget.empty() &&
+            entryPointName.find(traceDebugTarget) != std::string::npos)
+          traceOpWithName(dispatchOp, entryPointName);
+
+        if (!breakTarget && !breakDebugTarget.empty() &&
+            entryPointName.find(breakDebugTarget) != std::string::npos)
+          breakTarget = dispatchOp;
+      });
+
+      // Break on the selected operation (dispatch). Currently this breaks on
+      // the first occurance of a dispatch that matches the symbol by assuming
+      // no control flow within the function. This will fail if the target
+      // dispatch is not found within the entry block of the function.
+      if (breakTarget) {
+        Operation *operation = funcOp;
+        auto mlirFuncOp = dyn_cast<mlir::func::FuncOp>(operation);
+        if (!mlirFuncOp || failed(replaceReturnWithOpResults(
+                               getOperation(), mlirFuncOp, breakTarget)))
+          return signalPassFailure();
+      }
+    }
+  }
+};
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createInsertDebugTargetAtOrdinalPass(std::string breakDebugTarget,
+                                     std::string traceDebugTarget) {
+  return std::make_unique<InsertDebugTargetAtOrdinalPass>(breakDebugTarget,
+                                                          traceDebugTarget);
+}
+
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createInsertDebugTargetAtSymbolPass(std::string breakDebugTarget,
+                                    std::string traceDebugTarget) {
+  return std::make_unique<InsertDebugTargetAtSymbolPass>(breakDebugTarget,
+                                                         traceDebugTarget);
+}
+
+}  // namespace Flow
+}  // namespace IREE
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -35,7 +35,7 @@ static llvm::cl::opt<bool> clTraceDispatchTensors(
         "Trace runtime input/output tensors for each dispatch function."),
     llvm::cl::init(false));
 static llvm::cl::opt<std::string> clBreakOnDispatch(
-    "iree-flow-break-on-dispatch",
+    "iree-flow-break-dispatch",
     llvm::cl::desc(
         "Enables inserting a break after a specified dispatch. Supports two "
         "modes; breaking on the dispatch ordinal before deduplication "
@@ -46,7 +46,7 @@ static llvm::cl::opt<std::string> clTraceDispatch(
     llvm::cl::desc("Enables tracing tensors at specified dispatches. Supports "
                    "two modes; tracing the dispatch by ordinal before "
                    "deduplication (@function_name:<index>) and tracing all "
-                   "occurances of the dispatch symbol."),
+                   "occurrences of the dispatch symbol."),
     llvm::cl::init(""));
 static llvm::cl::opt<bool> clDemoteI64ToI32(
     "iree-flow-demote-i64-to-i32",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -34,7 +34,20 @@ static llvm::cl::opt<bool> clTraceDispatchTensors(
     llvm::cl::desc(
         "Trace runtime input/output tensors for each dispatch function."),
     llvm::cl::init(false));
-
+static llvm::cl::opt<std::string> clBreakOnDispatch(
+    "iree-flow-break-on-dispatch",
+    llvm::cl::desc(
+        "Enables inserting a break after a specified dispatch. Supports two "
+        "modes; breaking on the dispatch ordinal before deduplication "
+        "(@function_name:<index>) and breaking on the dispatch symbol."),
+    llvm::cl::init(""));
+static llvm::cl::opt<std::string> clTraceDispatch(
+    "iree-flow-trace-dispatch",
+    llvm::cl::desc("Enables tracing tensors at specified dispatches. Supports "
+                   "two modes; tracing the dispatch by ordinal before "
+                   "deduplication (@function_name:<index>) and tracing all "
+                   "occurances of the dispatch symbol."),
+    llvm::cl::init(""));
 static llvm::cl::opt<bool> clDemoteI64ToI32(
     "iree-flow-demote-i64-to-i32",
     llvm::cl::desc("Converts all i64 ops and values into i32 counterparts "
@@ -288,6 +301,21 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   // wrapped in executables.
   passManager.addPass(IREE::Flow::createOutlineDispatchRegionsPass());
 
+  // Trace/break dispatches by ordinal in the specified region. There is a
+  // similar version of the pass run both before and after deduplication
+  // depending on if the target is specified by ordinal or by symbol.
+  std::string dispatchBreakOrdinalStr =
+      !clBreakOnDispatch.empty() && clBreakOnDispatch[0] == '@'
+          ? clBreakOnDispatch
+          : std::string("");
+  std::string dispatchTraceOrdinalStr =
+      !clTraceDispatch.empty() && clTraceDispatch[0] == '@' ? clTraceDispatch
+                                                            : std::string("");
+  if (!dispatchBreakOrdinalStr.empty() || !dispatchTraceOrdinalStr.empty()) {
+    passManager.addPass(IREE::Flow::createInsertDebugTargetAtOrdinalPass(
+        dispatchBreakOrdinalStr, dispatchTraceOrdinalStr));
+  }
+
   // Strip assertions from executables. We could support them with a bunch of
   // work but our generated executables are designed to be safe in the face of
   // invalid values and it'd only be useful for debugging.
@@ -309,6 +337,20 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
   // resets, etc) is up to the author.
   if (clExportBenchmarkFuncs) {
     passManager.addPass(IREE::Flow::createExportBenchmarkFuncsPass());
+  }
+
+  // Trace/break dispatches by symbol. Symbols are partially matched against
+  // the exact string specified in the cli option.
+  std::string dispatchBreakSymbolStr =
+      !clBreakOnDispatch.empty() && clBreakOnDispatch[0] != '@'
+          ? clBreakOnDispatch
+          : std::string("");
+  std::string dispatchTraceSymbolStr =
+      !clTraceDispatch.empty() && clTraceDispatch[0] != '@' ? clTraceDispatch
+                                                            : std::string("");
+  if (!dispatchBreakSymbolStr.empty() || !dispatchTraceSymbolStr.empty()) {
+    passManager.addPass(IREE::Flow::createInsertDebugTargetAtSymbolPass(
+        dispatchBreakSymbolStr, dispatchTraceSymbolStr));
   }
 
   FunctionLikeNest(passManager)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -193,6 +193,16 @@ createOutlineDispatchRegionsPass();
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
 createInjectDispatchTracingPass();
 
+// Crops the program and inserts trace markers at the specified symbols.
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createInsertDebugTargetAtSymbolPass(std::string breakDebugTarget = "",
+                                    std::string traceDebugTarget = "");
+
+// Crops the program and inserts trace markers at the specified ordinals.
+std::unique_ptr<OperationPass<mlir::ModuleOp>>
+createInsertDebugTargetAtOrdinalPass(std::string breakDebugTarget = "",
+                                     std::string traceDebugTarget = "");
+
 // Exports all functions and dispatch executables as `() -> ()` benchmark funcs.
 std::unique_ptr<OperationPass<mlir::ModuleOp>> createExportBenchmarkFuncsPass();
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -182,6 +182,34 @@ def InjectDispatchTracing :
   let constructor = "mlir::iree_compiler::IREE::Flow::createInjectDispatchTracingPass()";
 }
 
+def InsertDebugTargetAtSymbol :
+    Pass<"iree-flow-insert-debug-target-at-symbol", "mlir::ModuleOp"> {
+  let summary = "Crops and/or traces the program at the specified symbol";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createInsertDebugTargetAtSymbolPass()";
+  let options = [
+    Option<"breakDebugTarget", "break-debug-target", "std::string",
+           /*default=*/"",
+           "Symbol at which to insert a break in the program.">,
+    Option<"traceDebugTarget", "trace-debug-target", "std::string",
+           /*default=*/"",
+           "Symbol to insert iree.flow.trace ops around.">
+  ];
+}
+
+def InsertDebugTargetAtOrdinal :
+    Pass<"iree-flow-insert-debug-target-at-ordinal", "mlir::ModuleOp"> {
+  let summary = "Crops and/or traces the program at the specified ordinal";
+  let constructor = "mlir::iree_compiler::IREE::Flow::createInsertDebugTargetAtOrdinalPass()";
+  let options = [
+    Option<"breakDebugTarget", "break-debug-target", "std::string",
+           /*default=*/"",
+           "Ordinal at which to insert a break in the program.">,
+    Option<"traceDebugTarget", "trace-debug-target", "std::string",
+           /*default=*/"",
+           "Ordinal to insert iree.flow.trace ops around.">
+  ];
+}
+
 def InterchangeGenericOps :
     Pass<"iree-flow-interchange-generic-ops", ""> {
   let summary = "Interchange generic op loops to have all the reduction loops to be inner loops.";

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/BUILD.bazel
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "infer_numeric_narrowing.mlir",
             "initialize_empty_tensors.mlir",
             "inject_dispatch_tracing.mlir",
+            "insert_dispatch_debug_markers.mlir",
             "interchange_generic_ops.mlir",
             "interchange_transpose_generic_ops.mlir",
             "optimize_numerics.mlir",

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/CMakeLists.txt
@@ -35,6 +35,7 @@ iree_lit_test_suite(
     "infer_numeric_narrowing.mlir"
     "initialize_empty_tensors.mlir"
     "inject_dispatch_tracing.mlir"
+    "insert_dispatch_debug_markers.mlir"
     "interchange_generic_ops.mlir"
     "interchange_transpose_generic_ops.mlir"
     "optimize_numerics.mlir"

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/insert_dispatch_debug_markers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/insert_dispatch_debug_markers.mlir
@@ -1,5 +1,5 @@
 // RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-ordinal{break-debug-target=@target_func:1 trace-debug-target=@target_func:1})" %s | FileCheck %s --check-prefixes=CHECK,ORDINAL
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-symbol{break-debug-target=dispatch_1 trace-debug-target=dispatch_1})" %s | FileCheck %s --check-prefixes=CHECK,SYMBOL
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-symbol{break-debug-target=dispatch_1 trace-debug-target=dispatch_1[^0-9]})" %s | FileCheck %s --check-prefixes=CHECK,SYMBOL
 
 /// Multiple functions
 
@@ -20,16 +20,16 @@ func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
 // CHECK-LABEL: func.func @other_func
 func.func @other_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
   %c4 = arith.constant 4 : index
-  // CHECK: %0 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  // CHECK: %[[D0:.+]] = flow.dispatch @dispatch_1::@dispatch_1_entry
   %0 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
 
-  // CHECK: %1 = flow.dispatch @dispatch_2::@dispatch_2_entry
+  // CHECK: %[[D1:.+]] = flow.dispatch @dispatch_2::@dispatch_2_entry
   %1 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK: %2 = flow.dispatch @dispatch_3::@dispatch_3_entry
+  // CHECK: %[[D2:.+]] = flow.dispatch @dispatch_3::@dispatch_3_entry
   %2 = flow.dispatch @dispatch_3::@dispatch_3_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
 
-  // ORDINAL: %[[ORIGINAL_EXPORT:.+]] = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
-  // SYMBOL:  %[[BREAK_EXPORT:.+]] = hal.tensor.export %0 : tensor<4xf32> -> !hal.buffer_view
+  // ORDINAL: %[[ORIGINAL_EXPORT:.+]] = hal.tensor.export %[[D2]] : tensor<4xf32> -> !hal.buffer_view
+  // SYMBOL:  %[[BREAK_EXPORT:.+]] = hal.tensor.export %[[D0]] : tensor<4xf32> -> !hal.buffer_view
   %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
 
   /// Only break on the symbol as the ordinal specifies a different function
@@ -44,14 +44,14 @@ func.func @other_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
 // CHECK-LABEL: func.func @target_func
 func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
   %c4 = arith.constant 4 : index
-  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  // CHECK: %[[D0:.+]] = flow.dispatch @dispatch_0::@dispatch_0_entry
   %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK: %1:2 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  // CHECK: %[[D1:.+]]:2 = flow.dispatch @dispatch_1::@dispatch_1_entry
   %1:2 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>)
   %2 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
   %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
-  // CHECK: %[[EXPORT_0:.+]] = hal.tensor.export %1#0 : tensor<4xf32> -> !hal.buffer_view
-  // CHECK: %[[EXPORT_1:.+]] = hal.tensor.export %1#1 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT_0:.+]] = hal.tensor.export %[[D1]]#0 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT_1:.+]] = hal.tensor.export %[[D1]]#1 : tensor<4xf32> -> !hal.buffer_view
   // CHECK: return %[[EXPORT_0]], %[[EXPORT_1]] : !hal.buffer_view
   return %3 : !hal.buffer_view
 }
@@ -62,11 +62,11 @@ func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
 // CHECK-LABEL: func.func @target_func
 func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
   %c4 = arith.constant 4 : index
-  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  // CHECK: %[[D0:.+]] = flow.dispatch @dispatch_0::@dispatch_0_entry
   %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
-  // CHECK: %1 = hal.tensor.export %0 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[D1:.+]] = hal.tensor.export %[[D0]] : tensor<4xf32> -> !hal.buffer_view
   %1 = hal.tensor.export %0 : tensor<4xf32> -> !hal.buffer_view
-  // CHECK: return %1 : !hal.buffer_view
+  // CHECK: return %[[D1]] : !hal.buffer_view
   return %1 : !hal.buffer_view
 }
 
@@ -74,21 +74,43 @@ func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
 
 /// Combine tracing and breaking on the same dispatch
 // CHECK-LABEL: func.func @target_func
+// CHECK-SAME:       %[[ARG0:.+]]: tensor<4xf32>
 func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
   %c4 = arith.constant 4 : index
-  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  // CHECK: %[[D0:.+]] = flow.dispatch @dispatch_0::@dispatch_0_entry
   %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
 
-  // ORDINAL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry::1 inputs"} %arg0 : tensor<4xf32>
-  // SYMBOL:  flow.tensor.trace {key = "dispatch_1::dispatch_1_entry inputs"} %arg0 : tensor<4xf32>
-  // CHECK: %1 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  // ORDINAL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry::1 inputs"} %[[ARG0]] : tensor<4xf32>
+  // SYMBOL:  flow.tensor.trace {key = "dispatch_1::dispatch_1_entry inputs"} %[[ARG0]] : tensor<4xf32>
+  // CHECK: %[[D1:.+]] = flow.dispatch @dispatch_1::@dispatch_1_entry
   %1 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
-  // ORDINAL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry::1 outputs"} %1 : tensor<4xf32>
-  // SYMBOL:  flow.tensor.trace {key = "dispatch_1::dispatch_1_entry outputs"} %1 : tensor<4xf32>
+  // ORDINAL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry::1 outputs"} %[[D1]] : tensor<4xf32>
+  // SYMBOL:  flow.tensor.trace {key = "dispatch_1::dispatch_1_entry outputs"} %[[D1]] : tensor<4xf32>
 
   %2 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
   %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
-  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %1 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %[[D1]] : tensor<4xf32> -> !hal.buffer_view
   // CHECK: return %[[EXPORT]] : !hal.buffer_view
   return %3 : !hal.buffer_view
+}
+
+
+// -----
+
+/// Check regex matching on symbol
+// CHECK-LABEL: func.func @target_func
+func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
+  %c4 = arith.constant 4 : index
+  // SYMBOL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry inputs"}
+  // CHECK:  flow.dispatch @dispatch_1::@dispatch_1_entry
+  %0 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  // SYMBOL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry outputs"}
+
+  // SYMBOL-NOT: flow.tensor.trace {key = "dispatch_11::dispatch_11_entry inputs"}
+  // CHECK:      flow.dispatch @dispatch_11::@dispatch_11_entry
+  %1 = flow.dispatch @dispatch_11::@dispatch_11_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  // SYMBOL-NOT: flow.tensor.trace {key = "dispatch_11::dispatch_11_entry outputs"}
+
+  %2 = hal.tensor.export %1 : tensor<4xf32> -> !hal.buffer_view
+  return %2 : !hal.buffer_view
 }

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/insert_dispatch_debug_markers.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/insert_dispatch_debug_markers.mlir
@@ -1,0 +1,94 @@
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-ordinal{break-debug-target=@target_func:1 trace-debug-target=@target_func:1})" %s | FileCheck %s --check-prefixes=CHECK,ORDINAL
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(iree-flow-insert-debug-target-at-symbol{break-debug-target=dispatch_1 trace-debug-target=dispatch_1})" %s | FileCheck %s --check-prefixes=CHECK,SYMBOL
+
+/// Multiple functions
+
+// CHECK-LABEL: func.func @target_func
+func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
+  %c4 = arith.constant 4 : index
+  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  // CHECK: %1 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  %1 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  %2 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %1 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: return %[[EXPORT]] : !hal.buffer_view
+  return %3 : !hal.buffer_view
+}
+
+// CHECK-LABEL: func.func @other_func
+func.func @other_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
+  %c4 = arith.constant 4 : index
+  // CHECK: %0 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  %0 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+
+  // CHECK: %1 = flow.dispatch @dispatch_2::@dispatch_2_entry
+  %1 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  // CHECK: %2 = flow.dispatch @dispatch_3::@dispatch_3_entry
+  %2 = flow.dispatch @dispatch_3::@dispatch_3_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+
+  // ORDINAL: %[[ORIGINAL_EXPORT:.+]] = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
+  // SYMBOL:  %[[BREAK_EXPORT:.+]] = hal.tensor.export %0 : tensor<4xf32> -> !hal.buffer_view
+  %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
+
+  /// Only break on the symbol as the ordinal specifies a different function
+  // SYMBOL:  return %[[BREAK_EXPORT]] : !hal.buffer_view
+  // ORDINAL: return %[[ORIGINAL_EXPORT]] : !hal.buffer_view
+  return %3 : !hal.buffer_view
+}
+
+// -----
+
+// Break on a dispatch with a different number of results
+// CHECK-LABEL: func.func @target_func
+func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
+  %c4 = arith.constant 4 : index
+  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  // CHECK: %1:2 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  %1:2 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> (tensor<4xf32>, tensor<4xf32>)
+  %2 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT_0:.+]] = hal.tensor.export %1#0 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT_1:.+]] = hal.tensor.export %1#1 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: return %[[EXPORT_0]], %[[EXPORT_1]] : !hal.buffer_view
+  return %3 : !hal.buffer_view
+}
+
+// -----
+
+// Break/trace on a dispatch not found in the target function should do nothing
+// CHECK-LABEL: func.func @target_func
+func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
+  %c4 = arith.constant 4 : index
+  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  // CHECK: %1 = hal.tensor.export %0 : tensor<4xf32> -> !hal.buffer_view
+  %1 = hal.tensor.export %0 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: return %1 : !hal.buffer_view
+  return %1 : !hal.buffer_view
+}
+
+// -----
+
+/// Combine tracing and breaking on the same dispatch
+// CHECK-LABEL: func.func @target_func
+func.func @target_func(%arg0: tensor<4xf32>) -> !hal.buffer_view {
+  %c4 = arith.constant 4 : index
+  // CHECK: %0 = flow.dispatch @dispatch_0::@dispatch_0_entry
+  %0 = flow.dispatch @dispatch_0::@dispatch_0_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+
+  // ORDINAL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry::1 inputs"} %arg0 : tensor<4xf32>
+  // SYMBOL:  flow.tensor.trace {key = "dispatch_1::dispatch_1_entry inputs"} %arg0 : tensor<4xf32>
+  // CHECK: %1 = flow.dispatch @dispatch_1::@dispatch_1_entry
+  %1 = flow.dispatch @dispatch_1::@dispatch_1_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  // ORDINAL: flow.tensor.trace {key = "dispatch_1::dispatch_1_entry::1 outputs"} %1 : tensor<4xf32>
+  // SYMBOL:  flow.tensor.trace {key = "dispatch_1::dispatch_1_entry outputs"} %1 : tensor<4xf32>
+
+  %2 = flow.dispatch @dispatch_2::@dispatch_2_entry[%c4] (%arg0) : (tensor<4xf32>) -> tensor<4xf32>
+  %3 = hal.tensor.export %2 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: %[[EXPORT:.+]] = hal.tensor.export %1 : tensor<4xf32> -> !hal.buffer_view
+  // CHECK: return %[[EXPORT]] : !hal.buffer_view
+  return %3 : !hal.buffer_view
+}


### PR DESCRIPTION
Opening a PR to see if this or something similar would be wanted in core IREE. Essentially this enables cropping the input program at a specified dispatch. We have been using this in SHARK-Runtime as a debugging tool.

For example, for certain backends and/or large models, `--iree-flow-trace-dispatch-tensors` is far too slow and produces too much output to easily iterate with so being able to quickly "binary search" can enable much faster isolation of correctness issues. This also has proven useful for isolating "soft" crashes/unwanted behavior like codegen blowing up (happens sometimes in SPIR-V).

The current implementation here is a bit hacky (and assumes single output everywhere) so feedback on a "correct" way to implement this is welcome.