### PR TITLE
Don't configure Python tests when bindings are disabled

### DIFF
--- a/build_tools/cmake/iree_python.cmake
+++ b/build_tools/cmake/iree_python.cmake
@@ -279,6 +279,9 @@ function(iree_py_test)
     "ARGS;LABELS;TIMEOUT"
     ${ARGN}
   )
+  if(NOT IREE_BUILD_PYTHON_BINDINGS)
+    return()
+  endif()
 
   iree_local_py_test(
     NAME


### PR DESCRIPTION
This is consistent with other test rules we have (e.g. lit and check
tests require the compiler be enabled). This came up in
https://github.com/openxla/iree/pull/12017, which adds an e2e Python
test that we try to run on CI builds that don't have the Python
bindings enabled.