### PR TITLE
Add additional options to the ApplyPatternsOp

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -139,7 +139,8 @@ void transform_dialect::ApplyPatternsOp::build(
   /// When touching something here, do not forget to update CommonExtensions.h.
   ///
   ADD_PATTERN(additionalIreePatterns, getAdditionalIreePatternsAttrName)
-  ADD_PATTERN(bubbleCollapseExpand, getBubbleCollapseExpandAttrName)
+  ADD_PATTERN(bubbleCollapse, getBubbleCollapseAttrName)
+  ADD_PATTERN(bubbleExpand, getBubbleExpandAttrName)
   ADD_PATTERN(bubblePackUnPack, getBubblePackUnPackAttrName)
   ADD_PATTERN(canonicalization, getCanonicalizationAttrName)
   ADD_PATTERN(cse, getCseAttrName)
@@ -318,7 +319,11 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
   MLIRContext *ctx = target->getContext();
   RewritePatternSet patterns(ctx);
   if (getAdditionalIreePatterns()) addAdditionalIreePatterns(patterns);
-  if (getBubbleCollapseExpand()) {
+  if (getBubbleCollapse()) {
+    linalg::populateFoldReshapeOpsByCollapsingPatterns(
+        patterns, [](OpOperand *) { return true; });
+  }
+  if (getBubbleExpand()) {
     linalg::populateFoldReshapeOpsByExpansionPatterns(
         patterns, [](OpOperand *) { return true; });
   }

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.cpp
@@ -153,6 +153,8 @@ void transform_dialect::ApplyPatternsOp::build(
   ADD_PATTERN(lowerTransferOpPermutations,
               getLowerTransferOpPermutationsAttrName)
   ADD_PATTERN(rankReducingLinalg, getRankReducingLinalgAttrName)
+  ADD_PATTERN(rankReducingLinalgViaReshapes,
+              getRankReducingLinalgViaReshapesAttrName)
   ADD_PATTERN(rankReducingVector, getRankReducingVectorAttrName)
   ADD_PATTERN(swapPaddingElideConditional,
               getSwapPaddingElideConditionalAttrName)
@@ -230,6 +232,12 @@ static void addEraseUnnecessaryTensorOperandsPatterns(
 static void addRankReducingLinalgPatterns(RewritePatternSet &patterns) {
   populateReshapeToInterfaceTensorPatterns(patterns);
   linalg::populateFoldUnitExtentDimsViaSlicesPatterns(patterns);
+}
+
+static void addRankReducingLinalgViaReshapesPatterns(
+    RewritePatternSet &patterns) {
+  populateReshapeToInterfaceTensorPatterns(patterns);
+  linalg::populateFoldUnitExtentDimsViaReshapesPatterns(patterns);
 }
 
 static void addRankReducingVectorPatterns(RewritePatternSet &patterns) {
@@ -324,6 +332,8 @@ DiagnosedSilenceableFailure transform_dialect::ApplyPatternsOp::applyToOne(
   if (getLowerTransferOpPermutations())
     addLowerTransferOpPermutationsPatterns(patterns);
   if (getRankReducingLinalg()) addRankReducingLinalgPatterns(patterns);
+  if (getRankReducingLinalgViaReshapes())
+    addRankReducingLinalgViaReshapesPatterns(patterns);
   if (getRankReducingVector()) addRankReducingVectorPatterns(patterns);
   if (getSwappingPatterns())
     addSwappingPatterns(patterns, getSwapPaddingElideConditional());

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -48,6 +48,7 @@ struct ApplyPatternsOpPatterns {
   bool lowerTransferOpPermutations = false;
   bool promoteForallCaptureToShared = false;
   bool rankReducingLinalg = false;
+  bool rankReducingLinalgViaReshapes = false;
   bool rankReducingVector = false;
   bool swapPaddingElideConditional = false;
   bool swappingPatterns = false;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -47,6 +47,7 @@ struct ApplyPatternsOpPatterns {
   bool foldReassociativeReshapes = false;
   bool foldTensorEmptyExtract = false;
   bool licm = false;
+  bool linalgElementwiseGreedyFusion = false;
   bool lowerTransferOpPermutations = false;
   bool promoteForallCaptureToShared = false;
   bool rankReducingLinalg = false;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -36,7 +36,8 @@ namespace transform_dialect {
 /// Selected patterns for ApplyPatternOp.
 struct ApplyPatternsOpPatterns {
   bool additionalIreePatterns = false;
-  bool bubbleCollapseExpand = false;
+  bool bubbleCollapse = false;
+  bool bubbleExpand = false;
   bool bubblePackUnPack = false;
   bool canonicalization = false;
   bool cse = false;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensions.h
@@ -37,6 +37,7 @@ namespace transform_dialect {
 struct ApplyPatternsOpPatterns {
   bool additionalIreePatterns = false;
   bool bubbleCollapseExpand = false;
+  bool bubblePackUnPack = false;
   bool canonicalization = false;
   bool cse = false;
   bool eraseUnnecessaryTensorOperands = false;

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -103,6 +103,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
       iteration loop promotion. This is not a set of patterns per se but is still
       very convenient to apply it close to canonicalization and other greedy 
       pattern applications.
+      - linalg_elementwise_greedy_fusion: add linalg elementwise ops fusion 
+      patterns using a naive default heuristic.
       - lower_transfer_op_permutations: Lower transfer ops to transfer ops
       with minor identity permutations.
       - rank_reducing_linalg: adds patterns that results in rank-reducing
@@ -154,6 +156,7 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
                        UnitAttr:$fold_reassociative_reshapes,
                        UnitAttr:$fold_tensor_empty_extract,
                        UnitAttr:$licm,
+                       UnitAttr:$linalg_elementwise_greedy_fusion,
                        UnitAttr:$lower_transfer_op_permutations,
                        UnitAttr:$rank_reducing_linalg,
                        UnitAttr:$rank_reducing_linalg_via_reshapes,

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -197,8 +197,8 @@ def HoistStaticAllocOp :  Op<Transform_Dialect, "iree.hoist_static_alloc",
     It always return success.
   }];
 
-  let arguments = (ins Transform_ConcreteOpType<"func.func">:$target);
-  let results = (outs Transform_ConcreteOpType<"func.func">:$result);
+  let arguments = (ins TransformHandleTypeInterface:$target);
+  let results = (outs TransformHandleTypeInterface:$result);
 
   let assemblyFormat = "$target attr-dict `:` functional-type(operands, results)";
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
@@ -425,10 +425,10 @@ def ShareForallOperandsOp : Op<
   }];
 
   let arguments = (
-      ins Transform_ConcreteOpType<"scf.forall">:$forall_op,
+      ins TransformHandleTypeInterface:$forall_op,
           DefaultValuedOptionalAttr<DenseI64ArrayAttr, "{}">:$share_operands
   );
-  let results = (outs Transform_ConcreteOpType<"scf.forall">:$result);
+  let results = (outs TransformHandleTypeInterface:$result);
 
   let cppNamespace = "mlir::iree_compiler::IREE::transform_dialect";
 

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -100,7 +100,9 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
       - lower_transfer_op_permutations: Lower transfer ops to transfer ops
       with minor identity permutations.
       - rank_reducing_linalg: adds patterns that results in rank-reducing
-      behavior on subset-based linalg operations.
+      behavior on subset-based linalg operations using insert/extract slices.
+      - rank_reducing_linalg_via_reshapes: adds patterns that results in rank-reducing
+      behavior on subset-based linalg operations using expand/collapse shape ops.
       - rank_reducing_vector: adds patterns that results in rank-reducing 
       behavior on subset-based vector operations.
       adopts the upstream version.
@@ -146,6 +148,7 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
                        UnitAttr:$licm,
                        UnitAttr:$lower_transfer_op_permutations,
                        UnitAttr:$rank_reducing_linalg,
+                       UnitAttr:$rank_reducing_linalg_via_reshapes,
                        UnitAttr:$rank_reducing_vector,
                        UnitAttr:$swap_padding_elide_conditional,
                        UnitAttr:$swapping_patterns,

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -76,6 +76,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
       will need to be sliced out better in the future.
       - bubble_collapse_expand: bubble `expand_shape` up and `collapse_shape`
       down across Linalg ops.
+      - bubble_pack_un_pack: bubble `pack` up and `unpack` down across Linalg
+      ops.
       - canonicalization: adds all the canonicalization patterns of all
       registered dialects and ops.
       - cse: additionally apply common subexpression elimination. This must
@@ -138,6 +140,7 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
   let arguments = (ins PDL_Operation:$target,
                        UnitAttr:$additional_iree_patterns,
                        UnitAttr:$bubble_collapse_expand,
+                       UnitAttr:$bubble_pack_un_pack,
                        UnitAttr:$canonicalization,
                        UnitAttr:$cse,
                        UnitAttr:$erase_unnecessary_tensor_operands,

--- a/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
+++ b/compiler/src/iree/compiler/Codegen/Common/TransformExtensions/CommonExtensionsOps.td
@@ -74,8 +74,12 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
     unspecified order:
       - additional_iree_patterns: fancy patterns we shortcut into the system,
       will need to be sliced out better in the future.
-      - bubble_collapse_expand: bubble `expand_shape` up and `collapse_shape`
-      down across Linalg ops.
+      - bubble_collapse: bubble `collapse_shape` down across Linalg ops. This 
+      must be applied separately from `bubble_expand` patterns because of some
+      upstream pattern interference issue atm.
+      - bubble_expand: bubble `expand_shape` down across Linalg ops. This 
+      must be applied separately from `bubble_collapse` patterns because of some
+      upstream pattern interference issue atm.
       - bubble_pack_un_pack: bubble `pack` up and `unpack` down across Linalg
       ops.
       - canonicalization: adds all the canonicalization patterns of all
@@ -139,7 +143,8 @@ def ApplyPatternsOp : Op<Transform_Dialect, "iree.apply_patterns",
 
   let arguments = (ins PDL_Operation:$target,
                        UnitAttr:$additional_iree_patterns,
-                       UnitAttr:$bubble_collapse_expand,
+                       UnitAttr:$bubble_collapse,
+                       UnitAttr:$bubble_expand,
                        UnitAttr:$bubble_pack_un_pack,
                        UnitAttr:$canonicalization,
                        UnitAttr:$cse,

--- a/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/reductions_codegen_spec.mlir
@@ -18,7 +18,7 @@ transform.sequence failures(propagate) {
     ( mapping = [#gpu.block<x>] )
   
   %func = transform.structured.match ops{["func.func"]} in %arg0 : (!pdl.operation) -> !pdl.operation
-  %func_1 = transform.iree.apply_patterns %func { bubble_collapse_expand }
+  %func_1 = transform.iree.apply_patterns %func { bubble_expand }
 
   // Excessively eager canonicalization results in `fill`s being "fused" due to
   // swapping with `extract_slice`, which confuses the fusion operation below.

--- a/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/transform_dialect_apply_pattern_op.mlir
@@ -87,5 +87,5 @@ func.func @bubble_up(%arg0: tensor<32x64xf32>) -> tensor<32x2x32xf32> {
 transform.sequence failures(propagate) {
 ^bb1(%arg1: !pdl.operation):
   %0 = transform.structured.match ops{["func.func"]} in %arg1 : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %0 { bubble_collapse_expand }
+  transform.iree.apply_patterns %0 { bubble_expand }
 }

--- a/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
+++ b/compiler/src/iree/compiler/Codegen/TransformDialectStrategies/Common/Common.cpp
@@ -341,7 +341,7 @@ struct ReductionSplitResult {
 /// produced as parent of reduction splitting if necessary for fusion of the
 /// leading elementwise operation.
 // TODO: consider passing a problem-specific struct to control information.
-static ReductionSplitResult createExpansionBubbleUp(
+static ReductionSplitResult createBubbleExpand(
     ImplicitLocOpBuilder &b, Value variantH,
     SplitReductionOp splitReductionTransformOp, bool hasLeadingEltwise,
     bool hasTrailingEltwise) {
@@ -355,7 +355,7 @@ static ReductionSplitResult createExpansionBubbleUp(
 
   auto funcH = b.create<MatchOp>(variantH, func::FuncOp::getOperationName());
   ApplyPatternsOpPatterns configuration;
-  configuration.bubbleCollapseExpand = true;
+  configuration.bubbleExpand = true;
   b.create<ApplyPatternsOp>(funcH, configuration);
   std::tie(result.originalFillH, result.splitFillH) =
       matchAndUnpack<2>(b, variantH, linalg::FillOp::getOperationName());

--- a/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_codegen_spec.mlir
@@ -25,7 +25,7 @@ transform.sequence failures(propagate) {
   // able to preserve the handles.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { bubble_collapse_expand }
+  transform.iree.apply_patterns %func { bubble_expand }
   %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
   %fill_2, %more_parallel_fill_2 = transform.split_handles %fills in [2]
     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)

--- a/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/eltwise_reduction_eltwise_codegen_spec.mlir
@@ -27,7 +27,7 @@ transform.sequence failures(propagate) {
   // able to preserve the handles.
   // ===========================================================================
   %func = transform.structured.match ops{["func.func"]} in %variant_op : (!pdl.operation) -> !pdl.operation
-  transform.iree.apply_patterns %func { bubble_collapse_expand }
+  transform.iree.apply_patterns %func { bubble_expand }
   %fills = transform.structured.match ops{["linalg.fill"]} in %variant_op : (!pdl.operation) -> !pdl.operation
   %fill_2, %more_parallel_fill_2 = transform.split_handles %fills in [2]
     : (!pdl.operation) -> (!pdl.operation, !pdl.operation)


### PR DESCRIPTION
The following upstream options are added to the ApplyPatternsOp:

1. rank-reduction of linalg ops via reshapes
2. pack/unpack propagation
3. split bubble_expand from bubble_collapse as these patterns exhibit an interference behavior
4. patterns for greedy fusion of linalg ops

All these are extensively tested upstream, this PR provides the plumbing to be used with the transform dialect.