### PR TITLE
[vulkan][spirv] Disable `reverse` tests failing on Pixel 6

### DIFF
--- a/tests/e2e/linalg_ext_ops/BUILD
+++ b/tests/e2e/linalg_ext_ops/BUILD
@@ -144,7 +144,6 @@ iree_check_single_backend_test_suite(
     srcs = enforce_glob(
         # keep sorted
         [
-            "reverse.mlir",
             "scatter.mlir",
             # Top-k test disabled due to miscompile on vulkan.
             #    "top-k.mlir",
@@ -154,6 +153,7 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
+            "reverse.mlir", #TODO(#12415): disabled due to miscompilation on Pixel 6.
             # TODO(antiagainst): scan fails on Adreno GPUs due to driver bug.
             # Re-enable this once we have new devices with up-to-date drivers.
             "top-k.mlir",

--- a/tests/e2e/linalg_ext_ops/BUILD
+++ b/tests/e2e/linalg_ext_ops/BUILD
@@ -153,7 +153,7 @@ iree_check_single_backend_test_suite(
         ],
         include = ["*.mlir"],
         exclude = [
-            "reverse.mlir", #TODO(#12415): disabled due to miscompilation on Pixel 6.
+            "reverse.mlir",  #TODO(#12415): disabled due to miscompilation on Pixel 6.
             # TODO(antiagainst): scan fails on Adreno GPUs due to driver bug.
             # Re-enable this once we have new devices with up-to-date drivers.
             "top-k.mlir",

--- a/tests/e2e/linalg_ext_ops/CMakeLists.txt
+++ b/tests/e2e/linalg_ext_ops/CMakeLists.txt
@@ -114,7 +114,6 @@ iree_check_single_backend_test_suite(
   NAME
     check_vulkan-spirv_vulkan
   SRCS
-    "reverse.mlir"
     "scatter.mlir"
     "sort.mlir"
     "winograd_input.mlir"

--- a/tests/e2e/xla_ops/BUILD
+++ b/tests/e2e/xla_ops/BUILD
@@ -366,7 +366,6 @@ iree_check_single_backend_test_suite(
             "reduce_window.mlir",
             "remainder.mlir",
             "reshape.mlir",
-            "reverse.mlir",
             "rng_normal.mlir",
             "rng_uniform.mlir",
             "round.mlir",
@@ -388,6 +387,7 @@ iree_check_single_backend_test_suite(
         exclude = [
             "exponential_fp16.mlir",
             "fft.mlir",  # TODO(#9583)
+            "reverse.mlir", #TODO(#12415): disabled due to miscompilation on Pixel 6.
         ],
     ),
     compiler_flags = ["--iree-input-type=mhlo"],

--- a/tests/e2e/xla_ops/BUILD
+++ b/tests/e2e/xla_ops/BUILD
@@ -387,7 +387,7 @@ iree_check_single_backend_test_suite(
         exclude = [
             "exponential_fp16.mlir",
             "fft.mlir",  # TODO(#9583)
-            "reverse.mlir", #TODO(#12415): disabled due to miscompilation on Pixel 6.
+            "reverse.mlir",  #TODO(#12415): disabled due to miscompilation on Pixel 6.
         ],
     ),
     compiler_flags = ["--iree-input-type=mhlo"],

--- a/tests/e2e/xla_ops/CMakeLists.txt
+++ b/tests/e2e/xla_ops/CMakeLists.txt
@@ -341,7 +341,6 @@ iree_check_single_backend_test_suite(
     "reduce_window.mlir"
     "remainder.mlir"
     "reshape.mlir"
-    "reverse.mlir"
     "rng_normal.mlir"
     "rng_uniform.mlir"
     "round.mlir"


### PR DESCRIPTION
We currently do not have a better mechanism to disable this only on affected Vulkan targets.

This is so that we can update our Pixel phones and use new Vulkan extensions.

Issue: https://github.com/openxla/iree/issues/12415