### PR TITLE
Use TensorFlow-exposed API for converting Saved Model to MLIR

### DIFF
--- a/compiler/src/iree/compiler/API/python/iree/compiler/tools/tf.py
+++ b/compiler/src/iree/compiler/API/python/iree/compiler/tools/tf.py
@@ -190,6 +190,9 @@ def compile_saved_model(saved_model_dir: str, **kwargs):
     A bytes-like object with the compiled output or None if output_file=
     was specified.
   """
+  print("XXX: kwargs: ", kwargs)
+  import traceback
+  traceback.print_stack()
   with TempFileSaver.implicit() as tfs:
     options = ImportOptions(**kwargs)
     import_cl = build_import_command_line(saved_model_dir, tfs, options)
@@ -219,6 +222,9 @@ def compile_module(module, saved_model_dir: Optional[str] = None, **kwargs):
   Returns:
     Same as compile_saved_model().
   """
+  print("XXX: kwargs: ", kwargs)
+  import traceback
+  traceback.print_stack()
   with TempFileSaver.implicit() as tfs:
 
     def do_it(saved_model_dir):

--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -91,6 +91,12 @@ cc_binary(
     ],
 )
 
+py_binary(
+    name = "iree-import-tf-py",
+    srcs = ["iree-import-tf-main.py"],
+    main = "iree-import-tf-main.py",
+)
+
 cc_binary(
     name = "iree-import-tflite",
     srcs = ["iree-import-tflite-main.cpp"],

--- a/integrations/tensorflow/iree_tf_compiler/BUILD
+++ b/integrations/tensorflow/iree_tf_compiler/BUILD
@@ -71,28 +71,28 @@ cc_binary(
     ],
 )
 
-cc_binary(
-    name = "iree-import-tf",
-    srcs = ["iree-import-tf-main.cpp"],
-    deps = [
-        "//iree_tf_compiler/MHLO",
-        "//iree_tf_compiler/TF",
-        "@llvm-project//llvm:Support",
-        "@llvm-project//mlir:BytecodeWriter",
-        "@llvm-project//mlir:IR",
-        "@llvm-project//mlir:Pass",
-        "@llvm-project//mlir:Support",
-        "@org_tensorflow//tensorflow/cc/saved_model:loader",
-        "@org_tensorflow//tensorflow/compiler/mlir:init_mlir",
-        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
-        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:import_model",
-        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_dialect_passes",
-        "@org_tensorflow//tensorflow/core/platform:errors",
-    ],
-)
+#cc_binary(
+#    name = "iree-import-tf",
+#    srcs = ["iree-import-tf-main.cpp"],
+#    deps = [
+#        "//iree_tf_compiler/MHLO",
+#        "//iree_tf_compiler/TF",
+#        "@llvm-project//llvm:Support",
+#        "@llvm-project//mlir:BytecodeWriter",
+#        "@llvm-project//mlir:IR",
+#        "@llvm-project//mlir:Pass",
+#        "@llvm-project//mlir:Support",
+#        "@org_tensorflow//tensorflow/cc/saved_model:loader",
+#        "@org_tensorflow//tensorflow/compiler/mlir:init_mlir",
+#        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow",
+#        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:import_model",
+#        "@org_tensorflow//tensorflow/compiler/mlir/tensorflow:tf_dialect_passes",
+#        "@org_tensorflow//tensorflow/core/platform:errors",
+#    ],
+#)
 
 py_binary(
-    name = "iree-import-tf-py",
+    name = "iree-import-tf",
     srcs = ["iree-import-tf-main.py"],
     main = "iree-import-tf-main.py",
 )

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.py
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.py
@@ -1,0 +1,18 @@
+import tensorflow as tf
+from tensorflow.python import pywrap_mlir
+from pathlib import Path
+
+def convert_to_hlo(model_path: str, use_stablehlo=True):
+  result = pywrap_mlir.experimental_convert_saved_model_to_mlir(
+      model_path, "", show_debug_info=False)
+  pipeline = ["tf-lower-to-mlprogram-and-hlo"]
+  if not use_stablehlo:
+    pipeline.append("stablehlo-legalize-to-hlo")
+  result = pywrap_mlir.experimental_run_pass_pipeline(
+      result, ",".join(pipeline), show_debug_info=False)
+  return result
+
+Path("/tmp/simple-model-new.stablehlo.mlir").write_text(
+  convert_to_hlo("/tmp/simple-model", True))
+Path("/tmp/simple-model-new.hlo.mlir").write_text(
+  convert_to_hlo("/tmp/simple-model", False))

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.py
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.py
@@ -1,3 +1,5 @@
+import re
+
 import tensorflow as tf
 from tensorflow.python import pywrap_mlir
 from pathlib import Path
@@ -5,6 +7,12 @@ from pathlib import Path
 def convert_to_hlo(model_path: str, use_stablehlo=True):
   result = pywrap_mlir.experimental_convert_saved_model_to_mlir(
       model_path, "", show_debug_info=False)
+
+  # See:
+  # * https://github.com/tensorflow/tensorflow/issues/59685
+  # * https://github.com/tensorflow/tensorflow/blob/cd5667ec9d8af787a18c5b1ae239f060e9fa6fdd/tensorflow/python/saved_model/function_deserialization.py#L641-L653
+  result = re.sub(r"__inference_(.*)_\d+", r"\1", result)
+
   pipeline = ["tf-lower-to-mlprogram-and-hlo"]
   if not use_stablehlo:
     pipeline.append("stablehlo-legalize-to-hlo")

--- a/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.py
+++ b/integrations/tensorflow/iree_tf_compiler/iree-import-tf-main.py
@@ -6,10 +6,16 @@ from tensorflow.python import pywrap_mlir
 from pathlib import Path
 
 parser = argparse.ArgumentParser()
-parser.add_argument('-p', '--saved_model_path', dest='saved_model_path', required=True,
-                        help='Path to the saved model directory to import.')
-parser.add_argument('-o', '--output_path', dest='output_path', required=True,
-                        help='Path to the mlir file name to output.')
+parser.add_argument('-p',
+                    '--saved_model_path',
+                    dest='saved_model_path',
+                    required=True,
+                    help='Path to the saved model directory to import.')
+parser.add_argument('-o',
+                    '--output_path',
+                    dest='output_path',
+                    required=True,
+                    help='Path to the mlir file name to output.')
 args = parser.parse_args()
 
 
@@ -23,8 +29,9 @@ def convert_to_hlo(model_path: str):
   result = re.sub(r"__inference_(.*)_\d+", r"\1", result)
 
   pipeline = ["tf-lower-to-mlprogram-and-hlo"]
-  result = pywrap_mlir.experimental_run_pass_pipeline(
-      result, ",".join(pipeline), show_debug_info=False)
+  result = pywrap_mlir.experimental_run_pass_pipeline(result,
+                                                      ",".join(pipeline),
+                                                      show_debug_info=False)
   return result
 
 

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tf/support/module_utils.py
@@ -51,6 +51,7 @@ def _get_tf_import_output_kwargs(artifacts_dir: str,
   Returns:
     A dict of output kwargs.
   """
+  print("XXX: _get_tf_import_output_kwargs")
   kwargs = {}
   backend_dir = os.path.join(artifacts_dir, backend_id)
   os.makedirs(backend_dir, exist_ok=True)

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tools/tf/scripts/iree_import_tf/__main__.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tools/tf/scripts/iree_import_tf/__main__.py
@@ -14,7 +14,7 @@ def main(args=None):
   if args is None:
     args = sys.argv[1:]
   # BEFORE SUBMIT: Add optional arg to use old tool
-  exe = iree.tools.tf.get_tool("iree-import-tf-py")
+  exe = iree.tools.tf.get_tool("iree-import-tf")
   return subprocess.call(args=[exe] + args)
 
 

--- a/integrations/tensorflow/python_projects/iree_tf/iree/tools/tf/scripts/iree_import_tf/__main__.py
+++ b/integrations/tensorflow/python_projects/iree_tf/iree/tools/tf/scripts/iree_import_tf/__main__.py
@@ -13,7 +13,8 @@ import iree.tools.tf
 def main(args=None):
   if args is None:
     args = sys.argv[1:]
-  exe = iree.tools.tf.get_tool("iree-import-tf")
+  # BEFORE SUBMIT: Add optional arg to use old tool
+  exe = iree.tools.tf.get_tool("iree-import-tf-py")
   return subprocess.call(args=[exe] + args)
 
 

--- a/integrations/tensorflow/symlink_binaries.sh
+++ b/integrations/tensorflow/symlink_binaries.sh
@@ -20,10 +20,10 @@ BINARIES_DIR="${1:-${SCRIPT_DIR}/bazel-bin/iree_tf_compiler}"
 function symlink_import_binary() {
   local type="$1"
   local import_binary="${BINARIES_DIR}/iree-import-${type}"
-  echo "XXX: symlink binaries ${from} {$to}"
   if [ -f "${import_binary}" ]; then
     local to="${SCRIPT_DIR}/python_projects/iree_${type}/iree/tools/${type}"
     local from="$(realpath --no-symlinks --relative-to=${to} --relative-base="${ROOT_DIR}" "${import_binary}")"
+    echo "XXX: symlink binaries ${from} {$to}"
     ln --symbolic --verbose --force "${from}" "${to}"
   fi
 }

--- a/integrations/tensorflow/symlink_binaries.sh
+++ b/integrations/tensorflow/symlink_binaries.sh
@@ -28,5 +28,6 @@ function symlink_import_binary() {
 }
 
 symlink_import_binary tf
+symlink_import_binary tf-py
 symlink_import_binary tflite
 symlink_import_binary xla

--- a/integrations/tensorflow/symlink_binaries.sh
+++ b/integrations/tensorflow/symlink_binaries.sh
@@ -20,6 +20,7 @@ BINARIES_DIR="${1:-${SCRIPT_DIR}/bazel-bin/iree_tf_compiler}"
 function symlink_import_binary() {
   local type="$1"
   local import_binary="${BINARIES_DIR}/iree-import-${type}"
+  echo "XXX: symlink binaries ${from} {$to}"
   if [ -f "${import_binary}" ]; then
     local to="${SCRIPT_DIR}/python_projects/iree_${type}/iree/tools/${type}"
     local from="$(realpath --no-symlinks --relative-to=${to} --relative-base="${ROOT_DIR}" "${import_binary}")"

--- a/integrations/tensorflow/symlink_binaries.sh
+++ b/integrations/tensorflow/symlink_binaries.sh
@@ -28,6 +28,5 @@ function symlink_import_binary() {
 }
 
 symlink_import_binary tf
-symlink_import_binary tf-py
 symlink_import_binary tflite
 symlink_import_binary xla


### PR DESCRIPTION
For background, see:

 * https://github.com/openxla/iree/issues/10849
 * https://github.com/tensorflow/tensorflow/issues/59685

After speaking with @jpienaar, I've gone ahead and added a regex to replace the internal, munged TensorFlow names with their nicer counterparts.  This isn't ideal, but it's a stopgap until @matthiaskramm exposes a pass that lets us avoid doing this.

I also looked into using location data exposed by passing `show_debug_info=True`.  Unfortunately, this only exposes internal TensorFlow `GraphDef` names, which are munged.  There's no information about Python line numbers for us to use to try to infer the original function name.

I'm leaving the old tool in place for now so we can have existing customers do some testing before cutting over fully.