### PR TITLE
[LLVMGPU] Optimize shared memory allocation size

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -7,6 +7,7 @@
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
 #include "iree/compiler/Dialect/HAL/IR/HALTypes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
@@ -40,15 +41,6 @@ static bool hasDefaultOrHALAddressSpace(MemRefType memrefType) {
   // space--the former is used by LLVMGPU while the latter is used by SPIR-V.
   if (intAttr && intAttr.getInt() == 0) return true;
   return addrSpace.isa<IREE::HAL::DescriptorTypeAttr>();
-}
-
-/// Returns true if the given `memrefType` has the numeric address space for
-/// GPU shared memory.
-static bool hasSharedMemoryAddressSpace(MemRefType memrefType) {
-  auto addrSpace =
-      memrefType.getMemorySpace().dyn_cast_or_null<gpu::AddressSpaceAttr>();
-  return addrSpace &&
-         addrSpace.getValue() == gpu::GPUDialect::getWorkgroupAddressSpace();
 }
 
 // Returns a new predicated operation to support unpeeled epilogue. Unpeeled

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/BUILD
@@ -21,6 +21,7 @@ iree_compiler_cc_library(
         "KernelConfig.cpp",
         "LLVMGPUDistribute.cpp",
         "LLVMGPULowerExecutableTarget.cpp",
+        "LLVMGPUPackSharedMemoryAlloc.cpp",
         "LLVMGPUTensorAlloc.cpp",
         "LLVMGPUTensorCoreVectorization.cpp",
         "LLVMGPUTensorPad.cpp",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/CMakeLists.txt
@@ -25,6 +25,7 @@ iree_cc_library(
     "KernelConfig.cpp"
     "LLVMGPUDistribute.cpp"
     "LLVMGPULowerExecutableTarget.cpp"
+    "LLVMGPUPackSharedMemoryAlloc.cpp"
     "LLVMGPUTensorAlloc.cpp"
     "LLVMGPUTensorCoreVectorization.cpp"
     "LLVMGPUTensorPad.cpp"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPackSharedMemoryAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPackSharedMemoryAlloc.cpp
@@ -1,0 +1,225 @@
+// Copyright 2023 The IREE Authors
+//
+// Licensed under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <algorithm>
+
+#include "iree/compiler/Codegen/LLVMGPU/Utils/LLVMGPUUtils.h"
+#include "iree/compiler/Codegen/PassDetail.h"
+#include "iree/compiler/Codegen/Passes.h"
+#include "iree/compiler/Codegen/Utils/GPUUtils.h"
+#include "mlir/Analysis/Liveness.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/NVGPU/IR/NVGPUDialect.h"
+#include "mlir/IR/Dominance.h"
+
+#define DEBUG_TYPE "iree-llvmgpu-pack-shared-memory-alloc"
+
+namespace mlir {
+namespace iree_compiler {
+
+using AliasGroup = SmallVector<Operation *>;
+
+/// Analyze the liverange of allocs and set them in individual groups if
+/// possible and mark allocs with an attributes.
+/// The algorithm is a simplistic memory allocation solution. It sorts
+/// allocations into alias groups. Everytime two alloc's liverange interfers
+/// they are merge into the same group. If a new alloc is part of multiple alias
+/// groups all those are merged into one. At the end we are left with groups of
+/// allocations that are disjoint and can use the same memory.
+// TODO: Move this to a common place if needed by other backends.
+static void analyzeSharedMemoryAlloc(func::FuncOp funcOp,
+                                     const SmallVector<Operation *> &allocs,
+                                     SmallVector<AliasGroup> &aliasGroups) {
+  struct AllocGroup {
+    SmallVector<Operation *> allocs;
+    // Keep track of every operation where any of the alloc in the group is
+    // live.
+    llvm::DenseSet<Operation *> liveness;
+  };
+  Liveness liveness(funcOp);
+  SmallVector<AllocGroup> groups;
+  for (Operation *alloc : allocs) {
+    SmallVector<size_t> aliasGroups;
+    for (size_t i : llvm::seq<size_t>(0, groups.size())) {
+      AllocGroup &group = groups[i];
+      for (Operation *user : alloc->getUsers()) {
+        // Skip the whole analysis if any user is a subview.
+        // TODO: This could be extended if needed by recursively merging
+        // liveness.
+        if (isa<memref::SubViewOp>(user)) return;
+        if (group.liveness.count(user)) {
+          aliasGroups.push_back(i);
+          break;
+        }
+      }
+    }
+    if (aliasGroups.empty()) {
+      // If we didn't find any alias group create a new one.
+      AllocGroup &newGroup = groups.emplace_back();
+      newGroup.allocs.push_back(alloc);
+      Liveness::OperationListT liveInfo =
+          liveness.resolveLiveness(alloc->getResult(0));
+      newGroup.liveness.insert(liveInfo.begin(), liveInfo.end());
+    } else {
+      // Merge the alloc into the first alias group it interfers with.
+      AllocGroup &mergeGroup = groups[aliasGroups[0]];
+      mergeGroup.allocs.push_back(alloc);
+      Liveness::OperationListT liveInfo =
+          liveness.resolveLiveness(alloc->getResult(0));
+      mergeGroup.liveness.insert(liveInfo.begin(), liveInfo.end());
+      // Then merge all the other alias groups into the first group.
+      for (size_t i = 1, e = aliasGroups.size(); i < e; i++) {
+        AllocGroup &group = groups[aliasGroups[i]];
+        mergeGroup.allocs.insert(mergeGroup.allocs.end(), group.allocs.begin(),
+                                 group.allocs.end());
+        mergeGroup.liveness.insert(group.liveness.begin(),
+                                   group.liveness.end());
+        // For simplicity we leave the group empty and don't remove it.
+        group.allocs.clear();
+        group.liveness.clear();
+      }
+    }
+  }
+
+  LLVM_DEBUG({
+    for (size_t i = 0; i < groups.size(); i++) {
+      llvm::dbgs() << "Alias group " << i << ":\n";
+      for (Operation *op : groups[i].allocs) op->dump();
+    }
+  });
+
+  for (size_t i = 0; i < groups.size(); i++) {
+    if (groups[i].allocs.empty()) continue;
+    aliasGroups.push_back(std::move(groups[i].allocs));
+  }
+}
+
+/// Insert barriers and wait operations if there are allocs of a different alias
+/// group before the given alloc.
+static void addBarrier(func::FuncOp funcOp, Operation *alloc,
+                       ArrayRef<Operation *> aliasGroup) {
+  Block *entryBlock = &(*funcOp.getBlocks().begin());
+  bool needBarrier = false;
+  if (alloc->getBlock() != entryBlock) {
+    needBarrier = true;
+  } else {
+    for (Operation &op : entryBlock->getOperations()) {
+      if (&op == alloc) break;
+      if (op.getNumRegions() != 0) {
+        needBarrier = true;
+        break;
+      }
+      if (isa<memref::AllocOp>(&op)) {
+        if (std::find(aliasGroup.begin(), aliasGroup.end(), &op) ==
+            aliasGroup.end()) {
+          needBarrier = true;
+          break;
+        }
+      }
+    }
+  }
+  if (!needBarrier) return;
+  OpBuilder builder(alloc);
+  // TODO: make it a option if needed.
+  bool hasAsyncCopies = true;
+  if (hasAsyncCopies) {
+    Value groupToken = builder.create<nvgpu::DeviceAsyncCreateGroupOp>(
+        funcOp.getLoc(), nvgpu::DeviceAsyncTokenType::get(funcOp.getContext()),
+        SmallVector<Value>());
+    builder.create<nvgpu::DeviceAsyncWaitOp>(funcOp.getLoc(), groupToken,
+                                             builder.getI32IntegerAttr(0));
+  }
+  builder.create<gpu::BarrierOp>(alloc->getLoc());
+}
+
+static int64_t getAllocSize(Operation *op, DataLayout &dataLayout) {
+  auto allocOp = cast<memref::AllocOp>(op);
+  int64_t numElements = allocOp.getType().getNumElements();
+  return (dataLayout.getTypeSizeInBits(allocOp.getType().getElementType()) *
+          numElements) /
+         8;
+}
+
+namespace {
+
+struct LLVMGPUPackSharedMemoryAllocPass
+    : public LLVMGPUPackSharedMemoryAllocBase<
+          LLVMGPUPackSharedMemoryAllocPass> {
+ public:
+  void getDependentDialects(DialectRegistry &registry) const override {
+    registry.insert<nvgpu::NVGPUDialect>();
+  }
+
+  void runOnOperation() override {
+    func::FuncOp funcOp = getOperation();
+    DominanceInfo dominators(funcOp);
+    SmallVector<Operation *> allocs;
+    funcOp.walk([&](memref::AllocOp alloc) {
+      if (hasSharedMemoryAddressSpace(alloc.getType())) {
+        allocs.push_back(alloc);
+      }
+    });
+    // First sink the alloc as low as possible in the CFG.
+    sinkOpsInCFG(allocs, dominators);
+    SmallVector<AliasGroup> aliasGroups;
+    analyzeSharedMemoryAlloc(funcOp, allocs, aliasGroups);
+    // If there is 1 or less alias group there is nothing to do.
+    if (aliasGroups.size() <= 1) return;
+
+    // Pack all the allocations into one i8 alloc.
+    // We may need to add extra barriers to make sure we are done writting or
+    // reading from the previous alias group before starting a new one.
+    for (size_t i = 0; i < aliasGroups.size(); i++) {
+      for (Operation *alloc : aliasGroups[i]) {
+        addBarrier(funcOp, alloc, aliasGroups[i]);
+      }
+    }
+
+    OpBuilder builder(funcOp.getContext());
+    DataLayout dataLayout = DataLayout::closest(funcOp);
+    builder.setInsertionPointToStart(&(*funcOp.getBody().begin()));
+    int64_t maxAlloc = 0;
+    for (size_t i = 0; i < aliasGroups.size(); i++) {
+      int64_t allocSize = 0;
+      for (Operation *alloc : aliasGroups[i]) {
+        allocSize += getAllocSize(alloc, dataLayout);
+      }
+      maxAlloc = std::max(maxAlloc, allocSize);
+    }
+
+    auto workgroupSpace = gpu::AddressSpaceAttr::get(
+        builder.getContext(), gpu::GPUDialect::getWorkgroupAddressSpace());
+    MemRefType allocType = MemRefType::get({maxAlloc}, builder.getI8Type(),
+                                           AffineMap(), workgroupSpace);
+    Value packedAlloc =
+        builder.create<memref::AllocOp>(funcOp.getLoc(), allocType);
+    for (size_t i = 0; i < aliasGroups.size(); i++) {
+      int64_t offset = 0;
+      for (Operation *alloc : aliasGroups[i]) {
+        Location loc = alloc->getLoc();
+        builder.setInsertionPoint(alloc);
+        Value offsetValue = builder.create<arith::ConstantIndexOp>(loc, offset);
+        Value newAlloc = builder.create<memref::ViewOp>(
+            packedAlloc.getLoc(), alloc->getResultTypes()[0], packedAlloc,
+            offsetValue, ArrayRef<Value>({}));
+        offset += getAllocSize(alloc, dataLayout);
+        alloc->replaceAllUsesWith(ArrayRef<Value>({newAlloc}));
+        alloc->erase();
+      }
+    }
+  }
+};
+}  // namespace
+
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMGPUPackSharedMemoryAlloc() {
+  return std::make_unique<LLVMGPUPackSharedMemoryAllocPass>();
+}
+
+}  // namespace iree_compiler
+}  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPackSharedMemoryAlloc.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPUPackSharedMemoryAlloc.cpp
@@ -80,7 +80,7 @@ struct LLVMGPUPackSharedMemoryAllocPass
     // First sink the alloc as low as possible in the CFG.
     sinkOpsInCFG(allocs, dominators);
     SmallVector<AliasGroup> aliasGroups;
-    analyzeSharedMemoryAlloc(funcOp, allocs, aliasGroups);
+    analyseAllocsForPacking(funcOp, allocs, aliasGroups);
     // If there is 1 or less alias group there is nothing to do.
     if (aliasGroups.size() <= 1) return;
 

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/Passes.cpp
@@ -272,6 +272,9 @@ void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUPipeliningPass(
       /*epiloguePeeling=*/false, pipelineDepth,
       PipeliningSchedulingStrategy::loadGlobalStage0));
+  // Optimize shared memory usage.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUPackSharedMemoryAlloc());
 }
 
 void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
@@ -329,6 +332,9 @@ void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
   nestedModulePM.addNestedPass<func::FuncOp>(createGPUPipeliningPass(
       /*epiloguePeeling=*/false, pipelineDepth,
       PipeliningSchedulingStrategy::nvidiaTensorCore));
+  // Optimize shared memory usage.
+  nestedModulePM.addNestedPass<func::FuncOp>(
+      createLLVMGPUPackSharedMemoryAlloc());
 }
 
 void addGPUTransposePassPipeline(OpPassManager &pm) {

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/BUILD
@@ -37,6 +37,7 @@ iree_lit_test_suite(
             "linalg_transform.mlir",
             "legalize.mlir",
             "pack_pipeline_test.mlir",
+            "pack_shared_memory_alloc.mlir",
             "tensor_alloc.mlir",
             "tensor_pad.mlir",
             "tensorcore_vectorization.mlir",

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/CMakeLists.txt
@@ -29,6 +29,7 @@ iree_lit_test_suite(
     "nvvm_mma_sync_pipeline_test.mlir"
     "nvvm_pipeline_test.mlir"
     "pack_pipeline_test.mlir"
+    "pack_shared_memory_alloc.mlir"
     "reduction_pipeline.mlir"
     "reduction_pipeline_transform.mlir"
     "rocdl_pipeline_test.mlir"

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pack_shared_memory_alloc.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/pack_shared_memory_alloc.mlir
@@ -1,0 +1,27 @@
+// RUN: iree-opt --split-input-file -iree-llvmgpu-pack-shared-memory-alloc -cse %s | FileCheck %s
+
+func.func @shared_memory_disjoint() {
+  %c0 = arith.constant 0 : index
+  %cst_f32 = arith.constant 0.000000e+00 : f32
+  %cst_i8 = arith.constant 0 : i8
+  %0 = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
+  %1 = memref.alloc() : memref<128xf32, #gpu.address_space<workgroup>>
+  %2 = memref.alloc() : memref<32xf32, #gpu.address_space<workgroup>>
+  memref.store %cst_f32, %0[%c0] : memref<128xf32, #gpu.address_space<workgroup>>
+  memref.store %cst_f32, %1[%c0] : memref<128xf32, #gpu.address_space<workgroup>>
+  memref.store %cst_f32, %0[%c0] : memref<128xf32, #gpu.address_space<workgroup>>
+  memref.store %cst_f32, %2[%c0] : memref<32xf32, #gpu.address_space<workgroup>>
+  return
+}
+
+// CHECK-LABEL: shared_memory_disjoint
+//   CHECK-NOT:   gpu.barrier
+//   CHECK-DAG:   %[[PACKED:.+]] = memref.alloc() : memref<1024xi8, #gpu.address_space<workgroup>>
+//   CHECK-DAG:   %[[C0:.+]] = arith.constant 0 : index
+//       CHECK:   memref.view %[[PACKED]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
+//       CHECK:   %[[C512:.+]] = arith.constant 512 : index
+//       CHECK:   memref.view %[[PACKED]][%[[C512]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<128xf32, #gpu.address_space<workgroup>>
+//       CHECK:   nvgpu.device_async_create_group 
+//       CHECK:   nvgpu.device_async_wait %0 {numGroups = 0 : i32}
+//       CHECK:   gpu.barrier
+//       CHECK:   memref.view %[[PACKED]][%[[C0]]][] : memref<1024xi8, #gpu.address_space<workgroup>> to memref<32xf32, #gpu.address_space<workgroup>>

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -528,6 +528,11 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU(
 //. Pass to pad out tensors up to static dimensions.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorPadPass();
 
+// Pass to pack shared memory allocations in order to reduce shared memory
+// usage.
+std::unique_ptr<OperationPass<func::FuncOp>>
+createLLVMGPUPackSharedMemoryAlloc();
+
 //------------------------------------------------------------------------------
 // SPIR-V Passes
 //------------------------------------------------------------------------------

--- a/compiler/src/iree/compiler/Codegen/Passes.td
+++ b/compiler/src/iree/compiler/Codegen/Passes.td
@@ -505,6 +505,12 @@ def LLVMGPUTensorAlloc :
   let constructor = "mlir::iree_compiler::createLLVMGPUTensorAlloc()";
 }
 
+def LLVMGPUPackSharedMemoryAlloc :
+    Pass<"iree-llvmgpu-pack-shared-memory-alloc", "func::FuncOp"> {
+  let summary = "Pass pack shared memory allocation in order to reduce memory usage.";
+  let constructor = "mlir::iree_compiler::createLLVMGPUPackSharedMemoryAlloc()";
+}
+
 def LLVMGPUTensorCoreVectorization :
     Pass<"iree-llvmgpu-tensorcore-vectorization", "func::FuncOp"> {
   let summary = "Pass to convert linalg into Vector and transform it to a form that can be lowered to GPU MMA ops";

--- a/compiler/src/iree/compiler/Codegen/Transforms/BUILD
+++ b/compiler/src/iree/compiler/Codegen/Transforms/BUILD
@@ -30,6 +30,7 @@ iree_compiler_cc_library(
         "@llvm-project//mlir:AffineDialect",
         "@llvm-project//mlir:AffineUtils",
         "@llvm-project//mlir:Analysis",
+        "@llvm-project//mlir:ArithDialect",
         "@llvm-project//mlir:FuncDialect",
         "@llvm-project//mlir:IR",
         "@llvm-project//mlir:LinalgDialect",

--- a/compiler/src/iree/compiler/Codegen/Transforms/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/Transforms/CMakeLists.txt
@@ -24,6 +24,7 @@ iree_cc_library(
     MLIRAffineDialect
     MLIRAffineUtils
     MLIRAnalysis
+    MLIRArithDialect
     MLIRFuncDialect
     MLIRIR
     MLIRLinalgDialect

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -473,9 +473,9 @@ struct RemoveDeadInterfaceBindings
 void populateRemoveDeadMemAllocPatterns(RewritePatternSet &patterns) {
   patterns.insert<RemoveDeadMemAllocs>(patterns.getContext());
   patterns.insert<RemoveDeadInterfaceBindings>(patterns.getContext());
+}
 
-void analyzeSharedMemoryAlloc(func::FuncOp funcOp,
-                              const SmallVector<Operation *> &allocs,
+void analyzeSharedMemoryAlloc(func::FuncOp funcOp, ArrayRef<Operation *> allocs,
                               SmallVector<AliasGroup> &aliasGroups) {
   // Represent of a group of allocations with overlapping liverange and the
   // liveness of the overall group.
@@ -483,9 +483,9 @@ void analyzeSharedMemoryAlloc(func::FuncOp funcOp,
     SmallVector<Operation *> allocs;
     // Keep track of every operation where any of the alloc in the group is
     // live.
-    // Liveness is represent as a set of Operations where the alloc is alive. To
-    // make it merge liveranges and check if a given Operation interfers with
-    // the liverange we store it as a DesneSet.
+    // Liveness is represent as a set of Operations where the alloc is alive.
+    // To make it merge liveranges and check if a given Operation interfers
+    // with the liverange we store it as a DesneSet.
     llvm::DenseSet<Operation *> liveness;
   };
   Liveness liveness(funcOp);
@@ -555,7 +555,7 @@ static int64_t getAllocSize(Operation *op, DataLayout &dataLayout) {
 }
 
 void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
-                SmallVector<AliasGroup> &aliasGroups) {
+                ArrayRef<AliasGroup> aliasGroups) {
   DataLayout dataLayout = DataLayout::closest(funcOp);
   builder.setInsertionPointToStart(&(*funcOp.getBody().begin()));
   int64_t maxAlloc = 0;

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -556,6 +556,7 @@ static int64_t getAllocSize(Operation *op, DataLayout &dataLayout) {
 
 void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
                 ArrayRef<AliasGroup> aliasGroups) {
+  if (aliasGroups.empty()) return;
   DataLayout dataLayout = DataLayout::closest(funcOp);
   builder.setInsertionPointToStart(&(*funcOp.getBody().begin()));
   int64_t maxAlloc = 0;
@@ -566,7 +567,6 @@ void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
     }
     maxAlloc = std::max(maxAlloc, allocSize);
   }
-
   Attribute memorySpace = aliasGroups[0][0]
                               ->getResultTypes()[0]
                               .cast<MemRefType>()

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -568,8 +568,7 @@ void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
   }
 
   Attribute memorySpace = aliasGroups[0][0]
-                              ->getOperand(0)
-                              .getType()
+                              ->getResultTypes()[0]
                               .cast<MemRefType>()
                               .getMemorySpace();
   MemRefType allocType = MemRefType::get({maxAlloc}, builder.getI8Type(),

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -475,8 +475,8 @@ void populateRemoveDeadMemAllocPatterns(RewritePatternSet &patterns) {
   patterns.insert<RemoveDeadInterfaceBindings>(patterns.getContext());
 }
 
-void analyzeSharedMemoryAlloc(func::FuncOp funcOp, ArrayRef<Operation *> allocs,
-                              SmallVector<AliasGroup> &aliasGroups) {
+void analyseAllocsForPacking(func::FuncOp funcOp, ArrayRef<Operation *> allocs,
+                             SmallVector<AliasGroup> &aliasGroups) {
   // Represent of a group of allocations with overlapping liverange and the
   // liveness of the overall group.
   struct AllocGroup {

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.cpp
@@ -13,7 +13,9 @@
 #include "iree/compiler/Codegen/Transforms/Transforms.h"
 
 #include "llvm/Support/Debug.h"
+#include "mlir/Analysis/Liveness.h"
 #include "mlir/Analysis/SliceAnalysis.h"
+#include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 
@@ -471,6 +473,123 @@ struct RemoveDeadInterfaceBindings
 void populateRemoveDeadMemAllocPatterns(RewritePatternSet &patterns) {
   patterns.insert<RemoveDeadMemAllocs>(patterns.getContext());
   patterns.insert<RemoveDeadInterfaceBindings>(patterns.getContext());
+
+void analyzeSharedMemoryAlloc(func::FuncOp funcOp,
+                              const SmallVector<Operation *> &allocs,
+                              SmallVector<AliasGroup> &aliasGroups) {
+  // Represent of a group of allocations with overlapping liverange and the
+  // liveness of the overall group.
+  struct AllocGroup {
+    SmallVector<Operation *> allocs;
+    // Keep track of every operation where any of the alloc in the group is
+    // live.
+    // Liveness is represent as a set of Operations where the alloc is alive. To
+    // make it merge liveranges and check if a given Operation interfers with
+    // the liverange we store it as a DesneSet.
+    llvm::DenseSet<Operation *> liveness;
+  };
+  Liveness liveness(funcOp);
+  SmallVector<AllocGroup> groups;
+  for (Operation *alloc : allocs) {
+    SmallVector<size_t> aliasGroups;
+    for (size_t i : llvm::seq<size_t>(0, groups.size())) {
+      AllocGroup &group = groups[i];
+      for (Operation *user : alloc->getUsers()) {
+        // Skip the whole analysis if any user is a subview.
+        // TODO: This could be extended if needed by recursively merging
+        // liveness.
+        if (isa<memref::SubViewOp>(user)) return;
+        if (group.liveness.count(user)) {
+          aliasGroups.push_back(i);
+          break;
+        }
+      }
+    }
+    if (aliasGroups.empty()) {
+      // If we didn't find any alias group create a new one.
+      AllocGroup &newGroup = groups.emplace_back();
+      newGroup.allocs.push_back(alloc);
+      Liveness::OperationListT liveInfo =
+          liveness.resolveLiveness(alloc->getResult(0));
+      newGroup.liveness.insert(liveInfo.begin(), liveInfo.end());
+    } else {
+      // Merge the alloc into the first alias group it interfers with.
+      AllocGroup &mergeGroup = groups[aliasGroups[0]];
+      mergeGroup.allocs.push_back(alloc);
+      Liveness::OperationListT liveInfo =
+          liveness.resolveLiveness(alloc->getResult(0));
+      mergeGroup.liveness.insert(liveInfo.begin(), liveInfo.end());
+      // Then merge all the other alias groups into the first group.
+      for (size_t i = 1, e = aliasGroups.size(); i < e; i++) {
+        AllocGroup &group = groups[aliasGroups[i]];
+        mergeGroup.allocs.insert(mergeGroup.allocs.end(), group.allocs.begin(),
+                                 group.allocs.end());
+        mergeGroup.liveness.insert(group.liveness.begin(),
+                                   group.liveness.end());
+        // For simplicity we leave the group empty and don't remove it.
+        group.allocs.clear();
+        group.liveness.clear();
+      }
+    }
+  }
+
+  LLVM_DEBUG({
+    for (size_t i = 0; i < groups.size(); i++) {
+      llvm::dbgs() << "Alias group " << i << ":\n";
+      for (Operation *op : groups[i].allocs) op->dump();
+    }
+  });
+
+  for (size_t i = 0; i < groups.size(); i++) {
+    if (groups[i].allocs.empty()) continue;
+    aliasGroups.push_back(std::move(groups[i].allocs));
+  }
+}
+
+static int64_t getAllocSize(Operation *op, DataLayout &dataLayout) {
+  auto allocOp = cast<memref::AllocOp>(op);
+  int64_t numElements = allocOp.getType().getNumElements();
+  return (dataLayout.getTypeSizeInBits(allocOp.getType().getElementType()) *
+          numElements) /
+         8;
+}
+
+void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
+                SmallVector<AliasGroup> &aliasGroups) {
+  DataLayout dataLayout = DataLayout::closest(funcOp);
+  builder.setInsertionPointToStart(&(*funcOp.getBody().begin()));
+  int64_t maxAlloc = 0;
+  for (size_t i = 0; i < aliasGroups.size(); i++) {
+    int64_t allocSize = 0;
+    for (Operation *alloc : aliasGroups[i]) {
+      allocSize += getAllocSize(alloc, dataLayout);
+    }
+    maxAlloc = std::max(maxAlloc, allocSize);
+  }
+
+  Attribute memorySpace = aliasGroups[0][0]
+                              ->getOperand(0)
+                              .getType()
+                              .cast<MemRefType>()
+                              .getMemorySpace();
+  MemRefType allocType = MemRefType::get({maxAlloc}, builder.getI8Type(),
+                                         AffineMap(), memorySpace);
+  Value packedAlloc =
+      builder.create<memref::AllocOp>(funcOp.getLoc(), allocType);
+  for (size_t i = 0; i < aliasGroups.size(); i++) {
+    int64_t offset = 0;
+    for (Operation *alloc : aliasGroups[i]) {
+      Location loc = alloc->getLoc();
+      builder.setInsertionPoint(alloc);
+      Value offsetValue = builder.create<arith::ConstantIndexOp>(loc, offset);
+      Value newAlloc = builder.create<memref::ViewOp>(
+          packedAlloc.getLoc(), alloc->getResultTypes()[0], packedAlloc,
+          offsetValue, ArrayRef<Value>({}));
+      offset += getAllocSize(alloc, dataLayout);
+      alloc->replaceAllUsesWith(ArrayRef<Value>({newAlloc}));
+      alloc->erase();
+    }
+  }
 }
 
 }  // namespace iree_compiler

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -106,8 +106,8 @@ using AliasGroup = SmallVector<Operation *>;
 /// they are merge into the same group. If a new alloc is part of multiple alias
 /// groups all those are merged into one. At the end we are left with groups of
 /// allocations that are disjoint and can use the same memory.
-void analyzeSharedMemoryAlloc(func::FuncOp funcOp, ArrayRef<Operation *> allocs,
-                              SmallVector<AliasGroup> &aliasGroups);
+void analyseAllocsForPacking(func::FuncOp funcOp, ArrayRef<Operation *> allocs,
+                             SmallVector<AliasGroup> &aliasGroups);
 
 /// Pack groups of allocations into a unique large i8 allocation and use
 /// memref.view to separate the indivudual allocations. This allows re-using

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -106,15 +106,14 @@ using AliasGroup = SmallVector<Operation *>;
 /// they are merge into the same group. If a new alloc is part of multiple alias
 /// groups all those are merged into one. At the end we are left with groups of
 /// allocations that are disjoint and can use the same memory.
-void analyzeSharedMemoryAlloc(func::FuncOp funcOp,
-                              const SmallVector<Operation *> &allocs,
+void analyzeSharedMemoryAlloc(func::FuncOp funcOp, ArrayRef<Operation *> allocs,
                               SmallVector<AliasGroup> &aliasGroups);
 
 /// Pack groups of allocations into a unique large i8 allocation and use
 /// memref.view to separate the indivudual allocations. This allows re-using
 /// memory across alias groups.
 void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
-                SmallVector<AliasGroup> &aliasGroups);
+                ArrayRef<AliasGroup> aliasGroups);
 
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
+++ b/compiler/src/iree/compiler/Codegen/Transforms/Transforms.h
@@ -96,6 +96,26 @@ void populateReshapeToInterfaceTensorPatterns(RewritePatternSet &patterns);
 /// Populate patterns that remove dead allocations
 void populateRemoveDeadMemAllocPatterns(RewritePatternSet &patterns);
 
+// Group of Alloc operations that have overlapping liveranges.
+using AliasGroup = SmallVector<Operation *>;
+
+/// Analyze the liverange of the given allocs and set them in individual groups
+/// if they don't overlap.
+/// The algorithm is a simplistic memory allocation solution. It sorts
+/// allocations into alias groups. Everytime two alloc's liverange interfers
+/// they are merge into the same group. If a new alloc is part of multiple alias
+/// groups all those are merged into one. At the end we are left with groups of
+/// allocations that are disjoint and can use the same memory.
+void analyzeSharedMemoryAlloc(func::FuncOp funcOp,
+                              const SmallVector<Operation *> &allocs,
+                              SmallVector<AliasGroup> &aliasGroups);
+
+/// Pack groups of allocations into a unique large i8 allocation and use
+/// memref.view to separate the indivudual allocations. This allows re-using
+/// memory across alias groups.
+void packAllocs(OpBuilder &builder, func::FuncOp funcOp,
+                SmallVector<AliasGroup> &aliasGroups);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -743,5 +743,12 @@ Optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
   return std::nullopt;
 }
 
+bool hasSharedMemoryAddressSpace(MemRefType memrefType) {
+  auto addrSpace =
+      memrefType.getMemorySpace().dyn_cast_or_null<gpu::AddressSpaceAttr>();
+  return addrSpace &&
+         addrSpace.getValue() == gpu::GPUDialect::getWorkgroupAddressSpace();
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.h
@@ -89,6 +89,9 @@ Optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op);
 /// Helper function to return native size for MMA.SYNC-based operations.
 Optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op);
 
+/// Return true if the given memref has workgroup memory space.
+bool hasSharedMemoryAddressSpace(MemRefType memrefType);
+
 }  // namespace iree_compiler
 }  // namespace mlir
 

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -752,5 +752,38 @@ void replaceMemrefUsesAndPropagateType(Operation *oldOp, Value val,
   for (Operation *op : opToDelete) op->erase();
 }
 
+void sinkOpsInCFG(const SmallVector<Operation *> &allocs,
+                  DominanceInfo &dominators) {
+  for (Operation *sinkOp : allocs) {
+    Block *dom = nullptr;
+    for (Operation *user : sinkOp->getUsers()) {
+      if (!dom) {
+        dom = user->getBlock();
+        // Find the block in the same region.
+        while (dom->getParent() != sinkOp->getParentRegion()) {
+          dom = dom->getParentOp()->getBlock();
+        }
+        continue;
+      }
+      dom = dominators.findNearestCommonDominator(dom, user->getBlock());
+    }
+    llvm::SmallDenseSet<Operation *> users;
+    for (Operation *user : sinkOp->getUsers()) {
+      while (user->getParentRegion() != sinkOp->getParentRegion()) {
+        user = user->getParentOp();
+      }
+      users.insert(user);
+    }
+    Operation *firstUse = dom->getTerminator();
+    for (Operation &op : dom->getOperations()) {
+      if (users.count(&op)) {
+        firstUse = &op;
+        break;
+      }
+    }
+    sinkOp->moveBefore(firstUse);
+  }
+}
+
 }  // namespace iree_compiler
 }  // namespace mlir

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -16,6 +16,7 @@
 #include "mlir/Dialect/Linalg/Utils/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/Dominance.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/ViewLikeInterface.h"
@@ -205,6 +206,10 @@ linalg::LinalgLoopDistributionOptions getIREELinalgLoopDistributionOptions(
 /// propagate the type change and erase old subview ops.
 void replaceMemrefUsesAndPropagateType(Operation *oldOp, Value val,
                                        OpBuilder &builder);
+
+/// Sink given operations as close as possible to their uses.
+void sinkOpsInCFG(const SmallVector<Operation *> &allocs,
+                  DominanceInfo &dominators);
 
 }  // namespace iree_compiler
 }  // namespace mlir


### PR DESCRIPTION
In order to improve performance for matmul with large tile sizes we need to be able to re-use shared memory between the allocation done for the input and output.
This adds a pass to pack memory allocations if we can prove that their liveranges are disjoint. This relies on a simplisitic algorithm that will sort allocations into alias groups that are independent of each others.
Since we currently don't have a way to represent packing at the memref level we rely on attributes and handle the real packing at convert to LLVM dialect time. This is a workaround and should be removed one we have a way to represent bitcasting of memref.