### PR TITLE
Show benchmark presets in CI summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,13 @@ jobs:
 
           ./build_tools/github_actions/configure_ci.py
 
+      - name: "Show benchmark presets"
+        env:
+          BENCHMARK_PRESETS: ${{ steps.configure.outputs.benchmark-presets }}
+        run: |
+          echo ":stopwatch: Enabled benchmarks: \`${BENCHMARK_PRESETS}\`" \
+            >> "${GITHUB_STEP_SUMMARY}"
+
   ################################### Basic ####################################
   # Jobs that build all of IREE "normally"
   ##############################################################################


### PR DESCRIPTION
Show the detected benchmark presets on CI summary page to provide more visible feedback

Example: https://github.com/openxla/iree/actions/runs/4318196202/attempts/2#summary-11728230775
![image](https://user-images.githubusercontent.com/2104162/222555127-2cbf037f-6c11-4a9c-8ae1-26791b86651c.png)