### PR TITLE
[vulkan][spirv] Plumb through support for KHR Integer Dot Product

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.td
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanAttributes.td
@@ -104,6 +104,13 @@ def VK_CapabilitiesAttr : VK_Attr<"Capabilities", "caps"> {
     OptionalParameter<"::mlir::UnitAttr">:$shaderFloat16,
     OptionalParameter<"::mlir::UnitAttr">:$shaderInt8,
 
+    // VK_KHR_shader_integer_dot_product features.
+    //
+    // This corresponds to the `VkPhysicalDeviceShaderIntegerDotProductFeatures`
+    // structure:
+    // https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderIntegerDotProductFeaturesKHR.html
+    OptionalParameter<"::mlir::UnitAttr">:$shaderIntegerDotProduct,
+
     // VK_KHR_variable_pointers features.
     // This corresponds to the `VkPhysicalDeviceVariablePointersFeatures`
     // structure:

--- a/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanBase.td
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/IR/VulkanBase.td
@@ -84,18 +84,19 @@ def VK_VersionAttr : VK_I32Enum<"Version", "valid Vulkan version", [
 def VK_KHR_16bit_storage : I32EnumAttrCase<"VK_KHR_16bit_storage", 0>;
 def VK_KHR_8bit_storage : I32EnumAttrCase<"VK_KHR_8bit_storage", 1>;
 def VK_KHR_shader_float16_int8 : I32EnumAttrCase<"VK_KHR_shader_float16_int8", 2>;
-def VK_KHR_spirv_1_4 : I32EnumAttrCase<"VK_KHR_spirv_1_4", 3>;
-def VK_KHR_storage_buffer_storage_class : I32EnumAttrCase<"VK_KHR_storage_buffer_storage_class", 4>;
-def VK_KHR_variable_pointers: I32EnumAttrCase<"VK_KHR_variable_pointers", 5>;
-def VK_EXT_subgroup_size_control : I32EnumAttrCase<"VK_EXT_subgroup_size_control", 6>;
-def VK_NV_cooperative_matrix : I32EnumAttrCase<"VK_NV_cooperative_matrix", 7>;
+def VK_KHR_shader_integer_dot_product : I32EnumAttrCase<"VK_KHR_shader_integer_dot_product", 3>;
+def VK_KHR_spirv_1_4 : I32EnumAttrCase<"VK_KHR_spirv_1_4", 4>;
+def VK_KHR_storage_buffer_storage_class : I32EnumAttrCase<"VK_KHR_storage_buffer_storage_class", 5>;
+def VK_KHR_variable_pointers: I32EnumAttrCase<"VK_KHR_variable_pointers", 6>;
+def VK_EXT_subgroup_size_control : I32EnumAttrCase<"VK_EXT_subgroup_size_control", 7>;
+def VK_NV_cooperative_matrix : I32EnumAttrCase<"VK_NV_cooperative_matrix", 8>;
 
 def VK_ExtensionAttr :
     VK_I32EnumAttr<"Extension", "supported Vulkan extension", "extension", [
       VK_KHR_16bit_storage, VK_KHR_8bit_storage, VK_KHR_shader_float16_int8,
-      VK_KHR_spirv_1_4, VK_KHR_storage_buffer_storage_class,
-      VK_KHR_variable_pointers, VK_EXT_subgroup_size_control,
-      VK_NV_cooperative_matrix
+      VK_KHR_shader_integer_dot_product, VK_KHR_spirv_1_4,
+      VK_KHR_storage_buffer_storage_class, VK_KHR_variable_pointers,
+      VK_EXT_subgroup_size_control, VK_NV_cooperative_matrix
     ]>;
 
 //===----------------------------------------------------------------------===//

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.cpp
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/TargetEnvironment.cpp
@@ -59,6 +59,9 @@ void convertExtensions(Vulkan::TargetEnvAttr vkTargetEnv,
       case Extension::VK_KHR_shader_float16_int8:
         // This extension allows using certain SPIR-V capabilities.
         break;
+      case Extension::VK_KHR_shader_integer_dot_product:
+        extensions.push_back(spirv::Extension::SPV_KHR_integer_dot_product);
+        break;
       case Extension::VK_KHR_spirv_1_4:
         // This extension only affects SPIR-V version.
         break;
@@ -140,6 +143,14 @@ void convertCapabilities(Vulkan::TargetEnvAttr vkTargetEnv,
   }
   if (vkCapabilities.getVariablePointersStorageBuffer()) {
     capabilities.push_back(spirv::Capability::VariablePointersStorageBuffer);
+  }
+  if (vkCapabilities.getShaderIntegerDotProduct()) {
+    capabilities.push_back(spirv::Capability::DotProduct);
+    capabilities.push_back(spirv::Capability::DotProductInputAll);
+    capabilities.push_back(spirv::Capability::DotProductInput4x8BitPacked);
+    if (vkCapabilities.getShaderInt8()) {
+      capabilities.push_back(spirv::Capability::DotProductInput4x8Bit);
+    }
   }
   if (ArrayAttr attr = vkCapabilities.getCooperativeMatrixPropertiesNV()) {
     if (!attr.empty()) {

--- a/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
+++ b/compiler/src/iree/compiler/Dialect/Vulkan/Utils/test/target_env_conversion.mlir
@@ -20,8 +20,8 @@
 // ADRENO-SAME: api=Vulkan, Qualcomm:IntegratedGPU, #spirv.resource_limits<max_compute_shared_memory_size = 32768, max_compute_workgroup_invocations = 1024, max_compute_workgroup_size = [1024, 1024, 64], subgroup_size = 64, cooperative_matrix_properties_nv = []>>
 
 // VALHALL: #spirv.target_env<#spirv.vce<v1.4,
-// VALHALL-SAME: [Shader, Float16, Int16, Int8, StorageBuffer16BitAccess, StorageUniform16, StoragePushConstant16, StorageBuffer8BitAccess, UniformAndStorageBuffer8BitAccess, StoragePushConstant8, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative, GroupNonUniformClustered, GroupNonUniformQuad, VariablePointers, VariablePointersStorageBuffer],
-// VALHALL-SAME: [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
+// VALHALL-SAME: [Shader, Float16, Int16, Int8, StorageBuffer16BitAccess, StorageUniform16, StoragePushConstant16, StorageBuffer8BitAccess, UniformAndStorageBuffer8BitAccess, StoragePushConstant8, GroupNonUniform, GroupNonUniformVote, GroupNonUniformArithmetic, GroupNonUniformBallot, GroupNonUniformShuffle, GroupNonUniformShuffleRelative, GroupNonUniformClustered, GroupNonUniformQuad, VariablePointers, VariablePointersStorageBuffer, DotProduct, DotProductInputAll, DotProductInput4x8BitPacked, DotProductInput4x8Bit],
+// VALHALL-SAME: [SPV_KHR_16bit_storage, SPV_KHR_8bit_storage, SPV_KHR_integer_dot_product, SPV_KHR_storage_buffer_storage_class, SPV_KHR_variable_pointers]>,
 // VALHALL-SAME: api=Vulkan, ARM:IntegratedGPU, #spirv.resource_limits<max_compute_shared_memory_size = 32768, max_compute_workgroup_invocations = 512, max_compute_workgroup_size = [512, 512, 512], subgroup_size = 16, cooperative_matrix_properties_nv = []>>
 
 // TURING: #spirv.target_env<#spirv.vce<v1.6,


### PR DESCRIPTION
This implements the Vulkan-side of the integer dot product extension: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VK_KHR_shader_integer_dot_product.html.

For now, only enable it for the `Valhall` target.

Also simplify how we append extensions (NFC).