### PR TITLE
[LLVMGPU][NFC] Break up mma.sync into its own codegen pipeline

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
+++ b/compiler/src/iree/compiler/Codegen/Dialect/LoweringConfig.td
@@ -37,21 +37,22 @@ def LLVMGPU_MatmulTensorCore : I32EnumAttrCase<"LLVMGPUMatmulTensorCore", 12>;
 def LLVMGPU_TransposeSharedMem : I32EnumAttrCase<"LLVMGPUTransposeSharedMem", 13>;
 def LLVMGPU_WarpReduction : I32EnumAttrCase<"LLVMGPUWarpReduction", 14>;
 def LLVMGPU_PackUnPack : I32EnumAttrCase<"LLVMGPUPackUnPack", 15>;
+def LLVMGPU_MatmulTensorCoreMmaSync : I32EnumAttrCase<"LLVMGPUMatmulTensorCoreMmaSync", 16>;
 
 def SPIRV_BaseDistribute
-    : I32EnumAttrCase<"SPIRVBaseDistribute", 16>;
+    : I32EnumAttrCase<"SPIRVBaseDistribute", 17>;
 def SPIRV_BaseVectorize
-    : I32EnumAttrCase<"SPIRVBaseVectorize", 17>;
+    : I32EnumAttrCase<"SPIRVBaseVectorize", 18>;
 def SPIRV_MatmulPromoteVectorize
-    : I32EnumAttrCase<"SPIRVMatmulPromoteVectorize", 18>;
+    : I32EnumAttrCase<"SPIRVMatmulPromoteVectorize", 19>;
 def SPIRV_CooperativeMatrixVectorize
-    : I32EnumAttrCase<"SPIRVCooperativeMatrixVectorize", 19>;
+    : I32EnumAttrCase<"SPIRVCooperativeMatrixVectorize", 20>;
 def SPIRV_SubgroupReduce
-    : I32EnumAttrCase<"SPIRVSubgroupReduce", 20>;
+    : I32EnumAttrCase<"SPIRVSubgroupReduce", 21>;
 def SPIRV_WinogradVectorize
-    : I32EnumAttrCase<"SPIRVWinogradVectorize", 21>;
+    : I32EnumAttrCase<"SPIRVWinogradVectorize", 22>;
 
-def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 22>;
+def VMVX_Default : I32EnumAttrCase<"VMVXDefault", 23>;
 
 
 def Linalg_TransformDialectCodegen
@@ -71,7 +72,8 @@ def DispatchLoweringPassPipelineEnum
             CPU_TripleTilingExpert, CPU_DataTiling, LLVMGPU_SimpleDistribute,
             LLVMGPU_Vectorize, LLVMGPU_MatmulSimt, LLVMGPU_MatmulTensorCore,
             LLVMGPU_TransposeSharedMem, LLVMGPU_WarpReduction,
-            LLVMGPU_PackUnPack, SPIRV_BaseDistribute, SPIRV_BaseVectorize,
+            LLVMGPU_PackUnPack, LLVMGPU_MatmulTensorCoreMmaSync,
+            SPIRV_BaseDistribute, SPIRV_BaseVectorize,
             SPIRV_MatmulPromoteVectorize, SPIRV_CooperativeMatrixVectorize,
             SPIRV_SubgroupReduce, SPIRV_WinogradVectorize, VMVX_Default,
             // Transform dialect based codegen

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/LLVMGPULowerExecutableTarget.cpp
@@ -174,6 +174,12 @@ void LLVMGPULowerExecutableTargetPass::runOnOperation() {
             translationInfo.value().getSoftwarePipelineDepth());
         break;
       case IREE::Codegen::DispatchLoweringPassPipeline::
+          LLVMGPUMatmulTensorCoreMmaSync:
+        addGPUMatmulTensorCoreMmaSyncPassPipeline(
+            executableLoweringPipeline,
+            translationInfo.value().getSoftwarePipelineDepth());
+        break;
+      case IREE::Codegen::DispatchLoweringPassPipeline::
           LLVMGPUTransposeSharedMem:
         addGPUTransposePassPipeline(executableLoweringPipeline);
         break;

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -445,6 +445,10 @@ LogicalResult verifyGPUMatmulTensorCorePipeline(
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
                                         unsigned pipelineDepth);
 
+/// Lowering using mma.sync tensorcore operations.
+void addGPUMatmulTensorCoreMmaSyncPassPipeline(OpPassManager &pm,
+                                               unsigned pipelineDepth);
+
 enum class GPUPromoteSharedMemPattern {
   ContractionOpPattern = 0,
   TransposeOpPattern = 1,
@@ -494,9 +498,15 @@ std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorAlloc(
 std::unique_ptr<OperationPass<IREE::HAL::ExecutableVariantOp>>
 createLLVMGPULowerExecutableTargetPass();
 
+enum class GPUTensorCoreType {
+  WMMA = 0,
+  MMA_SYNC = 1,
+};
+
 /// Convert Linalg ops to Vector and prepare converstion to GPU MMA ops.
 std::unique_ptr<OperationPass<func::FuncOp>>
-createLLVMGPUTensorCoreVectorizationPass();
+createLLVMGPUTensorCoreVectorizationPass(
+    GPUTensorCoreType tensorCoreType = GPUTensorCoreType::WMMA);
 
 /// Lower vector ops before convertion to LLVM.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorLoweringPass();
@@ -507,7 +517,8 @@ std::unique_ptr<OperationPass<func::FuncOp>>
 createGPUReduceSharedMemoryBankConflicts(int64_t paddingSizeBits = 128);
 
 /// Converts vector ops to gpu dialect.
-std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU();
+std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUVectorToGPU(
+    GPUTensorCoreType tensorCoreType = GPUTensorCoreType::WMMA);
 
 //. Pass to pad out tensors up to static dimensions.
 std::unique_ptr<OperationPass<func::FuncOp>> createLLVMGPUTensorPadPass();

--- a/compiler/src/iree/compiler/Codegen/Passes.h
+++ b/compiler/src/iree/compiler/Codegen/Passes.h
@@ -437,11 +437,11 @@ LogicalResult verifyGPUMatmulSimtPassPipeline(
     ArrayRef<int64_t> workgroupSize);
 void addGPUMatmulSimtPassPipeline(OpPassManager &pm);
 
-/// Lowering using tensorcore operations.
 LogicalResult verifyGPUMatmulTensorCorePipeline(
     Operation *op, IREE::Codegen::LoweringConfigAttr loweringConfig,
     IREE::Codegen::TranslationInfoAttr translationInfo,
     ArrayRef<int64_t> workgroupSize);
+/// Lowering using wmma tensorcore operations.
 void addGPUMatmulTensorCorePassPipeline(OpPassManager &pm,
                                         unsigned pipelineDepth);
 

--- a/tests/e2e/matmul/BUILD
+++ b/tests/e2e/matmul/BUILD
@@ -214,7 +214,6 @@ py_binary(
     name = "e2e_matmul_direct_f32_gpu_large_mma_sync_%s" % compilation_info,
     compiler_flags = [
         "--iree-hal-cuda-llvm-target-arch=sm_80",
-        "--iree-codegen-llvmgpu-use-mma-sync=true",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -235,7 +234,7 @@ py_binary(
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for compilation_info in [
-    "LLVMGPUMatmulTensorCore",
+    "LLVMGPUMatmulTensorCoreMmaSync",
 ]]
 
 # WMMA TensorCore(F16): wmma.161616.f16.f16
@@ -271,7 +270,6 @@ py_binary(
     name = "e2e_matmul_direct_f16_gpu_large_mma_sync_%s" % compilation_info,
     compiler_flags = [
         "--iree-hal-cuda-llvm-target-arch=sm_80",
-        "--iree-codegen-llvmgpu-use-mma-sync=true",
     ],
     generator = ":generate_e2e_matmul_tests",
     generator_args = [
@@ -292,7 +290,7 @@ py_binary(
     ],
     trace_runner = "//tools:iree-e2e-matmul-test",
 ) for compilation_info in [
-    "LLVMGPUMatmulTensorCore",
+    "LLVMGPUMatmulTensorCoreMmaSync",
 ]]
 
 [iree_generated_trace_runner_test(

--- a/tests/e2e/matmul/CMakeLists.txt
+++ b/tests/e2e/matmul/CMakeLists.txt
@@ -294,13 +294,13 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f32_gpu_large_mma_sync_LLVMGPUMatmulTensorCore
+    e2e_matmul_direct_f32_gpu_large_mma_sync_LLVMGPUMatmulTensorCoreMmaSync
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=f32"
     "--shapes=gpu_large"
-    "--compilation_info=LLVMGPUMatmulTensorCore"
+    "--compilation_info=LLVMGPUMatmulTensorCoreMmaSync"
   TRACE_RUNNER
     iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -309,7 +309,6 @@ iree_generated_trace_runner_test(
     "cuda"
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
-    "--iree-codegen-llvmgpu-use-mma-sync=true"
   LABELS
     "noasan"
     "nomsan"
@@ -345,13 +344,13 @@ iree_generated_trace_runner_test(
 
 iree_generated_trace_runner_test(
   NAME
-    e2e_matmul_direct_f16_gpu_large_mma_sync_LLVMGPUMatmulTensorCore
+    e2e_matmul_direct_f16_gpu_large_mma_sync_LLVMGPUMatmulTensorCoreMmaSync
   GENERATOR
     "generate_e2e_matmul_tests.py"
   GENERATOR_ARGS
     "--lhs_rhs_type=f16"
     "--shapes=gpu_large"
-    "--compilation_info=LLVMGPUMatmulTensorCore"
+    "--compilation_info=LLVMGPUMatmulTensorCoreMmaSync"
   TRACE_RUNNER
     iree-e2e-matmul-test
   TARGET_BACKENDS
@@ -360,7 +359,6 @@ iree_generated_trace_runner_test(
     "cuda"
   COMPILER_FLAGS
     "--iree-hal-cuda-llvm-target-arch=sm_80"
-    "--iree-codegen-llvmgpu-use-mma-sync=true"
   LABELS
     "noasan"
     "nomsan"

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -44,6 +44,7 @@ class CompilationInfoId(enum.Enum):
   NONE = ""
   LLVMGPUMatmulSimt = "LLVMGPUMatmulSimt"
   LLVMGPUMatmulTensorCore = "LLVMGPUMatmulTensorCore"
+  LLVMGPUMatmulTensorCoreMmaSync = "LLVMGPUMatmulTensorCoreMmaSync"
   SPIRVVectorizeMali = "SPIRVVectorizeMali"
   SPIRVVectorizeNVIDIA = "SPIRVVectorizeNVIDIA"
 

--- a/tests/e2e/matmul/generate_e2e_matmul_tests.py
+++ b/tests/e2e/matmul/generate_e2e_matmul_tests.py
@@ -211,7 +211,7 @@ def get_test_compilation_infos(
     tile_workgroup_size_pairs = get_all_spirv_tile_workgroup_size_pairs(32)
   elif compilation_info_id == CompilationInfoId.SPIRVVectorizeMali:
     tile_workgroup_size_pairs = get_all_spirv_tile_workgroup_size_pairs(4)
-  elif compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCore:
+  elif compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCore or compilation_info_id == CompilationInfoId.LLVMGPUMatmulTensorCoreMmaSync:
     tile_workgroup_size_pairs = []
     ## WarpShape = 2x2
     tile_workgroup_size_pairs.append(


### PR DESCRIPTION
Instead of having a global flag we now have a separate lowering pipeline to target mma.sync. This will allow use to transition to mma.sync pipeline by default gradually and will allow us to keep wmma pipeline alive for a longer time.