### PR TITLE
Rework CI setup variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         # See https://github.com/openxla/iree/issues/10042#issuecomment-1449250094
         # for more details.
         id: fetch-pr
-        if: github.event_name == 'pull_request'
+        if: fromJson(needs.setup.outputs.is-pr)
         env:
           PR_NUMBER: ${{ github.event.number }}
           PR_JSON: pull_request.json
@@ -125,7 +125,7 @@ jobs:
   ##############################################################################
   build_all:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -190,7 +190,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true' && contains(['push', 'workflow_dispatch'], github.event_name)
+    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
     runs-on: managed-windows-cpu
     defaults:
       run:
@@ -257,7 +257,7 @@ jobs:
 
   build_test_all_macos:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true' && contains(['push', 'workflow_dispatch'], github.event_name)
+    if: fromJson(needs.setup.outputs.should-run) && ! fromJson(needs.setup.outputs.is-pr)
     runs-on:
       - ${{ github.repository == 'openxla/iree' && 'self-hosted' || 'macos-11' }}  # must come first
       - runner-group=postsubmit
@@ -290,7 +290,7 @@ jobs:
 
   build_test_all_bazel:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -313,7 +313,7 @@ jobs:
 
   test_all:
     needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -343,7 +343,7 @@ jobs:
 
   test_gpu:
     needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -386,7 +386,7 @@ jobs:
   ##############################################################################
   build_test_runtime:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
@@ -414,7 +414,7 @@ jobs:
 
   build_test_runtime_windows:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on: managed-windows-cpu
     defaults:
       run:
@@ -443,7 +443,7 @@ jobs:
   ##############################################################################
   build_tf_integrations:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -490,7 +490,7 @@ jobs:
 
   test_tf_integrations:
     needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -529,7 +529,7 @@ jobs:
 
   test_tf_integrations_gpu:
     needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -577,7 +577,7 @@ jobs:
   # TODO(#11263): Drop this job once the IREE_BUILD_BENCHMARKS is removed.
   test_build_benchmark_suites:
     needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -620,7 +620,7 @@ jobs:
   ##############################################################################
   python_release_packages:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -661,7 +661,7 @@ jobs:
 
   asan:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -689,7 +689,7 @@ jobs:
 
   tsan:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -714,7 +714,7 @@ jobs:
 
   small_runtime:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on: ubuntu-20.04-64core
     env:
       BUILD_DIR: build-runtime
@@ -741,7 +741,7 @@ jobs:
 
   gcc:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -773,7 +773,7 @@ jobs:
 
   tracing:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -802,7 +802,7 @@ jobs:
 
   debug:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -835,7 +835,7 @@ jobs:
 
   build_benchmark_tools:
     needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -918,7 +918,7 @@ jobs:
 
   build_e2e_test_artifacts:
     needs: [setup, build_all, build_tf_integrations]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -986,7 +986,7 @@ jobs:
 
   compilation_benchmarks:
     needs: [setup, build_e2e_test_artifacts]
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
+    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -1060,7 +1060,7 @@ jobs:
 
   execution_benchmarks:
     needs: [setup, build_benchmark_tools, build_e2e_test_artifacts]
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
+    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
     uses: ./.github/workflows/benchmark_execution.yml
     with:
       # env.GCS_DIR is also duplicated in this workflow. See the note there on
@@ -1074,7 +1074,7 @@ jobs:
 
   process_benchmark_results:
     needs: [setup, compilation_benchmarks, execution_benchmarks]
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.benchmark-presets != ''
+    if: fromJson(needs.setup.outputs.should-run) && needs.setup.outputs.benchmark-presets != ''
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -1111,7 +1111,7 @@ jobs:
             "${EXECUTION_BENCHMARK_RESULTS_DIR}"
           echo "execution-benchmark-results-pattern=${EXECUTION_BENCHMARK_RESULTS_DIR}/benchmark-results-*.json" >> "${GITHUB_OUTPUT}"
       - name: Generating comment
-        if: github.event_name == 'pull_request'
+        if: fromJson(needs.setup.outputs.is-pr)
         id: generate-comment
         env:
           # Wildcard pattern to match all execution benchmark results. Empty if
@@ -1138,7 +1138,7 @@ jobs:
         # Due to security reasons, instead of posting the comment to PR, we only
         # upload the comment data in presubmit workflow and trigger the posting
         # workflow on the main branch. See post_benchmark_comment.yaml
-        if: github.event_name == 'pull_request'
+        if: fromJson(needs.setup.outputs.is-pr)
         env:
           BENCHMARK_COMMENT_ARTIFACT: ${{ steps.generate-comment.outputs.benchmark-comment-artifact }}
           BENCHMARK_COMMENT_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.generate-comment.outputs.benchmark-comment-artifact }}
@@ -1166,7 +1166,7 @@ jobs:
 
   cross_compile_and_test:
     needs: [setup, build_all]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}
@@ -1255,7 +1255,7 @@ jobs:
 
   test_benchmark_suites:
     needs: [setup, build_all, build_e2e_test_artifacts]
-    if: needs.setup.outputs.should-run == 'true'
+    if: fromJson(needs.setup.outputs.should-run)
     runs-on:
       - self-hosted  # must come first
       - runner-group=${{ needs.setup.outputs.runner-group }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       should-run: ${{ steps.configure.outputs.should-run }}
+      is-pr: ${{ steps.configure.outputs.is-pr }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
       write-caches: ${{ steps.configure.outputs.write-caches }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       BASE_REF: HEAD^
     outputs:
       should-run: ${{ steps.configure.outputs.should-run }}
-      ci-stage: ${{ steps.configure.outputs.ci-stage }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
       write-caches: ${{ steps.configure.outputs.write-caches }}
@@ -191,7 +190,7 @@ jobs:
 
   build_test_all_windows:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    if: needs.setup.outputs.should-run == 'true' && contains(['push', 'workflow_dispatch'], github.event_name)
     runs-on: managed-windows-cpu
     defaults:
       run:
@@ -258,7 +257,7 @@ jobs:
 
   build_test_all_macos:
     needs: setup
-    if: needs.setup.outputs.should-run == 'true' && needs.setup.outputs.ci-stage == 'postsubmit'
+    if: needs.setup.outputs.should-run == 'true' && contains(['push', 'workflow_dispatch'], github.event_name)
     runs-on:
       - ${{ github.repository == 'openxla/iree' && 'self-hosted' || 'macos-11' }}  # must come first
       - runner-group=postsubmit
@@ -1112,7 +1111,7 @@ jobs:
             "${EXECUTION_BENCHMARK_RESULTS_DIR}"
           echo "execution-benchmark-results-pattern=${EXECUTION_BENCHMARK_RESULTS_DIR}/benchmark-results-*.json" >> "${GITHUB_OUTPUT}"
       - name: Generating comment
-        if: needs.setup.outputs.ci-stage == 'presubmit'
+        if: github.event_name == 'pull_request'
         id: generate-comment
         env:
           # Wildcard pattern to match all execution benchmark results. Empty if
@@ -1139,7 +1138,7 @@ jobs:
         # Due to security reasons, instead of posting the comment to PR, we only
         # upload the comment data in presubmit workflow and trigger the posting
         # workflow on the main branch. See post_benchmark_comment.yaml
-        if: needs.setup.outputs.ci-stage == 'presubmit'
+        if: github.event_name == 'pull_request'
         env:
           BENCHMARK_COMMENT_ARTIFACT: ${{ steps.generate-comment.outputs.benchmark-comment-artifact }}
           BENCHMARK_COMMENT_GCS_ARTIFACT: ${{ env.GCS_DIR }}/${{ steps.generate-comment.outputs.benchmark-comment-artifact }}
@@ -1148,7 +1147,7 @@ jobs:
             "${BENCHMARK_COMMENT_ARTIFACT}" \
             "${BENCHMARK_COMMENT_GCS_ARTIFACT}"
       - name: Uploading results to dashboard
-        if: needs.setup.outputs.ci-stage == 'postsubmit'
+        if: github.ref_name == 'main'
         env:
           EXECUTION_BENCHMARK_RESULTS_PATTERN: ${{ steps.download-execution-results.outputs.execution-benchmark-results-pattern }}
           IREE_DASHBOARD_API_TOKEN: ${{ secrets.IREE_DASHBOARD_API_TOKEN }}
@@ -1393,7 +1392,7 @@ jobs:
           fi
       - name: Posting to Discord
         uses: sarisia/actions-status-discord@c193626e5ce172002b8161e116aa897de7ab5383 # v1.10.2
-        if: failure() && needs.setup.outputs.ci-stage == 'postsubmit'
+        if: failure() && github.ref_name == 'main'
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           description: "The following jobs failed: ${{ steps.failed_jobs.outputs.failed-jobs }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         # See https://github.com/openxla/iree/issues/10042#issuecomment-1449250094
         # for more details.
         id: fetch-pr
-        if: fromJson(needs.setup.outputs.is-pr)
+        if: github.event_name == 'pull_request'
         env:
           PR_NUMBER: ${{ github.event.number }}
           PR_JSON: pull_request.json

--- a/.github/workflows/run_shark_tank.yml
+++ b/.github/workflows/run_shark_tank.yml
@@ -20,7 +20,6 @@ jobs:
       PR_BODY: ${{ github.event.pull_request.body }}
     outputs:
       should-run: ${{ steps.configure.outputs.should-run }}
-      ci-stage: ${{ steps.configure.outputs.ci-stage }}
       runner-env: ${{ steps.configure.outputs.runner-env }}
       runner-group: ${{ steps.configure.outputs.runner-group }}
       write-caches: ${{ steps.configure.outputs.write-caches }}

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -204,9 +204,6 @@ def get_runner_env(trailers: Mapping[str, str]) -> str:
   return runner_env
 
 
-def run_on_fork(event_name):
-  return event_name == PULL_REQUEST_EVENT_NAME
-
 def get_benchmark_presets(event_name: str, trailers: Mapping[str, str]) -> str:
   """Parses and validates the benchmark presets from trailers.
 
@@ -247,9 +244,9 @@ def main():
   else:
     output["should-run"] = "false"
   output[RUNNER_ENV_KEY] = get_runner_env(trailers)
-  on_fork = run_on_fork(event_name)
-  output["runner-group"] = "presubmit" if on_fork else "postsubmit"
-  output["write-caches"] = "0" if on_fork else "1"
+  is_pr = event_name == PULL_REQUEST_EVENT_NAME
+  output["runner-group"] = "presubmit" if is_pr else "postsubmit"
+  output["write-caches"] = "0" if is_pr else "1"
   output["benchmark-presets"] = get_benchmark_presets(event_name, trailers)
 
   set_output(output)

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -29,15 +29,12 @@ not.
 
 import difflib
 import fnmatch
+import json
 import os
 import subprocess
 import textwrap
 from typing import Iterable, Mapping, MutableMapping
 
-PULL_REQUEST_EVENT_NAME = "pull_request"
-PUSH_EVENT_NAME = "push"
-SCHEDULE_EVENT_NAME = "schedule"
-WORKFLOW_DISPATCH_EVENT_NAME = "workflow_dispatch"
 SKIP_CI_KEY = "skip-ci"
 RUNNER_ENV_KEY = "runner-env"
 BENCHMARK_PRESET_KEY = "benchmarks"
@@ -86,7 +83,7 @@ def set_output(d: Mapping[str, str]):
   print(f"Setting outputs: {d}")
   step_output_file = os.environ["GITHUB_OUTPUT"]
   with open(step_output_file, "a") as f:
-    f.writelines(f"{k}={v}" "\n" for k, v in d.items())
+    f.writelines(f"{k}={v}" + "\n" for k, v in d.items())
 
 
 def write_job_summary(summary: str):
@@ -121,7 +118,9 @@ def check_description_and_show_diff(original_description: str,
   </details>""").format("".join(diffs)))
 
 
-def get_trailers() -> Mapping[str, str]:
+def get_trailers(is_pr: bool) -> Mapping[str, str]:
+  if not is_pr:
+    return {}
   title = os.environ["PR_TITLE"]
   body = os.environ.get("PR_BODY", "")
   original_title = os.environ.get("ORIGINAL_PR_TITLE")
@@ -167,10 +166,10 @@ def modifies_included_path(base_ref: str) -> bool:
   return any(not skip_path(p) for p in get_modified_paths(base_ref))
 
 
-def should_run_ci(event_name, trailers) -> bool:
-  if event_name != PULL_REQUEST_EVENT_NAME:
-    print(f"Running CI independent of diff because run was not triggered by a"
-          f" pull request event (event name is '{event_name}')")
+def should_run_ci(is_pr: bool, trailers: Mapping[str, str]) -> bool:
+  if not is_pr:
+    print("Running CI independent of diff because run was not triggered by a"
+          " pull request event.")
     return True
 
   if SKIP_CI_KEY in trailers:
@@ -204,7 +203,7 @@ def get_runner_env(trailers: Mapping[str, str]) -> str:
   return runner_env
 
 
-def get_benchmark_presets(event_name: str, trailers: Mapping[str, str]) -> str:
+def get_benchmark_presets(is_pr: bool, trailers: Mapping[str, str]) -> str:
   """Parses and validates the benchmark presets from trailers.
 
   Args:
@@ -214,7 +213,7 @@ def get_benchmark_presets(event_name: str, trailers: Mapping[str, str]) -> str:
     A comma separated preset string, which later will be parsed by
     build_tools/benchmarks/export_benchmark_config.py.
   """
-  if event_name != "pull_request":
+  if not is_pr:
     preset_options = ["all"]
   else:
     trailer = trailers.get(BENCHMARK_PRESET_KEY)
@@ -236,18 +235,16 @@ def get_benchmark_presets(event_name: str, trailers: Mapping[str, str]) -> str:
 
 
 def main():
-  output: MutableMapping[str, str] = {}
-  event_name = os.environ["GITHUB_EVENT_NAME"]
-  trailers = get_trailers() if event_name == PULL_REQUEST_EVENT_NAME else {}
-  if should_run_ci(event_name, trailers):
-    output["should-run"] = "true"
-  else:
-    output["should-run"] = "false"
-  output[RUNNER_ENV_KEY] = get_runner_env(trailers)
-  is_pr = event_name == PULL_REQUEST_EVENT_NAME
-  output["runner-group"] = "presubmit" if is_pr else "postsubmit"
-  output["write-caches"] = "0" if is_pr else "1"
-  output["benchmark-presets"] = get_benchmark_presets(event_name, trailers)
+  is_pr = os.environ["GITHUB_EVENT_NAME"] == "pull_request"
+  trailers = get_trailers(is_pr)
+  output = {
+      "should-run": json.dumps(should_run_ci(is_pr, trailers)),
+      "is-pr": json.dumps(is_pr),
+      "runner-env": get_runner_env(trailers),
+      "runner-group": "presubmit" if is_pr else "postsubmit",
+      "write-caches": "0" if is_pr else "1",
+      "benchmark-presets": get_benchmark_presets(is_pr, trailers),
+  }
 
   set_output(output)
 


### PR DESCRIPTION
`ci-stage` was a confusing concept that conflated a few different
things. I split those things out instead. We've had a few issues
related to this in the last week:
https://github.com/openxla/iree/pull/12482 and
https://github.com/openxla/iree/pull/12514, and posting benchmark
comments is still failing because that's triggered by `workflow_run`:
https://github.com/openxla/iree/actions/runs/4346904097.

This includes making booleans json rather than magic strings.
`write-caches` is still "0" or "1" because it's ultimately used by
bash.