### PR TITLE
Re-enable Cuda check test builds

### DIFF
--- a/build_tools/bazel/iree_check_test.bzl
+++ b/build_tools/bazel/iree_check_test.bzl
@@ -124,9 +124,6 @@ def iree_check_single_backend_test_suite(
 
     tests = []
     for src in srcs:
-        # CUDA backend/driver not supported by Bazel build.
-        if target_backend == "cuda" or driver == "cuda":
-            continue
         test_name = "_".join([name, src])
         iree_check_test(
             name = test_name,


### PR DESCRIPTION
Cuda does build on Bazel since
https://github.com/openxla/iree/pull/11651. Looks like we forgot to
re-enable this. Luckily, it works :-)

https://github.com/openxla/iree/actions/runs/4369920280/jobs/7644268799