### PR TITLE
[WIP] Add helper tool to print benchmark config in plain JSON

### DIFF
--- a/build_tools/benchmarks/benchmark_helper.py
+++ b/build_tools/benchmarks/benchmark_helper.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2023 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Miscellaneous tool to help work with benchmark suite and benchmark CI."""
+
+import sys
+import pathlib
+
+# Add build_tools python dir to the search path.
+sys.path.insert(0, str(pathlib.Path(__file__).parent.with_name("python")))
+
+import argparse
+import dataclasses
+import json
+from typing import Any, List, Type, Callable
+
+from benchmark_suites.iree import export_definitions
+from e2e_test_framework import serialization
+from e2e_test_framework.definitions import iree_definitions
+
+
+def _filter_and_serialize_into_plain_object(data: Any, root_type: Type,
+                                            filter: Callable[[Any], bool]):
+  # Re-pack into JSON serializable format but don't use references.
+  configs = serialization.unpack_and_deserialize(data=data, root_type=root_type)
+  configs = [config for config in configs if filter(config)]
+  return serialization.serialize_and_pack(obj=configs, use_ref=False)
+
+
+def _dump_config_handler(args: argparse.Namespace):
+  benchmark_id = args.benchmark_id
+  if benchmark_id is None:
+    filter = lambda _: True
+  else:
+    # Run and generation config have the same id field.
+    filter = lambda config: config.composite_id == benchmark_id
+
+  if args.execution_config is not None:
+    raw_data = json.loads(args.execution_config.read_text())
+    exported_config = export_definitions.ExecutionBenchmarkConfig(**raw_data)
+    plain_run_configs = _filter_and_serialize_into_plain_object(
+        data=exported_config.run_configs,
+        root_type=List[iree_definitions.E2EModelRunConfig],
+        filter=filter)
+    plain_exported_config = dataclasses.replace(exported_config,
+                                                run_configs=plain_run_configs)
+
+  elif args.compilation_config is not None:
+    raw_data = json.loads(args.compilation_config.read_text())
+    exported_config = export_definitions.CompilationBenchmarkConfig(**raw_data)
+    plain_generation_configs = _filter_and_serialize_into_plain_object(
+        data=exported_config.generation_configs,
+        root_type=List[iree_definitions.ModuleGenerationConfig],
+        filter=filter)
+    plain_exported_config = dataclasses.replace(
+        exported_config, generation_configs=plain_generation_configs)
+
+  else:
+    raise AssertionError("No config file is specified.")
+
+  # Config is packed back into their original format so it can be still feed
+  # into the benchmark tools.
+  print(json.dumps(dataclasses.asdict(plain_exported_config), indent=2))
+
+
+def _parse_arguments() -> argparse.Namespace:
+  parser = argparse.ArgumentParser(
+      description=
+      "Miscellaneous tool to work with benchmark suite and benchmark CI.")
+
+  subparser = parser.add_subparsers(required=True, title="operation")
+  dump_config_parser = subparser.add_parser(
+      "dump-config",
+      help="Dump the serialized benchmark config into plain JSON format.")
+  dump_config_parser.add_argument(
+      "--benchmark_id",
+      type=str,
+      help="Only dump the config for the specified benchmark ID.")
+  dump_config_input_parser = dump_config_parser.add_mutually_exclusive_group(
+      required=True)
+  dump_config_input_parser.add_argument(
+      "--execution_config",
+      type=pathlib.Path,
+      help="Config file exported from export_benchmark_config.py execution")
+  dump_config_input_parser.add_argument(
+      "--compilation_config",
+      type=pathlib.Path,
+      help="Config file exported from export_benchmark_config.py compilation")
+  dump_config_parser.set_defaults(handler=_dump_config_handler)
+
+  return parser.parse_args()
+
+
+def main(args: argparse.Namespace):
+  args.handler(args)
+
+
+if __name__ == "__main__":
+  main(_parse_arguments())

--- a/build_tools/benchmarks/export_benchmark_config.py
+++ b/build_tools/benchmarks/export_benchmark_config.py
@@ -39,11 +39,10 @@ import dataclasses
 import json
 import textwrap
 
-from benchmark_suites.iree import benchmark_collections
+from benchmark_suites.iree import benchmark_collections, export_definitions
 from e2e_test_artifacts import iree_artifacts
 from e2e_test_framework import serialization
 from e2e_test_framework.definitions import common_definitions, iree_definitions
-from e2e_test_framework.definitions import iree_definitions
 
 PresetMatcher = Callable[[iree_definitions.E2EModelRunConfig], bool]
 BENCHMARK_PRESET_MATCHERS: Dict[str, PresetMatcher] = {
@@ -132,11 +131,12 @@ def _export_execution_handler(args: argparse.Namespace):
     distinct_module_dir_paths = _get_distinct_module_dir_paths(
         config.module_generation_config for config in run_configs)
 
-    output_map[device_name] = {
-        "host_environment": dataclasses.asdict(host_environment),
-        "module_dir_paths": distinct_module_dir_paths,
-        "run_configs": serialization.serialize_and_pack(run_configs),
-    }
+    output_map[device_name] = dataclasses.asdict(
+        export_definitions.ExecutionBenchmarkConfig(
+            host_environment=dataclasses.asdict(host_environment),
+            module_dir_paths=distinct_module_dir_paths,
+            run_configs=serialization.serialize_and_pack(run_configs),
+        ))
 
   return output_map
 
@@ -151,12 +151,11 @@ def _export_compilation_handler(_args: argparse.Namespace):
   distinct_module_dir_paths = _get_distinct_module_dir_paths(
       compile_stats_gen_configs)
 
-  return {
-      "module_dir_paths":
-          distinct_module_dir_paths,
-      "generation_configs":
-          serialization.serialize_and_pack(compile_stats_gen_configs)
-  }
+  return dataclasses.asdict(
+      export_definitions.CompilationBenchmarkConfig(
+          module_dir_paths=distinct_module_dir_paths,
+          generation_configs=serialization.serialize_and_pack(
+              compile_stats_gen_configs)))
 
 
 def _parse_and_strip_list_argument(arg) -> List[str]:

--- a/build_tools/python/benchmark_suites/iree/export_definitions.py
+++ b/build_tools/python/benchmark_suites/iree/export_definitions.py
@@ -1,0 +1,25 @@
+## Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Definitions related to export benchmark configs.
+
+The definitions only use primitive types so they are JSON serializable.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+
+@dataclass(frozen=True)
+class ExecutionBenchmarkConfig(object):
+  host_environment: Dict[str, str]
+  module_dir_paths: List[str]
+  run_configs: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CompilationBenchmarkConfig(object):
+  module_dir_paths: List[str]
+  generation_configs: Dict[str, Any]


### PR DESCRIPTION
Originally we serialize the benchmark configs into JSON and use reference keys on shared objects to save space. But it also reduces the usability of the exported config as a deserializer is required to parse the reference keys.  

This change adds a helper tool to dump the execution/compilation configs into plain JSON w/o reference keys. The output JSON will be much larger (~10k lines) but we can use filters to only output partially.

This change contains two commits:

1. Add an option `use_ref=False` to serializer to disable the usage of reference keys.
2. Add `benchmark_helper.py` to dump config into plain JSON with a `--benchmark_id` filter.

The `benchmark_helper.py` can accommodate other helpers in the future.

Here is an example of a serialized compilation config with reference keys:
```json
...
      "iree_module_generation_configs:11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d": {
        "composite_id": "11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d",
        "imported_model": "394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337",
        "compile_config": "1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats",
        "compile_flags": [
          "--iree-hal-target-backends=llvm-cpu",
          "--iree-input-type=tosa",
          "--iree-llvm-target-triple=aarch64-none-linux-android29",
          "--iree-vm-emit-polyglot-zip=true",
          "--iree-llvm-debug-symbols=false"
        ]
      }
...
```
Here is the output of the same config with the helper tool:
```sh
build_tools/benchmarks/benchmark_helper.py dump-config \
  --compilation_config=./compilation_config.json \
  --benchmark_id=11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d
```
(The output still follows the benchmark config format and is accepted by benchmark tools)
```json
...
{                                                                                                                                                                                
  "composite_id": "11a9de4ea6e17feff81429ed53e52a70e89c1cfeef0a73f10740c8420341b81d",                                                                                            
  "imported_model": {                                                                                                                                                            
    "composite_id": "394878992fb35f2ed531b7f0442c05bde693346932f049cbb3614e06b3c82337",
    "model": {
      "id": "58855e40-eba9-4a71-b878-6b35e3460244",
      "name": "MobileNetV3Small_fp32",
      "tags": [
        "fp32",
        "imagenet"
      ],
      "source_type": "EXPORTED_TFLITE",
      "source_url": "https://storage.googleapis.com/iree-model-artifacts/MobileNetV3SmallStaticBatch.tflite",
      "entry_function": "main",
      "input_types": [
        "1x224x224x3xf32"
      ]
    },
    "import_config": {
      "id": "16280d67-7ce0-4807-ab4b-0cb3c771d206",
      "tool": "TFLITE_IMPORTER",
      "dialect_type": "TOSA",
      "import_flags": [
        "--output-format=mlir-bytecode"
      ]
    }
  },
  "compile_config": {
    "id": "1f2adf49-282e-4aff-9d4f-e63b1621f1e8-compile-stats",
    "tags": [
      "default-flags",
      "compile-stats"
    ],
    "compile_targets": [
      {
        "target_backend": "LLVM_CPU",
        "target_architecture": "ARMV8_2_A_GENERIC",
        "target_abi": "LINUX_ANDROID29"
      }
    ],
    "extra_flags": [
      "--iree-vm-emit-polyglot-zip=true",
      "--iree-llvm-debug-symbols=false"
    ]
  },
  "compile_flags": [
    "--iree-hal-target-backends=llvm-cpu",
    "--iree-input-type=tosa",
    "--iree-llvm-target-triple=aarch64-none-linux-android29",
    "--iree-vm-emit-polyglot-zip=true",
    "--iree-llvm-debug-symbols=false"
  ]
}
```

benchmarks: all