### PR TITLE
Add bazel `iree_link_compiler_shared` flag.

### DIFF
--- a/build_tools/bazel/iree.bazelrc
+++ b/build_tools/bazel/iree.bazelrc
@@ -5,14 +5,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ###############################################################################
-# Short-hand config settings for IREE specific features.
-###############################################################################
-
-# Equivalent to CMake flag IREE_ENABLE_RUNTIME_TRACING.
-# Builds the runtime with tracing support enabled.
-build --flag_alias=iree_enable_runtime_tracing=@tracy_client//:runtime_enable
-
-###############################################################################
 # Common flags that apply to all configurations.
 # Use sparingly for things common to all compilers and platforms.
 ###############################################################################
@@ -45,6 +37,10 @@ build --enable_runfiles
 # Build settings flag aliases. See https://bazel.build/rules/config
 ###############################################################################
 build --flag_alias=iree_drivers=//runtime/src/iree/hal/drivers:enabled_drivers
+build --flag_alias=iree_link_compiler_shared=//compiler/src/iree/compiler/API2:link_shared
+# Equivalent to CMake flag IREE_ENABLE_RUNTIME_TRACING.
+# Builds the runtime with tracing support enabled.
+build --flag_alias=iree_enable_runtime_tracing=@tracy_client//:runtime_enable
 
 ###############################################################################
 # Options for "generic_gcc" builds

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -227,6 +227,9 @@ class BuildFileFunctions(object):
   def alias(self, *args, **kwargs):
     pass
 
+  def bool_flag(self, *args, **kwargs):
+    pass
+
   def load(self, *args, **kwargs):
     pass
 
@@ -307,9 +310,11 @@ class BuildFileFunctions(object):
   def platform_trampoline_deps(self, basename, path="base"):
     return [f"//{path}/internal:{basename}_internal"]
 
-  def select(self, d):
-    self._convert_unimplemented_function("select", str(d))
-    return d["//conditions:default"]
+  def select(self, selector):
+    default_value = selector.get("//conditions:default")
+    if default_value is None:
+      raise ValueError("bazel_to_cmake can only convert selects with a default")
+    return default_value
 
   def cc_library(self,
                  name,

--- a/compiler/src/iree/compiler/API2/BUILD
+++ b/compiler/src/iree/compiler/API2/BUILD
@@ -70,11 +70,6 @@ config_setting(
     },
 )
 
-# Bazel does not have a well-defined mechanism for managing
-# shared libraries in a cross-platform way. Therefore, we
-# only support static linking of tools. Separately, we do
-# build an actual shared library for platforms that support
-# it, but this is only done to support stub use-cases.
 alias(
     name = "Impl",
     actual = select({

--- a/compiler/src/iree/compiler/API2/BUILD
+++ b/compiler/src/iree/compiler/API2/BUILD
@@ -4,6 +4,7 @@
 # See https://llvm.org/LICENSE.txt for license information.
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
 load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library")
 
 package(
@@ -49,6 +50,26 @@ iree_compiler_cc_library(
     ],
 )
 
+iree_compiler_cc_library(
+    name = "SharedImpl",
+    srcs = [
+        "//lib:libIREECompiler.so",
+    ],
+    tags = ["skip-bazel_to_cmake"],
+)
+
+bool_flag(
+    name = "link_shared",
+    build_setting_default = False,
+)
+
+config_setting(
+    name = "link_shared_config",
+    flag_values = {
+        ":link_shared": "True",
+    },
+)
+
 # Bazel does not have a well-defined mechanism for managing
 # shared libraries in a cross-platform way. Therefore, we
 # only support static linking of tools. Separately, we do
@@ -56,5 +77,8 @@ iree_compiler_cc_library(
 # it, but this is only done to support stub use-cases.
 alias(
     name = "Impl",
-    actual = ":StaticImpl",
+    actual = select({
+        ":link_shared_config": ":SharedImpl",
+        "//conditions:default": ":StaticImpl",
+    }),
 )


### PR DESCRIPTION
With prior changes, it is now possible to make Bazel mirror CMake with respect to shared linking of the compiler. This flag does that. We default it to false for safety (CMake defaults to true). I don't know how much we will use this but having 1:1 correspondance of the build system has some merit.