### PR TITLE
Add operand type info to summarizeLinalgOp::summarizeLinalgOp()

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/OutlineDispatchRegions.cpp
@@ -65,8 +65,8 @@ static std::string getLinalgOpLoopRanges(linalg::LinalgOp op) {
   return outputString;
 }
 
-static std::string operandTypeToString(OpOperand *opOperand) {
-  auto operandType = opOperand->get().getType();
+static std::string operandTypeToString(Value operandValue) {
+  auto operandType = operandValue.getType();
   std::string outputString;
   llvm::raw_string_ostream sstream(outputString);
   if (auto shapedType = dyn_cast<ShapedType>(operandType)) {
@@ -84,20 +84,12 @@ static std::string getLinalgDataTypes(linalg::LinalgOp op) {
   bool allTokensSame = true;
   SmallVector<std::string, 4> datatypeTokens;
 
-  for (OpOperand *opOperand : op.getDpsInputOperands()) {
-    datatypeTokens.push_back(operandTypeToString(opOperand));
+  for (Value operandValue : op->getOperands()) {
+    datatypeTokens.push_back(operandTypeToString(operandValue));
     if (firstToken.empty()) {
-      firstToken = operandTypeToString(opOperand);
+      firstToken = operandTypeToString(operandValue);
     } else if (allTokensSame) {
-      allTokensSame = firstToken == operandTypeToString(opOperand);
-    }
-  }
-  for (OpOperand *opOperand : op.getDpsInitOperands()) {
-    datatypeTokens.push_back(operandTypeToString(opOperand));
-    if (firstToken.empty()) {
-      firstToken = operandTypeToString(opOperand);
-    } else if (allTokensSame) {
-      allTokensSame = firstToken == operandTypeToString(opOperand);
+      allTokensSame = firstToken == operandTypeToString(operandValue);
     }
   }
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -183,7 +183,7 @@ func.func @dispatchWithCountRegion(%arg0: tensor<4xi32>) -> tensor<4xi32> {
 
 //      CHECK: flow.executable private @main_dispatch_0 {
 // CHECK-NEXT:   flow.executable.export public @main_dispatch_0_fill_4x8
-//      CHECK: func.func @main_dispatch_0_fill_4x8(
+//      CHECK: func.func @main_dispatch_0_fill_4x8_f32xf32(
 func.func @main() -> tensor<4x8xf32> {
   %x = arith.constant 100 : index
   %y = arith.constant 50 : index
@@ -205,7 +205,7 @@ func.func @main() -> tensor<4x8xf32> {
 
 //      CHECK: flow.executable private @main_dispatch_0 {
 // CHECK-NEXT:   flow.executable.export public @main_dispatch_0_fill_40
-//      CHECK: func.func @main_dispatch_0_fill_40(
+//      CHECK: func.func @main_dispatch_0_fill_40_f32xf32(
 func.func @main() -> tensor<10xf32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<10xf32>) = (
@@ -232,7 +232,7 @@ func.func @main() -> tensor<10xf32> {
 
 //      CHECK: flow.executable private @main_dispatch_0 {
 // CHECK-NEXT:   flow.executable.export public @main_dispatch_0_fill_DxDxD
-//      CHECK: func.func @main_dispatch_0_fill_DxDxD(
+//      CHECK: func.func @main_dispatch_0_fill_DxDxD_f32xf32(
 func.func @main(%arg0 : index) -> tensor<10xf32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<10xf32>) = (

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -183,7 +183,7 @@ func.func @dispatchWithCountRegion(%arg0: tensor<4xi32>) -> tensor<4xi32> {
 
 //      CHECK: flow.executable private @main_dispatch_0 {
 // CHECK-NEXT:   flow.executable.export public @main_dispatch_0_fill_4x8
-//      CHECK: func.func @main_dispatch_0_fill_4x8_f32xf32(
+//      CHECK: func.func @main_dispatch_0_fill_4x8_f32(
 func.func @main() -> tensor<4x8xf32> {
   %x = arith.constant 100 : index
   %y = arith.constant 50 : index
@@ -205,7 +205,7 @@ func.func @main() -> tensor<4x8xf32> {
 
 //      CHECK: flow.executable private @main_dispatch_0 {
 // CHECK-NEXT:   flow.executable.export public @main_dispatch_0_fill_40
-//      CHECK: func.func @main_dispatch_0_fill_40_f32xf32(
+//      CHECK: func.func @main_dispatch_0_fill_40_f32(
 func.func @main() -> tensor<10xf32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<10xf32>) = (
@@ -232,7 +232,7 @@ func.func @main() -> tensor<10xf32> {
 
 //      CHECK: flow.executable private @main_dispatch_0 {
 // CHECK-NEXT:   flow.executable.export public @main_dispatch_0_fill_DxDxD
-//      CHECK: func.func @main_dispatch_0_fill_DxDxD_f32xf32(
+//      CHECK: func.func @main_dispatch_0_fill_DxDxD_f32(
 func.func @main(%arg0 : index) -> tensor<10xf32> {
   %x = arith.constant 100 : index
   %0 = flow.dispatch.workgroups[%x]() : () -> (tensor<10xf32>) = (

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/outline_dispatch_regions.mlir
@@ -249,3 +249,35 @@ func.func @main(%arg0 : index) -> tensor<10xf32> {
   }
   return %0 : tensor<10xf32>
 }
+
+// -----
+
+// Dispatch key op with multiple datatypes should be reflected in summary.
+
+//      CHECK: flow.executable private @main_dispatch_0 {
+// CHECK-NEXT:   flow.executable.export public @main_dispatch_0_generic_4x8_i32xf32
+//      CHECK: func.func @main_dispatch_0_generic_4x8_i32xf32(
+func.func @main() -> tensor<4x8xf32> {
+  %x = arith.constant 100 : index
+  %y = arith.constant 50 : index
+  %0 = flow.dispatch.workgroups[%x, %y]() : () -> (tensor<4x8xf32>) = (
+    %ret: !flow.dispatch.tensor<writeonly:tensor<4x8xf32>>
+  ) {
+    %a = tensor.empty() : tensor<4x8xi32>
+    %b = tensor.empty() : tensor<4x8xf32>
+    %ans = linalg.generic {
+        indexing_maps = [affine_map<(d0, d1) -> (d0, d1)>, affine_map<(d0, d1) -> (d0, d1)>],
+        iterator_types = ["parallel", "parallel"]}
+        ins(%a : tensor<4x8xi32>) outs(%b : tensor<4x8xf32>) {
+      ^bb0(%b0 : i32, %b1 : f32):
+        %1 = arith.index_cast %b0 : i32 to index
+        %2 = tensor.extract %b[%1, %1] : tensor<4x8xf32>
+        linalg.yield %2 : f32
+      } -> tensor<4x8xf32>
+    flow.dispatch.tensor.store %ans, %ret, offsets = [0, 0], sizes = [4, 8], strides = [1, 1] : tensor<4x8xf32> -> !flow.dispatch.tensor<writeonly:tensor<4x8xf32>>
+    flow.return
+  }
+  return %0 : tensor<4x8xf32>
+}
+
+// -----

--- a/tests/transform_dialect/cpu/matmul.mlir
+++ b/tests/transform_dialect/cpu/matmul.mlir
@@ -22,14 +22,14 @@ func.func @matmul_static(
 
 // CODEGEN-CUSTOM-DISPATCH-FORMATION: hal.executable private @matmul_static_dispatch_0 {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:   hal.executable.variant public @embedded_elf_{{.+}}, target = #executable_target_embedded_elf_{{.+}} {
-// CODEGEN-CUSTOM-DISPATCH-FORMATION:     hal.executable.export public @matmul_static_dispatch_0_matmul_3x3x5 ordinal(0) layout(#{{.*}}) attributes {translation_info = #translation} {
+// CODEGEN-CUSTOM-DISPATCH-FORMATION:     hal.executable.export public @matmul_static_dispatch_0_matmul_3x3x5_f32xf32xf32 ordinal(0) layout(#{{.*}}) attributes {translation_info = #translation} {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:       ^bb0(%{{.*}}: !hal.device):
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:         %[[C2:.*]] = arith.constant 2 : index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:         %[[C1:.*]] = arith.constant 1 : index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:         hal.return %[[C2]], %[[C1]], %[[C1]] : index, index, index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:       }
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:       builtin.module {
-// CODEGEN-CUSTOM-DISPATCH-FORMATION:         func.func @matmul_static_dispatch_0_matmul_3x3x5() {
+// CODEGEN-CUSTOM-DISPATCH-FORMATION:         func.func @matmul_static_dispatch_0_matmul_3x3x5_f32xf32xf32() {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           arith.constant 0 : index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset({{.*}}) flags(ReadOnly) : memref<3x5xf32>
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           memref.assume_alignment %{{.*}}, 64 : memref<3x5xf32>

--- a/tests/transform_dialect/cpu/matmul.mlir
+++ b/tests/transform_dialect/cpu/matmul.mlir
@@ -22,14 +22,14 @@ func.func @matmul_static(
 
 // CODEGEN-CUSTOM-DISPATCH-FORMATION: hal.executable private @matmul_static_dispatch_0 {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:   hal.executable.variant public @embedded_elf_{{.+}}, target = #executable_target_embedded_elf_{{.+}} {
-// CODEGEN-CUSTOM-DISPATCH-FORMATION:     hal.executable.export public @matmul_static_dispatch_0_matmul_3x3x5_f32xf32xf32 ordinal(0) layout(#{{.*}}) attributes {translation_info = #translation} {
+// CODEGEN-CUSTOM-DISPATCH-FORMATION:     hal.executable.export public @matmul_static_dispatch_0_matmul_3x3x5_f32 ordinal(0) layout(#{{.*}}) attributes {translation_info = #translation} {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:       ^bb0(%{{.*}}: !hal.device):
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:         %[[C2:.*]] = arith.constant 2 : index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:         %[[C1:.*]] = arith.constant 1 : index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:         hal.return %[[C2]], %[[C1]], %[[C1]] : index, index, index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:       }
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:       builtin.module {
-// CODEGEN-CUSTOM-DISPATCH-FORMATION:         func.func @matmul_static_dispatch_0_matmul_3x3x5_f32xf32xf32() {
+// CODEGEN-CUSTOM-DISPATCH-FORMATION:         func.func @matmul_static_dispatch_0_matmul_3x3x5_f32() {
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           arith.constant 0 : index
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           hal.interface.binding.subspan set(0) binding(0) type(storage_buffer) alignment(64) offset({{.*}}) flags(ReadOnly) : memref<3x5xf32>
 // CODEGEN-CUSTOM-DISPATCH-FORMATION:           memref.assume_alignment %{{.*}}, 64 : memref<3x5xf32>


### PR DESCRIPTION
Appends a string of datatypes for each op operand during `summarizeLinalgOp()`. Note that the number of datatypes listed are based on the number of operands (input and output), not dimension. In the case that all the types match, only one type is printed (for brevity). 

Some examples of before:
```
forward_dispatch_1_generic_1x128x768
forward_dispatch_14_matmul_128x768x768
forward_dispatch_8_batch_matmul_12x128x128x64
```

... and after: 
```
forward_dispatch_1_generic_1x128x768_i32xi32xf32
forward_dispatch_14_matmul_128x768x768_f32
forward_dispatch_8_batch_matmul_12x128x128x64_f32x
```

(see the full dump for mobilebert after tile&distribute to workgroups [here](https://gist.github.com/KoolJBlack/90e4b7e45afcc72058391b35b49dda1b))