### PR TITLE
Parse benchmark presets from PR labels in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,10 +105,10 @@ jobs:
         env:
           PR_TITLE: ${{ fromJSON(steps.fetch-pr.outputs.pr-title || '""') }}
           PR_BODY: ${{ fromJSON(steps.fetch-pr.outputs.pr-body || '""') }}
-          PR_LABELS: ${{ join(fromJSON(steps.fetch-pr.outputs.pr-labels || '[]'), ',') }}
+          PR_LABELS: ${{ steps.fetch-pr.outputs.pr-labels || '[]' }}
           ORIGINAL_PR_TITLE: ${{ github.event.pull_request.title }}
           ORIGINAL_PR_BODY: ${{ github.event.pull_request.body }}
-          ORIGINAL_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          ORIGINAL_PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
         run: |
           # Just informative logging. There should only be two commits in the
           # history here, but limiting the depth helps when copying from a local

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,18 @@ jobs:
           # the JSON strings and later use fromJSON to decode them.
           echo "pr-title=$(jq '.title' ${PR_JSON})" >> "${GITHUB_OUTPUT}"
           echo "pr-body=$(jq '.body' ${PR_JSON})" >> "${GITHUB_OUTPUT}"
-
+          # Use --compact-output to avoid multiline JSON.
+          echo "pr-labels=$(jq --compact-output '.labels | map(.name)' \
+            ${PR_JSON})" >> "${GITHUB_OUTPUT}"
       - name: "Configuring CI options"
         id: configure
         env:
           PR_TITLE: ${{ fromJSON(steps.fetch-pr.outputs.pr-title || '""') }}
           PR_BODY: ${{ fromJSON(steps.fetch-pr.outputs.pr-body || '""') }}
+          PR_LABELS: ${{ join(fromJSON(steps.fetch-pr.outputs.pr-labels || '[]'), ',') }}
           ORIGINAL_PR_TITLE: ${{ github.event.pull_request.title }}
           ORIGINAL_PR_BODY: ${{ github.event.pull_request.body }}
+          ORIGINAL_PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
         run: |
           # Just informative logging. There should only be two commits in the
           # history here, but limiting the depth helps when copying from a local

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -116,7 +116,7 @@ def check_description_and_show_diff(original_description: str,
 
   write_job_summary(
       textwrap.dedent("""\
-  :pushpin: Using the PR description and labels different from the original PR event started this workflow.
+  :pushpin: Using the PR description and labels different from the original PR event that started this workflow.
 
   <details>
   <summary>Click to show diff (original vs. current)</summary>

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -114,6 +114,23 @@ def check_description_and_show_diff(original_description: str,
       current_description.splitlines(keepends=True))
   description_diffs = "".join(description_diffs)
 
+  if description_diffs != "":
+    description_diffs = textwrap.dedent("""\
+    ```diff
+    {}
+    ```
+    """).format(description_diffs)
+
+  if original_labels == current_labels:
+    label_diffs = ""
+  else:
+    label_diffs = textwrap.dedent("""\
+    ```
+    Original labels: {original_labels}
+    Current labels: {current_labels}
+    ```
+    """).format(original_labels=original_labels, current_labels=current_labels)
+
   write_job_summary(
       textwrap.dedent("""\
   :pushpin: Using the PR description and labels different from the original PR event that started this workflow.
@@ -121,15 +138,11 @@ def check_description_and_show_diff(original_description: str,
   <details>
   <summary>Click to show diff (original vs. current)</summary>
 
-  ```diff
   {description_diffs}
-  ```
 
-  Original labels: {original_labels}
-  Current labels: {current_labels}
+  {label_diffs}
   </details>""").format(description_diffs=description_diffs,
-                        original_labels=original_labels,
-                        current_labels=current_labels))
+                        label_diffs=label_diffs))
 
 
 def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -16,12 +16,15 @@ When GITHUB_EVENT_NAME is "pull_request", there are additional environment
 variables to be set:
 - PR_TITLE (required): PR title.
 - PR_BODY (optional): PR description.
+- PR_LABELS (optional): PR label names, splitted by comma.
 - BASE_REF (required): base commit SHA of the PR.
 - ORIGINAL_PR_TITLE (optional): PR title from the original PR event, showing a
     notice if PR_TITLE is different.
 - ORIGINAL_PR_BODY (optional): PR description from the original PR event,
     showing a notice if PR_BODY is different. ORIGINAL_PR_TITLE must also be
     set.
+- ORIGINAL_PR_LABELS (optional): PR labels from the original PR event, showing a
+    notice if PR_LABELS is different. ORIGINAL_PR_TITLE must also be set.
 
 Exit code 0 indicates that it should and exit code 2 indicates that it should
 not.
@@ -33,7 +36,7 @@ import json
 import os
 import subprocess
 import textwrap
-from typing import Iterable, Mapping, MutableMapping
+from typing import Iterable, List, Mapping, Sequence, Tuple
 
 SKIP_CI_KEY = "skip-ci"
 RUNNER_ENV_KEY = "runner-env"
@@ -97,7 +100,11 @@ def write_job_summary(summary: str):
 
 
 def check_description_and_show_diff(original_description: str,
-                                    current_description: str):
+                                    original_labels: Sequence[str],
+                                    current_description: str,
+                                    current_labels: Sequence[str]):
+  original_description += "\n\nLabels:\n" + "\n".join(original_labels)
+  current_description += "\n\nLabels:\n" + "\n".join(current_labels)
   if original_description == current_description:
     return
 
@@ -106,8 +113,7 @@ def check_description_and_show_diff(original_description: str,
 
   write_job_summary(
       textwrap.dedent("""\
-  :pushpin: Using a PR description different from the original PR event \
-  started this workflow.
+  :pushpin: Using the PR description and labels different from the original PR event started this workflow.
 
   <details>
   <summary>Click to show diff (original vs. current)</summary>
@@ -118,28 +124,38 @@ def check_description_and_show_diff(original_description: str,
   </details>""").format("".join(diffs)))
 
 
-def get_trailers(is_pr: bool) -> Mapping[str, str]:
+def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
   if not is_pr:
-    return {}
+    return ({}, [])
+
   title = os.environ["PR_TITLE"]
   body = os.environ.get("PR_BODY", "")
+  labels = os.environ.get("PR_LABELS", "")
   original_title = os.environ.get("ORIGINAL_PR_TITLE")
   original_body = os.environ.get("ORIGINAL_PR_BODY", "")
+  original_labels = os.environ.get("ORIGINAL_PR_LABELS", "")
 
   description = PR_DESCRIPTION_TEMPLATE.format(title=title, body=body)
+  labels = [label.strip() for label in labels.split(",")]
 
-  # PR_TITLE and PR_BODY can be fetched from API for the latest updates. If
+  # PR information can be fetched from API for the latest updates. If
   # ORIGINAL_PR_TITLE is set, compare the current and original description and
   # show a notice if they are different. This is mostly to inform users that the
   # workflow might not parse the PR description they expect.
   if original_title is not None:
     original_description = PR_DESCRIPTION_TEMPLATE.format(title=original_title,
                                                           body=original_body)
-    print("Original PR description:", original_description, sep="\n")
+    original_labels = [label.strip() for label in original_labels.split(",")]
+    print("Original PR description and labels:",
+          original_description,
+          original_labels,
+          sep="\n")
     check_description_and_show_diff(original_description=original_description,
-                                    current_description=description)
+                                    original_labels=original_labels,
+                                    current_description=description,
+                                    current_labels=labels)
 
-  print("Parsing PR description:", description, sep="\n")
+  print("Parsing PR description and labels:", description, labels, sep="\n")
 
   trailer_lines = subprocess.run(
       ["git", "interpret-trailers", "--parse", "--no-divider"],
@@ -148,10 +164,11 @@ def get_trailers(is_pr: bool) -> Mapping[str, str]:
       check=True,
       text=True,
       timeout=60).stdout.splitlines()
-  return {
+  trailer_map = {
       k.lower().strip(): v.strip()
       for k, v in (line.split(":", maxsplit=1) for line in trailer_lines)
   }
+  return (trailer_map, labels)
 
 
 def get_modified_paths(base_ref: str) -> Iterable[str]:
@@ -203,11 +220,14 @@ def get_runner_env(trailers: Mapping[str, str]) -> str:
   return runner_env
 
 
-def get_benchmark_presets(is_pr: bool, trailers: Mapping[str, str]) -> str:
+def get_benchmark_presets(is_pr: bool, trailers: Mapping[str, str],
+                          labels: Sequence[str]) -> str:
   """Parses and validates the benchmark presets from trailers.
 
   Args:
+    is_pr: is pull request event.
     trailers: trailers from PR description.
+    labels: list of PR labels.
 
   Returns:
     A comma separated preset string, which later will be parsed by
@@ -216,11 +236,16 @@ def get_benchmark_presets(is_pr: bool, trailers: Mapping[str, str]) -> str:
   if not is_pr:
     preset_options = ["all"]
   else:
+    preset_options = set(
+        label.split(":", maxsplit=1)[1]
+        for label in labels
+        if label.startswith(BENCHMARK_PRESET_KEY + ":"))
     trailer = trailers.get(BENCHMARK_PRESET_KEY)
-    if trailer is None:
-      return ""
-    print(f"Using benchmark preset '{trailer}' from PR description trailers")
-    preset_options = [option.strip() for option in trailer.split(",")]
+    if trailer is not None:
+      preset_options = preset_options.union(
+          option.strip() for option in trailer.split(","))
+    preset_options = sorted(preset_options)
+    print(f"Using benchmark preset '{preset_options}' from trailers and labels")
 
   for preset_option in preset_options:
     if preset_option not in BENCHMARK_PRESET_OPTIONS:
@@ -236,14 +261,14 @@ def get_benchmark_presets(is_pr: bool, trailers: Mapping[str, str]) -> str:
 
 def main():
   is_pr = os.environ["GITHUB_EVENT_NAME"] == "pull_request"
-  trailers = get_trailers(is_pr)
+  trailers, labels = get_trailers_and_labels(is_pr)
   output = {
       "should-run": json.dumps(should_run_ci(is_pr, trailers)),
       "is-pr": json.dumps(is_pr),
       "runner-env": get_runner_env(trailers),
       "runner-group": "presubmit" if is_pr else "postsubmit",
       "write-caches": "0" if is_pr else "1",
-      "benchmark-presets": get_benchmark_presets(is_pr, trailers),
+      "benchmark-presets": get_benchmark_presets(is_pr, trailers, labels),
   }
 
   set_output(output)

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -103,13 +103,16 @@ def check_description_and_show_diff(original_description: str,
                                     original_labels: Sequence[str],
                                     current_description: str,
                                     current_labels: Sequence[str]):
-  original_description += "\n\nLabels:\n" + "\n".join(original_labels)
-  current_description += "\n\nLabels:\n" + "\n".join(current_labels)
-  if original_description == current_description:
+  original_labels = sorted(original_labels)
+  current_labels = sorted(current_labels)
+  if (original_description == current_description and
+      original_labels == current_labels):
     return
 
-  diffs = difflib.unified_diff(original_description.splitlines(keepends=True),
-                               current_description.splitlines(keepends=True))
+  description_diffs = difflib.unified_diff(
+      original_description.splitlines(keepends=True),
+      current_description.splitlines(keepends=True))
+  description_diffs = "".join(description_diffs)
 
   write_job_summary(
       textwrap.dedent("""\
@@ -119,9 +122,14 @@ def check_description_and_show_diff(original_description: str,
   <summary>Click to show diff (original vs. current)</summary>
 
   ```diff
-  {}
+  {description_diffs}
   ```
-  </details>""").format("".join(diffs)))
+
+  Original labels: {original_labels}
+  Current labels: {current_labels}
+  </details>""").format(description_diffs=description_diffs,
+                        original_labels=original_labels,
+                        current_labels=current_labels))
 
 
 def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:

--- a/build_tools/github_actions/configure_ci.py
+++ b/build_tools/github_actions/configure_ci.py
@@ -16,7 +16,7 @@ When GITHUB_EVENT_NAME is "pull_request", there are additional environment
 variables to be set:
 - PR_TITLE (required): PR title.
 - PR_BODY (optional): PR description.
-- PR_LABELS (optional): PR label names, splitted by comma.
+- PR_LABELS (optional): JSON list of PR label names.
 - BASE_REF (required): base commit SHA of the PR.
 - ORIGINAL_PR_TITLE (optional): PR title from the original PR event, showing a
     notice if PR_TITLE is different.
@@ -130,13 +130,12 @@ def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
 
   title = os.environ["PR_TITLE"]
   body = os.environ.get("PR_BODY", "")
-  labels = os.environ.get("PR_LABELS", "")
+  labels = json.loads(os.environ.get("PR_LABELS", "[]"))
   original_title = os.environ.get("ORIGINAL_PR_TITLE")
   original_body = os.environ.get("ORIGINAL_PR_BODY", "")
-  original_labels = os.environ.get("ORIGINAL_PR_LABELS", "")
+  original_labels = json.loads(os.environ.get("ORIGINAL_PR_LABELS", "[]"))
 
   description = PR_DESCRIPTION_TEMPLATE.format(title=title, body=body)
-  labels = [label.strip() for label in labels.split(",")]
 
   # PR information can be fetched from API for the latest updates. If
   # ORIGINAL_PR_TITLE is set, compare the current and original description and
@@ -145,7 +144,6 @@ def get_trailers_and_labels(is_pr: bool) -> Tuple[Mapping[str, str], List[str]]:
   if original_title is not None:
     original_description = PR_DESCRIPTION_TEMPLATE.format(title=original_title,
                                                           body=original_body)
-    original_labels = [label.strip() for label in original_labels.split(",")]
     print("Original PR description and labels:",
           original_description,
           original_labels,


### PR DESCRIPTION
Get the labels from PR events and parse the benchmark labels from them.

Benchmark presets from trailers and labels are merged as the final benchmark presets. Later on we can deprecate the benchmark trailer in the PR description. These benchmark labels only trigger the default set of benchmarks commonly used. If we want to have some extra benchmark sets (e.g. larger models) in the future, we can have trailers like `extra-benchmarks:` and `extra-target-devices:` for them (and a `benchmarks:re-run` label to rerun all selected benchmarks). It basically simplifies the most common use cases and requires more steps (and more confusing) for rare use cases.

For the benchmark filter, right now I think it over-complicates the system and I don't see its usage in the near future. Well-organized benchmark presets should be enough to handle most of the cases.

The format of benchmark labels follows the benchmark preset trailer: `benchmarks:...`

Changes in the labels will also be shown in the re-run:
https://github.com/openxla/iree/actions/runs/4440358174
![image](https://user-images.githubusercontent.com/2104162/225717653-41dbed20-7757-4c3c-bb5d-0079fc7db120.png)

benchmarks: x86_64