### PR TITLE
Clean up uses of to_vector. NFC.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndVectorizeToCooperativeOps.cpp
@@ -164,7 +164,7 @@ Optional<SmallVector<int64_t>> getExtOpVectorShape(
       return std::nullopt;
   }
 
-  return llvm::to_vector<>(sliceType.getShape());
+  return llvm::to_vector(sliceType.getShape());
 }
 
 /// Returns vector shape matching native cooperative op sizes for unrolling
@@ -173,13 +173,13 @@ Optional<SmallVector<int64_t>> getCooperativeOpVectorShape(
     Operation *op, ArrayRef<int64_t> nativeShape) {
   // Unroll vector.contract ops according to native cooperative matrix size.
   if (auto contractOp = dyn_cast<vector::ContractionOp>(op)) {
-    return llvm::to_vector<>(nativeShape);
+    return llvm::to_vector(nativeShape);
   }
 
   // Unroll elementwise ops according to native cooperative matrix size.
   if (OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1) {
     if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>())
-      return llvm::to_vector<>(nativeShape.drop_back());  // Drop K dim size
+      return llvm::to_vector(nativeShape.drop_back());  // Drop K dim size
   }
 
   // Unrolling vector.contract generates vector.{insert|extract}_strided_slice
@@ -195,13 +195,13 @@ Optional<SmallVector<int64_t>> getCooperativeOpVectorShape(
     auto insert =
         writeOp.getVector().getDefiningOp<vector::InsertStridedSliceOp>();
     if (insert) {
-      return llvm::to_vector<>(insert.getSourceVectorType().getShape());
+      return llvm::to_vector(insert.getSourceVectorType().getShape());
     }
 
     // There can exist vector.transfer_write for initializing output. Unroll
     // them to native shape. Native shape is for ([B, ]M, N, K), here we only
     // need ([B, ]M, N).
-    return llvm::to_vector<>(nativeShape.drop_back());
+    return llvm::to_vector(nativeShape.drop_back());
   }
 
   if (auto readOp = dyn_cast<vector::TransferReadOp>(op)) {
@@ -220,7 +220,7 @@ Optional<SmallVector<int64_t>> getCooperativeOpVectorShape(
       if (sliceType && sliceType != vecType) return std::nullopt;
       sliceType = vecType;
     }
-    return llvm::to_vector<>(sliceType.getShape());
+    return llvm::to_vector(sliceType.getShape());
   }
 
   if (auto extOp = dyn_cast<arith::ExtSIOp>(op))

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVVectorize.cpp
@@ -99,7 +99,7 @@ Optional<SmallVector<int64_t>> getNativeVectorShape(Operation *op) {
   } else if (auto reductionOp = dyn_cast<vector::MultiDimReductionOp>(op)) {
     // Unroll all reduction dimensions by size 1 for vector.multi_reduction.
     VectorType srcVectorType = reductionOp.getSourceVectorType();
-    auto nativeSize = llvm::to_vector<>(srcVectorType.getShape());
+    auto nativeSize = llvm::to_vector(srcVectorType.getShape());
     auto dims = reductionOp.getReductionDims().getAsValueRange<IntegerAttr>();
     for (const auto &dimAttr : dims) {
       nativeSize[dimAttr.getZExtValue()] = 1;

--- a/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/GPUUtils.cpp
@@ -583,7 +583,7 @@ Optional<SmallVector<int64_t>> getWmmaNativeVectorSize(Operation *op) {
       if (sliceType && sliceType != vecType) return std::nullopt;
       sliceType = vecType;
     }
-    return llvm::to_vector<>(sliceType.getShape());
+    return llvm::to_vector(sliceType.getShape());
   }
   if ((OpTrait::hasElementwiseMappableTraits(op) && op->getNumResults() == 1)) {
     if (auto vecType = op->getResultTypes()[0].dyn_cast<VectorType>()) {
@@ -736,7 +736,7 @@ Optional<SmallVector<int64_t>> getMmaNativeVectorSize(Operation *op) {
           if (sliceType && sliceType != vecType) return std::nullopt;
           sliceType = vecType;
         }
-        return llvm::to_vector<>(sliceType.getShape());
+        return llvm::to_vector(sliceType.getShape());
       }
     }
   }


### PR DESCRIPTION
There's no need for spell out empty angle brackets when all function template arguments are set to their defaults.