### PR TITLE
Use new 'defaulting_select' instead of 'select' for bazel_to_cmake compatiblity.

### DIFF
--- a/build_tools/bazel/build_defs.oss.bzl
+++ b/build_tools/bazel/build_defs.oss.bzl
@@ -14,6 +14,8 @@ def defaulting_select(selector):
           include a "//conditions:default" branch, which is used by tooling
           outside of Bazel when converting to other build systems.
     """
+    if "//conditions:default" not in selector:
+        fail("defaulting_select requires a //conditions:default branch")
     return select(selector)
 
 def platform_trampoline_deps(basename, path = "runtime/src/iree/base"):

--- a/build_tools/bazel/build_defs.oss.bzl
+++ b/build_tools/bazel/build_defs.oss.bzl
@@ -6,6 +6,16 @@
 
 """Common Bazel definitions for IREE."""
 
+def defaulting_select(selector):
+    """Pass through to select() with special semantics when converting to CMake.
+
+    Args:
+        selector: The selector which is passed through to select(). Must
+          include a "//conditions:default" branch, which is used by tooling
+          outside of Bazel when converting to other build systems.
+    """
+    return select(selector)
+
 def platform_trampoline_deps(basename, path = "runtime/src/iree/base"):
     """Produce a list of deps for the given `basename` platform target.
 

--- a/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
+++ b/build_tools/bazel_to_cmake/bazel_to_cmake_converter.py
@@ -310,7 +310,12 @@ class BuildFileFunctions(object):
   def platform_trampoline_deps(self, basename, path="base"):
     return [f"//{path}/internal:{basename}_internal"]
 
-  def select(self, selector):
+  def select(self, d):
+    self._convert_unimplemented_function("select", str(d))
+    return d["//conditions:default"]
+
+  def defaulting_select(self, selector):
+    """Defined in build_defs.oss.bzl as a scoped alternative to select."""
     default_value = selector.get("//conditions:default")
     if default_value is None:
       raise ValueError("bazel_to_cmake can only convert selects with a default")

--- a/compiler/src/iree/compiler/API2/BUILD
+++ b/compiler/src/iree/compiler/API2/BUILD
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-load("//build_tools/bazel:build_defs.oss.bzl", "iree_compiler_cc_library")
+load("//build_tools/bazel:build_defs.oss.bzl", "defaulting_select", "iree_compiler_cc_library")
 
 package(
     default_visibility = ["//visibility:public"],
@@ -72,7 +72,7 @@ config_setting(
 
 alias(
     name = "Impl",
-    actual = select({
+    actual = defaulting_select({
         ":link_shared_config": ":SharedImpl",
         "//conditions:default": ":StaticImpl",
     }),


### PR DESCRIPTION
As a followup to #12508 based on comments from gcmn.