### PR TITLE
Fix failing test on macOS.

### DIFF
--- a/build_tools/cmake/ctest_all.sh
+++ b/build_tools/cmake/ctest_all.sh
@@ -102,8 +102,6 @@ elif [[ "$OSTYPE" =~ ^darwin ]]; then
   excluded_tests+=(
     #TODO(#12496): Remove after fixing the test on macOS
     "iree/compiler/bindings/c/loader_test"
-    #TODO(#12496): Remove after fixing the test on macOS
-    "iree/compiler/API/python/test/transforms/ireec/compile_sample_module"
   )
 fi
 

--- a/tools/test/iree-run-module-outputs.mlir
+++ b/tools/test/iree-run-module-outputs.mlir
@@ -2,7 +2,7 @@
 
 // RUN: (iree-compile --iree-hal-target-backends=vmvx %s | \
 // RUN:  iree-run-module --device=local-sync --function=no_output) | \
-// RUN: FileCheck --check-prefix=NO-OUTPUT %s
+// RUN: FileCheck --check-prefix=NO-OUTPUT-LABEL %s
 // NO-OUTPUT-LABEL: EXEC @no_output
 func.func @no_output() {
   return


### PR DESCRIPTION
The test is failing because --check-prefix does not point to the correct label. `--check-prefix=NO-OUTPUT` is replaced by
`--check-prefix=NO-OUTPUT-LABEL` to match the correct label.

issue: #12496