### PR TITLE
Add `-ftrivial-auto-var-init=pattern` to ASAN build

### DIFF
--- a/build_tools/cmake/iree_setup_toolchain.cmake
+++ b/build_tools/cmake/iree_setup_toolchain.cmake
@@ -97,6 +97,14 @@ endif()
 if(IREE_ENABLE_ASAN)
   string(APPEND CMAKE_CXX_FLAGS " -fsanitize=address")
   string(APPEND CMAKE_C_FLAGS " -fsanitize=address")
+
+  # Not technically ASAN, but it guards against similar bugs in accessing
+  # uninitialized memory. See the extensive description in that patch that
+  # originally introduced it:
+  # https://reviews.llvm.org/rG14daa20be1ad89639ec209d969232d19cf698845
+  string(APPEND CMAKE_CXX_FLAGS " -ftrivial-auto-var-init=pattern")
+  string(APPEND CMAKE_C_FLAGS " -ftrivial-auto-var-init=pattern")
+
   # If doing any kind of shared library builds, then we have to link against
   # the shared libasan, and the user will be responsible for adding the
   # appropriate path to LD_LIBRARY_PATH (or else binaries will fail to launch).


### PR DESCRIPTION
This option initializes automatic variables with a recognizable pattern
likely to cause helpful crashes rather than silent undefined behavior.
See the extensive description of this option to the patch that first
introduced it to clang:
https://reviews.llvm.org/rG14daa20be1ad89639ec209d969232d19cf698845

This isn't technically asan, but it guards against the same type of
memory errors. It's also much lower overhead, so we could consider
enabling it in more builds. For release builds we might consider
`-ftrivial-auto-var-init=zero`, which is more likely to mask bugs but
less likely to access uninitialized memory at runtime, resulting in
security vulnerabilities.

For now, turning it on in one build is a good step.

Example failure (now fixed):
https://github.com/openxla/iree/actions/runs/4308619652/jobs/7515099139

Thanks to @Maximus- for introducing us to this option and flagging the
above failure.