### PR TITLE
Always set `IREE_LLD_TARGET` while it isn't optional in the API.

### DIFF
--- a/build_tools/cmake/iree_llvm.cmake
+++ b/build_tools/cmake/iree_llvm.cmake
@@ -132,6 +132,11 @@ macro(iree_llvm_set_bundled_cmake_options)
   # Unconditionally enable mlir.
   list(APPEND LLVM_ENABLE_PROJECTS mlir)
 
+  # Currently always required.
+  # TODO(laurenzo): optional LLD in compiler API (only used by llvm-cpu)
+  #                 maybe some IREE_LLD_FLAVORS= option too?
+  set(IREE_LLD_TARGET lld)
+
   # Configure LLVM based on enabled IREE target backends.
   message(STATUS "IREE compiler target backends:")
   if(IREE_TARGET_BACKEND_CUDA)
@@ -143,13 +148,11 @@ macro(iree_llvm_set_bundled_cmake_options)
     message(STATUS "  - llvm-cpu")
     list(APPEND LLVM_TARGETS_TO_BUILD "${IREE_DEFAULT_CPU_LLVM_TARGETS}")
     set(IREE_CLANG_TARGET clang)
-    set(IREE_LLD_TARGET lld)
   endif()
   if(IREE_TARGET_BACKEND_LLVM_CPU_WASM)
     message(STATUS "  - llvm-cpu (wasm)")
     list(APPEND LLVM_TARGETS_TO_BUILD WebAssembly)
     set(IREE_CLANG_TARGET clang)
-    set(IREE_LLD_TARGET lld)
   endif()
   if(IREE_TARGET_BACKEND_METAL_SPIRV)
     message(STATUS "  - metal-spirv")


### PR DESCRIPTION
We currently always include LLD in the compiler API with all flavors: https://github.com/openxla/iree/blob/4032809de904b8992ae1cf8698b00150cf221ffd/compiler/src/iree/compiler/API/CMakeLists.txt#L34-L39 https://github.com/openxla/iree/blob/4032809de904b8992ae1cf8698b00150cf221ffd/compiler/src/iree/compiler/API/Internal/LLDToolEntryPoint.cpp#L83-L92

When using an external LLVM install, only some flavors may be included. When skipping IREE's `llvm-cpu` compiler target, LLD will not be used at all. Both of these cases are in need of some solution (this PR is not that solution).

We had some ideas about implementing a `IREE_LLD_FLAVORS=` option for more control, which would null out the entry point if empty (discussion [around here on Discord](https://discord.com/channels/689900678990135345/1079828394532945990/1082134480287961180)).