### PR TITLE
Rename aggrsssive fusion to fuse-multi-use

### DIFF
--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -66,11 +66,9 @@ static llvm::cl::opt<bool> clEnableFusePaddingIntoLinalgConsumerOps(
     llvm::cl::desc("Enable fusing tensor.pad ops into Linalg consumer ops"),
     llvm::cl::init(false));
 
-static llvm::cl::opt<bool> clEnableAggressiveFusion(
-    "iree-flow-enable-aggressive-fusion",
-    llvm::cl::desc(
-        "Enable the aggressive fusion heuristic to fuse multiuse ops and ops "
-        "with reduction loops"),
+static llvm::cl::opt<bool> clEnableFuseMultiUse(
+    "iree-flow-fuse-multi-use",
+    llvm::cl::desc("Fuse multi-use ops"),
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool> clDispatchGenerateWorkloadRegion(
@@ -216,7 +214,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(mlir::createCSEPass)
       // Elementwise fusion.
       .addPass([]() {
-        return createFusionOfTensorOpsPass(clEnableAggressiveFusion);
+        return createFusionOfTensorOpsPass(clEnableFuseMultiUse);
       })
       .addPass(mlir::createLinalgDetensorizePass)
       .addPass(mlir::createCanonicalizerPass)
@@ -247,7 +245,7 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       // transformations afterwards with a simple region and without bothering
       // producers.
       .addPass([&]() {
-        return createFormDispatchRegionsPass(clEnableAggressiveFusion,
+        return createFormDispatchRegionsPass(clEnableFuseMultiUse,
                                              clDispatchGenerateWorkloadRegion);
       })
       // Collapse dimensions of linalg Ops.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.cpp
@@ -67,8 +67,7 @@ static llvm::cl::opt<bool> clEnableFusePaddingIntoLinalgConsumerOps(
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool> clEnableFuseMultiUse(
-    "iree-flow-fuse-multi-use",
-    llvm::cl::desc("Fuse multi-use ops"),
+    "iree-flow-fuse-multi-use", llvm::cl::desc("Fuse multi-use ops"),
     llvm::cl::init(false));
 
 static llvm::cl::opt<bool> clDispatchGenerateWorkloadRegion(
@@ -213,9 +212,8 @@ void buildFlowTransformPassPipeline(OpPassManager &passManager,
       .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass)
       // Elementwise fusion.
-      .addPass([]() {
-        return createFusionOfTensorOpsPass(clEnableFuseMultiUse);
-      })
+      .addPass(
+          []() { return createFusionOfTensorOpsPass(clEnableFuseMultiUse); })
       .addPass(mlir::createLinalgDetensorizePass)
       .addPass(mlir::createCanonicalizerPass)
       .addPass(mlir::createCSEPass)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.h
@@ -140,7 +140,7 @@ std::unique_ptr<Pass> createVerifyInputLegalityPass();
 // is created for each tiled loop nest. This pass only moves the root compute op
 // into the dispatch region, allowing producers to be outside.
 std::unique_ptr<InterfacePass<mlir::FunctionOpInterface>>
-createFormDispatchRegionsPass(bool aggressiveFusion = false,
+createFormDispatchRegionsPass(bool fuseMultiUse = false,
                               bool generateWorkloadRegion = true);
 
 // Pass to collapse dimensions of Linalg Ops on tensor ops.

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/Passes.td
@@ -67,8 +67,8 @@ def FormDispatchRegions :
   let summary = "Form Dispatch Region Ops from Linalg operations on tensors to form dispatch.regions";
   let constructor = "mlir::iree_compiler::IREE::Flow::createFormDispatchRegionsPass()";
   let options = [
-    Option<"aggressiveFusion", "aggressive-fusion", "bool",
-           /*default=*/"false", "Fuse with aggressive heuristics">,
+    Option<"fuseMultiUse", "fuse-multi-use", "bool",
+           /*default=*/"false", "Fuse multi-use ops">,
     Option<"generateWorkloadRegion", "genereate-workload-region", "bool",
            /*default=*/"true", "Generate workload regions of WorkgroupOps">,
   ];

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/collapse_linalg_generic_on_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-collapse-dimensions))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --pass-pipeline="builtin.module(func.func(iree-flow-form-dispatch-regions{fuse-multi-use=true}, iree-flow-collapse-dimensions))" %s | FileCheck %s
 !type = tensor<2x4x8x16x32x64xf32>
 util.global private @"__transpose_10_input" {noinline} = dense<1.0> : !type
 

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(func.func(iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-clone-producers-into-dispatch-regions, iree-flow-form-dispatch-workgroups), cse, canonicalize, cse)" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(func.func(iree-flow-form-dispatch-regions{fuse-multi-use=true}, iree-flow-clone-producers-into-dispatch-regions, iree-flow-form-dispatch-workgroups), cse, canonicalize, cse)" %s | FileCheck %s
 func.func @tile_matmul_alone(%arg0 : tensor<?x?xf32>, %arg1 : tensor<?x?xf32>,
              %arg2 : tensor<?x?xf32>) -> tensor<?x?xf32> {
   %1 = linalg.matmul ins(%arg0, %arg1 : tensor<?x?xf32>, tensor<?x?xf32>)

--- a/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion_with_transpose.mlir
+++ b/compiler/src/iree/compiler/Dialect/Flow/Transforms/test/dispatch_linalg_on_tensors_fusion_with_transpose.mlir
@@ -1,4 +1,4 @@
-// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(func.func(iree-flow-interchange-transpose-generic-ops,iree-flow-form-dispatch-regions{aggressive-fusion=true}, iree-flow-form-dispatch-workgroups, canonicalize, cse))" %s | FileCheck %s
+// RUN: iree-opt --split-input-file --verify-diagnostics --pass-pipeline="builtin.module(func.func(iree-flow-interchange-transpose-generic-ops,iree-flow-form-dispatch-regions{fuse-multi-use=true}, iree-flow-form-dispatch-workgroups, canonicalize, cse))" %s | FileCheck %s
 
 func.func @fuse_batch_matmul_transpose(%a: tensor<4x384x384xf32>, %b: tensor<4x384x32xf32>) -> tensor<384x4x32xf32> {
   %cst = arith.constant 0.000000e+00 : f32

--- a/tests/e2e/regression/BUILD
+++ b/tests/e2e/regression/BUILD
@@ -128,7 +128,7 @@ iree_check_single_backend_test_suite(
         "softmax_large.mlir",
     ],
     compiler_flags = [
-        "--iree-flow-enable-aggressive-fusion",
+        "--iree-flow-fuse-multi-use",
     ],
     driver = "cuda",
     tags = [
@@ -158,7 +158,7 @@ iree_check_single_backend_test_suite(
         "softmax.mlir",
     ],
     compiler_flags = [
-        "--iree-flow-enable-aggressive-fusion",
+        "--iree-flow-fuse-multi-use",
     ],
     driver = "local-task",
     target_backend = "llvm-cpu",

--- a/tests/e2e/regression/CMakeLists.txt
+++ b/tests/e2e/regression/CMakeLists.txt
@@ -172,7 +172,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "cuda"
   COMPILER_FLAGS
-    "--iree-flow-enable-aggressive-fusion"
+    "--iree-flow-fuse-multi-use"
   LABELS
     "noasan"
     "nomsan"
@@ -204,7 +204,7 @@ iree_check_single_backend_test_suite(
   DRIVER
     "local-task"
   COMPILER_FLAGS
-    "--iree-flow-enable-aggressive-fusion"
+    "--iree-flow-fuse-multi-use"
 )
 
 iree_check_single_backend_test_suite(

--- a/tests/transform_dialect/cuda/BUILD
+++ b/tests/transform_dialect/cuda/BUILD
@@ -53,7 +53,7 @@ iree_lit_test_suite(
         #
         # FIXME: This must be used with the custom dispatch region formation
         # because IREE's does not fuse the 6 ops softmax version even with
-        # --iree-flow-enable-aggressive-fusion.
+        # --iree-flow-fuse-multi-use.
         #
         "softmax_dispatch_spec.mlir",
         # First few ops of softmax only, acts as a proxy example.

--- a/tests/transform_dialect/cuda/softmax.mlir
+++ b/tests/transform_dialect/cuda/softmax.mlir
@@ -4,7 +4,7 @@
 // RUN:     --iree-flow-transformation-pipeline  \
 /// This must be used with the custom dispatch region formation
 /// because IREE's does not fuse the 6 ops softmax version even with
-/// --iree-flow-enable-aggressive-fusion.
+/// --iree-flow-fuse-multi-use.
 // RUN:     --iree-flow-dispatch-use-transform-dialect=%p/softmax_dispatch_spec.mlir \
 // RUN:     --iree-stream-transformation-pipeline \
 // RUN:     --iree-hal-configuration-pipeline | \
@@ -18,7 +18,7 @@
 /// flags leak to the JIT session, which doesn't know what to do with them.
 /// This must be used with the custom dispatch region formation
 /// because IREE's does not fuse the 6 ops softmax version even with
-/// --iree-flow-enable-aggressive-fusion.
+/// --iree-flow-fuse-multi-use.
 // RUN:     --iree-flow-dispatch-use-transform-dialect=%p/softmax_dispatch_spec.mlir \
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/softmax_codegen_spec.mlir | \
 // RUN: iree-run-module --function=softmax --device=cuda | \

--- a/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_codegen_spec.mlir
@@ -17,7 +17,7 @@ transform.sequence failures(propagate) {
   // Step 1. First level of tiling + fusion parallelizes to blocks.
   // ==============================================================
   // This must be used with the custom dispatch region formation because IREE's
-  // does not fuse even with --iree-flow-enable-aggressive-fusion.
+  // does not fuse even with --iree-flow-fuse-multi-use.
   // %forall, %_ =
   // transform.iree.tile_to_forall_and_workgroup_count_region %div tile_sizes [1, 4]
   //   ( mapping = [#gpu.thread<x>, #gpu.thread<y>] )

--- a/tests/transform_dialect/cuda/softmax_dispatch_spec.mlir
+++ b/tests/transform_dialect/cuda/softmax_dispatch_spec.mlir
@@ -13,7 +13,7 @@ transform.sequence failures(propagate){
 
   /// This must be used with the custom dispatch region formation
   /// because IREE's does not fuse the 6 ops softmax version even with
-  /// --iree-flow-enable-aggressive-fusion.
+  /// --iree-flow-fuse-multi-use.
   %region_op = transform.iree.wrap_in_dispatch_region %div { generateWorkload = false }
 
   %non_div = transform.merge_handles %input_max_fill, %input_max, %exps_sum_fill, %exps, %exps_sum

--- a/tests/transform_dialect/cuda/softmax_v2.mlir
+++ b/tests/transform_dialect/cuda/softmax_v2.mlir
@@ -1,7 +1,7 @@
 // RUN: iree-opt %s --iree-hal-target-backends=cuda \
 // RUN:     --iree-abi-transformation-pipeline \
 // RUN:     --iree-flow-transformation-pipeline  \
-// RUN:     --iree-flow-enable-aggressive-fusion \
+// RUN:     --iree-flow-fuse-multi-use \
 // RUN:     --iree-stream-transformation-pipeline \
 // RUN:     --iree-hal-configuration-pipeline | \
 // RUN: iree-opt --pass-pipeline='builtin.module(hal.executable(hal.executable.variant(iree-llvmgpu-lower-executable-target)))' \
@@ -13,7 +13,7 @@
 // RUN:     --iree-opt-const-expr-hoisting=false --iree-opt-const-eval=false \
 /// Constant JIT'ing must be disabled because the transform-dialect debug
 /// flags leak to the JIT session, which doesn't know what to do with them.
-// RUN:     --iree-flow-enable-aggressive-fusion \
+// RUN:     --iree-flow-fuse-multi-use \
 // RUN:     --iree-codegen-llvmgpu-enable-transform-dialect-jit=false \
 // RUN:     --iree-codegen-llvmgpu-use-transform-dialect=%p/softmax_v2_codegen_spec.mlir | \
 // RUN: iree-run-module --function=softmax --device=cuda | \


### PR DESCRIPTION
Since most of the aggressive fusion has been enabled by default. This option now only controls the fusion for multi-use ops. Rename it and keep it off by default.

benchmarks: all