### PR TITLE
Replace some instances of github-runner with gh-runner

### DIFF
--- a/build_tools/github_actions/runner/gcp/create_instance_group.sh
+++ b/build_tools/github_actions/runner/gcp/create_instance_group.sh
@@ -20,7 +20,8 @@ ZONES="${ZONES:-us-west1-a,us-west1-b,us-west1-c}"
 AUTOSCALING="${AUTOSCALING:-1}"
 GROUP="${GROUP:-presubmit}"
 TYPE="${TYPE:-cpu}"
-MIG_NAME_PREFIX="${MIG_NAME_PREFIX:-github-runner}"
+MIG_NAME_PREFIX="${MIG_NAME_PREFIX:-gh-runner}"
+TEMPLATE_NAME_PREFIX="${TEMPLATE_NAME_PREFIX:-gh-runner}"
 DRY_RUN="${DRY_RUN:-0}"
 
 # For GPU groups, these should both be set to the target group size, as
@@ -44,7 +45,7 @@ function create_mig() {
     mig_name+="-testing"
   fi
   mig_name+="-${runner_group}-${type}-${REGION}"
-  template="github-runner-${runner_group}-${type}-${VERSION}"
+  template="${TEMPLATE_NAME_PREFIX}-${runner_group}-${type}-${VERSION}"
 
   local -a create_cmd=(
     gcloud beta compute instance-groups managed create

--- a/build_tools/github_actions/runner/gcp/create_templates.sh
+++ b/build_tools/github_actions/runner/gcp/create_templates.sh
@@ -27,7 +27,7 @@ GITHUB_RUNNER_SCOPE="${GITHUB_RUNNER_SCOPE:-openxla}"
 
 TEMPLATE_CONFIG_REPO="${TEMPLATE_CONFIG_REPO:-${PROD_TEMPLATE_CONFIG_REPO}}"
 TEMPLATE_CONFIG_REF="${TEMPLATE_CONFIG_REF:-$(git rev-parse HEAD)}"
-TEMPLATE_NAME_PREFIX="${TEMPLATE_NAME_PREFIX:-github-runner}"
+TEMPLATE_NAME_PREFIX="${TEMPLATE_NAME_PREFIX:-gh-runner}"
 
 if (( TESTING==0 )) && ! git merge-base --is-ancestor "${TEMPLATE_CONFIG_REF}" main; then
   echo "Creating testing template because TEMPLATE_CONFIG_REF='${TEMPLATE_CONFIG_REF}' is not on the main branch" >&2

--- a/build_tools/github_actions/runner/gcp/remove_idle_runners.sh
+++ b/build_tools/github_actions/runner/gcp/remove_idle_runners.sh
@@ -23,7 +23,7 @@ REGION="$3"
 # the number of runners removed at a time.
 COUNT="${4:--0}"
 
-MIG="github-runner-${GROUP}-${TYPE}-${REGION}"
+MIG="gh-runner-${GROUP}-${TYPE}-${REGION}"
 
 function remove_idle_runners() {
   local -a to_delete=($(gh api --paginate -H "Accept: application/vnd.github+json" \

--- a/build_tools/github_actions/runner/gcp/remove_stuck_runners.sh
+++ b/build_tools/github_actions/runner/gcp/remove_stuck_runners.sh
@@ -25,7 +25,7 @@ REGION="$3"
 # the number of runners removed at a time.
 COUNT="${4:--0}"
 
-MIG="github-runner-${GROUP}-${TYPE}-${REGION}"
+MIG="gh-runner-${GROUP}-${TYPE}-${REGION}"
 
 
 # Give VMs 5 minutes to startup and register with GitHub. This is pretty generous

--- a/build_tools/github_actions/runner/gcp/update_instance_groups.py
+++ b/build_tools/github_actions/runner/gcp/update_instance_groups.py
@@ -311,7 +311,7 @@ def parse_args():
   # These shouldn't be set very often, but it's just as easy to make them flags
   # as it is to make them global constants.
   subparser_base.add_argument("--name-prefix",
-                              default="github-runner",
+                              default="gh-runner",
                               help="The first part of MIG and template names.")
   subparser_base.add_argument(
       "--base-version-name",

--- a/build_tools/github_actions/runner/instance_deleter/main.py
+++ b/build_tools/github_actions/runner/instance_deleter/main.py
@@ -34,7 +34,7 @@ own docker container. For local development:
 You'll need to get a token that corresponds to an actual instance though or
 you'll get an error:
 
-  gcloud compute ssh github-runner-testing-presubmit-cpu-us-west1-h58j \
+  gcloud compute ssh gh-runner-testing-presubmit-cpu-us-west1-h58j \
     --user-output-enabled=false \
     --command "curl -sSfL \
         -H 'Metadata-Flavor: Google' \
@@ -54,7 +54,7 @@ To deploy:
     --service-account=managed-instance-deleter@iree-oss.iam.gserviceaccount.com \
     --ingress-settings=internal-only \
     --timeout=120s \
-    --set-env-vars ALLOWED_MIG_PATTERN='github-runner-.*'
+    --set-env-vars ALLOWED_MIG_PATTERN='gh-runner-.*'
 
 
 See https://cloud.google.com/functions/docs for more details.


### PR DESCRIPTION
I switched to this shorter naming scheme when we made the switch to the
OpenXLA GitHub org (because I needed different names anyway). This
updates the defaults to match the currently running MIGs.

Part of https://github.com/openxla/iree/issues/12102