### PR TITLE
Only build iree_bitcode_library targets when llvm-cpu is enabled.

### DIFF
--- a/runtime/src/iree/builtins/device/BUILD
+++ b/runtime/src/iree/builtins/device/BUILD
@@ -42,7 +42,7 @@ iree_runtime_cc_library(
 
 iree_cmake_extra_content(
     content = """
-if(NOT IREE_BUILD_COMPILER)
+if(NOT IREE_BUILD_COMPILER OR NOT IREE_TARGET_BACKEND_LLVM_CPU)
   return()
 endif()
 """,

--- a/runtime/src/iree/builtins/device/CMakeLists.txt
+++ b/runtime/src/iree/builtins/device/CMakeLists.txt
@@ -22,7 +22,7 @@ iree_cc_library(
   PUBLIC
 )
 
-if(NOT IREE_BUILD_COMPILER)
+if(NOT IREE_BUILD_COMPILER OR NOT IREE_TARGET_BACKEND_LLVM_CPU)
   return()
 endif()
 


### PR DESCRIPTION
This fixes CMake configuration when only `-DIREE_TARGET_BACKEND_VMVX=ON` is set, since `IREE_CLANG_TARGET` is _not_ set by https://github.com/openxla/iree/blob/bd512a0195f8deedc6673fc76f83d9c6ac194d7f/build_tools/cmake/iree_llvm.cmake#L164-L166 

---

The `iree_bitcode_library` targets are currently only referenced in https://github.com/openxla/iree/blob/bd512a0195f8deedc6673fc76f83d9c6ac194d7f/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/Builtins/BUILD#L27 which may be skipped by https://github.com/openxla/iree/blob/bd512a0195f8deedc6673fc76f83d9c6ac194d7f/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt#L11-L13

---

Note: this does not fully fix the _build_ when only `-DIREE_TARGET_BACKEND_VMVX=ON` is set, since we still include some `lld` targets unconditionally:
```
[build] LINK : fatal error LNK1104: cannot open file 'lldCOFF.lib'
```