### PR TITLE
Re-add pattern for removing dead interface bindings.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/test/remove_dead_allocs.mlir
+++ b/compiler/src/iree/compiler/Codegen/Common/test/remove_dead_allocs.mlir
@@ -16,3 +16,13 @@ func.func @alloc_keep(%arg0: index, %arg1: index) -> memref<?x?xf32> {
 // CHECK-LABEL: func.func @alloc_keep
 //  CHECK-NEXT:   %[[ALLOC:.+]] = memref.alloc
 //  CHECK-NEXT:   return %[[ALLOC]]
+
+// -----
+
+func.func @cleanup_only_assume_alignment_uses() {
+  %0 = hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) : memref<42xf32>
+  memref.assume_alignment %0, 64 : memref<42xf32>
+  return
+}
+// CHECK-LABEL: func.func @cleanup_only_assume_alignment_uses()
+//  CHECK-NEXT:   return


### PR DESCRIPTION
Re-adds the pattern for removing dead `hal.interface.binding.subspan` ops where the only users are `memref.assume_alignment` ops that no longer applies after making it a pure op.