### PR TITLE
Switch to use postsubmit runner group for macOS package release

### DIFF
--- a/.github/workflows/build_package.yml
+++ b/.github/workflows/build_package.yml
@@ -56,14 +56,14 @@ jobs:
           - runs-on:
               - ${{ github.repository == 'openxla/iree' && 'self-hosted' || 'macos-11' }}
               - os-family=macOS
-              - runner-group=releaser
+              - runner-group=postsubmit
             build-family: macos
             build-package: py-compiler-pkg
             experimental: true
           - runs-on:
               - ${{ github.repository == 'openxla/iree' && 'self-hosted' || 'macos-11' }}
               - os-family=macOS
-              - runner-group=releaser
+              - runner-group=postsubmit
             build-family: macos
             build-package: py-runtime-pkg
             experimental: true


### PR DESCRIPTION
Right now we only have one single Mac Mini, to be shared between release and postsubmit workload. Postsubmit runners can pick up tasks for release too.