### PR TITLE
Build libIREECompiler.so in bazel.

### DIFF
--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -49,6 +49,12 @@ timeout_map = {
 }
 
 
+def _should_skip_target(tags=None, **kwargs):
+  if tags and "skip-bazel_to_cmake" in tags:
+    return True
+  return False
+
+
 def _convert_timeout_arg_block(name, value):
   if value is None:
     return ""
@@ -255,6 +261,8 @@ class BuildFileFunctions(object):
     self._convert_unimplemented_function("filegroup", name)
 
   def sh_binary(self, name, **kwargs):
+    if _should_skip_target(**kwargs):
+      return
     self._convert_unimplemented_function("sh_binary", name)
 
   def enforce_glob(self, files, **kwargs):
@@ -316,6 +324,8 @@ class BuildFileFunctions(object):
                  linkopts=None,
                  includes=None,
                  **kwargs):
+    if _should_skip_target(**kwargs):
+      return
     if linkopts:
       self._convert_unimplemented_function("linkopts")
     name_block = _convert_string_arg_block("NAME", name, quote=False)
@@ -363,6 +373,8 @@ class BuildFileFunctions(object):
               tags=None,
               includes=None,
               **kwargs):
+    if _should_skip_target(tags=tags, **kwargs):
+      return
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     hdrs_block = _convert_string_list_block("HDRS", hdrs, sort=True)
     srcs_block = _convert_srcs_block(srcs)
@@ -406,6 +418,8 @@ class BuildFileFunctions(object):
                 testonly=None,
                 includes=None,
                 **kwargs):
+    if _should_skip_target(**kwargs):
+      return
     if linkopts:
       self._convert_unimplemented_function("linkopts")
     name_block = _convert_string_arg_block("NAME", name, quote=False)
@@ -442,6 +456,8 @@ class BuildFileFunctions(object):
                    identifier=None,
                    deps=None,
                    **kwargs):
+    if _should_skip_target(**kwargs):
+      return
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     srcs_block = _convert_srcs_block(srcs)
     c_file_output_block = _convert_string_arg_block("C_FILE_OUTPUT",
@@ -565,6 +581,8 @@ class BuildFileFunctions(object):
                             f")\n\n")
 
   def iree_gentbl_cc_library(self, **kwargs):
+    if _should_skip_target(**kwargs):
+      return
     # The bazel version of this rule adds some include directories and defs
     # that are implicitly handled by the cmake version.
     self.gentbl_cc_library(**kwargs)
@@ -598,6 +616,8 @@ class BuildFileFunctions(object):
                           tags=None,
                           timeout=None,
                           **kwargs):
+    if _should_skip_target(tags=tags, **kwargs):
+      return
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     srcs_block = _convert_srcs_block(srcs)
     tools_block = _convert_target_list_block("TOOLS", tools)
@@ -626,6 +646,8 @@ class BuildFileFunctions(object):
                                            target_cpu_features=None,
                                            timeout=None,
                                            **kwargs):
+    if _should_skip_target(tags=tags, **kwargs):
+      return
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     srcs_block = _convert_srcs_block(srcs)
     target_backend_block = _convert_string_arg_block("TARGET_BACKEND",
@@ -661,6 +683,8 @@ class BuildFileFunctions(object):
                             target_cpu_features_variants=None,
                             timeout=None,
                             **kwargs):
+    if _should_skip_target(tags=tags, **kwargs):
+      return
     target_backends = None
     drivers = None
     if target_backends_and_drivers is not None:
@@ -703,6 +727,8 @@ class BuildFileFunctions(object):
                                        tags=None,
                                        target_cpu_features_variants=None,
                                        **kwargs):
+    if _should_skip_target(tags=tags, **kwargs):
+      return
     target_backends = None
     drivers = None
     if target_backends_and_drivers is not None:
@@ -749,6 +775,8 @@ class BuildFileFunctions(object):
                   data=None,
                   tags=None,
                   timeout=None):
+    if _should_skip_target(tags=tags):
+      return
     if data is not None:
       self._convert_unimplemented_function("native_test", name + " has data")
 
@@ -779,7 +807,8 @@ class BuildFileFunctions(object):
       # unused
       size="small",
       timeout=None):
-
+    if _should_skip_target(tags=tags):
+      return
     name_block = _convert_string_arg_block("NAME", name, quote=False)
     srcs_block = _convert_srcs_block(srcs)
     data_block = _convert_target_list_block("DATA", data)

--- a/compiler/bindings/c/BUILD
+++ b/compiler/bindings/c/BUILD
@@ -33,4 +33,20 @@ cc_library(
     ],
 )
 
-# TODO: Support loader_test in Bazel.
+cc_test(
+    name = "loader_test",
+    srcs = [
+        "iree/compiler/loader/loader_test.c",
+    ],
+    args = [
+        "lib/libIREECompiler.so",
+    ],
+    data = [
+        "//lib:libIREECompiler.so",
+    ],
+    tags = ["skip-bazel_to_cmake"],
+    deps = [
+        ":headers",
+        ":loader",
+    ],
+)

--- a/lib/BUILD
+++ b/lib/BUILD
@@ -1,16 +1,15 @@
-# Copyright 2022 The IREE Authors
+# Copyright 2023 The IREE Authors
 #
 # Licensed under the Apache License v2.0 with LLVM Exceptions.
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-# bazel-to-cmake: skip
+package(
+    default_visibility = ["//visibility:public"],
+    features = ["layering_check"],
+    licenses = ["notice"],  # Apache 2.0
+)
 
-# This is problematic on anything non-Linux but Bazel has failed
-# for years to provide the flexibility to make it any better. Yolo.
-# We really only support this for some very narrow use cases that
-# need to dynamically load the compiler as a shared library, and other
-# uses are served by the cross-platform CMake build.
 cc_binary(
     name = "libIREECompiler.so",
     srcs = [


### PR DESCRIPTION
* Moves the deeply nested build rule to lib/. Unlike CMake, Bazel offers no control on where things are output in the tree (or name), so we just put the binary target in the place where CMake puts it, preserving the directory layout of artifacts between them. This results in a small deviation on where this target is actually declared (lib/ in bazel and iree/compiler/API2:SharedImpl in CMake) but the same output path.
* Wires up the loader_test in bazel and makes it able to find the shared library data dependency.
* Extends bazel_to_cmake to respect the `skip-bazel_to_cmake` tag to make it skip conversion of common targets. I've needed this for some time and I expect will let us normalize more build files that only differ by a target or two.
* I've confirmed that this works in Google's internal build system (with appropriate buildozer path changes and such).