### PR TITLE
[WIP] Add --iree-llvmcpu-linker-flags

### DIFF
--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.cpp
@@ -174,6 +174,13 @@ LLVMTargetOptions getLLVMTargetOptionsFromFlags() {
       llvm::cl::init(""));
   targetOptions.systemLinkerPath = clSystemLinkerPath;
 
+  static llvm::cl::opt<std::string> clSystemLinkerFlags(
+      "iree-llvmcpu-system-linker-flags",
+      llvm::cl::desc("Flags for the linker that links system shared libraries. "
+                     "Need --iree-llvmcpu-link-embedded=false."),
+      llvm::cl::init(""));
+  targetOptions.systemLinkerFlags = clSystemLinkerFlags;
+
   static llvm::cl::opt<std::string> clEmbeddedLinkerPath(
       "iree-llvmcpu-embedded-linker-path",
       llvm::cl::desc("Tool used to link embedded ELFs produced by IREE (for "

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/LLVMTargetOptions.h
@@ -55,6 +55,9 @@ struct LLVMTargetOptions {
   // arguments.
   std::string systemLinkerPath;
 
+  // Additional flags passing to systemLinkerPath.
+  std::string systemLinkerFlags;
+
   // Tool to use for linking embedded ELFs. Must be lld.
   std::string embeddedLinkerPath;
 

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
@@ -79,6 +79,9 @@ class UnixLinkerTool : public LinkerTool {
         "-o " + artifacts.libraryFile.path,
     };
 
+    // Link the System and C runtime library, and optionally SAN libraries.
+    flags.push_back(targetOptions.systemLinkerFlags);
+
     if (targetIsApple()) {
       // Statically link all dependencies so we don't have any runtime deps.
       // We cannot have any imports in the module we produce.
@@ -88,8 +91,6 @@ class UnixLinkerTool : public LinkerTool {
       flags.push_back("-dylib");
       // For flat namespace see https://stackoverflow.com/a/49392862/724872.
       flags.push_back("-flat_namespace");
-      // Link the System and C runtime library, and optionally SAN libraries.
-      flags.push_back(targetOptions.systemLinkerFlags);
     } else {
       // Avoids including any libc/startup files that initialize the CRT as
       // we don't use any of that. Our shared libraries must be freestanding.

--- a/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
+++ b/compiler/src/iree/compiler/Dialect/HAL/Target/LLVMCPU/internal/UnixLinkerTool.cpp
@@ -86,10 +86,10 @@ class UnixLinkerTool : public LinkerTool {
 
       // Produce a Mach-O dylib file.
       flags.push_back("-dylib");
+      // For flat namespace see https://stackoverflow.com/a/49392862/724872.
       flags.push_back("-flat_namespace");
-      flags.push_back(
-          "-L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib "
-          "-lSystem");
+      // Link the System and C runtime library, and optionally SAN libraries.
+      flags.push_back(targetOptions.systemLinkerFlags);
     } else {
       // Avoids including any libc/startup files that initialize the CRT as
       // we don't use any of that. Our shared libraries must be freestanding.


### PR DESCRIPTION
Fix https://github.com/openxla/iree/issues/12533

Runing the follow bash script in the directory of my local git clone of IREE, I can compile `simple_mul.mlir` into two vmfb's, one for macOS and the other for iOS Simulator.

```bash
XCODE_DEV_DIR=$(xcode-select -p)
CLANG_VERSION=$(clang --version | head -n 1 | cut -f 4 -d ' ')
CLANG_DARWIN_LIB_DIR=$XCODE_DEV_DIR/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/$CLANG_VERSION/lib/darwin/

INPUT_MLIR=./runtime/src/iree/runtime/testdata/simple_mul.mlir

OSX_SDK_DIR=$XCODE_DEV_DIR/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
OSX_CLANG_STATIC_LIB=$CLANG_DARWIN_LIB_DIR/libclang_rt.osx.a
OSX_ARM64_TRIPLE=arm64-apple-darwin

echo "Compiling $OSX_ARM64_TRIPLE"
echo " using OSX Clang runtime library: $OSX_CLANG_STATIC_LIB"
echo " using OSX system SDK and system runtime: $OSX_SDK_DIR"
iree-compile \
 $INPUT_MLIR \
 --iree-llvmcpu-link-embedded=false \
 --iree-llvmcpu-system-linker-flags="$OSX_CLANG_STATIC_LIB -lSystem -syslibroot $OSX_SDK_DIR" \
 --iree-llvmcpu-target-triple=$OSX_ARM64_TRIPLE \
 --iree-input-type=mhlo \
 --iree-hal-target-backends=llvm-cpu \
 -o /tmp/mul-osx.vmfb

IOS_SIM_SDK_DIR=$XCODE_DEV_DIR/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator.sdk
IOS_SIM_CLANG_STATIC_LIB=$CLANG_DARWIN_LIB_DIR/libclang_rt.iossim.a
IOS_SIM_ARM64_TRIPLE=arm64-apple-ios-simulator

echo "Compiling $IOS_SIM_ARM64_TRIPLE"
echo " using iOS Simulator Clang runtime library: $IOS_SIM_CLANG_STATIC_LIB"
echo " using iOS Simulator system SDK and system runtime: $IOS_SIM_SDK_DIR"
iree-compile \
 $INPUT_MLIR \
 --iree-llvmcpu-link-embedded=false \
 --iree-llvmcpu-system-linker-flags="$IOS_SIM_CLANG_STATIC_LIB -lSystem -syslibroot $IOS_SIM_SDK_DIR" \
 --iree-llvmcpu-target-triple=$IOS_SIM_ARM64_TRIPLE \
 --iree-input-type=mhlo \
 --iree-hal-target-backends=llvm-cpu \
 -o /tmp/mul-ios-sim.vmfb
```

However, executing the macOS version vmfb failed:

```
$ iree-run-module --module=/tmp/mul-osx.vmfb --device=local-task --function=abs --input="f32=-5"
iree/runtime/src/iree/base/internal/dynamic_library_posix.c:163: NOT_FOUND; failed to load dynamic library (possibly not found on any search path): dlopen(/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so, 0x0005): tried: '/iree_dylib_79AtHY_mem_.so' (no such file), '/Users/y/w/iree-ios/build/compiler/install/lib/iree_dylib_79AtHY_mem_.so' (no such file), '/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' (code signature in <1FDF71C6-273E-39EB-959F-6E20EFBE7DB7> '/private/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' not valid for use in process: Trying to load an unsigned library), '/System/Volumes/Preboot/Cryptexes/OS/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' (no such file), '/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' (code signature in <1FDF71C6-273E-39EB-959F-6E20EFBE7DB7> '/private/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' not valid for use in process: Trying to load an unsigned library), '/iree_dylib_79AtHY_mem_.so' (no such file), '/Users/y/w/iree-ios/build/compiler/install/lib/iree_dylib_79AtHY_mem_.so' (no such file), '/private/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' (code signature in <1FDF71C6-273E-39EB-959F-6E20EFBE7DB7> '/private/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' not valid for use in process: Trying to load an unsigned library), '/System/Volumes/Preboot/Cryptexes/OS/private/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' (no such file), '/private/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' (code signature in <1FDF71C6-273E-39EB-959F-6E20EFBE7DB7> '/private/var/folders/hd/6q8jftdn7b1fygsrzdkp5ww40000gn/T/iree_dylib_79AtHY_mem_.so' not valid for use in process: Trying to load an unsigned library); while invoking native function hal.executable.create; while calling import;
[ 1]   native hal.executable.create:0 -
[ 0] bytecode module.__init:250 ./runtime/src/iree/runtime/testdata/simple_mul.mlir:2:8
      at ./runtime/src/iree/runtime/testdata/simple_mul.mlir:1:1
ThreadSanitizer: reported 1 warnings
Abort trap: 6
```

**Note:** Both of `iree-compile` and `iree-run-module` above were built with **TSAN enabled**, as described in https://github.com/openxla/iree/issues/12549
