### PR TITLE
Basic plumbing to allow to build against libLLVM based installed LLVM.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -715,6 +715,9 @@ else()
   # we add usage requirements to libraries at the root of all things LLVM.
   iree_llvm_add_usage_requirements(LLVMSupport IREELLVMIncludeSetup)
   iree_llvm_add_usage_requirements(MLIRSupport IREELLVMIncludeSetup)
+  if(TARGET LLVM)
+    iree_llvm_add_usage_requirements(LLVM IREELLVMIncludeSetup)
+  endif()
 
   # Add default external projects.
   iree_llvm_add_external_project(mlir-iree-dialects ${CMAKE_CURRENT_SOURCE_DIR}/llvm-external-projects/iree-dialects)

--- a/build_tools/cmake/iree_cc_binary.cmake
+++ b/build_tools/cmake/iree_cc_binary.cmake
@@ -127,6 +127,7 @@ function(iree_cc_binary)
   if(IREE_IMPLICIT_DEFS_CC_DEPS)
     list(APPEND _RULE_DEPS ${IREE_IMPLICIT_DEFS_CC_DEPS})
   endif()
+  iree_cc_filter_deps(_RULE_DEPS)
 
   target_link_libraries(${_NAME}
     PUBLIC

--- a/build_tools/cmake/iree_cc_test.cmake
+++ b/build_tools/cmake/iree_cc_test.cmake
@@ -112,6 +112,7 @@ function(iree_cc_test)
   # Replace dependencies passed by ::name with iree::package::name
 
   list(TRANSFORM _RULE_DEPS REPLACE "^::" "${_PACKAGE_NS}::")
+  iree_cc_filter_deps(_RULE_DEPS)
 
   target_link_libraries(${_NAME}
     PUBLIC

--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -81,6 +81,11 @@ macro(iree_llvm_configure_installed)
   find_package(Clang REQUIRED)
   list(APPEND CMAKE_MODULE_PATH "${CLANG_CMAKE_DIR}")
 
+  # Tell IREE that we have clang and lld available.
+  set(IREE_CLANG_TARGET "clang")
+  set(IREE_LLD_TARGET "lld")
+  set(IREE_LLVM_LINK_TARGET "llvm-link")
+
   # Lit never gets installed with LLVM. So we have to reach into our copy
   # of the monorepo to get it. I'm sorry. If this doesn't work for you,
   # feel free to -DLLVM_EXTERNAL_LIT to provide your own.

--- a/build_tools/scripts/byo_llvm.sh
+++ b/build_tools/scripts/byo_llvm.sh
@@ -69,7 +69,7 @@ do_build_llvm() {
   echo "*********************** BUILDING LLVM *********************************"
   main_build_dir="${LLVM_BUILD_DIR}/llvm"
   main_install_dir="${LLVM_INSTALL_DIR}/llvm"
-  targets_to_build="${LLVM_TARGETS_TO_BUILD:-X86}"
+  targets_to_build="${LLVM_TARGETS_TO_BUILD:-AArch64;ARM;RISCV;WebAssembly;X86;NVPTX;WebAssembly}"
   enable_projects="${LLVM_ENABLE_TARGETS:-clang;lld}"
 
   cmake_options="-DLLVM_ENABLE_PROJECTS='${enable_projects}' -DLLVM_TARGETS_TO_BUILD='${targets_to_build}'"
@@ -77,6 +77,8 @@ do_build_llvm() {
   cmake_options="${cmake_options} -DLLVM_INSTALL_UTILS=ON"
   cmake_options="${cmake_options} -DCMAKE_BUILD_TYPE=Release"
   cmake_options="${cmake_options} -DLLVM_ENABLE_ASSERTIONS=ON"
+  cmake_options="${cmake_options} -DLLVM_BUILD_LLVM_DYLIB=ON"
+  cmake_options="${cmake_options} -DLLVM_LINK_LLVM_DYLIB=ON"
   cmake_options="${cmake_options} $(print_toolchain_config)"
   if $has_lld; then
     cmake_options="${cmake_options} -DLLVM_ENABLE_LLD=ON"
@@ -101,6 +103,7 @@ do_build_mlir() {
   cmake_options="${cmake_options} -DPython3_EXECUTABLE='$(which $python3_command)'"
   cmake_options="${cmake_options} -DLLVM_INSTALL_TOOLCHAIN_ONLY=OFF"
   cmake_options="${cmake_options} -DLLVM_BUILD_TOOLS=ON"
+  cmake_options="${cmake_options} -DCMAKE_BUILD_TYPE=Release"
   cmake_options="${cmake_options} -DLLVM_ENABLE_ASSERTIONS=ON"
   cmake_options="${cmake_options} -DMLIR_ENABLE_BINDINGS_PYTHON=ON"
   cmake_options="${cmake_options} $(print_toolchain_config)"
@@ -144,7 +147,7 @@ print_iree_config() {
     return 1
   fi
 
-  echo "-DLLVM_DIR='$llvm_cmake_dir' -DLLD_DIR='$lld_cmake_dir' -DCLANG_DIR='$clang_cmake_dir' -DMLIR_DIR='$mlir_cmake_dir' -DIREE_BUILD_BUNDLED_LLVM=OFF"
+  echo "-DLLVM_DIR='$llvm_cmake_dir' -DLLD_DIR='$lld_cmake_dir' -DClang_DIR='$clang_cmake_dir' -DMLIR_DIR='$mlir_cmake_dir' -DIREE_BUILD_BUNDLED_LLVM=OFF"
 }
 
 do_build_iree() {
@@ -156,6 +159,9 @@ do_build_iree() {
   cmake_options="${cmake_options} -DPython3_EXECUTABLE='$(which $python3_command)'"
   cmake_options="${cmake_options} -DIREE_BUILD_PYTHON_BINDINGS=ON"
   cmake_options="${cmake_options} -DIREE_TARGET_BACKEND_DEFAULTS=OFF"
+  # TODO: Needed so as to have the iree-llvm-embedded-linker-path cli option.
+  # Eliminate that need.
+  cmake_options="${cmake_options} -DIREE_TARGET_BACKEND_LLVM_CPU=ON"
   cmake_options="${cmake_options} -DIREE_HAL_DRIVER_DEFAULTS=OFF"
   cmake_options="${cmake_options} -DIREE_HAL_DRIVER_LOCAL_SYNC=ON"
   cmake_options="${cmake_options} -DIREE_HAL_DRIVER_LOCAL_TASK=ON"

--- a/build_tools/scripts/byo_llvm.sh
+++ b/build_tools/scripts/byo_llvm.sh
@@ -76,7 +76,7 @@ do_build_llvm() {
   cmake_options="${cmake_options} -DLLVM_BUILD_EXAMPLES=OFF"
   cmake_options="${cmake_options} -DLLVM_INSTALL_UTILS=ON"
   cmake_options="${cmake_options} -DCMAKE_BUILD_TYPE=Release"
-  cmake_options="${cmake_options} -DLLVM_ENABLE_ASSERTIONS=ON"
+  #cmake_options="${cmake_options} -DLLVM_ENABLE_ASSERTIONS=ON"
   cmake_options="${cmake_options} -DLLVM_BUILD_LLVM_DYLIB=ON"
   cmake_options="${cmake_options} -DLLVM_LINK_LLVM_DYLIB=ON"
   cmake_options="${cmake_options} $(print_toolchain_config)"
@@ -104,7 +104,7 @@ do_build_mlir() {
   cmake_options="${cmake_options} -DLLVM_INSTALL_TOOLCHAIN_ONLY=OFF"
   cmake_options="${cmake_options} -DLLVM_BUILD_TOOLS=ON"
   cmake_options="${cmake_options} -DCMAKE_BUILD_TYPE=Release"
-  cmake_options="${cmake_options} -DLLVM_ENABLE_ASSERTIONS=ON"
+  #cmake_options="${cmake_options} -DLLVM_ENABLE_ASSERTIONS=ON"
   cmake_options="${cmake_options} -DMLIR_ENABLE_BINDINGS_PYTHON=ON"
   cmake_options="${cmake_options} $(print_toolchain_config)"
   if $has_lld; then
@@ -166,7 +166,7 @@ do_build_iree() {
   cmake_options="${cmake_options} -DIREE_HAL_DRIVER_LOCAL_SYNC=ON"
   cmake_options="${cmake_options} -DIREE_HAL_DRIVER_LOCAL_TASK=ON"
   cmake_options="${cmake_options} -DCMAKE_BUILD_TYPE=Release"
-  cmake_options="${cmake_options} -DIREE_ENABLE_ASSERTIONS=ON"
+  #cmake_options="${cmake_options} -DIREE_ENABLE_ASSERTIONS=ON"
   cmake_options="${cmake_options} $(print_toolchain_config)"
   if $has_lld; then
     cmake_options="${cmake_options} -DIREE_ENABLE_LLD=ON"

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVM/CMakeLists.txt
@@ -146,11 +146,13 @@ add_library(IREELLVMCPUTargetDeps INTERFACE)
 function(_add_optional_llvm_target_deps target)
   # Key off of the CodeGen target and then include the rest.
   if(TARGET "LLVM${target}CodeGen")
-    target_link_libraries(IREELLVMCPUTargetDeps INTERFACE
+    set(_deps
       "LLVM${target}AsmParser"
       "LLVM${target}CodeGen"
       "LLVM${target}Desc"
       "LLVM${target}Info")
+    iree_cc_filter_deps(_deps)
+    target_link_libraries(IREELLVMCPUTargetDeps INTERFACE ${_deps})
   endif()
 endfunction()
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -190,11 +190,14 @@ if(IREE_BUILD_COMPILER)
   # If a target backend that requires LLD to link codegen executables is
   # enabled, install the target.
   if(IREE_LLD_TARGET)
-    install(
-      TARGETS lld
-      COMPONENT Compiler
-      RUNTIME DESTINATION bin
-    )
+    get_target_property(_is_lld_imported ${IREE_LLD_TARGET} IMPORTED)
+    if(NOT _is_lld_imported)
+      install(
+        TARGETS lld
+        COMPONENT Compiler
+        RUNTIME DESTINATION bin
+      )
+    endif()
   endif()
 
   iree_cc_binary(
@@ -205,12 +208,12 @@ if(IREE_BUILD_COMPILER)
       "${IREE_SOURCE_DIR}/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp"
       "${IREE_SOURCE_DIR}/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp"
     DEPS
-      LLVMSupport
-      LLVMTableGen
-      MLIRSupport
+      # Important: Tablegen is special and is only ever linked static and
+      # must not include other MLIR/LLVM libraries. See notes on the
+      # MLIRTblgenLib target. Violating this will cause global symbol conflicts
+      # in libLLVM builds.
       MLIRTableGen
       MLIRTblgenLib
-      iree::compiler::Utils
     HOSTONLY
   )
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -205,6 +205,7 @@ if(IREE_BUILD_COMPILER)
       iree-tblgen
     SRCS
       "${IREE_ROOT_DIR}/third_party/llvm-project/mlir/tools/mlir-tblgen/mlir-tblgen.cpp"
+      "${IREE_ROOT_DIR}/third_party/llvm-project/mlir/lib/Support/IndentedOstream.cpp"
       "${IREE_SOURCE_DIR}/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpEncoderGen.cpp"
       "${IREE_SOURCE_DIR}/compiler/src/iree/compiler/Dialect/VM/Tools/VMOpTableGen.cpp"
     DEPS


### PR DESCRIPTION
This is an inherently fragile build setup for LLVM, and there are things that won't work without upstream fixes. But this is about as good as it will get as a downstream given how LLVM reasons about this stuff.

For best results, this needs the installed LLVM to have https://reviews.llvm.org/D145351. If it does not, it should still function but not as much will be taken from libLLVM.so (more will be bundled into IREE statically).