### PR TITLE
Print meaningful error when too much shared memory is allocated on CUDA

### DIFF
--- a/runtime/src/iree/hal/drivers/cuda/context_wrapper.h
+++ b/runtime/src/iree/hal/drivers/cuda/context_wrapper.h
@@ -14,6 +14,7 @@
 // Structure to wrap all objects constant within a context. This makes it
 // simpler to pass it to the different objects and saves memory.
 typedef struct iree_hal_cuda_context_wrapper_t {
+  CUdevice cu_device;
   CUcontext cu_context;
   iree_allocator_t host_allocator;
   iree_hal_cuda_dynamic_symbols_t* syms;

--- a/runtime/src/iree/hal/drivers/cuda/cuda_device.c
+++ b/runtime/src/iree/hal/drivers/cuda/cuda_device.c
@@ -110,6 +110,7 @@ static iree_status_t iree_hal_cuda_device_create_internal(
   device->params = *params;
   device->device = cu_device;
   device->stream = stream;
+  device->context_wrapper.cu_device = cu_device;
   device->context_wrapper.cu_context = context;
   device->context_wrapper.host_allocator = host_allocator;
   iree_arena_block_pool_initialize(params->arena_block_size, host_allocator,

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -120,13 +120,14 @@ iree_status_t iree_hal_cuda_native_executable_create(
         break;
       }
 
-      int32_t max_shared_mem;
+      int32_t max_shared_mem = 0;
       status = CU_RESULT_TO_STATUS(
           context->syms,
           cuDeviceGetAttribute(&max_shared_mem,
                                CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
                                context->cu_device),
           "cuDeviceGetAttribute");
+      if (!iree_status_is_ok(status)) break;
       if (shared_memory_sizes[i] > max_shared_mem) {
         status = iree_make_status(
             IREE_STATUS_INTERNAL,

--- a/runtime/src/iree/hal/drivers/cuda/native_executable.c
+++ b/runtime/src/iree/hal/drivers/cuda/native_executable.c
@@ -123,16 +123,17 @@ iree_status_t iree_hal_cuda_native_executable_create(
       int32_t max_shared_mem = 0;
       status = CU_RESULT_TO_STATUS(
           context->syms,
-          cuDeviceGetAttribute(&max_shared_mem,
-                               CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
-                               context->cu_device),
+          cuDeviceGetAttribute(
+              &max_shared_mem,
+              CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
+              context->cu_device),
           "cuDeviceGetAttribute");
       if (!iree_status_is_ok(status)) break;
       if (shared_memory_sizes[i] > max_shared_mem) {
-        status = iree_make_status(
-            IREE_STATUS_INTERNAL,
-            "Requested shared memory size of %d larger than allowed size of %d",
-            shared_memory_sizes[i], max_shared_mem);
+        status = iree_make_status(IREE_STATUS_INTERNAL,
+                                  "CUDA driver error: Requested shared memory "
+                                  "size of %d larger than allowed size of %d",
+                                  shared_memory_sizes[i], max_shared_mem);
       } else {
         status = CU_RESULT_TO_STATUS(
             context->syms,


### PR DESCRIPTION
Queries  the driver for the max amount of shared memory allowed then errors if too much is requested. 

Addresses #12146