### PR TITLE
Avoid pinning cmake / ninja in pyproject.toml

### DIFF
--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -4,8 +4,8 @@ requires = [
     "wheel",
     # There is no fundamental reason to pin this CMake version, beyond
     # build stability.
-    "cmake==3.22.2",
-    "ninja==1.10.2",
+    "cmake",
+    "ninja",
     # MLIR build depends.
     "numpy",
     "packaging",

--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -2,8 +2,6 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    # There is no fundamental reason to pin this CMake version, beyond
-    # build stability.
     "cmake",
     "ninja",
     # MLIR build depends.

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -2,10 +2,8 @@
 requires = [
     "setuptools>=42",
     "wheel",
-    # There is no fundamental reason to pin this CMake version, beyond
-    # build stability.
-    "cmake==3.22.2",
-    "ninja==1.10.2",
+    "cmake",
+    "ninja",
     "packaging",
     "pybind11>=2.10.1",
     "PyYAML",


### PR DESCRIPTION
Platforms such as Apple M1 may not have those specific versions available. In general we should be able to build with a recent CMake / Ninja. 