### PR TITLE
[spirv] Add basics for supporting transform dialect CodeGen

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -705,6 +705,9 @@ void addSPIRVWinogradVectorizePassPipeline(OpPassManager &pm);
 std::unique_ptr<OperationPass<func::FuncOp>>
 createSPIRVAnnotateWinogradLoopsPass();
 
+/// Pass pipeline to lower IREE HAL executables via transform dialect schedules.
+void addSPIRVTransformDialectPassPipeline(OpPassManager &pm);
+
 //----------------------------------------------------------------------------//
 // SPIRV Codegen Pass Pipelines.
 //----------------------------------------------------------------------------//

--- a/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/BUILD.bazel
@@ -58,6 +58,8 @@ iree_compiler_cc_library(
         "//llvm-external-projects/iree-dialects:IREELinalgExtDialect",
         "//llvm-external-projects/iree-dialects:IREELinalgExtPasses",
         "//llvm-external-projects/iree-dialects:IREELinalgExtTransforms",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialect",
+        "//llvm-external-projects/iree-dialects:IREELinalgTransformDialectPasses",
         "@llvm-project//llvm:Support",
         "@llvm-project//mlir:AffineAnalysis",
         "@llvm-project//mlir:AffineDialect",

--- a/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/CMakeLists.txt
@@ -46,6 +46,8 @@ iree_cc_library(
     IREELinalgExtDialect
     IREELinalgExtPasses
     IREELinalgExtTransforms
+    IREELinalgTransformDialect
+    IREELinalgTransformDialectPasses
     LLVMSupport
     MLIRAffineAnalysis
     MLIRAffineDialect

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVLowerExecutableTargetPass.cpp
@@ -28,6 +28,8 @@
 namespace mlir {
 namespace iree_compiler {
 
+using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
+
 namespace {
 /// Lowers a hal.executable.variant inner module to SPIR-V scalar/native-vector
 /// code. Invokes different compilation pipeline to
@@ -77,8 +79,6 @@ static LogicalResult verifyLoweringConfiguration(
 static LogicalResult verifyEntryPoint(
     ModuleOp moduleOp, IREE::Codegen::TranslationInfoAttr translationInfo,
     IREE::HAL::ExecutableExportOp exportOp) {
-  using CodeGenPipeline = IREE::Codegen::DispatchLoweringPassPipeline;
-
   if (translationInfo.getDispatchLoweringPassPipeline() ==
       CodeGenPipeline::TransformDialectCodegen) {
     // Transform dialect encodes configuration into the schedule directly.
@@ -160,31 +160,29 @@ void SPIRVLowerExecutableTargetPass::runOnOperation() {
 
   if (!testLoweringConfiguration && translationInfo.has_value()) {
     switch (translationInfo.value().getDispatchLoweringPassPipeline()) {
-      case IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseDistribute:
+      case CodeGenPipeline::SPIRVBaseDistribute:
         addSPIRVBaseDistributePassPipeline(pipeline);
         break;
-      case IREE::Codegen::DispatchLoweringPassPipeline::SPIRVBaseVectorize:
+      case CodeGenPipeline::SPIRVBaseVectorize:
         addSPIRVBaseVectorizePassPipeline(pipeline);
         break;
-      case IREE::Codegen::DispatchLoweringPassPipeline::
-          SPIRVCooperativeMatrixVectorize:
+      case CodeGenPipeline::SPIRVCooperativeMatrixVectorize:
         addSPIRVCooperativeMatrixVectorizePassPipeline(
             pipeline, translationInfo.value().getSoftwarePipelineDepth(),
             translationInfo.value().getSoftwarePipelineStoreStage());
         break;
-      case IREE::Codegen::DispatchLoweringPassPipeline::
-          SPIRVMatmulPromoteVectorize:
+      case CodeGenPipeline::SPIRVMatmulPromoteVectorize:
         addSPIRVMatmulPromoteVectorizePassPipeline(
             pipeline, translationInfo.value().getSoftwarePipelineDepth(),
             translationInfo.value().getSoftwarePipelineStoreStage());
         break;
-      case IREE::Codegen::DispatchLoweringPassPipeline::SPIRVSubgroupReduce:
+      case CodeGenPipeline::SPIRVSubgroupReduce:
         addSPIRVSubgroupReducePassPipeline(pipeline);
         break;
-      case IREE::Codegen::DispatchLoweringPassPipeline::SPIRVWinogradVectorize:
+      case CodeGenPipeline::SPIRVWinogradVectorize:
         addSPIRVWinogradVectorizePassPipeline(pipeline);
         break;
-      case IREE::Codegen::DispatchLoweringPassPipeline::TransformDialectCodegen:
+      case CodeGenPipeline::TransformDialectCodegen:
         addSPIRVTransformDialectPassPipeline(pipeline);
         break;
       default:


### PR DESCRIPTION
This commit plumbs through a pass pipeline for transform dialect
driven SPIR-V CodeGen. Right now it is not used for any concrete
CodeGen yet.
