### PR TITLE
Consider OS when query processor count in ctest_all.sh

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -15,8 +15,16 @@ set -euo pipefail
 
 BUILD_DIR="$1"
 
+get_default_parallel_level() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    echo $(sysctl -n hw.physicalcpu)
+  else
+    echo $(nproc)
+  fi
+}
+
 # Respect the user setting, but default to as many jobs as we have cores.
-export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(nproc)}
+export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(get_default_parallel_level)}
 
 # Respect the user setting, but default to turning on Vulkan.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -15,16 +15,9 @@ set -euo pipefail
 
 BUILD_DIR="$1"
 
-get_default_parallel_level() {
-  if [[ "$(uname)" == "Darwin" ]]; then
-    echo $(sysctl -n hw.logicalcpu)
-  else
-    echo $(nproc)
-  fi
-}
-
 # Respect the user setting, but default to as many jobs as we have cores.
-export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(get_default_parallel_level)}
+DEFAULT_PARALLEL_LEVEL=$([[ "$(uname)" == "Darwin" ]] && echo $(sysctl -n hw.logicalcpu) || echo $(nproc))
+export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-${DEFAULT_PARALLEL_LEVEL}}
 
 # Respect the user setting, but default to turning on Vulkan.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -15,9 +15,16 @@ set -euo pipefail
 
 BUILD_DIR="$1"
 
+get_default_parallel_level() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    echo $(sysctl -n hw.logicalcpu)
+  else
+    echo $(nproc)
+  fi
+}
+
 # Respect the user setting, but default to as many jobs as we have cores.
-DEFAULT_PARALLEL_LEVEL=$([[ "$(uname)" == "Darwin" ]] && echo $(sysctl -n hw.logicalcpu) || echo $(nproc))
-export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-${DEFAULT_PARALLEL_LEVEL}}
+export CTEST_PARALLEL_LEVEL=${CTEST_PARALLEL_LEVEL:-$(get_default_parallel_level)}
 
 # Respect the user setting, but default to turning on Vulkan.
 export IREE_VULKAN_DISABLE=${IREE_VULKAN_DISABLE:-0}

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -17,7 +17,7 @@ BUILD_DIR="$1"
 
 get_default_parallel_level() {
   if [[ "$(uname)" == "Darwin" ]]; then
-    echo $(sysctl -n hw.physicalcpu)
+    echo $(sysctl -n hw.logicalcpu)
   else
     echo $(nproc)
   fi

--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -17,9 +17,9 @@ BUILD_DIR="$1"
 
 get_default_parallel_level() {
   if [[ "$(uname)" == "Darwin" ]]; then
-    echo $(sysctl -n hw.logicalcpu)
+    echo "$(sysctl -n hw.logicalcpu)"
   else
-    echo $(nproc)
+    echo "$(nproc)"
   fi
 }
 


### PR DESCRIPTION
On macOS, we don't have `nproc`. Instead, we should use `sysctl -n hw.logicalcpu`.