### PR TITLE
Reserving x18 for AArch64 platforms

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -235,6 +235,7 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
         llvm::TargetRegistry::printRegisteredTargetsForVersion(llvm::outs());
         exit(0);
       }));
+  llvm::errs() << "Murali: " << targetOptions.target.cpuFeatures << "\n";
 
   return targetOptions;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -64,12 +64,12 @@ static LLVMTargetOptions getDefaultLLVMTargetOptions() {
 
 static void addTargetCPUFeaturesForCPU(LLVMTarget &target) {
   if (!(llvm::Triple(target.triple).isX86() ||
-        llvm::Triple(target.triple).isAArch64())) {
+        llvm::Triple(target.triple).isMacOSX())) {
     // Currently only implemented on x86 or AArch64.
     return;
   }
   llvm::SubtargetFeatures targetCpuFeatures(target.cpuFeatures);
-  if (llvm::Triple(target.triple).isAArch64()) {
+  if (llvm::Triple(target.triple).isMacOSX()) {
     targetCpuFeatures.AddFeature("reserve-x18", true);
   } else {
     llvm::SmallVector<llvm::StringRef> cpuFeatures;

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -63,15 +63,20 @@ static LLVMTargetOptions getDefaultLLVMTargetOptions() {
 }
 
 static void addTargetCPUFeaturesForCPU(LLVMTarget &target) {
-  if (!llvm::Triple(target.triple).isX86()) {
-    // Currently only implemented on x86.
+  if (!(llvm::Triple(target.triple).isX86() ||
+        llvm::Triple(target.triple).isAArch64())) {
+    // Currently only implemented on x86 or AArch64.
     return;
   }
   llvm::SubtargetFeatures targetCpuFeatures(target.cpuFeatures);
-  llvm::SmallVector<llvm::StringRef> cpuFeatures;
-  llvm::X86::getFeaturesForCPU(target.cpu, cpuFeatures);
-  for (auto &feature : cpuFeatures) {
-    targetCpuFeatures.AddFeature(feature);
+  if (llvm::Triple(target.triple).isAArch64()) {
+    targetCpuFeatures.AddFeature("reserve-x18", true);
+  } else {
+    llvm::SmallVector<llvm::StringRef> cpuFeatures;
+    llvm::X86::getFeaturesForCPU(target.cpu, cpuFeatures);
+    for (auto &feature : cpuFeatures) {
+      targetCpuFeatures.AddFeature(feature);
+    }
   }
   target.cpuFeatures = targetCpuFeatures.getString();
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/LLVMTargetOptions.cpp
@@ -117,6 +117,9 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
   if (clTargetCPU != "host" && clTargetCPU != "generic") {
     addTargetCPUFeaturesForCPU(targetOptions.target);
   }
+  // TODO(muralivi): Move this into `addTargetCPUFeaturesForCPU`, after fixing
+  // the predicate for when `addTargetCPUFeaturesForCPU` is called (i.e.
+  // removing the condition that clTargetCPU is neither host nor generic).
   if (llvm::Triple(targetOptions.target.triple).isAArch64()) {
     llvm::SubtargetFeatures targetCpuFeatures(targetOptions.target.cpuFeatures);
     targetCpuFeatures.AddFeature("reserve-x18", true);


### PR DESCRIPTION
Currently reserving X18 register for all AArch64 platforms. This is a workaround if https://reviews.llvm.org/D145131 doesn't land