### PR TITLE
Add TF passes needed for reproducer

### DIFF
--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -41,6 +41,7 @@ cc_binary(
         "@llvm-project//mlir:Transforms",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
         "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tensorflow_passes",
+        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_saved_model_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/tosa:tf_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/tosa:tf_tfl_passes",
         "@org_tensorflow//tensorflow/compiler/mlir/tosa:tfl_passes",

--- a/integrations/tensorflow/iree_tf_compiler/iree-tf-opt-main.cpp
+++ b/integrations/tensorflow/iree_tf_compiler/iree-tf-opt-main.cpp
@@ -22,6 +22,7 @@
 #include "stablehlo/dialect/ChloOps.h"
 #include "tensorflow/compiler/mlir/tensorflow/dialect_registration.h"
 #include "tensorflow/compiler/mlir/tensorflow/transforms/passes.h"
+#include "tensorflow/compiler/mlir/tensorflow/transforms/tf_saved_model_passes.h"
 #include "tensorflow/compiler/mlir/tosa/tf_passes.h"
 #include "tensorflow/compiler/mlir/tosa/tfl_passes.h"
 #include "tensorflow/compiler/mlir/tosa/transforms/passes.h"
@@ -53,6 +54,13 @@ int main(int argc, char **argv) {
   mlir::registerTensorFlowShapeInferencePassPass();
   mlir::registerTensorFlowOptimizePassPass();
   mlir::TFDevice::registerDecomposeResourceOpsPassPass();
+  // Needed for reproducer.
+  mlir::registerDeviceIndexSelectorPass();
+  mlir::registerExecutorIslandCoarseningPass();
+  mlir::registerGuaranteeAllFuncsOneUsePass();
+  mlir::registerMaterializePassthroughOpPass();
+  mlir::registerFunctionalControlFlowToCFGPass();
+  mlir::tf_saved_model::registerOptimizeGlobalTensorsPass();
 
   // Old style static registration based TF passes.
   mlir::TF::CreateDeviceIndexSelectorPass();


### PR DESCRIPTION
Without these some of the reproducers are not usable with iree-tf-opt.
This is not complete set, only what I found while getting a reproducer
working.
