### PR TITLE
Drop setting CMAKE_OSX_ARCHITECTURES

### DIFF
--- a/build_tools/python_deploy/build_macos_packages.sh
+++ b/build_tools/python_deploy/build_macos_packages.sh
@@ -29,7 +29,6 @@ packages="${packages:-iree-runtime iree-runtime-instrumented iree-compiler}"
 # Note that this typically is selected to match the version that the official
 # Python distributed is built at.
 export MACOSX_DEPLOYMENT_TARGET=11.0
-export CMAKE_OSX_ARCHITECTURES="arm64;x86_64"
 
 # cpuinfo is incompatible with universal builds.
 export IREE_ENABLE_CPUINFO=OFF


### PR DESCRIPTION
Since we want to move to native M1 mac builders drop trying to build x86 on M1 machines. This will default to whatever arch we build on.