### PR TITLE
Rework `cpu.c` to make room for x86 path

### DIFF
--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -23,7 +23,7 @@
 #if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
 
 // For now as we only need ISA feature bits and no CPU identification beyond
-// that, and as we are OK with requring a sufficiently recent linux kernel to
+// that, and as we are OK with requiring a sufficiently recent linux kernel to
 // expose the features that we need, we can just rely on the basic HWCAP way.
 #include <sys/auxv.h>
 
@@ -35,8 +35,8 @@
 
 static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
                                               uint64_t* out_fields) {
-  uint32_t auvx_HWCAP = getauxval(AT_HWCAP);
-  uint32_t auvx_HWCAP2 = getauxval(AT_HWCAP2);
+  uint32_t hwcap = getauxval(AT_HWCAP);
+  uint32_t hwcap2 = getauxval(AT_HWCAP2);
   if (hwcap & IREE_HWCAP_ASIMDDP)
     out_fields[0] |= IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD;
   if (hwcap2 & IREE_HWCAP2_I8MM)

--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -74,6 +74,13 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
 
 #endif  // IREE_PLATFORM_*
 
+#else  // defined(IREE_ARCH_ARM_64)
+
+static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
+                                              uint64_t* out_fields) {
+  // No implementation available. CPU data will be all zeros.
+}
+
 #endif  // defined(IREE_ARCH_ARM_64)
 
 //===----------------------------------------------------------------------===//

--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -33,8 +33,7 @@
 #define IREE_HWCAP_ASIMDDP (1u << 20)
 #define IREE_HWCAP2_I8MM (1u << 13)
 
-static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
-                                              uint64_t* out_fields) {
+static void iree_cpu_initialize_from_platform_arm_64(uint64_t* out_fields) {
   uint32_t hwcap = getauxval(AT_HWCAP);
   uint32_t hwcap2 = getauxval(AT_HWCAP2);
   if (hwcap & IREE_HWCAP_ASIMDDP)
@@ -57,8 +56,7 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
     }                                                             \
   } while (0)
 
-static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
-                                              uint64_t* out_fields) {
+static void iree_cpu_initialize_from_platform_arm_64(uint64_t* out_fields) {
   IREE_QUERY_SYSCTL("hw.optional.arm.FEAT_DotProd", out_fields[0],
                     IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD);
   IREE_QUERY_SYSCTL("hw.optional.arm.FEAT_I8MM", out_fields[0],
@@ -67,21 +65,23 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
 
 #else
 
-static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
-                                              uint64_t* out_fields) {
+static void iree_cpu_initialize_from_platform_arm_64(uint64_t* out_fields) {
   // No implementation available. CPU data will be all zeros.
 }
 
 #endif  // IREE_PLATFORM_*
 
-#else  // defined(IREE_ARCH_ARM_64)
+#endif  // defined(IREE_ARCH_ARM_64)
 
 static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
                                               uint64_t* out_fields) {
+#if defined(IREE_ARCH_ARM_64)
+  (void)temp_allocator;  // unused on ARM_64
+  iree_cpu_initialize_from_platform_arm_64(out_fields);
+#else
   // No implementation available. CPU data will be all zeros.
+#endif
 }
-
-#endif  // defined(IREE_ARCH_ARM_64)
 
 //===----------------------------------------------------------------------===//
 // Architecture-specific string lookup

--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -40,8 +40,9 @@ static void iree_cpu_initialize_from_platform_arm_64(uint64_t* out_fields) {
   uint32_t hwcap = getauxval(AT_HWCAP);
   uint32_t hwcap2 = getauxval(AT_HWCAP2);
   uint64_t out0 = 0;
-  iree_copy_bits(out0, IREE_CPU_DATA0_ARM_DOTPROD, hwcap, IREE_HWCAP_ASIMDDP);
-  iree_copy_bits(out0, IREE_CPU_DATA0_ARM_I8MM, hwcap2, IREE_HWCAP2_I8MM);
+  iree_copy_bits(out0, IREE_CPU_DATA0_ARM_64_DOTPROD, hwcap,
+                 IREE_HWCAP_ASIMDDP);
+  iree_copy_bits(out0, IREE_CPU_DATA0_ARM_64_I8MM, hwcap2, IREE_HWCAP2_I8MM);
   out_fields[0] = out0;
 }
 
@@ -61,9 +62,9 @@ static void iree_cpu_initialize_from_platform_arm_64(uint64_t* out_fields) {
 
 static void iree_cpu_initialize_from_platform_arm_64(uint64_t* out_fields) {
   IREE_QUERY_SYSCTL("hw.optional.arm.FEAT_DotProd", out_fields[0],
-                    IREE_CPU_DATA0_ARM_DOTPROD);
+                    IREE_CPU_DATA0_ARM_64_DOTPROD);
   IREE_QUERY_SYSCTL("hw.optional.arm.FEAT_I8MM", out_fields[0],
-                    IREE_CPU_DATA0_ARM_I8MM);
+                    IREE_CPU_DATA0_ARM_64_I8MM);
 }
 
 #else
@@ -100,8 +101,8 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
 static bool iree_cpu_lookup_data_by_key_for_arch(
     const uint64_t* fields, iree_string_view_t key,
     int64_t* IREE_RESTRICT out_value) {
-  IREE_TEST_FIELD_BIT("dotprod", fields[0], IREE_CPU_DATA0_ARM_DOTPROD);
-  IREE_TEST_FIELD_BIT("i8mm", fields[0], IREE_CPU_DATA0_ARM_I8MM);
+  IREE_TEST_FIELD_BIT("dotprod", fields[0], IREE_CPU_DATA0_ARM_64_DOTPROD);
+  IREE_TEST_FIELD_BIT("i8mm", fields[0], IREE_CPU_DATA0_ARM_64_I8MM);
   return false;
 }
 

--- a/runtime/src/iree/base/internal/cpu.c
+++ b/runtime/src/iree/base/internal/cpu.c
@@ -16,48 +16,31 @@
 // Platform-specific processor data queries
 //===----------------------------------------------------------------------===//
 
+#if defined(IREE_ARCH_ARM_64)
+// On ARM, CPU feature info is not directly accessible to userspace (EL0). The
+// OS needs to be involved one way or another.
+
 #if defined(IREE_PLATFORM_ANDROID) || defined(IREE_PLATFORM_LINUX)
+
+// For now as we only need ISA feature bits and no CPU identification beyond
+// that, and as we are OK with requring a sufficiently recent linux kernel to
+// expose the features that we need, we can just rely on the basic HWCAP way.
+#include <sys/auxv.h>
 
 // NOTE: not all kernel versions have all of the cap bits we need defined so as
 // a practice we always define the feature bits we need locally.
-#include <sys/auxv.h>
-
-// OR's |field_bit| into |field_value| if |hwcap_bit| is set in |hwcap_value|.
-#define IREE_SET_IF_HWCAP(hwcap_value, hwcap_bit, field_value, field_bit) \
-  if (iree_all_bits_set(hwcap_value, hwcap_bit)) (field_value) |= (field_bit)
-
-#if defined(IREE_ARCH_ARM_64)
-
-// TODO: support the code in iree/tooling/cpu_features.c that checks to see if
-// HWCAP_CPUID is available and directly queries the architectural registers.
-// We'll still need the fallback to HWCAP checks but it would allow us to
-// detect features even on kernel versions that don't yet understand them.
-
 // https://docs.kernel.org/arm64/elf_hwcaps.html
-#define IREE_HWCAP_ASIMDDP (1 << 20)
-#define IREE_HWCAP2_I8MM (1 << 13)
-static void iree_cpu_query_data_arch_hwcaps(uint32_t hwcap, uint32_t hwcap2,
-                                            uint64_t* out_fields) {
-  IREE_SET_IF_HWCAP(hwcap, IREE_HWCAP_ASIMDDP, out_fields[0],
-                    IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD);
-  IREE_SET_IF_HWCAP(hwcap2, IREE_HWCAP2_I8MM, out_fields[0],
-                    IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM);
-}
-
-#else
-static void iree_cpu_query_data_arch_hwcaps(uint32_t hwcap, uint32_t hwcap2,
-                                            uint64_t* out_fields) {
-  // Not supported on this arch.
-}
-#endif  // IREE_ARCH_*
-
-#undef IREE_SET_IF_HWCAP
+#define IREE_HWCAP_ASIMDDP (1u << 20)
+#define IREE_HWCAP2_I8MM (1u << 13)
 
 static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
                                               uint64_t* out_fields) {
-  uint32_t hwcap = getauxval(AT_HWCAP);
-  uint32_t hwcap2 = getauxval(AT_HWCAP2);
-  iree_cpu_query_data_arch_hwcaps(hwcap, hwcap2, out_fields);
+  uint32_t auvx_HWCAP = getauxval(AT_HWCAP);
+  uint32_t auvx_HWCAP2 = getauxval(AT_HWCAP2);
+  if (hwcap & IREE_HWCAP_ASIMDDP)
+    out_fields[0] |= IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD;
+  if (hwcap2 & IREE_HWCAP2_I8MM)
+    out_fields[0] |= IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM;
 }
 
 #elif defined(IREE_PLATFORM_MACOS) || defined(IREE_PLATFORM_IOS)
@@ -76,12 +59,10 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
 
 static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
                                               uint64_t* out_fields) {
-#if defined(IREE_ARCH_ARM_64)
   IREE_QUERY_SYSCTL("hw.optional.arm.FEAT_DotProd", out_fields[0],
                     IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD);
   IREE_QUERY_SYSCTL("hw.optional.arm.FEAT_I8MM", out_fields[0],
                     IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM);
-#endif
 }
 
 #else
@@ -92,6 +73,8 @@ static void iree_cpu_initialize_from_platform(iree_allocator_t temp_allocator,
 }
 
 #endif  // IREE_PLATFORM_*
+
+#endif  // defined(IREE_ARCH_ARM_64)
 
 //===----------------------------------------------------------------------===//
 // Architecture-specific string lookup

--- a/runtime/src/iree/base/internal/cpu.h
+++ b/runtime/src/iree/base/internal/cpu.h
@@ -40,7 +40,7 @@ const uint64_t* iree_cpu_data_fields(void);
 //
 // Common usage:
 // if (iree_all_bits_set(iree_cpu_data_field(0),
-//                       IREE_CPU_DATA0_ARM_DOTPROD)) {
+//                       IREE_CPU_DATA0_ARM_64_DOTPROD)) {
 //   // Bit is set and known true.
 // } else {
 //   // Bit is unset but _may_ be true (CPU data not available, etc).

--- a/runtime/src/iree/base/internal/cpu.h
+++ b/runtime/src/iree/base/internal/cpu.h
@@ -40,7 +40,7 @@ const uint64_t* iree_cpu_data_fields(void);
 //
 // Common usage:
 // if (iree_all_bits_set(iree_cpu_data_field(0),
-//                       IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD)) {
+//                       IREE_CPU_DATA0_ARM_DOTPROD)) {
 //   // Bit is set and known true.
 // } else {
 //   // Bit is unset but _may_ be true (CPU data not available, etc).

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -18,7 +18,7 @@ static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_arm_64_i8i8i32_8x8x8(
     const iree_uk_mmt4d_params_t* params) {
 #ifdef IREE_UK_BUILD_ARM_64_I8MM
-  if (params->cpu_data[0] & IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_I8MM) {
     return iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm;
   }
 #else
@@ -31,7 +31,7 @@ static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_arm_64_i8i8i32_8x8x4(
     const iree_uk_mmt4d_params_t* params) {
 #ifdef IREE_UK_BUILD_ARM_64_DOTPROD
-  if (params->cpu_data[0] & IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_DOTPROD) {
     return iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod;
   }
 #else

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/mmt4d_arm_64.c
@@ -18,7 +18,7 @@ static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_arm_64_i8i8i32_8x8x8(
     const iree_uk_mmt4d_params_t* params) {
 #ifdef IREE_UK_BUILD_ARM_64_I8MM
-  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_I8MM) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_64_I8MM) {
     return iree_uk_mmt4d_tile_i8i8i32_8x8x8_arm_64_i8mm;
   }
 #else
@@ -31,7 +31,7 @@ static iree_uk_mmt4d_tile_func_t
 iree_uk_mmt4d_select_tile_func_arm_64_i8i8i32_8x8x4(
     const iree_uk_mmt4d_params_t* params) {
 #ifdef IREE_UK_BUILD_ARM_64_DOTPROD
-  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_DOTPROD) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_64_DOTPROD) {
     return iree_uk_mmt4d_tile_i8i8i32_8x8x4_arm_64_dotprod;
   }
 #else

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/query_tile_sizes_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/query_tile_sizes_arm_64.c
@@ -19,12 +19,12 @@ static iree_uk_matmul_tile_sizes_t
 iree_uk_query_matmul_tile_sizes_arm_64_i8i8i32(
     const iree_uk_query_tile_sizes_2d_params_t* params) {
 #ifdef IREE_UK_BUILD_ARM_64_I8MM
-  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_I8MM) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_64_I8MM) {
     return (iree_uk_matmul_tile_sizes_t){.M = 8, .K = 8, .N = 8};
   }
 #endif
 #ifdef IREE_UK_BUILD_ARM_64_DOTPROD
-  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_DOTPROD) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_64_DOTPROD) {
     return (iree_uk_matmul_tile_sizes_t){.M = 8, .K = 4, .N = 8};
   }
 #endif

--- a/runtime/src/iree/builtins/ukernel/arch/arm_64/query_tile_sizes_arm_64.c
+++ b/runtime/src/iree/builtins/ukernel/arch/arm_64/query_tile_sizes_arm_64.c
@@ -19,12 +19,12 @@ static iree_uk_matmul_tile_sizes_t
 iree_uk_query_matmul_tile_sizes_arm_64_i8i8i32(
     const iree_uk_query_tile_sizes_2d_params_t* params) {
 #ifdef IREE_UK_BUILD_ARM_64_I8MM
-  if (params->cpu_data[0] & IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_I8MM) {
     return (iree_uk_matmul_tile_sizes_t){.M = 8, .K = 8, .N = 8};
   }
 #endif
 #ifdef IREE_UK_BUILD_ARM_64_DOTPROD
-  if (params->cpu_data[0] & IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD) {
+  if (params->cpu_data[0] & IREE_CPU_DATA0_ARM_DOTPROD) {
     return (iree_uk_matmul_tile_sizes_t){.M = 8, .K = 4, .N = 8};
   }
 #endif

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -151,7 +151,7 @@ static void iree_mmt4d_benchmark_register(
 #define MMT4D_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(_type, _m0, _n0, _k0, \
                                                          _cpu_feature)         \
   MMT4D_BENCHMARK_REGISTER(_type, _m0, _n0, _k0,                               \
-                           IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_##_cpu_feature,  \
+                           IREE_CPU_DATA0_ARM_##_cpu_feature,                  \
                            arm_64_##_cpu_feature)
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_benchmark.c
@@ -151,7 +151,7 @@ static void iree_mmt4d_benchmark_register(
 #define MMT4D_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(_type, _m0, _n0, _k0, \
                                                          _cpu_feature)         \
   MMT4D_BENCHMARK_REGISTER(_type, _m0, _n0, _k0,                               \
-                           IREE_CPU_DATA0_ARM_##_cpu_feature,                  \
+                           IREE_CPU_DATA0_ARM_64_##_cpu_feature,               \
                            arm_64_##_cpu_feature)
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
@@ -313,7 +313,8 @@ MMT4D_TEST(i8i8i32, 9, 6, 3, generic, 0)
   MMT4D_TEST(type, M0, N0, K0, arm_64, 0)
 
 #define MMT4D_ARM_64_TEST_WITH_CPU_FEATURE(type, M0, N0, K0, FEATURE) \
-  MMT4D_TEST(type, M0, N0, K0, arm_64_##FEATURE, IREE_CPU_DATA0_ARM_##FEATURE)
+  MMT4D_TEST(type, M0, N0, K0, arm_64_##FEATURE,                      \
+             IREE_CPU_DATA0_ARM_64_##FEATURE)
 
 MMT4D_ARM_64_TEST(f32f32f32, 8, 8, 1)
 MMT4D_ARM_64_TEST(i8i8i32, 8, 8, 1)

--- a/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/mmt4d_test.cc
@@ -313,8 +313,7 @@ MMT4D_TEST(i8i8i32, 9, 6, 3, generic, 0)
   MMT4D_TEST(type, M0, N0, K0, arm_64, 0)
 
 #define MMT4D_ARM_64_TEST_WITH_CPU_FEATURE(type, M0, N0, K0, FEATURE) \
-  MMT4D_TEST(type, M0, N0, K0, arm_64_##FEATURE,                      \
-             IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_##FEATURE)
+  MMT4D_TEST(type, M0, N0, K0, arm_64_##FEATURE, IREE_CPU_DATA0_ARM_##FEATURE)
 
 MMT4D_ARM_64_TEST(f32f32f32, 8, 8, 1)
 MMT4D_ARM_64_TEST(i8i8i32, 8, 8, 1)

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -214,7 +214,7 @@ static void iree_pack_benchmark_register(
 #define PACK_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(_type, _size2, _size3, \
                                                         _cpu_feature)          \
   PACK_BENCHMARK_REGISTER(_type, _size2, _size3,                               \
-                          IREE_CPU_DATA0_ARM_##_cpu_feature,                   \
+                          IREE_CPU_DATA0_ARM_64_##_cpu_feature,                \
                           arm_64_##_cpu_feature)
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_benchmark.c
@@ -214,7 +214,7 @@ static void iree_pack_benchmark_register(
 #define PACK_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(_type, _size2, _size3, \
                                                         _cpu_feature)          \
   PACK_BENCHMARK_REGISTER(_type, _size2, _size3,                               \
-                          IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_##_cpu_feature,   \
+                          IREE_CPU_DATA0_ARM_##_cpu_feature,                   \
                           arm_64_##_cpu_feature)
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
@@ -265,7 +265,7 @@ PACK_TEST(i8i8, 8, 8, generic, 0)
 #define PACK_ARM_64_TEST_WITH_CPU_FEATURE(type, tile_size0, tile_size1, \
                                           FEATURE)                      \
   PACK_TEST(type, tile_size0, tile_size1, arm_64_##FEATURE,             \
-            IREE_CPU_DATA0_ARM_##FEATURE)
+            IREE_CPU_DATA0_ARM_64_##FEATURE)
 
 PACK_ARM_64_TEST(f32f32, 8, 1)
 PACK_ARM_64_TEST(f32f32, 8, 8)

--- a/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/pack_test.cc
@@ -265,7 +265,7 @@ PACK_TEST(i8i8, 8, 8, generic, 0)
 #define PACK_ARM_64_TEST_WITH_CPU_FEATURE(type, tile_size0, tile_size1, \
                                           FEATURE)                      \
   PACK_TEST(type, tile_size0, tile_size1, arm_64_##FEATURE,             \
-            IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_##FEATURE)
+            IREE_CPU_DATA0_ARM_##FEATURE)
 
 PACK_ARM_64_TEST(f32f32, 8, 1)
 PACK_ARM_64_TEST(f32f32, 8, 8)

--- a/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
@@ -184,10 +184,10 @@ int iree_uk_test_cpu_features_str(char* buf, int buf_length,
     return snprintf(buf, buf_length, "(none)");
   }
 #if defined(IREE_UK_ARCH_ARM_64)
-  if (cpu_data[0] & IREE_CPU_DATA0_ARM_I8MM) {
+  if (cpu_data[0] & IREE_CPU_DATA0_ARM_64_I8MM) {
     return snprintf(buf, buf_length, "i8mm");
   }
-  if (cpu_data[0] & IREE_CPU_DATA0_ARM_DOTPROD) {
+  if (cpu_data[0] & IREE_CPU_DATA0_ARM_64_DOTPROD) {
     return snprintf(buf, buf_length, "dotprod");
   }
 #endif  // defined(IREE_UK_ARCH_ARM_64)

--- a/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
+++ b/runtime/src/iree/builtins/ukernel/tools/ukernel_test_utils.cc
@@ -184,10 +184,10 @@ int iree_uk_test_cpu_features_str(char* buf, int buf_length,
     return snprintf(buf, buf_length, "(none)");
   }
 #if defined(IREE_UK_ARCH_ARM_64)
-  if (cpu_data[0] & IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM) {
+  if (cpu_data[0] & IREE_CPU_DATA0_ARM_I8MM) {
     return snprintf(buf, buf_length, "i8mm");
   }
-  if (cpu_data[0] & IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD) {
+  if (cpu_data[0] & IREE_CPU_DATA0_ARM_DOTPROD) {
     return snprintf(buf, buf_length, "dotprod");
   }
 #endif  // defined(IREE_UK_ARCH_ARM_64)

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -207,10 +207,10 @@ static void iree_unpack_benchmark_register(
 #define UNPACK_BENCHMARK_REGISTER_ARM_64(_type, _size2, _size3) \
   UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3, 0, arm_64)
 
-#define UNPACK_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(                     \
-    _type, _size2, _size3, _cpu_feature)                                       \
-  UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3,                             \
-                            IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_##_cpu_feature, \
+#define UNPACK_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(     \
+    _type, _size2, _size3, _cpu_feature)                       \
+  UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3,             \
+                            IREE_CPU_DATA0_ARM_##_cpu_feature, \
                             arm_64_##_cpu_feature)
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
+++ b/runtime/src/iree/builtins/ukernel/tools/unpack_benchmark.c
@@ -207,10 +207,10 @@ static void iree_unpack_benchmark_register(
 #define UNPACK_BENCHMARK_REGISTER_ARM_64(_type, _size2, _size3) \
   UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3, 0, arm_64)
 
-#define UNPACK_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(     \
-    _type, _size2, _size3, _cpu_feature)                       \
-  UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3,             \
-                            IREE_CPU_DATA0_ARM_##_cpu_feature, \
+#define UNPACK_BENCHMARK_REGISTER_ARM_64_WITH_CPU_FEATURE(        \
+    _type, _size2, _size3, _cpu_feature)                          \
+  UNPACK_BENCHMARK_REGISTER(_type, _size2, _size3,                \
+                            IREE_CPU_DATA0_ARM_64_##_cpu_feature, \
                             arm_64_##_cpu_feature)
 
 int main(int argc, char** argv) {

--- a/runtime/src/iree/schemas/cpu_data.h
+++ b/runtime/src/iree/schemas/cpu_data.h
@@ -21,9 +21,7 @@
 // will ever be used in a compiled binary from another architecture. This
 // allows us to simplify this interface as we can't for example load the same
 // executable library for both aarch64 on riscv32 and don't need to normalize
-// any of the fields across them both. However, we may choose to share constants
-// among some closely related architectures, e.g. 32bit/64bit variants of x86 or
-// ARM, just for convenience, shrinking some boilerplate code, etc.
+// any of the fields across them both.
 //
 // As the values of the fields are encoded in generated binaries their meaning
 // here cannot change once deployed: only new meaning for unused bits can be
@@ -73,8 +71,8 @@ enum iree_cpu_data_field_0_e {
   // bits for some families/eras. If we just start out with bits 0 and 1
   // allocated for dotprod and i8mm, we are quickly going to have a hard-to-read
   // enumeration here.
-  IREE_CPU_DATA0_ARM_DOTPROD = 1ull << 0,
-  IREE_CPU_DATA0_ARM_I8MM = 1ull << 1,
+  IREE_CPU_DATA0_ARM_64_DOTPROD = 1ull << 0,
+  IREE_CPU_DATA0_ARM_64_I8MM = 1ull << 1,
 
 };
 

--- a/runtime/src/iree/schemas/cpu_data.h
+++ b/runtime/src/iree/schemas/cpu_data.h
@@ -21,7 +21,9 @@
 // will ever be used in a compiled binary from another architecture. This
 // allows us to simplify this interface as we can't for example load the same
 // executable library for both aarch64 on riscv32 and don't need to normalize
-// any of the fields across them both.
+// any of the fields across them both. However, we may choose to share constants
+// among some closely related architectures, e.g. 32bit/64bit variants of x86 or
+// ARM, just for convenience, shrinking some boilerplate code, etc.
 //
 // As the values of the fields are encoded in generated binaries their meaning
 // here cannot change once deployed: only new meaning for unused bits can be
@@ -29,6 +31,17 @@
 // Since IREE executables can run on many architectures and operating systems we
 // also cannot directly expose the architecture-specific registers as not all
 // environments and access-levels can query them.
+//
+// On a best-effort basis, we try to pack the most commonly used values in data
+// field 0, and we try to have some consistency in the bit allocation: ideally,
+// ISA extensions that are either closely related or from the same era should
+// occupy bits close to each other, if only so that the bit values enumedated
+// below from lowest to highest bits are easier to read (e.g. look up at a
+// glance which AVX512 features we already have bits for). Inevitably, the
+// aforementioned requirement that bits are set in stone, will force us away
+// from that at times. To strike a decent compromise, we typically try to
+// reserve some range of bits for families or eras of ISA extensions, but don't
+// overthink it.
 //
 // This is similar in functionality to getauxval(AT_HWCAP*) in linux but
 // platform-independent and with additional fields and values that may not yet
@@ -53,25 +66,15 @@
 enum iree_cpu_data_field_0_e {
 
   //===--------------------------------------------------------------------===//
-  // IREE_ARCH_ARM_64 / aarch64
+  // IREE_ARCH_ARM_32 | IREE_ARCH_ARM_64
   //===--------------------------------------------------------------------===//
 
-  // Indicates support for Dot Product instructions.
-  //
-  // UDOT and SDOT instructions implemented.
-  //
-  // Source: ID_AA64ISAR0_EL1.DP [47:44] == 0b0001 / HWCAP_ASIMDDP
-  // Canonical key: "dotprod"
-  IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_DOTPROD = 1ull << 0,
-
-  // Indicates support for Advanced SIMD and Floating-point Int8 matrix
-  // multiplication instructions.
-  //
-  // SMMLA, SUDOT, UMMLA, USMMLA, and USDOT instructions are implemented.
-  //
-  // Source: ID_AA64ISAR1_EL1.I8MM [55:52] == 0b0001 / HWCAP2_I8MM
-  // Canonical key: "i8mm"
-  IREE_CPU_DATA_FIELD_0_AARCH64_HAVE_I8MM = 1ull << 1,
+  // TODO: add several common ARM ISA extensions and allocate some ranges of
+  // bits for some families/eras. If we just start out with bits 0 and 1
+  // allocated for dotprod and i8mm, we are quickly going to have a hard-to-read
+  // enumeration here.
+  IREE_CPU_DATA0_ARM_DOTPROD = 1ull << 0,
+  IREE_CPU_DATA0_ARM_I8MM = 1ull << 1,
 
 };
 

--- a/runtime/src/iree/schemas/cpu_data.h
+++ b/runtime/src/iree/schemas/cpu_data.h
@@ -64,7 +64,7 @@
 enum iree_cpu_data_field_0_e {
 
   //===--------------------------------------------------------------------===//
-  // IREE_ARCH_ARM_32 | IREE_ARCH_ARM_64
+  // IREE_ARCH_ARM_64 / aarch64
   //===--------------------------------------------------------------------===//
 
   // TODO: add several common ARM ISA extensions and allocate some ranges of


### PR DESCRIPTION
The main change is to switch the nesting of the `#if`'s. This used to be first `#if` on platform/OS, then `#if` on CPU architecture.  But actually the fact that the platform/OS needs to be involved is a ARM-ism; it is the CPU architecture that drives the higher level approach. And structuring the code this way makes it possible to later split it into separate files for each architecture (not doing it for now because this opens questions of what we do with the Bazel+CMake build system, so deferring that until there's a concrete need).

And even for the existing code, having the `#if` on CPU architecture at the top results in simplification as a couple of platform/OS-centric functions don't need a fallback anymore now that they only exist within a CPU-architecture-specific section.

Also flattened some helpers, IMO making code more readable.

Also renamed cpu_data identifiers to be shorter.