### PR TITLE
[LLVMCPU] Re-implement the flow of setting dispatch configurations.

### DIFF
--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1818,9 +1818,10 @@ static LogicalResult setVMVXRootConfigImpl(func::FuncOp entryPointFn,
 }
 
 /// Find the root operation for the dispatch region. The priority is:
-///   1. A Linalg operation that has reduction loops.
-///   2. Any other Lainlg op or LinalgExt op.
-///   3. An operation that implements TilingInterface.
+///   1. A tensor.pack op or a tensor.unpack op/
+///   2. A Linalg operation that has reduction loops.
+///   3. Any other Lainlg op or LinalgExt op.
+///   4. An operation that implements TilingInterface.
 /// If there are multiple operations meeting the same priority, the one closer
 /// to the end of the function is the root op.
 static FailureOr<Operation *> getRootOperation(

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1819,7 +1819,7 @@ static LogicalResult setVMVXRootConfigImpl(func::FuncOp entryPointFn,
 
 /// Find the root operation for the dispatch region. The priority is:
 ///   1. A Linalg operation that has reduction loops.
-///   2. Any other Linalg op.
+///   2. Any other Lainlg op or LinalgExt op.
 ///   3. An operation that implements TilingInterface.
 /// If there are multiple operations meeting the same priority, the one closer
 /// to the end of the function is the root op.
@@ -1837,9 +1837,8 @@ static FailureOr<Operation *> getRootOperation(
     if (linalgOp.getNumReductionLoops()) return op;
   }
 
-  // If no root operation is found yet. Look for linalg generic ops.
   for (auto op : llvm::reverse(computeOps)) {
-    if (isa<linalg::LinalgOp>(op)) return op;
+    if (isa<linalg::LinalgOp, IREE::LinalgExt::LinalgExtOp>(op)) return op;
   }
 
   for (auto op : llvm::reverse(computeOps)) {


### PR DESCRIPTION
It defines how we find a root op clearly, and move the check of preset path to entry point. This also addresses the odd logic, which is returning success() when it does not meet the preconditions.

benchmarks: x86_64, comp-stats