### PR TITLE
[spirv] Make confugration deduction return state consistent 

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AMDConfig.cpp
@@ -37,12 +37,11 @@ constexpr unsigned AMDNumMNTilesPerSubgroup = 8;
 
 static LogicalResult setAMDMatmulConfig(linalg::LinalgOp op,
                                         const spirv::TargetEnv &targetEnv) {
-  if (failed(setCooperativeMatrixConfig(
+  if (succeeded(setCooperativeMatrixConfig(
           targetEnv, op, AMDNumSubgroupsPerWorkgroup, AMDNumMNTilesPerSubgroup,
           AMDCoopMatrixSoftwarePipelineDepth,
           AMDCoopMatrixSoftwarePipelineStoreStage)))
-    return failure();
-  if (getLoweringConfig(op)) return success();
+    return success();
 
   spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
   const int subgroupSize = limits.getSubgroupSize();
@@ -98,7 +97,7 @@ LogicalResult setAMDCodeGenConfig(const spirv::TargetEnv &targetEnv,
         int bestTilingFactor = hasPaddedInput ? 16 : 32;
         return setConvOpConfig(op, subgroupSize, bestTilingFactor);
       })
-      .Default([](Operation *) { return success(); });
+      .Default([](Operation *) { return failure(); });
 }
 
 }  // namespace detail

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AdrenoConfig.cpp
@@ -61,7 +61,7 @@ LogicalResult setAdrenoCodeGenConfig(const spirv::TargetEnv &targetEnv,
         return setConvOpConfig(op, subgroupSize,
                                /*bestTilingFactor=*/16);
       })
-      .Default([](Operation *) { return success(); });
+      .Default([](Operation *) { return failure(); });
 }
 
 }  // namespace detail

--- a/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/AppleConfig.cpp
@@ -61,7 +61,7 @@ LogicalResult setAppleCodeGenConfig(const spirv::TargetEnv &targetEnv,
         return setConvOpConfig(op, subgroupSize,
                                /*bestTilingFactor=*/16);
       })
-      .Default([](Operation *) { return success(); });
+      .Default([](Operation *) { return failure(); });
 }
 
 }  // namespace detail

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.h
@@ -78,9 +78,8 @@ LogicalResult setCooperativeMatrixConfig(
 /// `translation_info` attribute to the entry point containing `rootOp` and a
 /// `lowering_config` attribute to `rootOp`.
 ///
-/// Returns success when either no configuration is found or a configuration is
-/// successfullly attached as attribute. Returns failure only when there is an
-/// issue attaching the attribute.
+/// Returns success when a configuration is successfullly attached as attribute.
+/// Returns failure otherwise.
 
 LogicalResult setAdrenoCodeGenConfig(const spirv::TargetEnv &targetEnv,
                                      Operation *rootOp);

--- a/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/MaliConfig.cpp
@@ -68,7 +68,7 @@ LogicalResult setMaliCodeGenConfig(const spirv::TargetEnv &targetEnv,
         int bestTilingFactor = hasPaddedInput ? 8 : 16;
         return setConvOpConfig(op, subgroupSize, bestTilingFactor);
       })
-      .Default([](Operation *) { return success(); });
+      .Default([](Operation *) { return failure(); });
 }
 
 }  // namespace detail

--- a/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/NVIDIAConfig.cpp
@@ -36,11 +36,10 @@ static LogicalResult setNVIDIAMatmulConfig(linalg::LinalgOp op,
                                            const spirv::TargetEnv &targetEnv) {
   // First try to see if we can use tensor cores.
   spirv::ResourceLimitsAttr limits = targetEnv.getResourceLimits();
-  if (failed(setCooperativeMatrixConfig(targetEnv, op,
-                                        NVIDIANumSubgroupsPerWorkgroup,
-                                        NVIDIANumMNTilesPerSubgroup)))
-    return failure();
-  if (getLoweringConfig(op)) return success();
+  if (succeeded(setCooperativeMatrixConfig(targetEnv, op,
+                                           NVIDIANumSubgroupsPerWorkgroup,
+                                           NVIDIANumMNTilesPerSubgroup)))
+    return success();
 
   const int subgroupSize = limits.getSubgroupSize();
   const std::array<int64_t, 2> workgroupXY = {subgroupSize, 8};
@@ -95,7 +94,7 @@ LogicalResult setNVIDIACodeGenConfig(const spirv::TargetEnv &targetEnv,
   return TypeSwitch<Operation *, LogicalResult>(rootOp)
       .Case<linalg::BatchMatmulOp, linalg::MatmulOp>(
           [&](auto op) { return setNVIDIAMatmulConfig(op, targetEnv); })
-      .Default([](Operation *) { return success(); });
+      .Default([](Operation *) { return failure(); });
 }
 
 }  // namespace detail


### PR DESCRIPTION
We have some kernel confugration deduction function (e.g., for reduction) returning `failure()` on failing to find a configuration, and the rest returning `success()`. This is inconsistent and confusing.

Additionally, for the latter we rely on `getLoweringConfig()` as a separate call to check whether a configuration is indeed set. This won't actually work anymore with transform dialect, where we will embed the configuration in the schedule.

So this commit switches all into returning `failure()` meaning unable to find a configuration.

This is a preliminary step towards enabling transform dialect in SPIR-V CodeGen. 