### PR TITLE
Pad fusion bufferization workaround.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -597,7 +597,7 @@ LogicalResult createTensorEquivalenceClasses(func::FuncOp funcOp,
         .Case<scf::ForOp>(
             [&](scf::ForOp forOp) { return analyseScfForOp(forOp, plan); })
         .Case<scf::YieldOp, tensor::EmptyOp, tensor::DimOp, tensor::ExtractOp,
-              tensor::PadOp, bufferization::ToMemrefOp,
+              tensor::GenerateOp, tensor::PadOp, bufferization::ToMemrefOp,
               bufferization::AllocTensorOp>(
             [&](Operation *op) { return success(); })
         .Default([&](Operation *op) -> LogicalResult {

--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.cpp
@@ -119,6 +119,32 @@ static OpType getEquivalentOpOfType(Value value, BufferizationPlan &plan) {
   return equivalentOp;
 }
 
+/// Check if two sets can be merged based on what operations exist in that set.
+static bool canSetsBeMerged(Value v1, Value v2, BufferizationPlan &plan) {
+  // Dont merge two sets if one of the sets is a constant.
+  if (getEquivalentOpOfType<arith::ConstantOp>(v1, plan) ||
+      getEquivalentOpOfType<arith::ConstantOp>(v2, plan)) {
+    return false;
+  }
+  auto v1InterfaceBinding =
+      getEquivalentOpOfType<IREE::HAL::InterfaceBindingSubspanOp>(v1, plan);
+  auto v2InterfaceBinding =
+      getEquivalentOpOfType<IREE::HAL::InterfaceBindingSubspanOp>(v2, plan);
+  // If any of these sets do not have a interface binding, they can be merged.
+  if (!v1InterfaceBinding || !v2InterfaceBinding) {
+    return true;
+  }
+  if (v1InterfaceBinding.getSet() != v2InterfaceBinding.getSet() ||
+      v1InterfaceBinding.getBinding() != v2InterfaceBinding.getBinding() ||
+      v1InterfaceBinding.getByteOffset() !=
+          v2InterfaceBinding.getByteOffset()) {
+    // If the set, binding or offsets are different, map these to different
+    // memrefs.
+    return false;
+  }
+  return true;
+}
+
 /// Returns true if the value and target of a `flow.dispatch.tensor.store`
 /// operation can be added to the same equivalence set. This can be done only if
 /// - The `value` is not from a equivalence set that contains a read-only
@@ -130,32 +156,24 @@ static OpType getEquivalentOpOfType(Value value, BufferizationPlan &plan) {
 /// `hal.interface.binding.subspan` op.'
 static bool canSetStoreValueAndTargetAsEquivalent(
     IREE::Flow::DispatchTensorStoreOp storeOp, BufferizationPlan &plan) {
-  Value value = storeOp.getValue();
-  Value target = storeOp.getTarget();
-  auto targetInterfaceOp =
-      getEquivalentOpOfType<IREE::HAL::InterfaceBindingSubspanOp>(target, plan);
-  assert(targetInterfaceOp);
-  if (auto valueConstantOp =
-          getEquivalentOpOfType<arith::ConstantOp>(value, plan)) {
+  if (!canSetsBeMerged(storeOp.getValue(), storeOp.getTarget(), plan)) {
     return false;
   }
-  if (auto valueInterfaceOp =
-          getEquivalentOpOfType<IREE::HAL::InterfaceBindingSubspanOp>(value,
-                                                                      plan)) {
-    if (targetInterfaceOp.getBinding() != valueInterfaceOp.getBinding() ||
-        targetInterfaceOp.getByteOffset() != valueInterfaceOp.getByteOffset()) {
-      // If the binding and offsets are different, map these to different
-      // memrefs.
-      return false;
-    }
-    // If the binding and offsets are the same, make sure that the
-    // !flow.dispatch.tensor is read-write.
-    auto sourceType =
-        valueInterfaceOp.getType().dyn_cast<IREE::Flow::DispatchTensorType>();
-    return sourceType &&
-           sourceType.getAccess() == IREE::Flow::TensorAccess::ReadWrite;
+  auto valueInterfaceBinding =
+      getEquivalentOpOfType<IREE::HAL::InterfaceBindingSubspanOp>(
+          storeOp.getValue(), plan);
+  auto targetInterfaceBinding =
+      getEquivalentOpOfType<IREE::HAL::InterfaceBindingSubspanOp>(
+          storeOp.getTarget(), plan);
+  if (!valueInterfaceBinding || !targetInterfaceBinding) {
+    return true;
   }
-  return true;
+  // If the binding and offsets are the same, make sure that the
+  // !flow.dispatch.tensor is read-write.
+  auto sourceType = valueInterfaceBinding.getType()
+                        .dyn_cast<IREE::Flow::DispatchTensorType>();
+  return sourceType &&
+         sourceType.getAccess() == IREE::Flow::TensorAccess::ReadWrite;
 }
 
 /// Tries to add the `value` and `target` to the same equivalence class.
@@ -459,6 +477,25 @@ static void tieOperandsForOperandFusion(linalg::LinalgOp linalgOp,
         break;
       }
     }
+  }
+}
+
+void BufferizationPlan::unionSets(Value v1, Value v2) {
+  if (!canSetsBeMerged(v1, v2, *this)) {
+    return;
+  }
+  // If one the sets was part of the store set, the store set
+  // needs to be updated to drop the all leaders from the store set
+  // and add the new leader to it.
+  Value leader1 = getLeaderValue(v1);
+  Value leader2 = getLeaderValue(v2);
+  bool insertNewStoreLeader =
+      storeLeaders.count(leader1) || storeLeaders.count(leader2);
+  storeLeaders.erase(leader1);
+  storeLeaders.erase(leader2);
+  mappedTensors.unionSets(getPointer(v1), getPointer(v2));
+  if (insertNewStoreLeader) {
+    storeLeaders.insert(getLeaderValue(v1));
   }
 }
 

--- a/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.h
+++ b/compiler/src/iree/compiler/Codegen/Common/BufferizationAnalysis.h
@@ -52,21 +52,9 @@ class BufferizationPlan {
 
   void insert(Value v) { mappedTensors.insert(getPointer(v)); }
 
-  void unionSets(Value v1, Value v2) {
-    // If one the sets was part of the store set, the store set
-    // needs to be updated to drop the all leaders from the store set
-    // and add the new leader to it.
-    Value leader1 = getLeaderValue(v1);
-    Value leader2 = getLeaderValue(v2);
-    bool insertNewStoreLeader =
-        storeLeaders.count(leader1) || storeLeaders.count(leader2);
-    storeLeaders.erase(leader1);
-    storeLeaders.erase(leader2);
-    mappedTensors.unionSets(getPointer(v1), getPointer(v2));
-    if (insertNewStoreLeader) {
-      storeLeaders.insert(getLeaderValue(v1));
-    }
-  }
+  /// Union the sets containing `v1` and `v2`. Checks if the union can be
+  /// done and does nothing if union is invalid.
+  void unionSets(Value v1, Value v2);
 
   /// Sets the equivalance class that contains `v` as the set that contains the
   /// result tensor of the dispatch region (i.e. a tensor that is the `value`

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -523,6 +523,64 @@ struct RemoveCstOutsDependency
     return success();
   }
 };
+
+/// Add a pattern to switch
+/// ```mlir
+///  %0 = scf.if %cond {
+///    ...
+///    scf.yield %true
+///  } else {
+///    ...
+///    scf.yield %false
+///  }
+///  flow.dispatch.tensor.store %0, %target, ...
+/// ```
+///
+/// to
+///
+/// ```mlir
+///  scf.if %cond {
+///    ...
+///    flow.dispatch.tensor.store %true, %target
+///  } else {
+///    ...
+///    flow.dispatch.tensor.store %true, %target
+///  }
+/// ```
+/// This is a workaround for #11273 while a proper fix lands.
+struct SwitchStoreOfIfResultValue
+    : public OpRewritePattern<IREE::Flow::DispatchTensorStoreOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(IREE::Flow::DispatchTensorStoreOp storeOp,
+                                PatternRewriter &rewriter) const override {
+    auto ifOp = storeOp.getValue().getDefiningOp<scf::IfOp>();
+    if (!ifOp) {
+      return rewriter.notifyMatchFailure(storeOp,
+                                         "store source is not an if statement");
+    }
+
+    auto resultNumber = storeOp.getValue().cast<OpResult>().getResultNumber();
+    auto moveStoreInsideBody = [&](Block *body) {
+      OpBuilder::InsertionGuard g2(rewriter);
+      auto yieldOp = cast<scf::YieldOp>(body->getTerminator());
+      rewriter.setInsertionPoint(yieldOp);
+      auto yieldedVal = yieldOp.getOperand(resultNumber);
+      SliceAndDynamicDims sliceAndDynamicDims =
+          cloneOffsetsSizesAndStrides(rewriter, storeOp);
+      rewriter.create<IREE::Flow::DispatchTensorStoreOp>(
+          storeOp.getLoc(), yieldedVal, storeOp.getTarget(),
+          sliceAndDynamicDims.dynamicDims, sliceAndDynamicDims.offsets,
+          sliceAndDynamicDims.sizes, sliceAndDynamicDims.strides);
+    };
+
+    moveStoreInsideBody(&ifOp.getThenRegion().front());
+    moveStoreInsideBody(&ifOp.getElseRegion().front());
+    rewriter.eraseOp(storeOp);
+    return success();
+  }
+};
+
 }  // namespace
 
 void ConvertToDestinationPassingStylePass::runOnOperation() {
@@ -563,6 +621,14 @@ void ConvertToDestinationPassingStylePass::runOnOperation() {
   {
     RewritePatternSet patterns(context);
     linalg::populateEraseUnusedOperandsAndResultsPatterns(patterns);
+    if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
+      return signalPassFailure();
+    }
+  }
+
+  {
+    RewritePatternSet patterns(context);
+    patterns.insert<SwitchStoreOfIfResultValue>(context);
     if (failed(applyPatternsAndFoldGreedily(funcOp, std::move(patterns)))) {
       return signalPassFailure();
     }

--- a/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/ConvertToDestinationPassingStylePass.cpp
@@ -562,7 +562,7 @@ struct SwitchStoreOfIfResultValue
 
     auto resultNumber = storeOp.getValue().cast<OpResult>().getResultNumber();
     auto moveStoreInsideBody = [&](Block *body) {
-      OpBuilder::InsertionGuard g2(rewriter);
+      OpBuilder::InsertionGuard guard(rewriter);
       auto yieldOp = cast<scf::YieldOp>(body->getTerminator());
       rewriter.setInsertionPoint(yieldOp);
       auto yieldedVal = yieldOp.getOperand(resultNumber);


### PR DESCRIPTION
It seems like handling the code generated by the tiling of pad operations needs more work in bufferization. To unblock the work of handling pad operations natively in IREE,
https://github.com/openxla/iree/issues/11273#issuecomment-1330301425 is implemented here as a workaround.

To ensure bufferization without allocation, yields of the then and else branch and the result of the `scf.if` are all tied together. If the `then` and `else` come from different bindings, then this would be illegal (because a copy is needed). This example led to adding more constraints on what sets can be merged during the
`BufferizationAnalysis` to avoid merging sets that have constants or have two different `interface_bindings`.

benchmarks: x86_64, cuda