### PR TITLE
[WIP] Use human readable name for e2e test artifacts

### DIFF
--- a/build_tools/cmake/iree_benchmark_suite.cmake
+++ b/build_tools/cmake/iree_benchmark_suite.cmake
@@ -43,7 +43,7 @@ function(iree_import_tflite_model)
       COMMAND
         "${IREE_IMPORT_TFLITE_PATH}"
         "${_RULE_SOURCE}"
-        "-o=${_RULE_OUTPUT_MLIR_FILE}"
+        "-o=\"${_RULE_OUTPUT_MLIR_FILE}\""
         ${_RULE_IMPORT_FLAGS}
       DEPENDS
         "${_RULE_SOURCE}"
@@ -98,7 +98,7 @@ function(iree_import_tf_model)
       COMMAND
         "${IREE_IMPORT_TF_PATH}"
         "${_RULE_SOURCE}"
-        "-o=${_RULE_OUTPUT_MLIR_FILE}"
+        "-o=\"${_RULE_OUTPUT_MLIR_FILE}\""
         ${_RULE_IMPORT_FLAGS}
       DEPENDS
         "${_RULE_SOURCE}"

--- a/build_tools/python/cmake_builder/rules.py
+++ b/build_tools/python/cmake_builder/rules.py
@@ -87,6 +87,11 @@ def _convert_block_to_string(block: List[str]) -> str:
   return "\n".join(block + [""])
 
 
+def sanitize_target_name(target_name: str):
+  """Replace common special character disallowed in CMake target name."""
+  return target_name.replace(",", "-")
+
+
 def build_iree_bytecode_module(target_name: str,
                                src: str,
                                module_name: str,

--- a/build_tools/python/cmake_builder/rules.py
+++ b/build_tools/python/cmake_builder/rules.py
@@ -91,7 +91,7 @@ def _convert_block_to_string(block: List[str]) -> str:
   return "\n".join(block + [""])
 
 
-def sanitize_target_name(target_name: str):
+def sanitize_target(target_name: str):
   """Replace characters disallowed in CMake target name with _."""
   return DISALLOWED_TARGET_CHAR_MATCHER.sub("_", target_name)
 

--- a/build_tools/python/cmake_builder/rules.py
+++ b/build_tools/python/cmake_builder/rules.py
@@ -175,7 +175,7 @@ def build_iree_import_tflite_model(target_path: str, source: str,
 
 def build_iree_benchmark_suite_module_test(
     target_name: str,
-    model: str,
+    imported_model: str,
     driver: str,
     expected_output: str,
     runner_args: Sequence[str],
@@ -184,7 +184,7 @@ def build_iree_benchmark_suite_module_test(
     xfail_platforms: Sequence[str] = [],
     unsupported_platforms: Sequence[str] = []) -> str:
   name_block = _get_string_arg_block("NAME", target_name)
-  model_block = _get_string_arg_block("MODEL", model)
+  imported_model_block = _get_string_arg_block("IMPORTED_MODEL", imported_model)
   driver_block = _get_string_arg_block("DRIVER", driver)
   expected_output_block = _get_string_arg_block("EXPECTED_OUTPUT",
                                                 expected_output)
@@ -200,7 +200,7 @@ def build_iree_benchmark_suite_module_test(
   return _convert_block_to_string(
       _build_call_rule(rule_name="iree_benchmark_suite_module_test",
                        parameter_blocks=[
-                           name_block, model_block, driver_block,
+                           name_block, imported_model_block, driver_block,
                            expected_output_block, timeout_block,
                            runner_args_block, labels_block,
                            xfail_platforms_block, unsupported_platforms_block

--- a/build_tools/python/cmake_builder/rules.py
+++ b/build_tools/python/cmake_builder/rules.py
@@ -91,7 +91,7 @@ def _convert_block_to_string(block: List[str]) -> str:
   return "\n".join(block + [""])
 
 
-def sanitize_target(target_name: str):
+def sanitize_target_name(target_name: str):
   """Replace characters disallowed in CMake target name with _."""
   return DISALLOWED_TARGET_CHAR_MATCHER.sub("_", target_name)
 

--- a/build_tools/python/cmake_builder/rules.py
+++ b/build_tools/python/cmake_builder/rules.py
@@ -30,9 +30,13 @@ iree_fetch_artifact(
 )
 """
 
+import re
 from typing import List, Optional, Sequence
 
 INDENT_SPACES = " " * 2
+# Match any character not allowed in CMake target name.
+# https://cmake.org/cmake/help/latest/policy/CMP0037.html
+DISALLOWED_TARGET_CHAR_MATCHER = re.compile(r"[^A-Za-z0-9_.+-]")
 
 
 def _get_string_list(values: Sequence[str], quote: bool = True) -> List[str]:
@@ -88,8 +92,8 @@ def _convert_block_to_string(block: List[str]) -> str:
 
 
 def sanitize_target_name(target_name: str):
-  """Replace common special character disallowed in CMake target name."""
-  return target_name.replace(",", "-")
+  """Replace characters disallowed in CMake target name with _."""
+  return DISALLOWED_TARGET_CHAR_MATCHER.sub("_", target_name)
 
 
 def build_iree_bytecode_module(target_name: str,

--- a/build_tools/python/cmake_builder/rules_test.py
+++ b/build_tools/python/cmake_builder/rules_test.py
@@ -147,7 +147,7 @@ class RulesTest(unittest.TestCase):
   def test_build_iree_benchmark_suite_module_test(self):
     rule = cmake_builder.rules.build_iree_benchmark_suite_module_test(
         target_name="model_test",
-        model="123_abc",
+        imported_model="123",
         driver="LOCAL_TASK",
         expected_output="xyz",
         runner_args=["--x=0", "--y=1"],
@@ -162,8 +162,8 @@ class RulesTest(unittest.TestCase):
         iree_benchmark_suite_module_test(
           NAME
             "model_test"
-          MODEL
-            "123_abc"
+          IMPORTED_MODEL
+            "123"
           DRIVER
             "LOCAL_TASK"
           EXPECTED_OUTPUT

--- a/build_tools/python/e2e_model_tests/cmake_generator.py
+++ b/build_tools/python/e2e_model_tests/cmake_generator.py
@@ -18,13 +18,13 @@ def generate_rules() -> List[str]:
   for platform in test_definitions.CMakePlatform:
     cmake_rule = cmake_builder.rules.build_set(
         variable_name=f"IREE_MODULE_COMPILE_CONFIG_ID_{platform.value.upper()}",
-        value=f'"{test_definitions.PLATFORM_COMPILE_CONFIG_MAP[platform].id}"')
+        value=f'"{test_definitions.PLATFORM_COMPILE_CONFIG_MAP[platform]}"')
     cmake_rules.append(cmake_rule)
 
   for test_config in test_definitions.TEST_CONFIGS:
-    model = test_config.model
+    imported_model = test_config.imported_model
     runner_args = run_module_utils.build_run_flags_for_model(
-        model=model,
+        model=imported_model.model,
         model_input_data=test_config.input_data) + test_config.extra_test_flags
     # TODO(#11136): Currently the DRIVER is a separate field in the CMake rule (
     # and has effect on test labels). Rules should be generated in another way
@@ -33,7 +33,7 @@ def generate_rules() -> List[str]:
         test_config.execution_config, with_driver=False)
     cmake_rule = cmake_builder.rules.build_iree_benchmark_suite_module_test(
         target_name=test_config.name,
-        model=f"{model.id}_{model.name}",
+        model=f"{imported_model}",
         driver=test_config.execution_config.driver.value,
         expected_output=test_config.expected_output,
         runner_args=runner_args,

--- a/build_tools/python/e2e_model_tests/test_definitions.py
+++ b/build_tools/python/e2e_model_tests/test_definitions.py
@@ -42,7 +42,7 @@ class ModelTestConfig(object):
   """Defines an e2e model test to run by iree-run-module."""
   # Test name shown in the test rule.
   name: str
-  model: common_definitions.Model
+  imported_model: iree_definitions.ImportedModel
   execution_config: iree_definitions.ModuleExecutionConfig
 
   # Either a string literal or a file path.
@@ -62,7 +62,8 @@ TEST_CONFIGS = [
     # mobilenet_v1_fp32_correctness_test
     ModelTestConfig(
         name="mobilenet_v1_fp32_correctness_test",
-        model=tflite_models.MOBILENET_V1,
+        imported_model=iree_definitions.ImportedModel.from_model(
+            tflite_models.MOBILENET_V1),
         execution_config=module_execution_configs.ELF_LOCAL_SYNC_CONFIG,
         expected_output="mobilenet_v1_fp32_expected_output.txt",
         unsupported_platforms=[
@@ -71,14 +72,16 @@ TEST_CONFIGS = [
     # efficientnet_int8_correctness_test
     ModelTestConfig(
         name="efficientnet_int8_correctness_test",
-        model=tflite_models.EFFICIENTNET_INT8,
+        imported_model=iree_definitions.ImportedModel.from_model(
+            tflite_models.EFFICIENTNET_INT8),
         execution_config=module_execution_configs.ELF_LOCAL_SYNC_CONFIG,
         expected_output="efficientnet_int8_expected_output.txt",
         unsupported_platforms=[CMakePlatform.ANDROID_ARMV8_A]),
     # deeplab_v3_fp32_correctness_test
     ModelTestConfig(
         name="deeplab_v3_fp32_correctness_test",
-        model=tflite_models.DEEPLABV3_FP32,
+        imported_model=iree_definitions.ImportedModel.from_model(
+            tflite_models.DEEPLABV3_FP32),
         execution_config=module_execution_configs.ELF_LOCAL_SYNC_CONFIG,
         expected_output="deeplab_v3_fp32_input_0_expected_output.npy",
         extra_test_flags=["--expected_f32_threshold=0.001"],
@@ -86,7 +89,8 @@ TEST_CONFIGS = [
     # person_detect_int8_correctness_test
     ModelTestConfig(
         name="person_detect_int8_correctness_test",
-        model=tflite_models.PERSON_DETECT_INT8,
+        imported_model=iree_definitions.ImportedModel.from_model(
+            tflite_models.PERSON_DETECT_INT8),
         execution_config=module_execution_configs.ELF_LOCAL_SYNC_CONFIG,
         expected_output="1x2xi8=[72 -72]",
         unsupported_platforms=[CMakePlatform.ANDROID_ARMV8_A])

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -59,7 +59,8 @@ class IreeRuleBuilder(object):
                                  cmake_rules=[])
 
     # Import target name: iree-imported-model-<imported_model_str>
-    target_name = f"iree-imported-model-{imported_model}"
+    target_name = cmake_builder.rules.sanitize_target_name(
+        f"iree-imported-model-{imported_model}")
 
     import_flags = import_config.materialize_import_flags(model)
     if import_config.tool == iree_definitions.ImportTool.TFLITE_IMPORTER:
@@ -100,7 +101,8 @@ class IreeRuleBuilder(object):
     ) + compile_config.extra_flags
 
     # Module target name: iree-module-<module_generation_config_str>
-    target_name = f"iree-module-{module_generation_config}"
+    target_name = cmake_builder.rules.sanitize_target_name(
+        f"iree-module-{module_generation_config}")
 
     cmake_rules = [
         cmake_builder.rules.build_iree_bytecode_module(
@@ -117,10 +119,10 @@ class IreeRuleBuilder(object):
                                  cmake_rules=cmake_rules)
 
   def build_target_path(self, target_name: str):
-    """Returns the full target path by combining the package name and the
-    sanitized target name.
+    """Returns the full target path by combining the package name and the target
+    name.
     """
-    return f"{self._package_name}_{cmake_builder.rules.sanitize_target_name(target_name)}"
+    return f"{self._package_name}_{target_name}"
 
   def _generate_compile_flags(self,
                               compile_config: iree_definitions.CompileConfig,

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -59,7 +59,7 @@ class IreeRuleBuilder(object):
                                  cmake_rules=[])
 
     # Import target name: iree-imported-model-<imported_model_str>
-    target_name = cmake_builder.rules.sanitize_target(
+    target_name = cmake_builder.rules.sanitize_target_name(
         f"iree-imported-model-{imported_model}")
 
     import_flags = import_config.materialize_import_flags(model)
@@ -101,7 +101,7 @@ class IreeRuleBuilder(object):
     ) + compile_config.extra_flags
 
     # Module target name: iree-module-<module_generation_config_str>
-    target_name = cmake_builder.rules.sanitize_target(
+    target_name = cmake_builder.rules.sanitize_target_name(
         f"iree-module-{module_generation_config}")
 
     cmake_rules = [

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -59,7 +59,7 @@ class IreeRuleBuilder(object):
                                  cmake_rules=[])
 
     # Import target name: iree-imported-model-<imported_model_str>
-    target_name = cmake_builder.rules.sanitize_target_name(
+    target_name = cmake_builder.rules.sanitize_target(
         f"iree-imported-model-{imported_model}")
 
     import_flags = import_config.materialize_import_flags(model)
@@ -101,7 +101,7 @@ class IreeRuleBuilder(object):
     ) + compile_config.extra_flags
 
     # Module target name: iree-module-<module_generation_config_str>
-    target_name = cmake_builder.rules.sanitize_target_name(
+    target_name = cmake_builder.rules.sanitize_target(
         f"iree-module-{module_generation_config}")
 
     cmake_rules = [

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator.py
@@ -12,7 +12,7 @@ import pathlib
 from benchmark_suites.iree import benchmark_collections
 from e2e_test_artifacts import iree_artifacts
 from e2e_test_artifacts.cmake_generator import model_rule_generator
-from e2e_test_framework.definitions import common_definitions, iree_definitions
+from e2e_test_framework.definitions import iree_definitions
 import cmake_builder.rules
 
 BENCHMARK_IMPORT_MODELS_CMAKE_TARGET = "iree-benchmark-import-models"

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
@@ -43,7 +43,7 @@ class IreeRuleBuilderTest(unittest.TestCase):
 
     self.assertEqual(
         rule.target_name,
-        cmake_builder.rules.sanitize_target_name(
+        cmake_builder.rules.sanitize_target(
             f"iree-imported-model-{tflite_imported_model}"))
     self.assertEqual(rule.output_file_path, output_file_path)
 
@@ -107,7 +107,7 @@ class IreeRuleBuilderTest(unittest.TestCase):
 
     self.assertEqual(
         rule.target_name,
-        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config}"))
+        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config}"))
     self.assertEqual(rule.output_module_path, output_file_path)
 
   def test_build_target_path(self):
@@ -205,28 +205,28 @@ class IreeGeneratorTest(unittest.TestCase):
     concated_cmake_rules = "\n".join(cmake_rules)
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target_name(
+        cmake_builder.rules.sanitize_target(
             f"iree-imported-model-{imported_model_a}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target_name(
+        cmake_builder.rules.sanitize_target(
             f"iree-imported-model-{imported_model_b}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target_name(
+        cmake_builder.rules.sanitize_target(
             f"iree-imported-model-{imported_model_c}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_a}"))
+        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_a}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_b}"))
+        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_b}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_c}"))
+        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_c}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_d}"))
+        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_d}"))
 
 
 if __name__ == "__main__":

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
@@ -43,7 +43,7 @@ class IreeRuleBuilderTest(unittest.TestCase):
 
     self.assertEqual(
         rule.target_name,
-        cmake_builder.rules.sanitize_target(
+        cmake_builder.rules.sanitize_target_name(
             f"iree-imported-model-{tflite_imported_model}"))
     self.assertEqual(rule.output_file_path, output_file_path)
 
@@ -107,7 +107,7 @@ class IreeRuleBuilderTest(unittest.TestCase):
 
     self.assertEqual(
         rule.target_name,
-        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config}"))
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config}"))
     self.assertEqual(rule.output_module_path, output_file_path)
 
   def test_build_target_path(self):
@@ -205,28 +205,28 @@ class IreeGeneratorTest(unittest.TestCase):
     concated_cmake_rules = "\n".join(cmake_rules)
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target(
+        cmake_builder.rules.sanitize_target_name(
             f"iree-imported-model-{imported_model_a}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target(
+        cmake_builder.rules.sanitize_target_name(
             f"iree-imported-model-{imported_model_b}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target(
+        cmake_builder.rules.sanitize_target_name(
             f"iree-imported-model-{imported_model_c}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_a}"))
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_a}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_b}"))
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_b}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_c}"))
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_c}"))
     self.assertRegex(
         concated_cmake_rules,
-        cmake_builder.rules.sanitize_target(f"iree-module-{gen_config_d}"))
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_d}"))
 
 
 if __name__ == "__main__":

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/iree_rule_generator_test.py
@@ -41,7 +41,10 @@ class IreeRuleBuilderTest(unittest.TestCase):
         imported_model=tflite_imported_model,
         output_file_path=output_file_path)
 
-    self.assertEqual(rule.target_name, f"iree-imported-model-{tflite_model.id}")
+    self.assertEqual(
+        rule.target_name,
+        cmake_builder.rules.sanitize_target_name(
+            f"iree-imported-model-{tflite_imported_model}"))
     self.assertEqual(rule.output_file_path, output_file_path)
 
   def test_build_model_import_rule_linalg(self):
@@ -200,17 +203,30 @@ class IreeGeneratorTest(unittest.TestCase):
         model_rule_map=model_rule_map)
 
     concated_cmake_rules = "\n".join(cmake_rules)
-    self.assertRegex(concated_cmake_rules, f"iree-imported-model-{model_a.id}")
-    self.assertRegex(concated_cmake_rules, f"iree-imported-model-{model_b.id}")
-    self.assertRegex(concated_cmake_rules, f"iree-imported-model-{model_c.id}")
-    self.assertRegex(concated_cmake_rules,
-                     f"iree-module-{model_a.id}-{compile_config_a.id}")
-    self.assertRegex(concated_cmake_rules,
-                     f"iree-module-{model_b.id}-{compile_config_a.id}")
-    self.assertRegex(concated_cmake_rules,
-                     f"iree-module-{model_b.id}-{compile_config_b.id}")
-    self.assertRegex(concated_cmake_rules,
-                     f"iree-module-{model_c.id}-{compile_config_b.id}")
+    self.assertRegex(
+        concated_cmake_rules,
+        cmake_builder.rules.sanitize_target_name(
+            f"iree-imported-model-{imported_model_a}"))
+    self.assertRegex(
+        concated_cmake_rules,
+        cmake_builder.rules.sanitize_target_name(
+            f"iree-imported-model-{imported_model_b}"))
+    self.assertRegex(
+        concated_cmake_rules,
+        cmake_builder.rules.sanitize_target_name(
+            f"iree-imported-model-{imported_model_c}"))
+    self.assertRegex(
+        concated_cmake_rules,
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_a}"))
+    self.assertRegex(
+        concated_cmake_rules,
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_b}"))
+    self.assertRegex(
+        concated_cmake_rules,
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_c}"))
+    self.assertRegex(
+        concated_cmake_rules,
+        cmake_builder.rules.sanitize_target_name(f"iree-module-{gen_config_d}"))
 
 
 if __name__ == "__main__":

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
@@ -30,7 +30,7 @@ def generate_model_rule_map(
   model_rules = {}
   for model in models:
     # Model target: <package_name>-model-<model_id>
-    target_name = cmake_builder.rules.sanitize_target(f"model-{model}")
+    target_name = cmake_builder.rules.sanitize_target_name(f"model-{model}")
     model_path = model_artifacts.get_model_path(model=model,
                                                 root_path=root_path)
 

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
@@ -30,7 +30,7 @@ def generate_model_rule_map(
   model_rules = {}
   for model in models:
     # Model target: <package_name>-model-<model_id>
-    target_name = cmake_builder.rules.sanitize_target_name(f"model-{model}")
+    target_name = cmake_builder.rules.sanitize_target(f"model-{model}")
     model_path = model_artifacts.get_model_path(model=model,
                                                 root_path=root_path)
 

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator.py
@@ -30,7 +30,7 @@ def generate_model_rule_map(
   model_rules = {}
   for model in models:
     # Model target: <package_name>-model-<model_id>
-    target_name = f"model-{model.id}"
+    target_name = cmake_builder.rules.sanitize_target_name(f"model-{model}")
     model_path = model_artifacts.get_model_path(model=model,
                                                 root_path=root_path)
 

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
@@ -10,6 +10,7 @@ import unittest
 from e2e_test_artifacts import model_artifacts
 from e2e_test_artifacts.cmake_generator import model_rule_generator
 from e2e_test_framework.definitions import common_definitions
+import cmake_builder.rules
 
 
 class CommonGeneratorsTest(unittest.TestCase):
@@ -37,11 +38,15 @@ class CommonGeneratorsTest(unittest.TestCase):
         root_path=root_path, models=[model_a, model_b])
 
     self.assertEqual(list(rule_map.keys()), [model_a.id, model_b.id])
-    self.assertEqual(rule_map[model_a.id].target_name, f"model-{model_a.id}")
+    self.assertEqual(
+        rule_map[model_a.id].target_name,
+        cmake_builder.rules.sanitize_target_name(f"model-{model_a}"))
     self.assertEqual(
         rule_map[model_a.id].file_path,
         model_artifacts.get_model_path(model=model_a, root_path=root_path))
-    self.assertEqual(rule_map[model_b.id].target_name, f"model-{model_b.id}")
+    self.assertEqual(
+        rule_map[model_b.id].target_name,
+        cmake_builder.rules.sanitize_target_name(f"model-{model_b}"))
     self.assertEqual(
         rule_map[model_b.id].file_path,
         model_artifacts.get_model_path(model=model_b, root_path=root_path))

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
@@ -38,13 +38,15 @@ class CommonGeneratorsTest(unittest.TestCase):
         root_path=root_path, models=[model_a, model_b])
 
     self.assertEqual(list(rule_map.keys()), [model_a.id, model_b.id])
-    self.assertEqual(rule_map[model_a.id].target_name,
-                     cmake_builder.rules.sanitize_target(f"model-{model_a}"))
+    self.assertEqual(
+        rule_map[model_a.id].target_name,
+        cmake_builder.rules.sanitize_target_name(f"model-{model_a}"))
     self.assertEqual(
         rule_map[model_a.id].file_path,
         model_artifacts.get_model_path(model=model_a, root_path=root_path))
-    self.assertEqual(rule_map[model_b.id].target_name,
-                     cmake_builder.rules.sanitize_target(f"model-{model_b}"))
+    self.assertEqual(
+        rule_map[model_b.id].target_name,
+        cmake_builder.rules.sanitize_target_name(f"model-{model_b}"))
     self.assertEqual(
         rule_map[model_b.id].file_path,
         model_artifacts.get_model_path(model=model_b, root_path=root_path))

--- a/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
+++ b/build_tools/python/e2e_test_artifacts/cmake_generator/model_rule_generator_test.py
@@ -38,15 +38,13 @@ class CommonGeneratorsTest(unittest.TestCase):
         root_path=root_path, models=[model_a, model_b])
 
     self.assertEqual(list(rule_map.keys()), [model_a.id, model_b.id])
-    self.assertEqual(
-        rule_map[model_a.id].target_name,
-        cmake_builder.rules.sanitize_target_name(f"model-{model_a}"))
+    self.assertEqual(rule_map[model_a.id].target_name,
+                     cmake_builder.rules.sanitize_target(f"model-{model_a}"))
     self.assertEqual(
         rule_map[model_a.id].file_path,
         model_artifacts.get_model_path(model=model_a, root_path=root_path))
-    self.assertEqual(
-        rule_map[model_b.id].target_name,
-        cmake_builder.rules.sanitize_target_name(f"model-{model_b}"))
+    self.assertEqual(rule_map[model_b.id].target_name,
+                     cmake_builder.rules.sanitize_target(f"model-{model_b}"))
     self.assertEqual(
         rule_map[model_b.id].file_path,
         model_artifacts.get_model_path(model=model_b, root_path=root_path))

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -9,6 +9,7 @@ from typing import Dict, Iterable
 import pathlib
 
 from e2e_test_artifacts import model_artifacts
+import e2e_test_artifacts.utils
 from e2e_test_framework.definitions import common_definitions, iree_definitions
 
 IREE_ARTIFACT_PREFIX = "iree"
@@ -35,7 +36,9 @@ def get_imported_model_path(
     return model_artifacts.get_model_path(model=model, root_path=root_path)
 
   # Imported model path: <root_path>/<artifact_prefix>_<imported_model_str>.mlir
-  return root_path / f"{IREE_ARTIFACT_PREFIX}_{imported_model}.mlir"
+  imported_model_str = e2e_test_artifacts.utils.sanitize_path_name(
+      str(imported_model))
+  return root_path / f"{IREE_ARTIFACT_PREFIX}_{imported_model_str}.mlir"
 
 
 def get_module_dir_path(
@@ -52,8 +55,10 @@ def get_module_dir_path(
   Returns:
     Path of the module directory.
   """
-  # Module path: <root_path>/<artifact_prefix>_<module_generation_config_str>
-  return root_path / f"{IREE_ARTIFACT_PREFIX}_{module_generation_config}"
+  # Module path: <root_path>/<artifact_prefix>_module_<module_generation_config_str>
+  gen_config_str = e2e_test_artifacts.utils.sanitize_path_name(
+      str(module_generation_config))
+  return root_path / f"{IREE_ARTIFACT_PREFIX}_module_{gen_config_str}"
 
 
 def get_dependent_model_map(

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts.py
@@ -15,13 +15,6 @@ IREE_ARTIFACT_PREFIX = "iree"
 MODULE_FILENAME = "module.vmfb"
 
 
-def _get_model_prefix(imported_model: iree_definitions.ImportedModel) -> str:
-  """Returns the path of an IREE model dir."""
-  model = imported_model.model
-  # IREE model prefix: <iree_artifact_prefix>_<model_id>_<model_name>
-  return f"{IREE_ARTIFACT_PREFIX}_{model.id}_{model.name}"
-
-
 def get_imported_model_path(
     imported_model: iree_definitions.ImportedModel,
     root_path: pathlib.PurePath = pathlib.PurePath()
@@ -41,9 +34,8 @@ def get_imported_model_path(
     # Uses the MLIR model directly.
     return model_artifacts.get_model_path(model=model, root_path=root_path)
 
-  model_prefix = _get_model_prefix(imported_model)
-  # Imported model path: <root_path>/<model_prefix>.mlir
-  return root_path / f"{model_prefix}.mlir"
+  # Imported model path: <root_path>/<artifact_prefix>_<imported_model_str>.mlir
+  return root_path / f"{IREE_ARTIFACT_PREFIX}_{imported_model}.mlir"
 
 
 def get_module_dir_path(
@@ -60,9 +52,8 @@ def get_module_dir_path(
   Returns:
     Path of the module directory.
   """
-  model_prefix = _get_model_prefix(module_generation_config.imported_model)
-  # Module path: <root_path>/<model_prefix>_<compile_config_id>
-  return root_path / f"{model_prefix}_{module_generation_config.compile_config.id}"
+  # Module path: <root_path>/<artifact_prefix>_<module_generation_config_str>
+  return root_path / f"{IREE_ARTIFACT_PREFIX}_{module_generation_config}"
 
 
 def get_dependent_model_map(

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
@@ -7,8 +7,9 @@
 import pathlib
 import unittest
 
-from e2e_test_framework.definitions import common_definitions, iree_definitions
 from e2e_test_artifacts import model_artifacts, iree_artifacts
+import e2e_test_artifacts.utils
+from e2e_test_framework.definitions import common_definitions, iree_definitions
 
 
 class IreeArtifactsTest(unittest.TestCase):
@@ -28,9 +29,11 @@ class IreeArtifactsTest(unittest.TestCase):
     path = iree_artifacts.get_imported_model_path(imported_model=imported_model,
                                                   root_path=root_path)
 
+    imported_model_str = e2e_test_artifacts.utils.sanitize_path_name(
+        str(imported_model))
     self.assertEqual(
         path, root_path /
-        f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{imported_model}.mlir")
+        f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{imported_model_str}.mlir")
 
   def test_get_imported_model_path_with_mlir_model(self):
     model = common_definitions.Model(
@@ -77,8 +80,11 @@ class IreeArtifactsTest(unittest.TestCase):
     path = iree_artifacts.get_module_dir_path(
         module_generation_config=gen_config, root_path=root_path)
 
+    gen_config_str = e2e_test_artifacts.utils.sanitize_path_name(
+        str(gen_config))
     self.assertEqual(
-        path, root_path / f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{gen_config}")
+        path, root_path /
+        f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_module_{gen_config_str}")
 
   def test_get_dependent_model_map(self):
     model_a = common_definitions.Model(

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
@@ -30,7 +30,7 @@ class IreeArtifactsTest(unittest.TestCase):
 
     self.assertEqual(
         path, root_path /
-        f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{model.id}_{model.name}.mlir")
+        f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{imported_model}.mlir")
 
   def test_get_imported_model_path_with_mlir_model(self):
     model = common_definitions.Model(

--- a/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/iree_artifacts_test.py
@@ -78,9 +78,7 @@ class IreeArtifactsTest(unittest.TestCase):
         module_generation_config=gen_config, root_path=root_path)
 
     self.assertEqual(
-        path, root_path /
-        f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{model.id}_{model.name}_{compile_config.id}"
-    )
+        path, root_path / f"{iree_artifacts.IREE_ARTIFACT_PREFIX}_{gen_config}")
 
   def test_get_dependent_model_map(self):
     model_a = common_definitions.Model(

--- a/build_tools/python/e2e_test_artifacts/model_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/model_artifacts.py
@@ -36,5 +36,4 @@ def get_model_path(
   model_ext = "".join(file_exts)
 
   # Model path: <root_path>/<model_artifact_prefix>_<model_id>_<model_name><model_ext>
-  return (root_path /
-          f"{MODEL_ARTIFACT_PREFIX}_{model.id}_{model.name}{model_ext}")
+  return (root_path / f"{MODEL_ARTIFACT_PREFIX}_{model}{model_ext}")

--- a/build_tools/python/e2e_test_artifacts/model_artifacts.py
+++ b/build_tools/python/e2e_test_artifacts/model_artifacts.py
@@ -9,6 +9,7 @@ import pathlib
 import urllib.parse
 
 from e2e_test_framework.definitions import common_definitions
+import e2e_test_artifacts.utils
 
 MODEL_ARTIFACT_PREFIX = "model"
 # Archive extensions used to pack models.
@@ -35,5 +36,6 @@ def get_model_path(
     file_exts.pop()
   model_ext = "".join(file_exts)
 
-  # Model path: <root_path>/<model_artifact_prefix>_<model_id>_<model_name><model_ext>
-  return (root_path / f"{MODEL_ARTIFACT_PREFIX}_{model}{model_ext}")
+  # Model path: <root_path>/<model_artifact_prefix>_<model_str><model_ext>
+  model_str = e2e_test_artifacts.utils.sanitize_path_name(str(model))
+  return (root_path / f"{MODEL_ARTIFACT_PREFIX}_{model_str}{model_ext}")

--- a/build_tools/python/e2e_test_artifacts/model_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/model_artifacts_test.py
@@ -8,6 +8,7 @@ import pathlib
 import unittest
 
 from e2e_test_artifacts import model_artifacts
+import e2e_test_artifacts.utils
 from e2e_test_framework.definitions import common_definitions
 
 
@@ -17,7 +18,7 @@ class ModelArtifactsTest(unittest.TestCase):
     tflite_model = common_definitions.Model(
         id="1234",
         name="tflite_m",
-        tags=[],
+        tags=["fp16"],
         source_type=common_definitions.ModelSourceType.EXPORTED_TFLITE,
         source_url="https://example.com/xyz.tflite",
         entry_function="main",
@@ -27,15 +28,16 @@ class ModelArtifactsTest(unittest.TestCase):
     path = model_artifacts.get_model_path(model=tflite_model,
                                           root_path=root_path)
 
+    model_str = e2e_test_artifacts.utils.sanitize_path_name(str(tflite_model))
     self.assertEqual(
         path, root_path /
-        f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tflite_model}.tflite")
+        f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{model_str}.tflite")
 
   def test_get_model_path_with_tf_model(self):
     tf_model = common_definitions.Model(
         id="5678",
         name="tf_m",
-        tags=[],
+        tags=["fp32"],
         source_type=common_definitions.ModelSourceType.EXPORTED_TF_V2,
         source_url="https://example.com/xyz_saved_model",
         entry_function="predict",
@@ -44,8 +46,10 @@ class ModelArtifactsTest(unittest.TestCase):
 
     path = model_artifacts.get_model_path(model=tf_model, root_path=root_path)
 
+    model_str = e2e_test_artifacts.utils.sanitize_path_name(str(tf_model))
     self.assertEqual(
-        path, root_path / f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tf_model}")
+        path,
+        root_path / f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{model_str}")
 
 
 if __name__ == "__main__":

--- a/build_tools/python/e2e_test_artifacts/model_artifacts_test.py
+++ b/build_tools/python/e2e_test_artifacts/model_artifacts_test.py
@@ -29,8 +29,7 @@ class ModelArtifactsTest(unittest.TestCase):
 
     self.assertEqual(
         path, root_path /
-        f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tflite_model.id}_{tflite_model.name}.tflite"
-    )
+        f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tflite_model}.tflite")
 
   def test_get_model_path_with_tf_model(self):
     tf_model = common_definitions.Model(
@@ -46,9 +45,7 @@ class ModelArtifactsTest(unittest.TestCase):
     path = model_artifacts.get_model_path(model=tf_model, root_path=root_path)
 
     self.assertEqual(
-        path, root_path /
-        f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tf_model.id}_{tf_model.name}"
-    )
+        path, root_path / f"{model_artifacts.MODEL_ARTIFACT_PREFIX}_{tf_model}")
 
 
 if __name__ == "__main__":

--- a/build_tools/python/e2e_test_artifacts/utils.py
+++ b/build_tools/python/e2e_test_artifacts/utils.py
@@ -1,0 +1,15 @@
+## Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Helpers for path generation."""
+
+import re
+
+# Match any character that are not friendly in filesystem path.
+DISALLOWED_TARGET_CHAR_MATCHER = re.compile(r"[^A-Za-z0-9_.+-]")
+
+
+def sanitize_path_name(name: str) -> str:
+  return DISALLOWED_TARGET_CHAR_MATCHER.sub("_", name)

--- a/build_tools/python/e2e_test_framework/definitions/common_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/common_definitions.py
@@ -138,6 +138,12 @@ class Model(object):
   # Input types. E.g., ["100x100xf32", "200x200x5xf32"].
   input_types: List[str]
 
+  def __str__(self):
+    name = self.name
+    if len(self.tags) > 0:
+      name += f'[{",".join(self.tags)}]'
+    return name
+
 
 @serialization.serializable(type_key="model_input_data")
 @dataclass(frozen=True)

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
@@ -75,7 +75,7 @@ class CompileConfig(object):
   extra_flags: List[str] = dataclasses.field(default_factory=list)
 
   def __str__(self):
-    name = f'[{",".join(str(target) for target in self.compile_targets)}]'
+    name = f'{",".join(str(target) for target in self.compile_targets)}'
     if len(self.tags) > 0:
       name += f'[{",".join(self.tags)}]'
     return name

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
@@ -189,7 +189,7 @@ class ImportedModel(object):
     return unique_ids.hash_composite_id([self.model.id, self.import_config.id])
 
   def __str__(self):
-    return f"{self.model}[{self.import_config}]"
+    return f"{self.model}({self.import_config})"
 
   @staticmethod
   def from_model(model: common_definitions.Model):

--- a/build_tools/testing/generate_cmake_e2e_model_tests.py
+++ b/build_tools/testing/generate_cmake_e2e_model_tests.py
@@ -14,6 +14,7 @@ import argparse
 # Add build_tools python dir to the search path.
 sys.path.insert(0, str(pathlib.Path(__file__).parent / ".." / "python"))
 
+import benchmark_suites.iree.benchmark_collections
 import e2e_model_tests.cmake_generator
 
 TEMPLATE_DIR = pathlib.Path(__file__).parent
@@ -33,7 +34,10 @@ def parse_arguments():
 
 
 def main(args: argparse.Namespace):
-  cmake_rules = e2e_model_tests.cmake_generator.generate_rules()
+  (gen_configs,
+   _) = benchmark_suites.iree.benchmark_collections.generate_benchmarks()
+  cmake_rules = e2e_model_tests.cmake_generator.generate_rules(
+      module_generation_configs=gen_configs)
   output = GENERATED_E2E_MODEL_TESTS_CMAKE_TEMPLATE.substitute(
       __TEST_RULES="\n".join(cmake_rules))
   with open(args.output, "w") as output_file:

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -5,19 +5,19 @@
 ################################################################################
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_ANDROID-ARM64-V8A
-  "[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+  "cpu-armv8.2-a-generic-linux-android29-llvm-cpu[default-flags]"
 )
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_RISCV32-LINUX
-  "[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
+  "cpu-riscv_32-generic-linux-gnu-llvm-cpu[default-flags]"
 )
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_RISCV64-LINUX
-  "[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
+  "cpu-riscv_64-generic-linux-gnu-llvm-cpu[default-flags]"
 )
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_X86_64
-  "[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+  "cpu-x86_64-cascadelake-linux-gnu-llvm-cpu[default-flags]"
 )
 
 iree_benchmark_suite_module_test(

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -5,26 +5,26 @@
 ################################################################################
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_ANDROID-ARM64-V8A
-  "1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+  "[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
 )
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_RISCV32-LINUX
-  "6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4"
+  "[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
 )
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_RISCV64-LINUX
-  "cdf579a9-5446-403b-a991-802a6c702e65"
+  "[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
 )
 
 set(IREE_MODULE_COMPILE_CONFIG_ID_X86_64
-  "e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+  "[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
 )
 
 iree_benchmark_suite_module_test(
   NAME
     "mobilenet_v1_fp32_correctness_test"
   MODEL
-    "78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32"
+    "MobileNetV1_fp32[fp32,imagenet][tosa]"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -42,7 +42,7 @@ iree_benchmark_suite_module_test(
   NAME
     "efficientnet_int8_correctness_test"
   MODEL
-    "4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8"
+    "EfficientNet_int8[int8][tosa]"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -59,7 +59,7 @@ iree_benchmark_suite_module_test(
   NAME
     "deeplab_v3_fp32_correctness_test"
   MODEL
-    "c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32"
+    "DeepLabV3_fp32[fp32][tosa]"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -77,7 +77,7 @@ iree_benchmark_suite_module_test(
   NAME
     "person_detect_int8_correctness_test"
   MODEL
-    "bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8"
+    "PersonDetect_int8[int8][tosa]"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -4,27 +4,55 @@
 # file.                                                                        #
 ################################################################################
 
-set(IREE_MODULE_COMPILE_CONFIG_ID_ANDROID-ARM64-V8A
-  "cpu-armv8.2-a-generic-linux-android29-llvm-cpu[default-flags]"
+set(IREE_TEST_MODULE_A359C8F1E19B6F476E843BDC5566F9554E329CBFB3B4437995AD9CCCFB381AEE_RISCV64-LINUX
+  "iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
 )
 
-set(IREE_MODULE_COMPILE_CONFIG_ID_RISCV32-LINUX
-  "cpu-riscv_32-generic-linux-gnu-llvm-cpu[default-flags]"
+set(IREE_TEST_MODULE_A359C8F1E19B6F476E843BDC5566F9554E329CBFB3B4437995AD9CCCFB381AEE_X86_64
+  "iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
 )
 
-set(IREE_MODULE_COMPILE_CONFIG_ID_RISCV64-LINUX
-  "cpu-riscv_64-generic-linux-gnu-llvm-cpu[default-flags]"
+set(IREE_TEST_MODULE_3F492FDE47ABECD3640F1E04C14F2BFC24940F1CF11F66E72128C590BC711025_RISCV32-LINUX
+  "iree_module_EfficientNet_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
 )
 
-set(IREE_MODULE_COMPILE_CONFIG_ID_X86_64
-  "cpu-x86_64-cascadelake-linux-gnu-llvm-cpu[default-flags]"
+set(IREE_TEST_MODULE_3F492FDE47ABECD3640F1E04C14F2BFC24940F1CF11F66E72128C590BC711025_RISCV64-LINUX
+  "iree_module_EfficientNet_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
+)
+
+set(IREE_TEST_MODULE_3F492FDE47ABECD3640F1E04C14F2BFC24940F1CF11F66E72128C590BC711025_X86_64
+  "iree_module_EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
+)
+
+set(IREE_TEST_MODULE_05C50F54FFEA1FCE722D07588E7DE026CE10324ECCC5D83D1EAC2C5A9F5D639D_ANDROID-ARM64-V8A
+  "iree_module_DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
+)
+
+set(IREE_TEST_MODULE_05C50F54FFEA1FCE722D07588E7DE026CE10324ECCC5D83D1EAC2C5A9F5D639D_RISCV64-LINUX
+  "iree_module_DeepLabV3_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
+)
+
+set(IREE_TEST_MODULE_05C50F54FFEA1FCE722D07588E7DE026CE10324ECCC5D83D1EAC2C5A9F5D639D_X86_64
+  "iree_module_DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
+)
+
+set(IREE_TEST_MODULE_93C0F75188363AF77647CB2F1DEB41446575C9CD084D86119287156EB181D850_RISCV32-LINUX
+  "iree_module_PersonDetect_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
+)
+
+set(IREE_TEST_MODULE_93C0F75188363AF77647CB2F1DEB41446575C9CD084D86119287156EB181D850_RISCV64-LINUX
+  "iree_module_PersonDetect_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
+)
+
+set(IREE_TEST_MODULE_93C0F75188363AF77647CB2F1DEB41446575C9CD084D86119287156EB181D850_X86_64
+  "iree_module_PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
 )
 
 iree_benchmark_suite_module_test(
   NAME
     "mobilenet_v1_fp32_correctness_test"
-  MODEL
-    "MobileNetV1_fp32[fp32,imagenet](tosa)"
+  IMPORTED_MODEL
+    "a359c8f1e19b6f476e843bdc5566f9554e329cbfb3b4437995ad9cccfb381aee"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -41,8 +69,8 @@ iree_benchmark_suite_module_test(
 iree_benchmark_suite_module_test(
   NAME
     "efficientnet_int8_correctness_test"
-  MODEL
-    "EfficientNet_int8[int8](tosa)"
+  IMPORTED_MODEL
+    "3f492fde47abecd3640f1e04c14f2bfc24940f1cf11f66e72128c590bc711025"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -58,8 +86,8 @@ iree_benchmark_suite_module_test(
 iree_benchmark_suite_module_test(
   NAME
     "deeplab_v3_fp32_correctness_test"
-  MODEL
-    "DeepLabV3_fp32[fp32](tosa)"
+  IMPORTED_MODEL
+    "05c50f54ffea1fce722d07588e7de026ce10324eccc5d83d1eac2c5a9f5d639d"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -76,8 +104,8 @@ iree_benchmark_suite_module_test(
 iree_benchmark_suite_module_test(
   NAME
     "person_detect_int8_correctness_test"
-  MODEL
-    "PersonDetect_int8[int8](tosa)"
+  IMPORTED_MODEL
+    "93c0f75188363af77647cb2f1deb41446575c9cd084d86119287156eb181d850"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT

--- a/tests/e2e/models/generated_e2e_model_tests.cmake
+++ b/tests/e2e/models/generated_e2e_model_tests.cmake
@@ -24,7 +24,7 @@ iree_benchmark_suite_module_test(
   NAME
     "mobilenet_v1_fp32_correctness_test"
   MODEL
-    "MobileNetV1_fp32[fp32,imagenet][tosa]"
+    "MobileNetV1_fp32[fp32,imagenet](tosa)"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -42,7 +42,7 @@ iree_benchmark_suite_module_test(
   NAME
     "efficientnet_int8_correctness_test"
   MODEL
-    "EfficientNet_int8[int8][tosa]"
+    "EfficientNet_int8[int8](tosa)"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -59,7 +59,7 @@ iree_benchmark_suite_module_test(
   NAME
     "deeplab_v3_fp32_correctness_test"
   MODEL
-    "DeepLabV3_fp32[fp32][tosa]"
+    "DeepLabV3_fp32[fp32](tosa)"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT
@@ -77,7 +77,7 @@ iree_benchmark_suite_module_test(
   NAME
     "person_detect_int8_correctness_test"
   MODEL
-    "PersonDetect_int8[int8][tosa]"
+    "PersonDetect_int8[int8](tosa)"
   DRIVER
     "local-sync"
   EXPECTED_OUTPUT

--- a/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
@@ -1,6 +1,6 @@
 iree_fetch_artifact(
   NAME
-    "model-DeepLabV3_fp32[fp32]"
+    "model-DeepLabV3_fp32_fp32_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/deeplabv3.tflite"
   OUTPUT
@@ -10,7 +10,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-EfficientNet_int8[int8]"
+    "model-EfficientNet_int8_int8_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet_lite0_int8_2.tflite"
   OUTPUT
@@ -20,7 +20,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MobileBertSquad_fp16[fp16]"
+    "model-MobileBertSquad_fp16_fp16_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebertsquad.tflite"
   OUTPUT
@@ -30,7 +30,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MobileBertSquad_fp32[fp32]"
+    "model-MobileBertSquad_fp32_fp32_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-float.tflite"
   OUTPUT
@@ -40,7 +40,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MobileBertSquad_int8[int8]"
+    "model-MobileBertSquad_int8_int8_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-quant.tflite"
   OUTPUT
@@ -50,7 +50,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MobileNetV1_fp32[fp32-imagenet]"
+    "model-MobileNetV1_fp32_fp32_imagenet_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
   OUTPUT
@@ -60,7 +60,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MobileNetV2_fp32[fp32-imagenet]"
+    "model-MobileNetV2_fp32_fp32_imagenet_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v2_1.0_224.tflite"
   OUTPUT
@@ -70,7 +70,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MobileNetV3Small_fp32[fp32-imagenet]"
+    "model-MobileNetV3Small_fp32_fp32_imagenet_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/MobileNetV3SmallStaticBatch.tflite"
   OUTPUT
@@ -80,7 +80,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MobileSSD_fp32[fp32]"
+    "model-MobileSSD_fp32_fp32_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobile_ssd_v2_float_coco.tflite"
   OUTPUT
@@ -90,7 +90,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-PersonDetect_int8[int8]"
+    "model-PersonDetect_int8_int8_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/person_detect.tflite"
   OUTPUT
@@ -100,7 +100,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-PoseNet_fp32[fp32]"
+    "model-PoseNet_fp32_fp32_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/posenet.tflite"
   OUTPUT
@@ -110,7 +110,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-BertForMaskedLMTF[fp32-seqlen512-tensorflow]"
+    "model-BertForMaskedLMTF_fp32_seqlen512_tensorflow_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/bert-for-masked-lm-seq512-tf-model.tar.gz"
   OUTPUT
@@ -120,7 +120,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-BertLargeTF[fp32-seqlen384-tensorflow]"
+    "model-BertLargeTF_fp32_seqlen384_tensorflow_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/bert-large-seq384-tf-model.tar.gz"
   OUTPUT
@@ -130,7 +130,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-EfficientNetV2STF[fp32-cnn-tensorflow]"
+    "model-EfficientNetV2STF_fp32_cnn_tensorflow_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet-v2-s-tf-model.tar.gz"
   OUTPUT
@@ -140,7 +140,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-MiniLML12H384Uncased[int32-seqlen128]"
+    "model-MiniLML12H384Uncased_int32_seqlen128_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/minilm-l12-h384-uncased-seqlen128-tf-model.tar.gz"
   OUTPUT
@@ -150,7 +150,7 @@ iree_fetch_artifact(
 
 iree_fetch_artifact(
   NAME
-    "model-Resnet50TF[fp32]"
+    "model-Resnet50TF_fp32_"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/resnet50-tf-model.tar.gz"
   OUTPUT

--- a/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
@@ -1,159 +1,159 @@
 iree_fetch_artifact(
   NAME
-    "model-c36c63b0-220a-4d78-8ade-c45ce47d89d3"
+    "model-DeepLabV3_fp32[fp32]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/deeplabv3.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32[fp32].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-4a6f545e-1b4e-41a5-9236-792aa578184b"
+    "model-EfficientNet_int8[int8]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet_lite0_int8_2.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8[int8].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-73a0402e-271b-4aa8-a6a5-ac05839ca569"
+    "model-MobileBertSquad_fp16[fp16]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebertsquad.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16[fp16].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-cc69d69f-6d1f-4a1a-a31e-e021888d0d28"
+    "model-MobileBertSquad_fp32[fp32]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-float.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32[fp32].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-e3997104-a3d2-46b4-9fbf-39069906d123"
+    "model-MobileBertSquad_int8[int8]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-quant.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8[int8].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-78eab9e5-9ff1-4769-9b55-933c81cc9a0f"
+    "model-MobileNetV1_fp32[fp32-imagenet]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.0_float.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32[fp32,imagenet].0_float.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-7d45f8e5-bb5e-48d0-928d-8f125104578f"
+    "model-MobileNetV2_fp32[fp32-imagenet]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v2_1.0_224.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.0_224.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32[fp32,imagenet].0_224.tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-58855e40-eba9-4a71-b878-6b35e3460244"
+    "model-MobileNetV3Small_fp32[fp32-imagenet]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/MobileNetV3SmallStaticBatch.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32[fp32,imagenet].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-0e466f69-91d6-4e50-b62b-a82b6213a231"
+    "model-MobileSSD_fp32[fp32]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobile_ssd_v2_float_coco.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32[fp32].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-bc1338be-e3df-44fd-82e4-40ba9560a073"
+    "model-PersonDetect_int8[int8]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/person_detect.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8[int8].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-5afc3014-d29d-4e88-a840-fbaf678acf2b"
+    "model-PoseNet_fp32[fp32]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/posenet.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32[fp32].tflite"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-39d157ad-f0ec-4a76-963b-d783beaed60f"
+    "model-BertForMaskedLMTF[fp32-seqlen512-tensorflow]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/bert-for-masked-lm-seq512-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF"
+    "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF[fp32,seqlen512,tensorflow]"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-8871f602-571c-4eb8-b94d-554cc8ceec5a"
+    "model-BertLargeTF[fp32-seqlen384-tensorflow]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/bert-large-seq384-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF"
+    "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF[fp32,seqlen384,tensorflow]"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-ebe7897f-5613-435b-a330-3cb967704e5e"
+    "model-EfficientNetV2STF[fp32-cnn-tensorflow]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet-v2-s-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF[fp32,cnn,tensorflow]"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493"
+    "model-MiniLML12H384Uncased[int32-seqlen128]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/minilm-l12-h384-uncased-seqlen128-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased"
+    "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased[int32,seqlen128]"
   UNPACK
 )
 
 iree_fetch_artifact(
   NAME
-    "model-c393b4fa-beb4-45d5-982a-c6328aa05d08"
+    "model-Resnet50TF[fp32]"
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/resnet50-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF"
+    "${ROOT_ARTIFACTS_DIR}/model_Resnet50TF[fp32]"
   UNPACK
 )

--- a/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_fetch_models.cmake
@@ -4,7 +4,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/deeplabv3.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32_fp32_.tflite"
   UNPACK
 )
 
@@ -14,7 +14,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet_lite0_int8_2.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8[int8].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8_int8_.tflite"
   UNPACK
 )
 
@@ -24,7 +24,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebertsquad.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16[fp16].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16_fp16_.tflite"
   UNPACK
 )
 
@@ -34,7 +34,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-float.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32_fp32_.tflite"
   UNPACK
 )
 
@@ -44,7 +44,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilebert-baseline-tf2-quant.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8[int8].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8_int8_.tflite"
   UNPACK
 )
 
@@ -54,7 +54,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v1_224_1.0_float.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32[fp32,imagenet].0_float.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32_fp32_imagenet_.0_float.tflite"
   UNPACK
 )
 
@@ -64,7 +64,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobilenet_v2_1.0_224.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32[fp32,imagenet].0_224.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32_fp32_imagenet_.0_224.tflite"
   UNPACK
 )
 
@@ -74,7 +74,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/MobileNetV3SmallStaticBatch.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32[fp32,imagenet].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32_fp32_imagenet_.tflite"
   UNPACK
 )
 
@@ -84,7 +84,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/mobile_ssd_v2_float_coco.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32_fp32_.tflite"
   UNPACK
 )
 
@@ -94,7 +94,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/person_detect.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8[int8].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8_int8_.tflite"
   UNPACK
 )
 
@@ -104,7 +104,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/posenet.tflite"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32_fp32_.tflite"
   UNPACK
 )
 
@@ -114,7 +114,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/bert-for-masked-lm-seq512-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF[fp32,seqlen512,tensorflow]"
+    "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF_fp32_seqlen512_tensorflow_"
   UNPACK
 )
 
@@ -124,7 +124,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/bert-large-seq384-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF[fp32,seqlen384,tensorflow]"
+    "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF_fp32_seqlen384_tensorflow_"
   UNPACK
 )
 
@@ -134,7 +134,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/efficientnet-v2-s-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF[fp32,cnn,tensorflow]"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF_fp32_cnn_tensorflow_"
   UNPACK
 )
 
@@ -144,7 +144,7 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/minilm-l12-h384-uncased-seqlen128-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased[int32,seqlen128]"
+    "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased_int32_seqlen128_"
   UNPACK
 )
 
@@ -154,6 +154,6 @@ iree_fetch_artifact(
   SOURCE_URL
     "https://storage.googleapis.com/iree-model-artifacts/resnet50-tf-model.tar.gz"
   OUTPUT
-    "${ROOT_ARTIFACTS_DIR}/model_Resnet50TF[fp32]"
+    "${ROOT_ARTIFACTS_DIR}/model_Resnet50TF_fp32_"
   UNPACK
 )

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -1,6 +1,6 @@
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32[fp32][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32_fp32__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32[fp32].tflite"
   IMPORT_FLAGS
@@ -11,7 +11,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8[int8][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8_int8__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8[int8].tflite"
   IMPORT_FLAGS
@@ -22,7 +22,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16[fp16][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16_fp16__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16[fp16].tflite"
   IMPORT_FLAGS
@@ -33,7 +33,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32[fp32][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32_fp32__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32[fp32].tflite"
   IMPORT_FLAGS
@@ -44,7 +44,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8[int8][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8_int8__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8[int8].tflite"
   IMPORT_FLAGS
@@ -55,7 +55,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32[fp32-imagenet][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32_fp32_imagenet__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32[fp32,imagenet].0_float.tflite"
   IMPORT_FLAGS
@@ -66,7 +66,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32[fp32-imagenet][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32_fp32_imagenet__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32[fp32,imagenet].0_224.tflite"
   IMPORT_FLAGS
@@ -77,7 +77,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32[fp32-imagenet][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32_fp32_imagenet__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32[fp32,imagenet].tflite"
   IMPORT_FLAGS
@@ -88,7 +88,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32[fp32][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32_fp32__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32[fp32].tflite"
   IMPORT_FLAGS
@@ -99,7 +99,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8[int8][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8_int8__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8[int8].tflite"
   IMPORT_FLAGS
@@ -110,7 +110,7 @@ iree_import_tflite_model(
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32[fp32][tosa]"
+    "${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32_fp32__tosa_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32[fp32].tflite"
   IMPORT_FLAGS
@@ -121,7 +121,7 @@ iree_import_tflite_model(
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo]"
+    "${PACKAGE_NAME}_iree-imported-model-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF[fp32,seqlen512,tensorflow]"
   IMPORT_FLAGS
@@ -134,7 +134,7 @@ iree_import_tf_model(
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-BertLargeTF[fp32-seqlen384-tensorflow][mhlo]"
+    "${PACKAGE_NAME}_iree-imported-model-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF[fp32,seqlen384,tensorflow]"
   IMPORT_FLAGS
@@ -147,7 +147,7 @@ iree_import_tf_model(
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo]"
+    "${PACKAGE_NAME}_iree-imported-model-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF[fp32,cnn,tensorflow]"
   IMPORT_FLAGS
@@ -160,7 +160,7 @@ iree_import_tf_model(
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-MiniLML12H384Uncased[int32-seqlen128][mhlo]"
+    "${PACKAGE_NAME}_iree-imported-model-MiniLML12H384Uncased_int32_seqlen128__mhlo_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased[int32,seqlen128]"
   IMPORT_FLAGS
@@ -173,7 +173,7 @@ iree_import_tf_model(
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-Resnet50TF[fp32][mhlo]"
+    "${PACKAGE_NAME}_iree-imported-model-Resnet50TF_fp32__mhlo_"
   SOURCE
     "${ROOT_ARTIFACTS_DIR}/model_Resnet50TF[fp32]"
   IMPORT_FLAGS
@@ -186,7 +186,7 @@ iree_import_tf_model(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -201,7 +201,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -216,7 +216,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -231,7 +231,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -246,7 +246,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -261,7 +261,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -276,7 +276,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -291,7 +291,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -306,7 +306,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -321,7 +321,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -336,7 +336,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -351,7 +351,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -366,7 +366,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -381,7 +381,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -396,7 +396,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
@@ -411,7 +411,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
@@ -426,7 +426,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -443,7 +443,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -460,7 +460,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -477,7 +477,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -494,7 +494,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -511,7 +511,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -528,7 +528,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -545,7 +545,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -562,7 +562,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -579,7 +579,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -596,7 +596,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -613,7 +613,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -630,7 +630,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -647,7 +647,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -664,7 +664,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
@@ -681,7 +681,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -695,7 +695,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -709,7 +709,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -723,7 +723,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
@@ -737,7 +737,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
+    "iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
@@ -751,7 +751,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -769,7 +769,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -787,7 +787,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -805,7 +805,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -823,7 +823,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -841,7 +841,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -859,7 +859,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -877,7 +877,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -895,7 +895,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -913,7 +913,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -927,7 +927,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -941,7 +941,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -955,7 +955,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -969,7 +969,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -983,7 +983,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -997,7 +997,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1011,7 +1011,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1028,7 +1028,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1045,7 +1045,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1062,7 +1062,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1079,7 +1079,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1096,7 +1096,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1113,7 +1113,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1131,7 +1131,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1145,7 +1145,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1159,7 +1159,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1173,7 +1173,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1187,7 +1187,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1201,7 +1201,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1215,7 +1215,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1230,7 +1230,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1245,7 +1245,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1260,7 +1260,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1275,7 +1275,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1290,7 +1290,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1305,7 +1305,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1321,7 +1321,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1337,7 +1337,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1353,7 +1353,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1369,7 +1369,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1383,7 +1383,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1397,7 +1397,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1411,7 +1411,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1425,7 +1425,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1439,7 +1439,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1453,7 +1453,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -1468,7 +1468,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1483,7 +1483,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
+    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1498,7 +1498,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
+    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1513,7 +1513,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1528,7 +1528,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1543,7 +1543,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1558,7 +1558,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1573,7 +1573,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1588,7 +1588,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1603,7 +1603,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -1619,7 +1619,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1635,7 +1635,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
+    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1651,7 +1651,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
+    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1667,7 +1667,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1683,7 +1683,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1699,7 +1699,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1715,7 +1715,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1731,7 +1731,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1747,7 +1747,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1763,7 +1763,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -1780,7 +1780,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1797,7 +1797,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
+    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1814,7 +1814,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
+    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1831,7 +1831,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1844,7 +1844,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1857,7 +1857,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1874,7 +1874,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1891,7 +1891,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -1908,7 +1908,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -1925,7 +1925,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -1942,7 +1942,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1959,7 +1959,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1976,7 +1976,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -1993,7 +1993,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2010,7 +2010,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2027,7 +2027,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2044,7 +2044,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2061,7 +2061,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2078,7 +2078,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2095,7 +2095,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2112,7 +2112,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2129,7 +2129,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2148,7 +2148,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2167,7 +2167,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -2186,7 +2186,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2205,7 +2205,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2224,7 +2224,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2243,7 +2243,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2262,7 +2262,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2281,7 +2281,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2300,7 +2300,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2319,7 +2319,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2338,7 +2338,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2357,7 +2357,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2376,7 +2376,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2395,7 +2395,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2414,7 +2414,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2430,7 +2430,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2446,7 +2446,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2462,7 +2462,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2478,7 +2478,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
+    "iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
@@ -2494,7 +2494,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2514,7 +2514,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2534,7 +2534,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2554,7 +2554,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2574,7 +2574,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2594,7 +2594,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2614,7 +2614,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2634,7 +2634,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2654,7 +2654,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2674,7 +2674,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2690,7 +2690,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2706,7 +2706,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2722,7 +2722,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2738,7 +2738,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2754,7 +2754,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2770,7 +2770,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2786,7 +2786,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2805,7 +2805,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2824,7 +2824,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2843,7 +2843,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2862,7 +2862,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2881,7 +2881,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -2900,7 +2900,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -2920,7 +2920,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2936,7 +2936,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2952,7 +2952,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2968,7 +2968,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -2984,7 +2984,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3000,7 +3000,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3016,7 +3016,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3033,7 +3033,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3050,7 +3050,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3067,7 +3067,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3084,7 +3084,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3101,7 +3101,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3118,7 +3118,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3136,7 +3136,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3154,7 +3154,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3172,7 +3172,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3190,7 +3190,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3206,7 +3206,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3222,7 +3222,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3238,7 +3238,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3254,7 +3254,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3270,7 +3270,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3286,7 +3286,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -3303,7 +3303,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3320,7 +3320,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
+    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3337,7 +3337,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
+    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3354,7 +3354,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3371,7 +3371,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3388,7 +3388,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3405,7 +3405,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3422,7 +3422,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3439,7 +3439,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3456,7 +3456,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -3474,7 +3474,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3492,7 +3492,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
+    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3510,7 +3510,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
+    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3528,7 +3528,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3546,7 +3546,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3564,7 +3564,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3582,7 +3582,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
@@ -3600,7 +3600,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3618,7 +3618,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3636,7 +3636,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
@@ -3655,7 +3655,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
+    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3674,7 +3674,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
+    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3693,7 +3693,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
+    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
@@ -3712,7 +3712,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3727,7 +3727,7 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_"
   SRC
     "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
@@ -3741,240 +3741,240 @@ iree_bytecode_module(
 )
 
 add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32[fp32][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8[int8][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16[fp16][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32[fp32][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8[int8][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32[fp32-imagenet][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32[fp32-imagenet][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32[fp32-imagenet][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32[fp32][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8[int8][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32[fp32][tosa]
-  ${PACKAGE_NAME}_iree-imported-model-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo]
-  ${PACKAGE_NAME}_iree-imported-model-BertLargeTF[fp32-seqlen384-tensorflow][mhlo]
-  ${PACKAGE_NAME}_iree-imported-model-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo]
-  ${PACKAGE_NAME}_iree-imported-model-MiniLML12H384Uncased[int32-seqlen128][mhlo]
-  ${PACKAGE_NAME}_iree-imported-model-Resnet50TF[fp32][mhlo]
+  ${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32_fp32__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8_int8__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16_fp16__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32_fp32__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8_int8__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32_fp32_imagenet__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32_fp32_imagenet__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32_fp32_imagenet__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32_fp32__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8_int8__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32_fp32__tosa_
+  ${PACKAGE_NAME}_iree-imported-model-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_
+  ${PACKAGE_NAME}_iree-imported-model-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_
+  ${PACKAGE_NAME}_iree-imported-model-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_
+  ${PACKAGE_NAME}_iree-imported-model-MiniLML12H384Uncased_int32_seqlen128__mhlo_
+  ${PACKAGE_NAME}_iree-imported-model-Resnet50TF_fp32__mhlo_
 )
 
 add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
-  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
-  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-dotprod]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_
 )
 
 add_dependencies(iree-e2e-compile-stats-suites
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-dotprod-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags-compile-stats]
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_
 )

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -2,195 +2,195 @@ iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32_fp32__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32_fp32_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8_int8__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8[int8].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8_int8_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16_fp16__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16[fp16].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16_fp16_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32_fp32__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32_fp32_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8_int8__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8[int8].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8_int8_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32_fp32_imagenet__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32[fp32,imagenet].0_float.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32_fp32_imagenet_.0_float.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_fp32_imagenet__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32_fp32_imagenet__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32[fp32,imagenet].0_224.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32_fp32_imagenet_.0_224.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32_fp32_imagenet__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32[fp32,imagenet].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32_fp32_imagenet_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32_fp32__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32_fp32_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8_int8__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8[int8].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8_int8_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32_fp32__tosa_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32[fp32].tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32_fp32_.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF[fp32,seqlen512,tensorflow]"
+    "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF_fp32_seqlen512_tensorflow_"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_.mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF[fp32,seqlen384,tensorflow]"
+    "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF_fp32_seqlen384_tensorflow_"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v1"
     "--tf-savedmodel-exported-names=serving_default"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_.mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF[fp32,cnn,tensorflow]"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF_fp32_cnn_tensorflow_"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_.mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-MiniLML12H384Uncased_int32_seqlen128__mhlo_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased[int32,seqlen128]"
+    "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased_int32_seqlen128_"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=predict"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_int32_seqlen128__mhlo_.mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
     "${PACKAGE_NAME}_iree-imported-model-Resnet50TF_fp32__mhlo_"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_Resnet50TF[fp32]"
+    "${ROOT_ARTIFACTS_DIR}/model_Resnet50TF_fp32_"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF_fp32__mhlo_.mlir"
 )
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -201,11 +201,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -216,11 +216,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -231,11 +231,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -246,11 +246,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -261,11 +261,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -276,11 +276,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -291,11 +291,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -306,11 +306,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -321,11 +321,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -336,11 +336,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -351,11 +351,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -366,11 +366,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -381,11 +381,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -396,11 +396,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_int32_seqlen128__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -411,11 +411,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-Resnet50TF_fp32__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF_fp32__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TF_fp32__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -426,11 +426,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -443,11 +443,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -460,11 +460,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -477,11 +477,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -494,11 +494,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -511,11 +511,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -528,11 +528,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -545,11 +545,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -562,11 +562,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -579,11 +579,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -596,11 +596,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -613,28 +613,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=mhlo"
-    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
-    "--iree-llvm-target-cpu=cascadelake"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -647,11 +630,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -664,11 +647,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -681,11 +664,28 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_int32_seqlen128__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -695,11 +695,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -709,11 +709,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -723,11 +723,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_int32_seqlen128__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_int32_seqlen128__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -737,11 +737,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
+    "iree-module-Resnet50TF_fp32__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF_fp32__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TF_fp32__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -751,11 +751,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -769,11 +769,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -787,11 +787,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -805,11 +805,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -823,11 +823,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -841,11 +841,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -859,11 +859,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -877,11 +877,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -895,11 +895,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -913,11 +913,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -927,11 +927,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -941,11 +941,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -955,11 +955,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -969,11 +969,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -983,11 +983,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -997,11 +997,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1011,28 +1011,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=tosa"
-    "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1045,11 +1028,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1062,11 +1045,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1079,11 +1062,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1096,11 +1079,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1113,11 +1096,28 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_dotprod_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_dotprod_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1131,11 +1131,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1145,11 +1145,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1159,11 +1159,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1173,11 +1173,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1187,11 +1187,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1201,11 +1201,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1215,26 +1215,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=adreno-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1245,11 +1230,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1260,11 +1245,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1275,11 +1260,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1290,11 +1275,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1305,27 +1290,26 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=adreno-unknown-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=16"
   PUBLIC
 )
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1337,11 +1321,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1353,11 +1337,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1369,11 +1353,27 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1383,11 +1383,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1397,11 +1397,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1411,11 +1411,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1425,11 +1425,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1439,11 +1439,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1453,11 +1453,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1468,11 +1468,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1483,11 +1483,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
+    "iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1498,11 +1498,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
+    "iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1513,11 +1513,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1528,11 +1528,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1543,11 +1543,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1558,11 +1558,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1573,11 +1573,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1588,11 +1588,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1603,43 +1603,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1651,11 +1619,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1667,11 +1635,43 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1683,11 +1683,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1699,11 +1699,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1715,11 +1715,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1731,11 +1731,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1747,11 +1747,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1763,45 +1763,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1814,11 +1780,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1831,11 +1797,45 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_"
+    "iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -1844,11 +1844,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -1857,11 +1857,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1874,11 +1874,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1891,11 +1891,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1908,11 +1908,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1925,11 +1925,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1942,11 +1942,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1959,11 +1959,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1976,11 +1976,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1993,11 +1993,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2010,11 +2010,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2027,11 +2027,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2044,11 +2044,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2061,11 +2061,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2078,11 +2078,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2095,11 +2095,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_int32_seqlen128__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2112,11 +2112,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-Resnet50TF_fp32__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF_fp32__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TF_fp32__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2129,11 +2129,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2148,11 +2148,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2167,11 +2167,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2186,11 +2186,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2205,11 +2205,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2224,11 +2224,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2243,11 +2243,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2262,11 +2262,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2281,11 +2281,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2300,11 +2300,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2319,11 +2319,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2338,30 +2338,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=mhlo"
-    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
-    "--iree-llvm-target-cpu=cascadelake"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2376,11 +2357,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2395,11 +2376,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2414,11 +2395,30 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_int32_seqlen128__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2430,11 +2430,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
+    "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_BertLargeTF_fp32_seqlen384_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2446,11 +2446,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
+    "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2462,11 +2462,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
+    "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased_int32_seqlen128__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MiniLML12H384Uncased_int32_seqlen128__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2478,11 +2478,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
+    "iree-module-Resnet50TF_fp32__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF_fp32__mhlo_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_Resnet50TF_fp32__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2494,11 +2494,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2514,11 +2514,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2534,11 +2534,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV1_fp32_fp32_imagenet__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2554,11 +2554,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2574,11 +2574,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2594,11 +2594,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2614,11 +2614,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2634,11 +2634,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2654,11 +2654,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2674,11 +2674,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2690,11 +2690,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2706,11 +2706,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2722,11 +2722,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2738,11 +2738,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2754,11 +2754,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2770,11 +2770,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2786,30 +2786,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=tosa"
-    "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2824,11 +2805,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2843,11 +2824,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2862,11 +2843,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2881,11 +2862,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2900,11 +2881,30 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_dotprod_compile-stats_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_dotprod_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2920,11 +2920,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2936,11 +2936,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2952,11 +2952,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2968,11 +2968,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2984,11 +2984,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3000,11 +3000,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3016,28 +3016,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=adreno-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3050,11 +3033,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3067,11 +3050,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3084,11 +3067,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3101,11 +3084,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3118,17 +3101,16 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=adreno-unknown-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=16"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
   PUBLIC
@@ -3136,11 +3118,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3154,11 +3136,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3172,11 +3154,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3190,11 +3172,29 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3206,11 +3206,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3222,11 +3222,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3238,11 +3238,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3254,11 +3254,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3270,11 +3270,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3286,11 +3286,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3303,11 +3303,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3320,11 +3320,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
+    "iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3337,11 +3337,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
+    "iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3354,11 +3354,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3371,11 +3371,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3388,11 +3388,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3405,11 +3405,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3422,11 +3422,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3439,11 +3439,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3456,47 +3456,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3510,11 +3474,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3528,11 +3492,47 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32_fp32__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3546,11 +3546,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3564,11 +3564,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3582,11 +3582,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32_fp32__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3600,11 +3600,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3618,11 +3618,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3636,49 +3636,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
+    "iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16_fp16__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3693,11 +3655,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
+    "iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3712,11 +3674,49 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_"
+    "iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8_int8__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8_int8__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_compile-stats_"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32_fp32_imagenet__tosa_.mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV2_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -3727,11 +3727,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_"
+    "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32_fp32_imagenet__tosa_.mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_module_MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_compile-stats_/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -3760,221 +3760,221 @@ add_dependencies(iree-benchmark-import-models
 )
 
 add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
-  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
-  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_dotprod_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_
 )
 
 add_dependencies(iree-e2e-compile-stats-suites
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_
-  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_cpu-x86_64-cascadelake-linux-gnu-llvm-cpu_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-Resnet50TF_fp32__mhlo_gpu-cuda-sm_80-linux-gnu-cuda_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32_fp32_imagenet__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_64-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_cpu-riscv_32-generic-linux-gnu-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_cpu-armv8.2-a-generic-linux-android29-llvm-cpu_experimental-flags_mmt4d_dotprod_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-adreno-generic-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_default-flags_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32_fp32__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16_fp16__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_compile-stats_
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa_cpu-vmvx-generic-vmvx-vmvx_default-flags_compile-stats_
 )

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -6,7 +6,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -17,7 +17,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -28,7 +28,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -39,7 +39,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -50,7 +50,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -61,7 +61,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -72,7 +72,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -83,7 +83,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -94,7 +94,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -105,7 +105,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
 )
 
 iree_import_tflite_model(
@@ -116,7 +116,7 @@ iree_import_tflite_model(
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
 )
 
 iree_import_tf_model(
@@ -129,7 +129,7 @@ iree_import_tf_model(
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
 )
 
 iree_import_tf_model(
@@ -142,7 +142,7 @@ iree_import_tf_model(
     "--tf-import-type=savedmodel_v1"
     "--tf-savedmodel-exported-names=serving_default"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
 )
 
 iree_import_tf_model(
@@ -155,7 +155,7 @@ iree_import_tf_model(
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
 )
 
 iree_import_tf_model(
@@ -168,7 +168,7 @@ iree_import_tf_model(
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=predict"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
 )
 
 iree_import_tf_model(
@@ -181,16 +181,16 @@ iree_import_tf_model(
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
 )
 
 iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -203,9 +203,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -218,9 +218,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -233,9 +233,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -248,9 +248,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -263,9 +263,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -278,9 +278,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -293,9 +293,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -308,9 +308,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -323,9 +323,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -338,9 +338,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -353,9 +353,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -368,9 +368,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -383,9 +383,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -398,9 +398,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -413,9 +413,9 @@ iree_bytecode_module(
   NAME
     "iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -428,9 +428,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -445,9 +445,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -462,9 +462,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -479,9 +479,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -496,9 +496,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -513,9 +513,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -530,9 +530,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -547,9 +547,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -564,9 +564,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -581,9 +581,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -598,9 +598,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -615,9 +615,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -632,9 +632,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -649,9 +649,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -666,9 +666,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -683,9 +683,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -697,9 +697,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -711,9 +711,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -725,9 +725,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -739,9 +739,9 @@ iree_bytecode_module(
   NAME
     "iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -753,9 +753,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -771,9 +771,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -789,9 +789,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -807,9 +807,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -825,9 +825,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -843,9 +843,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -861,9 +861,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -879,9 +879,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -897,9 +897,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -915,9 +915,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -929,9 +929,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -943,9 +943,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -957,9 +957,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -971,9 +971,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -985,9 +985,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -999,9 +999,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1013,9 +1013,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1030,9 +1030,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1047,9 +1047,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1064,9 +1064,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1081,9 +1081,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1098,9 +1098,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1115,9 +1115,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1133,9 +1133,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1147,9 +1147,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1161,9 +1161,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1175,9 +1175,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1189,9 +1189,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1203,9 +1203,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1217,9 +1217,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1232,9 +1232,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1247,9 +1247,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1262,9 +1262,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1277,9 +1277,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1292,9 +1292,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1307,9 +1307,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1323,9 +1323,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1339,9 +1339,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1355,9 +1355,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1371,9 +1371,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1385,9 +1385,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1399,9 +1399,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1413,9 +1413,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1427,9 +1427,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1441,9 +1441,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1455,9 +1455,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1470,9 +1470,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1485,9 +1485,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1500,9 +1500,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1515,9 +1515,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1530,9 +1530,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1545,9 +1545,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1560,9 +1560,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1575,9 +1575,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1590,9 +1590,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1605,9 +1605,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1621,9 +1621,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1637,9 +1637,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1653,9 +1653,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1669,9 +1669,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1685,9 +1685,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1701,9 +1701,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1717,9 +1717,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1733,9 +1733,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1749,9 +1749,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1765,9 +1765,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1782,9 +1782,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1799,9 +1799,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1816,9 +1816,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1833,9 +1833,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -1846,9 +1846,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -1859,9 +1859,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1876,9 +1876,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1893,9 +1893,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1910,9 +1910,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1927,9 +1927,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1944,9 +1944,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1961,9 +1961,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1978,9 +1978,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1995,9 +1995,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2012,9 +2012,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2029,9 +2029,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2046,9 +2046,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2063,9 +2063,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2080,9 +2080,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2097,9 +2097,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2114,9 +2114,9 @@ iree_bytecode_module(
   NAME
     "iree-module-Resnet50TF_fp32__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2131,9 +2131,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2150,9 +2150,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2169,9 +2169,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2188,9 +2188,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2207,9 +2207,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2226,9 +2226,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2245,9 +2245,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2264,9 +2264,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2283,9 +2283,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2302,9 +2302,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2321,9 +2321,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2340,9 +2340,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2359,9 +2359,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2378,9 +2378,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2397,9 +2397,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__cpu-x86_64-cascadelake-linux-gnu-llvm-cpu__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2416,9 +2416,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertForMaskedLMTF_fp32_seqlen512_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2432,9 +2432,9 @@ iree_bytecode_module(
   NAME
     "iree-module-BertLargeTF_fp32_seqlen384_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2448,9 +2448,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNetV2STF_fp32_cnn_tensorflow__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2464,9 +2464,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MiniLML12H384Uncased_int32_seqlen128__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2480,9 +2480,9 @@ iree_bytecode_module(
   NAME
     "iree-module-Resnet50TF_fp32__mhlo__gpu-cuda-sm_80-linux-gnu-cuda__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32](mhlo)[gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2496,9 +2496,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2516,9 +2516,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2536,9 +2536,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV1_fp32_fp32_imagenet__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2556,9 +2556,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2576,9 +2576,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2596,9 +2596,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_64-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2616,9 +2616,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2636,9 +2636,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2656,9 +2656,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__cpu-riscv_32-generic-linux-gnu-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2676,9 +2676,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2692,9 +2692,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2708,9 +2708,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2724,9 +2724,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2740,9 +2740,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2756,9 +2756,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2772,9 +2772,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2788,9 +2788,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2807,9 +2807,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2826,9 +2826,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2845,9 +2845,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2864,9 +2864,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2883,9 +2883,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2902,9 +2902,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__cpu-armv8.2-a-generic-linux-android29-llvm-cpu__experimental-flags_mmt4d_dotprod_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2922,9 +2922,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2938,9 +2938,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2954,9 +2954,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2970,9 +2970,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2986,9 +2986,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3002,9 +3002,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3018,9 +3018,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3035,9 +3035,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3052,9 +3052,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3069,9 +3069,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3086,9 +3086,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3103,9 +3103,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3120,9 +3120,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3138,9 +3138,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3156,9 +3156,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3174,9 +3174,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-adreno-generic-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3192,9 +3192,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3208,9 +3208,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3224,9 +3224,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3240,9 +3240,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3256,9 +3256,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3272,9 +3272,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3288,9 +3288,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3305,9 +3305,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3322,9 +3322,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3339,9 +3339,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__default-flags_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3356,9 +3356,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3373,9 +3373,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3390,9 +3390,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3407,9 +3407,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3424,9 +3424,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3441,9 +3441,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3458,9 +3458,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3476,9 +3476,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3494,9 +3494,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3512,9 +3512,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3530,9 +3530,9 @@ iree_bytecode_module(
   NAME
     "iree-module-DeepLabV3_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3548,9 +3548,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileSSD_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3566,9 +3566,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PoseNet_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3584,9 +3584,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp32_fp32__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3602,9 +3602,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3620,9 +3620,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3638,9 +3638,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_fp16_fp16__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3657,9 +3657,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileBertSquad_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3676,9 +3676,9 @@ iree_bytecode_module(
   NAME
     "iree-module-EfficientNet_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3695,9 +3695,9 @@ iree_bytecode_module(
   NAME
     "iree-module-PersonDetect_int8_int8__tosa__gpu-valhall-mali-android31-vulkan-spirv__experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8](tosa)[gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3714,9 +3714,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV2_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -3729,9 +3729,9 @@ iree_bytecode_module(
   NAME
     "iree-module-MobileNetV3Small_fp32_fp32_imagenet__tosa__cpu-vmvx-generic-vmvx-vmvx__default-flags_compile-stats_"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa).mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet](tosa)[cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"

--- a/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
+++ b/tests/e2e/test_artifacts/generated_e2e_test_iree_artifacts.cmake
@@ -1,196 +1,196 @@
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-c36c63b0-220a-4d78-8ade-c45ce47d89d3"
+    "${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32[fp32][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_DeepLabV3_fp32[fp32].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-4a6f545e-1b4e-41a5-9236-792aa578184b"
+    "${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8[int8][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNet_int8[int8].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-73a0402e-271b-4aa8-a6a5-ac05839ca569"
+    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16[fp16][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp16[fp16].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-cc69d69f-6d1f-4a1a-a31e-e021888d0d28"
+    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32[fp32][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_fp32[fp32].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-e3997104-a3d2-46b4-9fbf-39069906d123"
+    "${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8[int8][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileBertSquad_int8[int8].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-78eab9e5-9ff1-4769-9b55-933c81cc9a0f"
+    "${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32[fp32-imagenet][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.0_float.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV1_fp32[fp32,imagenet].0_float.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-7d45f8e5-bb5e-48d0-928d-8f125104578f"
+    "${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32[fp32-imagenet][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.0_224.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV2_fp32[fp32,imagenet].0_224.tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-58855e40-eba9-4a71-b878-6b35e3460244"
+    "${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32[fp32-imagenet][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileNetV3Small_fp32[fp32,imagenet].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-0e466f69-91d6-4e50-b62b-a82b6213a231"
+    "${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32[fp32][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_MobileSSD_fp32[fp32].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-bc1338be-e3df-44fd-82e4-40ba9560a073"
+    "${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8[int8][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PersonDetect_int8[int8].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
 )
 
 iree_import_tflite_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-5afc3014-d29d-4e88-a840-fbaf678acf2b"
+    "${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32[fp32][tosa]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.tflite"
+    "${ROOT_ARTIFACTS_DIR}/model_PoseNet_fp32[fp32].tflite"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-39d157ad-f0ec-4a76-963b-d783beaed60f"
+    "${PACKAGE_NAME}_iree-imported-model-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF"
+    "${ROOT_ARTIFACTS_DIR}/model_BertForMaskedLMTF[fp32,seqlen512,tensorflow]"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-8871f602-571c-4eb8-b94d-554cc8ceec5a"
+    "${PACKAGE_NAME}_iree-imported-model-BertLargeTF[fp32-seqlen384-tensorflow][mhlo]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF"
+    "${ROOT_ARTIFACTS_DIR}/model_BertLargeTF[fp32,seqlen384,tensorflow]"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v1"
     "--tf-savedmodel-exported-names=serving_default"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-ebe7897f-5613-435b-a330-3cb967704e5e"
+    "${PACKAGE_NAME}_iree-imported-model-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF"
+    "${ROOT_ARTIFACTS_DIR}/model_EfficientNetV2STF[fp32,cnn,tensorflow]"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493"
+    "${PACKAGE_NAME}_iree-imported-model-MiniLML12H384Uncased[int32-seqlen128][mhlo]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased"
+    "${ROOT_ARTIFACTS_DIR}/model_MiniLML12H384Uncased[int32,seqlen128]"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=predict"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
 )
 
 iree_import_tf_model(
   TARGET_NAME
-    "${PACKAGE_NAME}_iree-imported-model-c393b4fa-beb4-45d5-982a-c6328aa05d08"
+    "${PACKAGE_NAME}_iree-imported-model-Resnet50TF[fp32][mhlo]"
   SOURCE
-    "${ROOT_ARTIFACTS_DIR}/model_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF"
+    "${ROOT_ARTIFACTS_DIR}/model_Resnet50TF[fp32]"
   IMPORT_FLAGS
     "--output-format=mlir-bytecode"
     "--tf-import-type=savedmodel_v2"
     "--tf-savedmodel-exported-names=forward"
   OUTPUT_MLIR_FILE
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
 )
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -201,11 +201,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -216,11 +216,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -231,11 +231,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -246,11 +246,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -261,11 +261,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -276,11 +276,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -291,11 +291,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -306,11 +306,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -321,11 +321,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -336,11 +336,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -351,11 +351,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -366,11 +366,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -381,11 +381,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -396,11 +396,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -411,11 +411,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9"
+    "iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -426,11 +426,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -443,11 +443,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -460,11 +460,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -477,11 +477,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -494,11 +494,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -511,11 +511,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -528,11 +528,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -545,11 +545,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -562,11 +562,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -579,11 +579,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -596,11 +596,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -613,28 +613,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=mhlo"
-    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
-    "--iree-llvm-target-cpu=cascadelake"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-6d0d5716-5525-44ad-b71d-8075ee1583a6"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -647,11 +630,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -664,11 +647,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6"
+    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_6d0d5716-5525-44ad-b71d-8075ee1583a6/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -681,11 +664,28 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030"
+    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_09cb5300-7f73-45cf-9f68-e114c77ca030/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -695,11 +695,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-09cb5300-7f73-45cf-9f68-e114c77ca030"
+    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF_09cb5300-7f73-45cf-9f68-e114c77ca030/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -709,11 +709,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030"
+    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_09cb5300-7f73-45cf-9f68-e114c77ca030/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -723,11 +723,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030"
+    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_09cb5300-7f73-45cf-9f68-e114c77ca030/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -737,11 +737,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030"
+    "iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF_09cb5300-7f73-45cf-9f68-e114c77ca030/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -751,11 +751,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_cdf579a9-5446-403b-a991-802a6c702e65/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -769,11 +769,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_cdf579a9-5446-403b-a991-802a6c702e65/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -787,11 +787,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65"
+    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_cdf579a9-5446-403b-a991-802a6c702e65/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -805,11 +805,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_cdf579a9-5446-403b-a991-802a6c702e65/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -823,11 +823,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_cdf579a9-5446-403b-a991-802a6c702e65/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -841,11 +841,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_cdf579a9-5446-403b-a991-802a6c702e65/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -859,11 +859,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -877,11 +877,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -895,11 +895,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -913,11 +913,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -927,11 +927,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -941,11 +941,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -955,11 +955,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -969,11 +969,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -983,11 +983,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -997,11 +997,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_1f2adf49-282e-4aff-9d4f-e63b1621f1e8/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1011,28 +1011,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_d463322c-24e6-4685-85ca-d541b41a405f/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=tosa"
-    "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_d463322c-24e6-4685-85ca-d541b41a405f/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1045,11 +1028,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_d463322c-24e6-4685-85ca-d541b41a405f/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1062,11 +1045,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_d463322c-24e6-4685-85ca-d541b41a405f/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1079,11 +1062,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_d463322c-24e6-4685-85ca-d541b41a405f/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1096,11 +1079,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_d463322c-24e6-4685-85ca-d541b41a405f/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1113,11 +1096,28 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_f672a6b9-99fc-47ce-8b1b-8e5f44a541a1/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1131,11 +1131,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1145,11 +1145,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1159,11 +1159,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1173,11 +1173,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1187,11 +1187,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1201,11 +1201,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1215,26 +1215,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=adreno-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1245,11 +1230,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1260,11 +1245,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1275,11 +1260,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1290,11 +1275,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1305,27 +1290,26 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_70b823ca-2807-4531-8c00-e02af7d70466/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=adreno-unknown-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=16"
   PUBLIC
 )
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_70b823ca-2807-4531-8c00-e02af7d70466/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1337,11 +1321,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_70b823ca-2807-4531-8c00-e02af7d70466/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1353,11 +1337,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_70b823ca-2807-4531-8c00-e02af7d70466/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1369,11 +1353,27 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1383,11 +1383,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1397,11 +1397,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1411,11 +1411,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1425,11 +1425,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1439,11 +1439,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1453,11 +1453,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1468,11 +1468,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16"
+    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1483,11 +1483,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16"
+    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1498,11 +1498,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16"
+    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1513,11 +1513,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1528,11 +1528,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1543,11 +1543,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1558,11 +1558,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1573,11 +1573,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1588,11 +1588,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1603,43 +1603,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1651,11 +1619,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16"
+    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1667,11 +1635,43 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
+    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1683,11 +1683,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1699,11 +1699,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1715,11 +1715,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1731,11 +1731,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1747,11 +1747,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1763,45 +1763,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1814,11 +1780,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16"
+    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -1831,11 +1797,45 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4"
+    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_75336abd-8108-462c-9ce3-15443e3f32f4/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -1844,11 +1844,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-75336abd-8108-462c-9ce3-15443e3f32f4"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_75336abd-8108-462c-9ce3-15443e3f32f4/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -1857,11 +1857,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1874,11 +1874,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1891,11 +1891,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1908,11 +1908,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1925,11 +1925,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1942,11 +1942,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1959,11 +1959,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1976,11 +1976,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -1993,11 +1993,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2010,11 +2010,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2027,11 +2027,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2044,11 +2044,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2061,11 +2061,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2078,11 +2078,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2095,11 +2095,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2112,11 +2112,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats"
+    "iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF_e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2129,11 +2129,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2148,11 +2148,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2167,11 +2167,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2186,11 +2186,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2205,11 +2205,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2224,11 +2224,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2243,11 +2243,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2262,11 +2262,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2281,11 +2281,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2300,11 +2300,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2319,11 +2319,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2338,30 +2338,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=mhlo"
-    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
-    "--iree-llvm-target-cpu=cascadelake"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2376,11 +2357,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2395,11 +2376,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats"
+    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=mhlo"
@@ -2414,11 +2395,30 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_39d157ad-f0ec-4a76-963b-d783beaed60f_BertForMaskedLMTF_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=mhlo"
+    "--iree-llvm-target-triple=x86_64-unknown-linux-gnu"
+    "--iree-llvm-target-cpu=cascadelake"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_BertForMaskedLMTF[fp32,seqlen512,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2430,11 +2430,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+    "iree-module-BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_8871f602-571c-4eb8-b94d-554cc8ceec5a_BertLargeTF_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_BertLargeTF[fp32,seqlen384,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2446,11 +2446,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+    "iree-module-EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ebe7897f-5613-435b-a330-3cb967704e5e_EfficientNetV2STF_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNetV2STF[fp32,cnn,tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2462,11 +2462,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+    "iree-module-MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_ecf5c970-ee97-49f0-a4ed-df1f34e9d493_MiniLML12H384Uncased_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MiniLML12H384Uncased[int32,seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2478,11 +2478,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats"
+    "iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c393b4fa-beb4-45d5-982a-c6328aa05d08_Resnet50TF_09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=cuda"
     "--iree-input-type=mhlo"
@@ -2494,11 +2494,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2514,11 +2514,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2534,11 +2534,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+    "iree-module-MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_78eab9e5-9ff1-4769-9b55-933c81cc9a0f_MobileNetV1_fp32_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV1_fp32[fp32,imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2554,11 +2554,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2574,11 +2574,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2594,11 +2594,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_cdf579a9-5446-403b-a991-802a6c702e65-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2614,11 +2614,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats"
+    "iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2634,11 +2634,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2654,11 +2654,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats"
+    "iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2674,11 +2674,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2690,11 +2690,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2706,11 +2706,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2722,11 +2722,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2738,11 +2738,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2754,11 +2754,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2770,11 +2770,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2786,30 +2786,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=llvm-cpu"
-    "--iree-input-type=tosa"
-    "--iree-llvm-target-triple=aarch64-none-linux-android29"
-    "--iree-flow-enable-data-tiling"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-llvmcpu-enable-pad-consumer-fusion"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2824,11 +2805,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2843,11 +2824,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2862,11 +2843,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2881,11 +2862,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_d463322c-24e6-4685-85ca-d541b41a405f-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2900,11 +2881,30 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_f672a6b9-99fc-47ce-8b1b-8e5f44a541a1-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,compile-stats]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=llvm-cpu"
+    "--iree-input-type=tosa"
+    "--iree-llvm-target-triple=aarch64-none-linux-android29"
+    "--iree-flow-enable-data-tiling"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-llvmcpu-enable-pad-consumer-fusion"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod,compile-stats]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags,mmt4d,dotprod,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=llvm-cpu"
     "--iree-input-type=tosa"
@@ -2920,11 +2920,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2936,11 +2936,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2952,11 +2952,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2968,11 +2968,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -2984,11 +2984,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3000,11 +3000,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3016,28 +3016,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=adreno-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3050,11 +3033,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3067,11 +3050,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3084,11 +3067,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3101,11 +3084,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3118,17 +3101,16 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
     "--iree-vulkan-target-triple=adreno-unknown-android31"
     "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=16"
     "--iree-vm-emit-polyglot-zip=true"
     "--iree-llvm-debug-symbols=false"
   PUBLIC
@@ -3136,11 +3118,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3154,11 +3136,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3172,11 +3154,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_70b823ca-2807-4531-8c00-e02af7d70466-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3190,11 +3172,29 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=adreno-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3206,11 +3206,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3222,11 +3222,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3238,11 +3238,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3254,11 +3254,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3270,11 +3270,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3286,11 +3286,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3303,11 +3303,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3320,11 +3320,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats"
+    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3337,11 +3337,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats"
+    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3354,11 +3354,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3371,11 +3371,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3388,11 +3388,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3405,11 +3405,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3422,11 +3422,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3439,11 +3439,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3456,47 +3456,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3510,11 +3474,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3528,11 +3492,47 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_c36c63b0-220a-4d78-8ade-c45ce47d89d3_DeepLabV3_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,demote-f32-to-f16,compile-stats]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3546,11 +3546,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+    "iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_0e466f69-91d6-4e50-b62b-a82b6213a231_MobileSSD_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3564,11 +3564,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+    "iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_5afc3014-d29d-4e88-a840-fbaf678acf2b_PoseNet_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3582,11 +3582,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+    "iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_cc69d69f-6d1f-4a1a-a31e-e021888d0d28_MobileBertSquad_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3600,11 +3600,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3618,11 +3618,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3636,49 +3636,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats"
+    "iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_73a0402e-271b-4aa8-a6a5-ac05839ca569_MobileBertSquad_fp16_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_e3997104-a3d2-46b4-9fbf-39069906d123_MobileBertSquad_int8_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats/module.vmfb"
-  FLAGS
-    "--iree-hal-target-backends=vulkan-spirv"
-    "--iree-input-type=tosa"
-    "--iree-vulkan-target-triple=valhall-unknown-android31"
-    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
-    "--iree-hal-benchmark-dispatch-repeat-count=32"
-    "--iree-flow-demote-f32-to-f16"
-    "--iree-vm-emit-polyglot-zip=true"
-    "--iree-llvm-debug-symbols=false"
-  PUBLIC
-)
-
-iree_bytecode_module(
-  NAME
-    "iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats"
-  SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8.mlir"
-  MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_4a6f545e-1b4e-41a5-9236-792aa578184b_EfficientNet_int8_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3693,11 +3655,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats"
+    "iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_bc1338be-e3df-44fd-82e4-40ba9560a073_PersonDetect_int8_6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vulkan-spirv"
     "--iree-input-type=tosa"
@@ -3712,11 +3674,49 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats"
+    "iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_7d45f8e5-bb5e-48d0-928d-8f125104578f_MobileNetV2_fp32_75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags,fuse-padding,repeated-kernel,demote-f32-to-f16,compile-stats]/module.vmfb"
+  FLAGS
+    "--iree-hal-target-backends=vulkan-spirv"
+    "--iree-input-type=tosa"
+    "--iree-vulkan-target-triple=valhall-unknown-android31"
+    "--iree-flow-enable-fuse-padding-into-linalg-consumer-ops"
+    "--iree-hal-benchmark-dispatch-repeat-count=32"
+    "--iree-flow-demote-f32-to-f16"
+    "--iree-vm-emit-polyglot-zip=true"
+    "--iree-llvm-debug-symbols=false"
+  PUBLIC
+)
+
+iree_bytecode_module(
+  NAME
+    "iree-module-MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]"
+  SRC
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa].mlir"
+  MODULE_FILE_NAME
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV2_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -3727,11 +3727,11 @@ iree_bytecode_module(
 
 iree_bytecode_module(
   NAME
-    "iree-module-58855e40-eba9-4a71-b878-6b35e3460244-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats"
+    "iree-module-MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]"
   SRC
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32.mlir"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa].mlir"
   MODULE_FILE_NAME
-    "${ROOT_ARTIFACTS_DIR}/iree_58855e40-eba9-4a71-b878-6b35e3460244_MobileNetV3Small_fp32_75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats/module.vmfb"
+    "${ROOT_ARTIFACTS_DIR}/iree_MobileNetV3Small_fp32[fp32,imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags,compile-stats]/module.vmfb"
   FLAGS
     "--iree-hal-target-backends=vmvx"
     "--iree-input-type=tosa"
@@ -3741,240 +3741,240 @@ iree_bytecode_module(
 )
 
 add_dependencies(iree-benchmark-import-models
-  ${PACKAGE_NAME}_iree-imported-model-c36c63b0-220a-4d78-8ade-c45ce47d89d3
-  ${PACKAGE_NAME}_iree-imported-model-4a6f545e-1b4e-41a5-9236-792aa578184b
-  ${PACKAGE_NAME}_iree-imported-model-73a0402e-271b-4aa8-a6a5-ac05839ca569
-  ${PACKAGE_NAME}_iree-imported-model-cc69d69f-6d1f-4a1a-a31e-e021888d0d28
-  ${PACKAGE_NAME}_iree-imported-model-e3997104-a3d2-46b4-9fbf-39069906d123
-  ${PACKAGE_NAME}_iree-imported-model-78eab9e5-9ff1-4769-9b55-933c81cc9a0f
-  ${PACKAGE_NAME}_iree-imported-model-7d45f8e5-bb5e-48d0-928d-8f125104578f
-  ${PACKAGE_NAME}_iree-imported-model-58855e40-eba9-4a71-b878-6b35e3460244
-  ${PACKAGE_NAME}_iree-imported-model-0e466f69-91d6-4e50-b62b-a82b6213a231
-  ${PACKAGE_NAME}_iree-imported-model-bc1338be-e3df-44fd-82e4-40ba9560a073
-  ${PACKAGE_NAME}_iree-imported-model-5afc3014-d29d-4e88-a840-fbaf678acf2b
-  ${PACKAGE_NAME}_iree-imported-model-39d157ad-f0ec-4a76-963b-d783beaed60f
-  ${PACKAGE_NAME}_iree-imported-model-8871f602-571c-4eb8-b94d-554cc8ceec5a
-  ${PACKAGE_NAME}_iree-imported-model-ebe7897f-5613-435b-a330-3cb967704e5e
-  ${PACKAGE_NAME}_iree-imported-model-ecf5c970-ee97-49f0-a4ed-df1f34e9d493
-  ${PACKAGE_NAME}_iree-imported-model-c393b4fa-beb4-45d5-982a-c6328aa05d08
+  ${PACKAGE_NAME}_iree-imported-model-DeepLabV3_fp32[fp32][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-EfficientNet_int8[int8][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp16[fp16][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_fp32[fp32][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-MobileBertSquad_int8[int8][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV1_fp32[fp32-imagenet][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV2_fp32[fp32-imagenet][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-MobileNetV3Small_fp32[fp32-imagenet][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-MobileSSD_fp32[fp32][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-PersonDetect_int8[int8][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-PoseNet_fp32[fp32][tosa]
+  ${PACKAGE_NAME}_iree-imported-model-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo]
+  ${PACKAGE_NAME}_iree-imported-model-BertLargeTF[fp32-seqlen384-tensorflow][mhlo]
+  ${PACKAGE_NAME}_iree-imported-model-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo]
+  ${PACKAGE_NAME}_iree-imported-model-MiniLML12H384Uncased[int32-seqlen128][mhlo]
+  ${PACKAGE_NAME}_iree-imported-model-Resnet50TF[fp32][mhlo]
 )
 
 add_dependencies(iree-benchmark-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030
-  ${PACKAGE_NAME}_iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-09cb5300-7f73-45cf-9f68-e114c77ca030
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030
-  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-75336abd-8108-462c-9ce3-15443e3f32f4
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
+  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
+  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-dotprod]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags]
 )
 
 add_dependencies(iree-e2e-compile-stats-suites
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-e7e18b0f-c72d-4f1c-89b1-5afee70df6e9-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-6d0d5716-5525-44ad-b71d-8075ee1583a6-compile-stats
-  ${PACKAGE_NAME}_iree-module-39d157ad-f0ec-4a76-963b-d783beaed60f-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
-  ${PACKAGE_NAME}_iree-module-8871f602-571c-4eb8-b94d-554cc8ceec5a-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
-  ${PACKAGE_NAME}_iree-module-ebe7897f-5613-435b-a330-3cb967704e5e-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
-  ${PACKAGE_NAME}_iree-module-ecf5c970-ee97-49f0-a4ed-df1f34e9d493-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
-  ${PACKAGE_NAME}_iree-module-c393b4fa-beb4-45d5-982a-c6328aa05d08-09cb5300-7f73-45cf-9f68-e114c77ca030-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
-  ${PACKAGE_NAME}_iree-module-78eab9e5-9ff1-4769-9b55-933c81cc9a0f-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-cdf579a9-5446-403b-a991-802a6c702e65-compile-stats
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6d9ce240-ec14-4d8f-a8e4-1b20aa17b4e4-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d463322c-24e6-4685-85ca-d541b41a405f-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-f672a6b9-99fc-47ce-8b1b-8e5f44a541a1-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-c7eea358-d8d2-4199-9d75-bb741c399b1b-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-d3038b95-c889-456a-bff6-5cbabd10f1ad-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-70b823ca-2807-4531-8c00-e02af7d70466-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-compile-stats
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-8da35f2b-a042-4b7d-9dcf-5ebbc1728765-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-compile-stats
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-32a56c8d-cc6c-41b8-8620-1f8eda0b8223-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-c36c63b0-220a-4d78-8ade-c45ce47d89d3-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
-  ${PACKAGE_NAME}_iree-module-0e466f69-91d6-4e50-b62b-a82b6213a231-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
-  ${PACKAGE_NAME}_iree-module-5afc3014-d29d-4e88-a840-fbaf678acf2b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
-  ${PACKAGE_NAME}_iree-module-cc69d69f-6d1f-4a1a-a31e-e021888d0d28-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-6b601a8d-4824-42e0-bcc6-500c0c3fa346-compile-stats
-  ${PACKAGE_NAME}_iree-module-73a0402e-271b-4aa8-a6a5-ac05839ca569-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-e3997104-a3d2-46b4-9fbf-39069906d123-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-4a6f545e-1b4e-41a5-9236-792aa578184b-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-bc1338be-e3df-44fd-82e4-40ba9560a073-6b601a8d-4824-42e0-bcc6-500c0c3fa346-demote-f32-to-16-compile-stats
-  ${PACKAGE_NAME}_iree-module-7d45f8e5-bb5e-48d0-928d-8f125104578f-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats
-  ${PACKAGE_NAME}_iree-module-58855e40-eba9-4a71-b878-6b35e3460244-75336abd-8108-462c-9ce3-15443e3f32f4-compile-stats
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][cpu-x86_64-cascadelake-linux-gnu-llvm-cpu][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-BertForMaskedLMTF[fp32-seqlen512-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-BertLargeTF[fp32-seqlen384-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNetV2STF[fp32-cnn-tensorflow][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MiniLML12H384Uncased[int32-seqlen128][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-Resnet50TF[fp32][mhlo][gpu-cuda-sm_80-linux-gnu-cuda][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV1_fp32[fp32-imagenet][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_64-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][cpu-riscv_32-generic-linux-gnu-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][cpu-armv8.2-a-generic-linux-android29-llvm-cpu][experimental-flags-mmt4d-dotprod-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-adreno-generic-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][default-flags-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-DeepLabV3_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileSSD_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PoseNet_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp32[fp32][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_fp16[fp16][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileBertSquad_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-EfficientNet_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-PersonDetect_int8[int8][tosa][gpu-valhall-mali-android31-vulkan-spirv][experimental-flags-fuse-padding-repeated-kernel-demote-f32-to-f16-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV2_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags-compile-stats]
+  ${PACKAGE_NAME}_iree-module-MobileNetV3Small_fp32[fp32-imagenet][tosa][cpu-vmvx-generic-vmvx-vmvx][default-flags-compile-stats]
 )


### PR DESCRIPTION
I think we made a mistake to use random artificial ids as filenames for e2e test artifacts. It's hard to find modules and flag files for debugging and triage because those names are meaningless (e.g. w/o the tool #12217, it's very hard to find the modules from the benchmark name showing on the IREE perf dashboard).

With the meaningful file names, people can easily find the related files from the benchmark names on the dashboard, without tools. It also makes it easier to understand the build errors from the file names.

This changes:

1. Gives human readable names to benchmark configs
2. Use those readable names for output files and cmake target names

The 1. is also useful for naming the benchmarks on the IREE perf dashboard. Currently we use the legacy benchmark framework to generate display names for the dashboard. it'd be good to move that part into the new framework.

Since now we are using artificial id to index benchmark series, it's also much easier to change formats of these names later, if needed.

Format used in this change:

- Model: `<model.name>[model tags,...]`
- Imported MLIR: `<model>(<dialect>[import tags,...]).mlir`
- Module: `<model>(<dialect>[import tags,...])[<architecture>-<backend>,...][compile tags,...]`

If `[tags,...]` is empty, the whole `[]` is omitted. Filename and cmake target name are only allowed `[A-Za-z0-9_.+-]`, other characters are replaced with `_`

With this format, the current longest directory name is 164 characters
```
iree_module_MobileBertSquad_int8_int8__tosa_gpu-valhall-mali-android31-vulkan-spirv_experimental-flags_fuse-padding_repeated-kernel_demote-f32-to-f16_compile-stats_
```
It can probably be shorter if we shorten some long tag names (or have a `friendly_tag` field in the framework to override the concatenated tag, when needed)

Right now we rely on CMake to check duplication for us, #10556 will add a validation for this.

benchmarks: x86_64,cuda