### PR TITLE
Simplify getComputeOps methods after IREE moves distribution to backends

### DIFF
--- a/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
+++ b/compiler/src/iree/compiler/Codegen/Common/TileAndDistributeToWorkgroupsPass.cpp
@@ -324,16 +324,7 @@ void TileAndDistributeToWorkgroupsPass::runOnOperation() {
     auto exportOp = entryPoints.lookup(funcOp.getName());
     if (!exportOp) continue;
 
-    SmallVector<Operation *> computeOps;
-    SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
-    if (failed(getComputeOps(funcOp, computeOps, tiledLoops))) {
-      funcOp.emitOpError("failed to get compute ops in dispatch");
-      return signalPassFailure();
-    }
-    if (!tiledLoops.empty()) {
-      // The entry point already has distribution to workgroups. Do nothing.
-      continue;
-    }
+    SmallVector<Operation *> computeOps = getComputeOps(funcOp);
     SmallVector<int64_t> tileSizes, staticLoopRanges, interchange;
     SmallVector<unsigned> partitionableLoops;
     Operation *dispatchRootOp = nullptr;

--- a/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMCPU/KernelDispatch.cpp
@@ -1876,6 +1876,11 @@ static FailureOr<Operation *> getRootOperation(
 /// Sets the translation information to use for a dispatch region.
 static LogicalResult setTranslationInfoAndRootConfig(
     func::FuncOp entryPointFn, ArrayRef<Operation *> computeOps) {
+  if (computeOps.empty()) {
+    // No compute operations found. Allow to pass through without a config.
+    return success();
+  }
+
   // First check if the operations have a preset pipeline. If the config is
   // preset, do not overwrite it.
   for (auto computeOp : computeOps) {
@@ -1941,13 +1946,7 @@ LogicalResult initCPULaunchConfig(ModuleOp moduleOp) {
       continue;
     }
 
-    SmallVector<Operation *> computeOps;
-
-    // If there are no linalg ops, not using Linalg based lowering.
-    if (failed(getComputeOps(funcOp, computeOps))) {
-      return failure();
-    }
-
+    SmallVector<Operation *> computeOps = getComputeOps(funcOp);
     if (failed(setTranslationInfoAndRootConfig(funcOp, computeOps))) {
       return failure();
     }

--- a/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/LLVMGPU/KernelConfig.cpp
@@ -1002,11 +1002,7 @@ LogicalResult initGPULaunchConfig(ModuleOp moduleOp) {
     auto exportOp = exportOps.lookup(funcOp.getName());
     if (!exportOp) continue;
     if (getTranslationInfo(exportOp)) continue;
-    SmallVector<Operation *> computeOps;
-    if (failed(getComputeOps(funcOp, computeOps))) {
-      return funcOp.emitOpError("failed to get compute ops");
-    }
-
+    SmallVector<Operation *> computeOps = getComputeOps(funcOp);
     Operation *rootOperation = nullptr;
     // Find the root operation. linalg.generic and linalg.fill are not root
     // operations if there are other compute operations present.

--- a/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/KernelConfig.cpp
@@ -1424,11 +1424,7 @@ static LogicalResult setSPIRVOpConfig(const spirv::TargetEnv &targetEnv,
 static LogicalResult setConfigForKernel(const spirv::TargetEnv &targetEnv,
                                         IREE::HAL::ExecutableExportOp exportOp,
                                         func::FuncOp funcOp) {
-  SmallVector<Operation *> computeOps;
-  if (failed(getComputeOps(funcOp, computeOps))) {
-    return funcOp.emitOpError("failed to get compute ops");
-  }
-
+  SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   if (computeOps.empty()) {
     // No compute operations found. Allow to pass through without a config.
     return success();

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTile.cpp
@@ -62,9 +62,7 @@ static FailureOr<IREE::Codegen::LoweringConfigAttr> collectComputeOps(
 
   SmallVector<IREE::Codegen::LoweringConfigAttr> configs;
   if (ifOps.empty()) {
-    if (failed(getComputeOps(funcOp, computeOps))) {
-      return funcOp.emitOpError("does not contain compute ops");
-    }
+    computeOps = getComputeOps(funcOp);
     for (Operation *op : computeOps) {
       if (auto config = getLoweringConfig(op)) configs.push_back(config);
     }

--- a/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/SPIRVTileAndPromote.cpp
@@ -297,10 +297,7 @@ LogicalResult SPIRVTileAndPromotePass::doPromoteCMatrix(
   MLIRContext *context = funcOp.getContext();
   if (!promoteCMatrix) return success();
 
-  SmallVector<Operation *> computeOps;
-  if (failed(getComputeOps(funcOp, computeOps)))
-    return funcOp.emitError("failed to get compute ops");
-
+  SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   SmallVector<Operation *> linalgOps;
   for (Operation *op : computeOps) {
     if (isa<linalg::FillOp>(op)) continue;  // Don't care

--- a/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/SPIRV/Utils.cpp
@@ -62,11 +62,7 @@ llvm::Optional<int> getSPIRVSubgroupSize(func::FuncOp funcOp) {
 
 FailureOr<SmallVector<int64_t>> getSPIRVTileSize(func::FuncOp funcOp,
                                                  int tilingLevel) {
-  SmallVector<Operation *> computeOps;
-  if (failed(getComputeOps(funcOp, computeOps))) {
-    return funcOp.emitOpError("failed to get compute ops");
-  }
-
+  SmallVector<Operation *> computeOps = getComputeOps(funcOp);
   auto config = getLoweringConfig(computeOps);
   if (failed(config)) {
     return funcOp.emitOpError("failed to get lowering configuration");

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.cpp
@@ -577,45 +577,21 @@ Optional<LoopTilingAndDistributionInfo> isTiledAndDistributedLoop(
   return loopInfo;
 }
 
-LogicalResult getFilteredOps(
-    func::FuncOp funcOp, RootOpFilteringFn filteringFn,
-    SmallVectorImpl<Operation *> &filteredOps,
-    SmallVectorImpl<LoopTilingAndDistributionInfo> &tiledLoops) {
-  Region &region = funcOp.getFunctionBody();
-  if (!llvm::hasSingleElement(region)) {
-    return funcOp.emitError("unable dispatch function with multiple blocks");
-  }
-  Block *body = &region.front();
+SmallVector<Operation *> getComputeOps(func::FuncOp funcOp) {
+  Block *body = &funcOp.getFunctionBody().front();
   auto forOps = body->getOps<scf::ForOp>();
   while (!forOps.empty()) {
-    if (!llvm::hasSingleElement(forOps)) return failure();
+    assert(llvm::hasSingleElement(forOps) &&
+           "expected dispatch function with single block");
     scf::ForOp forOp = *(forOps.begin());
-    if (auto tiledLoopInfo = isTiledAndDistributedLoop(forOp)) {
-      tiledLoops.emplace_back(std::move(tiledLoopInfo.value()));
-    }
     body = forOp.getBody();
     forOps = body->getOps<scf::ForOp>();
   }
-  for (Operation &op : body->getOperations()) {
-    if (filteringFn(&op)) {
-      filteredOps.push_back(&op);
-    }
+  SmallVector<Operation *> computeOps;
+  for (auto op : body->getOps<TilingInterface>()) {
+    computeOps.push_back(op);
   }
-  return success();
-}
-
-LogicalResult getComputeOps(
-    func::FuncOp funcOp, SmallVectorImpl<Operation *> &computeOps,
-    SmallVectorImpl<LoopTilingAndDistributionInfo> &tiledLoops) {
-  if (failed(getFilteredOps(
-          funcOp,
-          [](Operation *op) {
-            return isa<linalg::LinalgOp, TilingInterface>(op);
-          },
-          computeOps, tiledLoops))) {
-    return failure();
-  }
-  return success();
+  return computeOps;
 }
 
 SmallVector<LoopTilingAndDistributionInfo> getTiledAndDistributedLoopInfo(

--- a/compiler/src/iree/compiler/Codegen/Utils/Utils.h
+++ b/compiler/src/iree/compiler/Codegen/Utils/Utils.h
@@ -161,26 +161,10 @@ struct LoopTilingAndDistributionInfo {
 ///   }
 /// }
 ///
-/// Returns the list of filtered operations in the functions. If there are no
-/// `scf.for` operations in the function return the linalg operations in the
-/// body of the function if it has a single basic block. Return failure in all
-/// other cases.
-using RootOpFilteringFn = std::function<bool(Operation *)>;
-LogicalResult getFilteredOps(
-    func::FuncOp funcOp, RootOpFilteringFn filteringFn,
-    SmallVectorImpl<Operation *> &filteredOps,
-    SmallVectorImpl<LoopTilingAndDistributionInfo> &tiledLoops);
-
-/// Specialization of `getFilteredOps` for filtering `LinalgOp`s and
-/// `LinagExtOp`s.
-LogicalResult getComputeOps(
-    func::FuncOp funcOp, SmallVectorImpl<Operation *> &computeOps,
-    SmallVectorImpl<LoopTilingAndDistributionInfo> &tiledLoops);
-inline LogicalResult getComputeOps(func::FuncOp funcOp,
-                                   SmallVectorImpl<Operation *> &computeOps) {
-  SmallVector<LoopTilingAndDistributionInfo> tiledLoops;
-  return getComputeOps(funcOp, computeOps, tiledLoops);
-}
+/// Returns the list of TilingInterface ops in the functions. If there are no
+/// `scf.for` operations in the function return the TilingInterface operations
+/// in the body of the function if it has a single basic block.
+SmallVector<Operation *> getComputeOps(func::FuncOp funcOp);
 
 /// If the given `forOp` is a tiled and distributed loop, returns its tiling and
 /// distribution information.


### PR DESCRIPTION
The TilingInterface has been upstreamed, so we can update the method to find all TilingInterface ops, not only for Linalg ops.