### PR TITLE
Use Release mode for GCC CI Build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -707,6 +707,7 @@ jobs:
           ./build_tools/github_actions/docker_run.sh \
             --env CC=/usr/bin/gcc-9 \
             --env CXX=/usr/bin/g++-9 \
+            --env CMAKE_BUILD_TYPE=Release \
             --env "IREE_TARGET_BACKEND_WEBGPU=OFF" \
             --env "IREE_CCACHE_GCP_TOKEN=$(gcloud auth application-default print-access-token)" \
             --env "IREE_WRITE_REMOTE_CCACHE=${IREE_WRITE_REMOTE_CCACHE}" \


### PR DESCRIPTION
The GCC build directory is getting huge and we never run tests with it
(since this is an ancillary build to ensure this compiler configuration
works). It's gotten so big that we're running out of disk (really tmpfs)
space on the CI runners. From my local testing, this cuts the disk usage
for the build directory after build_all.sh from ~100GB to ~4GB.
