### PR TITLE
Adding compilation reentrancy tests and new HAL pipeline phases.

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/MemoizeDeviceQueries.cpp
@@ -64,6 +64,7 @@ class MemoizeDeviceQueriesPass
     }
 
     // Create each query variable and replace the uses with loads.
+    SymbolTable symbolTable(moduleOp);
     auto moduleBuilder = OpBuilder::atBlockBegin(moduleOp.getBody());
     for (auto queryKey : llvm::enumerate(deviceQueryKeys)) {
       auto queryOps = deviceQueryOps[queryKey.value()];
@@ -82,10 +83,12 @@ class MemoizeDeviceQueriesPass
       auto valueGlobalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
           fusedLoc, variableName,
           /*isMutable=*/false, queryType);
+      symbolTable.insert(valueGlobalOp);
       valueGlobalOp.setPrivate();
       auto okGlobalOp = moduleBuilder.create<IREE::Util::GlobalOp>(
           fusedLoc, variableName + "_ok",
           /*isMutable=*/false, moduleBuilder.getI1Type());
+      symbolTable.insert(okGlobalOp);
       okGlobalOp.setPrivate();
 
       auto initializerOp =

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/Passes.h
@@ -25,6 +25,15 @@ namespace HAL {
 // Helpers
 //===----------------------------------------------------------------------===//
 
+enum class PipelinePhase {
+  // Runs the transform pipeline up to executable sources (pre translation).
+  ExecutableSources,
+  // Runs the transform pipeline until just after executable translation.
+  ExecutableTargets,
+  // Runs the full pipeline.
+  End,
+};
+
 // Adds a set of passes to the given pass manager that run the required HAL
 // transforms in the canonical order.
 //
@@ -35,8 +44,9 @@ namespace HAL {
 //   <run conversion to flow/sequencer/etc>
 //   buildHALTransformPassPipeline & run
 //   <run conversion from HAL to vm/etc>
-void buildHALTransformPassPipeline(OpPassManager &passManager,
-                                   const TargetOptions &targetOptions);
+void buildHALTransformPassPipeline(
+    OpPassManager &passManager, const TargetOptions &targetOptions,
+    PipelinePhase compileTo = PipelinePhase::End);
 
 // Adds a set of passes to the given pass manager that run the head of the HAL
 // pipeline to assign devices, materialize interfaces, and translate

--- a/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
+++ b/compiler/src/iree/compiler/Dialect/HAL/Transforms/test/materialize_resource_caches.mlir
@@ -208,3 +208,73 @@ func.func @exeLookup(%device : !hal.device) -> !hal.executable {
 }
 
 }
+
+// -----
+
+// Tests that materialization no-ops when resource caches have already been
+// materialized. Today this is rather simplistic and just bails if the names
+// match with the expectation being that users are mostly just running through
+// with --compile-to=hal and not trying to mutate intermediate HAL state. We
+// could rework the pass to support only materializing what's required based on
+// what resources are looked up.
+
+#pipeline_layout_0 = #hal.pipeline.layout<push_constants = 0, sets = [
+  #hal.descriptor_set.layout<0, bindings = [
+    #hal.descriptor_set.binding<0, storage_buffer>,
+    #hal.descriptor_set.binding<1, storage_buffer>
+  ]>
+]>
+
+module attributes {hal.device.targets = [#hal.device.target<"llvm-cpu">]} {
+
+util.global private @_descriptor_set_layout_0 : !hal.descriptor_set_layout
+util.initializer {
+  %device = hal.ex.shared_device : !hal.device
+  %descriptor_set_layout = hal.descriptor_set_layout.create device(%device : !hal.device) flags("None") bindings([#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>]) : !hal.descriptor_set_layout
+  util.global.store %descriptor_set_layout, @_descriptor_set_layout_0 : !hal.descriptor_set_layout
+  util.initializer.return
+}
+
+util.global private @_pipeline_layout_0 : !hal.pipeline_layout
+util.initializer {
+  %_descriptor_set_layout_0 = util.global.load @_descriptor_set_layout_0 : !hal.descriptor_set_layout
+  %device = hal.ex.shared_device : !hal.device
+  %pipeline_layout = hal.pipeline_layout.create device(%device : !hal.device) push_constants(0) layouts([%_descriptor_set_layout_0]) : !hal.pipeline_layout
+  util.global.store %pipeline_layout, @_pipeline_layout_0 : !hal.pipeline_layout
+  util.initializer.return
+}
+
+util.global private @_executable_exe : !hal.executable
+util.initializer {
+  %device = hal.ex.shared_device : !hal.device
+  %0 = hal.device.switch<%device : !hal.device> -> !hal.executable
+  #hal.device.match.executable.format<"vmvx-bytecode-fb"> {
+    %_pipeline_layout_0 = util.global.load @_pipeline_layout_0 : !hal.pipeline_layout
+    %exe = hal.executable.create device(%device : !hal.device) target(@exe0::@vmvx) layouts([%_pipeline_layout_0]) : !hal.executable
+    hal.return %exe : !hal.executable
+  },
+  #hal.match.always {
+    %1 = util.null : !hal.executable
+    hal.return %1 : !hal.executable
+  }
+  util.global.store %0, @_executable_exe : !hal.executable
+  util.initializer.return
+}
+
+hal.executable @exe {
+  hal.executable.variant @vmvx, target = <"vmvx", "vmvx-bytecode-fb"> {
+    hal.executable.export @entry ordinal(0) layout(#pipeline_layout_0) attributes {
+      workgroup_size = [32 : index, 1 : index, 1 : index]
+    }
+  }
+}
+
+// CHECK-LABEL: @exeLookup
+func.func @exeLookup(%device : !hal.device) -> !hal.executable {
+  // CHECK: %[[EXE:.+]] = util.global.load @_executable_exe : !hal.executable
+  %0 = util.global.load @_executable_exe : !hal.executable
+  // CHECK-NEXT: return %[[EXE]]
+  return %0 : !hal.executable
+}
+
+}

--- a/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
+++ b/compiler/src/iree/compiler/Dialect/Util/IR/UtilOps.td
@@ -350,7 +350,11 @@ def Util_UnfoldableConstantOp : Util_Op<"unfoldable_constant"> {
   let hasCanonicalizer = 1;
 }
 
-def Util_UnreachableOp : Util_Op<"unreachable", [NoMemoryEffect, Terminator]> {
+def Util_UnreachableOp : Util_Op<"unreachable", [
+    NoMemoryEffect,
+    ReturnLike,
+    Terminator
+  ]> {
   let summary = [{unreachable assertion op}];
   let description = [{
     Signals to the compiler that the parent block should not be reachable.

--- a/compiler/src/iree/compiler/Pipelines/Pipelines.h
+++ b/compiler/src/iree/compiler/Pipelines/Pipelines.h
@@ -34,6 +34,8 @@ enum class IREEVMPipelinePhase {
   Preprocessing,
   Flow,
   Stream,
+  ExecutableSources,
+  ExecutableTargets,
   HAL,
   VM,
   End,
@@ -54,6 +56,11 @@ inline static void enumerateIREEVMPipelinePhases(
            "Compiles up to the `flow` dialect.");
   callback(IREEVMPipelinePhase::Stream, "stream",
            "Compiles up to the `stream` dialect.");
+  callback(IREEVMPipelinePhase::ExecutableSources, "executable-sources",
+           "Compiles up to just before `hal.executable`s are translated, "
+           "excluding codegen.");
+  callback(IREEVMPipelinePhase::ExecutableTargets, "executable-targets",
+           "Compiles up to translated `hal.executable`s, including codegen.");
   callback(IREEVMPipelinePhase::HAL, "hal",
            "Compiles up to the `hal` dialect, including codegen.");
   callback(IREEVMPipelinePhase::VM, "vm", "Compiles up to the `vm` dialect.");

--- a/tools/test/BUILD
+++ b/tools/test/BUILD
@@ -18,6 +18,8 @@ iree_lit_test_suite(
     name = "lit",
     srcs = enforce_glob(
         [
+            "compile_pipelines.mlir",
+            "compile_to_continuation.mlir",
             "compile_to_phase.mlir",
             "executable_benchmarks.mlir",
             "executable_sources.mlir",
@@ -46,6 +48,7 @@ iree_lit_test_suite(
     tools = [
         "//tools:iree-benchmark-module",
         "//tools:iree-compile",
+        "//tools:iree-opt",
         "//tools:iree-run-mlir",
         "//tools:iree-run-module",
         "@llvm-project//lld",

--- a/tools/test/CMakeLists.txt
+++ b/tools/test/CMakeLists.txt
@@ -14,6 +14,8 @@ iree_lit_test_suite(
   NAME
     lit
   SRCS
+    "compile_pipelines.mlir"
+    "compile_to_continuation.mlir"
     "compile_to_phase.mlir"
     "executable_benchmarks.mlir"
     "executable_sources.mlir"
@@ -32,6 +34,7 @@ iree_lit_test_suite(
     FileCheck
     iree-benchmark-module
     iree-compile
+    iree-opt
     iree-run-mlir
     iree-run-module
     not

--- a/tools/test/compile_pipelines.mlir
+++ b/tools/test/compile_pipelines.mlir
@@ -1,0 +1,14 @@
+// RUN: iree-opt --iree-common-input-transformation-pipeline %s | \
+// RUN: iree-opt --iree-abi-transformation-pipeline - | \
+// RUN: iree-opt --iree-common-input-transformation-pipeline - | \
+// RUN: iree-opt --iree-flow-transformation-pipeline - | \
+// RUN: iree-opt --iree-stream-transformation-pipeline - | \
+// RUN: iree-opt --iree-hal-transformation-pipeline --iree-hal-target-backends=vmvx - | \
+// RUN: iree-opt --iree-vm-transformation-pipeline - | \
+// RUN: FileCheck %s
+
+// CHECK: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {
+  %result = math.absf %input : tensor<f32>
+  return %result : tensor<f32>
+}

--- a/tools/test/compile_to_continuation.mlir
+++ b/tools/test/compile_to_continuation.mlir
@@ -1,0 +1,44 @@
+// RUN: iree-compile --compile-to=input %s | \
+// RUN: iree-compile --output-format=vm-asm --iree-hal-target-backends=vmvx - | \
+// RUN: FileCheck %s --check-prefix=INPUT-PHASE
+// INPUT-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+// RUN: iree-compile --compile-to=abi %s | \
+// RUN: iree-compile --output-format=vm-asm --iree-hal-target-backends=vmvx - | \
+// RUN: FileCheck %s --check-prefix=ABI-PHASE
+// ABI-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+// RUN: iree-compile --compile-to=flow %s | \
+// RUN: iree-compile --output-format=vm-asm --iree-hal-target-backends=vmvx - | \
+// RUN: FileCheck %s --check-prefix=FLOW-PHASE
+// FLOW-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+// RUN: iree-compile --compile-to=stream %s | \
+// RUN: iree-compile --output-format=vm-asm --iree-hal-target-backends=vmvx - | \
+// RUN: FileCheck %s --check-prefix=STREAM-PHASE
+// STREAM-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+// RUN: iree-compile --compile-to=executable-sources --iree-hal-target-backends=vmvx %s | \
+// RUN: iree-compile --output-format=vm-asm - | \
+// RUN: FileCheck %s --check-prefix=EXECUTABLE-SOURCES-PHASE
+// EXECUTABLE-SOURCES-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+// RUN: iree-compile --compile-to=executable-targets --iree-hal-target-backends=vmvx %s | \
+// RUN: iree-compile --output-format=vm-asm - | \
+// RUN: FileCheck %s --check-prefix=EXECUTABLE-TARGETS-PHASE
+// EXECUTABLE-TARGETS-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+// RUN: iree-compile --compile-to=hal --iree-hal-target-backends=vmvx %s | \
+// RUN: iree-compile --output-format=vm-asm - | \
+// RUN: FileCheck %s --check-prefix=HAL-PHASE
+// HAL-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+// RUN: iree-compile --compile-to=vm --iree-hal-target-backends=vmvx %s | \
+// RUN: iree-compile --output-format=vm-asm - | \
+// RUN: FileCheck %s --check-prefix=VM-PHASE
+// VM-PHASE: vm.func private @abs(%arg0: !vm.ref<!hal.buffer_view>) -> !vm.ref<!hal.buffer_view>
+
+func.func @abs(%input : tensor<f32>) -> (tensor<f32>) {
+  %result = math.absf %input : tensor<f32>
+  return %result : tensor<f32>
+}

--- a/tools/test/compile_to_phase.mlir
+++ b/tools/test/compile_to_phase.mlir
@@ -1,19 +1,30 @@
-// RUN: iree-compile --compile-to=input --iree-hal-target-backends=vmvx %s | FileCheck %s --check-prefix=INPUT-PHASE
+// RUN: iree-compile --compile-to=input %s | FileCheck %s --check-prefix=INPUT-PHASE
 // INPUT-PHASE: func.func @abs(%[[ARG0:.+]]: tensor<f32>)
 // INPUT-PHASE: math.absf %[[ARG0]] : tensor<f32>
 
-// RUN: iree-compile --compile-to=abi --iree-hal-target-backends=vmvx %s | FileCheck %s --check-prefix=ABI-PHASE
+// RUN: iree-compile --compile-to=abi %s | FileCheck %s --check-prefix=ABI-PHASE
 // ABI-PHASE: func.func @abs(%[[ARG0:.+]]: !hal.buffer_view)
 // ABI-PHASE: %[[INPUT:.+]] = hal.tensor.import %[[ARG0]] : !hal.buffer_view -> tensor<f32>
 // ABI-PHASE: math.absf %[[INPUT]] : tensor<f32>
 
-// RUN: iree-compile --compile-to=flow --iree-hal-target-backends=vmvx %s | FileCheck %s --check-prefix=FLOW-PHASE
+// RUN: iree-compile --compile-to=flow %s | FileCheck %s --check-prefix=FLOW-PHASE
 // FLOW-PHASE: flow.executable.export public @abs_dispatch_0
 // FLOW-PHASE: flow.dispatch @abs_dispatch_0
 
-// RUN: iree-compile --compile-to=stream --iree-hal-target-backends=vmvx %s | FileCheck %s --check-prefix=STREAM-PHASE
+// RUN: iree-compile --compile-to=stream %s | FileCheck %s --check-prefix=STREAM-PHASE
 // STREAM-PHASE: stream.executable.export public @abs_dispatch_0
 // STREAM-PHASE: stream.cmd.dispatch @abs_dispatch_0
+
+// RUN: iree-compile --compile-to=executable-sources --iree-hal-target-backends=vmvx %s | FileCheck %s --check-prefix=EXECUTABLE-SOURCES-PHASE
+// EXECUTABLE-SOURCES-PHASE: hal.executable private @abs_dispatch_0
+// EXECUTABLE-SOURCES-PHASE: hal.executable.variant
+// EXECUTABLE-SOURCES-PHASE: linalg.generic
+// EXECUTABLE-SOURCES-PHASE: math.absf
+
+// RUN: iree-compile --compile-to=executable-targets --iree-hal-target-backends=vmvx %s | FileCheck %s --check-prefix=EXECUTABLE-TARGETS-PHASE
+// EXECUTABLE-TARGETS-PHASE: hal.executable private @abs_dispatch_0
+// EXECUTABLE-TARGETS-PHASE: hal.executable.variant
+// EXECUTABLE-TARGETS-PHASE: vm.abs.f32
 
 // RUN: iree-compile --compile-to=hal --iree-hal-target-backends=vmvx %s | FileCheck %s --check-prefix=HAL-PHASE
 // HAL-PHASE: hal.executable private @abs_dispatch_0


### PR DESCRIPTION
Two new `--compile-to=` phases are supported:
- `executable-sources`: run just past interface materialization where `hal.executable` ops with target configurations are present.
- `executable-targets`: run just past executable translation where `hal.executable.variant` ops have been lowered to their final MLIR form before linking and serialization (LLVM dialect, SPIR-V dialect, etc).

New tests are added that demonstrate and verify that iree-opt pipelines can be run piecewise to produce a final output and that `--compile-to=` at any particular phase can be passed back in and lowered down to a final output.

A few passes were tweaked to ensure these tests pass.