### PR TITLE
Extract and improve script to download CUDA toolkit components.

### DIFF
--- a/build_tools/third_party/cuda/CMakeLists.txt
+++ b/build_tools/third_party/cuda/CMakeLists.txt
@@ -5,79 +5,18 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 function(fetch_cuda_toolkit)
-  # Parameters to the download script.
-  # Look for an appropriate redistrib_*.json here to verify:
-  #   https://developer.download.nvidia.com/compute/cuda/redist/
-  set(_VERSION "11.6.2")
-  set(_PRODUCT "cuda")
-  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(_OS "linux")
-  elseif(WIN32)
-    set(_OS "windows")
-  else()
-    message(SEND_ERROR "Unsupported OS environment. Must be Windows or Linux.")
-    return()
+  set(_DOWNLOAD_SCRIPT_PATH "${IREE_SOURCE_DIR}/third_party/nvidia_sdk_download/fetch_cuda_toolkit.py")
+  message(STATUS "Checking and downloading CUDA SDK toolkit components")
+  execute_process(COMMAND ${Python3_EXECUTABLE}
+    "${_DOWNLOAD_SCRIPT_PATH}" "${CMAKE_CURRENT_BINARY_DIR}"
+    RESULT_VARIABLE _EXEC_RESULT
+    OUTPUT_VARIABLE _ACTUAL_DOWNLOAD_PATH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(_EXEC_RESULT AND NOT _EXEC_RESULT EQUAL 0)
+    message(FATAL_ERROR "Error fetching CUDA toolkit")
   endif()
-  # CUDA is only supported on Linux/Windows where x64 is the only arch for now.
-  # Note: CMAKE_HOST_SYSTEM_PROCESSOR may be AMD64 on Windows, but we still
-  # want to use `x86_64` here.
-  set(_ARCH "x86_64")
-
-  set(_TARGET_DIR "${CMAKE_CURRENT_BINARY_DIR}/${_VERSION}")
-  set(_DOWNLOAD_SCRIPT_URL "https://raw.githubusercontent.com/NVIDIA/build-system-archive-import-examples/44dfb51fad75a8a2f1044a4fe221aba70571b86f/parse_redist.py")
-  set(_DOWNLOAD_SCRIPT_PATH "${_TARGET_DIR}/parse_redist.py")
-
-  # Only download if haven't already.
-  # This will produce a unified directory tree under:
-  #   flat/$OS-$ARCH
-  set(_ARCH_DIR "${_TARGET_DIR}/${_OS}-${_ARCH}")
-  set(_TOUCH_FILE "${_TARGET_DIR}/cuda_toolkit.downloaded")
-
-  if(NOT EXISTS "${_TOUCH_FILE}")
-    # The parse_redist.py script requires the Python requests module, which
-    # is not yet installed by default. Check for it.
-    execute_process(
-      COMMAND ${Python3_EXECUTABLE} -c "import requests"
-      RESULT_VARIABLE _PY_MODULES_EXIST_CODE
-      OUTPUT_QUIET
-    )
-    if(NOT ${_PY_MODULES_EXIST_CODE} EQUAL 0)
-      message(SEND_ERROR "CUDA auto-download requires Python packages that do not exist on your system. Recommend running: \n  ${Python3_EXECUTABLE} -m pip install requests")
-      return()
-    endif()
-
-    # Components that we need to fetch.
-    set(_COMPONENTS_TO_FETCH "")
-    list(APPEND _COMPONENTS_TO_FETCH "cuda_nvcc")
-    list(APPEND _COMPONENTS_TO_FETCH "cuda_cudart")
-
-    message(STATUS "Extracting CUDA Toolkit to ${_TARGET_DIR}")
-    file(MAKE_DIRECTORY ${_TARGET_DIR})
-
-    # First fetch the download script to its own directory.
-    file(DOWNLOAD ${_DOWNLOAD_SCRIPT_URL} ${_DOWNLOAD_SCRIPT_PATH})
-
-    # Then use the download script to fetch and flatten each component we want
-    # into the target dir.
-    foreach(COMPONENT ${_COMPONENTS_TO_FETCH})
-      message(STATUS "Downloading component ${COMPONENT}")
-      execute_process(COMMAND ${Python3_EXECUTABLE} "${_DOWNLOAD_SCRIPT_PATH}"
-        --label "${_VERSION}"
-        --product "${_PRODUCT}"
-        --os "${_OS}"
-        --arch "${_ARCH}"
-        --component "${COMPONENT}"
-        --output "${_TARGET_DIR}")
-    endforeach()
-  endif()
-
-  if(NOT EXISTS "${_ARCH_DIR}")
-    message(FATAL_ERROR "Download did not produce expected source dir: ${_ARCH_DIR}")
-    return()
-  endif()
-
-  file(TOUCH "${_TOUCH_FILE}")
-  set(CUDAToolkit_ROOT "${_ARCH_DIR}" PARENT_SCOPE)
+  set(CUDAToolkit_ROOT ${_ACTUAL_DOWNLOAD_PATH} PARENT_SCOPE)
 endfunction()
 
 if(DEFINED ENV{IREE_CUDA_DEPS_DIR})

--- a/compiler/pyproject.toml
+++ b/compiler/pyproject.toml
@@ -9,6 +9,5 @@ requires = [
     "packaging",
     "pybind11>=2.10.1",
     "PyYAML",
-    "requests",
 ]
 build-backend = "setuptools.build_meta"

--- a/runtime/pyproject.toml
+++ b/runtime/pyproject.toml
@@ -7,6 +7,5 @@ requires = [
     "packaging",
     "pybind11>=2.10.1",
     "PyYAML",
-    "requests",
 ]
 build-backend = "setuptools.build_meta"

--- a/third_party/nvidia_sdk_download/LICENSE
+++ b/third_party/nvidia_sdk_download/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2021 NVIDIA Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/third_party/nvidia_sdk_download/fetch_cuda_toolkit.py
+++ b/third_party/nvidia_sdk_download/fetch_cuda_toolkit.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# Copyright 2022 The IREE Authors
+#
+# Licensed under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Fetches components of the CUDA toolkit that we need to build.
+
+Syntax:
+  fetch_cuda_toolkit.py {output_dir}
+
+This will download an appropriate toolkit (subset) and print the full path
+to the resulting directory (which will be a sub-directory of the output_dir).
+"""
+
+from pathlib import Path
+import platform
+import shutil
+import subprocess
+import sys
+
+VERSION = "11.6.2"
+PRODUCT = "cuda"
+COMPONENTS = ["cuda_nvcc", "cuda_cudart"]
+
+
+def main(output_dir: Path):
+  system = platform.system()
+  if system == "Linux":
+    os = "linux"
+  elif system == "Windows":
+    os = "windows"
+  else:
+    print("ERROR: Fetching CUDA toolkit only supported on windows and linux")
+    sys.exit(1)
+
+  arch = platform.machine()
+  if arch == "AMD64":
+    arch = "x86_64"
+
+  target_dir = output_dir / VERSION
+  arch_dir = target_dir / f"{os}-{arch}"
+  touch_file = arch_dir / "cuda_toolkit.downloaded"
+  if touch_file.exists():
+    print(f"Not downloading because touch file exists: {touch_file}",
+          file=sys.stderr)
+  else:
+    # Remove and create arch dir.
+    if arch_dir.exists():
+      shutil.rmtree(arch_dir)
+    arch_dir.mkdir(parents=True, exist_ok=True)
+
+    for component in COMPONENTS:
+      print(f"Downloading component {component}", file=sys.stderr)
+      subprocess.check_call([
+          sys.executable,
+          str(Path(__file__).resolve().parent / "parse_redist.py"),
+          "--label",
+          VERSION,
+          "--product",
+          PRODUCT,
+          "--os",
+          os,
+          "--arch",
+          arch,
+          "--component",
+          component,
+          "--output",
+          target_dir,
+      ],
+                            cwd=target_dir,
+                            stdout=sys.stderr)
+
+    # Touch the file to note done.
+    with open(touch_file, "w") as f:
+      pass
+
+  # Report back.
+  print(arch_dir)
+
+
+if __name__ == "__main__":
+  if len(sys.argv) != 2:
+    print("ERROR: Expected output_dir", file=sys.stderr)
+    sys.exit(1)
+  main(Path(sys.argv[1]))

--- a/third_party/nvidia_sdk_download/parse_redist.py
+++ b/third_party/nvidia_sdk_download/parse_redist.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+# Copyright 2021, NVIDIA Corporation
+# SPDX-License-Identifier: MIT
+"""
+Sample parser for redistrib JSON manifests
+1. Downloads each archive
+2. Validates SHA256 checksums
+3. Extracts archives
+4. Flattens into a collapsed directory structure
+"""
+from distutils.dir_util import copy_tree
+import argparse
+import os.path
+import hashlib
+import json
+import re
+import shutil
+import tarfile
+import zipfile
+import sys
+import requests
+
+__version__ = "0.1.0"
+
+ARCHIVES = {}
+DOMAIN = "https://developer.download.nvidia.com"
+OUTPUT = "flat"
+PRODUCT = None
+LABEL = None
+URL = None
+OS = None
+ARCH = None
+PLATFORM = None
+COMPONENT = None
+
+# Default actions
+RETRIEVE = True
+VALIDATE = True
+UNROLLED = True
+COLLAPSE = True
+
+
+def err(msg):
+  """Print error message and exit"""
+  print("ERROR: " + msg)
+  sys.exit(1)
+
+
+def fetch_file(full_path, filename):
+  """Download file to disk"""
+  download = requests.get(full_path)
+  if download.status_code != 200:
+    print("  -> Failed: " + filename)
+  else:
+    print(":: Fetching: " + full_path)
+    with open(filename, "wb") as file:
+      file.write(download.content)
+      print("  -> Wrote: " + filename)
+
+
+def get_hash(filename):
+  """Calculate SHA256 checksum for file"""
+  buffer_size = 65536
+  sha256 = hashlib.sha256()
+  with open(filename, "rb") as file:
+    while True:
+      chunk = file.read(buffer_size)
+      if not chunk:
+        break
+      sha256.update(chunk)
+  return sha256.hexdigest()
+
+
+def check_hash(filename, checksum):
+  """Compare checksum with expected"""
+  sha256 = get_hash(filename)
+  if checksum == sha256:
+    print("     Verified sha256sum: " + sha256)
+  else:
+    print("  => Mismatch sha256sum:")
+    print("    -> Calculation: " + sha256)
+    print("    -> Expectation: " + checksum)
+
+
+def flatten_tree(src, dest):
+  """Merge hierarchy from multiple directories"""
+  try:
+    copy_tree(src, dest, preserve_symlinks=1, update=1, verbose=1)
+  except FileExistsError:
+    pass
+  shutil.rmtree(src)
+
+
+def fetch_action(parent):
+  """Do actions while parsing JSON"""
+  for component in MANIFEST.keys():
+    if not 'name' in MANIFEST[component]:
+      continue
+
+    if COMPONENT is not None and component != COMPONENT:
+      continue
+
+    print("\n" + MANIFEST[component]['name'] + ": " +
+          MANIFEST[component]['version'])
+
+    for platform in MANIFEST[component].keys():
+      if not platform in ARCHIVES:
+        ARCHIVES[platform] = []
+
+      if not isinstance(MANIFEST[component][platform], str):
+        if PLATFORM is not None and platform != PLATFORM:
+          print("  -> Skipping platform: " + platform)
+          continue
+
+        full_path = parent + MANIFEST[component][platform]['relative_path']
+        filename = os.path.basename(full_path)
+        ARCHIVES[platform].append(filename)
+
+        if RETRIEVE and not os.path.exists(filename):
+          # Download archive
+          fetch_file(full_path, filename)
+        elif os.path.exists(filename):
+          print("  -> Found: " + filename)
+
+        checksum = MANIFEST[component][platform]['sha256']
+        if VALIDATE and os.path.exists(filename):
+          # Compare checksum
+          check_hash(filename, checksum)
+
+
+def post_action():
+  """Extract archives and merge directories"""
+  if len(ARCHIVES) == 0:
+    return
+
+  print("\nArchives:")
+  if not os.path.exists(OUTPUT):
+    os.makedirs(OUTPUT)
+
+  for platform in ARCHIVES:
+    for archive in ARCHIVES[platform]:
+      # Tar files
+      if UNROLLED and re.search(r"\.tar\.", archive):
+        print(":: tar: " + archive)
+        tarball = tarfile.open(archive)
+        topdir = os.path.commonprefix(tarball.getnames())
+        tarball.extractall()
+        tarball.close()
+        print("  -> Extracted: " + topdir + "/")
+        if COLLAPSE:
+          flatten_tree(topdir, OUTPUT + "/" + platform)
+
+      # Zip files
+      elif UNROLLED and re.search(r"\.zip", archive):
+        print(":: zip: " + archive)
+        with zipfile.ZipFile(archive) as zippy:
+          topdir = os.path.commonprefix(zippy.namelist())
+          zippy.extractall()
+        zippy.close()
+
+        print("  -> Extracted: " + topdir)
+        if COLLAPSE:
+          flatten_tree(topdir, OUTPUT + "/" + platform)
+
+  print("\nOutput: " + OUTPUT + "/")
+  for item in sorted(os.listdir(OUTPUT)):
+    if os.path.isdir(OUTPUT + "/" + item):
+      print(" - " + item + "/")
+    elif os.path.isfile(OUTPUT + "/" + item):
+      print(" - " + item)
+
+
+# If running standalone
+if __name__ == '__main__':
+  # Parse CLI arguments
+  PARSER = argparse.ArgumentParser()
+  # Input options
+  PARSER_GROUP = PARSER.add_mutually_exclusive_group(required=True)
+  PARSER_GROUP.add_argument('-u', '--url', dest='url', help='URL to manifest')
+  PARSER_GROUP.add_argument('-l',
+                            '--label',
+                            dest='label',
+                            help='Release label version')
+  PARSER.add_argument('-p', '--product', dest='product', help='Product name')
+  PARSER.add_argument('-o', '--output', dest='output', help='Output directory')
+  # Filter options
+  PARSER.add_argument('--component', dest='component', help='Component name')
+  PARSER.add_argument('--os', dest='os', help='Operating System')
+  PARSER.add_argument('--arch', dest='arch', help='Architecture')
+  # Toggle actions
+  PARSER.add_argument('-w', '--download', dest='retrieve', action='store_true', \
+       help='Download archives', default=True)
+  PARSER.add_argument('-W', '--no-download', dest='retrieve', action='store_false', \
+       help='Parse manifest without downloads')
+  PARSER.add_argument('-s', '--checksum', dest='validate', action='store_true', \
+       help='Verify SHA256 checksum', default=True)
+  PARSER.add_argument('-S', '--no-checksum', dest='validate', action='store_false', \
+       help='Skip SHA256 checksum validation')
+  PARSER.add_argument('-x', '--extract', dest='unrolled', action='store_true', \
+       help='Extract archives', default=True)
+  PARSER.add_argument('-X', '--no-extract', dest='unrolled', action='store_false', \
+       help='Do not extract archives')
+  PARSER.add_argument('-f', '--flatten', dest='collapse', action='store_true', \
+       help='Collapse directories', default=True)
+  PARSER.add_argument('-F', '--no-flatten', dest='collapse', action='store_false', \
+       help='Do not collapse directories')
+
+  ARGS = PARSER.parse_args()
+  #print(ARGS)
+  RETRIEVE = ARGS.retrieve
+  VALIDATE = ARGS.validate
+  UNROLLED = ARGS.unrolled
+  COLLAPSE = ARGS.collapse
+
+  # Define variables
+  if ARGS.label is not None:
+    LABEL = ARGS.label
+  if ARGS.product is not None:
+    PRODUCT = ARGS.product
+  if ARGS.url is not None:
+    URL = ARGS.url
+  if ARGS.output is not None:
+    OUTPUT = ARGS.output
+  if ARGS.component is not None:
+    COMPONENT = ARGS.component
+  if ARGS.os is not None:
+    OS = ARGS.os
+  if ARGS.arch is not None:
+    ARCH = ARGS.arch
+
+#
+# Setup
+#
+
+# Sanity check
+if not UNROLLED:
+  COLLAPSE = False
+
+# Short-hand
+if LABEL:
+  if PRODUCT:
+    URL = f"{DOMAIN}/compute/{PRODUCT}/redist/redistrib_{LABEL}.json"
+  else:
+    err("Must pass --product argument")
+
+# Concatentate
+if ARCH is not None and OS is not None:
+  PLATFORM = f"{OS}-{ARCH}"
+elif ARCH is not None and OS is None:
+  err("Must pass --os argument")
+elif OS is not None and ARCH is None:
+  err("Must pass --arch argument")
+
+#
+# Run
+#
+
+# Parse JSON
+try:
+  MANIFEST = requests.get(URL).json()
+except json.decoder.JSONDecodeError:
+  err("redistrib JSON manifest file not found")
+
+print(":: Parsing JSON: " + URL)
+
+# Do stuff
+fetch_action(os.path.dirname(URL) + "/")
+post_action()
+
+### END ###


### PR DESCRIPTION
Previous to this, we were fetching a sample from an NVIDIA github repo and using CMake scripting to use it to download an appropriate SDK. This patch:

* Forks the parse_redist.py sample locally into third_party/nvidia_sdk_download.
* Fixes a number of things in parse_redist.py to make it more robust, remove warnings, and eliminate the dependency on the Python requests package.
* Removes the 'requests' package from setup.py releases files as it is no longer needed. Leaves it in runtime/build_requirements.txt as it is still used in some benchmark scripts.
* Adds a fetch_cuda_toolkit.py which duplicates the behavior that was open coded in CMake scripting.
* Updates the build_tools/third_party/cuda/CMakeLists.txt to use the new script instead of its internal approach.

In a follow-on, I will use this script on the Bazel side to make it auto-fetch the CUDA SDK as needed as well.