### PR TITLE
Strongly home flag registration statics in C++ files.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/TargetBackend.cpp
@@ -15,6 +15,9 @@
 #include "mlir/IR/Dialect.h"
 #include "mlir/Support/FileUtilities.h"
 
+IREE_DEFINE_COMPILER_OPTION_FLAGS(
+    mlir::iree_compiler::IREE::HAL::TargetOptions);
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {

--- a/compiler/src/iree/compiler/Dialect/VM/Conversion/TargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Conversion/TargetOptions.cpp
@@ -8,6 +8,8 @@
 
 #include "llvm/Support/CommandLine.h"
 
+IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::IREE::VM::TargetOptions);
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {

--- a/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
+++ b/compiler/src/iree/compiler/Dialect/VM/Target/Bytecode/BytecodeModuleTarget.cpp
@@ -39,6 +39,9 @@
 #include "mlir/Transforms/LocationSnapshot.h"
 #include "mlir/Transforms/Passes.h"
 
+IREE_DEFINE_COMPILER_OPTION_FLAGS(
+    mlir::iree_compiler::IREE::VM::BytecodeTargetOptions);
+
 namespace mlir {
 namespace iree_compiler {
 namespace IREE {

--- a/compiler/src/iree/compiler/Pipelines/Options.cpp
+++ b/compiler/src/iree/compiler/Pipelines/Options.cpp
@@ -6,6 +6,13 @@
 
 #include "iree/compiler/Pipelines/Options.h"
 
+IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::BindingOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::InputDialectOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(
+    mlir::iree_compiler::HighLevelOptimizationOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::SchedulingOptions);
+IREE_DEFINE_COMPILER_OPTION_FLAGS(mlir::iree_compiler::PreprocessingOptions);
+
 namespace mlir {
 namespace iree_compiler {
 


### PR DESCRIPTION
The way this was, the statics were getting visibility restricted due to being inline in headers and an interplay of esoteric rules. Strongly homing such things in cc files is the gold standard, so do that. This fixes some lingering flag registration issues in shared library builds.