### PR TITLE
Create install directory before querying its real path

### DIFF
--- a/build_tools/cmake/build_all.sh
+++ b/build_tools/cmake/build_all.sh
@@ -27,6 +27,9 @@ IREE_TARGET_BACKEND_WEBGPU="${IREE_TARGET_BACKEND_WEBGPU:-ON}"
 source build_tools/cmake/setup_build.sh
 source build_tools/cmake/setup_ccache.sh
 
+# Create install directory now--we need to get its real path later.
+mkdir -p "${INSTALL_DIR}"
+
 declare -a CMAKE_ARGS=(
   "-G" "Ninja"
   "-B" "${BUILD_DIR}"


### PR DESCRIPTION
Otherwise we may hit issue of "No such file or directory".