### PR TITLE
[LLVMGPU] Improve how we distribute small inner shapes

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -104,14 +104,6 @@ static LogicalResult getTileAndDistributeConfig(
     tileSizes[loopId] = 0;
   }
 
-  // Loops with a tile size of 0 shouldn't be distributed.
-  partitionableLoops.erase(
-      std::remove_if(partitionableLoops.begin(), partitionableLoops.end(),
-                     [&](unsigned loopId) {
-                       return loopId >= tileSizes.size() ||
-                              tileSizes[loopId] == 0;
-                     }),
-      partitionableLoops.end());
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(*rootOp)) {
     staticLoopRanges = linalgOp.getStaticLoopRanges();
   }
@@ -211,6 +203,7 @@ struct LowerDispatchWorkgroupCountForDagRootOp
     // slowest varying.
     SmallVector<Value> numWorkgroups;
     for (auto partitionedLoop : llvm::reverse(partitionedLoops)) {
+      if (isConstantIntValue(tileSizes[partitionedLoop], 0)) continue;
       Value numTileAlongDim = getValueOrCreateConstantIndexOp(
           rewriter, loc, numTiles[partitionedLoop]);
       if (numWorkgroups.size() == kNumMaxParallelDims) {

--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -104,6 +104,14 @@ static LogicalResult getTileAndDistributeConfig(
     tileSizes[loopId] = 0;
   }
 
+  // Loops with a tile size of 0 shouldn't be distributed.
+  partitionableLoops.erase(
+      std::remove_if(partitionableLoops.begin(), partitionableLoops.end(),
+                     [&](unsigned loopId) {
+                       return loopId >= tileSizes.size() ||
+                              tileSizes[loopId] == 0;
+                     }),
+      partitionableLoops.end());
   if (auto linalgOp = dyn_cast<linalg::LinalgOp>(*rootOp)) {
     staticLoopRanges = linalgOp.getStaticLoopRanges();
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -428,7 +428,7 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
       workgroupTileSizes[depth] = 0;
     }
   }
-
+  int64_t skipInnerTiling = 0;
   if (auto genericOp = dyn_cast<linalg::GenericOp>(op)) {
     for (auto [index, outputOperand] :
          llvm::enumerate(genericOp.getDpsInitOperands())) {
@@ -462,6 +462,25 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
         vectorSize = 1;
         break;
       }
+      // If the inner dimension is too small to have one element per thread
+      // reduce the workgroup size try to distribute amonst more dimensions.
+      if (shape.back() < vectorSize * workgroupSize[0]) {
+        int64_t flatWG = workgroupSize[0];
+        vectorSize = 1;
+        int64_t id = 0;
+        for (int64_t dim : llvm::reverse(shape)) {
+          if (dim < flatWG) {
+            skipInnerTiling++;
+            workgroupSize[id] = dim;
+          } else {
+            workgroupSize[id] = flatWG;
+            break;
+          }
+          flatWG = flatWG / dim;
+          id++;
+          if (flatWG <= 1 || id >= workgroupSize.size()) break;
+        }
+      }
     }
   }
 
@@ -480,13 +499,24 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
         IREE::Codegen::DispatchLoweringPassPipeline::LLVMGPUVectorize;
   }
 
+  int64_t id = 0;
   // Set the inner most parallel loop to `lowerTs`.
   for (int64_t depth = numLoops; depth > 0; depth--) {
     if (partitionedLoopsSet.count(depth - 1)) {
-      workgroupTileSizes[depth - 1] = workgroupSize[0] * vectorSize;
+      if (skipInnerTiling > 0) {
+        // For dimensions that don't need to be distributed across blocks skip
+        // tiling by setting tile size to 0.
+        workgroupTileSizes[depth - 1] = 0;
+        skipInnerTiling--;
+        id++;
+        if (id >= workgroupSize.size()) break;
+        continue;
+      }
+      workgroupTileSizes[depth - 1] = workgroupSize[id] * vectorSize;
       break;
     }
   }
+
   if (linalgOp) {
     // Tile reduction dimension to 4 to allow doing load4 if the reduction size
     // is the most inner dimension.

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -463,7 +463,7 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
         break;
       }
       // If the inner dimension is too small to have one element per thread
-      // reduce the workgroup size try to distribute amonst more dimensions.
+      // reduce the workgroup size try to distribute amongst more dimensions.
       if (shape.back() < vectorSize * workgroupSize[0]) {
         int64_t flatWG = workgroupSize[0];
         vectorSize = 1;

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -480,6 +480,7 @@ static LogicalResult setRootDefaultConfig(func::FuncOp entryPoint,
           id++;
           if (flatWG <= 1 || id >= workgroupSize.size()) break;
         }
+        break;
       }
     }
   }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -25,6 +25,7 @@ iree_lit_test_suite(
             "create_async_groups.mlir",
             "distribute_to_thread.mlir",
             "distribute_foreach.mlir",
+            "elementwise_pipeline.mlir",
             "gpu_set_num_workgroups.mlir",
             "nvvm_pipeline_test.mlir",
             "nvvm_mma_sync_pipeline_test.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -21,6 +21,7 @@ iree_lit_test_suite(
     "create_async_groups.mlir"
     "distribute_foreach.mlir"
     "distribute_to_thread.mlir"
+    "elementwise_pipeline.mlir"
     "gpu_set_num_workgroups.mlir"
     "illegal_configuration.mlir"
     "legalize.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/elementwise_pipeline.mlir
@@ -1,0 +1,36 @@
+
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))" %s | FileCheck %s
+
+hal.executable @warp_reduction_dispatch {
+hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_35"}> {
+  hal.executable.export public @forward_dispatch_0_generic_320x320x3x3 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [<0, bindings = [<0, storage_buffer, ReadOnly>, <1, storage_buffer>]>]>) {
+  ^bb0(%arg0: !hal.device, %arg1: index, %arg2: index, %arg3: index, %arg4: index):
+    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2, %arg3, %arg4
+    hal.return %x, %y, %z : index, index, index
+  }
+  builtin.module {
+    func.func @forward_dispatch_0_generic_320x320x3x3() {
+      %c0 = arith.constant 0 : index
+      %cst = arith.constant 0.000000e+00 : f32
+      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset(%c0) flags(ReadOnly) : !flow.dispatch.tensor<readonly:tensor<3x320x320x3xf32>>
+      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) alignment(64) offset(%c0) : !flow.dispatch.tensor<writeonly:tensor<320x320x3x3xf32>>
+      %2 = flow.dispatch.tensor.load %0, offsets = [0, 0, 0, 0], sizes = [3, 320, 320, 3], strides = [1, 1, 1, 1] : !flow.dispatch.tensor<readonly:tensor<3x320x320x3xf32>> -> tensor<3x320x320x3xf32>
+      %3 = tensor.empty() : tensor<320x320x3x3xf32>
+      %4 = linalg.generic {indexing_maps = [affine_map<(d0, d1, d2, d3) -> (d2, d1, d0, d3)>, affine_map<(d0, d1, d2, d3) -> (d0, d1, d2, d3)>], iterator_types = ["parallel", "parallel", "parallel", "parallel"]} ins(%2 : tensor<3x320x320x3xf32>) outs(%3 : tensor<320x320x3x3xf32>) {
+      ^bb0(%in: f32, %out: f32):
+        %5 = arith.addf %in, %cst : f32
+        linalg.yield %5 : f32
+      } -> tensor<320x320x3x3xf32>
+      flow.dispatch.tensor.store %4, %1, offsets = [0, 0, 0, 0], sizes = [320, 320, 3, 3], strides = [1, 1, 1, 1] : tensor<320x320x3x3xf32> -> !flow.dispatch.tensor<writeonly:tensor<320x320x3x3xf32>>
+      return
+    }
+  }
+}
+}
+
+// CHECK-LABEL: hal.executable.export public @forward_dispatch_0_generic_320x320x3x3
+//     CHECK:     workgroup_size = [3 : index, 3 : index, 7 : index]}
+// CHECK-DAG:     %[[C46:.+]] = arith.constant 46 : index
+// CHECK-DAG:     %[[C320:.+]] = arith.constant 320 : index
+// CHECK-DAG:     %[[C1:.+]] = arith.constant 1 : index
+//     CHECK:     hal.return %[[C46]], %[[C320]], %[[C1]] : index, index, index


### PR DESCRIPTION
Improve the default kernel configuration for cases where the inner dimensions are smaller than the workgroup size we want to target. Also fix a bug in tile and distribute for loops that are not distributed.