### PR TITLE
Add tool field to E2EModelRunConfig

### DIFF
--- a/build_tools/benchmarks/common/benchmark_suite.py
+++ b/build_tools/benchmarks/common/benchmark_suite.py
@@ -220,14 +220,13 @@ class BenchmarkSuite(object):
 
       model = module_gen_config.imported_model.model
 
-      benchmark_case = BenchmarkCase(
-          model_name=model.name,
-          model_tags=model.tags,
-          bench_mode=module_exec_config.tags,
-          target_arch=target_arch,
-          driver_info=driver_info,
-          benchmark_tool_name="iree-benchmark-module",
-          run_config=run_config)
+      benchmark_case = BenchmarkCase(model_name=model.name,
+                                     model_tags=model.tags,
+                                     bench_mode=module_exec_config.tags,
+                                     target_arch=target_arch,
+                                     driver_info=driver_info,
+                                     benchmark_tool_name=run_config.tool.value,
+                                     run_config=run_config)
       category = pathlib.Path(model.source_type.value)
       suite_map[category].append(benchmark_case)
 

--- a/build_tools/benchmarks/common/benchmark_suite_test.py
+++ b/build_tools/benchmarks/common/benchmark_suite_test.py
@@ -182,7 +182,8 @@ class BenchmarkSuiteTest(unittest.TestCase):
                 id="1", tags=[], compile_targets=[compile_target])),
         module_execution_config=exec_config_a,
         target_device_spec=device_spec_a,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     run_config_b = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=iree_definitions.ModuleGenerationConfig.
         with_flag_generation(
@@ -192,7 +193,8 @@ class BenchmarkSuiteTest(unittest.TestCase):
                 id="2", tags=[], compile_targets=[compile_target])),
         module_execution_config=exec_config_b,
         target_device_spec=device_spec_b,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     run_config_c = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=iree_definitions.ModuleGenerationConfig.
         with_flag_generation(
@@ -201,7 +203,8 @@ class BenchmarkSuiteTest(unittest.TestCase):
                 id="3", tags=[], compile_targets=[compile_target])),
         module_execution_config=exec_config_a,
         target_device_spec=device_spec_a,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     run_configs = [run_config_a, run_config_b, run_config_c]
 
     suite = BenchmarkSuite.load_from_run_configs(run_configs=run_configs)

--- a/build_tools/benchmarks/export_benchmark_config_test.py
+++ b/build_tools/benchmarks/export_benchmark_config_test.py
@@ -59,17 +59,20 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_a,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     unmatched_run_config_b = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_b,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     matched_run_config_c = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_c,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     matchers = [(lambda config: config.target_device_spec.architecture.
                  architecture == "cuda"),
                 (lambda config: config.target_device_spec.host_environment.
@@ -107,17 +110,20 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_a,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     run_config_b = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_b,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     run_config_c = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_c,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
 
     run_config_map = export_benchmark_config.filter_and_group_run_configs(
         run_configs=[run_config_a, run_config_b, run_config_c])
@@ -144,12 +150,14 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_a,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     run_config_b = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=COMMON_GEN_CONFIG,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_b,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
 
     run_config_map = export_benchmark_config.filter_and_group_run_configs(
         run_configs=[run_config_a, run_config_b],
@@ -203,12 +211,14 @@ class ExportBenchmarkConfigTest(unittest.TestCase):
         module_generation_config=small_gen_config,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_a,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
     run_config_b = iree_definitions.E2EModelRunConfig.with_flag_generation(
         module_generation_config=big_gen_config,
         module_execution_config=COMMON_EXEC_CONFIG,
         target_device_spec=device_spec_b,
-        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
+        input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+        tool=iree_definitions.E2EModelRunTool.IREE_BENCHMARK_MODULE)
 
     run_config_map = export_benchmark_config.filter_and_group_run_configs(
         run_configs=[run_config_a, run_config_b],

--- a/build_tools/python/benchmark_suites/iree/utils.py
+++ b/build_tools/python/benchmark_suites/iree/utils.py
@@ -15,6 +15,8 @@ def generate_e2e_model_run_configs(
         iree_definitions.ModuleGenerationConfig],
     module_execution_configs: Sequence[iree_definitions.ModuleExecutionConfig],
     device_specs: Sequence[common_definitions.DeviceSpec],
+    tool: iree_definitions.E2EModelRunTool = iree_definitions.E2EModelRunTool.
+    IREE_BENCHMARK_MODULE
 ) -> List[iree_definitions.E2EModelRunConfig]:
   """Generates the run specs from the product of compile specs and run configs.
   """
@@ -23,8 +25,8 @@ def generate_e2e_model_run_configs(
           module_generation_config=module_generation_config,
           module_execution_config=module_execution_config,
           target_device_spec=device_spec,
-          input_data=common_definitions.ZEROS_MODEL_INPUT_DATA)
-      for module_generation_config,
+          input_data=common_definitions.ZEROS_MODEL_INPUT_DATA,
+          tool=tool) for module_generation_config,
       module_execution_config, device_spec in itertools.product(
           module_generation_configs, module_execution_configs, device_specs)
   ]

--- a/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
+++ b/build_tools/python/e2e_test_framework/definitions/iree_definitions.py
@@ -217,6 +217,11 @@ class ModuleGenerationConfig(object):
 E2E_MODEL_RUN_CONFIG_GPU_ID_PLACEHOLDER = r"${GPU_ID_PLACEHOLDER}"
 
 
+class E2EModelRunTool(Enum):
+  """Tool to run a module."""
+  IREE_BENCHMARK_MODULE = "iree-benchmark-module"
+
+
 @serialization.serializable(type_key="iree_e2e_model_run_configs",
                             id_field="composite_id")
 @dataclass(frozen=True)
@@ -232,6 +237,7 @@ class E2EModelRunConfig(object):
   # decouple from the generation code. Also serves as useful information in the
   # serialized JSON.
   run_flags: List[str]
+  tool: E2EModelRunTool
 
   def materialize_run_flags(self, gpu_id: str = "0"):
     """Materialize flags with dependent values."""
@@ -244,7 +250,8 @@ class E2EModelRunConfig(object):
   def with_flag_generation(module_generation_config: ModuleGenerationConfig,
                            module_execution_config: ModuleExecutionConfig,
                            target_device_spec: common_definitions.DeviceSpec,
-                           input_data: common_definitions.ModelInputData):
+                           input_data: common_definitions.ModelInputData,
+                           tool: E2EModelRunTool):
     composite_id = unique_ids.hash_composite_id([
         module_generation_config.composite_id, module_execution_config.id,
         target_device_spec.id, input_data.id
@@ -259,7 +266,8 @@ class E2EModelRunConfig(object):
                              module_execution_config=module_execution_config,
                              target_device_spec=target_device_spec,
                              input_data=input_data,
-                             run_flags=run_flags)
+                             run_flags=run_flags,
+                             tool=tool)
 
 
 def generate_run_flags(imported_model: ImportedModel,


### PR DESCRIPTION
While working on the helper tool #12530, I realized we didn't put the `tool` field to the `iree_definitions.E2EModelRunConfig`, which is an essential part to know how to run a model.

This change adds the missing tool field.

benchmarks: all