### PR TITLE
Starting support for HAL dispatch specialization.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Analysis/BindingLayout.cpp
@@ -45,9 +45,11 @@ static BindingLayoutAnalysis::ExportDispatchMap findAllDispatchSites(
   SymbolTable symbolTable(rootOp);
   BindingLayoutAnalysis::ExportDispatchMap dispatchMap;
   rootOp->walk([&](IREE::Stream::CmdDispatchOp dispatchOp) {
-    auto exportOp = symbolTable.lookupNearestSymbolFrom(
-        dispatchOp, dispatchOp.getEntryPointAttr());
-    dispatchMap[exportOp].push_back(dispatchOp);
+    dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPointAttr) {
+      auto exportOp =
+          symbolTable.lookupNearestSymbolFrom(dispatchOp, entryPointAttr);
+      dispatchMap[exportOp].push_back(dispatchOp);
+    });
   });
   return dispatchMap;
 }

--- a/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Conversion/StreamToHAL/test/cmd_ops.mlir
@@ -232,7 +232,7 @@ func.func @cmdDispatch(%arg0: !stream.resource<transient>, %arg1: index, %arg2: 
     // CHECK: hal.command_buffer.dispatch.symbol<%[[CMD]]
     // CHECK-SAME: target(@ex::@embedded_elf_x86_64::@dispatch)
     // CHECK-SAME: workgroups([%[[X]], %[[YZ]], %[[YZ]]])
-    stream.cmd.dispatch @ex::@dispatch[%c1, %c2, %c3](%c4_i32, %c5_i32 : i32, i32) {
+    stream.cmd.dispatch @ex::@embedded_elf_x86_64::@dispatch[%c1, %c2, %c3](%c4_i32, %c5_i32 : i32, i32) {
       ro %arg4[%c0 for %c128] : !stream.resource<transient>{%arg1},
       wo %arg5[%c0 for %c128] : !stream.resource<external>{%arg3}
     } attributes {

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/dump_executable_benchmarks.mlir
@@ -124,7 +124,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
     %result, %result_timepoint = stream.resource.alloca uninitialized : !stream.resource<transient>{%c128} => !stream.timepoint
     %6 = stream.cmd.execute await(%result_timepoint) => with(%result as %result_capture: !stream.resource<transient>{%c128}) {
       // Dispatches with static and dynamic args.
-      stream.cmd.dispatch @ex0::@dispatch0[%c512](%c100_i32, %c200_i32 : i32, i32) {
+      stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch0[%c512](%c100_i32, %c200_i32 : i32, i32) {
         ro %result_capture[%c0 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c32 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
@@ -135,7 +135,7 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
       ]}
       // NOTE: today the dynamic args will prevent us from generating
       // benchmarks. We could handle this better by tracking alignment and such.
-      stream.cmd.dispatch @ex0::@dispatch0[%c512](%c300_i32, %dynamic_arg : i32, i32) {
+      stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch0[%c512](%c300_i32, %dynamic_arg : i32, i32) {
         ro %result_capture[%c0 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c32 for %c32] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
@@ -147,21 +147,21 @@ module attributes {hal.device.targets = [#device_target_cpu]}  {
 
       // Multiple dispatches to a single entry point.
       // Dispatches are deduplicated and the two 128x32x1 should combine.
-      stream.cmd.dispatch @ex0::@dispatch1[%c512, %c1] {
+      stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch1[%c512, %c1] {
         ro %result_capture[%c0 for %c64] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
       } attributes {hal.interface.bindings = [
         #hal.interface.binding<0, 0>,
         #hal.interface.binding<0, 1>
       ]}
-      stream.cmd.dispatch @ex0::@dispatch1[%c128, %c32] {
+      stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch1[%c128, %c32] {
         ro %result_capture[%c0 for %c64] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
       } attributes {hal.interface.bindings = [
         #hal.interface.binding<0, 0>,
         #hal.interface.binding<0, 1>
       ]}
-      stream.cmd.dispatch @ex0::@dispatch1[%c128, %c32] {
+      stream.cmd.dispatch @ex0::@embedded_elf_x86_64::@dispatch1[%c128, %c32] {
         ro %result_capture[%c0 for %c64] : !stream.resource<transient>{%c128},
         rw %result_capture[%c64 for %c32] : !stream.resource<transient>{%c128}
       } attributes {hal.interface.bindings = [

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_interfaces.mlir
@@ -54,7 +54,7 @@ module attributes {hal.device.targets = [
     %c2 = arith.constant 2 : index
     %0 = stream.resource.alloc uninitialized : !stream.resource<transient>{%arg2}
     %1 = stream.cmd.execute with(%arg0 as %arg4: !stream.resource<constant>{%arg2}, %arg1 as %arg5: !stream.resource<transient>{%arg2}, %0 as %arg6: !stream.resource<transient>{%arg2}) {
-      // CHECK: stream.cmd.dispatch @ex_workgroups::@entry
+      // CHECK: stream.cmd.dispatch {@ex_workgroups::@embedded_elf_arm_64::@entry, @ex_workgroups::@embedded_elf_x86_64::@entry}
       // CHECK: attributes {
       // CHECK-SAME: hal.interface.bindings = [
       // CHECK-SAME:   #hal.interface.binding<0, 0>,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/StreamOps.td
@@ -2481,7 +2481,7 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
 
   let arguments = (ins
     Variadic<Index>:$workload,
-    SymbolRefAttr:$entry_point,
+    SymbolRefArrayAttr:$entry_points,
     Variadic<Stream_PrimitiveType>:$uniform_operands,
     Variadic<Stream_AnyStreamResource>:$resources,
     Variadic<Stream_Size>:$resource_sizes,
@@ -2492,7 +2492,7 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
   let results = (outs);
 
   let assemblyFormat = [{
-    $entry_point
+    custom<DispatchEntryPoints>($entry_points)
     (`[` $workload^ `]`)? ``
     (`(` $uniform_operands^ `:` type($uniform_operands) `)`)? `{`
     custom<DispatchResources>($resources, type($resources), $resource_sizes,
@@ -2503,6 +2503,13 @@ def Stream_CmdDispatchOp : Stream_Op<"cmd.dispatch", [
   }];
 
   let extraClassDeclaration = [{
+    auto getEntryPointRefs() {
+      return getEntryPoints().getAsRange<SymbolRefAttr>();
+    }
+    void forEachEntryPointAttr(std::function<void(SymbolRefAttr)> fn) {
+      for (auto entryPointAttr : getEntryPointRefs()) fn(entryPointAttr);
+    }
+
     Value getOperandSize(unsigned idx) {
       return findValueSizeInList(
           idx - getODSOperandIndexAndLength(2).first,

--- a/compiler/src/iree/compiler/Dialect/Stream/IR/test/cmd_ops.mlir
+++ b/compiler/src/iree/compiler/Dialect/Stream/IR/test/cmd_ops.mlir
@@ -106,11 +106,11 @@ func.func @cmdDispatch(%arg0: !stream.resource<transient>, %arg1: index, %arg2: 
   %c5 = arith.constant 5 : index
   %c128 = arith.constant 128 : index
   %0 = stream.cmd.execute with(%arg0 as %arg4: !stream.resource<transient>{%arg1}, %arg2 as %arg5: !stream.resource<external>{%arg3}) {
-    //      CHECK: stream.cmd.dispatch @executable::@dispatch[%c1, %c2, %c3](%c4, %c5 : index, index) {
+    //      CHECK: stream.cmd.dispatch {@executable::@dispatch0, @executable::@dispatch1}[%c1, %c2, %c3](%c4, %c5 : index, index) {
     // CHECK-NEXT:   ro %arg4[%c0 for %c128] : !stream.resource<transient>{%arg1},
     // CHECK-NEXT:   wo %arg5[%c0 for %c128] : !stream.resource<external>{%arg3}
     // CHECK-NEXT: }
-    stream.cmd.dispatch @executable::@dispatch[%c1, %c2, %c3](%c4, %c5 : index, index) {
+    stream.cmd.dispatch {@executable::@dispatch0, @executable::@dispatch1}[%c1, %c2, %c3](%c4, %c5 : index, index) {
       ro %arg4[%c0 for %c128] : !stream.resource<transient>{%arg1},
       wo %arg5[%c0 for %c128] : !stream.resource<external>{%arg3}
     }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/AnnotateDispatchArguments.cpp
@@ -340,9 +340,11 @@ class ArgumentAnalysis {
 
     // Find all dispatches and bucket by their target entry point.
     rootOp->walk([&](IREE::Stream::CmdDispatchOp dispatchOp) {
-      auto exportOp = explorer.getSymbolTables().lookupNearestSymbolFrom(
-          dispatchOp, dispatchOp.getEntryPoint());
-      entryDispatchMap[exportOp].push_back(dispatchOp);
+      dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPointAttr) {
+        auto exportOp = explorer.getSymbolTables().lookupNearestSymbolFrom(
+            dispatchOp, entryPointAttr);
+        entryDispatchMap[exportOp].push_back(dispatchOp);
+      });
     });
   }
 

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/FoldUniformOperands.cpp
@@ -267,9 +267,11 @@ class FoldUniformOperandsPass
     DenseMap<Operation *, SmallVector<IREE::Stream::CmdDispatchOp>>
         entryDispatchMap;
     getOperation()->walk([&](IREE::Stream::CmdDispatchOp dispatchOp) {
-      auto exportOp = symbolTable.lookupNearestSymbolFrom(
-          dispatchOp, dispatchOp.getEntryPoint());
-      entryDispatchMap[exportOp].push_back(dispatchOp);
+      dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPointAttr) {
+        auto exportOp =
+            symbolTable.lookupNearestSymbolFrom(dispatchOp, entryPointAttr);
+        entryDispatchMap[exportOp].push_back(dispatchOp);
+      });
     });
 
     // Optimize each dispatch op.

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/PackDispatchOperands.cpp
@@ -337,12 +337,15 @@ class PackDispatchOperandsPass
 
     // Walk the module and update all dispatch operands.
     getOperation()->walk([&](IREE::Stream::CmdDispatchOp dispatchOp) {
-      auto exportOp =
-          symbolTable.lookupNearestSymbolFrom<IREE::Stream::ExecutableExportOp>(
-              dispatchOp, dispatchOp.getEntryPoint());
-      if (exportOp) {
-        updateDispatchOp(dispatchOp, exportOp);
-      }
+      dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPointAttr) {
+        auto exportOp =
+            symbolTable
+                .lookupNearestSymbolFrom<IREE::Stream::ExecutableExportOp>(
+                    dispatchOp, entryPointAttr);
+        if (exportOp) {
+          updateDispatchOp(dispatchOp, exportOp);
+        }
+      });
       return WalkResult::advance();
     });
   }

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/ScheduleAllocation.cpp
@@ -693,9 +693,10 @@ static LogicalResult applyAsyncDispatchOp(IREE::Stream::AsyncDispatchOp asyncOp,
   }
 
   auto newOp = builder.create<IREE::Stream::CmdDispatchOp>(
-      asyncOp.getLoc(), asyncOp.getWorkload(), asyncOp.getEntryPoint(),
-      newOperands, newResources, newResourceSizes, newResourceOffsets,
-      newResourceLengths, builder.getArrayAttr(newResourceAccesses));
+      asyncOp.getLoc(), asyncOp.getWorkload(),
+      builder.getArrayAttr({asyncOp.getEntryPoint()}), newOperands,
+      newResources, newResourceSizes, newResourceOffsets, newResourceLengths,
+      builder.getArrayAttr(newResourceAccesses));
   newOp->setDialectAttrs(asyncOp->getDialectAttrs());
   asyncOp.erase();
   return success();

--- a/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
+++ b/compiler/src/iree/compiler/Dialect/Stream/Transforms/SpecializeDispatches.cpp
@@ -343,9 +343,11 @@ class SpecializeDispatchesPass
     DenseMap<Operation *, SmallVector<IREE::Stream::CmdDispatchOp>>
         entryDispatchMap;
     getOperation()->walk([&](IREE::Stream::CmdDispatchOp dispatchOp) {
-      auto exportOp = symbolTable.lookupNearestSymbolFrom(
-          dispatchOp, dispatchOp.getEntryPoint());
-      entryDispatchMap[exportOp].push_back(dispatchOp);
+      dispatchOp.forEachEntryPointAttr([&](SymbolRefAttr entryPointAttr) {
+        auto exportOp =
+            symbolTable.lookupNearestSymbolFrom(dispatchOp, entryPointAttr);
+        entryDispatchMap[exportOp].push_back(dispatchOp);
+      });
     });
 
     // Optimize each dispatchable function and its dispatch sites.

--- a/samples/custom_dispatch/cpu/embedded/example_hal.mlir
+++ b/samples/custom_dispatch/cpu/embedded/example_hal.mlir
@@ -243,9 +243,7 @@ module @example attributes {hal.device.targets = [#cpu_target]} {
     %dim_i32 = arith.index_cast %dim : index to i32
 
     // Dispatch a basic `ret = lhs * rhs` using an external function.
-    // This form (@executable::@export) allows for automatic variant selection
-    // when multi-targeting (@x86_64 will be chosen if available).
-    %0 = flow.dispatch @executable::@simple_mul[%dim](%dim_i32, %arg0, %arg1) {
+    %0 = flow.dispatch @executable::@x86_64::@simple_mul[%dim](%dim_i32, %arg0, %arg1) {
       // Bindings are automatically inferred when possible as part of the ABI
       // but can be overridden if the user wants to use features such as sparse
       // bindings or multiple descriptor sets. To do so the


### PR DESCRIPTION
This allows `stream.cmd.dispatch` ops to specify multiple entry points in executables that can be dispatched. During interface materialization the entry points are expanded for all materialized variants. HAL backends are also able to add their own entry points either in existing variants or new ones during translation (no helpers yet, but it's possible). When lowering the `stream.cmd.dispatch` into `hal.command_buffer.dispatch` each export now chooses the condition for which it should be selected.

This initial work just prepares the op for this conditional dispatch and also solves an issue with compiler reentrancy where between interface materialization and HAL conversion we had IR that would not verify (stream ops still referencing un-materialized exports). Only the existing target variant matcher condition is supported but we now have the place where we'd call out to HAL backend-produced logic for selection (`getExportConditionAttr`).

The `inline-dynamic` HAL model can support this too but for now that's deferred until we add the backend support - the `hal.device.switch` op needs a reworking to be used in that context.

Fixes #12476.