### PR TITLE
[Plan to Close this PR] Mainloop multistaged pipeline and instruction scheduling for NVIDIA Ampere Tensor Cores (F16)

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -370,7 +370,7 @@ struct MainLoopInfo {
            "Expected only one async.create.group op");
     assert(asyncWaitOps.size() == 1 && "Expected only one async.wait op");
     assert(
-        barrierOps.size() == 1 &&
+        barrierOps.size() == 2 &&
         "Expected only two barrier ops ,i.e., around each Shared Memory copy");
 
     // Collect the dependent operations for cp.async for couarse-grained
@@ -477,7 +477,8 @@ static void getNvidiaAmpereTensorCorePipeline(
 
   // Schedule and pipeline all async.wait and barrier
   ops.push_back(std::make_pair(info.asyncWaitOps[0], numStages - 2));
-  ops.push_back(std::make_pair(info.barrierOps[0], numStages - 2));
+  info.barrierOps[0]->erase();
+  ops.push_back(std::make_pair(info.barrierOps[1], numStages - 2));
   //////////////////////////////////////////////////////////////////////////////
 
   // Coarse-grained instruction pipelining: pipeline Shared Memory loads

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -126,19 +126,34 @@ static void addOpsAndDeps(llvm::SmallDenseSet<Operation*>& filter,
   }
 }
 
-/// Add an op and its dependency to `ops` set and skip operations contained into
-/// filter. This also adds all the ops to filter so that they don't get matched
-/// again.
-static void addOpsAndDepsWithFilter(llvm::SmallDenseSet<Operation*>& filter,
-                                    llvm::SmallDenseSet<Operation*>& skippedOps,
-                                    llvm::SmallDenseSet<Operation*>& ops,
-                                    Operation* op, Block* block) {
-  if (!filter.insert(op).second || skippedOps.count(op)) return;
-  ops.insert(op);
+/// Insert an op and its dependency chain to `dependentOps` set.
+static void insertDependentOps(llvm::SetVector<Operation*>& dependentOps,
+                               Operation* op, Block* block) {
+  dependentOps.insert(op);
   for (Value operand : op->getOperands()) {
     Operation* defOp = operand.getDefiningOp();
     if (defOp && defOp->getBlock() == block)
-      addOpsAndDepsWithFilter(filter, skippedOps, ops, defOp, block);
+      insertDependentOps(dependentOps, defOp, block);
+  }
+}
+
+/// Insert an op and its dependency chain to `dependentOps` set. It skip
+/// operations that are already scheduled (`scheduleOps` list) or ignored
+/// (`filteredOps` list).
+static void insertUnscheduledDependentOps(
+    llvm::SetVector<Operation*>& scheduledOps,
+    llvm::SetVector<Operation*>& filteredOps,
+    llvm::SetVector<Operation*>& dependentOps, Operation* op, Block* block) {
+  if (filteredOps.count(op) || !scheduledOps.insert(op)) return;
+  std::cout << "insertUnscheduledDependentOps ";
+  std::cout << std::flush;
+  op->dump();
+  dependentOps.insert(op);
+  for (Value operand : op->getOperands()) {
+    Operation* defOp = operand.getDefiningOp();
+    if (defOp && defOp->getBlock() == block)
+      insertUnscheduledDependentOps(scheduledOps, filteredOps, dependentOps,
+                                    defOp, block);
   }
 }
 
@@ -279,28 +294,74 @@ struct WarpMmaOp {
   llvm::SetVector<Operation*> mmaOperations;
 };
 
+struct KgroupStagePair {
+  int kgroup;
+  int stage;
+  KgroupStagePair() : kgroup(-1), stage(-1) {}
+  KgroupStagePair(int kgroup, int stage) : kgroup(kgroup), stage(stage) {}
+
+  bool operator==(const KgroupStagePair& other) const {
+    return kgroup == other.kgroup && stage == other.stage;
+  }
+  bool operator!=(const KgroupStagePair& other) const {
+    return !(*this == other);
+  }
+};
 /// Structure to hold the matmul's mainloop information:
 /// Seperates the mmasync operations into kgroups and collects the Shared Memory
 /// loads for each kgroup. This information is used to pipeline the mainloop and
 /// to generate an optimal schedule interleaving Global Memory loads, Shared
 /// Memory loads, and math operations.
 struct MainLoopInfo {
+  using KgroupToWarpMmaMap = std::unordered_map<int, WarpMmaOp>;
+  using OperationDepMap =
+      std::unordered_map<Operation*, llvm::SetVector<Operation*>>;
+
   //
   // Data members
   //
 
   // Mainloop operations GlobalMemory -> SharedMemory
-  SmallVector<Operation*> copyGlobalToSharedOps;
-  SmallVector<Operation*> barrierOps;
-  SmallVector<Operation*> asyncWaitOps;
+  SetVector<Operation*> copyGlobalToSharedOps;
+  SetVector<Operation*> asyncCreateGroupOp;
+  SetVector<Operation*> barrierOps;
+  SetVector<Operation*> asyncWaitOps;
+  int totalPipelineStages;
 
   // Warp-level MMA operations SharedMemory -> Registers -> MMA.
   // Map: kgroupIdx -> WarpMmaOp
-  std::unordered_map<int, WarpMmaOp> warpOperations;
+  KgroupToWarpMmaMap warpOperations;
+  OperationDepMap operationDeps;
+
+  // Map: Operation -> kgroupIdx
+  std::unordered_map<Operation*, int> opToKgroupMap;
+  std::unordered_map<Operation*, KgroupStagePair> opToKgroupStageMap;
+
+  // Set to track the dependencies already seen to a backward slice.
+  llvm::SetVector<Operation*> seenDepOps;
+
+  // Set to track the mma operations in forward slice to count kgroups and
+  // populate the warp-level WarpMmaOp kgroupIdx -> WarpMmaOp map.
+  llvm::SetVector<Operation*> seenMmaOps;
 
   //
   // Methods
   //
+
+  // Populates the dependent operations in ``dependentOps`` for the given a op
+  // recursively that are in the same block and not added to the backward slice
+  // of some other op.
+  void backwardSliceOfDependentOps(llvm::SetVector<Operation*>& dependentOps,
+                                   Operation* op, Block* block) {
+    if (!seenDepOps.insert(op)) return;
+    // Add the unseen op to the dependentOps and recurse on its operands.
+    dependentOps.insert(op);
+    for (Value operand : op->getOperands()) {
+      Operation* defOp = operand.getDefiningOp();
+      if (defOp && defOp->getBlock() == block)
+        backwardSliceOfDependentOps(dependentOps, defOp, block);
+    }
+  }
 
   // Backtrack from the MmaSyncOp operand (mlir::OpOperand) to its defining
   // `mlir::Operation` to find the ldmatrix or ld.shared operations that load
@@ -311,27 +372,28 @@ struct MainLoopInfo {
     if (!op) return;
 
     if (isa<nvgpu::LdMatrixOp>(op)) {
-      if (op->getBlock() == block) loadOperations.insert(op);
+      if (op->getBlock() == block) {
+        loadOperations.insert(op);
+      }
       return;
     }
 
-    // Recurse upwards towards the definition until a load is found.
-    // Assumption here is that only single operand operations are leading up to
-    // LdMatrix.
+    // Recurse upwards towards the definition until a Shared Memory load is
+    // found. Assumption here is that only single operand operations are leading
+    // up to LdMatrix.
     Operation* defOp = op->getOperand(0).getDefiningOp();
 
     backtrackToFindSmemLoad(defOp, loadOperations, block);
   }
 
   // Recursively traverse the chain of mma operations for all kgroups from 0
-  // 0 (start) to numKgroups (ends scf.yield).
-  void vistMmaSyncOp(Operation* op, int kgroupIdx,
-                     llvm::SmallDenseSet<Operation*>& seenMmaSyncOps) {
+  // (start) to numKgroups (ends scf.yield).
+  void vistMmaSyncOp(Operation* op, int kgroupIdx) {
     // if the operation in an `scf.yield`, we reached the end of MmaSyncOp chain
     // return.
-    if (seenMmaSyncOps.count(op) || isa<scf::YieldOp>(op)) return;
+    if (seenMmaOps.count(op) || isa<scf::YieldOp>(op)) return;
 
-    seenMmaSyncOps.insert(op);
+    seenMmaOps.insert(op);
     warpOperations[kgroupIdx].mmaOperations.insert(op);
 
     backtrackToFindSmemLoad(op->getOperand(0).getDefiningOp(),
@@ -342,91 +404,151 @@ struct MainLoopInfo {
                             warpOperations[kgroupIdx].loadOperationsB,
                             op->getBlock());
 
-    vistMmaSyncOp((op->getUses().begin())->getOwner(), ++kgroupIdx,
-                  seenMmaSyncOps);
+    vistMmaSyncOp((op->getUses().begin())->getOwner(), ++kgroupIdx);
+  }
+
+  void setDependentOps(Operation* op, Block* block) {
+    llvm::SetVector<Operation*> dependentOps;
+    backwardSliceOfDependentOps(dependentOps, op, block);
+    operationDeps[op] = std::move(dependentOps);
   }
 
   // ctor
-  MainLoopInfo() {}
+  MainLoopInfo(int totalPipelineStages)
+      : totalPipelineStages(totalPipelineStages) {}
 
-  // Iterate through the mainloop and collect the async.copy, barrier, and
-  // async.wait operations. These operations are used to pipeline the
-  // mainloop. Additionally, collect the mma.sync operations and separate them
-  // into kgroups. These operations are used to generate an optimal
-  // finer-grained schedule for Shared Memory loads, Global Memory loads, and
+  // Iterate through the mainloop and collect the `async.copy`,
+  // `async.wait`, and `barrier` operations. These operations are used to
+  // pipeline the mainloop. Additionally, collect the `mma.sync` operations and
+  // separate them into kgroups. These operations are used to generate an
+  // optimal finer-grained schedule of  Global Memory, Shared Memory loads, and
   // math operations.
   void collect(scf::ForOp forOp) {
-    llvm::SmallDenseSet<Operation*> seenMmaSyncOps;
-    std::cout << "Collecting MainLoopInfo: " << std::endl;
+    int numForLoopInst = 0;
+    std::cout << "ForOp: " << std::endl;
+    forOp.dump();
+    // std::cout << "Collecting MainLoopInfo: " << std::endl;
     for (Operation& op : forOp.getBody()->getOperations()) {
-      op.dump();
-      if (isa<nvgpu::MmaSyncOp>(op)) {
-        vistMmaSyncOp(&op, 0 /*kgroup = 0*/, seenMmaSyncOps);
+      numForLoopInst++;
+      // Collect the async.copy, async.wait, and barrier operations. These are
+      // used for coarse-grained pipelining of the mainloop.
+      if (isa<nvgpu::DeviceAsyncCopyOp>(op)) {
+        copyGlobalToSharedOps.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
       }
-      if (isa<nvgpu::DeviceAsyncCopyOp, nvgpu::DeviceAsyncCreateGroupOp>(op)) {
-        copyGlobalToSharedOps.push_back(&op);
+      if (isa<nvgpu::DeviceAsyncCreateGroupOp>(op)) {
+        asyncCreateGroupOp.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
       }
       if (isa<gpu::BarrierOp>(op)) {
-        barrierOps.push_back(&op);
+        barrierOps.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
       }
       if (isa<nvgpu::DeviceAsyncWaitOp>(op)) {
-        asyncWaitOps.push_back(&op);
+        asyncWaitOps.insert(&op);
+        // setDependentOps(&op, forOp.getBody());
+      }
+      // Collect the warp-level mma.sync and Shared Memory load operations and
+      // separate them into kgroups. These are used for fine-grained instruction
+      // scheduling.
+      if (isa<nvgpu::LdMatrixOp>(op)) {
+        // setDependentOps(&op, forOp.getBody());
+      }
+      if (isa<nvgpu::MmaSyncOp>(op)) {
+        vistMmaSyncOp(&op, 0 /*kgroup = 0*/);
+        // setDependentOps(&op, forOp.getBody());
       }
     }
+    std::cout << "Number of for loop instructions: " << numForLoopInst
+              << std::endl;
 
     // Assert that barrierOps and asyncWaitOps have only 1 occurance in
     // un-pipelined mainloop.
     assert(barrierOps.size() == 1 && "Expected only one barrier op");
     assert(asyncWaitOps.size() == 1 && "Expected only one async.wait op");
 
-#if 0
-    // Obtain the list of all the MmaSyncOps within the mainloop.
-    auto mmaSyncOps = forOp.getBody()->getOps<nvgpu::MmaSyncOp>();
-
-    for (auto mmaSyncOp : mmaSyncOps) {
-      vistMmaSyncOp(mmaSyncOp.getOperation(), 0, visited);
-      // mmaSyncOp.dump();
+    // Fill the reverse map from operation to kgroup, stage.
+    for (auto& warpOp : warpOperations) {
+      for (auto mmaOp : warpOp.second.mmaOperations) {
+        opToKgroupMap[mmaOp] = warpOp.first;
+        opToKgroupStageMap[mmaOp] = {warpOp.first, totalPipelineStages - 1};
+      }
+      for (auto loadOp : warpOp.second.loadOperationsA) {
+        opToKgroupMap[loadOp] = warpOp.first;
+        int stage = totalPipelineStages - 1;
+        if (warpOp.first == 0) {
+          stage = totalPipelineStages - 2;
+        }
+        opToKgroupStageMap[loadOp] = {warpOp.first, stage};
+      }
+      for (auto loadOp : warpOp.second.loadOperationsB) {
+        opToKgroupMap[loadOp] = warpOp.first;
+        int stage = totalPipelineStages - 1;
+        if (warpOp.first == 0) {
+          stage = totalPipelineStages - 2;
+        }
+        opToKgroupStageMap[loadOp] = {warpOp.first, stage};
+      }
     }
-#endif
+
+    // Assign all cp.async a kgroup and stage.
+    for (auto copyOp : copyGlobalToSharedOps) {
+      opToKgroupStageMap[copyOp] = {0, 0};
+    }
+
+    opToKgroupStageMap[asyncCreateGroupOp[0]] = {0, 0};
+
+    opToKgroupStageMap[asyncWaitOps[0]] = {0, totalPipelineStages - 2};
+    opToKgroupStageMap[barrierOps[0]] = {0, totalPipelineStages - 2};
+
+    // Find all the dependent operations for each kgroup, stage in the schedule
+    // order.
   }
 
   // Returns the number of kgroups in the Warp-level MMA operations.
   int getNumKGroups() { return warpOperations.size(); }
 
-  // Dump the Mainloop info collected.
+  void dumpDeps(Operation* op) {
+    std::cout << "Backward slice operations for op leading upto op: ";
+    std::cout << std::flush;
+    op->dump();
+    for (auto depOp : operationDeps[op]) {
+      depOp->dump();
+    }
+  }
+
+  // Debug dump the MainloopInfo.
   void dump() {
     // Debug prints
+    std::cout << ">>> MainLoopInfo::dump() for kGroup *fine-grained* "
+                 "instruction scheduling"
+              << std::endl;
     for (auto warpOp : warpOperations) {
       std::cout << "Load operations for operandA kGroup (" << warpOp.first
                 << ")" << std::endl;
-      for (auto loadOp : warpOp.second.loadOperationsA) {
-        loadOp->dump();
-      }
+
+      for (auto loadOp : warpOp.second.loadOperationsA) dumpDeps(loadOp);
+
       std::cout << "Load operations for operandB kGroup (" << warpOp.first
                 << ")" << std::endl;
-      for (auto loadOp : warpOp.second.loadOperationsB) {
-        loadOp->dump();
-      }
+
+      for (auto loadOp : warpOp.second.loadOperationsB) dumpDeps(loadOp);
+
       std::cout << "Mma Sync kGroup (" << warpOp.first << ")" << std::endl;
-      for (auto mmaOp : warpOp.second.mmaOperations) {
-        mmaOp->dump();
-      }
+      for (auto mmaOp : warpOp.second.mmaOperations) dumpDeps(mmaOp);
     }
 
+    std::cout << ">>> MainLoopInfo::dump() for kGroup *course-grained* "
+                 "software pipelining"
+              << std::endl;
     std::cout << "Copy Global to Shared Memory" << std::endl;
-    for (auto copyOp : copyGlobalToSharedOps) {
-      copyOp->dump();
-    }
+    for (auto copyOp : copyGlobalToSharedOps) dumpDeps(copyOp);
 
-    std::cout << "Barrier" << std::endl;
-    for (auto barrierOp : barrierOps) {
-      barrierOp->dump();
-    }
+    std::cout << "Gpu Barrier" << std::endl;
+    for (auto barrierOp : barrierOps) dumpDeps(barrierOp);
 
-    std::cout << "Async Wait" << std::endl;
-    for (auto asyncWaitOp : asyncWaitOps) {
-      asyncWaitOp->dump();
-    }
+    std::cout << "CpAsync Wait" << std::endl;
+    for (auto asyncWaitOp : asyncWaitOps) dumpDeps(asyncWaitOp);
   }
 };
 
@@ -516,30 +638,30 @@ static void getNvidiaTensorCorePipeline(
       ops.push_back(std::make_pair(&op, depth - 2));
   }
 
-  // Print schedule
-  std::cout << "getNvidiaTensorCorePipeline Schedule" << std::endl;
-  for (auto op : ops) {
-    std::cout << " Stage: " << op.second;
-    std::cout << " Operation: ";
-    op.first->dump();
-    std::cout << std::endl;
+  llvm::SmallDenseSet<Operation*> scheduledOperations;
+  std::cout << std::flush;
+  std::cout << ">>>> Final schedule for the mainloop: Instructions "
+            << ops.size() << std::endl;
+  for (auto& stage_op_pair : ops) {
+    std::cout << " Stage (" << stage_op_pair.second << ") , Operation: ";
+    std::cout << std::flush;
+    stage_op_pair.first->dump();
+    scheduledOperations.insert(stage_op_pair.first);
+    std::cout << std::flush;
   }
-
-  // Create schedule and assign software pipelining stages kgroup-by-kgroup.
 }
 
 /// Schedule operations and assign software pipelining stages.
 static void scheduleOperations(
     std::vector<std::pair<Operation*, unsigned>>& ops,
-    llvm::SmallDenseSet<Operation*> dependentOps, unsigned pipelineDepth) {
-  for (Operation* op : dependentOps) {
-    std::cout << "Stage : " << pipelineDepth << " ";
-    std::cout << "Schedule operation: ";
-    op->dump();
+    llvm::SetVector<Operation*> dependentOps, unsigned pipelineDepth) {
+  // for (Operation* op : dependentOps) {
+  for (auto op_it = dependentOps.rbegin(); op_it != dependentOps.rend();
+       ++op_it) {
+    std::cout << " scheduleOperations: ";
     std::cout << std::flush;
-    std::cout << std::endl;
-    std::cout << std::endl;
-    ops.push_back(std::make_pair(op, pipelineDepth));
+    (*op_it)->dump();
+    ops.push_back(std::make_pair(*op_it, pipelineDepth));
   }
 }
 
@@ -548,90 +670,112 @@ static void scheduleOperations(
 static void getNvidiaTensorCoreScheduleAndPipeline(
     scf::ForOp forOp, std::vector<std::pair<Operation*, unsigned>>& ops,
     unsigned depth) {
-  MainLoopInfo info;
+  MainLoopInfo info(depth);
   info.collect(forOp);
   info.dump();
 
-  // Schedule the mainloop kgroup-by-kgroup.
-  llvm::SmallDenseSet<Operation*> scheduledOps;
-  llvm::SmallDenseSet<Operation*> skippedOps;
+  // Schedule loads for kgroup 1.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::LdMatrixOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 1) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 1);
+      }
+    }
+  }
 
-  for (int kgroup = 0; kgroup < info.getNumKGroups(); kgroup++) {
-    // Schedule warp-level mma.sync operations.
+  // Schedule math for kgroup 0.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::MmaSyncOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 0) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 1);
+      }
+    }
+  }
+
+  // Schedule cp.async
+  for (auto& copyOp : info.copyGlobalToSharedOps) {
+    scheduleOperations(ops, info.operationDeps[copyOp], 0);
+  }
+  scheduleOperations(ops, info.operationDeps[info.asyncWaitOps[0]], depth - 2);
+  scheduleOperations(ops, info.operationDeps[info.barrierOps[0]], depth - 2);
+
+  // Schedule loads for kgroup 0.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::LdMatrixOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 0) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 2);
+      }
+    }
+  }
+
+  // Schedule math for kgroup 1.
+  for (Operation& op : forOp.getBody()->getOperations()) {
+    if (isa<nvgpu::MmaSyncOp>(&op)) {
+      if (info.opToKgroupMap[&op] == 1) {
+        scheduleOperations(ops, info.operationDeps[&op], depth - 1);
+      }
+    }
+  }
+
+#if 0
+  for (int kgroup = 0; kgroup < info.getNumKGroups(); kgroup = kgroup + 2) {
+    // Schedule load operations for kgroup + 1.
+    for (auto& ldmatrixOp : info.warpOperations[kgroup + 1].loadOperationsA) {
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], depth - 1);
+    }
+
+    for (auto& ldmatrixOp : info.warpOperations[kgroup + 1].loadOperationsB) {
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], depth - 1);
+    }
+
+    // Schedule mma.sync for kgroup.
     for (auto& mmaOp : info.warpOperations[kgroup].mmaOperations) {
-      skippedOps.insert(info.warpOperations[0].loadOperationsA.begin(),
-                        info.warpOperations[0].loadOperationsA.end());
-      skippedOps.insert(info.warpOperations[0].loadOperationsB.begin(),
-                        info.warpOperations[0].loadOperationsB.end());
-
-      llvm::SmallDenseSet<Operation*> dependentOps;
-
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps, mmaOp,
-                              forOp.getBody());
-      scheduleOperations(ops, dependentOps, depth - 1);
+      scheduleOperations(ops, info.operationDeps[mmaOp], depth - 1);
     }
 
-    skippedOps.clear();
+    // TODO: Distribute cp.async accross kgroup and schedule wait and bar.sync
+    // after the last cp.async.
+    // Schedule *all* cp.async.wait and bar.sync 0 if
+    // it is the kgroup 0.
+    if (kgroup == 0) {
+      for (auto& copyOp : info.copyGlobalToSharedOps) {
+        scheduleOperations(ops, info.operationDeps[copyOp], 0);
+      }
 
-    // Schedule warp-level ldmatrix or ld.shared operations for operandA.
+      scheduleOperations(ops, info.operationDeps[info.asyncWaitOps[0]],
+                         depth - 2);
+      scheduleOperations(ops, info.operationDeps[info.barrierOps[0]],
+                         depth - 2);
+    }
+
+    // Schedule load operations for kgroup.
     for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsA) {
-      llvm::SmallDenseSet<Operation*> dependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
-                              ldmatrixOp, forOp.getBody());
-      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
-      scheduleOperations(ops, dependentOps, pipelineStage);
+      int pipelineStage = (kgroup == 0) ? depth - 2 : depth - 1;
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], pipelineStage);
     }
 
-    // Schedule warp-level ldmatrix or ld.shared operations for operandB.
     for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsB) {
-      llvm::SmallDenseSet<Operation*> dependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
-                              ldmatrixOp, forOp.getBody());
-      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
-      scheduleOperations(ops, dependentOps, pipelineStage);
+      int pipelineStage = (kgroup == 0) ? depth - 2 : depth - 1;
+      scheduleOperations(ops, info.operationDeps[ldmatrixOp], pipelineStage);
     }
 
-#if 0  // TODO: Distribute cp.async operations across.
-    // Schedule async copy from Global Memory to Shared Memory.
-    int copyIdxStart =
-        kgroup * (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
-    int copyIdxEnd = (kgroup + 1) *
-                     (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
-
-    for (int idx = copyIdxStart; idx < copyIdxEnd; idx++) {
-      llvm::SmallDenseSet<Operation*> dependentOps;
-      addOpsAndDeps(scheduledOps, dependentOps, info.copyGlobalToSharedOps[idx],
-                    forOp.getBody());
-      scheduleOperations(ops, dependentOps, 0);
+    // Schedule mma.sync for kgroup + 1.
+    for (auto& mmaOp : info.warpOperations[kgroup + 1].mmaOperations) {
+      scheduleOperations(ops, info.operationDeps[mmaOp], depth - 1);
     }
+  }
 #endif
 
-    if (kgroup == info.getNumKGroups() - 1) {
-      // Schedule any remaining cp.async or cp.async.commit_group operations.
-      int idx = 0;
-
-      while (idx < info.copyGlobalToSharedOps.size()) {
-        info.copyGlobalToSharedOps[idx]->dump();
-        llvm::SmallDenseSet<Operation*> dependentOps;
-        addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
-                                info.copyGlobalToSharedOps[idx],
-                                forOp.getBody());
-        scheduleOperations(ops, dependentOps, 0);
-        idx++;
-      }
-      // Schedule cp.async.wait_group and bar.sync 0 for after the last
-      // cp.async.
-      llvm::SmallDenseSet<Operation*> asyncWaitDependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, asyncWaitDependentOps,
-                              info.asyncWaitOps[0], forOp.getBody());
-      scheduleOperations(ops, asyncWaitDependentOps, 0);
-
-      llvm::SmallDenseSet<Operation*> barrierDependentOps;
-      addOpsAndDepsWithFilter(scheduledOps, skippedOps, barrierDependentOps,
-                              info.barrierOps[0], forOp.getBody());
-
-      scheduleOperations(ops, barrierDependentOps, 0);
-    }
+  llvm::SmallDenseSet<Operation*> scheduledOperations;
+  std::cout << std::flush;
+  std::cout << ">>>> Final schedule for the mainloop: Instructions "
+            << ops.size() << std::endl;
+  for (auto& stage_op_pair : ops) {
+    std::cout << " Stage (" << stage_op_pair.second << ") , Operation: ";
+    std::cout << std::flush;
+    stage_op_pair.first->dump();
+    scheduledOperations.insert(stage_op_pair.first);
+    std::cout << std::flush;
   }
 }
 
@@ -657,8 +801,8 @@ static FailureOr<scf::ForOp> applyPipelining(
                          scf::ForOp forOp,
                          std::vector<std::pair<Operation*, unsigned>>& ops) {
     if (schedule == PipeliningSchedulingStrategy::nvidiaTensorCore) {
-      return getNvidiaTensorCoreScheduleAndPipeline(forOp, ops, maxDepth);
-      // return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
+      // return getNvidiaTensorCoreScheduleAndPipeline(forOp, ops, maxDepth);
+      return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
     }
     return getPipelineStages(forOp, ops, maxDepth);
   };

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -501,8 +501,14 @@ static void getNvidiaAmpereTensorCorePipeline(
 
   llvm::SmallDenseSet<Operation*> scheduledOperations;
   std::cout << std::flush;
-  std::cout << ">>>> Final schedule for the mainloop: Instructions "
-            << ops.size() << std::endl;
+  std::cout << ">> Debug prints from getNvidiaAmpereTensorCorePipeline() call "
+            << " in GPUPipelining.cpp " << std::endl;
+  std::cout << " Number of stages: " << numStages << std::endl;
+  std::cout << " Number of kgroups: " << numKgroups << std::endl;
+  std::cout << " Number of mainloop instructions " << ops.size() << std::endl;
+  std::cout << " Mainloop instructions schedule and stage assignment: "
+            << std::endl;
+
   for (auto& stage_op_pair : ops) {
     std::cout << " Stage (" << stage_op_pair.second << ") , Operation: ";
     std::cout << std::flush;

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -437,7 +437,7 @@ struct MainLoopInfo {
 /// stage.
 /// @param numStages the total number of pipeline stages used for pipelining the
 /// mainloop.
-static void getMultiStagedPipelineSchedule(
+static void getNvidiaAmpereTensorCorePipeline(
     scf::ForOp forOp, std::vector<std::pair<Operation*, unsigned>>& ops,
     unsigned numStages) {
   // Analyze the main loop and obtain information for coarse-grained pipelining
@@ -527,7 +527,7 @@ static FailureOr<scf::ForOp> applyPipelining(
                          scf::ForOp forOp,
                          std::vector<std::pair<Operation*, unsigned>>& ops) {
     if (schedule == PipeliningSchedulingStrategy::nvidiaTensorCore) {
-      return getMultiStagedPipelineSchedule(forOp, ops, maxDepth);
+      return getNvidiaAmpereTensorCorePipeline(forOp, ops, maxDepth);
     }
     return getPipelineStages(forOp, ops, maxDepth);
   };

--- a/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/GPUPipelining.cpp
@@ -4,6 +4,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+#include <iostream>
+
 #include "iree/compiler/Codegen/Common/Transforms.h"
 #include "iree/compiler/Codegen/PassDetail.h"
 #include "iree/compiler/Codegen/Passes.h"
@@ -121,6 +123,22 @@ static void addOpsAndDeps(llvm::SmallDenseSet<Operation*>& filter,
     Operation* defOp = operand.getDefiningOp();
     if (defOp && defOp->getBlock() == block)
       addOpsAndDeps(filter, ops, defOp, block);
+  }
+}
+
+/// Add an op and its dependency to `ops` set and skip operations contained into
+/// filter. This also adds all the ops to filter so that they don't get matched
+/// again.
+static void addOpsAndDepsWithFilter(llvm::SmallDenseSet<Operation*>& filter,
+                                    llvm::SmallDenseSet<Operation*>& skippedOps,
+                                    llvm::SmallDenseSet<Operation*>& ops,
+                                    Operation* op, Block* block) {
+  if (!filter.insert(op).second || skippedOps.count(op)) return;
+  ops.insert(op);
+  for (Value operand : op->getOperands()) {
+    Operation* defOp = operand.getDefiningOp();
+    if (defOp && defOp->getBlock() == block)
+      addOpsAndDepsWithFilter(filter, skippedOps, ops, defOp, block);
   }
 }
 
@@ -251,6 +269,167 @@ static bool isAOperand(Operation* op) { return isMMAOperand(op, 0); }
 /// Return true if the op is used as operand B of an mma.sync op.
 static bool isBOperand(Operation* op) { return isMMAOperand(op, 1); }
 
+/// Loads from Shared Memory and the MMA operations on registers for a kgroup.
+struct WarpMmaOp {
+  // Load matrixA from Shared Memory to registers.
+  llvm::SetVector<Operation*> loadOperationsA;
+  // Load matrixB from Shared Memory to registers.
+  llvm::SetVector<Operation*> loadOperationsB;
+  // Warp-level MMA operations on registers.
+  llvm::SetVector<Operation*> mmaOperations;
+};
+
+/// Structure to hold the matmul's mainloop information:
+/// Seperates the mmasync operations into kgroups and collects the Shared Memory
+/// loads for each kgroup. This information is used to pipeline the mainloop and
+/// to generate an optimal schedule interleaving Global Memory loads, Shared
+/// Memory loads, and math operations.
+struct MainLoopInfo {
+  //
+  // Data members
+  //
+
+  // Mainloop operations GlobalMemory -> SharedMemory
+  SmallVector<Operation*> copyGlobalToSharedOps;
+  SmallVector<Operation*> barrierOps;
+  SmallVector<Operation*> asyncWaitOps;
+
+  // Warp-level MMA operations SharedMemory -> Registers -> MMA.
+  // Map: kgroupIdx -> WarpMmaOp
+  std::unordered_map<int, WarpMmaOp> warpOperations;
+
+  //
+  // Methods
+  //
+
+  // Backtrack from the MmaSyncOp operand (mlir::OpOperand) to its defining
+  // `mlir::Operation` to find the ldmatrix or ld.shared operations that load
+  // MmaSyncOp operands.
+  void backtrackToFindSmemLoad(Operation* op,
+                               llvm::SetVector<Operation*>& loadOperations,
+                               Block* block) {
+    if (!op) return;
+
+    if (isa<nvgpu::LdMatrixOp>(op)) {
+      if (op->getBlock() == block) loadOperations.insert(op);
+      return;
+    }
+
+    // Recurse upwards towards the definition until a load is found.
+    // Assumption here is that only single operand operations are leading up to
+    // LdMatrix.
+    Operation* defOp = op->getOperand(0).getDefiningOp();
+
+    backtrackToFindSmemLoad(defOp, loadOperations, block);
+  }
+
+  // Recursively traverse the chain of mma operations for all kgroups from 0
+  // 0 (start) to numKgroups (ends scf.yield).
+  void vistMmaSyncOp(Operation* op, int kgroupIdx,
+                     llvm::SmallDenseSet<Operation*>& seenMmaSyncOps) {
+    // if the operation in an `scf.yield`, we reached the end of MmaSyncOp chain
+    // return.
+    if (seenMmaSyncOps.count(op) || isa<scf::YieldOp>(op)) return;
+
+    seenMmaSyncOps.insert(op);
+    warpOperations[kgroupIdx].mmaOperations.insert(op);
+
+    backtrackToFindSmemLoad(op->getOperand(0).getDefiningOp(),
+                            warpOperations[kgroupIdx].loadOperationsA,
+                            op->getBlock());
+
+    backtrackToFindSmemLoad(op->getOperand(1).getDefiningOp(),
+                            warpOperations[kgroupIdx].loadOperationsB,
+                            op->getBlock());
+
+    vistMmaSyncOp((op->getUses().begin())->getOwner(), ++kgroupIdx,
+                  seenMmaSyncOps);
+  }
+
+  // ctor
+  MainLoopInfo() {}
+
+  // Iterate through the mainloop and collect the async.copy, barrier, and
+  // async.wait operations. These operations are used to pipeline the
+  // mainloop. Additionally, collect the mma.sync operations and separate them
+  // into kgroups. These operations are used to generate an optimal
+  // finer-grained schedule for Shared Memory loads, Global Memory loads, and
+  // math operations.
+  void collect(scf::ForOp forOp) {
+    llvm::SmallDenseSet<Operation*> seenMmaSyncOps;
+    std::cout << "Collecting MainLoopInfo: " << std::endl;
+    for (Operation& op : forOp.getBody()->getOperations()) {
+      op.dump();
+      if (isa<nvgpu::MmaSyncOp>(op)) {
+        vistMmaSyncOp(&op, 0 /*kgroup = 0*/, seenMmaSyncOps);
+      }
+      if (isa<nvgpu::DeviceAsyncCopyOp, nvgpu::DeviceAsyncCreateGroupOp>(op)) {
+        copyGlobalToSharedOps.push_back(&op);
+      }
+      if (isa<gpu::BarrierOp>(op)) {
+        barrierOps.push_back(&op);
+      }
+      if (isa<nvgpu::DeviceAsyncWaitOp>(op)) {
+        asyncWaitOps.push_back(&op);
+      }
+    }
+
+    // Assert that barrierOps and asyncWaitOps have only 1 occurance in
+    // un-pipelined mainloop.
+    assert(barrierOps.size() == 1 && "Expected only one barrier op");
+    assert(asyncWaitOps.size() == 1 && "Expected only one async.wait op");
+
+#if 0
+    // Obtain the list of all the MmaSyncOps within the mainloop.
+    auto mmaSyncOps = forOp.getBody()->getOps<nvgpu::MmaSyncOp>();
+
+    for (auto mmaSyncOp : mmaSyncOps) {
+      vistMmaSyncOp(mmaSyncOp.getOperation(), 0, visited);
+      // mmaSyncOp.dump();
+    }
+#endif
+  }
+
+  // Returns the number of kgroups in the Warp-level MMA operations.
+  int getNumKGroups() { return warpOperations.size(); }
+
+  // Dump the Mainloop info collected.
+  void dump() {
+    // Debug prints
+    for (auto warpOp : warpOperations) {
+      std::cout << "Load operations for operandA kGroup (" << warpOp.first
+                << ")" << std::endl;
+      for (auto loadOp : warpOp.second.loadOperationsA) {
+        loadOp->dump();
+      }
+      std::cout << "Load operations for operandB kGroup (" << warpOp.first
+                << ")" << std::endl;
+      for (auto loadOp : warpOp.second.loadOperationsB) {
+        loadOp->dump();
+      }
+      std::cout << "Mma Sync kGroup (" << warpOp.first << ")" << std::endl;
+      for (auto mmaOp : warpOp.second.mmaOperations) {
+        mmaOp->dump();
+      }
+    }
+
+    std::cout << "Copy Global to Shared Memory" << std::endl;
+    for (auto copyOp : copyGlobalToSharedOps) {
+      copyOp->dump();
+    }
+
+    std::cout << "Barrier" << std::endl;
+    for (auto barrierOp : barrierOps) {
+      barrierOp->dump();
+    }
+
+    std::cout << "Async Wait" << std::endl;
+    for (auto asyncWaitOp : asyncWaitOps) {
+      asyncWaitOp->dump();
+    }
+  }
+};
+
 /// Return a pipelining schedule that gives good performance on Nvidia
 /// Ampere target.
 static void getNvidiaTensorCorePipeline(
@@ -305,7 +484,7 @@ static void getNvidiaTensorCorePipeline(
       stageCompute.empty())
     return;
 
-  // Track dependencies of stage 0 ops.
+  // Add all the dependencies of the operations in the stages.
   llvm::SmallDenseSet<Operation*> deps;
   llvm::SmallDenseSet<Operation*> stageCopyToSharedMemoryDeps;
   llvm::SmallDenseSet<Operation*> stageNMinusOneDeps;
@@ -321,17 +500,138 @@ static void getNvidiaTensorCorePipeline(
   for (Operation* op : stageCompute) {
     addOpsAndDeps(deps, stageNDeps, op, forOp.getBody());
   }
-  // Schedule Last stage followed by stage 0 follwed by prefetch.
+
+  // Schedule Compute and dependent load operations in stage (depth - 1).
   for (Operation& op : forOp.getBody()->getOperations()) {
     if (stageNDeps.count(&op)) ops.push_back(std::make_pair(&op, depth - 1));
   }
+  // Schedule copy to shared memory in stage 0.
   for (Operation& op : forOp.getBody()->getOperations()) {
     if (stageCopyToSharedMemoryDeps.count(&op))
       ops.push_back(std::make_pair(&op, 0));
   }
+  // Schedule prefetch data into register in stage (depth - 2).
   for (Operation& op : forOp.getBody()->getOperations()) {
     if (stageNMinusOneDeps.count(&op))
       ops.push_back(std::make_pair(&op, depth - 2));
+  }
+
+  // Print schedule
+  std::cout << "getNvidiaTensorCorePipeline Schedule" << std::endl;
+  for (auto op : ops) {
+    std::cout << " Stage: " << op.second;
+    std::cout << " Operation: ";
+    op.first->dump();
+    std::cout << std::endl;
+  }
+
+  // Create schedule and assign software pipelining stages kgroup-by-kgroup.
+}
+
+/// Schedule operations and assign software pipelining stages.
+static void scheduleOperations(
+    std::vector<std::pair<Operation*, unsigned>>& ops,
+    llvm::SmallDenseSet<Operation*> dependentOps, unsigned pipelineDepth) {
+  for (Operation* op : dependentOps) {
+    std::cout << "Stage : " << pipelineDepth << " ";
+    std::cout << "Schedule operation: ";
+    op->dump();
+    std::cout << std::flush;
+    std::cout << std::endl;
+    std::cout << std::endl;
+    ops.push_back(std::make_pair(op, pipelineDepth));
+  }
+}
+
+/// Return a pipelining schedule that gives good performance on Nvidia
+/// Ampere target.
+static void getNvidiaTensorCoreScheduleAndPipeline(
+    scf::ForOp forOp, std::vector<std::pair<Operation*, unsigned>>& ops,
+    unsigned depth) {
+  MainLoopInfo info;
+  info.collect(forOp);
+  info.dump();
+
+  // Schedule the mainloop kgroup-by-kgroup.
+  llvm::SmallDenseSet<Operation*> scheduledOps;
+  llvm::SmallDenseSet<Operation*> skippedOps;
+
+  for (int kgroup = 0; kgroup < info.getNumKGroups(); kgroup++) {
+    // Schedule warp-level mma.sync operations.
+    for (auto& mmaOp : info.warpOperations[kgroup].mmaOperations) {
+      skippedOps.insert(info.warpOperations[0].loadOperationsA.begin(),
+                        info.warpOperations[0].loadOperationsA.end());
+      skippedOps.insert(info.warpOperations[0].loadOperationsB.begin(),
+                        info.warpOperations[0].loadOperationsB.end());
+
+      llvm::SmallDenseSet<Operation*> dependentOps;
+
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps, mmaOp,
+                              forOp.getBody());
+      scheduleOperations(ops, dependentOps, depth - 1);
+    }
+
+    skippedOps.clear();
+
+    // Schedule warp-level ldmatrix or ld.shared operations for operandA.
+    for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsA) {
+      llvm::SmallDenseSet<Operation*> dependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
+                              ldmatrixOp, forOp.getBody());
+      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
+      scheduleOperations(ops, dependentOps, pipelineStage);
+    }
+
+    // Schedule warp-level ldmatrix or ld.shared operations for operandB.
+    for (auto& ldmatrixOp : info.warpOperations[kgroup].loadOperationsB) {
+      llvm::SmallDenseSet<Operation*> dependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
+                              ldmatrixOp, forOp.getBody());
+      int pipelineStage = (kgroup == 0) ? (depth - 2) : (depth - 1);
+      scheduleOperations(ops, dependentOps, pipelineStage);
+    }
+
+#if 0  // TODO: Distribute cp.async operations across.
+    // Schedule async copy from Global Memory to Shared Memory.
+    int copyIdxStart =
+        kgroup * (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
+    int copyIdxEnd = (kgroup + 1) *
+                     (info.copyGlobalToSharedOps.size() / info.getNumKGroups());
+
+    for (int idx = copyIdxStart; idx < copyIdxEnd; idx++) {
+      llvm::SmallDenseSet<Operation*> dependentOps;
+      addOpsAndDeps(scheduledOps, dependentOps, info.copyGlobalToSharedOps[idx],
+                    forOp.getBody());
+      scheduleOperations(ops, dependentOps, 0);
+    }
+#endif
+
+    if (kgroup == info.getNumKGroups() - 1) {
+      // Schedule any remaining cp.async or cp.async.commit_group operations.
+      int idx = 0;
+
+      while (idx < info.copyGlobalToSharedOps.size()) {
+        info.copyGlobalToSharedOps[idx]->dump();
+        llvm::SmallDenseSet<Operation*> dependentOps;
+        addOpsAndDepsWithFilter(scheduledOps, skippedOps, dependentOps,
+                                info.copyGlobalToSharedOps[idx],
+                                forOp.getBody());
+        scheduleOperations(ops, dependentOps, 0);
+        idx++;
+      }
+      // Schedule cp.async.wait_group and bar.sync 0 for after the last
+      // cp.async.
+      llvm::SmallDenseSet<Operation*> asyncWaitDependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, asyncWaitDependentOps,
+                              info.asyncWaitOps[0], forOp.getBody());
+      scheduleOperations(ops, asyncWaitDependentOps, 0);
+
+      llvm::SmallDenseSet<Operation*> barrierDependentOps;
+      addOpsAndDepsWithFilter(scheduledOps, skippedOps, barrierDependentOps,
+                              info.barrierOps[0], forOp.getBody());
+
+      scheduleOperations(ops, barrierDependentOps, 0);
+    }
   }
 }
 
@@ -357,7 +657,8 @@ static FailureOr<scf::ForOp> applyPipelining(
                          scf::ForOp forOp,
                          std::vector<std::pair<Operation*, unsigned>>& ops) {
     if (schedule == PipeliningSchedulingStrategy::nvidiaTensorCore) {
-      return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
+      return getNvidiaTensorCoreScheduleAndPipeline(forOp, ops, maxDepth);
+      // return getNvidiaTensorCorePipeline(forOp, ops, maxDepth);
     }
     return getPipelineStages(forOp, ops, maxDepth);
   };
@@ -431,8 +732,8 @@ FailureOr<scf::ForOp> pipelineSharedMemoryCopy(
 /// Pass options
 /// epiloguePeeling - try enable/disable epilogue peeling.
 /// true  : Peel epilogue (no additional checks required)
-/// false : Try and use unpeeled epilogue (check if predication is supported is
-/// avialable)
+/// false : Try and use unpeeled epilogue (check if predication is supported
+/// is avialable)
 std::unique_ptr<OperationPass<func::FuncOp>> createGPUPipeliningPass(
     bool epiloguePeeling, unsigned depth,
     PipeliningSchedulingStrategy schedule) {

--- a/compiler/src/iree/compiler/Codegen/Common/test/gpu_pipeline.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/gpu_pipeline.mlir
@@ -491,12 +491,13 @@ func.func @nvidia_tenscore_schedule() {
 //          CHECK-NV:  gpu.barrier
 //  CHECK-NV-COUNT-8:  nvgpu.ldmatrix
 //          CHECK-NV:  scf.for
-//  CHECK-NV-COUNT-8:    nvgpu.ldmatrix
-// CHECK-NV-COUNT-64:    nvgpu.mma.sync
+//  CHECK-NV-COUNT-4:    nvgpu.ldmatrix
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
 //  CHECK-NV-COUNT-6:    nvgpu.device_async_copy
 //          CHECK-NV:    nvgpu.device_async_create_group
 //          CHECK-NV:    nvgpu.device_async_wait %{{.*}} {numGroups = 1 : i32}
 //          CHECK-NV:    gpu.barrier
 //  CHECK-NV-COUNT-8:    nvgpu.ldmatrix
+// CHECK-NV-COUNT-32:    nvgpu.mma.sync
 //          CHECK-NV:  }
 //          CHECK-NV:  vector.store

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/test/nvvm_mma_sync_pipeline_test.mlir
@@ -67,13 +67,15 @@ hal.executable @mma_fused_fp16 {
 //  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
 //          CHECK:   nvvm.cp.async.commit.group
 //          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-4:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
 //          CHECK:   llvm.br
-//  CHECK-COUNT-4:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, shape = #nvvm.shape<m = 16, n = 8, k = 16>} : (vector<2xf16>, vector<2xf16>, vector<2xf16>) -> !llvm.struct<(vector<2xf16>, vector<2xf16>)>
+//  CHECK-COUNT-2:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, shape = #nvvm.shape<m = 16, n = 8, k = 16>} : (vector<2xf16>, vector<2xf16>, vector<2xf16>) -> !llvm.struct<(vector<2xf16>, vector<2xf16>)>
 //  CHECK-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
 //          CHECK:   nvvm.cp.async.commit.group
 //          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-4:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.ldmatrix {{.*}} : (!llvm.ptr<f16, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
+//  CHECK-COUNT-2:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, shape = #nvvm.shape<m = 16, n = 8, k = 16>} : (vector<2xf16>, vector<2xf16>, vector<2xf16>) -> !llvm.struct<(vector<2xf16>, vector<2xf16>)>
 //          CHECK:   llvm.br
 //      CHECK-NOT:   nvvm.mma.sync
 //  CHECK-COUNT-4:   llvm.store {{.*}} : !llvm.ptr<vector<2xf16>, 3>
@@ -82,86 +84,3 @@ hal.executable @mma_fused_fp16 {
 
 // -----
 
-
-#pipeline_layout = #hal.pipeline.layout<push_constants = 0, sets = [
-  #hal.descriptor_set.layout<0, bindings = [
-    #hal.descriptor_set.binding<0, storage_buffer>,
-    #hal.descriptor_set.binding<1, storage_buffer>,
-    #hal.descriptor_set.binding<2, storage_buffer>
-  ]>
-]>
-hal.executable @mma_fused {
-  hal.executable.variant public @cuda_nvptx_fb, target = <"cuda", "cuda-nvptx-fb", {target_arch = "sm_80"}> {
-  hal.executable.export public @_large_aligned_dispatch_0 ordinal(0) layout(#hal.pipeline.layout<push_constants = 0, sets = [#hal.descriptor_set.layout<0, bindings = [#hal.descriptor_set.binding<0, storage_buffer>, #hal.descriptor_set.binding<1, storage_buffer>, #hal.descriptor_set.binding<2, storage_buffer>]>]>) {
-  ^bb0(%arg0: !hal.device, %arg1: index, %arg2 : index):
-    %x, %y, %z = flow.dispatch.workgroup_count_from_dag_root %arg1, %arg2
-    hal.return %x, %y, %z : index, index, index
-  }
-  builtin.module {
-    func.func @_large_aligned_dispatch_0() {
-      %c0 = arith.constant 0 : index
-      %cst = arith.constant 0.000000e+00 : f32
-      %c2048 = arith.constant 2048 : index
-      %c512 = arith.constant 512 : index
-      %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>>
-      %1 = hal.interface.binding.subspan set(0) binding(1) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>>
-      %2 = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
-      %di = hal.interface.binding.subspan set(0) binding(2) type(storage_buffer) : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>>
-      %3 = flow.dispatch.tensor.load %0, offsets = [0, 0], sizes = [2048, 1024], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:tensor<2048x1024xf32>> -> tensor<2048x1024xf32>
-      %4 = flow.dispatch.tensor.load %1, offsets = [0, 0], sizes = [1024, 512], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:tensor<1024x512xf32>> -> tensor<1024x512xf32>
-      %d = flow.dispatch.tensor.load %di, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
-          : !flow.dispatch.tensor<readonly:tensor<2048x512xf32>> -> tensor<2048x512xf32>
-      %init = tensor.empty() : tensor<2048x512xf32>
-      %f = linalg.fill ins(%cst : f32) outs(%init : tensor<2048x512xf32>) -> tensor<2048x512xf32>
-      %m = linalg.matmul ins(%3, %4 : tensor<2048x1024xf32>, tensor<1024x512xf32>) outs(%f : tensor<2048x512xf32>) -> tensor<2048x512xf32>
-      %init2 = tensor.empty() : tensor<2048x512xf32>
-      %a = linalg.generic {
-          indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
-          iterator_types = ["parallel", "parallel"]}
-          ins(%m, %d : tensor<2048x512xf32>, tensor<2048x512xf32>) outs(%init2 : tensor<2048x512xf32>) {
-        ^bb0(%arg3: f32, %arg4: f32, %arg5: f32):  // no predecessors
-          %19 = arith.addf %arg3, %arg4 : f32
-          linalg.yield %19 : f32
-        } -> (tensor<2048x512xf32>)
-        flow.dispatch.tensor.store %a, %2, offsets = [0, 0], sizes = [2048, 512], strides = [1, 1]
-          : tensor<2048x512xf32> -> !flow.dispatch.tensor<writeonly:tensor<2048x512xf32>>
-      return
-    }
-  }
-}
-}
-
-// mma.sync.1688.f32.tf32 / TensorCore(f32):
-//    CHECK-LABEL: hal.executable public @mma_fused
-//          CHECK:   hal.executable.variant public @cuda
-//      CHECK-NOT:   llvm.store
-//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
-//          CHECK:   nvvm.cp.async.commit.group
-//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
-//          CHECK:   nvvm.cp.async.commit.group
-//  CHECK-COUNT-2:   nvvm.cp.async.shared.global {{.*}}, {{.*}}, 16
-//          CHECK:   nvvm.cp.async.commit.group
-//          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-2:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
-//          CHECK:   llvm.br
-//  CHECK-COUNT-4:   nvvm.mma.sync {{.*}} {layoutA = #nvvm.mma_layout<row>, layoutB = #nvvm.mma_layout<col>, multiplicandAPtxType = #nvvm.mma_type<tf32>, multiplicandBPtxType = #nvvm.mma_type<tf32>, shape = #nvvm.shape<m = 16, n = 8, k = 8>} : (i32, i32, f32) -> !llvm.struct<(f32, f32, f32, f32)>
-//  CHECK-COUNT-2:   llvm.inline_asm has_side_effects asm_dialect = att "cp.async.cg.shared.global [$0], [$1], $2, $3;\0A", "r,l,n,r" {{.*}}, {{.*}}, {{.*}}, {{.*}} : (!llvm.ptr<i8, 3>, !llvm.ptr<i8, 1>, i32, i32) -> !llvm.void
-//          CHECK:   nvvm.cp.async.commit.group
-//          CHECK:   nvvm.cp.async.wait.group 2
-//  CHECK-COUNT-2:   nvvm.ldmatrix{{.*}} : (!llvm.ptr<f32, 3>) -> !llvm.struct<(i32, i32, i32, i32)>
-//          CHECK:   llvm.br
-//      CHECK-NOT:   nvvm.mma.sync
-//  CHECK-COUNT-4:   llvm.store {{.*}} : !llvm.ptr<vector<2xf32>, 3>
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
-//    CHECK-COUNT:   nvvm.barrier0
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>
-//    CHECK-COUNT:   llvm.load {{.*}} : !llvm.ptr<vector<4xf32>, 3>
-//    CHECK-COUNT:   llvm.fadd {{.*}} : vector<4xf32>
-//    CHECK-COUNT:   llvm.store {{.*}} : !llvm.ptr<vector<4xf32>>

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -280,7 +280,7 @@ void insertBarriersAroundSharedMemoryCopy(func::FuncOp funcOp) {
       Operation *prevOp = copyOp->getPrevNode();
       if (!prevOp || !hasMarker(prevOp, getCopyToWorkgroupMemoryMarker())) {
         builder.setInsertionPoint(copyOp);
-        builder.create<gpu::BarrierOp>(copyOp->getLoc());
+        // builder.create<gpu::BarrierOp>(copyOp->getLoc());
       }
       Operation *nextOp = copyOp->getNextNode();
       if (!nextOp || !hasMarker(nextOp, getCopyToWorkgroupMemoryMarker())) {

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -280,7 +280,7 @@ void insertBarriersAroundSharedMemoryCopy(func::FuncOp funcOp) {
       Operation *prevOp = copyOp->getPrevNode();
       if (!prevOp || !hasMarker(prevOp, getCopyToWorkgroupMemoryMarker())) {
         builder.setInsertionPoint(copyOp);
-        // builder.create<gpu::BarrierOp>(copyOp->getLoc());
+        builder.create<gpu::BarrierOp>(copyOp->getLoc());
       }
       Operation *nextOp = copyOp->getNextNode();
       if (!nextOp || !hasMarker(nextOp, getCopyToWorkgroupMemoryMarker())) {

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -209,34 +209,6 @@ py_binary(
     "LLVMGPUMatmulTensorCore",
 ]]
 
-# MMA.SYNC TensorCore(F32): mma.sync.1688.f32.t32
-[iree_generated_trace_runner_test(
-    name = "e2e_matmul_direct_f32_gpu_large_mma_sync_%s" % compilation_info,
-    compiler_flags = [
-        "--iree-hal-cuda-llvm-target-arch=sm_80",
-    ],
-    generator = ":generate_e2e_matmul_tests",
-    generator_args = [
-        "--lhs_rhs_type=f32",
-        "--shapes=gpu_large",
-        "--compilation_info=%s" % compilation_info,
-    ],
-    tags = [
-        # CUDA cuInit fails with sanitizer on.
-        "noasan",
-        "nomsan",
-        "notsan",
-        "noubsan",
-        "requires-gpu-nvidia",
-    ],
-    target_backends_and_drivers = [
-        ("cuda", "cuda"),
-    ],
-    trace_runner = "//tools:iree-e2e-matmul-test",
-) for compilation_info in [
-    "LLVMGPUMatmulTensorCoreMmaSync",
-]]
-
 # WMMA TensorCore(F16): wmma.161616.f16.f16
 [iree_generated_trace_runner_test(
     name = "e2e_matmul_direct_f16_gpu_large_%s" % compilation_info,

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -294,31 +294,6 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f32_gpu_large_mma_sync_LLVMGPUMatmulTensorCoreMmaSync
-  GENERATOR
-    "generate_e2e_matmul_tests.py"
-  GENERATOR_ARGS
-    "--lhs_rhs_type=f32"
-    "--shapes=gpu_large"
-    "--compilation_info=LLVMGPUMatmulTensorCoreMmaSync"
-  TRACE_RUNNER
-    iree-e2e-matmul-test
-  TARGET_BACKENDS
-    "cuda"
-  DRIVERS
-    "cuda"
-  COMPILER_FLAGS
-    "--iree-hal-cuda-llvm-target-arch=sm_80"
-  LABELS
-    "noasan"
-    "nomsan"
-    "notsan"
-    "noubsan"
-    "requires-gpu-nvidia"
-)
-
-iree_generated_trace_runner_test(
-  NAME
     e2e_matmul_direct_f16_gpu_large_LLVMGPUMatmulTensorCore
   GENERATOR
     "generate_e2e_matmul_tests.py"


### PR DESCRIPTION
This PR creates a _coarse-grained_ multistage pipelining and _fine-grained_ instruction scheduling for optimal performance on NVIDIA Ampere Tensor Cores. 

Multi-staging is essential to hide the Global Memory load latency by building longer software pipelines and using the available Shared Memory capacity, especially on NVIDIA A100. Additionally, fine-grained instruction scheduling hides the Shared Memory load latency by prefetching the math operands into registers. 

**Note** that this PR removes `mma.sync.1688.f32.tf32` tests. The `mma.sync.1688.f32.tf32` needs fine-grained schedule as well, the support for it added in the next [PR 12603](https://github.com/openxla/iree/pull/12603). Once this is merged, rebase 12630 and it can pushed in as well. 



